### PR TITLE
Fix for https://issues.apache.org/jira/browse/OPTIQ-269

### DIFF
--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>2.11.1</version>
+      <version>2.12.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Detects the version of mongod to determine which kind of intermediate
result to utilize.

For versions 2.6+, a Cursor result will be returned form the
DBCollection otherwise a AggregationOutput result is returned.

An Iterator<DBObject> object is retrieved from the intermediate result 
and returned by MongoTable.aggregate.

Updated dependency in for mongo-java-driver in master/mongodb/pom.xml:

```
<dependency>
  <groupId>org.mongodb</groupId>
  <artifactId>mongo-java-driver</artifactId>
  <version>2.12.3</version>
</dependency>
```
