### PR TITLE
CALCITE-464: Allow dynamically set the max length for sql identifier use...

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -125,6 +125,7 @@ public class ${parser.class} extends SqlAbstractParserImpl
 
     private Casing unquotedCasing;
     private Casing quotedCasing;
+    private int identifierMaxLength;
 
     /**
      * {@link SqlParserImplFactory} implementation for creating parser.
@@ -184,6 +185,12 @@ public class ${parser.class} extends SqlAbstractParserImpl
     public void setUnquotedCasing(Casing unquotedCasing)
     {
         this.unquotedCasing = unquotedCasing;
+    }
+
+    // implement SqlAbstractParserImpl
+    public void setIdentifierMaxLength(int identifierMaxLength)
+    {
+        this.identifierMaxLength = identifierMaxLength;
     }
 
     // implement SqlAbstractParserImpl
@@ -3363,9 +3370,9 @@ String Identifier() :
         | id = NonReservedKeyWord()
     )
     {
-        if (id.length() > 128) {
+        if (id.length() > this.identifierMaxLength) {
             throw SqlUtil.newContextException(getPos(),
-                RESOURCE.identifierTooLong(id, 128));
+                RESOURCE.identifierTooLong(id, this.identifierMaxLength));
         }
         return id;
     }

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.prepare;
 
 import org.apache.calcite.adapter.java.JavaTypeFactory;
-import org.apache.calcite.config.Lex;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -59,7 +58,8 @@ public class PlannerImpl implements Planner {
   /** Holds the trait definitions to be registered with planner. May be null. */
   private final ImmutableList<RelTraitDef> traitDefs;
 
-  private final Lex lex;
+  private final SqlParser.ParserConfig parserConfig;
+
   private final SqlParserImplFactory parserFactory;
   private final SqlRexConvertletTable convertletTable;
 
@@ -90,7 +90,7 @@ public class PlannerImpl implements Planner {
     this.defaultSchema = config.getDefaultSchema();
     this.operatorTable = config.getOperatorTable();
     this.programs = config.getPrograms();
-    this.lex = config.getLex();
+    this.parserConfig = config.getParserConfig();
     this.parserFactory = config.getParserFactory();
     this.state = State.STATE_0_CLOSED;
     this.traitDefs = config.getTraitDefs();
@@ -165,7 +165,7 @@ public class PlannerImpl implements Planner {
     }
     ensure(State.STATE_2_READY);
     SqlParser parser = SqlParser.create(parserFactory, sql,
-        lex.quoting, lex.unquotedCasing, lex.quotedCasing);
+        parserConfig);
     SqlNode sqlNode = parser.parseStmt();
     state = State.STATE_3_PARSED;
     return sqlNode;
