### PR TITLE
Add support for converting a MongoDB date to a SQL timestamp type

### DIFF
--- a/mongodb/src/main/java/net/hydromatic/optiq/impl/mongodb/MongoEnumerator.java
+++ b/mongodb/src/main/java/net/hydromatic/optiq/impl/mongodb/MongoEnumerator.java
@@ -122,9 +122,16 @@ class MongoEnumerator implements Enumerator<Object> {
     if (o == null || clazz.isInstance(o)) {
       return o;
     }
-    if (clazz == int.class || clazz == Integer.class) {
-      if (o instanceof Date) {
+    if (o instanceof Date) {
+      // If the return type is an int, then the number of *days* since
+      // Jan 1, 1970 is expected
+      if (clazz == int.class || clazz == Integer.class) {
         return (int) (((Date) o).getTime() / DateTimeUtil.MILLIS_PER_DAY);
+      }
+      // If the return type is a long, then the number of *milliseconds* since
+      // Jan 1, 1970 00:00:00 is expected
+      if (clazz == long.class || clazz == Long.class) {
+        return (long) (((Date) o).getTime());
       }
     }
     return o;


### PR DESCRIPTION
This is related to OPTIQ-286, but that was to support MongoDB's date objects to SQL Date types; this patch allows MongoDB date objects to be converted to SQL Timestamp types.