@@ -206,8 +206,8 @@ public class PlannerImpl implements Planner {
   public class ViewExpanderImpl implements ViewExpander {
     public RelNode expandView(RelDataType rowType, String queryString,
         List<String> schemaPath) {
-      final SqlParser parser = SqlParser.create(parserFactory, queryString,
-          lex.quoting, lex.unquotedCasing, lex.quotedCasing);
+      SqlParser parser = SqlParser.create(parserFactory, queryString,
+          parserConfig);
       SqlNode sqlNode;
       try {
         sqlNode = parser.parseQuery();

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlAbstractParserImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlAbstractParserImpl.java
@@ -437,6 +437,11 @@ public abstract class SqlAbstractParserImpl {
   public abstract void setUnquotedCasing(Casing unquotedCasing);
 
   /**
+   * Sets the maximum length for sql identifier.
+   */
+  public abstract void setIdentifierMaxLength(int identifierMaxLength);
+
+  /**
    * Change parser state.
    *
    * @param stateName new state.

--- a/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
+++ b/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserImplFactory;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 
@@ -40,6 +41,11 @@ public interface FrameworkConfig {
    * and quoted identifier syntax.
    */
   Lex getLex();
+
+  /**
+   * The configuration of SQL parser
+   */
+  SqlParser.ParserConfig getParserConfig();
 
   /**
    * Provides the parser factory that creates the SqlParser used in parsing

--- a/core/src/main/java/org/apache/calcite/tools/Frameworks.java
+++ b/core/src/main/java/org/apache/calcite/tools/Frameworks.java
@@ -32,6 +32,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.server.CalciteServerStatement;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserImplFactory;
 import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
@@ -178,7 +179,8 @@ public class Frameworks {
     private ImmutableList<Program> programs = ImmutableList.of();
     private Context context;
     private ImmutableList<RelTraitDef> traitDefs;
-    private Lex lex = Lex.ORACLE;
+    private SqlParser.ParserConfig parserConfig =
+        SqlParser.ORACLE_PARSER_CONFIG;
     private SchemaPlus defaultSchema;
     private RelOptCostFactory costFactory;
     private SqlParserImplFactory parserFactory = SqlParserImpl.FACTORY;
@@ -188,8 +190,8 @@ public class Frameworks {
 
     public FrameworkConfig build() {
       return new StdFrameworkConfig(context, convertletTable, operatorTable,
-          programs, traitDefs, lex, defaultSchema, costFactory, parserFactory,
-          typeSystem);
+          programs, traitDefs, parserConfig, defaultSchema, costFactory, //
+          parserFactory, typeSystem);
     }
 
     public ConfigBuilder context(Context c) {
@@ -222,8 +224,9 @@ public class Frameworks {
       return this;
     }
 
-    public ConfigBuilder lex(Lex lex) {
-      this.lex = Preconditions.checkNotNull(lex);
+    public ConfigBuilder parserConfig(SqlParser.ParserConfig parserConfig) {
+      Preconditions.checkNotNull(parserConfig);
+      this.parserConfig = parserConfig;
       return this;
     }
 
@@ -276,7 +279,7 @@ public class Frameworks {
     private final SqlOperatorTable operatorTable;
     private final ImmutableList<Program> programs;
     private final ImmutableList<RelTraitDef> traitDefs;
-    private final Lex lex;
+    private final SqlParser.ParserConfig parserConfig;
     private final SchemaPlus defaultSchema;
     private final RelOptCostFactory costFactory;
     private final SqlParserImplFactory parserFactory;
@@ -287,7 +290,7 @@ public class Frameworks {
         SqlOperatorTable operatorTable,
         ImmutableList<Program> programs,
         ImmutableList<RelTraitDef> traitDefs,
-        Lex lex,
+        SqlParser.ParserConfig parserConfig,
         SchemaPlus defaultSchema,
         RelOptCostFactory costFactory,
         SqlParserImplFactory parserFactory,
@@ -297,7 +300,7 @@ public class Frameworks {
       this.operatorTable = operatorTable;
       this.programs = programs;
       this.traitDefs = traitDefs;
-      this.lex = lex;
+      this.parserConfig = parserConfig;
       this.defaultSchema = defaultSchema;
       this.costFactory = costFactory;
       this.parserFactory = parserFactory;
@@ -305,7 +308,11 @@ public class Frameworks {
     }
 
     public Lex getLex() {
-      return lex;
+      return parserConfig.getLex();
+    }
+
+    public SqlParser.ParserConfig getParserConfig() {
+      return this.parserConfig;
     }
 
     public SqlParserImplFactory getParserFactory() {

--- a/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
@@ -18,12 +18,12 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
-import org.apache.calcite.config.Lex;
 import org.apache.calcite.interpreter.Interpreter;
 import org.apache.calcite.linq4j.QueryProvider;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
@@ -76,7 +76,7 @@ public class InterpreterTest {
   @Before public void setUp() {
     rootSchema = Frameworks.createRootSchema(true);
     final FrameworkConfig config = Frameworks.newConfigBuilder()
-        .lex(Lex.ORACLE)
+        .parserConfig(SqlParser.ORACLE_PARSER_CONFIG)
         .defaultSchema(
             CalciteAssert.addSchema(rootSchema, CalciteAssert.SchemaSpec.HR))
         .build();


### PR DESCRIPTION
...d in SQL parser. Parser configuration goes to ParserConfig.

Make the max length for sql identifier configurable at runtime. Wrap the configuration for sql parser into SqlParser.ParserConfig.  The ParserConfig would contain both Lex and identifier max length.  

Add new unit test case to test a query with an identifier length > 128. 
