### PR TITLE
CALCITE-903 stateless avatica

### DIFF
--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
@@ -67,7 +67,7 @@ public class JdbcMeta implements Meta {
 
   private static final String STMT_CACHE_KEY_BASE = "avatica.statementcache";
 
-  /** Special value for {@link Statement#getLargeMaxRows()} that means fetch
+  /** Special value for {@code Statement#getLargeMaxRows()} that means fetch
    * an unlimited number of rows in a single batch.
    *
    * <p>Any other negative value will return an unlimited number of rows but

--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
@@ -88,7 +88,7 @@ class JdbcResultSet extends Meta.MetaResultSet {
       } else {
         fetchRowCount = (int) maxRowCount;
       }
-      final Meta.Frame firstFrame = frame(resultSet, 0, fetchRowCount, calendar);
+      final Meta.Frame firstFrame = frame(null, resultSet, 0, fetchRowCount, calendar);
       if (firstFrame.done) {
         resultSet.close();
       }
@@ -114,7 +114,7 @@ class JdbcResultSet extends Meta.MetaResultSet {
 
   /** Creates a frame containing a given number or unlimited number of rows
    * from a result set. */
-  static Meta.Frame frame(ResultSet resultSet, long offset,
+  static Meta.Frame frame(StatementInfo info, ResultSet resultSet, long offset,
       int fetchMaxRowCount, Calendar calendar) throws SQLException {
     final ResultSetMetaData metaData = resultSet.getMetaData();
     final int columnCount = metaData.getColumnCount();
@@ -126,7 +126,13 @@ class JdbcResultSet extends Meta.MetaResultSet {
     // Meta prepare/prepareAndExecute 0 return 0 row and done
     boolean done = fetchMaxRowCount == 0;
     for (int i = 0; fetchMaxRowCount < 0 || i < fetchMaxRowCount; i++) {
-      if (!resultSet.next()) {
+      final boolean hasRow;
+      if (null != info) {
+        hasRow = info.next();
+      } else {
+        hasRow = resultSet.next();
+      }
+      if (!hasRow) {
         done = true;
         resultSet.close();
         break;

--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/StatementInfo.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/StatementInfo.java
@@ -77,7 +77,7 @@ public class StatementInfo {
   }
 
   /**
-   * @see {@link ResultSet#next()}
+   * @see ResultSet#next()
    */
   public boolean next() throws SQLException {
     return _next(resultSet);

--- a/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/StatementInfo.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/jdbc/StatementInfo.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.jdbc;
+
+import com.google.common.base.Preconditions;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.Objects;
+
+/**
+ *  All we know about a statement. Encapsulates a {@link ResultSet}.
+ */
+public class StatementInfo {
+  private volatile Boolean relativeSupported = null;
+
+  final Statement statement; // sometimes a PreparedStatement
+  private ResultSet resultSet;
+  private long position = 0;
+
+  // True when setResultSet(ResultSet) is called to let us determine the difference between
+  // a null ResultSet (from an update) from the lack of a ResultSet.
+  private boolean resultsInitialized = false;
+
+  public StatementInfo(Statement statement) {
+    this.statement = Objects.requireNonNull(statement);
+  }
+
+  // Visible for testing
+  void setPosition(long position) {
+    this.position = position;
+  }
+
+  // Visible for testing
+  long getPosition() {
+    return this.position;
+  }
+
+  /**
+   * Set a ResultSet on this object.
+   *
+   * @param resultSet The current ResultSet
+   */
+  public void setResultSet(ResultSet resultSet) {
+    resultsInitialized = true;
+    this.resultSet = resultSet;
+  }
+
+  /**
+   * @return The {@link ResultSet} for this Statement, may be null.
+   */
+  public ResultSet getResultSet() {
+    return this.resultSet;
+  }
+
+  /**
+   * @return True if {@link #setResultSet(ResultSet)} was ever invoked.
+   */
+  public boolean isResultSetInitialized() {
+    return resultsInitialized;
+  }
+
+  /**
+   * @see {@link ResultSet#next()}
+   */
+  public boolean next() throws SQLException {
+    return _next(resultSet);
+  }
+
+  boolean _next(ResultSet results) throws SQLException {
+    boolean ret = results.next();
+    position++;
+    return ret;
+  }
+
+  /**
+   * Consumes <code>offset - position</code> elements from the {@link ResultSet}
+   * @param offset The offset to advance to
+   * @return True if the resultSet was advanced to the current point, false if insufficient rows
+   *      were present to advance to the requested offset.
+   */
+  public boolean advanceResultSetToOffset(ResultSet results, long offset) throws SQLException {
+    Preconditions.checkArgument(offset >= 0 && offset >= position, "Offset should be "
+        + " non-negative and not less than the current position. " + offset + ", " + position);
+    if (position >= offset) {
+      return true;
+    }
+
+    if (null == relativeSupported) {
+      Boolean moreResults = null;
+      synchronized (this) {
+        if (null == relativeSupported) {
+          try {
+            moreResults = advanceByRelative(results, offset);
+            relativeSupported = true;
+          } catch (SQLFeatureNotSupportedException e) {
+            relativeSupported = false;
+          }
+        }
+      }
+
+      if (null != moreResults) {
+        // We figured out whether or not relative is supported.
+        // Make sure we actually do the necessary work.
+        if (!relativeSupported) {
+          // We avoided calling advanceByNext in the synchronized block earlier.
+          moreResults = advanceByNext(results, offset);
+        }
+
+        return moreResults;
+      }
+
+      // Another thread updated the RELATIVE_SUPPORTED before we did, fall through.
+    }
+
+    if (relativeSupported) {
+      return advanceByRelative(results, offset);
+    } else {
+      return advanceByNext(results, offset);
+    }
+  }
+
+  private boolean advanceByRelative(ResultSet results, long offset) throws SQLException {
+    long diff = offset - position;
+    while (diff > Integer.MAX_VALUE) {
+      if (!results.relative(Integer.MAX_VALUE)) {
+        // Avoid updating position until relative succeeds.
+        position += Integer.MAX_VALUE;
+        return false;
+      }
+      // Avoid updating position until relative succeeds.
+      position += Integer.MAX_VALUE;
+      diff -= Integer.MAX_VALUE;
+    }
+    boolean ret = results.relative((int) diff);
+    // Make sure we only update the position after successfully calling relative(int).
+    position += diff;
+    return ret;
+  }
+
+  private boolean advanceByNext(ResultSet results, long offset) throws SQLException {
+    while (position < offset) {
+      // Advance while maintaining `position`
+      if (!_next(results)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+// End StatementInfo.java

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/jdbc/StatementInfoTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/jdbc/StatementInfoTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.jdbc;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.sql.ResultSet;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests covering {@link StatementInfo}.
+ */
+public class StatementInfoTest {
+
+  @Test
+  public void testLargeOffsets() throws Exception {
+    Statement stmt = Mockito.mock(Statement.class);
+    ResultSet results = Mockito.mock(ResultSet.class);
+
+    StatementInfo info = new StatementInfo(stmt);
+
+    Mockito.when(results.relative(Integer.MAX_VALUE)).thenReturn(true, true);
+    Mockito.when(results.relative(1)).thenReturn(true);
+
+    long offset = 1L + Integer.MAX_VALUE + Integer.MAX_VALUE;
+    assertTrue(info.advanceResultSetToOffset(results, offset));
+
+    InOrder inOrder = Mockito.inOrder(results);
+
+    inOrder.verify(results, Mockito.times(2)).relative(Integer.MAX_VALUE);
+    inOrder.verify(results).relative(1);
+
+    assertEquals(offset, info.getPosition());
+  }
+
+  @Test
+  public void testNextUpdatesPosition() throws Exception {
+    Statement stmt = Mockito.mock(Statement.class);
+    ResultSet results = Mockito.mock(ResultSet.class);
+
+    StatementInfo info = new StatementInfo(stmt);
+    info.setResultSet(results);
+
+    Mockito.when(results.next()).thenReturn(true, true, true, false);
+
+    for (int i = 0; i < 3; i++) {
+      assertTrue(i + "th call of next() should return true", info.next());
+      assertEquals(info.getPosition(), i + 1);
+    }
+
+    assertFalse("Expected last next() to return false", info.next());
+    assertEquals(info.getPosition(), 4L);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNoMovement() throws Exception {
+    Statement stmt = Mockito.mock(Statement.class);
+    ResultSet results = Mockito.mock(ResultSet.class);
+
+    StatementInfo info = new StatementInfo(stmt);
+    info.setPosition(500);
+
+    info.advanceResultSetToOffset(results, 400);
+  }
+
+  @Test public void testResultSetGetter() throws Exception {
+    Statement stmt = Mockito.mock(Statement.class);
+    ResultSet results = Mockito.mock(ResultSet.class);
+
+    StatementInfo info = new StatementInfo(stmt);
+
+    assertFalse("ResultSet should not be initialized", info.isResultSetInitialized());
+    assertNull("ResultSet should be null", info.getResultSet());
+
+    info.setResultSet(results);
+
+    assertTrue("ResultSet should be initialized", info.isResultSetInitialized());
+    assertEquals(results, info.getResultSet());
+  }
+
+  @Test public void testCheckPositionAfterFailedRelative() throws Exception {
+    Statement stmt = Mockito.mock(Statement.class);
+    ResultSet results = Mockito.mock(ResultSet.class);
+    final long offset = 500;
+
+    StatementInfo info = new StatementInfo(stmt);
+    info.setResultSet(results);
+
+    // relative() doesn't work
+    Mockito.when(results.relative((int) offset)).thenThrow(new SQLFeatureNotSupportedException());
+    // Should fall back to next(), 500 calls to next, 1 false
+    Mockito.when(results.next()).then(new Answer<Boolean>() {
+      private long invocations = 0;
+
+      // Return true until 500, false after.
+      @Override public Boolean answer(InvocationOnMock invocation) throws Throwable {
+        invocations++;
+        if (invocations >= offset) {
+          return false;
+        }
+        return true;
+      }
+    });
+
+    info.advanceResultSetToOffset(results, offset);
+
+    // Verify correct position
+    assertEquals(offset, info.getPosition());
+    // Make sure that we actually advanced the result set
+    Mockito.verify(results, Mockito.times(500)).next();
+  }
+}
+
+// End StatementInfoTest.java

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+import org.apache.calcite.avatica.AvaticaConnection;
+import org.apache.calcite.avatica.AvaticaStatement;
+import org.apache.calcite.avatica.ConnectionConfig;
+import org.apache.calcite.avatica.ConnectionPropertiesImpl;
+import org.apache.calcite.avatica.ConnectionSpec;
+import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.jdbc.JdbcMeta;
+import org.apache.calcite.avatica.server.AvaticaHandler;
+import org.apache.calcite.avatica.server.HttpServer;
+import org.apache.calcite.avatica.server.Main;
+import org.apache.calcite.avatica.server.Main.HandlerFactory;
+
+import com.google.common.cache.Cache;
+
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that verify that the Driver still functions when requests are randomly bounced between
+ * more than one server.
+ */
+public class AlternatingRemoteMetaTest {
+  private static final ConnectionSpec CONNECTION_SPEC = ConnectionSpec.HSQLDB;
+
+  static {
+    try {
+      DriverManager.registerDriver(new AlternatingDriver());
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // Keep a reference to the servers we start to clean them up after
+  private static final List<HttpServer> ACTIVE_SERVERS = new ArrayList<>();
+
+  /** Factory that provides a {@link JdbcMeta}. */
+  public static class FullyRemoteJdbcMetaFactory implements Meta.Factory {
+
+    private static JdbcMeta instance = null;
+
+    private static JdbcMeta getInstance() {
+      if (instance == null) {
+        try {
+          instance = new JdbcMeta(CONNECTION_SPEC.url, CONNECTION_SPEC.username,
+              CONNECTION_SPEC.password);
+        } catch (SQLException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return instance;
+    }
+
+    @Override public Meta create(List<String> args) {
+      return getInstance();
+    }
+  }
+
+  /**
+   * AvaticaHttpClient implementation that randomly chooses among the provided URLs.
+   */
+  public static class AlternatingAvaticaHttpClient implements AvaticaHttpClient {
+    private final List<AvaticaHttpClientImpl> clients;
+    private final Random r = new Random();
+
+    public AlternatingAvaticaHttpClient(List<URL> urls) {
+      //System.out.println("Constructing clients for " + urls);
+      clients = new ArrayList<>(urls.size());
+      for (URL url : urls) {
+        clients.add(new AvaticaHttpClientImpl(url));
+      }
+    }
+
+    @Override
+    public byte[] send(byte[] request) {
+      AvaticaHttpClientImpl client = clients.get(r.nextInt(clients.size()));
+      //System.out.println("URL: " + client.url);
+      return client.send(request);
+    }
+
+  }
+
+  /**
+   * Driver implementation {@link AlternativeAvaticaHttpClient}.
+   */
+  public static class AlternatingDriver extends Driver {
+
+    public static final String PREFIX = "jdbc:avatica:remote-alternating:";
+
+    @Override protected String getConnectStringPrefix() {
+      return PREFIX;
+    }
+
+    @Override public Meta createMeta(AvaticaConnection connection) {
+      final ConnectionConfig config = connection.config();
+      return new RemoteMeta(connection, new RemoteService(getHttpClient(connection, config)));
+    }
+
+    @Override AvaticaHttpClient getHttpClient(AvaticaConnection connection,
+        ConnectionConfig config) {
+      return new AlternatingAvaticaHttpClient(parseUrls(config.url()));
+    }
+
+    List<URL> parseUrls(String urlStr) {
+      final List<URL> urls = new ArrayList<>();
+      final char comma = ',';
+
+      int prevIndex = 0;
+      int index = urlStr.indexOf(comma);
+      if (-1 == index) {
+        try {
+          return Collections.singletonList(new URL(urlStr));
+        } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      // String split w/o regex
+      while (-1 != index) {
+        try {
+          urls.add(new URL(urlStr.substring(prevIndex, index)));
+        } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+        }
+        prevIndex = index + 1;
+        index = urlStr.indexOf(comma, prevIndex);
+      }
+
+      // Get the last one
+      try {
+        urls.add(new URL(urlStr.substring(prevIndex)));
+      } catch (MalformedURLException e) {
+        throw new RuntimeException(e);
+      }
+
+      return urls;
+    }
+
+  }
+
+  private static String url;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    final String[] mainArgs = new String[] { FullyRemoteJdbcMetaFactory.class.getName() };
+
+    // Bind to '0' to pluck an ephemeral port instead of expecting a certain one to be free
+
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 2; i++) {
+      if (sb.length() > 0) {
+        sb.append(",");
+      }
+      HttpServer jsonServer = Main.start(mainArgs, 0, new HandlerFactory() {
+        @Override public AbstractHandler createHandler(Service service) {
+          return new AvaticaHandler(service);
+        }
+      });
+      ACTIVE_SERVERS.add(jsonServer);
+      sb.append("http://localhost:").append(jsonServer.getPort());
+    }
+
+    url = AlternatingDriver.PREFIX + "url=" + sb.toString();
+  }
+
+  @AfterClass public static void afterClass() throws Exception {
+    for (HttpServer server : ACTIVE_SERVERS) {
+      if (server != null) {
+        server.stop();
+      }
+    }
+  }
+
+  private static Meta getMeta(AvaticaConnection conn) throws Exception {
+    Field f = AvaticaConnection.class.getDeclaredField("meta");
+    f.setAccessible(true);
+    return (Meta) f.get(conn);
+  }
+
+  private static Meta.ExecuteResult prepareAndExecuteInternal(AvaticaConnection conn,
+    final AvaticaStatement statement, String sql, int maxRowCount) throws Exception {
+    Method m =
+        AvaticaConnection.class.getDeclaredMethod("prepareAndExecuteInternal",
+            AvaticaStatement.class, String.class, long.class);
+    m.setAccessible(true);
+    return (Meta.ExecuteResult) m.invoke(conn, statement, sql, maxRowCount);
+  }
+
+  private static Connection getConnection(JdbcMeta m, String id) throws Exception {
+    Field f = JdbcMeta.class.getDeclaredField("connectionCache");
+    f.setAccessible(true);
+    //noinspection unchecked
+    Cache<String, Connection> connectionCache = (Cache<String, Connection>) f.get(m);
+    return connectionCache.getIfPresent(id);
+  }
+
+  @Test public void testRemoteExecuteMaxRowCount() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try (AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url)) {
+      final AvaticaStatement statement = conn.createStatement();
+      prepareAndExecuteInternal(conn, statement,
+        "select * from (values ('a', 1), ('b', 2))", 0);
+      ResultSet rs = statement.getResultSet();
+      int count = 0;
+      while (rs.next()) {
+        count++;
+      }
+      assertEquals("Check maxRowCount=0 and ResultSets is 0 row", count, 0);
+      assertEquals("Check result set meta is still there",
+        rs.getMetaData().getColumnCount(), 2);
+      rs.close();
+      statement.close();
+      conn.close();
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-780">[CALCITE-780]
+   * HTTP error 413 when sending a long string to the Avatica server</a>. */
+  @Test public void testRemoteExecuteVeryLargeQuery() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      // Before the bug was fixed, a value over 7998 caused an HTTP 413.
+      // 16K bytes, I guess.
+      checkLargeQuery(8);
+      checkLargeQuery(240);
+      checkLargeQuery(8000);
+      checkLargeQuery(240000);
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  private void checkLargeQuery(int n) throws Exception {
+    try (AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url)) {
+      final AvaticaStatement statement = conn.createStatement();
+      final String frenchDisko = "It said human existence is pointless\n"
+          + "As acts of rebellious solidarity\n"
+          + "Can bring sense in this world\n"
+          + "La resistance!\n";
+      final String sql = "select '"
+          + longString(frenchDisko, n)
+          + "' as s from (values 'x')";
+      prepareAndExecuteInternal(conn, statement, sql, -1);
+      ResultSet rs = statement.getResultSet();
+      int count = 0;
+      while (rs.next()) {
+        count++;
+      }
+      assertThat(count, is(1));
+      rs.close();
+      statement.close();
+      conn.close();
+    }
+  }
+
+  /** Creates a string of exactly {@code length} characters by concatenating
+   * {@code fragment}. */
+  private static String longString(String fragment, int length) {
+    assert fragment.length() > 0;
+    final StringBuilder buf = new StringBuilder();
+    while (buf.length() < length) {
+      buf.append(fragment);
+    }
+    buf.setLength(length);
+    return buf.toString();
+  }
+
+  @Test public void testRemoteConnectionProperties() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try (AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url)) {
+      String id = conn.id;
+      final Map<String, ConnectionPropertiesImpl> m = ((RemoteMeta) getMeta(conn)).propsMap;
+      assertFalse("remote connection map should start ignorant", m.containsKey(id));
+      // force creating a connection object on the remote side.
+      try (final Statement stmt = conn.createStatement()) {
+        assertTrue("creating a statement starts a local object.", m.containsKey(id));
+        assertTrue(stmt.execute("select count(1) from EMP"));
+      }
+      Connection remoteConn = getConnection(FullyRemoteJdbcMetaFactory.getInstance(), id);
+      final boolean defaultRO = remoteConn.isReadOnly();
+      final boolean defaultAutoCommit = remoteConn.getAutoCommit();
+      final String defaultCatalog = remoteConn.getCatalog();
+      final String defaultSchema = remoteConn.getSchema();
+      conn.setReadOnly(!defaultRO);
+      assertTrue("local changes dirty local state", m.get(id).isDirty());
+      assertEquals("remote connection has not been touched", defaultRO, remoteConn.isReadOnly());
+      conn.setAutoCommit(!defaultAutoCommit);
+      assertEquals("remote connection has not been touched",
+          defaultAutoCommit, remoteConn.getAutoCommit());
+
+      // further interaction with the connection will force a sync
+      try (final Statement stmt = conn.createStatement()) {
+        assertEquals(!defaultAutoCommit, remoteConn.getAutoCommit());
+        assertFalse("local values should be clean", m.get(id).isDirty());
+      }
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  @Test public void testQuery() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try (AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url);
+        Statement statement = conn.createStatement()) {
+      assertFalse(statement.execute("SET SCHEMA \"SCOTT\""));
+      assertFalse(statement.execute(
+          "CREATE TABLE \"FOO\"(\"KEY\" INTEGER NOT NULL, \"VALUE\" VARCHAR(10))"));
+      assertFalse(statement.execute("SET TABLE \"FOO\" READONLY FALSE"));
+
+      final int numRecords = 1000;
+      for (int i = 0; i < numRecords; i++) {
+        assertFalse(statement.execute("INSERT INTO \"FOO\" VALUES(" + i + ", '" + i + "')"));
+      }
+
+      // Make sure all the records are there that we expect
+      ResultSet results = statement.executeQuery("SELECT count(KEY) FROM FOO");
+      assertTrue(results.next());
+      assertEquals(1000, results.getInt(1));
+      assertFalse(results.next());
+
+      results = statement.executeQuery("SELECT KEY, VALUE FROM FOO ORDER BY KEY ASC");
+      for (int i = 0; i < numRecords; i++) {
+        assertTrue(results.next());
+        assertEquals(i, results.getInt(1));
+        assertEquals(Integer.toString(i), results.getString(2));
+      }
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  @Test public void testSingleUrlParsing() throws Exception {
+    AlternatingDriver d = new AlternatingDriver();
+    List<URL> urls = d.parseUrls("http://localhost:1234");
+    assertEquals(Arrays.asList(new URL("http://localhost:1234")), urls);
+  }
+
+  @Test public void testMultipleUrlParsing() throws Exception {
+    AlternatingDriver d = new AlternatingDriver();
+    List<URL> urls = d.parseUrls("http://localhost:1234,http://localhost:2345,"
+        + "http://localhost:3456");
+    List<URL> expectedUrls = Arrays.asList(new URL("http://localhost:1234"),
+        new URL("http://localhost:2345"), new URL("http://localhost:3456"));
+    assertEquals(expectedUrls, urls);
+  }
+}
+
+// End AlternatingRemoteMetaTest.java

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
@@ -122,7 +122,7 @@ public class AlternatingRemoteMetaTest {
   }
 
   /**
-   * Driver implementation {@link AlternativeAvaticaHttpClient}.
+   * Driver implementation {@link AlternatingAvaticaHttpClient}.
    */
   public static class AlternatingDriver extends Driver {
 

--- a/avatica-server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
@@ -35,6 +35,7 @@ import com.google.common.cache.Cache;
 
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -344,6 +345,7 @@ public class RemoteMetaTest {
     }
   }
 
+  @Ignore("[CALCITE-942] AvaticaConnection should fail-fast when closed.")
   @Test public void testRemoteConnectionClosing() throws Exception {
     AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url);
     // Verify connection is usable
@@ -354,9 +356,9 @@ public class RemoteMetaTest {
     try {
       conn.createStatement();
       fail("expected exception");
-    } catch (RuntimeException e) {
+    } catch (SQLException e) {
       assertThat(e.getMessage(),
-          containsString("Connection not found: invalid id, closed, or expired"));
+          containsString("Connection is closed"));
     }
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -436,6 +436,7 @@ public abstract class AvaticaConnection implements Connection {
    * @param statement     Statement
    * @param signature     Prepared query
    * @param firstFrame    First frame of rows, or null if we need to execute
+   * @param state         The state used to create the given result
    * @return Result set
    * @throws java.sql.SQLException if a database error occurs
    */

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -16,7 +16,10 @@
  */
 package org.apache.calcite.avatica;
 
+import org.apache.calcite.avatica.AvaticaConnection.CallableWithoutException;
 import org.apache.calcite.avatica.Meta.MetaResultSet;
+import org.apache.calcite.avatica.remote.Service.ErrorResponse;
+import org.apache.calcite.avatica.remote.Service.OpenConnectionRequest;
 import org.apache.calcite.avatica.remote.TypedValue;
 
 import java.sql.Array;
@@ -57,6 +60,9 @@ public abstract class AvaticaConnection implements Connection {
    * the number of rows modified. */
   public static final String ROWCOUNT_COLUMN_NAME = "ROWCOUNT";
 
+  public static final String NUM_EXECUTE_RETRIES_KEY = "avatica.statement.retries";
+  public static final String NUM_EXECUTE_RETRIES_DEFAULT = "5";
+
   /** The name of the sole column returned by an EXPLAIN statement.
    *
    * <p>Actually Avatica does not care what this column is called, but here is
@@ -80,6 +86,7 @@ public abstract class AvaticaConnection implements Connection {
   public final Map<InternalProperty, Object> properties = new HashMap<>();
   public final Map<Integer, AvaticaStatement> statementMap =
       new ConcurrentHashMap<>();
+  protected final long maxRetriesPerExecute;
 
   /**
    * Creates an AvaticaConnection.
@@ -105,6 +112,15 @@ public abstract class AvaticaConnection implements Connection {
     this.meta = driver.createMeta(this);
     this.metaData = factory.newDatabaseMetaData(this);
     this.holdability = metaData.getResultSetHoldability();
+    this.maxRetriesPerExecute = getNumStatementRetries(info);
+  }
+
+  /**
+   * Compute the number of retries {@link #executeInternal(String) should retry before failing.
+   */
+  long getNumStatementRetries(Properties props) {
+    return Long.valueOf(Objects.requireNonNull(props)
+        .getProperty(NUM_EXECUTE_RETRIES_KEY, NUM_EXECUTE_RETRIES_DEFAULT));
   }
 
   /** Returns a view onto this connection's configuration properties. Code
@@ -114,6 +130,14 @@ public abstract class AvaticaConnection implements Connection {
    * properties. */
   public ConnectionConfig config() {
     return new ConnectionConfigImpl(info);
+  }
+
+  /**
+   * Opens the connection on the server.
+   */
+  public void openConnection() {
+    // Open the connection on the server
+    this.meta.openConnection(handle, OpenConnectionRequest.serializeProperties(info));
   }
 
   // Connection methods
@@ -416,7 +440,7 @@ public abstract class AvaticaConnection implements Connection {
    * @throws java.sql.SQLException if a database error occurs
    */
   protected ResultSet executeQueryInternal(AvaticaStatement statement,
-      Meta.Signature signature, Meta.Frame firstFrame) throws SQLException {
+      Meta.Signature signature, Meta.Frame firstFrame, QueryState state) throws SQLException {
     // Close the previous open result set, if there is one.
     Meta.Frame frame = firstFrame;
     Meta.Signature signature2 = signature;
@@ -453,8 +477,9 @@ public abstract class AvaticaConnection implements Connection {
       if (frame == null && signature2 == null && statement.updateCount != -1) {
         statement.openResultSet = null;
       } else {
+        // Duplicative SQL, for support non-prepared statements
         statement.openResultSet =
-            factory.newResultSet(statement, signature2, timeZone, frame);
+            factory.newResultSet(statement, state, signature2, timeZone, frame);
       }
     }
     // Release the monitor before executing, to give another thread the
@@ -502,8 +527,8 @@ public abstract class AvaticaConnection implements Connection {
   }
 
   protected Meta.ExecuteResult prepareAndExecuteInternal(
-      final AvaticaStatement statement, String sql, long maxRowCount)
-      throws SQLException {
+      final AvaticaStatement statement, final String sql, long maxRowCount)
+      throws SQLException, NoSuchStatementException {
     final Meta.PrepareCallback callback =
         new Meta.PrepareCallback() {
           public Object getMonitor() {
@@ -531,7 +556,7 @@ public abstract class AvaticaConnection implements Connection {
               statement.updateCount = updateCount;
             } else {
               final TimeZone timeZone = getTimeZone();
-              statement.openResultSet = factory.newResultSet(statement,
+              statement.openResultSet = factory.newResultSet(statement, new QueryState(sql),
                   signature, timeZone, firstFrame);
             }
           }
@@ -546,13 +571,13 @@ public abstract class AvaticaConnection implements Connection {
     return meta.prepareAndExecute(statement.handle, sql, maxRowCount, callback);
   }
 
-  protected ResultSet createResultSet(Meta.MetaResultSet metaResultSet)
+  protected ResultSet createResultSet(Meta.MetaResultSet metaResultSet, QueryState state)
       throws SQLException {
     final Meta.StatementHandle h = new Meta.StatementHandle(
         metaResultSet.connectionId, metaResultSet.statementId, null);
     final AvaticaStatement statement = lookupStatement(h);
     ResultSet resultSet = executeQueryInternal(statement, metaResultSet.signature.sanitize(),
-        metaResultSet.firstFrame);
+        metaResultSet.firstFrame, state);
     if (metaResultSet.ownStatement) {
       resultSet.getStatement().closeOnCompletion();
     }
@@ -615,6 +640,44 @@ public abstract class AvaticaConnection implements Connection {
      * {@link org.apache.calcite.avatica.AvaticaConnection#meta}. */
     public Meta getMeta(AvaticaConnection connection) {
       return connection.meta;
+    }
+  }
+
+  /**
+   * A Callable-like interface but without a "throws Exception".
+   *
+   * @param <T> The return type from {@code call}.
+   */
+  public interface CallableWithoutException<T> {
+    T call();
+  }
+
+  /**
+   * Invokes the given "callable", retrying the call when the server responds with an error
+   * denoting that the connection is missing on the server.
+   *
+   * @param callable The function to invoke.
+   * @return The value from the result of the callable.
+   */
+  public <T> T invokeWithRetries(CallableWithoutException<T> callable) {
+    RuntimeException lastException = null;
+    for (int i = 0; i < maxRetriesPerExecute; i++) {
+      try {
+        return callable.call();
+      } catch (AvaticaClientRuntimeException e) {
+        lastException = e;
+        if (ErrorResponse.MISSING_CONNECTION_ERROR_CODE == e.getErrorCode()) {
+          this.openConnection();
+          continue;
+        }
+        throw e;
+      }
+    }
+    if (null != lastException) {
+      throw lastException;
+    } else {
+      // Shouldn't ever happen.
+      throw new IllegalStateException();
     }
   }
 }

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaDatabaseMetaData.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaDatabaseMetaData.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.avatica;
 
+import org.apache.calcite.avatica.AvaticaConnection.CallableWithoutException;
+import org.apache.calcite.avatica.remote.MetaDataOperation;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.avatica.util.Quoting;
 
@@ -182,28 +184,53 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public String getSQLKeywords() throws SQLException {
-    return Meta.DatabaseProperty.GET_S_Q_L_KEYWORDS
-        .getProp(connection.meta, connection.handle, String.class);
+    return connection.invokeWithRetries(new CallableWithoutException<String>() {
+      @Override
+      public String call() {
+        return Meta.DatabaseProperty.GET_S_Q_L_KEYWORDS
+            .getProp(connection.meta, connection.handle, String.class);
+      }
+    });
   }
 
   public String getNumericFunctions() throws SQLException {
-    return Meta.DatabaseProperty.GET_NUMERIC_FUNCTIONS
-        .getProp(connection.meta, connection.handle, String.class);
+    return connection.invokeWithRetries(new CallableWithoutException<String>() {
+      @Override
+      public String call() {
+        return Meta.DatabaseProperty.GET_NUMERIC_FUNCTIONS
+            .getProp(connection.meta, connection.handle, String.class);
+      }
+    });
   }
 
   public String getStringFunctions() throws SQLException {
-    return Meta.DatabaseProperty.GET_STRING_FUNCTIONS
-        .getProp(connection.meta, connection.handle, String.class);
+    return connection.invokeWithRetries(new CallableWithoutException<String>() {
+      @Override
+      public String call() {
+        return Meta.DatabaseProperty.GET_STRING_FUNCTIONS
+            .getProp(connection.meta, connection.handle, String.class);
+      }
+    });
   }
 
   public String getSystemFunctions() throws SQLException {
-    return Meta.DatabaseProperty.GET_SYSTEM_FUNCTIONS
-        .getProp(connection.meta, connection.handle, String.class);
+    return connection.invokeWithRetries(new CallableWithoutException<String>() {
+      @Override
+      public String call() {
+        return Meta.DatabaseProperty.GET_SYSTEM_FUNCTIONS
+            .getProp(connection.meta, connection.handle, String.class);
+      }
+    });
   }
 
   public String getTimeDateFunctions() throws SQLException {
-    return Meta.DatabaseProperty.GET_TIME_DATE_FUNCTIONS
-        .getProp(connection.meta, connection.handle, String.class);
+    return connection.invokeWithRetries(new CallableWithoutException<String>() {
+      @Override
+      public String call() {
+        return Meta.DatabaseProperty.GET_TIME_DATE_FUNCTIONS
+            .getProp(connection.meta, connection.handle, String.class);
+      }
+    });
   }
 
   public String getSearchStringEscape() throws SQLException {
@@ -528,8 +555,13 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public int getDefaultTransactionIsolation() throws SQLException {
-    return Meta.DatabaseProperty.GET_DEFAULT_TRANSACTION_ISOLATION
-        .getProp(connection.meta, connection.handle, Integer.class);
+    return connection.invokeWithRetries(new CallableWithoutException<Integer>() {
+      @Override
+      public Integer call() {
+        return Meta.DatabaseProperty.GET_DEFAULT_TRANSACTION_ISOLATION
+            .getProp(connection.meta, connection.handle, Integer.class);
+      }
+    });
   }
 
   public boolean supportsTransactions() throws SQLException {
@@ -560,33 +592,88 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public ResultSet getProcedures(
-      String catalog,
-      String schemaPattern,
-      String procedureNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getProcedures(connection.handle, catalog, pat(schemaPattern),
-            pat(procedureNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String procedureNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getProcedures(connection.handle, catalog, pat(schemaPattern),
+                    pat(procedureNamePattern)), new QueryState(MetaDataOperation.GET_PROCEDURES,
+                        catalog, schemaPattern, procedureNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getProcedureColumns(
-      String catalog,
-      String schemaPattern,
-      String procedureNamePattern,
-      String columnNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getProcedureColumns(connection.handle, catalog, pat(schemaPattern),
-            pat(procedureNamePattern), pat(columnNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String procedureNamePattern,
+      final String columnNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getProcedureColumns(connection.handle, catalog, pat(schemaPattern),
+                    pat(procedureNamePattern), pat(columnNamePattern)),
+                new QueryState(MetaDataOperation.GET_PROCEDURE_COLUMNS, catalog,
+                  schemaPattern, procedureNamePattern, columnNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getTables(
-      String catalog,
+      final String catalog,
       final String schemaPattern,
-      String tableNamePattern,
-      String[] types) throws SQLException {
-    List<String> typeList = types == null ? null : Arrays.asList(types);
-    return connection.createResultSet(
-        connection.meta.getTables(connection.handle, catalog, pat(schemaPattern),
-            pat(tableNamePattern), typeList));
+      final String tableNamePattern,
+      final String[] types) throws SQLException {
+    final List<String> typeList = types == null ? null : Arrays.asList(types);
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getTables(connection.handle, catalog, pat(schemaPattern),
+                    pat(tableNamePattern), typeList), new QueryState(MetaDataOperation.GET_TABLES,
+                        catalog, schemaPattern, tableNamePattern, types));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   private static Meta.Pat pat(String schemaPattern) {
@@ -594,11 +681,29 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public ResultSet getSchemas(
-      String catalog, String schemaPattern) throws SQLException {
+      final String catalog, final String schemaPattern) throws SQLException {
     // TODO: add a 'catch ... throw new SQLException' logic to this and other
     // getXxx methods. Right now any error will throw a RuntimeException
-    return connection.createResultSet(
-        connection.meta.getSchemas(connection.handle, catalog, pat(schemaPattern)));
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getSchemas(connection.handle, catalog, pat(schemaPattern)),
+                new QueryState(MetaDataOperation.GET_SCHEMAS_WITH_ARGS, catalog, schemaPattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getSchemas() throws SQLException {
@@ -606,103 +711,338 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public ResultSet getCatalogs() throws SQLException {
-    return connection.createResultSet(connection.meta.getCatalogs(connection.handle));
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(connection.meta.getCatalogs(connection.handle),
+                new QueryState(MetaDataOperation.GET_CATALOGS));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getTableTypes() throws SQLException {
-    return connection.createResultSet(connection.meta.getTableTypes(connection.handle));
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(connection.meta.getTableTypes(connection.handle),
+                new QueryState(MetaDataOperation.GET_TABLE_TYPES));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getColumns(
-      String catalog,
-      String schemaPattern,
-      String tableNamePattern,
-      String columnNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getColumns(connection.handle,
-            catalog, pat(schemaPattern),
-            pat(tableNamePattern), pat(columnNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String tableNamePattern,
+      final String columnNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getColumns(connection.handle, catalog, pat(schemaPattern),
+                    pat(tableNamePattern), pat(columnNamePattern)),
+                new QueryState(MetaDataOperation.GET_COLUMNS, catalog, schemaPattern,
+                    tableNamePattern, columnNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getColumnPrivileges(
-      String catalog,
-      String schema,
-      String table,
-      String columnNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getColumnPrivileges(connection.handle, catalog, schema, table,
-            pat(columnNamePattern)));
+      final String catalog,
+      final String schema,
+      final String table,
+      final String columnNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getColumnPrivileges(connection.handle, catalog, schema, table,
+                    pat(columnNamePattern)), new QueryState(MetaDataOperation.GET_COLUMN_PRIVILEGES,
+                        catalog, schema, table, columnNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getTablePrivileges(
-      String catalog,
-      String schemaPattern,
-      String tableNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getTablePrivileges(connection.handle, catalog, pat(schemaPattern),
-            pat(tableNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String tableNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getTablePrivileges(connection.handle, catalog, pat(schemaPattern),
+                    pat(tableNamePattern)), new QueryState(MetaDataOperation.GET_TABLE_PRIVILEGES,
+                        catalog, schemaPattern, tableNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getBestRowIdentifier(
-      String catalog,
-      String schema,
-      String table,
-      int scope,
-      boolean nullable) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getBestRowIdentifier(connection.handle, catalog, schema, table, scope,
-            nullable));
+      final String catalog,
+      final String schema,
+      final String table,
+      final int scope,
+      final boolean nullable) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getBestRowIdentifier(connection.handle, catalog, schema, table,
+                    scope, nullable), new QueryState(MetaDataOperation.GET_BEST_ROW_IDENTIFIER,
+                        catalog, table, scope, nullable));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getVersionColumns(
-      String catalog, String schema, String table) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getVersionColumns(connection.handle, catalog, schema, table));
+      final String catalog, final String schema, final String table) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getVersionColumns(connection.handle, catalog, schema, table),
+                new QueryState(MetaDataOperation.GET_VERSION_COLUMNS, catalog, schema, table));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getPrimaryKeys(
-      String catalog, String schema, String table) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getPrimaryKeys(connection.handle, catalog, schema, table));
+      final String catalog, final String schema, final String table) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getPrimaryKeys(connection.handle, catalog, schema, table),
+                new QueryState(MetaDataOperation.GET_PRIMARY_KEYS, catalog, schema, table));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getImportedKeys(
-      String catalog, String schema, String table) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getImportedKeys(connection.handle, catalog, schema, table));
+      final String catalog, final String schema, final String table) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getImportedKeys(connection.handle, catalog, schema, table),
+                new QueryState(MetaDataOperation.GET_IMPORTED_KEYS, catalog, schema, table));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getExportedKeys(
-      String catalog, String schema, String table) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getExportedKeys(connection.handle, catalog, schema, table));
+      final String catalog, final String schema, final String table) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getExportedKeys(connection.handle, catalog, schema, table),
+                new QueryState(MetaDataOperation.GET_EXPORTED_KEYS, catalog, schema, table));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getCrossReference(
-      String parentCatalog,
-      String parentSchema,
-      String parentTable,
-      String foreignCatalog,
-      String foreignSchema,
-      String foreignTable) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getCrossReference(connection.handle, parentCatalog, parentSchema,
-            parentTable, foreignCatalog, foreignSchema, foreignTable));
+      final String parentCatalog,
+      final String parentSchema,
+      final String parentTable,
+      final String foreignCatalog,
+      final String foreignSchema,
+      final String foreignTable) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getCrossReference(connection.handle, parentCatalog, parentSchema,
+                    parentTable, foreignCatalog, foreignSchema, foreignTable), new QueryState(
+                        MetaDataOperation.GET_CROSS_REFERENCE, parentCatalog, parentSchema,
+                        parentTable, foreignCatalog, foreignSchema, foreignTable));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getTypeInfo() throws SQLException {
-    return connection.createResultSet(connection.meta.getTypeInfo(connection.handle));
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(connection.meta.getTypeInfo(connection.handle),
+                new QueryState(MetaDataOperation.GET_TYPE_INFO));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getIndexInfo(
-      String catalog,
-      String schema,
-      String table,
-      boolean unique,
-      boolean approximate) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getIndexInfo(connection.handle, catalog, schema, table, unique,
-            approximate));
+      final String catalog,
+      final String schema,
+      final String table,
+      final boolean unique,
+      final boolean approximate) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getIndexInfo(connection.handle, catalog, schema, table, unique,
+                    approximate), new QueryState(MetaDataOperation.GET_INDEX_INFO, catalog, schema,
+                        table, unique, approximate));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public boolean supportsResultSetType(int type) throws SQLException {
@@ -756,13 +1096,31 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public ResultSet getUDTs(
-      String catalog,
-      String schemaPattern,
-      String typeNamePattern,
-      int[] types) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getUDTs(connection.handle, catalog, pat(schemaPattern),
-            pat(typeNamePattern), types));
+      final String catalog,
+      final String schemaPattern,
+      final String typeNamePattern,
+      final int[] types) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getUDTs(connection.handle, catalog, pat(schemaPattern),
+                    pat(typeNamePattern), types), new QueryState(MetaDataOperation.GET_UDTS,
+                        catalog, schemaPattern, typeNamePattern, types));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public Connection getConnection() throws SQLException {
@@ -786,31 +1144,86 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public ResultSet getSuperTypes(
-      String catalog,
-      String schemaPattern,
-      String typeNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getSuperTypes(connection.handle, catalog, pat(schemaPattern),
-            pat(typeNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String typeNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getSuperTypes(connection.handle, catalog, pat(schemaPattern),
+                    pat(typeNamePattern)), new QueryState(MetaDataOperation.GET_SUPER_TYPES,
+                        catalog, schemaPattern, typeNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getSuperTables(
-      String catalog,
-      String schemaPattern,
-      String tableNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getSuperTables(connection.handle, catalog, pat(schemaPattern),
-            pat(tableNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String tableNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getSuperTables(connection.handle, catalog, pat(schemaPattern),
+                    pat(tableNamePattern)), new QueryState(MetaDataOperation.GET_SUPER_TABLES,
+                        catalog, schemaPattern, tableNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getAttributes(
-      String catalog,
-      String schemaPattern,
-      String typeNamePattern,
-      String attributeNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getAttributes(connection.handle, catalog, pat(schemaPattern),
-            pat(typeNamePattern), pat(attributeNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String typeNamePattern,
+      final String attributeNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getAttributes(connection.handle, catalog, pat(schemaPattern),
+                    pat(typeNamePattern), pat(attributeNamePattern)), new QueryState(
+                        MetaDataOperation.GET_ATTRIBUTES, catalog, schemaPattern, typeNamePattern,
+                        attributeNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public boolean supportsResultSetHoldability(int holdability)
@@ -864,37 +1277,111 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public ResultSet getClientInfoProperties() throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getClientInfoProperties(connection.handle));
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getClientInfoProperties(connection.handle), new QueryState(
+                    MetaDataOperation.GET_CLIENT_INFO_PROPERTIES));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getFunctions(
-      String catalog,
-      String schemaPattern,
-      String functionNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getFunctions(connection.handle, catalog, pat(schemaPattern),
-            pat(functionNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String functionNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getFunctions(connection.handle, catalog, pat(schemaPattern),
+                    pat(functionNamePattern)), new QueryState(MetaDataOperation.GET_FUNCTIONS,
+                        catalog, schemaPattern, functionNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getFunctionColumns(
-      String catalog,
-      String schemaPattern,
-      String functionNamePattern,
-      String columnNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getFunctionColumns(connection.handle, catalog, pat(schemaPattern),
-            pat(functionNamePattern), pat(columnNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String functionNamePattern,
+      final String columnNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getFunctionColumns(connection.handle, catalog, pat(schemaPattern),
+                    pat(functionNamePattern), pat(columnNamePattern)),
+                new QueryState(MetaDataOperation.GET_FUNCTION_COLUMNS, catalog, schemaPattern,
+                    functionNamePattern, columnNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public ResultSet getPseudoColumns(
-      String catalog,
-      String schemaPattern,
-      String tableNamePattern,
-      String columnNamePattern) throws SQLException {
-    return connection.createResultSet(
-        connection.meta.getPseudoColumns(connection.handle, catalog, pat(schemaPattern),
-            pat(tableNamePattern), pat(columnNamePattern)));
+      final String catalog,
+      final String schemaPattern,
+      final String tableNamePattern,
+      final String columnNamePattern) throws SQLException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ResultSet>() {
+        @Override
+        public ResultSet call() {
+          try {
+            return connection.createResultSet(
+                connection.meta.getPseudoColumns(connection.handle, catalog, pat(schemaPattern),
+                    pat(tableNamePattern), pat(columnNamePattern)),
+                new QueryState(MetaDataOperation.GET_PSEUDO_COLUMNS, catalog, schemaPattern,
+                    tableNamePattern, columnNamePattern));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException) {
+        throw (SQLException) cause;
+      }
+      throw e;
+    }
   }
 
   public boolean generatedKeyAlwaysReturned() throws SQLException {

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaFactory.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaFactory.java
@@ -51,13 +51,14 @@ public interface AvaticaFactory {
    * {@link AvaticaResultSet#execute()} on it.
    *
    * @param statement Statement
+   * @param state The state used to create this result set
    * @param signature Prepared statement
    * @param timeZone Time zone
    * @param firstFrame Frame containing the first (or perhaps only) rows in the
    *                   result, or null if an execute/fetch is required
    * @return Result set
    */
-  AvaticaResultSet newResultSet(AvaticaStatement statement,
+  AvaticaResultSet newResultSet(AvaticaStatement statement, QueryState state,
       Meta.Signature signature, TimeZone timeZone, Meta.Frame firstFrame)
       throws SQLException;
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaJdbc41Factory.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaJdbc41Factory.java
@@ -84,10 +84,10 @@ class AvaticaJdbc41Factory implements AvaticaFactory {
   }
 
   public AvaticaResultSet newResultSet(AvaticaStatement statement,
-      Meta.Signature signature, TimeZone timeZone, Meta.Frame firstFrame) {
+      QueryState state, Meta.Signature signature, TimeZone timeZone, Meta.Frame firstFrame) {
     final ResultSetMetaData metaData =
         newResultSetMetaData(statement, signature);
-    return new AvaticaResultSet(statement, signature, metaData, timeZone,
+    return new AvaticaResultSet(statement, state, signature, metaData, timeZone,
         firstFrame);
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaPreparedStatement.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaPreparedStatement.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.avatica;
 
+import org.apache.calcite.avatica.Meta.Signature;
 import org.apache.calcite.avatica.remote.TypedValue;
 
 import java.io.InputStream;
@@ -106,7 +107,9 @@ public abstract class AvaticaPreparedStatement
 
   public ResultSet executeQuery() throws SQLException {
     this.updateCount = -1;
-    return getConnection().executeQueryInternal(this, getSignature(), null);
+    final Signature sig = getSignature();
+    return getConnection().executeQueryInternal(this, sig, null,
+        new QueryState(sig.sql));
   }
 
   public ParameterMetaData getParameterMetaData() throws SQLException {
@@ -118,7 +121,8 @@ public abstract class AvaticaPreparedStatement
   }
 
   public long executeLargeUpdate() throws SQLException {
-    getConnection().executeQueryInternal(this, getSignature(), null);
+    getConnection().executeQueryInternal(this, getSignature(), null,
+        new QueryState(getSignature().sql));
     return updateCount;
   }
 
@@ -199,7 +203,8 @@ public abstract class AvaticaPreparedStatement
 
   public boolean execute() throws SQLException {
     this.updateCount = -1;
-    getConnection().executeQueryInternal(this, getSignature(), null);
+    getConnection().executeQueryInternal(this, getSignature(), null,
+        new QueryState(getSignature().sql));
     // Result set is null for DML or DDL.
     // Result set is closed if user cancelled the query.
     return openResultSet != null && !openResultSet.isClosed();

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
@@ -49,6 +49,7 @@ import java.util.TimeZone;
  */
 public class AvaticaResultSet implements ResultSet, ArrayImpl.Factory {
   protected final AvaticaStatement statement;
+  protected final QueryState state;
   protected final Meta.Signature signature;
   protected final Meta.Frame firstFrame;
   protected final List<ColumnMetaData> columnMetaDataList;
@@ -69,11 +70,13 @@ public class AvaticaResultSet implements ResultSet, ArrayImpl.Factory {
   private Cursor timeoutCursor;
 
   public AvaticaResultSet(AvaticaStatement statement,
+      QueryState state,
       Meta.Signature signature,
       ResultSetMetaData resultSetMetaData,
       TimeZone timeZone,
       Meta.Frame firstFrame) {
     this.statement = statement;
+    this.state = state;
     this.signature = signature;
     this.firstFrame = firstFrame;
     this.columnMetaDataList = signature.columns;
@@ -182,7 +185,7 @@ public class AvaticaResultSet implements ResultSet, ArrayImpl.Factory {
   protected AvaticaResultSet execute() throws SQLException {
     final List<TypedValue> parameterValues = statement.getBoundParameterValues();
     final Iterable<Object> iterable1 =
-        statement.connection.meta.createIterable(statement.handle, signature,
+        statement.connection.meta.createIterable(statement.handle, state, signature,
             parameterValues, firstFrame);
     this.cursor = MetaImpl.createCursor(signature.cursorFactory, iterable1);
     this.accessorList =

--- a/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
@@ -204,7 +204,7 @@ public interface Meta {
    * <p>The default implementation just returns {@code iterable}, which it
    * requires to be not null; derived classes may instead choose to execute the
    * relational expression in {@code signature}. */
-  Iterable<Object> createIterable(StatementHandle handle, Signature signature,
+  Iterable<Object> createIterable(StatementHandle stmt, QueryState state, Signature signature,
       List<TypedValue> parameterValues, Frame firstFrame);
 
   /** Prepares a statement.
@@ -227,7 +227,7 @@ public interface Meta {
    *     first frame of data
    */
   ExecuteResult prepareAndExecute(StatementHandle h, String sql,
-      long maxRowCount, PrepareCallback callback);
+      long maxRowCount, PrepareCallback callback) throws NoSuchStatementException;
 
   /** Returns a frame of rows.
    *
@@ -243,7 +243,8 @@ public interface Meta {
    * no limit
    * @return Frame, or null if there are no more
    */
-  Frame fetch(StatementHandle h, long offset, int fetchMaxRowCount);
+  Frame fetch(StatementHandle h, long offset, int fetchMaxRowCount) throws
+      NoSuchStatementException, MissingResultsException;
 
   /** Executes a prepared statement.
    *
@@ -254,7 +255,7 @@ public interface Meta {
    * @return Frame, or null if there are no more
    */
   ExecuteResult execute(StatementHandle h, List<TypedValue> parameterValues,
-      long maxRowCount);
+      long maxRowCount) throws NoSuchStatementException;
 
   /** Called during the creation of a statement to allocate a new handle.
    *
@@ -279,6 +280,13 @@ public interface Meta {
 
   /** Closes a connection */
   void closeConnection(ConnectionHandle ch);
+
+  /**
+   * Re-set the {@link ResultSet} on a Statement. Not a JDBC method.
+   * @return True if there are results to fetch after resetting to the given offset. False otherwise
+   */
+  boolean syncResults(StatementHandle sh, QueryState state, long offset)
+      throws NoSuchStatementException;
 
   /** Sync client and server view of connection properties.
    *

--- a/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/Meta.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/avatica/src/main/java/org/apache/calcite/avatica/MissingResultsException.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/MissingResultsException.java
@@ -14,26 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.calcite.avatica.remote;
+package org.apache.calcite.avatica;
 
-import java.nio.charset.StandardCharsets;
+import org.apache.calcite.avatica.Meta.StatementHandle;
 
 /**
- * Implementation of {@link org.apache.calcite.avatica.remote.Service}
- * that translates requests into JSON and sends them to a remote server,
- * usually an HTTP server.
+ * An Exception which denotes that a cached Statement is present but has no {@link ResultSet}.
  */
-public class RemoteService extends JsonService {
-  private final AvaticaHttpClient client;
+public class MissingResultsException extends Exception {
 
-  public RemoteService(AvaticaHttpClient client) {
-    this.client = client;
+  private static final long serialVersionUID = 1L;
+
+  private final StatementHandle handle;
+
+  public MissingResultsException(StatementHandle handle) {
+    this.handle = handle;
   }
 
-  @Override public String apply(String request) {
-    byte[] response = client.send(request.getBytes(StandardCharsets.UTF_8));
-    return new String(response, StandardCharsets.UTF_8);
+  public StatementHandle getHandle() {
+    return handle;
   }
 }
-
-// End RemoteService.java

--- a/avatica/src/main/java/org/apache/calcite/avatica/MissingResultsException.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/MissingResultsException.java
@@ -18,6 +18,8 @@ package org.apache.calcite.avatica;
 
 import org.apache.calcite.avatica.Meta.StatementHandle;
 
+import java.sql.ResultSet;
+
 /**
  * An Exception which denotes that a cached Statement is present but has no {@link ResultSet}.
  */

--- a/avatica/src/main/java/org/apache/calcite/avatica/NoSuchConnectionException.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/NoSuchConnectionException.java
@@ -14,26 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.calcite.avatica.remote;
-
-import java.nio.charset.StandardCharsets;
+package org.apache.calcite.avatica;
 
 /**
- * Implementation of {@link org.apache.calcite.avatica.remote.Service}
- * that translates requests into JSON and sends them to a remote server,
- * usually an HTTP server.
+ * An Exception that denotes that the given Connection is not cached.
  */
-public class RemoteService extends JsonService {
-  private final AvaticaHttpClient client;
+public class NoSuchConnectionException extends RuntimeException {
 
-  public RemoteService(AvaticaHttpClient client) {
-    this.client = client;
+  private static final long serialVersionUID = 1L;
+
+  private final String connectionId;
+
+  public NoSuchConnectionException(String connectionId) {
+    this.connectionId = connectionId;
   }
 
-  @Override public String apply(String request) {
-    byte[] response = client.send(request.getBytes(StandardCharsets.UTF_8));
-    return new String(response, StandardCharsets.UTF_8);
+  public String getConnectionId() {
+    return connectionId;
   }
 }
-
-// End RemoteService.java

--- a/avatica/src/main/java/org/apache/calcite/avatica/NoSuchStatementException.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/NoSuchStatementException.java
@@ -14,26 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.calcite.avatica.remote;
+package org.apache.calcite.avatica;
 
-import java.nio.charset.StandardCharsets;
+import org.apache.calcite.avatica.Meta.StatementHandle;
 
 /**
- * Implementation of {@link org.apache.calcite.avatica.remote.Service}
- * that translates requests into JSON and sends them to a remote server,
- * usually an HTTP server.
+ * An Exception that denotes that the given Statement is not cached.
  */
-public class RemoteService extends JsonService {
-  private final AvaticaHttpClient client;
+public class NoSuchStatementException extends Exception {
 
-  public RemoteService(AvaticaHttpClient client) {
-    this.client = client;
+  private static final long serialVersionUID = 1L;
+
+  private final StatementHandle stmtHandle;
+
+  public NoSuchStatementException(StatementHandle stmtHandle) {
+    this.stmtHandle = stmtHandle;
   }
 
-  @Override public String apply(String request) {
-    byte[] response = client.send(request.getBytes(StandardCharsets.UTF_8));
-    return new String(response, StandardCharsets.UTF_8);
+  public StatementHandle getStatementHandle() {
+    return stmtHandle;
   }
 }
-
-// End RemoteService.java

--- a/avatica/src/main/java/org/apache/calcite/avatica/QueryState.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/QueryState.java
@@ -1,0 +1,489 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.apache.calcite.avatica.proto.Common;
+import org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument;
+import org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType;
+import org.apache.calcite.avatica.remote.MetaDataOperation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A struct used to encapsulate the necessary information to reconstitute a ResultSet in the
+ * Avatica server.
+ */
+public class QueryState {
+
+  /**
+   * An enumeration that represents how a ResultSet was created.
+   */
+  public static enum StateType {
+    SQL,
+    METADATA;
+
+    public Common.StateType toProto() {
+      switch (this) {
+      case SQL:
+        return Common.StateType.SQL;
+      case METADATA:
+        return Common.StateType.METADATA;
+      default:
+        return Common.StateType.UNRECOGNIZED;
+      }
+    }
+
+    public static StateType fromProto(Common.StateType protoType) {
+      switch (protoType) {
+      case SQL:
+        return StateType.SQL;
+      case METADATA:
+        return StateType.METADATA;
+      default:
+        throw new IllegalArgumentException("Unhandled StateType " + protoType);
+      }
+    }
+  }
+
+  @JsonProperty("type")
+  public final StateType type;
+
+  @JsonProperty("sql")
+  public final String sql;
+
+  @JsonProperty("metaDataOperation")
+  public final MetaDataOperation metaDataOperation;
+  @JsonProperty("operationArgs")
+  public final Object[] operationArgs;
+
+  /**
+   * Constructor encapsulating a SQL query used to create a result set.
+   *
+   * @param sql The SQL query.
+   */
+  public QueryState(String sql) {
+    // This doesn't to be non-null
+    this.sql = sql;
+    this.type = StateType.SQL;
+
+    // Null out the members we don't use.
+    this.metaDataOperation = null;
+    this.operationArgs = null;
+  }
+
+  /**
+   * Constructor encapsulating a metadata operation's result set.
+   *
+   * @param op A pointer to the {@link DatabaseMetaData} operation being invoked.
+   * @param args The arguments to the method being invoked.
+   */
+  public QueryState(MetaDataOperation op, Object... args) {
+    this.metaDataOperation = Objects.requireNonNull(op);
+    this.operationArgs = Arrays.copyOf(Objects.requireNonNull(args), args.length);
+    this.type = StateType.METADATA;
+
+    // Null out the members we won't use
+    this.sql = null;
+  }
+
+  /**
+   * Not intended for external use. For Jackson-databind only.
+   */
+  public QueryState(StateType type, String sql, MetaDataOperation op, Object... args) {
+    this.type = Objects.requireNonNull(type);
+    switch (type) {
+    case SQL:
+      this.sql = Objects.requireNonNull(sql);
+      if (null != op) {
+        throw new IllegalArgumentException("Expected null MetaDataOperation, but got " + op);
+      }
+      this.metaDataOperation = null;
+      if (null != args) {
+        throw new IllegalArgumentException("Expected null arguments, but got "
+            + Arrays.toString(args));
+      }
+      this.operationArgs = null;
+      break;
+    case METADATA:
+      this.metaDataOperation = Objects.requireNonNull(op);
+      this.operationArgs = Objects.requireNonNull(args);
+      if (null != sql) {
+        throw new IllegalArgumentException("Expected null SQl but got " + sql);
+      }
+      this.sql = null;
+      break;
+    default:
+      throw new IllegalArgumentException("Unable to handle StateType " + type);
+    }
+  }
+
+  /**
+   * Not intended for external use. For Jackson-databind only.
+   */
+  public QueryState() {
+    this.sql = null;
+    this.metaDataOperation = null;
+    this.type = null;
+    this.operationArgs = null;
+  }
+
+  /**
+   * @return The {@link StateType} for this encapsulated state.
+   */
+  public StateType getType() {
+    return type;
+  }
+
+  /**
+   * @return The SQL expression to invoke.
+   */
+  public String getSql() {
+    assert type == StateType.SQL;
+    return sql;
+  }
+
+  /**
+   * @return The metadata operation to invoke.
+   */
+  public MetaDataOperation getMetaDataOperation() {
+    assert type == StateType.METADATA;
+    return metaDataOperation;
+  }
+
+  /**
+   * @return The Arguments for the given metadata operation.
+   */
+  public Object[] getOperationArgs() {
+    assert type == StateType.METADATA;
+    return operationArgs;
+  }
+
+  public ResultSet invoke(Connection conn, Statement statement) throws SQLException {
+    switch (type) {
+    case SQL:
+      boolean ret = Objects.requireNonNull(statement).execute(sql);
+      ResultSet results = statement.getResultSet();
+
+      // Either execute(sql) returned true or the resultSet was null
+      assert ret || null == results;
+
+      return results;
+    case METADATA:
+      DatabaseMetaData metadata = Objects.requireNonNull(conn).getMetaData();
+      switch (metaDataOperation) {
+      case GET_ATTRIBUTES:
+        verifyOpArgs(4);
+        return metadata.getAttributes((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String) operationArgs[3]);
+      case GET_BEST_ROW_IDENTIFIER:
+        verifyOpArgs(5);
+        return metadata.getBestRowIdentifier((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (int) operationArgs[3],
+            (boolean) operationArgs[4]);
+      case GET_CATALOGS:
+        verifyOpArgs(0);
+        return metadata.getCatalogs();
+      case GET_COLUMNS:
+        verifyOpArgs(4);
+        return metadata.getColumns((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String) operationArgs[3]);
+      case GET_COLUMN_PRIVILEGES:
+        verifyOpArgs(4);
+        return metadata.getColumnPrivileges((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String) operationArgs[3]);
+      case GET_CROSS_REFERENCE:
+        verifyOpArgs(6);
+        return metadata.getCrossReference((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String) operationArgs[3],
+            (String) operationArgs[4],
+            (String) operationArgs[5]);
+      case GET_EXPORTED_KEYS:
+        verifyOpArgs(3);
+        return metadata.getExportedKeys((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_FUNCTIONS:
+        verifyOpArgs(3);
+        return metadata.getFunctions((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_FUNCTION_COLUMNS:
+        verifyOpArgs(4);
+        return metadata.getFunctionColumns((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String) operationArgs[3]);
+      case GET_IMPORTED_KEYS:
+        verifyOpArgs(3);
+        return metadata.getImportedKeys((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_INDEX_INFO:
+        verifyOpArgs(5);
+        return metadata.getIndexInfo((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (boolean) operationArgs[3],
+            (boolean) operationArgs[4]);
+      case GET_PRIMARY_KEYS:
+        verifyOpArgs(3);
+        return metadata.getPrimaryKeys((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_PROCEDURES:
+        verifyOpArgs(3);
+        return metadata.getProcedures((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_PROCEDURE_COLUMNS:
+        verifyOpArgs(4);
+        return metadata.getProcedureColumns((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String) operationArgs[3]);
+      case GET_PSEUDO_COLUMNS:
+        verifyOpArgs(4);
+        return metadata.getPseudoColumns((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String) operationArgs[3]);
+      case GET_SCHEMAS:
+        verifyOpArgs(0);
+        return metadata.getSchemas();
+      case GET_SCHEMAS_WITH_ARGS:
+        verifyOpArgs(2);
+        return metadata.getSchemas((String) operationArgs[0],
+            (String) operationArgs[1]);
+      case GET_SUPER_TABLES:
+        verifyOpArgs(3);
+        return metadata.getSuperTables((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_SUPER_TYPES:
+        verifyOpArgs(3);
+        return metadata.getSuperTypes((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_TABLES:
+        verifyOpArgs(4);
+        return metadata.getTables((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (String[]) operationArgs[3]);
+      case GET_TABLE_PRIVILEGES:
+        verifyOpArgs(3);
+        return metadata.getTablePrivileges((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      case GET_TABLE_TYPES:
+        verifyOpArgs(0);
+        return metadata.getTableTypes();
+      case GET_TYPE_INFO:
+        verifyOpArgs(0);
+        return metadata.getTypeInfo();
+      case GET_UDTS:
+        verifyOpArgs(4);
+        return metadata.getUDTs((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2],
+            (int[]) operationArgs[3]);
+      case GET_VERSION_COLUMNS:
+        verifyOpArgs(3);
+        return metadata.getVersionColumns((String) operationArgs[0],
+            (String) operationArgs[1],
+            (String) operationArgs[2]);
+      default:
+        throw new IllegalArgumentException("Unhandled Metadata operation: " + metaDataOperation);
+      }
+    default:
+      throw new IllegalArgumentException("Unable to process QueryState of type " + type);
+    }
+  }
+
+  private void verifyOpArgs(int expectedArgs) {
+    if (expectedArgs != operationArgs.length) {
+      throw new RuntimeException("Expected " + expectedArgs + " arguments, but got "
+          + Arrays.toString(operationArgs));
+    }
+  }
+
+  public Common.QueryState toProto() {
+    Common.QueryState.Builder builder = Common.QueryState.newBuilder();
+
+    // Required
+    switch (type) {
+    case SQL:
+      builder.setType(Common.StateType.SQL);
+      break;
+    case METADATA:
+      builder.setType(Common.StateType.METADATA);
+      break;
+    default:
+      throw new IllegalStateException("Unhandled type: " + type);
+    }
+
+    // Optional SQL
+    if (null != sql) {
+      builder.setSql(sql).setHasSql(true);
+    }
+
+    // Optional metaDataOperation
+    if (null != metaDataOperation) {
+      builder.setOp(metaDataOperation.toProto()).setHasOp(true);
+    }
+
+    // Optional operationArgs
+    if (null != operationArgs) {
+      builder.setHasArgs(true);
+      for (Object arg : operationArgs) {
+        MetaDataOperationArgument.Builder argBuilder = MetaDataOperationArgument.newBuilder();
+
+        if (null == arg) {
+          builder.addArgs(argBuilder.setType(ArgumentType.NULL).build());
+        } else if (arg instanceof String) {
+          builder.addArgs(argBuilder.setType(ArgumentType.STRING)
+              .setStringValue((String) arg).build());
+        } else if (arg instanceof Integer) {
+          builder.addArgs(argBuilder.setType(ArgumentType.INT).setIntValue((int) arg).build());
+        } else if (arg instanceof Boolean) {
+          builder.addArgs(
+              argBuilder.setType(ArgumentType.BOOL).setBoolValue((boolean) arg).build());
+        } else if (arg instanceof String[]) {
+          argBuilder.setType(ArgumentType.REPEATED_STRING);
+          for (String strArg : (String[]) arg) {
+            argBuilder.addStringArrayValues(strArg);
+          }
+          builder.addArgs(argBuilder.build());
+        } else if (arg instanceof int[]) {
+          argBuilder.setType(ArgumentType.REPEATED_INT);
+          for (int intArg : (int[]) arg) {
+            argBuilder.addIntArrayValues(intArg);
+          }
+          builder.addArgs(argBuilder.build());
+        } else {
+          throw new RuntimeException("Unexpected operation argument: " + arg.getClass());
+        }
+      }
+    } else {
+      builder.setHasArgs(false);
+    }
+
+    return builder.build();
+  }
+
+  public static QueryState fromProto(Common.QueryState protoState) {
+    StateType type = StateType.fromProto(protoState.getType());
+    String sql = protoState.getHasSql() ? protoState.getSql() : null;
+    MetaDataOperation op = protoState.getHasOp()
+        ? MetaDataOperation.fromProto(protoState.getOp()) : null;
+    Object[] opArgs = null;
+    if (protoState.getHasArgs()) {
+      opArgs = new Object[protoState.getArgsCount()];
+      int i = 0;
+      for (Common.MetaDataOperationArgument arg : protoState.getArgsList()) {
+        switch (arg.getType()) {
+        case STRING:
+          opArgs[i] = arg.getStringValue();
+          break;
+        case BOOL:
+          opArgs[i] = arg.getBoolValue();
+          break;
+        case INT:
+          opArgs[i] = arg.getIntValue();
+          break;
+        case REPEATED_STRING:
+          opArgs[i] = arg.getStringArrayValuesList().toArray(
+              new String[arg.getStringArrayValuesCount()]);
+          break;
+        case REPEATED_INT:
+          int[] arr = new int[arg.getIntArrayValuesCount()];
+          int offset = 0;
+          for (Integer val : arg.getIntArrayValuesList()) {
+            arr[offset] = val;
+            offset++;
+          }
+          opArgs[i] = arr;
+          break;
+        case NULL:
+          opArgs[i] = null;
+          break;
+        default:
+          throw new RuntimeException("Could not interpret " + arg.getType());
+        }
+
+        i++;
+      }
+    }
+
+    return new QueryState(type, sql, op, opArgs);
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((metaDataOperation == null) ? 0 : metaDataOperation.hashCode());
+    result = prime * result + Arrays.hashCode(operationArgs);
+    result = prime * result + ((sql == null) ? 0 : sql.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof QueryState)) {
+      return false;
+    }
+
+    QueryState other = (QueryState) obj;
+    if (metaDataOperation != other.metaDataOperation) {
+      return false;
+    }
+    if (!Arrays.deepEquals(operationArgs, other.operationArgs)) {
+      return false;
+    }
+    if (sql == null) {
+      if (other.sql != null) {
+        return false;
+      }
+    } else if (!sql.equals(other.sql)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/avatica/src/main/java/org/apache/calcite/avatica/UnregisteredDriver.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/UnregisteredDriver.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  * <p>The provider must implement:</p>
  * <ul>
  *   <li>{@link Meta#prepare(Meta.ConnectionHandle, String, long)}
- *   <li>{@link Meta#createIterable(org.apache.calcite.avatica.Meta.StatementHandle, org.apache.calcite.avatica.Meta.Signature, java.util.List, Meta.Frame)}
+ *   <li>{@link Meta#createIterable(org.apache.calcite.avatica.Meta.StatementHandle, org.apache.calcite.avatica.QueryState, org.apache.calcite.avatica.Meta.Signature, java.util.List, Meta.Frame)}
  * </ul>
  */
 public abstract class UnregisteredDriver implements java.sql.Driver {

--- a/avatica/src/main/java/org/apache/calcite/avatica/proto/Common.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/proto/Common.java
@@ -669,6 +669,410 @@ package org.apache.calcite.avatica.proto;
     // @@protoc_insertion_point(enum_scope:Severity)
   }
 
+  /**
+   * Protobuf enum {@code MetaDataOperation}
+   *
+   * <pre>
+   * Enumeration corresponding to DatabaseMetaData operations
+   * </pre>
+   */
+  public enum MetaDataOperation
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>GET_ATTRIBUTES = 0;</code>
+     */
+    GET_ATTRIBUTES(0, 0),
+    /**
+     * <code>GET_BEST_ROW_IDENTIFIER = 1;</code>
+     */
+    GET_BEST_ROW_IDENTIFIER(1, 1),
+    /**
+     * <code>GET_CATALOGS = 2;</code>
+     */
+    GET_CATALOGS(2, 2),
+    /**
+     * <code>GET_CLIENT_INFO_PROPERTIES = 3;</code>
+     */
+    GET_CLIENT_INFO_PROPERTIES(3, 3),
+    /**
+     * <code>GET_COLUMN_PRIVILEGES = 4;</code>
+     */
+    GET_COLUMN_PRIVILEGES(4, 4),
+    /**
+     * <code>GET_COLUMNS = 5;</code>
+     */
+    GET_COLUMNS(5, 5),
+    /**
+     * <code>GET_CROSS_REFERENCE = 6;</code>
+     */
+    GET_CROSS_REFERENCE(6, 6),
+    /**
+     * <code>GET_EXPORTED_KEYS = 7;</code>
+     */
+    GET_EXPORTED_KEYS(7, 7),
+    /**
+     * <code>GET_FUNCTION_COLUMNS = 8;</code>
+     */
+    GET_FUNCTION_COLUMNS(8, 8),
+    /**
+     * <code>GET_FUNCTIONS = 9;</code>
+     */
+    GET_FUNCTIONS(9, 9),
+    /**
+     * <code>GET_IMPORTED_KEYS = 10;</code>
+     */
+    GET_IMPORTED_KEYS(10, 10),
+    /**
+     * <code>GET_INDEX_INFO = 11;</code>
+     */
+    GET_INDEX_INFO(11, 11),
+    /**
+     * <code>GET_PRIMARY_KEYS = 12;</code>
+     */
+    GET_PRIMARY_KEYS(12, 12),
+    /**
+     * <code>GET_PROCEDURE_COLUMNS = 13;</code>
+     */
+    GET_PROCEDURE_COLUMNS(13, 13),
+    /**
+     * <code>GET_PROCEDURES = 14;</code>
+     */
+    GET_PROCEDURES(14, 14),
+    /**
+     * <code>GET_PSEUDO_COLUMNS = 15;</code>
+     */
+    GET_PSEUDO_COLUMNS(15, 15),
+    /**
+     * <code>GET_SCHEMAS = 16;</code>
+     */
+    GET_SCHEMAS(16, 16),
+    /**
+     * <code>GET_SCHEMAS_WITH_ARGS = 17;</code>
+     */
+    GET_SCHEMAS_WITH_ARGS(17, 17),
+    /**
+     * <code>GET_SUPER_TABLES = 18;</code>
+     */
+    GET_SUPER_TABLES(18, 18),
+    /**
+     * <code>GET_SUPER_TYPES = 19;</code>
+     */
+    GET_SUPER_TYPES(19, 19),
+    /**
+     * <code>GET_TABLE_PRIVILEGES = 20;</code>
+     */
+    GET_TABLE_PRIVILEGES(20, 20),
+    /**
+     * <code>GET_TABLES = 21;</code>
+     */
+    GET_TABLES(21, 21),
+    /**
+     * <code>GET_TABLE_TYPES = 22;</code>
+     */
+    GET_TABLE_TYPES(22, 22),
+    /**
+     * <code>GET_TYPE_INFO = 23;</code>
+     */
+    GET_TYPE_INFO(23, 23),
+    /**
+     * <code>GET_UDTS = 24;</code>
+     */
+    GET_UDTS(24, 24),
+    /**
+     * <code>GET_VERSION_COLUMNS = 25;</code>
+     */
+    GET_VERSION_COLUMNS(25, 25),
+    UNRECOGNIZED(-1, -1),
+    ;
+
+    /**
+     * <code>GET_ATTRIBUTES = 0;</code>
+     */
+    public static final int GET_ATTRIBUTES_VALUE = 0;
+    /**
+     * <code>GET_BEST_ROW_IDENTIFIER = 1;</code>
+     */
+    public static final int GET_BEST_ROW_IDENTIFIER_VALUE = 1;
+    /**
+     * <code>GET_CATALOGS = 2;</code>
+     */
+    public static final int GET_CATALOGS_VALUE = 2;
+    /**
+     * <code>GET_CLIENT_INFO_PROPERTIES = 3;</code>
+     */
+    public static final int GET_CLIENT_INFO_PROPERTIES_VALUE = 3;
+    /**
+     * <code>GET_COLUMN_PRIVILEGES = 4;</code>
+     */
+    public static final int GET_COLUMN_PRIVILEGES_VALUE = 4;
+    /**
+     * <code>GET_COLUMNS = 5;</code>
+     */
+    public static final int GET_COLUMNS_VALUE = 5;
+    /**
+     * <code>GET_CROSS_REFERENCE = 6;</code>
+     */
+    public static final int GET_CROSS_REFERENCE_VALUE = 6;
+    /**
+     * <code>GET_EXPORTED_KEYS = 7;</code>
+     */
+    public static final int GET_EXPORTED_KEYS_VALUE = 7;
+    /**
+     * <code>GET_FUNCTION_COLUMNS = 8;</code>
+     */
+    public static final int GET_FUNCTION_COLUMNS_VALUE = 8;
+    /**
+     * <code>GET_FUNCTIONS = 9;</code>
+     */
+    public static final int GET_FUNCTIONS_VALUE = 9;
+    /**
+     * <code>GET_IMPORTED_KEYS = 10;</code>
+     */
+    public static final int GET_IMPORTED_KEYS_VALUE = 10;
+    /**
+     * <code>GET_INDEX_INFO = 11;</code>
+     */
+    public static final int GET_INDEX_INFO_VALUE = 11;
+    /**
+     * <code>GET_PRIMARY_KEYS = 12;</code>
+     */
+    public static final int GET_PRIMARY_KEYS_VALUE = 12;
+    /**
+     * <code>GET_PROCEDURE_COLUMNS = 13;</code>
+     */
+    public static final int GET_PROCEDURE_COLUMNS_VALUE = 13;
+    /**
+     * <code>GET_PROCEDURES = 14;</code>
+     */
+    public static final int GET_PROCEDURES_VALUE = 14;
+    /**
+     * <code>GET_PSEUDO_COLUMNS = 15;</code>
+     */
+    public static final int GET_PSEUDO_COLUMNS_VALUE = 15;
+    /**
+     * <code>GET_SCHEMAS = 16;</code>
+     */
+    public static final int GET_SCHEMAS_VALUE = 16;
+    /**
+     * <code>GET_SCHEMAS_WITH_ARGS = 17;</code>
+     */
+    public static final int GET_SCHEMAS_WITH_ARGS_VALUE = 17;
+    /**
+     * <code>GET_SUPER_TABLES = 18;</code>
+     */
+    public static final int GET_SUPER_TABLES_VALUE = 18;
+    /**
+     * <code>GET_SUPER_TYPES = 19;</code>
+     */
+    public static final int GET_SUPER_TYPES_VALUE = 19;
+    /**
+     * <code>GET_TABLE_PRIVILEGES = 20;</code>
+     */
+    public static final int GET_TABLE_PRIVILEGES_VALUE = 20;
+    /**
+     * <code>GET_TABLES = 21;</code>
+     */
+    public static final int GET_TABLES_VALUE = 21;
+    /**
+     * <code>GET_TABLE_TYPES = 22;</code>
+     */
+    public static final int GET_TABLE_TYPES_VALUE = 22;
+    /**
+     * <code>GET_TYPE_INFO = 23;</code>
+     */
+    public static final int GET_TYPE_INFO_VALUE = 23;
+    /**
+     * <code>GET_UDTS = 24;</code>
+     */
+    public static final int GET_UDTS_VALUE = 24;
+    /**
+     * <code>GET_VERSION_COLUMNS = 25;</code>
+     */
+    public static final int GET_VERSION_COLUMNS_VALUE = 25;
+
+
+    public final int getNumber() {
+      if (index == -1) {
+        throw new java.lang.IllegalArgumentException(
+            "Can't get the number of an unknown enum value.");
+      }
+      return value;
+    }
+
+    public static MetaDataOperation valueOf(int value) {
+      switch (value) {
+        case 0: return GET_ATTRIBUTES;
+        case 1: return GET_BEST_ROW_IDENTIFIER;
+        case 2: return GET_CATALOGS;
+        case 3: return GET_CLIENT_INFO_PROPERTIES;
+        case 4: return GET_COLUMN_PRIVILEGES;
+        case 5: return GET_COLUMNS;
+        case 6: return GET_CROSS_REFERENCE;
+        case 7: return GET_EXPORTED_KEYS;
+        case 8: return GET_FUNCTION_COLUMNS;
+        case 9: return GET_FUNCTIONS;
+        case 10: return GET_IMPORTED_KEYS;
+        case 11: return GET_INDEX_INFO;
+        case 12: return GET_PRIMARY_KEYS;
+        case 13: return GET_PROCEDURE_COLUMNS;
+        case 14: return GET_PROCEDURES;
+        case 15: return GET_PSEUDO_COLUMNS;
+        case 16: return GET_SCHEMAS;
+        case 17: return GET_SCHEMAS_WITH_ARGS;
+        case 18: return GET_SUPER_TABLES;
+        case 19: return GET_SUPER_TYPES;
+        case 20: return GET_TABLE_PRIVILEGES;
+        case 21: return GET_TABLES;
+        case 22: return GET_TABLE_TYPES;
+        case 23: return GET_TYPE_INFO;
+        case 24: return GET_UDTS;
+        case 25: return GET_VERSION_COLUMNS;
+        default: return null;
+      }
+    }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<MetaDataOperation>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static final com.google.protobuf.Internal.EnumLiteMap<
+        MetaDataOperation> internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<MetaDataOperation>() {
+            public MetaDataOperation findValueByNumber(int number) {
+              return MetaDataOperation.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Common.getDescriptor().getEnumTypes().get(3);
+    }
+
+    private static final MetaDataOperation[] VALUES = values();
+
+    public static MetaDataOperation valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      if (desc.getIndex() == -1) {
+        return UNRECOGNIZED;
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private MetaDataOperation(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:MetaDataOperation)
+  }
+
+  /**
+   * Protobuf enum {@code StateType}
+   */
+  public enum StateType
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>SQL = 0;</code>
+     */
+    SQL(0, 0),
+    /**
+     * <code>METADATA = 1;</code>
+     */
+    METADATA(1, 1),
+    UNRECOGNIZED(-1, -1),
+    ;
+
+    /**
+     * <code>SQL = 0;</code>
+     */
+    public static final int SQL_VALUE = 0;
+    /**
+     * <code>METADATA = 1;</code>
+     */
+    public static final int METADATA_VALUE = 1;
+
+
+    public final int getNumber() {
+      if (index == -1) {
+        throw new java.lang.IllegalArgumentException(
+            "Can't get the number of an unknown enum value.");
+      }
+      return value;
+    }
+
+    public static StateType valueOf(int value) {
+      switch (value) {
+        case 0: return SQL;
+        case 1: return METADATA;
+        default: return null;
+      }
+    }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<StateType>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static final com.google.protobuf.Internal.EnumLiteMap<
+        StateType> internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<StateType>() {
+            public StateType findValueByNumber(int number) {
+              return StateType.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Common.getDescriptor().getEnumTypes().get(4);
+    }
+
+    private static final StateType[] VALUES = values();
+
+    public static StateType valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      if (desc.getIndex() == -1) {
+        return UNRECOGNIZED;
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private StateType(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:StateType)
+  }
+
   public interface ConnectionPropertiesOrBuilder extends
       // @@protoc_insertion_point(interface_extends:ConnectionProperties)
       com.google.protobuf.MessageOrBuilder {
@@ -13383,6 +13787,2321 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface MetaDataOperationArgumentOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:MetaDataOperationArgument)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string string_value = 1;</code>
+     */
+    java.lang.String getStringValue();
+    /**
+     * <code>optional string string_value = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getStringValueBytes();
+
+    /**
+     * <code>optional bool bool_value = 2;</code>
+     */
+    boolean getBoolValue();
+
+    /**
+     * <code>optional sint32 int_value = 3;</code>
+     */
+    int getIntValue();
+
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    com.google.protobuf.ProtocolStringList
+        getStringArrayValuesList();
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    int getStringArrayValuesCount();
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    java.lang.String getStringArrayValues(int index);
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getStringArrayValuesBytes(int index);
+
+    /**
+     * <code>repeated sint32 int_array_values = 5;</code>
+     */
+    java.util.List<java.lang.Integer> getIntArrayValuesList();
+    /**
+     * <code>repeated sint32 int_array_values = 5;</code>
+     */
+    int getIntArrayValuesCount();
+    /**
+     * <code>repeated sint32 int_array_values = 5;</code>
+     */
+    int getIntArrayValues(int index);
+
+    /**
+     * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+     */
+    int getTypeValue();
+    /**
+     * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType getType();
+  }
+  /**
+   * Protobuf type {@code MetaDataOperationArgument}
+   *
+   * <pre>
+   * Represents the breadth of arguments to DatabaseMetaData functions
+   * </pre>
+   */
+  public  static final class MetaDataOperationArgument extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:MetaDataOperationArgument)
+      MetaDataOperationArgumentOrBuilder {
+    // Use MetaDataOperationArgument.newBuilder() to construct.
+    private MetaDataOperationArgument(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private MetaDataOperationArgument() {
+      stringValue_ = "";
+      boolValue_ = false;
+      intValue_ = 0;
+      stringArrayValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      intArrayValues_ = java.util.Collections.emptyList();
+      type_ = 0;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private MetaDataOperationArgument(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              String s = input.readStringRequireUtf8();
+
+              stringValue_ = s;
+              break;
+            }
+            case 16: {
+
+              boolValue_ = input.readBool();
+              break;
+            }
+            case 24: {
+
+              intValue_ = input.readSInt32();
+              break;
+            }
+            case 34: {
+              String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                stringArrayValues_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000008;
+              }
+              stringArrayValues_.add(s);
+              break;
+            }
+            case 40: {
+              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+                intArrayValues_ = new java.util.ArrayList<java.lang.Integer>();
+                mutable_bitField0_ |= 0x00000010;
+              }
+              intArrayValues_.add(input.readSInt32());
+              break;
+            }
+            case 42: {
+              int length = input.readRawVarint32();
+              int limit = input.pushLimit(length);
+              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010) && input.getBytesUntilLimit() > 0) {
+                intArrayValues_ = new java.util.ArrayList<java.lang.Integer>();
+                mutable_bitField0_ |= 0x00000010;
+              }
+              while (input.getBytesUntilLimit() > 0) {
+                intArrayValues_.add(input.readSInt32());
+              }
+              input.popLimit(limit);
+              break;
+            }
+            case 48: {
+              int rawValue = input.readEnum();
+
+              type_ = rawValue;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+          stringArrayValues_ = stringArrayValues_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+          intArrayValues_ = java.util.Collections.unmodifiableList(intArrayValues_);
+        }
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Common.internal_static_MetaDataOperationArgument_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Common.internal_static_MetaDataOperationArgument_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.class, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder.class);
+    }
+
+    /**
+     * Protobuf enum {@code MetaDataOperationArgument.ArgumentType}
+     */
+    public enum ArgumentType
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>STRING = 0;</code>
+       */
+      STRING(0, 0),
+      /**
+       * <code>BOOL = 1;</code>
+       */
+      BOOL(1, 1),
+      /**
+       * <code>INT = 2;</code>
+       */
+      INT(2, 2),
+      /**
+       * <code>REPEATED_STRING = 3;</code>
+       */
+      REPEATED_STRING(3, 3),
+      /**
+       * <code>REPEATED_INT = 4;</code>
+       */
+      REPEATED_INT(4, 4),
+      /**
+       * <code>NULL = 5;</code>
+       */
+      NULL(5, 5),
+      UNRECOGNIZED(-1, -1),
+      ;
+
+      /**
+       * <code>STRING = 0;</code>
+       */
+      public static final int STRING_VALUE = 0;
+      /**
+       * <code>BOOL = 1;</code>
+       */
+      public static final int BOOL_VALUE = 1;
+      /**
+       * <code>INT = 2;</code>
+       */
+      public static final int INT_VALUE = 2;
+      /**
+       * <code>REPEATED_STRING = 3;</code>
+       */
+      public static final int REPEATED_STRING_VALUE = 3;
+      /**
+       * <code>REPEATED_INT = 4;</code>
+       */
+      public static final int REPEATED_INT_VALUE = 4;
+      /**
+       * <code>NULL = 5;</code>
+       */
+      public static final int NULL_VALUE = 5;
+
+
+      public final int getNumber() {
+        if (index == -1) {
+          throw new java.lang.IllegalArgumentException(
+              "Can't get the number of an unknown enum value.");
+        }
+        return value;
+      }
+
+      public static ArgumentType valueOf(int value) {
+        switch (value) {
+          case 0: return STRING;
+          case 1: return BOOL;
+          case 2: return INT;
+          case 3: return REPEATED_STRING;
+          case 4: return REPEATED_INT;
+          case 5: return NULL;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<ArgumentType>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          ArgumentType> internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<ArgumentType>() {
+              public ArgumentType findValueByNumber(int number) {
+                return ArgumentType.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final ArgumentType[] VALUES = values();
+
+      public static ArgumentType valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        if (desc.getIndex() == -1) {
+          return UNRECOGNIZED;
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private ArgumentType(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:MetaDataOperationArgument.ArgumentType)
+    }
+
+    private int bitField0_;
+    public static final int STRING_VALUE_FIELD_NUMBER = 1;
+    private volatile java.lang.Object stringValue_;
+    /**
+     * <code>optional string string_value = 1;</code>
+     */
+    public java.lang.String getStringValue() {
+      java.lang.Object ref = stringValue_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        stringValue_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string string_value = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getStringValueBytes() {
+      java.lang.Object ref = stringValue_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        stringValue_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int BOOL_VALUE_FIELD_NUMBER = 2;
+    private boolean boolValue_;
+    /**
+     * <code>optional bool bool_value = 2;</code>
+     */
+    public boolean getBoolValue() {
+      return boolValue_;
+    }
+
+    public static final int INT_VALUE_FIELD_NUMBER = 3;
+    private int intValue_;
+    /**
+     * <code>optional sint32 int_value = 3;</code>
+     */
+    public int getIntValue() {
+      return intValue_;
+    }
+
+    public static final int STRING_ARRAY_VALUES_FIELD_NUMBER = 4;
+    private com.google.protobuf.LazyStringList stringArrayValues_;
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getStringArrayValuesList() {
+      return stringArrayValues_;
+    }
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    public int getStringArrayValuesCount() {
+      return stringArrayValues_.size();
+    }
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    public java.lang.String getStringArrayValues(int index) {
+      return stringArrayValues_.get(index);
+    }
+    /**
+     * <code>repeated string string_array_values = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getStringArrayValuesBytes(int index) {
+      return stringArrayValues_.getByteString(index);
+    }
+
+    public static final int INT_ARRAY_VALUES_FIELD_NUMBER = 5;
+    private java.util.List<java.lang.Integer> intArrayValues_;
+    /**
+     * <code>repeated sint32 int_array_values = 5;</code>
+     */
+    public java.util.List<java.lang.Integer>
+        getIntArrayValuesList() {
+      return intArrayValues_;
+    }
+    /**
+     * <code>repeated sint32 int_array_values = 5;</code>
+     */
+    public int getIntArrayValuesCount() {
+      return intArrayValues_.size();
+    }
+    /**
+     * <code>repeated sint32 int_array_values = 5;</code>
+     */
+    public int getIntArrayValues(int index) {
+      return intArrayValues_.get(index);
+    }
+    private int intArrayValuesMemoizedSerializedSize = -1;
+
+    public static final int TYPE_FIELD_NUMBER = 6;
+    private int type_;
+    /**
+     * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+     */
+    public int getTypeValue() {
+      return type_;
+    }
+    /**
+     * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType getType() {
+      org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType result = org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType.valueOf(type_);
+      return result == null ? org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType.UNRECOGNIZED : result;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (!getStringValueBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, stringValue_);
+      }
+      if (boolValue_ != false) {
+        output.writeBool(2, boolValue_);
+      }
+      if (intValue_ != 0) {
+        output.writeSInt32(3, intValue_);
+      }
+      for (int i = 0; i < stringArrayValues_.size(); i++) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 4, stringArrayValues_.getRaw(i));
+      }
+      if (getIntArrayValuesList().size() > 0) {
+        output.writeRawVarint32(42);
+        output.writeRawVarint32(intArrayValuesMemoizedSerializedSize);
+      }
+      for (int i = 0; i < intArrayValues_.size(); i++) {
+        output.writeSInt32NoTag(intArrayValues_.get(i));
+      }
+      if (type_ != org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType.STRING.getNumber()) {
+        output.writeEnum(6, type_);
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getStringValueBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, stringValue_);
+      }
+      if (boolValue_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(2, boolValue_);
+      }
+      if (intValue_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeSInt32Size(3, intValue_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < stringArrayValues_.size(); i++) {
+          dataSize += computeStringSizeNoTag(stringArrayValues_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getStringArrayValuesList().size();
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < intArrayValues_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeSInt32SizeNoTag(intArrayValues_.get(i));
+        }
+        size += dataSize;
+        if (!getIntArrayValuesList().isEmpty()) {
+          size += 1;
+          size += com.google.protobuf.CodedOutputStream
+              .computeInt32SizeNoTag(dataSize);
+        }
+        intArrayValuesMemoizedSerializedSize = dataSize;
+      }
+      if (type_ != org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType.STRING.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(6, type_);
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code MetaDataOperationArgument}
+     *
+     * <pre>
+     * Represents the breadth of arguments to DatabaseMetaData functions
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:MetaDataOperationArgument)
+        org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Common.internal_static_MetaDataOperationArgument_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Common.internal_static_MetaDataOperationArgument_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.class, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        stringValue_ = "";
+
+        boolValue_ = false;
+
+        intValue_ = 0;
+
+        stringArrayValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        intArrayValues_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000010);
+        type_ = 0;
+
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Common.internal_static_MetaDataOperationArgument_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument build() {
+        org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument buildPartial() {
+        org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument result = new org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        result.stringValue_ = stringValue_;
+        result.boolValue_ = boolValue_;
+        result.intValue_ = intValue_;
+        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          stringArrayValues_ = stringArrayValues_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000008);
+        }
+        result.stringArrayValues_ = stringArrayValues_;
+        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+          intArrayValues_ = java.util.Collections.unmodifiableList(intArrayValues_);
+          bitField0_ = (bitField0_ & ~0x00000010);
+        }
+        result.intArrayValues_ = intArrayValues_;
+        result.type_ = type_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument other) {
+        if (other == org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.getDefaultInstance()) return this;
+        if (!other.getStringValue().isEmpty()) {
+          stringValue_ = other.stringValue_;
+          onChanged();
+        }
+        if (other.getBoolValue() != false) {
+          setBoolValue(other.getBoolValue());
+        }
+        if (other.getIntValue() != 0) {
+          setIntValue(other.getIntValue());
+        }
+        if (!other.stringArrayValues_.isEmpty()) {
+          if (stringArrayValues_.isEmpty()) {
+            stringArrayValues_ = other.stringArrayValues_;
+            bitField0_ = (bitField0_ & ~0x00000008);
+          } else {
+            ensureStringArrayValuesIsMutable();
+            stringArrayValues_.addAll(other.stringArrayValues_);
+          }
+          onChanged();
+        }
+        if (!other.intArrayValues_.isEmpty()) {
+          if (intArrayValues_.isEmpty()) {
+            intArrayValues_ = other.intArrayValues_;
+            bitField0_ = (bitField0_ & ~0x00000010);
+          } else {
+            ensureIntArrayValuesIsMutable();
+            intArrayValues_.addAll(other.intArrayValues_);
+          }
+          onChanged();
+        }
+        if (other.type_ != 0) {
+          setTypeValue(other.getTypeValue());
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object stringValue_ = "";
+      /**
+       * <code>optional string string_value = 1;</code>
+       */
+      public java.lang.String getStringValue() {
+        java.lang.Object ref = stringValue_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          stringValue_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string string_value = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getStringValueBytes() {
+        java.lang.Object ref = stringValue_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          stringValue_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string string_value = 1;</code>
+       */
+      public Builder setStringValue(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        stringValue_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string string_value = 1;</code>
+       */
+      public Builder clearStringValue() {
+        
+        stringValue_ = getDefaultInstance().getStringValue();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string string_value = 1;</code>
+       */
+      public Builder setStringValueBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        stringValue_ = value;
+        onChanged();
+        return this;
+      }
+
+      private boolean boolValue_ ;
+      /**
+       * <code>optional bool bool_value = 2;</code>
+       */
+      public boolean getBoolValue() {
+        return boolValue_;
+      }
+      /**
+       * <code>optional bool bool_value = 2;</code>
+       */
+      public Builder setBoolValue(boolean value) {
+        
+        boolValue_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool bool_value = 2;</code>
+       */
+      public Builder clearBoolValue() {
+        
+        boolValue_ = false;
+        onChanged();
+        return this;
+      }
+
+      private int intValue_ ;
+      /**
+       * <code>optional sint32 int_value = 3;</code>
+       */
+      public int getIntValue() {
+        return intValue_;
+      }
+      /**
+       * <code>optional sint32 int_value = 3;</code>
+       */
+      public Builder setIntValue(int value) {
+        
+        intValue_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional sint32 int_value = 3;</code>
+       */
+      public Builder clearIntValue() {
+        
+        intValue_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList stringArrayValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureStringArrayValuesIsMutable() {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+          stringArrayValues_ = new com.google.protobuf.LazyStringArrayList(stringArrayValues_);
+          bitField0_ |= 0x00000008;
+         }
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getStringArrayValuesList() {
+        return stringArrayValues_.getUnmodifiableView();
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public int getStringArrayValuesCount() {
+        return stringArrayValues_.size();
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public java.lang.String getStringArrayValues(int index) {
+        return stringArrayValues_.get(index);
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getStringArrayValuesBytes(int index) {
+        return stringArrayValues_.getByteString(index);
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public Builder setStringArrayValues(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureStringArrayValuesIsMutable();
+        stringArrayValues_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public Builder addStringArrayValues(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureStringArrayValuesIsMutable();
+        stringArrayValues_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public Builder addAllStringArrayValues(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureStringArrayValuesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, stringArrayValues_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public Builder clearStringArrayValues() {
+        stringArrayValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string string_array_values = 4;</code>
+       */
+      public Builder addStringArrayValuesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureStringArrayValuesIsMutable();
+        stringArrayValues_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<java.lang.Integer> intArrayValues_ = java.util.Collections.emptyList();
+      private void ensureIntArrayValuesIsMutable() {
+        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+          intArrayValues_ = new java.util.ArrayList<java.lang.Integer>(intArrayValues_);
+          bitField0_ |= 0x00000010;
+         }
+      }
+      /**
+       * <code>repeated sint32 int_array_values = 5;</code>
+       */
+      public java.util.List<java.lang.Integer>
+          getIntArrayValuesList() {
+        return java.util.Collections.unmodifiableList(intArrayValues_);
+      }
+      /**
+       * <code>repeated sint32 int_array_values = 5;</code>
+       */
+      public int getIntArrayValuesCount() {
+        return intArrayValues_.size();
+      }
+      /**
+       * <code>repeated sint32 int_array_values = 5;</code>
+       */
+      public int getIntArrayValues(int index) {
+        return intArrayValues_.get(index);
+      }
+      /**
+       * <code>repeated sint32 int_array_values = 5;</code>
+       */
+      public Builder setIntArrayValues(
+          int index, int value) {
+        ensureIntArrayValuesIsMutable();
+        intArrayValues_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated sint32 int_array_values = 5;</code>
+       */
+      public Builder addIntArrayValues(int value) {
+        ensureIntArrayValuesIsMutable();
+        intArrayValues_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated sint32 int_array_values = 5;</code>
+       */
+      public Builder addAllIntArrayValues(
+          java.lang.Iterable<? extends java.lang.Integer> values) {
+        ensureIntArrayValuesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, intArrayValues_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated sint32 int_array_values = 5;</code>
+       */
+      public Builder clearIntArrayValues() {
+        intArrayValues_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000010);
+        onChanged();
+        return this;
+      }
+
+      private int type_ = 0;
+      /**
+       * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+       */
+      public int getTypeValue() {
+        return type_;
+      }
+      /**
+       * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+       */
+      public Builder setTypeValue(int value) {
+        type_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType getType() {
+        org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType result = org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType.valueOf(type_);
+        return result == null ? org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType.UNRECOGNIZED : result;
+      }
+      /**
+       * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+       */
+      public Builder setType(org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.ArgumentType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        type_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .MetaDataOperationArgument.ArgumentType type = 6;</code>
+       */
+      public Builder clearType() {
+        
+        type_ = 0;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:MetaDataOperationArgument)
+    }
+
+    // @@protoc_insertion_point(class_scope:MetaDataOperationArgument)
+    private static final org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument();
+    }
+
+    public static org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<MetaDataOperationArgument>
+        PARSER = new com.google.protobuf.AbstractParser<MetaDataOperationArgument>() {
+      public MetaDataOperationArgument parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new MetaDataOperationArgument(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<MetaDataOperationArgument> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MetaDataOperationArgument> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface QueryStateOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:QueryState)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .StateType type = 1;</code>
+     */
+    int getTypeValue();
+    /**
+     * <code>optional .StateType type = 1;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.StateType getType();
+
+    /**
+     * <code>optional string sql = 2;</code>
+     */
+    java.lang.String getSql();
+    /**
+     * <code>optional string sql = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getSqlBytes();
+
+    /**
+     * <code>optional .MetaDataOperation op = 3;</code>
+     */
+    int getOpValue();
+    /**
+     * <code>optional .MetaDataOperation op = 3;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.MetaDataOperation getOp();
+
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    java.util.List<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument> 
+        getArgsList();
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument getArgs(int index);
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    int getArgsCount();
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    java.util.List<? extends org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder> 
+        getArgsOrBuilderList();
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder getArgsOrBuilder(
+        int index);
+
+    /**
+     * <code>optional bool has_args = 5;</code>
+     */
+    boolean getHasArgs();
+
+    /**
+     * <code>optional bool has_sql = 6;</code>
+     */
+    boolean getHasSql();
+
+    /**
+     * <code>optional bool has_op = 7;</code>
+     */
+    boolean getHasOp();
+  }
+  /**
+   * Protobuf type {@code QueryState}
+   */
+  public  static final class QueryState extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:QueryState)
+      QueryStateOrBuilder {
+    // Use QueryState.newBuilder() to construct.
+    private QueryState(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private QueryState() {
+      type_ = 0;
+      sql_ = "";
+      op_ = 0;
+      args_ = java.util.Collections.emptyList();
+      hasArgs_ = false;
+      hasSql_ = false;
+      hasOp_ = false;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private QueryState(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              int rawValue = input.readEnum();
+
+              type_ = rawValue;
+              break;
+            }
+            case 18: {
+              String s = input.readStringRequireUtf8();
+
+              sql_ = s;
+              break;
+            }
+            case 24: {
+              int rawValue = input.readEnum();
+
+              op_ = rawValue;
+              break;
+            }
+            case 34: {
+              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                args_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument>();
+                mutable_bitField0_ |= 0x00000008;
+              }
+              args_.add(input.readMessage(org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.parser(), extensionRegistry));
+              break;
+            }
+            case 40: {
+
+              hasArgs_ = input.readBool();
+              break;
+            }
+            case 48: {
+
+              hasSql_ = input.readBool();
+              break;
+            }
+            case 56: {
+
+              hasOp_ = input.readBool();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+          args_ = java.util.Collections.unmodifiableList(args_);
+        }
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Common.internal_static_QueryState_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Common.internal_static_QueryState_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Common.QueryState.class, org.apache.calcite.avatica.proto.Common.QueryState.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int TYPE_FIELD_NUMBER = 1;
+    private int type_;
+    /**
+     * <code>optional .StateType type = 1;</code>
+     */
+    public int getTypeValue() {
+      return type_;
+    }
+    /**
+     * <code>optional .StateType type = 1;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.StateType getType() {
+      org.apache.calcite.avatica.proto.Common.StateType result = org.apache.calcite.avatica.proto.Common.StateType.valueOf(type_);
+      return result == null ? org.apache.calcite.avatica.proto.Common.StateType.UNRECOGNIZED : result;
+    }
+
+    public static final int SQL_FIELD_NUMBER = 2;
+    private volatile java.lang.Object sql_;
+    /**
+     * <code>optional string sql = 2;</code>
+     */
+    public java.lang.String getSql() {
+      java.lang.Object ref = sql_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        sql_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string sql = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getSqlBytes() {
+      java.lang.Object ref = sql_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        sql_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int OP_FIELD_NUMBER = 3;
+    private int op_;
+    /**
+     * <code>optional .MetaDataOperation op = 3;</code>
+     */
+    public int getOpValue() {
+      return op_;
+    }
+    /**
+     * <code>optional .MetaDataOperation op = 3;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.MetaDataOperation getOp() {
+      org.apache.calcite.avatica.proto.Common.MetaDataOperation result = org.apache.calcite.avatica.proto.Common.MetaDataOperation.valueOf(op_);
+      return result == null ? org.apache.calcite.avatica.proto.Common.MetaDataOperation.UNRECOGNIZED : result;
+    }
+
+    public static final int ARGS_FIELD_NUMBER = 4;
+    private java.util.List<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument> args_;
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    public java.util.List<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument> getArgsList() {
+      return args_;
+    }
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    public java.util.List<? extends org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder> 
+        getArgsOrBuilderList() {
+      return args_;
+    }
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    public int getArgsCount() {
+      return args_.size();
+    }
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument getArgs(int index) {
+      return args_.get(index);
+    }
+    /**
+     * <code>repeated .MetaDataOperationArgument args = 4;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder getArgsOrBuilder(
+        int index) {
+      return args_.get(index);
+    }
+
+    public static final int HAS_ARGS_FIELD_NUMBER = 5;
+    private boolean hasArgs_;
+    /**
+     * <code>optional bool has_args = 5;</code>
+     */
+    public boolean getHasArgs() {
+      return hasArgs_;
+    }
+
+    public static final int HAS_SQL_FIELD_NUMBER = 6;
+    private boolean hasSql_;
+    /**
+     * <code>optional bool has_sql = 6;</code>
+     */
+    public boolean getHasSql() {
+      return hasSql_;
+    }
+
+    public static final int HAS_OP_FIELD_NUMBER = 7;
+    private boolean hasOp_;
+    /**
+     * <code>optional bool has_op = 7;</code>
+     */
+    public boolean getHasOp() {
+      return hasOp_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (type_ != org.apache.calcite.avatica.proto.Common.StateType.SQL.getNumber()) {
+        output.writeEnum(1, type_);
+      }
+      if (!getSqlBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 2, sql_);
+      }
+      if (op_ != org.apache.calcite.avatica.proto.Common.MetaDataOperation.GET_ATTRIBUTES.getNumber()) {
+        output.writeEnum(3, op_);
+      }
+      for (int i = 0; i < args_.size(); i++) {
+        output.writeMessage(4, args_.get(i));
+      }
+      if (hasArgs_ != false) {
+        output.writeBool(5, hasArgs_);
+      }
+      if (hasSql_ != false) {
+        output.writeBool(6, hasSql_);
+      }
+      if (hasOp_ != false) {
+        output.writeBool(7, hasOp_);
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (type_ != org.apache.calcite.avatica.proto.Common.StateType.SQL.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, type_);
+      }
+      if (!getSqlBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, sql_);
+      }
+      if (op_ != org.apache.calcite.avatica.proto.Common.MetaDataOperation.GET_ATTRIBUTES.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(3, op_);
+      }
+      for (int i = 0; i < args_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(4, args_.get(i));
+      }
+      if (hasArgs_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(5, hasArgs_);
+      }
+      if (hasSql_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(6, hasSql_);
+      }
+      if (hasOp_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(7, hasOp_);
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Common.QueryState parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Common.QueryState prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code QueryState}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:QueryState)
+        org.apache.calcite.avatica.proto.Common.QueryStateOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Common.internal_static_QueryState_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Common.internal_static_QueryState_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Common.QueryState.class, org.apache.calcite.avatica.proto.Common.QueryState.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Common.QueryState.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getArgsFieldBuilder();
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        type_ = 0;
+
+        sql_ = "";
+
+        op_ = 0;
+
+        if (argsBuilder_ == null) {
+          args_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+        } else {
+          argsBuilder_.clear();
+        }
+        hasArgs_ = false;
+
+        hasSql_ = false;
+
+        hasOp_ = false;
+
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Common.internal_static_QueryState_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Common.QueryState getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Common.QueryState.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Common.QueryState build() {
+        org.apache.calcite.avatica.proto.Common.QueryState result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Common.QueryState buildPartial() {
+        org.apache.calcite.avatica.proto.Common.QueryState result = new org.apache.calcite.avatica.proto.Common.QueryState(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        result.type_ = type_;
+        result.sql_ = sql_;
+        result.op_ = op_;
+        if (argsBuilder_ == null) {
+          if (((bitField0_ & 0x00000008) == 0x00000008)) {
+            args_ = java.util.Collections.unmodifiableList(args_);
+            bitField0_ = (bitField0_ & ~0x00000008);
+          }
+          result.args_ = args_;
+        } else {
+          result.args_ = argsBuilder_.build();
+        }
+        result.hasArgs_ = hasArgs_;
+        result.hasSql_ = hasSql_;
+        result.hasOp_ = hasOp_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Common.QueryState) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Common.QueryState)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Common.QueryState other) {
+        if (other == org.apache.calcite.avatica.proto.Common.QueryState.getDefaultInstance()) return this;
+        if (other.type_ != 0) {
+          setTypeValue(other.getTypeValue());
+        }
+        if (!other.getSql().isEmpty()) {
+          sql_ = other.sql_;
+          onChanged();
+        }
+        if (other.op_ != 0) {
+          setOpValue(other.getOpValue());
+        }
+        if (argsBuilder_ == null) {
+          if (!other.args_.isEmpty()) {
+            if (args_.isEmpty()) {
+              args_ = other.args_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+            } else {
+              ensureArgsIsMutable();
+              args_.addAll(other.args_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.args_.isEmpty()) {
+            if (argsBuilder_.isEmpty()) {
+              argsBuilder_.dispose();
+              argsBuilder_ = null;
+              args_ = other.args_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+              argsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getArgsFieldBuilder() : null;
+            } else {
+              argsBuilder_.addAllMessages(other.args_);
+            }
+          }
+        }
+        if (other.getHasArgs() != false) {
+          setHasArgs(other.getHasArgs());
+        }
+        if (other.getHasSql() != false) {
+          setHasSql(other.getHasSql());
+        }
+        if (other.getHasOp() != false) {
+          setHasOp(other.getHasOp());
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Common.QueryState parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Common.QueryState) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private int type_ = 0;
+      /**
+       * <code>optional .StateType type = 1;</code>
+       */
+      public int getTypeValue() {
+        return type_;
+      }
+      /**
+       * <code>optional .StateType type = 1;</code>
+       */
+      public Builder setTypeValue(int value) {
+        type_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .StateType type = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.StateType getType() {
+        org.apache.calcite.avatica.proto.Common.StateType result = org.apache.calcite.avatica.proto.Common.StateType.valueOf(type_);
+        return result == null ? org.apache.calcite.avatica.proto.Common.StateType.UNRECOGNIZED : result;
+      }
+      /**
+       * <code>optional .StateType type = 1;</code>
+       */
+      public Builder setType(org.apache.calcite.avatica.proto.Common.StateType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        type_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .StateType type = 1;</code>
+       */
+      public Builder clearType() {
+        
+        type_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object sql_ = "";
+      /**
+       * <code>optional string sql = 2;</code>
+       */
+      public java.lang.String getSql() {
+        java.lang.Object ref = sql_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          sql_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string sql = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getSqlBytes() {
+        java.lang.Object ref = sql_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          sql_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string sql = 2;</code>
+       */
+      public Builder setSql(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        sql_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sql = 2;</code>
+       */
+      public Builder clearSql() {
+        
+        sql_ = getDefaultInstance().getSql();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sql = 2;</code>
+       */
+      public Builder setSqlBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        sql_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int op_ = 0;
+      /**
+       * <code>optional .MetaDataOperation op = 3;</code>
+       */
+      public int getOpValue() {
+        return op_;
+      }
+      /**
+       * <code>optional .MetaDataOperation op = 3;</code>
+       */
+      public Builder setOpValue(int value) {
+        op_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .MetaDataOperation op = 3;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperation getOp() {
+        org.apache.calcite.avatica.proto.Common.MetaDataOperation result = org.apache.calcite.avatica.proto.Common.MetaDataOperation.valueOf(op_);
+        return result == null ? org.apache.calcite.avatica.proto.Common.MetaDataOperation.UNRECOGNIZED : result;
+      }
+      /**
+       * <code>optional .MetaDataOperation op = 3;</code>
+       */
+      public Builder setOp(org.apache.calcite.avatica.proto.Common.MetaDataOperation value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        op_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .MetaDataOperation op = 3;</code>
+       */
+      public Builder clearOp() {
+        
+        op_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument> args_ =
+        java.util.Collections.emptyList();
+      private void ensureArgsIsMutable() {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+          args_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument>(args_);
+          bitField0_ |= 0x00000008;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder> argsBuilder_;
+
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument> getArgsList() {
+        if (argsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(args_);
+        } else {
+          return argsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public int getArgsCount() {
+        if (argsBuilder_ == null) {
+          return args_.size();
+        } else {
+          return argsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument getArgs(int index) {
+        if (argsBuilder_ == null) {
+          return args_.get(index);
+        } else {
+          return argsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder setArgs(
+          int index, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument value) {
+        if (argsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureArgsIsMutable();
+          args_.set(index, value);
+          onChanged();
+        } else {
+          argsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder setArgs(
+          int index, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder builderForValue) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          argsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder addArgs(org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument value) {
+        if (argsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureArgsIsMutable();
+          args_.add(value);
+          onChanged();
+        } else {
+          argsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder addArgs(
+          int index, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument value) {
+        if (argsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureArgsIsMutable();
+          args_.add(index, value);
+          onChanged();
+        } else {
+          argsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder addArgs(
+          org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder builderForValue) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.add(builderForValue.build());
+          onChanged();
+        } else {
+          argsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder addArgs(
+          int index, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder builderForValue) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          argsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder addAllArgs(
+          java.lang.Iterable<? extends org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument> values) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, args_);
+          onChanged();
+        } else {
+          argsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder clearArgs() {
+        if (argsBuilder_ == null) {
+          args_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+          onChanged();
+        } else {
+          argsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public Builder removeArgs(int index) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.remove(index);
+          onChanged();
+        } else {
+          argsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder getArgsBuilder(
+          int index) {
+        return getArgsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder getArgsOrBuilder(
+          int index) {
+        if (argsBuilder_ == null) {
+          return args_.get(index);  } else {
+          return argsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public java.util.List<? extends org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder> 
+           getArgsOrBuilderList() {
+        if (argsBuilder_ != null) {
+          return argsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(args_);
+        }
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder addArgsBuilder() {
+        return getArgsFieldBuilder().addBuilder(
+            org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder addArgsBuilder(
+          int index) {
+        return getArgsFieldBuilder().addBuilder(
+            index, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .MetaDataOperationArgument args = 4;</code>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder> 
+           getArgsBuilderList() {
+        return getArgsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder> 
+          getArgsFieldBuilder() {
+        if (argsBuilder_ == null) {
+          argsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgument.Builder, org.apache.calcite.avatica.proto.Common.MetaDataOperationArgumentOrBuilder>(
+                  args_,
+                  ((bitField0_ & 0x00000008) == 0x00000008),
+                  getParentForChildren(),
+                  isClean());
+          args_ = null;
+        }
+        return argsBuilder_;
+      }
+
+      private boolean hasArgs_ ;
+      /**
+       * <code>optional bool has_args = 5;</code>
+       */
+      public boolean getHasArgs() {
+        return hasArgs_;
+      }
+      /**
+       * <code>optional bool has_args = 5;</code>
+       */
+      public Builder setHasArgs(boolean value) {
+        
+        hasArgs_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool has_args = 5;</code>
+       */
+      public Builder clearHasArgs() {
+        
+        hasArgs_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean hasSql_ ;
+      /**
+       * <code>optional bool has_sql = 6;</code>
+       */
+      public boolean getHasSql() {
+        return hasSql_;
+      }
+      /**
+       * <code>optional bool has_sql = 6;</code>
+       */
+      public Builder setHasSql(boolean value) {
+        
+        hasSql_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool has_sql = 6;</code>
+       */
+      public Builder clearHasSql() {
+        
+        hasSql_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean hasOp_ ;
+      /**
+       * <code>optional bool has_op = 7;</code>
+       */
+      public boolean getHasOp() {
+        return hasOp_;
+      }
+      /**
+       * <code>optional bool has_op = 7;</code>
+       */
+      public Builder setHasOp(boolean value) {
+        
+        hasOp_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool has_op = 7;</code>
+       */
+      public Builder clearHasOp() {
+        
+        hasOp_ = false;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:QueryState)
+    }
+
+    // @@protoc_insertion_point(class_scope:QueryState)
+    private static final org.apache.calcite.avatica.proto.Common.QueryState DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Common.QueryState();
+    }
+
+    public static org.apache.calcite.avatica.proto.Common.QueryState getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<QueryState>
+        PARSER = new com.google.protobuf.AbstractParser<QueryState>() {
+      public QueryState parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new QueryState(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<QueryState> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<QueryState> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Common.QueryState getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ConnectionProperties_descriptor;
   private static
@@ -13448,6 +16167,16 @@ package org.apache.calcite.avatica.proto;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_TypedValue_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_MetaDataOperationArgument_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_MetaDataOperationArgument_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_QueryState_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_QueryState_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -13501,26 +16230,54 @@ package org.apache.calcite.avatica.proto;
       "ep\022\022\n\nbool_value\030\002 \001(\010\022\024\n\014string_value\030\003" +
       " \001(\t\022\024\n\014number_value\030\004 \001(\022\022\024\n\014bytes_valu" +
       "es\030\005 \001(\014\022\024\n\014double_value\030\006 \001(\001\022\014\n\004null\030\007" +
-      " \001(\010*\237\001\n\rStatementType\022\n\n\006SELECT\020\000\022\n\n\006IN" +
-      "SERT\020\001\022\n\n\006UPDATE\020\002\022\n\n\006DELETE\020\003\022\n\n\006UPSERT" +
-      "\020\004\022\t\n\005MERGE\020\005\022\r\n\tOTHER_DML\020\006\022\n\n\006CREATE\020\007" +
-      "\022\010\n\004DROP\020\010\022\t\n\005ALTER\020\t\022\r\n\tOTHER_DDL\020\n\022\010\n\004" +
-      "CALL\020\013*\342\003\n\003Rep\022\025\n\021PRIMITIVE_BOOLEAN\020\000\022\022\n" +
-      "\016PRIMITIVE_BYTE\020\001\022\022\n\016PRIMITIVE_CHAR\020\002\022\023\n",
-      "\017PRIMITIVE_SHORT\020\003\022\021\n\rPRIMITIVE_INT\020\004\022\022\n" +
-      "\016PRIMITIVE_LONG\020\005\022\023\n\017PRIMITIVE_FLOAT\020\006\022\024" +
-      "\n\020PRIMITIVE_DOUBLE\020\007\022\013\n\007BOOLEAN\020\010\022\010\n\004BYT" +
-      "E\020\t\022\r\n\tCHARACTER\020\n\022\t\n\005SHORT\020\013\022\013\n\007INTEGER" +
-      "\020\014\022\010\n\004LONG\020\r\022\t\n\005FLOAT\020\016\022\n\n\006DOUBLE\020\017\022\017\n\013B" +
-      "IG_INTEGER\020\031\022\017\n\013BIG_DECIMAL\020\032\022\021\n\rJAVA_SQ" +
-      "L_TIME\020\020\022\026\n\022JAVA_SQL_TIMESTAMP\020\021\022\021\n\rJAVA" +
-      "_SQL_DATE\020\022\022\022\n\016JAVA_UTIL_DATE\020\023\022\017\n\013BYTE_" +
-      "STRING\020\024\022\n\n\006STRING\020\025\022\n\n\006NUMBER\020\026\022\n\n\006OBJE" +
-      "CT\020\027\022\010\n\004NULL\020\030\022\t\n\005ARRAY\020\033\022\n\n\006STRUCT\020\034\022\014\n",
-      "\010MULTISET\020\035*^\n\010Severity\022\024\n\020UNKNOWN_SEVER" +
-      "ITY\020\000\022\022\n\016FATAL_SEVERITY\020\001\022\022\n\016ERROR_SEVER" +
-      "ITY\020\002\022\024\n\020WARNING_SEVERITY\020\003B\"\n org.apach" +
-      "e.calcite.avatica.protob\006proto3"
+      " \001(\010\"\246\002\n\031MetaDataOperationArgument\022\024\n\014st" +
+      "ring_value\030\001 \001(\t\022\022\n\nbool_value\030\002 \001(\010\022\021\n\t" +
+      "int_value\030\003 \001(\021\022\033\n\023string_array_values\030\004" +
+      " \003(\t\022\030\n\020int_array_values\030\005 \003(\021\0225\n\004type\030\006" +
+      " \001(\0162\'.MetaDataOperationArgument.Argumen" +
+      "tType\"^\n\014ArgumentType\022\n\n\006STRING\020\000\022\010\n\004BOO",
+      "L\020\001\022\007\n\003INT\020\002\022\023\n\017REPEATED_STRING\020\003\022\020\n\014REP" +
+      "EATED_INT\020\004\022\010\n\004NULL\020\005\"\260\001\n\nQueryState\022\030\n\004" +
+      "type\030\001 \001(\0162\n.StateType\022\013\n\003sql\030\002 \001(\t\022\036\n\002o" +
+      "p\030\003 \001(\0162\022.MetaDataOperation\022(\n\004args\030\004 \003(" +
+      "\0132\032.MetaDataOperationArgument\022\020\n\010has_arg" +
+      "s\030\005 \001(\010\022\017\n\007has_sql\030\006 \001(\010\022\016\n\006has_op\030\007 \001(\010" +
+      "*\237\001\n\rStatementType\022\n\n\006SELECT\020\000\022\n\n\006INSERT" +
+      "\020\001\022\n\n\006UPDATE\020\002\022\n\n\006DELETE\020\003\022\n\n\006UPSERT\020\004\022\t" +
+      "\n\005MERGE\020\005\022\r\n\tOTHER_DML\020\006\022\n\n\006CREATE\020\007\022\010\n\004" +
+      "DROP\020\010\022\t\n\005ALTER\020\t\022\r\n\tOTHER_DDL\020\n\022\010\n\004CALL",
+      "\020\013*\342\003\n\003Rep\022\025\n\021PRIMITIVE_BOOLEAN\020\000\022\022\n\016PRI" +
+      "MITIVE_BYTE\020\001\022\022\n\016PRIMITIVE_CHAR\020\002\022\023\n\017PRI" +
+      "MITIVE_SHORT\020\003\022\021\n\rPRIMITIVE_INT\020\004\022\022\n\016PRI" +
+      "MITIVE_LONG\020\005\022\023\n\017PRIMITIVE_FLOAT\020\006\022\024\n\020PR" +
+      "IMITIVE_DOUBLE\020\007\022\013\n\007BOOLEAN\020\010\022\010\n\004BYTE\020\t\022" +
+      "\r\n\tCHARACTER\020\n\022\t\n\005SHORT\020\013\022\013\n\007INTEGER\020\014\022\010" +
+      "\n\004LONG\020\r\022\t\n\005FLOAT\020\016\022\n\n\006DOUBLE\020\017\022\017\n\013BIG_I" +
+      "NTEGER\020\031\022\017\n\013BIG_DECIMAL\020\032\022\021\n\rJAVA_SQL_TI" +
+      "ME\020\020\022\026\n\022JAVA_SQL_TIMESTAMP\020\021\022\021\n\rJAVA_SQL" +
+      "_DATE\020\022\022\022\n\016JAVA_UTIL_DATE\020\023\022\017\n\013BYTE_STRI",
+      "NG\020\024\022\n\n\006STRING\020\025\022\n\n\006NUMBER\020\026\022\n\n\006OBJECT\020\027" +
+      "\022\010\n\004NULL\020\030\022\t\n\005ARRAY\020\033\022\n\n\006STRUCT\020\034\022\014\n\010MUL" +
+      "TISET\020\035*^\n\010Severity\022\024\n\020UNKNOWN_SEVERITY\020" +
+      "\000\022\022\n\016FATAL_SEVERITY\020\001\022\022\n\016ERROR_SEVERITY\020" +
+      "\002\022\024\n\020WARNING_SEVERITY\020\003*\327\004\n\021MetaDataOper" +
+      "ation\022\022\n\016GET_ATTRIBUTES\020\000\022\033\n\027GET_BEST_RO" +
+      "W_IDENTIFIER\020\001\022\020\n\014GET_CATALOGS\020\002\022\036\n\032GET_" +
+      "CLIENT_INFO_PROPERTIES\020\003\022\031\n\025GET_COLUMN_P" +
+      "RIVILEGES\020\004\022\017\n\013GET_COLUMNS\020\005\022\027\n\023GET_CROS" +
+      "S_REFERENCE\020\006\022\025\n\021GET_EXPORTED_KEYS\020\007\022\030\n\024",
+      "GET_FUNCTION_COLUMNS\020\010\022\021\n\rGET_FUNCTIONS\020" +
+      "\t\022\025\n\021GET_IMPORTED_KEYS\020\n\022\022\n\016GET_INDEX_IN" +
+      "FO\020\013\022\024\n\020GET_PRIMARY_KEYS\020\014\022\031\n\025GET_PROCED" +
+      "URE_COLUMNS\020\r\022\022\n\016GET_PROCEDURES\020\016\022\026\n\022GET" +
+      "_PSEUDO_COLUMNS\020\017\022\017\n\013GET_SCHEMAS\020\020\022\031\n\025GE" +
+      "T_SCHEMAS_WITH_ARGS\020\021\022\024\n\020GET_SUPER_TABLE" +
+      "S\020\022\022\023\n\017GET_SUPER_TYPES\020\023\022\030\n\024GET_TABLE_PR" +
+      "IVILEGES\020\024\022\016\n\nGET_TABLES\020\025\022\023\n\017GET_TABLE_" +
+      "TYPES\020\026\022\021\n\rGET_TYPE_INFO\020\027\022\014\n\010GET_UDTS\020\030" +
+      "\022\027\n\023GET_VERSION_COLUMNS\020\031*\"\n\tStateType\022\007",
+      "\n\003SQL\020\000\022\014\n\010METADATA\020\001B\"\n org.apache.calc" +
+      "ite.avatica.protob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -13612,6 +16369,18 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_TypedValue_descriptor,
         new java.lang.String[] { "Type", "BoolValue", "StringValue", "NumberValue", "BytesValues", "DoubleValue", "Null", });
+    internal_static_MetaDataOperationArgument_descriptor =
+      getDescriptor().getMessageTypes().get(13);
+    internal_static_MetaDataOperationArgument_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_MetaDataOperationArgument_descriptor,
+        new java.lang.String[] { "StringValue", "BoolValue", "IntValue", "StringArrayValues", "IntArrayValues", "Type", });
+    internal_static_QueryState_descriptor =
+      getDescriptor().getMessageTypes().get(14);
+    internal_static_QueryState_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_QueryState_descriptor,
+        new java.lang.String[] { "Type", "Sql", "Op", "Args", "HasArgs", "HasSql", "HasOp", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/avatica/src/main/java/org/apache/calcite/avatica/proto/Requests.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/proto/Requests.java
@@ -10369,6 +10369,758 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface SyncResultsRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:SyncResultsRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
+
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    int getStatementId();
+
+    /**
+     * <code>optional .QueryState state = 3;</code>
+     */
+    boolean hasState();
+    /**
+     * <code>optional .QueryState state = 3;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.QueryState getState();
+    /**
+     * <code>optional .QueryState state = 3;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.QueryStateOrBuilder getStateOrBuilder();
+
+    /**
+     * <code>optional uint64 offset = 4;</code>
+     */
+    long getOffset();
+  }
+  /**
+   * Protobuf type {@code SyncResultsRequest}
+   */
+  public  static final class SyncResultsRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:SyncResultsRequest)
+      SyncResultsRequestOrBuilder {
+    // Use SyncResultsRequest.newBuilder() to construct.
+    private SyncResultsRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private SyncResultsRequest() {
+      connectionId_ = "";
+      statementId_ = 0;
+      offset_ = 0L;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private SyncResultsRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              String s = input.readStringRequireUtf8();
+
+              connectionId_ = s;
+              break;
+            }
+            case 16: {
+
+              statementId_ = input.readUInt32();
+              break;
+            }
+            case 26: {
+              org.apache.calcite.avatica.proto.Common.QueryState.Builder subBuilder = null;
+              if (state_ != null) {
+                subBuilder = state_.toBuilder();
+              }
+              state_ = input.readMessage(org.apache.calcite.avatica.proto.Common.QueryState.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(state_);
+                state_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 32: {
+
+              offset_ = input.readUInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_SyncResultsRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_SyncResultsRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Requests.SyncResultsRequest.class, org.apache.calcite.avatica.proto.Requests.SyncResultsRequest.Builder.class);
+    }
+
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        connectionId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STATEMENT_ID_FIELD_NUMBER = 2;
+    private int statementId_;
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    public int getStatementId() {
+      return statementId_;
+    }
+
+    public static final int STATE_FIELD_NUMBER = 3;
+    private org.apache.calcite.avatica.proto.Common.QueryState state_;
+    /**
+     * <code>optional .QueryState state = 3;</code>
+     */
+    public boolean hasState() {
+      return state_ != null;
+    }
+    /**
+     * <code>optional .QueryState state = 3;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.QueryState getState() {
+      return state_ == null ? org.apache.calcite.avatica.proto.Common.QueryState.getDefaultInstance() : state_;
+    }
+    /**
+     * <code>optional .QueryState state = 3;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.QueryStateOrBuilder getStateOrBuilder() {
+      return getState();
+    }
+
+    public static final int OFFSET_FIELD_NUMBER = 4;
+    private long offset_;
+    /**
+     * <code>optional uint64 offset = 4;</code>
+     */
+    public long getOffset() {
+      return offset_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getConnectionIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        output.writeUInt32(2, statementId_);
+      }
+      if (state_ != null) {
+        output.writeMessage(3, getState());
+      }
+      if (offset_ != 0L) {
+        output.writeUInt64(4, offset_);
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(2, statementId_);
+      }
+      if (state_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, getState());
+      }
+      if (offset_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(4, offset_);
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Requests.SyncResultsRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code SyncResultsRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:SyncResultsRequest)
+        org.apache.calcite.avatica.proto.Requests.SyncResultsRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_SyncResultsRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_SyncResultsRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Requests.SyncResultsRequest.class, org.apache.calcite.avatica.proto.Requests.SyncResultsRequest.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Requests.SyncResultsRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        connectionId_ = "";
+
+        statementId_ = 0;
+
+        if (stateBuilder_ == null) {
+          state_ = null;
+        } else {
+          state_ = null;
+          stateBuilder_ = null;
+        }
+        offset_ = 0L;
+
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_SyncResultsRequest_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.SyncResultsRequest getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Requests.SyncResultsRequest.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.SyncResultsRequest build() {
+        org.apache.calcite.avatica.proto.Requests.SyncResultsRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.SyncResultsRequest buildPartial() {
+        org.apache.calcite.avatica.proto.Requests.SyncResultsRequest result = new org.apache.calcite.avatica.proto.Requests.SyncResultsRequest(this);
+        result.connectionId_ = connectionId_;
+        result.statementId_ = statementId_;
+        if (stateBuilder_ == null) {
+          result.state_ = state_;
+        } else {
+          result.state_ = stateBuilder_.build();
+        }
+        result.offset_ = offset_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Requests.SyncResultsRequest) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Requests.SyncResultsRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.SyncResultsRequest other) {
+        if (other == org.apache.calcite.avatica.proto.Requests.SyncResultsRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
+        if (other.getStatementId() != 0) {
+          setStatementId(other.getStatementId());
+        }
+        if (other.hasState()) {
+          mergeState(other.getState());
+        }
+        if (other.getOffset() != 0L) {
+          setOffset(other.getOffset());
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Requests.SyncResultsRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Requests.SyncResultsRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          connectionId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int statementId_ ;
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public int getStatementId() {
+        return statementId_;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder setStatementId(int value) {
+        
+        statementId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder clearStatementId() {
+        
+        statementId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private org.apache.calcite.avatica.proto.Common.QueryState state_ = null;
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.QueryState, org.apache.calcite.avatica.proto.Common.QueryState.Builder, org.apache.calcite.avatica.proto.Common.QueryStateOrBuilder> stateBuilder_;
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public boolean hasState() {
+        return stateBuilder_ != null || state_ != null;
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.QueryState getState() {
+        if (stateBuilder_ == null) {
+          return state_ == null ? org.apache.calcite.avatica.proto.Common.QueryState.getDefaultInstance() : state_;
+        } else {
+          return stateBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public Builder setState(org.apache.calcite.avatica.proto.Common.QueryState value) {
+        if (stateBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          state_ = value;
+          onChanged();
+        } else {
+          stateBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public Builder setState(
+          org.apache.calcite.avatica.proto.Common.QueryState.Builder builderForValue) {
+        if (stateBuilder_ == null) {
+          state_ = builderForValue.build();
+          onChanged();
+        } else {
+          stateBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public Builder mergeState(org.apache.calcite.avatica.proto.Common.QueryState value) {
+        if (stateBuilder_ == null) {
+          if (state_ != null) {
+            state_ =
+              org.apache.calcite.avatica.proto.Common.QueryState.newBuilder(state_).mergeFrom(value).buildPartial();
+          } else {
+            state_ = value;
+          }
+          onChanged();
+        } else {
+          stateBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public Builder clearState() {
+        if (stateBuilder_ == null) {
+          state_ = null;
+          onChanged();
+        } else {
+          state_ = null;
+          stateBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.QueryState.Builder getStateBuilder() {
+        
+        onChanged();
+        return getStateFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.QueryStateOrBuilder getStateOrBuilder() {
+        if (stateBuilder_ != null) {
+          return stateBuilder_.getMessageOrBuilder();
+        } else {
+          return state_ == null ?
+              org.apache.calcite.avatica.proto.Common.QueryState.getDefaultInstance() : state_;
+        }
+      }
+      /**
+       * <code>optional .QueryState state = 3;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.QueryState, org.apache.calcite.avatica.proto.Common.QueryState.Builder, org.apache.calcite.avatica.proto.Common.QueryStateOrBuilder> 
+          getStateFieldBuilder() {
+        if (stateBuilder_ == null) {
+          stateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.calcite.avatica.proto.Common.QueryState, org.apache.calcite.avatica.proto.Common.QueryState.Builder, org.apache.calcite.avatica.proto.Common.QueryStateOrBuilder>(
+                  getState(),
+                  getParentForChildren(),
+                  isClean());
+          state_ = null;
+        }
+        return stateBuilder_;
+      }
+
+      private long offset_ ;
+      /**
+       * <code>optional uint64 offset = 4;</code>
+       */
+      public long getOffset() {
+        return offset_;
+      }
+      /**
+       * <code>optional uint64 offset = 4;</code>
+       */
+      public Builder setOffset(long value) {
+        
+        offset_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint64 offset = 4;</code>
+       */
+      public Builder clearOffset() {
+        
+        offset_ = 0L;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:SyncResultsRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:SyncResultsRequest)
+    private static final org.apache.calcite.avatica.proto.Requests.SyncResultsRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Requests.SyncResultsRequest();
+    }
+
+    public static org.apache.calcite.avatica.proto.Requests.SyncResultsRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SyncResultsRequest>
+        PARSER = new com.google.protobuf.AbstractParser<SyncResultsRequest>() {
+      public SyncResultsRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new SyncResultsRequest(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<SyncResultsRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SyncResultsRequest> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Requests.SyncResultsRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static com.google.protobuf.Descriptors.Descriptor
     internal_static_CatalogsRequest_descriptor;
   private static
@@ -10454,6 +11206,11 @@ package org.apache.calcite.avatica.proto;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ExecuteRequest_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_SyncResultsRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_SyncResultsRequest_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -10498,8 +11255,11 @@ package org.apache.calcite.avatica.proto;
       "ExecuteRequest\022)\n\017statementHandle\030\001 \001(\0132" +
       "\020.StatementHandle\022%\n\020parameter_values\030\002 " +
       "\003(\0132\013.TypedValue\022\025\n\rmax_row_count\030\003 \001(\004\022" +
-      "\034\n\024has_parameter_values\030\004 \001(\010B\"\n org.apa" +
-      "che.calcite.avatica.protob\006proto3"
+      "\034\n\024has_parameter_values\030\004 \001(\010\"m\n\022SyncRes" +
+      "ultsRequest\022\025\n\rconnection_id\030\001 \001(\t\022\024\n\014st" +
+      "atement_id\030\002 \001(\r\022\032\n\005state\030\003 \001(\0132\013.QueryS" +
+      "tate\022\016\n\006offset\030\004 \001(\004B\"\n org.apache.calci" +
+      "te.avatica.protob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -10616,6 +11376,12 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ExecuteRequest_descriptor,
         new java.lang.String[] { "StatementHandle", "ParameterValues", "MaxRowCount", "HasParameterValues", });
+    internal_static_SyncResultsRequest_descriptor =
+      getDescriptor().getMessageTypes().get(16);
+    internal_static_SyncResultsRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_SyncResultsRequest_descriptor,
+        new java.lang.String[] { "ConnectionId", "StatementId", "State", "Offset", });
     org.apache.calcite.avatica.proto.Common.getDescriptor();
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/proto/Responses.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/proto/Responses.java
@@ -1075,6 +1075,15 @@ package org.apache.calcite.avatica.proto;
      */
     org.apache.calcite.avatica.proto.Responses.ResultSetResponseOrBuilder getResultsOrBuilder(
         int index);
+
+    /**
+     * <code>optional bool missing_statement = 2;</code>
+     *
+     * <pre>
+     * Did the request fail because of no-cached statement
+     * </pre>
+     */
+    boolean getMissingStatement();
   }
   /**
    * Protobuf type {@code ExecuteResponse}
@@ -1093,6 +1102,7 @@ package org.apache.calcite.avatica.proto;
     }
     private ExecuteResponse() {
       results_ = java.util.Collections.emptyList();
+      missingStatement_ = false;
     }
 
     @java.lang.Override
@@ -1127,6 +1137,11 @@ package org.apache.calcite.avatica.proto;
               results_.add(input.readMessage(org.apache.calcite.avatica.proto.Responses.ResultSetResponse.parser(), extensionRegistry));
               break;
             }
+            case 16: {
+
+              missingStatement_ = input.readBool();
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -1154,6 +1169,7 @@ package org.apache.calcite.avatica.proto;
               org.apache.calcite.avatica.proto.Responses.ExecuteResponse.class, org.apache.calcite.avatica.proto.Responses.ExecuteResponse.Builder.class);
     }
 
+    private int bitField0_;
     public static final int RESULTS_FIELD_NUMBER = 1;
     private java.util.List<org.apache.calcite.avatica.proto.Responses.ResultSetResponse> results_;
     /**
@@ -1189,6 +1205,19 @@ package org.apache.calcite.avatica.proto;
       return results_.get(index);
     }
 
+    public static final int MISSING_STATEMENT_FIELD_NUMBER = 2;
+    private boolean missingStatement_;
+    /**
+     * <code>optional bool missing_statement = 2;</code>
+     *
+     * <pre>
+     * Did the request fail because of no-cached statement
+     * </pre>
+     */
+    public boolean getMissingStatement() {
+      return missingStatement_;
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -1204,6 +1233,9 @@ package org.apache.calcite.avatica.proto;
       for (int i = 0; i < results_.size(); i++) {
         output.writeMessage(1, results_.get(i));
       }
+      if (missingStatement_ != false) {
+        output.writeBool(2, missingStatement_);
+      }
     }
 
     public int getSerializedSize() {
@@ -1214,6 +1246,10 @@ package org.apache.calcite.avatica.proto;
       for (int i = 0; i < results_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, results_.get(i));
+      }
+      if (missingStatement_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(2, missingStatement_);
       }
       memoizedSize = size;
       return size;
@@ -1337,6 +1373,8 @@ package org.apache.calcite.avatica.proto;
         } else {
           resultsBuilder_.clear();
         }
+        missingStatement_ = false;
+
         return this;
       }
 
@@ -1360,6 +1398,7 @@ package org.apache.calcite.avatica.proto;
       public org.apache.calcite.avatica.proto.Responses.ExecuteResponse buildPartial() {
         org.apache.calcite.avatica.proto.Responses.ExecuteResponse result = new org.apache.calcite.avatica.proto.Responses.ExecuteResponse(this);
         int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
         if (resultsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
             results_ = java.util.Collections.unmodifiableList(results_);
@@ -1369,6 +1408,8 @@ package org.apache.calcite.avatica.proto;
         } else {
           result.results_ = resultsBuilder_.build();
         }
+        result.missingStatement_ = missingStatement_;
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -1409,6 +1450,9 @@ package org.apache.calcite.avatica.proto;
               resultsBuilder_.addAllMessages(other.results_);
             }
           }
+        }
+        if (other.getMissingStatement() != false) {
+          setMissingStatement(other.getMissingStatement());
         }
         onChanged();
         return this;
@@ -1675,6 +1719,44 @@ package org.apache.calcite.avatica.proto;
           results_ = null;
         }
         return resultsBuilder_;
+      }
+
+      private boolean missingStatement_ ;
+      /**
+       * <code>optional bool missing_statement = 2;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public boolean getMissingStatement() {
+        return missingStatement_;
+      }
+      /**
+       * <code>optional bool missing_statement = 2;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public Builder setMissingStatement(boolean value) {
+        
+        missingStatement_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool missing_statement = 2;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public Builder clearMissingStatement() {
+        
+        missingStatement_ = false;
+        onChanged();
+        return this;
       }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -2259,6 +2341,24 @@ package org.apache.calcite.avatica.proto;
      * <code>optional .Frame frame = 1;</code>
      */
     org.apache.calcite.avatica.proto.Common.FrameOrBuilder getFrameOrBuilder();
+
+    /**
+     * <code>optional bool missing_statement = 2;</code>
+     *
+     * <pre>
+     * Did the request fail because of no-cached statement
+     * </pre>
+     */
+    boolean getMissingStatement();
+
+    /**
+     * <code>optional bool missing_results = 3;</code>
+     *
+     * <pre>
+     * Did the request fail because of a cached-statement w/o ResultSet
+     * </pre>
+     */
+    boolean getMissingResults();
   }
   /**
    * Protobuf type {@code FetchResponse}
@@ -2276,6 +2376,8 @@ package org.apache.calcite.avatica.proto;
       super(builder);
     }
     private FetchResponse() {
+      missingStatement_ = false;
+      missingResults_ = false;
     }
 
     @java.lang.Override
@@ -2313,6 +2415,16 @@ package org.apache.calcite.avatica.proto;
                 frame_ = subBuilder.buildPartial();
               }
 
+              break;
+            }
+            case 16: {
+
+              missingStatement_ = input.readBool();
+              break;
+            }
+            case 24: {
+
+              missingResults_ = input.readBool();
               break;
             }
           }
@@ -2360,6 +2472,32 @@ package org.apache.calcite.avatica.proto;
       return getFrame();
     }
 
+    public static final int MISSING_STATEMENT_FIELD_NUMBER = 2;
+    private boolean missingStatement_;
+    /**
+     * <code>optional bool missing_statement = 2;</code>
+     *
+     * <pre>
+     * Did the request fail because of no-cached statement
+     * </pre>
+     */
+    public boolean getMissingStatement() {
+      return missingStatement_;
+    }
+
+    public static final int MISSING_RESULTS_FIELD_NUMBER = 3;
+    private boolean missingResults_;
+    /**
+     * <code>optional bool missing_results = 3;</code>
+     *
+     * <pre>
+     * Did the request fail because of a cached-statement w/o ResultSet
+     * </pre>
+     */
+    public boolean getMissingResults() {
+      return missingResults_;
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2375,6 +2513,12 @@ package org.apache.calcite.avatica.proto;
       if (frame_ != null) {
         output.writeMessage(1, getFrame());
       }
+      if (missingStatement_ != false) {
+        output.writeBool(2, missingStatement_);
+      }
+      if (missingResults_ != false) {
+        output.writeBool(3, missingResults_);
+      }
     }
 
     public int getSerializedSize() {
@@ -2385,6 +2529,14 @@ package org.apache.calcite.avatica.proto;
       if (frame_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getFrame());
+      }
+      if (missingStatement_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(2, missingStatement_);
+      }
+      if (missingResults_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(3, missingResults_);
       }
       memoizedSize = size;
       return size;
@@ -2507,6 +2659,10 @@ package org.apache.calcite.avatica.proto;
           frame_ = null;
           frameBuilder_ = null;
         }
+        missingStatement_ = false;
+
+        missingResults_ = false;
+
         return this;
       }
 
@@ -2534,6 +2690,8 @@ package org.apache.calcite.avatica.proto;
         } else {
           result.frame_ = frameBuilder_.build();
         }
+        result.missingStatement_ = missingStatement_;
+        result.missingResults_ = missingResults_;
         onBuilt();
         return result;
       }
@@ -2551,6 +2709,12 @@ package org.apache.calcite.avatica.proto;
         if (other == org.apache.calcite.avatica.proto.Responses.FetchResponse.getDefaultInstance()) return this;
         if (other.hasFrame()) {
           mergeFrame(other.getFrame());
+        }
+        if (other.getMissingStatement() != false) {
+          setMissingStatement(other.getMissingStatement());
+        }
+        if (other.getMissingResults() != false) {
+          setMissingResults(other.getMissingResults());
         }
         onChanged();
         return this;
@@ -2693,6 +2857,82 @@ package org.apache.calcite.avatica.proto;
           frame_ = null;
         }
         return frameBuilder_;
+      }
+
+      private boolean missingStatement_ ;
+      /**
+       * <code>optional bool missing_statement = 2;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public boolean getMissingStatement() {
+        return missingStatement_;
+      }
+      /**
+       * <code>optional bool missing_statement = 2;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public Builder setMissingStatement(boolean value) {
+        
+        missingStatement_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool missing_statement = 2;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public Builder clearMissingStatement() {
+        
+        missingStatement_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean missingResults_ ;
+      /**
+       * <code>optional bool missing_results = 3;</code>
+       *
+       * <pre>
+       * Did the request fail because of a cached-statement w/o ResultSet
+       * </pre>
+       */
+      public boolean getMissingResults() {
+        return missingResults_;
+      }
+      /**
+       * <code>optional bool missing_results = 3;</code>
+       *
+       * <pre>
+       * Did the request fail because of a cached-statement w/o ResultSet
+       * </pre>
+       */
+      public Builder setMissingResults(boolean value) {
+        
+        missingResults_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool missing_results = 3;</code>
+       *
+       * <pre>
+       * Did the request fail because of a cached-statement w/o ResultSet
+       * </pre>
+       */
+      public Builder clearMissingResults() {
+        
+        missingResults_ = false;
+        onChanged();
+        return this;
       }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -7204,6 +7444,480 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface SyncResultsResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:SyncResultsResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional bool missing_statement = 1;</code>
+     *
+     * <pre>
+     * Server doesn't have the statement with the ID from the request
+     * </pre>
+     */
+    boolean getMissingStatement();
+
+    /**
+     * <code>optional bool more_results = 2;</code>
+     *
+     * <pre>
+     * Should the client fetch() to get more results
+     * </pre>
+     */
+    boolean getMoreResults();
+  }
+  /**
+   * Protobuf type {@code SyncResultsResponse}
+   */
+  public  static final class SyncResultsResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:SyncResultsResponse)
+      SyncResultsResponseOrBuilder {
+    // Use SyncResultsResponse.newBuilder() to construct.
+    private SyncResultsResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private SyncResultsResponse() {
+      missingStatement_ = false;
+      moreResults_ = false;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private SyncResultsResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+
+              missingStatement_ = input.readBool();
+              break;
+            }
+            case 16: {
+
+              moreResults_ = input.readBool();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_SyncResultsResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_SyncResultsResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Responses.SyncResultsResponse.class, org.apache.calcite.avatica.proto.Responses.SyncResultsResponse.Builder.class);
+    }
+
+    public static final int MISSING_STATEMENT_FIELD_NUMBER = 1;
+    private boolean missingStatement_;
+    /**
+     * <code>optional bool missing_statement = 1;</code>
+     *
+     * <pre>
+     * Server doesn't have the statement with the ID from the request
+     * </pre>
+     */
+    public boolean getMissingStatement() {
+      return missingStatement_;
+    }
+
+    public static final int MORE_RESULTS_FIELD_NUMBER = 2;
+    private boolean moreResults_;
+    /**
+     * <code>optional bool more_results = 2;</code>
+     *
+     * <pre>
+     * Should the client fetch() to get more results
+     * </pre>
+     */
+    public boolean getMoreResults() {
+      return moreResults_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (missingStatement_ != false) {
+        output.writeBool(1, missingStatement_);
+      }
+      if (moreResults_ != false) {
+        output.writeBool(2, moreResults_);
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (missingStatement_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(1, missingStatement_);
+      }
+      if (moreResults_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(2, moreResults_);
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Responses.SyncResultsResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code SyncResultsResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:SyncResultsResponse)
+        org.apache.calcite.avatica.proto.Responses.SyncResultsResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_SyncResultsResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_SyncResultsResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Responses.SyncResultsResponse.class, org.apache.calcite.avatica.proto.Responses.SyncResultsResponse.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Responses.SyncResultsResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        missingStatement_ = false;
+
+        moreResults_ = false;
+
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_SyncResultsResponse_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.SyncResultsResponse getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Responses.SyncResultsResponse.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.SyncResultsResponse build() {
+        org.apache.calcite.avatica.proto.Responses.SyncResultsResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.SyncResultsResponse buildPartial() {
+        org.apache.calcite.avatica.proto.Responses.SyncResultsResponse result = new org.apache.calcite.avatica.proto.Responses.SyncResultsResponse(this);
+        result.missingStatement_ = missingStatement_;
+        result.moreResults_ = moreResults_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Responses.SyncResultsResponse) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Responses.SyncResultsResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Responses.SyncResultsResponse other) {
+        if (other == org.apache.calcite.avatica.proto.Responses.SyncResultsResponse.getDefaultInstance()) return this;
+        if (other.getMissingStatement() != false) {
+          setMissingStatement(other.getMissingStatement());
+        }
+        if (other.getMoreResults() != false) {
+          setMoreResults(other.getMoreResults());
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Responses.SyncResultsResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Responses.SyncResultsResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private boolean missingStatement_ ;
+      /**
+       * <code>optional bool missing_statement = 1;</code>
+       *
+       * <pre>
+       * Server doesn't have the statement with the ID from the request
+       * </pre>
+       */
+      public boolean getMissingStatement() {
+        return missingStatement_;
+      }
+      /**
+       * <code>optional bool missing_statement = 1;</code>
+       *
+       * <pre>
+       * Server doesn't have the statement with the ID from the request
+       * </pre>
+       */
+      public Builder setMissingStatement(boolean value) {
+        
+        missingStatement_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool missing_statement = 1;</code>
+       *
+       * <pre>
+       * Server doesn't have the statement with the ID from the request
+       * </pre>
+       */
+      public Builder clearMissingStatement() {
+        
+        missingStatement_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean moreResults_ ;
+      /**
+       * <code>optional bool more_results = 2;</code>
+       *
+       * <pre>
+       * Should the client fetch() to get more results
+       * </pre>
+       */
+      public boolean getMoreResults() {
+        return moreResults_;
+      }
+      /**
+       * <code>optional bool more_results = 2;</code>
+       *
+       * <pre>
+       * Should the client fetch() to get more results
+       * </pre>
+       */
+      public Builder setMoreResults(boolean value) {
+        
+        moreResults_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool more_results = 2;</code>
+       *
+       * <pre>
+       * Should the client fetch() to get more results
+       * </pre>
+       */
+      public Builder clearMoreResults() {
+        
+        moreResults_ = false;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:SyncResultsResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:SyncResultsResponse)
+    private static final org.apache.calcite.avatica.proto.Responses.SyncResultsResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Responses.SyncResultsResponse();
+    }
+
+    public static org.apache.calcite.avatica.proto.Responses.SyncResultsResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SyncResultsResponse>
+        PARSER = new com.google.protobuf.AbstractParser<SyncResultsResponse>() {
+      public SyncResultsResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new SyncResultsResponse(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<SyncResultsResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SyncResultsResponse> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Responses.SyncResultsResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ResultSetResponse_descriptor;
   private static
@@ -7264,6 +7978,11 @@ package org.apache.calcite.avatica.proto;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ErrorResponse_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_SyncResultsResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_SyncResultsResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -7278,24 +7997,28 @@ package org.apache.calcite.avatica.proto;
       "statement_id\030\002 \001(\r\022\025\n\rown_statement\030\003 \001(" +
       "\010\022\035\n\tsignature\030\004 \001(\0132\n.Signature\022\033\n\013firs" +
       "t_frame\030\005 \001(\0132\006.Frame\022\024\n\014update_count\030\006 " +
-      "\001(\004\"6\n\017ExecuteResponse\022#\n\007results\030\001 \003(\0132" +
-      "\022.ResultSetResponse\"6\n\017PrepareResponse\022#" +
-      "\n\tstatement\030\001 \001(\0132\020.StatementHandle\"&\n\rF" +
-      "etchResponse\022\025\n\005frame\030\001 \001(\0132\006.Frame\"F\n\027C" +
-      "reateStatementResponse\022\025\n\rconnection_id\030",
-      "\001 \001(\t\022\024\n\014statement_id\030\002 \001(\r\"\030\n\026CloseStat" +
-      "ementResponse\"\030\n\026OpenConnectionResponse\"" +
-      "\031\n\027CloseConnectionResponse\"C\n\026Connection" +
-      "SyncResponse\022)\n\nconn_props\030\001 \001(\0132\025.Conne" +
-      "ctionProperties\"U\n\027DatabasePropertyEleme" +
-      "nt\022\036\n\003key\030\001 \001(\0132\021.DatabaseProperty\022\032\n\005va" +
-      "lue\030\002 \001(\0132\013.TypedValue\"C\n\030DatabaseProper" +
-      "tyResponse\022\'\n\005props\030\001 \003(\0132\030.DatabaseProp" +
-      "ertyElement\"~\n\rErrorResponse\022\022\n\nexceptio" +
-      "ns\030\001 \003(\t\022\025\n\rerror_message\030\002 \001(\t\022\033\n\010sever",
-      "ity\030\003 \001(\0162\t.Severity\022\022\n\nerror_code\030\004 \001(\r" +
-      "\022\021\n\tsql_state\030\005 \001(\tB\"\n org.apache.calcit" +
-      "e.avatica.protob\006proto3"
+      "\001(\004\"Q\n\017ExecuteResponse\022#\n\007results\030\001 \003(\0132" +
+      "\022.ResultSetResponse\022\031\n\021missing_statement" +
+      "\030\002 \001(\010\"6\n\017PrepareResponse\022#\n\tstatement\030\001" +
+      " \001(\0132\020.StatementHandle\"Z\n\rFetchResponse\022" +
+      "\025\n\005frame\030\001 \001(\0132\006.Frame\022\031\n\021missing_statem",
+      "ent\030\002 \001(\010\022\027\n\017missing_results\030\003 \001(\010\"F\n\027Cr" +
+      "eateStatementResponse\022\025\n\rconnection_id\030\001" +
+      " \001(\t\022\024\n\014statement_id\030\002 \001(\r\"\030\n\026CloseState" +
+      "mentResponse\"\030\n\026OpenConnectionResponse\"\031" +
+      "\n\027CloseConnectionResponse\"C\n\026ConnectionS" +
+      "yncResponse\022)\n\nconn_props\030\001 \001(\0132\025.Connec" +
+      "tionProperties\"U\n\027DatabasePropertyElemen" +
+      "t\022\036\n\003key\030\001 \001(\0132\021.DatabaseProperty\022\032\n\005val" +
+      "ue\030\002 \001(\0132\013.TypedValue\"C\n\030DatabasePropert" +
+      "yResponse\022\'\n\005props\030\001 \003(\0132\030.DatabasePrope",
+      "rtyElement\"~\n\rErrorResponse\022\022\n\nexception" +
+      "s\030\001 \003(\t\022\025\n\rerror_message\030\002 \001(\t\022\033\n\010severi" +
+      "ty\030\003 \001(\0162\t.Severity\022\022\n\nerror_code\030\004 \001(\r\022" +
+      "\021\n\tsql_state\030\005 \001(\t\"F\n\023SyncResultsRespons" +
+      "e\022\031\n\021missing_statement\030\001 \001(\010\022\024\n\014more_res" +
+      "ults\030\002 \001(\010B\"\n org.apache.calcite.avatica" +
+      ".protob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -7321,7 +8044,7 @@ package org.apache.calcite.avatica.proto;
     internal_static_ExecuteResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ExecuteResponse_descriptor,
-        new java.lang.String[] { "Results", });
+        new java.lang.String[] { "Results", "MissingStatement", });
     internal_static_PrepareResponse_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_PrepareResponse_fieldAccessorTable = new
@@ -7333,7 +8056,7 @@ package org.apache.calcite.avatica.proto;
     internal_static_FetchResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_FetchResponse_descriptor,
-        new java.lang.String[] { "Frame", });
+        new java.lang.String[] { "Frame", "MissingStatement", "MissingResults", });
     internal_static_CreateStatementResponse_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_CreateStatementResponse_fieldAccessorTable = new
@@ -7382,6 +8105,12 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ErrorResponse_descriptor,
         new java.lang.String[] { "Exceptions", "ErrorMessage", "Severity", "ErrorCode", "SqlState", });
+    internal_static_SyncResultsResponse_descriptor =
+      getDescriptor().getMessageTypes().get(12);
+    internal_static_SyncResultsResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_SyncResultsResponse_descriptor,
+        new java.lang.String[] { "MissingStatement", "MoreResults", });
     org.apache.calcite.avatica.proto.Common.getDescriptor();
   }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/AbstractHandler.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/AbstractHandler.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.avatica.remote;
 
 import org.apache.calcite.avatica.AvaticaSeverity;
+import org.apache.calcite.avatica.NoSuchConnectionException;
 import org.apache.calcite.avatica.remote.Service.ErrorResponse;
 import org.apache.calcite.avatica.remote.Service.Request;
 import org.apache.calcite.avatica.remote.Service.Response;
@@ -68,6 +69,10 @@ public abstract class AbstractHandler<T> implements Handler<T> {
       sqlState = rte.getSqlState();
       severity = rte.getSeverity();
       errorMsg = rte.getErrorMessage();
+    } else if (e instanceof NoSuchConnectionException) {
+      errorCode = ErrorResponse.MISSING_CONNECTION_ERROR_CODE;
+      severity = AvaticaSeverity.ERROR;
+      errorMsg = e.getMessage();
     } else {
       // Try to construct a meaningful error message when the server impl doesn't provide one.
       errorMsg = getCausalChain(e);

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/AbstractService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/AbstractService.java
@@ -130,6 +130,9 @@ public abstract class AbstractService implements Service {
   }
 
   ExecuteResponse finagle(ExecuteResponse r) {
+    if (r.missingStatement) {
+      return r;
+    }
     final List<ResultSetResponse> results = new ArrayList<>();
     int changeCount = 0;
     for (ResultSetResponse result : r.results) {
@@ -142,7 +145,7 @@ public abstract class AbstractService implements Service {
     if (changeCount == 0) {
       return r;
     }
-    return new ExecuteResponse(results);
+    return new ExecuteResponse(results, r.missingStatement);
   }
 }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClient.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClient.java
@@ -16,24 +16,17 @@
  */
 package org.apache.calcite.avatica.remote;
 
-import java.nio.charset.StandardCharsets;
-
 /**
- * Implementation of {@link org.apache.calcite.avatica.remote.Service}
- * that translates requests into JSON and sends them to a remote server,
- * usually an HTTP server.
+ * An interface which defines how requests are sent to the Avatica server.
  */
-public class RemoteService extends JsonService {
-  private final AvaticaHttpClient client;
+public interface AvaticaHttpClient {
 
-  public RemoteService(AvaticaHttpClient client) {
-    this.client = client;
-  }
+  /**
+   * Sends a serialized request to the Avatica server.
+   *
+   * @param request The serialized request.
+   * @return The serialized response.
+   */
+  byte[] send(byte[] request);
 
-  @Override public String apply(String request) {
-    byte[] response = client.send(request.getBytes(StandardCharsets.UTF_8));
-    return new String(response, StandardCharsets.UTF_8);
-  }
 }
-
-// End RemoteService.java

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClientImpl.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClientImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+import org.apache.calcite.avatica.AvaticaUtils;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * A common class to invoke HTTP requests against the Avatica server agnostic of the data being
+ * sent and received across the wire.
+ */
+public class AvaticaHttpClientImpl implements AvaticaHttpClient {
+  protected final URL url;
+
+  public AvaticaHttpClientImpl(URL url) {
+    this.url = url;
+  }
+
+  @Override
+  public byte[] send(byte[] request) {
+    // TODO back-off policy?
+    while (true) {
+      try {
+        final HttpURLConnection connection = openConnection();
+        connection.setRequestMethod("POST");
+        connection.setDoInput(true);
+        connection.setDoOutput(true);
+        try (DataOutputStream wr = new DataOutputStream(connection.getOutputStream())) {
+          wr.write(request);
+          wr.flush();
+          wr.close();
+        }
+        final int responseCode = connection.getResponseCode();
+        final InputStream inputStream;
+        if (responseCode == HttpURLConnection.HTTP_UNAVAILABLE) {
+          // Could be sitting behind a load-balancer, try again.
+          continue;
+        } else if (responseCode != HttpURLConnection.HTTP_OK) {
+          inputStream = connection.getErrorStream();
+        } else {
+          inputStream = connection.getInputStream();
+        }
+        return AvaticaUtils.readFullyToBytes(inputStream);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  HttpURLConnection openConnection() throws IOException {
+    return (HttpURLConnection) url.openConnection();
+  }
+}

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Driver.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Driver.java
@@ -31,9 +31,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -85,27 +83,28 @@ public class Driver extends UnregisteredDriver {
     return new RemoteMeta(connection, service);
   }
 
-  private Service createService(AvaticaConnection connection, ConnectionConfig config) {
+  /**
+   * Creates a {@link Service} with the given {@link AvaticaConnection} and configuration.
+   *
+   * @param connection The {@link AvaticaConnection} to use.
+   * @param config Configuration properties
+   * @return A Service implementation.
+   */
+  Service createService(AvaticaConnection connection, ConnectionConfig config) {
     final Service.Factory metaFactory = config.factory();
     final Service service;
     if (metaFactory != null) {
       service = metaFactory.create(connection);
     } else if (config.url() != null) {
-      final URL url;
-      try {
-        url = new URL(config.url());
-      } catch (MalformedURLException e) {
-        throw new RuntimeException(e);
-      }
-
-      Serialization serializationType = getSerialization(config);
+      final AvaticaHttpClient httpClient = getHttpClient(connection, config);
+      final Serialization serializationType = getSerialization(config);
 
       switch (serializationType) {
       case JSON:
-        service = new RemoteService(url);
+        service = new RemoteService(httpClient);
         break;
       case PROTOBUF:
-        service = new RemoteProtobufService(url, new ProtobufTranslationImpl());
+        service = new RemoteProtobufService(httpClient, new ProtobufTranslationImpl());
         break;
       default:
         throw new IllegalArgumentException("Unhandled serialization type: " + serializationType);
@@ -114,6 +113,24 @@ public class Driver extends UnregisteredDriver {
       service = new MockJsonService(Collections.<String, String>emptyMap());
     }
     return service;
+  }
+
+  /**
+   * Creates the HTTP client that communicates with the Avatica server.
+   *
+   * @param connection The {@link AvaticaConnection}.
+   * @param config The configuration.
+   * @return An {@link AvaticaHttpClient} implementation.
+   */
+  AvaticaHttpClient getHttpClient(AvaticaConnection connection, ConnectionConfig config) {
+    URL url;
+    try {
+      url = new URL(config.url());
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+
+    return new AvaticaHttpClientImpl(url);
   }
 
   @Override public Connection connect(String url, Properties info)
@@ -128,28 +145,13 @@ public class Driver extends UnregisteredDriver {
     ConnectionConfig config = conn.config();
     Service service = createService(conn, config);
 
-    Map<String, String> infoAsString = new HashMap<>();
-    for (Map.Entry<Object, Object> entry : info.entrySet()) {
-      // Determine if this is a property we want to forward to the server
-      boolean localProperty = false;
-      for (BuiltInConnectionProperty prop : BuiltInConnectionProperty.values()) {
-        if (prop.camelName().equals(entry.getKey())) {
-          localProperty = true;
-          break;
-        }
-      }
-
-      if (!localProperty) {
-        infoAsString.put(entry.getKey().toString(), entry.getValue().toString());
-      }
-    }
-
-    service.apply(new Service.OpenConnectionRequest(conn.id, infoAsString));
+    service.apply(new Service.OpenConnectionRequest(conn.id,
+        Service.OpenConnectionRequest.serializeProperties(info)));
 
     return conn;
   }
 
-  private Serialization getSerialization(ConnectionConfig config) {
+  Serialization getSerialization(ConnectionConfig config) {
     final String serializationStr = config.serialization();
     Serialization serializationType = Serialization.JSON;
     if (null != serializationStr) {

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Handler.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Handler.java
@@ -46,6 +46,10 @@ public interface Handler<T> {
     public int getStatusCode() {
       return statusCode;
     }
+
+    @Override public String toString() {
+      return "Response: " + response + ", Status:" + statusCode;
+    }
   }
 
   HandlerResponse<T> apply(T request);

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
@@ -198,6 +198,14 @@ public abstract class JsonService extends AbstractService {
       throw handle(e);
     }
   }
+
+  public SyncResultsResponse apply(SyncResultsRequest request) {
+    try {
+      return decode(apply(encode(request)), SyncResultsResponse.class);
+    } catch (IOException e) {
+      throw handle(e);
+    }
+  }
 }
 
 // End JsonService.java

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
@@ -18,6 +18,8 @@ package org.apache.calcite.avatica.remote;
 
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.MetaImpl;
+import org.apache.calcite.avatica.MissingResultsException;
+import org.apache.calcite.avatica.NoSuchStatementException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -103,7 +105,7 @@ public class LocalService implements Service {
     final Meta.StatementHandle h = new Meta.StatementHandle(
         resultSet.connectionId, resultSet.statementId, null);
     final List<TypedValue> parameterValues = Collections.emptyList();
-    final Iterable<Object> iterable = meta.createIterable(h,
+    final Iterable<Object> iterable = meta.createIterable(h, null,
         resultSet.signature, parameterValues, resultSet.firstFrame);
     final List<List<Object>> list = new ArrayList<>();
     return MetaImpl.collect(resultSet.signature.cursorFactory, iterable, list);
@@ -173,49 +175,65 @@ public class LocalService implements Service {
   public ExecuteResponse apply(PrepareAndExecuteRequest request) {
     final Meta.StatementHandle sh =
         new Meta.StatementHandle(request.connectionId, request.statementId, null);
-    final Meta.ExecuteResult executeResult =
-        meta.prepareAndExecute(sh, request.sql, request.maxRowCount,
-            new Meta.PrepareCallback() {
-              @Override public Object getMonitor() {
-                return LocalService.class;
-              }
+    try {
+      final Meta.ExecuteResult executeResult =
+          meta.prepareAndExecute(sh, request.sql, request.maxRowCount,
+              new Meta.PrepareCallback() {
+                @Override public Object getMonitor() {
+                  return LocalService.class;
+                }
 
-              @Override public void clear() {
-              }
+                @Override public void clear() {
+                }
 
-              @Override public void assign(Meta.Signature signature,
-                  Meta.Frame firstFrame, long updateCount) {
-              }
+                @Override public void assign(Meta.Signature signature,
+                    Meta.Frame firstFrame, long updateCount) {
+                }
 
-              @Override public void execute() {
-              }
-            });
-    final List<ResultSetResponse> results = new ArrayList<>();
-    for (Meta.MetaResultSet metaResultSet : executeResult.resultSets) {
-      results.add(toResponse(metaResultSet));
+                @Override public void execute() {
+                }
+              });
+      final List<ResultSetResponse> results = new ArrayList<>();
+      for (Meta.MetaResultSet metaResultSet : executeResult.resultSets) {
+        results.add(toResponse(metaResultSet));
+      }
+      return new ExecuteResponse(results, false);
+    } catch (NoSuchStatementException e) {
+      // The Statement doesn't exist anymore, bubble up this information
+      return new ExecuteResponse(null, true);
     }
-    return new ExecuteResponse(results);
   }
 
   public FetchResponse apply(FetchRequest request) {
     final Meta.StatementHandle h = new Meta.StatementHandle(
         request.connectionId, request.statementId, null);
-    final Meta.Frame frame =
-        meta.fetch(h,
-            request.offset,
-            request.fetchMaxRowCount);
-    return new FetchResponse(frame);
+    try {
+      final Meta.Frame frame =
+          meta.fetch(h,
+              request.offset,
+              request.fetchMaxRowCount);
+      return new FetchResponse(frame, false, false);
+    } catch (NullPointerException | NoSuchStatementException e) {
+      // The Statement doesn't exist anymore, bubble up this information
+      return new FetchResponse(null, true, true);
+    } catch (MissingResultsException e) {
+      return new FetchResponse(null, false, true);
+    }
   }
 
   public ExecuteResponse apply(ExecuteRequest request) {
-    final Meta.ExecuteResult executeResult = meta.execute(request.statementHandle,
-        request.parameterValues, request.maxRowCount);
+    try {
+      final Meta.ExecuteResult executeResult = meta.execute(request.statementHandle,
+          request.parameterValues, request.maxRowCount);
 
-    final List<ResultSetResponse> results = new ArrayList<>();
-    for (Meta.MetaResultSet metaResultSet : executeResult.resultSets) {
-      results.add(toResponse(metaResultSet));
+      final List<ResultSetResponse> results = new ArrayList<>();
+      for (Meta.MetaResultSet metaResultSet : executeResult.resultSets) {
+        results.add(toResponse(metaResultSet));
+      }
+      return new ExecuteResponse(results, false);
+    } catch (NoSuchStatementException e) {
+      return new ExecuteResponse(null, true);
     }
-    return new ExecuteResponse(results);
   }
 
   public CreateStatementResponse apply(CreateStatementRequest request) {
@@ -258,6 +276,22 @@ public class LocalService implements Service {
     final Meta.ConnectionHandle ch =
         new Meta.ConnectionHandle(request.connectionId);
     return new DatabasePropertyResponse(meta.getDatabaseProperties(ch));
+  }
+
+  @Override
+  public SyncResultsResponse apply(SyncResultsRequest request) {
+    final Meta.StatementHandle h = new Meta.StatementHandle(
+        request.connectionId, request.statementId, null);
+    SyncResultsResponse response;
+    try {
+      // Set success on the cached statement
+      response = new SyncResultsResponse(meta.syncResults(h, request.state, request.offset), false);
+    } catch (NoSuchStatementException e) {
+      // Tried to sync results on a statement which wasn't cached
+      response = new SyncResultsResponse(false, true);
+    }
+
+    return response;
   }
 }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/MetaDataOperation.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/MetaDataOperation.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+import org.apache.calcite.avatica.proto.Common;
+
+/**
+ * Identifies an operation from {@link DatabaseMetaData} which returns a {@link ResultSet}. This
+ * enum is used to allow clients to request the server to re-instantiate a {@link ResultSet} for
+ * these operations which do not have a SQL string associated with them as a normal query does.
+ */
+public enum MetaDataOperation {
+  GET_ATTRIBUTES,
+  GET_BEST_ROW_IDENTIFIER,
+  GET_CATALOGS,
+  GET_CLIENT_INFO_PROPERTIES,
+  GET_COLUMN_PRIVILEGES,
+  GET_COLUMNS,
+  GET_CROSS_REFERENCE,
+  GET_EXPORTED_KEYS,
+  GET_FUNCTION_COLUMNS,
+  GET_FUNCTIONS,
+  GET_IMPORTED_KEYS,
+  GET_INDEX_INFO,
+  GET_PRIMARY_KEYS,
+  GET_PROCEDURE_COLUMNS,
+  GET_PROCEDURES,
+  GET_PSEUDO_COLUMNS,
+  GET_SCHEMAS,
+  GET_SCHEMAS_WITH_ARGS,
+  GET_SUPER_TABLES,
+  GET_SUPER_TYPES,
+  GET_TABLE_PRIVILEGES,
+  GET_TABLES,
+  GET_TABLE_TYPES,
+  GET_TYPE_INFO,
+  GET_UDTS,
+  GET_VERSION_COLUMNS;
+
+  public Common.MetaDataOperation toProto() {
+    switch (this) {
+    case GET_ATTRIBUTES:
+      return Common.MetaDataOperation.GET_ATTRIBUTES;
+    case GET_BEST_ROW_IDENTIFIER:
+      return Common.MetaDataOperation.GET_BEST_ROW_IDENTIFIER;
+    case GET_CATALOGS:
+      return Common.MetaDataOperation.GET_CATALOGS;
+    case GET_CLIENT_INFO_PROPERTIES:
+      return Common.MetaDataOperation.GET_CLIENT_INFO_PROPERTIES;
+    case GET_COLUMNS:
+      return Common.MetaDataOperation.GET_COLUMNS;
+    case GET_COLUMN_PRIVILEGES:
+      return Common.MetaDataOperation.GET_COLUMN_PRIVILEGES;
+    case GET_CROSS_REFERENCE:
+      return Common.MetaDataOperation.GET_CROSS_REFERENCE;
+    case GET_EXPORTED_KEYS:
+      return Common.MetaDataOperation.GET_EXPORTED_KEYS;
+    case GET_FUNCTIONS:
+      return Common.MetaDataOperation.GET_FUNCTIONS;
+    case GET_FUNCTION_COLUMNS:
+      return Common.MetaDataOperation.GET_FUNCTION_COLUMNS;
+    case GET_IMPORTED_KEYS:
+      return Common.MetaDataOperation.GET_IMPORTED_KEYS;
+    case GET_INDEX_INFO:
+      return Common.MetaDataOperation.GET_INDEX_INFO;
+    case GET_PRIMARY_KEYS:
+      return Common.MetaDataOperation.GET_PRIMARY_KEYS;
+    case GET_PROCEDURES:
+      return Common.MetaDataOperation.GET_PROCEDURES;
+    case GET_PROCEDURE_COLUMNS:
+      return Common.MetaDataOperation.GET_PROCEDURE_COLUMNS;
+    case GET_PSEUDO_COLUMNS:
+      return Common.MetaDataOperation.GET_PSEUDO_COLUMNS;
+    case GET_SCHEMAS:
+      return Common.MetaDataOperation.GET_SCHEMAS;
+    case GET_SCHEMAS_WITH_ARGS:
+      return Common.MetaDataOperation.GET_SCHEMAS_WITH_ARGS;
+    case GET_SUPER_TABLES:
+      return Common.MetaDataOperation.GET_SUPER_TABLES;
+    case GET_SUPER_TYPES:
+      return Common.MetaDataOperation.GET_SUPER_TYPES;
+    case GET_TABLES:
+      return Common.MetaDataOperation.GET_TABLES;
+    case GET_TABLE_PRIVILEGES:
+      return Common.MetaDataOperation.GET_TABLE_PRIVILEGES;
+    case GET_TABLE_TYPES:
+      return Common.MetaDataOperation.GET_TABLE_TYPES;
+    case GET_TYPE_INFO:
+      return Common.MetaDataOperation.GET_TYPE_INFO;
+    case GET_UDTS:
+      return Common.MetaDataOperation.GET_UDTS;
+    case GET_VERSION_COLUMNS:
+      return Common.MetaDataOperation.GET_VERSION_COLUMNS;
+    default:
+      throw new RuntimeException("Unknown type: " + this);
+    }
+  }
+
+  public static MetaDataOperation fromProto(Common.MetaDataOperation protoOp) {
+    // Null is acceptable
+    if (null == protoOp) {
+      return null;
+    }
+
+    switch (protoOp) {
+    case GET_ATTRIBUTES:
+      return MetaDataOperation.GET_ATTRIBUTES;
+    case GET_BEST_ROW_IDENTIFIER:
+      return MetaDataOperation.GET_BEST_ROW_IDENTIFIER;
+    case GET_CATALOGS:
+      return MetaDataOperation.GET_CATALOGS;
+    case GET_CLIENT_INFO_PROPERTIES:
+      return MetaDataOperation.GET_CLIENT_INFO_PROPERTIES;
+    case GET_COLUMNS:
+      return MetaDataOperation.GET_COLUMNS;
+    case GET_COLUMN_PRIVILEGES:
+      return MetaDataOperation.GET_COLUMN_PRIVILEGES;
+    case GET_CROSS_REFERENCE:
+      return MetaDataOperation.GET_CROSS_REFERENCE;
+    case GET_EXPORTED_KEYS:
+      return MetaDataOperation.GET_EXPORTED_KEYS;
+    case GET_FUNCTIONS:
+      return MetaDataOperation.GET_FUNCTIONS;
+    case GET_FUNCTION_COLUMNS:
+      return MetaDataOperation.GET_FUNCTION_COLUMNS;
+    case GET_IMPORTED_KEYS:
+      return MetaDataOperation.GET_IMPORTED_KEYS;
+    case GET_INDEX_INFO:
+      return MetaDataOperation.GET_INDEX_INFO;
+    case GET_PRIMARY_KEYS:
+      return MetaDataOperation.GET_PRIMARY_KEYS;
+    case GET_PROCEDURES:
+      return MetaDataOperation.GET_PROCEDURES;
+    case GET_PROCEDURE_COLUMNS:
+      return MetaDataOperation.GET_PROCEDURE_COLUMNS;
+    case GET_PSEUDO_COLUMNS:
+      return MetaDataOperation.GET_PSEUDO_COLUMNS;
+    case GET_SCHEMAS:
+      return MetaDataOperation.GET_SCHEMAS;
+    case GET_SCHEMAS_WITH_ARGS:
+      return MetaDataOperation.GET_SCHEMAS_WITH_ARGS;
+    case GET_SUPER_TABLES:
+      return MetaDataOperation.GET_SUPER_TABLES;
+    case GET_SUPER_TYPES:
+      return MetaDataOperation.GET_SUPER_TYPES;
+    case GET_TABLES:
+      return MetaDataOperation.GET_TABLES;
+    case GET_TABLE_PRIVILEGES:
+      return MetaDataOperation.GET_TABLE_PRIVILEGES;
+    case GET_TABLE_TYPES:
+      return MetaDataOperation.GET_TABLE_TYPES;
+    case GET_TYPE_INFO:
+      return MetaDataOperation.GET_TYPE_INFO;
+    case GET_UDTS:
+      return MetaDataOperation.GET_UDTS;
+    case GET_VERSION_COLUMNS:
+      return MetaDataOperation.GET_VERSION_COLUMNS;
+    default:
+      throw new RuntimeException("Unknown type: " + protoOp);
+    }
+  }
+}

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/MetaDataOperation.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/MetaDataOperation.java
@@ -18,6 +18,9 @@ package org.apache.calcite.avatica.remote;
 
 import org.apache.calcite.avatica.proto.Common;
 
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+
 /**
  * Identifies an operation from {@link DatabaseMetaData} which returns a {@link ResultSet}. This
  * enum is used to allow clients to request the server to re-instantiate a {@link ResultSet} for

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/MockJsonService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/MockJsonService.java
@@ -46,7 +46,7 @@ public class MockJsonService extends JsonService {
   /** Factory that creates a {@code MockJsonService}. */
   public static class Factory implements Service.Factory {
     public Service create(AvaticaConnection connection) {
-      final String connectionId = connection.handle.id;
+      final String connectionId = connection.id;
       final Map<String, String> map1 = new HashMap<>();
       try {
         map1.put(

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/MockProtobufService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/MockProtobufService.java
@@ -136,7 +136,7 @@ public class MockProtobufService extends ProtobufService {
    */
   public static class MockProtobufServiceFactory implements Service.Factory {
     @Override public Service create(AvaticaConnection connection) {
-      return new MockProtobufService(connection.handle.id);
+      return new MockProtobufService(connection.id);
     }
   }
 }

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
@@ -99,6 +99,10 @@ public abstract class ProtobufService extends AbstractService {
     return finagle((ExecuteResponse) _apply(request));
   }
 
+  @Override public SyncResultsResponse apply(SyncResultsRequest request) {
+    return (SyncResultsResponse) _apply(request);
+  }
+
   /**
    * Determines whether the given message has the field, denoted by the provided number, set.
    *

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
@@ -30,6 +30,7 @@ import org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareRequest;
 import org.apache.calcite.avatica.proto.Requests.SchemasRequest;
+import org.apache.calcite.avatica.proto.Requests.SyncResultsRequest;
 import org.apache.calcite.avatica.proto.Requests.TableTypesRequest;
 import org.apache.calcite.avatica.proto.Requests.TablesRequest;
 import org.apache.calcite.avatica.proto.Requests.TypeInfoRequest;
@@ -44,6 +45,7 @@ import org.apache.calcite.avatica.proto.Responses.FetchResponse;
 import org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse;
 import org.apache.calcite.avatica.proto.Responses.PrepareResponse;
 import org.apache.calcite.avatica.proto.Responses.ResultSetResponse;
+import org.apache.calcite.avatica.proto.Responses.SyncResultsResponse;
 import org.apache.calcite.avatica.remote.Service.Request;
 import org.apache.calcite.avatica.remote.Service.Response;
 
@@ -106,6 +108,8 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
         new RequestTranslator(TypeInfoRequest.parser(), new Service.TypeInfoRequest()));
     reqParsers.put(ExecuteRequest.class.getName(),
         new RequestTranslator(ExecuteRequest.parser(), new Service.ExecuteRequest()));
+    reqParsers.put(SyncResultsRequest.class.getName(),
+        new RequestTranslator(SyncResultsRequest.parser(), new Service.SyncResultsRequest()));
 
     REQUEST_PARSERS = Collections.unmodifiableMap(reqParsers);
 
@@ -138,6 +142,8 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
         new ResponseTranslator(ResultSetResponse.parser(), new Service.ResultSetResponse()));
     respParsers.put(ErrorResponse.class.getName(),
         new ResponseTranslator(ErrorResponse.parser(), new Service.ErrorResponse()));
+    respParsers.put(SyncResultsResponse.class.getName(),
+        new ResponseTranslator(SyncResultsResponse.parser(), new Service.SyncResultsResponse()));
 
     RESPONSE_PARSERS = Collections.unmodifiableMap(respParsers);
   }

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
@@ -17,11 +17,15 @@
 package org.apache.calcite.avatica.remote;
 
 import org.apache.calcite.avatica.AvaticaConnection;
+import org.apache.calcite.avatica.AvaticaConnection.CallableWithoutException;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.ConnectionPropertiesImpl;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.MetaImpl;
+import org.apache.calcite.avatica.MissingResultsException;
+import org.apache.calcite.avatica.NoSuchStatementException;
+import org.apache.calcite.avatica.QueryState;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -75,150 +79,275 @@ class RemoteMeta extends MetaImpl {
     }
   }
 
-  @Override public StatementHandle createStatement(ConnectionHandle ch) {
-    connectionSync(ch, new ConnectionPropertiesImpl()); // sync connection state if necessary
-    final Service.CreateStatementResponse response =
-        service.apply(new Service.CreateStatementRequest(ch.id));
-    return new StatementHandle(response.connectionId, response.statementId,
-        null);
+  @Override public StatementHandle createStatement(final ConnectionHandle ch) {
+    return connection.invokeWithRetries(new CallableWithoutException<StatementHandle>() {
+      public StatementHandle call() {
+        connectionSync(ch, new ConnectionPropertiesImpl()); // sync connection state if necessary
+        final Service.CreateStatementResponse response =
+            service.apply(new Service.CreateStatementRequest(ch.id));
+        return new StatementHandle(response.connectionId, response.statementId, null);
+      }
+    });
   }
 
-  @Override public void closeStatement(StatementHandle h) {
-    final Service.CloseStatementResponse response =
-        service.apply(new Service.CloseStatementRequest(h.connectionId, h.id));
+  @Override public void closeStatement(final StatementHandle h) {
+    connection.invokeWithRetries(new CallableWithoutException<Void>() {
+      public Void call() {
+        final Service.CloseStatementResponse response =
+            service.apply(new Service.CloseStatementRequest(h.connectionId, h.id));
+        return null;
+      }
+    });
   }
 
-  @Override public void openConnection(ConnectionHandle ch, Map<String, String> info) {
-    final Service.OpenConnectionResponse response =
-        service.apply(new Service.OpenConnectionRequest(ch.id, info));
+  @Override public void openConnection(final ConnectionHandle ch, final Map<String, String> info) {
+    connection.invokeWithRetries(new CallableWithoutException<Void>() {
+      public Void call() {
+        final Service.OpenConnectionResponse response =
+            service.apply(new Service.OpenConnectionRequest(ch.id, info));
+        return null;
+      }
+    });
   }
 
-  @Override public void closeConnection(ConnectionHandle ch) {
-    final Service.CloseConnectionResponse response =
-        service.apply(new Service.CloseConnectionRequest(ch.id));
-    propsMap.remove(ch.id);
+  @Override public void closeConnection(final ConnectionHandle ch) {
+    connection.invokeWithRetries(new CallableWithoutException<Void>() {
+      public Void call() {
+        final Service.CloseConnectionResponse response =
+            service.apply(new Service.CloseConnectionRequest(ch.id));
+        propsMap.remove(ch.id);
+        return null;
+      }
+    });
   }
 
-  @Override public ConnectionProperties connectionSync(ConnectionHandle ch,
-      ConnectionProperties connProps) {
-    ConnectionPropertiesImpl localProps = propsMap.get(ch.id);
-    if (localProps == null) {
-      localProps = new ConnectionPropertiesImpl();
-      localProps.setDirty(true);
-      propsMap.put(ch.id, localProps);
-    }
+  @Override public ConnectionProperties connectionSync(final ConnectionHandle ch,
+      final ConnectionProperties connProps) {
+    return connection.invokeWithRetries(new CallableWithoutException<ConnectionProperties>() {
+      public ConnectionProperties call() {
+        ConnectionPropertiesImpl localProps = propsMap.get(ch.id);
+        if (localProps == null) {
+          localProps = new ConnectionPropertiesImpl();
+          localProps.setDirty(true);
+          propsMap.put(ch.id, localProps);
+        }
 
-    // Only make an RPC if necessary. RPC is necessary when we have local changes that need
-    // flushed to the server (be sure to introduce any new changes from connProps before checking
-    // AND when connProps.isEmpty() (meaning, this was a request for a value, not overriding a
-    // value). Otherwise, accumulate the change locally and return immediately.
-    if (localProps.merge(connProps).isDirty() && connProps.isEmpty()) {
-      final Service.ConnectionSyncResponse response = service.apply(
-          new Service.ConnectionSyncRequest(ch.id, localProps));
-      propsMap.put(ch.id, (ConnectionPropertiesImpl) response.connProps);
-      return response.connProps;
-    } else {
-      return localProps;
-    }
-  }
-
-  @Override public MetaResultSet getCatalogs(ConnectionHandle ch) {
-    final Service.ResultSetResponse response =
-        service.apply(new Service.CatalogsRequest(ch.id));
-    return toResultSet(MetaCatalog.class, response);
-  }
-
-  @Override public MetaResultSet getSchemas(ConnectionHandle ch, String catalog,
-      Pat schemaPattern) {
-    final Service.ResultSetResponse response =
-        service.apply(new Service.SchemasRequest(ch.id, catalog, schemaPattern.s));
-    return toResultSet(MetaSchema.class, response);
-  }
-
-  @Override public MetaResultSet getTables(ConnectionHandle ch, String catalog, Pat schemaPattern,
-      Pat tableNamePattern, List<String> typeList) {
-    final Service.ResultSetResponse response =
-        service.apply(
-            new Service.TablesRequest(ch.id, catalog, schemaPattern.s,
-                tableNamePattern.s, typeList));
-    return toResultSet(MetaTable.class, response);
-  }
-
-  @Override public MetaResultSet getTableTypes(ConnectionHandle ch) {
-    final Service.ResultSetResponse response =
-        service.apply(new Service.TableTypesRequest(ch.id));
-    return toResultSet(MetaTableType.class, response);
-  }
-
-  @Override public MetaResultSet getTypeInfo(ConnectionHandle ch) {
-    final Service.ResultSetResponse response =
-        service.apply(new Service.TypeInfoRequest(ch.id));
-    return toResultSet(MetaTypeInfo.class, response);
-  }
-
-  @Override public MetaResultSet getColumns(ConnectionHandle ch, String catalog, Pat schemaPattern,
-      Pat tableNamePattern, Pat columnNamePattern) {
-    final Service.ResultSetResponse response =
-        service.apply(
-            new Service.ColumnsRequest(ch.id, catalog, schemaPattern.s,
-                tableNamePattern.s, columnNamePattern.s));
-    return toResultSet(MetaColumn.class, response);
-  }
-
-  @Override public StatementHandle prepare(ConnectionHandle ch, String sql,
-      long maxRowCount) {
-    connectionSync(ch, new ConnectionPropertiesImpl()); // sync connection state if necessary
-    final Service.PrepareResponse response = service.apply(
-        new Service.PrepareRequest(ch.id, sql, maxRowCount));
-    return response.statement;
-  }
-
-  @Override public ExecuteResult prepareAndExecute(StatementHandle h,
-      String sql, long maxRowCount, PrepareCallback callback) {
-    // sync connection state if necessary
-    connectionSync(new ConnectionHandle(h.connectionId), new ConnectionPropertiesImpl());
-    final Service.ExecuteResponse response;
-    try {
-      synchronized (callback.getMonitor()) {
-        callback.clear();
-        response = service.apply(
-            new Service.PrepareAndExecuteRequest(h.connectionId,
-              h.id, sql, maxRowCount));
-        if (response.results.size() > 0) {
-          final Service.ResultSetResponse result = response.results.get(0);
-          callback.assign(result.signature, result.firstFrame,
-              result.updateCount);
+        // Only make an RPC if necessary. RPC is necessary when we have local changes that need
+        // flushed to the server (be sure to introduce any new changes from connProps before
+        // checking AND when connProps.isEmpty() (meaning, this was a request for a value, not
+        // overriding a value). Otherwise, accumulate the change locally and return immediately.
+        if (localProps.merge(connProps).isDirty() && connProps.isEmpty()) {
+          final Service.ConnectionSyncResponse response = service.apply(
+              new Service.ConnectionSyncRequest(ch.id, localProps));
+          propsMap.put(ch.id, (ConnectionPropertiesImpl) response.connProps);
+          return response.connProps;
+        } else {
+          return localProps;
         }
       }
-      callback.execute();
-      List<MetaResultSet> metaResultSets = new ArrayList<>();
-      for (Service.ResultSetResponse result : response.results) {
-        metaResultSets.add(toResultSet(null, result));
+    });
+  }
+
+  @Override public MetaResultSet getCatalogs(final ConnectionHandle ch) {
+    return connection.invokeWithRetries(new CallableWithoutException<MetaResultSet>() {
+      public MetaResultSet call() {
+        final Service.ResultSetResponse response =
+            service.apply(new Service.CatalogsRequest(ch.id));
+        return toResultSet(MetaCatalog.class, response);
       }
-      return new ExecuteResult(metaResultSets);
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
+    });
+  }
+
+  @Override public MetaResultSet getSchemas(final ConnectionHandle ch, final String catalog,
+      final Pat schemaPattern) {
+    return connection.invokeWithRetries(new CallableWithoutException<MetaResultSet>() {
+      public MetaResultSet call() {
+        final Service.ResultSetResponse response =
+            service.apply(new Service.SchemasRequest(ch.id, catalog, schemaPattern.s));
+        return toResultSet(MetaSchema.class, response);
+      }
+    });
+  }
+
+  @Override public MetaResultSet getTables(final ConnectionHandle ch, final String catalog,
+      final Pat schemaPattern, final Pat tableNamePattern, final List<String> typeList) {
+    return connection.invokeWithRetries(new CallableWithoutException<MetaResultSet>() {
+      public MetaResultSet call() {
+        final Service.ResultSetResponse response =
+            service.apply(
+                new Service.TablesRequest(ch.id, catalog, schemaPattern.s,
+                    tableNamePattern.s, typeList));
+        return toResultSet(MetaTable.class, response);
+      }
+    });
+  }
+
+  @Override public MetaResultSet getTableTypes(final ConnectionHandle ch) {
+    return connection.invokeWithRetries(new CallableWithoutException<MetaResultSet>() {
+      public MetaResultSet call() {
+        final Service.ResultSetResponse response =
+            service.apply(new Service.TableTypesRequest(ch.id));
+        return toResultSet(MetaTableType.class, response);
+      }
+    });
+  }
+
+  @Override public MetaResultSet getTypeInfo(final ConnectionHandle ch) {
+    return connection.invokeWithRetries(new CallableWithoutException<MetaResultSet>() {
+      public MetaResultSet call() {
+        final Service.ResultSetResponse response =
+            service.apply(new Service.TypeInfoRequest(ch.id));
+        return toResultSet(MetaTypeInfo.class, response);
+      }
+    });
+  }
+
+  @Override public MetaResultSet getColumns(final ConnectionHandle ch, final String catalog,
+      final Pat schemaPattern, final Pat tableNamePattern, final Pat columnNamePattern) {
+    return connection.invokeWithRetries(new CallableWithoutException<MetaResultSet>() {
+      public MetaResultSet call() {
+        final Service.ResultSetResponse response =
+            service.apply(
+                new Service.ColumnsRequest(ch.id, catalog, schemaPattern.s,
+                    tableNamePattern.s, columnNamePattern.s));
+        return toResultSet(MetaColumn.class, response);
+      }
+    });
+  }
+
+  @Override public StatementHandle prepare(final ConnectionHandle ch, final String sql,
+      final long maxRowCount) {
+    return connection.invokeWithRetries(new CallableWithoutException<StatementHandle>() {
+      public StatementHandle call() {
+        connectionSync(ch, new ConnectionPropertiesImpl()); // sync connection state if necessary
+        final Service.PrepareResponse response = service.apply(
+            new Service.PrepareRequest(ch.id, sql, maxRowCount));
+        return response.statement;
+      }
+    });
+  }
+
+  @Override public ExecuteResult prepareAndExecute(final StatementHandle h, final String sql,
+      final long maxRowCount, final PrepareCallback callback) throws NoSuchStatementException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ExecuteResult>() {
+        public ExecuteResult call() {
+          // sync connection state if necessary
+          connectionSync(new ConnectionHandle(h.connectionId), new ConnectionPropertiesImpl());
+          final Service.ExecuteResponse response;
+          try {
+            synchronized (callback.getMonitor()) {
+              callback.clear();
+              response = service.apply(
+                  new Service.PrepareAndExecuteRequest(h.connectionId,
+                    h.id, sql, maxRowCount));
+              if (response.missingStatement) {
+                throw new RuntimeException(new NoSuchStatementException(h));
+              }
+              if (response.results.size() > 0) {
+                final Service.ResultSetResponse result = response.results.get(0);
+                callback.assign(result.signature, result.firstFrame,
+                    result.updateCount);
+              }
+            }
+            callback.execute();
+            List<MetaResultSet> metaResultSets = new ArrayList<>();
+            for (Service.ResultSetResponse result : response.results) {
+              metaResultSets.add(toResultSet(null, result));
+            }
+            return new ExecuteResult(metaResultSets);
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof NoSuchStatementException) {
+        throw (NoSuchStatementException) cause;
+      }
+      throw e;
     }
   }
 
-  @Override public Frame fetch(StatementHandle h, long offset, int fetchMaxRowCount) {
-    final Service.FetchResponse response =
-        service.apply(
-            new Service.FetchRequest(h.connectionId, h.id, offset, fetchMaxRowCount));
-    return response.frame;
+  @Override public Frame fetch(final StatementHandle h, final long offset,
+      final int fetchMaxRowCount) throws NoSuchStatementException, MissingResultsException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<Frame>() {
+        public Frame call() {
+          final Service.FetchResponse response =
+              service.apply(
+                  new Service.FetchRequest(h.connectionId, h.id, offset, fetchMaxRowCount));
+          if (response.missingStatement) {
+            throw new RuntimeException(new NoSuchStatementException(h));
+          }
+          if (response.missingResults) {
+            throw new RuntimeException(new MissingResultsException(h));
+          }
+          return response.frame;
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof NoSuchStatementException) {
+        throw (NoSuchStatementException) cause;
+      } else if (cause instanceof MissingResultsException) {
+        throw (MissingResultsException) cause;
+      }
+      throw e;
+    }
   }
 
-  @Override public ExecuteResult execute(StatementHandle h,
-      List<TypedValue> parameterValues, long maxRowCount) {
-    final Service.ExecuteResponse response = service.apply(
-        new Service.ExecuteRequest(h, parameterValues, maxRowCount));
+  @Override public ExecuteResult execute(final StatementHandle h,
+      final List<TypedValue> parameterValues, final long maxRowCount)
+      throws NoSuchStatementException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<ExecuteResult>() {
+        public ExecuteResult call() {
+          final Service.ExecuteResponse response = service.apply(
+              new Service.ExecuteRequest(h, parameterValues, maxRowCount));
 
-    List<MetaResultSet> metaResultSets = new ArrayList<>();
-    for (Service.ResultSetResponse result : response.results) {
-      metaResultSets.add(toResultSet(null, result));
+          if (response.missingStatement) {
+            throw new RuntimeException(new NoSuchStatementException(h));
+          }
+
+          List<MetaResultSet> metaResultSets = new ArrayList<>();
+          for (Service.ResultSetResponse result : response.results) {
+            metaResultSets.add(toResultSet(null, result));
+          }
+
+          return new ExecuteResult(metaResultSets);
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof NoSuchStatementException) {
+        throw (NoSuchStatementException) cause;
+      }
+      throw e;
     }
+  }
 
-    return new ExecuteResult(metaResultSets);
+  @Override public boolean syncResults(final StatementHandle h, final QueryState state,
+      final long offset) throws NoSuchStatementException {
+    try {
+      return connection.invokeWithRetries(new CallableWithoutException<Boolean>() {
+        public Boolean call() {
+          final Service.SyncResultsResponse response =
+              service.apply(new Service.SyncResultsRequest(h.connectionId, h.id, state, offset));
+          if (response.missingStatement) {
+            throw new RuntimeException(new NoSuchStatementException(h));
+          }
+          return response.moreResults;
+        }
+      });
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof NoSuchStatementException) {
+        throw (NoSuchStatementException) cause;
+      }
+      throw e;
+    }
   }
 }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Service.java
@@ -19,8 +19,10 @@ package org.apache.calcite.avatica.remote;
 import org.apache.calcite.avatica.AvaticaClientRuntimeException;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaSeverity;
+import org.apache.calcite.avatica.BuiltInConnectionProperty;
 import org.apache.calcite.avatica.ConnectionPropertiesImpl;
 import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.QueryState;
 import org.apache.calcite.avatica.proto.Common;
 import org.apache.calcite.avatica.proto.Requests;
 import org.apache.calcite.avatica.proto.Responses;
@@ -42,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Properties;
 
 /**
  * API for request-response calls to an Avatica server.
@@ -56,6 +59,7 @@ public interface Service {
   PrepareResponse apply(PrepareRequest request);
   ExecuteResponse apply(ExecuteRequest request);
   ExecuteResponse apply(PrepareAndExecuteRequest request);
+  SyncResultsResponse apply(SyncResultsRequest request);
   FetchResponse apply(FetchRequest request);
   CreateStatementResponse apply(CreateStatementRequest request);
   CloseStatementResponse apply(CloseStatementRequest request);
@@ -95,7 +99,8 @@ public interface Service {
       @JsonSubTypes.Type(value = CloseConnectionRequest.class,
           name = "closeConnection"),
       @JsonSubTypes.Type(value = ConnectionSyncRequest.class, name = "connectionSync"),
-      @JsonSubTypes.Type(value = DatabasePropertyRequest.class, name = "databaseProperties") })
+      @JsonSubTypes.Type(value = DatabasePropertyRequest.class, name = "databaseProperties"),
+      @JsonSubTypes.Type(value = SyncResultsRequest.class, name = "syncResults") })
   abstract class Request {
     abstract Response accept(Service service);
     abstract Request deserialize(Message genericMsg);
@@ -121,7 +126,8 @@ public interface Service {
       @JsonSubTypes.Type(value = ConnectionSyncResponse.class, name = "connectionSync"),
       @JsonSubTypes.Type(value = DatabasePropertyResponse.class, name = "databaseProperties"),
       @JsonSubTypes.Type(value = ExecuteResponse.class, name = "executeResults"),
-      @JsonSubTypes.Type(value = ErrorResponse.class, name = "error") })
+      @JsonSubTypes.Type(value = ErrorResponse.class, name = "error"),
+      @JsonSubTypes.Type(value = SyncResultsResponse.class, name = "syncResults") })
   abstract class Response {
     abstract Response deserialize(Message genericMsg);
     abstract Message serialize();
@@ -1242,15 +1248,17 @@ public interface Service {
    * {@link org.apache.calcite.avatica.remote.Service.PrepareAndExecuteRequest}. */
   class ExecuteResponse extends Response {
     public final List<ResultSetResponse> results;
+    public boolean missingStatement = false;
 
     ExecuteResponse() {
       results = null;
     }
 
     @JsonCreator
-    public ExecuteResponse(
-        @JsonProperty("resultSets") List<ResultSetResponse> results) {
+    public ExecuteResponse(@JsonProperty("resultSets") List<ResultSetResponse> results,
+        @JsonProperty("missingStatement") boolean missingStatement) {
       this.results = results;
+      this.missingStatement = missingStatement;
     }
 
     @Override ExecuteResponse deserialize(Message genericMsg) {
@@ -1268,7 +1276,7 @@ public interface Service {
         copiedResults.add(ResultSetResponse.fromProto(msgResult));
       }
 
-      return new ExecuteResponse(copiedResults);
+      return new ExecuteResponse(copiedResults, msg.getMissingStatement());
     }
 
     @Override Responses.ExecuteResponse serialize() {
@@ -1278,7 +1286,7 @@ public interface Service {
         builder.addResults(result.serialize());
       }
 
-      return builder.build();
+      return builder.setMissingStatement(missingStatement).build();
     }
 
     @Override public int hashCode() {
@@ -1581,14 +1589,20 @@ public interface Service {
    * {@link org.apache.calcite.avatica.remote.Service.FetchRequest}. */
   class FetchResponse extends Response {
     public final Meta.Frame frame;
+    public boolean missingStatement = false;
+    public boolean missingResults = false;
 
     FetchResponse() {
       frame = null;
     }
 
     @JsonCreator
-    public FetchResponse(@JsonProperty("frame") Meta.Frame frame) {
+    public FetchResponse(@JsonProperty("frame") Meta.Frame frame,
+        @JsonProperty("missingStatement") boolean missingStatement,
+        @JsonProperty("missingResults") boolean missingResults) {
       this.frame = frame;
+      this.missingStatement = missingStatement;
+      this.missingResults = missingResults;
     }
 
     @Override FetchResponse deserialize(Message genericMsg) {
@@ -1599,7 +1613,8 @@ public interface Service {
 
       Responses.FetchResponse msg = (Responses.FetchResponse) genericMsg;
 
-      return new FetchResponse(Meta.Frame.fromProto(msg.getFrame()));
+      return new FetchResponse(Meta.Frame.fromProto(msg.getFrame()), msg.getMissingStatement(),
+          msg.getMissingResults());
     }
 
     @Override Responses.FetchResponse serialize() {
@@ -1609,7 +1624,8 @@ public interface Service {
         builder.setFrame(frame.toProto());
       }
 
-      return builder.build();
+      return builder.setMissingStatement(missingStatement)
+          .setMissingResults(missingResults).build();
     }
 
     @Override public int hashCode() {
@@ -1634,7 +1650,7 @@ public interface Service {
           return false;
         }
 
-        return true;
+        return missingStatement == other.missingStatement;
       }
 
       return false;
@@ -1930,6 +1946,31 @@ public interface Service {
 
     @Override OpenConnectionResponse accept(Service service) {
       return service.apply(this);
+    }
+
+    /**
+     * Serializes the necessary properties into a Map.
+     *
+     * @param props The properties to serialize.
+     * @return A representation of the Properties as a Map.
+     */
+    public static Map<String, String> serializeProperties(Properties props) {
+      Map<String, String> infoAsString = new HashMap<>();
+      for (Map.Entry<Object, Object> entry : props.entrySet()) {
+        // Determine if this is a property we want to forward to the server
+        boolean localProperty = false;
+        for (BuiltInConnectionProperty prop : BuiltInConnectionProperty.values()) {
+          if (prop.camelName().equals(entry.getKey())) {
+            localProperty = true;
+            break;
+          }
+        }
+
+        if (!localProperty) {
+          infoAsString.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+      }
+      return infoAsString;
     }
 
     @Override Request deserialize(Message genericMsg) {
@@ -2452,6 +2493,8 @@ public interface Service {
    */
   public class ErrorResponse extends Response {
     public static final int UNKNOWN_ERROR_CODE = -1;
+    public static final int MISSING_CONNECTION_ERROR_CODE = 1;
+
     public static final String UNKNOWN_SQL_STATE = "00000";
 
     public final List<String> exceptions;
@@ -2588,6 +2631,178 @@ public interface Service {
     public AvaticaClientRuntimeException toException() {
       return new AvaticaClientRuntimeException("Remote driver error: " + errorMessage, errorCode,
           sqlState, severity, exceptions);
+    }
+  }
+
+  /**
+   * Request for {@link Service#apply(SyncResultsRequest)}
+   */
+  class SyncResultsRequest extends Request {
+    public final String connectionId;
+    public final int statementId;
+    public final QueryState state;
+    public final long offset;
+
+    SyncResultsRequest() {
+      this.connectionId = null;
+      this.statementId = 0;
+      this.state = null;
+      this.offset = 0L;
+    }
+
+    public SyncResultsRequest(@JsonProperty("connectionId") String connectionId,
+        @JsonProperty("statementId") int statementId, @JsonProperty("state") QueryState state,
+        @JsonProperty("offset") long offset) {
+      this.connectionId = connectionId;
+      this.statementId = statementId;
+      this.state = state;
+      this.offset = offset;
+    }
+
+    @Override
+    SyncResultsResponse accept(Service service) {
+      return service.apply(this);
+    }
+
+    @Override
+    Request deserialize(Message genericMsg) {
+      if (!(genericMsg instanceof Requests.SyncResultsRequest)) {
+        throw new IllegalArgumentException(
+            "Expected SyncResultsRequest, but got " + genericMsg.getClass().getName());
+      }
+
+      Requests.SyncResultsRequest msg = (Requests.SyncResultsRequest) genericMsg;
+
+      return new SyncResultsRequest(msg.getConnectionId(), msg.getStatementId(),
+          QueryState.fromProto(msg.getState()), msg.getOffset());
+    }
+
+    @Override
+    Requests.SyncResultsRequest serialize() {
+      Requests.SyncResultsRequest.Builder builder = Requests.SyncResultsRequest.newBuilder();
+
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
+
+      if (null != state) {
+        builder.setState(state.toProto());
+      }
+
+      builder.setStatementId(statementId);
+      builder.setOffset(offset);
+
+      return builder.build();
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((connectionId == null) ? 0 : connectionId.hashCode());
+      result = prime * result + (int) (offset ^ (offset >>> 32));
+      result = prime * result + ((state == null) ? 0 : state.hashCode());
+      result = prime * result + statementId;
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+
+      if (null == obj || !(obj instanceof SyncResultsRequest)) {
+        return false;
+      }
+
+      SyncResultsRequest other = (SyncResultsRequest) obj;
+
+      if (connectionId == null) {
+        if (other.connectionId != null) {
+          return false;
+        }
+      } else if (!connectionId.equals(other.connectionId)) {
+        return false;
+      }
+
+      if (offset != other.offset) {
+        return false;
+      }
+
+      if (state == null) {
+        if (other.state != null) {
+          return false;
+        }
+      } else if (!state.equals(other.state)) {
+        return false;
+      }
+
+      if (statementId != other.statementId) {
+        return false;
+      }
+
+      return true;
+    }
+  }
+
+  /**
+   * Response for {@link Service#apply(SyncResultsRequest)}
+   */
+  class SyncResultsResponse extends Response {
+    public boolean missingStatement = false;
+    public final boolean moreResults;
+
+    SyncResultsResponse() {
+      this.moreResults = false;
+    }
+
+    public SyncResultsResponse(@JsonProperty("moreResults") boolean moreResults,
+        @JsonProperty("missingStatement") boolean missingStatement) {
+      this.moreResults = moreResults;
+      this.missingStatement = missingStatement;
+    }
+
+    @Override
+    SyncResultsResponse deserialize(Message genericMsg) {
+      if (!(genericMsg instanceof Responses.SyncResultsResponse)) {
+        throw new IllegalArgumentException(
+            "Expected SyncResultsResponse, but got " + genericMsg.getClass().getName());
+      }
+
+      Responses.SyncResultsResponse msg = (Responses.SyncResultsResponse) genericMsg;
+
+      return new SyncResultsResponse(msg.getMoreResults(), msg.getMissingStatement());
+    }
+
+    @Override
+    Responses.SyncResultsResponse serialize() {
+      Responses.SyncResultsResponse.Builder builder = Responses.SyncResultsResponse.newBuilder();
+
+      return builder.setMoreResults(moreResults).setMissingStatement(missingStatement).build();
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + (missingStatement ? 1231 : 1237);
+      result = prime * result + (moreResults ? 1231 : 1237);
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || !(obj instanceof SyncResultsResponse)) {
+        return false;
+      }
+
+      SyncResultsResponse other = (SyncResultsResponse) obj;
+
+      return missingStatement == other.missingStatement && moreResults == other.moreResults;
     }
   }
 }

--- a/avatica/src/main/protobuf/common.proto
+++ b/avatica/src/main/protobuf/common.proto
@@ -206,3 +206,67 @@ enum Severity {
   ERROR_SEVERITY = 2;
   WARNING_SEVERITY = 3;
 }
+
+// Enumeration corresponding to DatabaseMetaData operations
+enum MetaDataOperation {
+  GET_ATTRIBUTES = 0;
+  GET_BEST_ROW_IDENTIFIER = 1;
+  GET_CATALOGS = 2;
+  GET_CLIENT_INFO_PROPERTIES = 3;
+  GET_COLUMN_PRIVILEGES = 4;
+  GET_COLUMNS = 5;
+  GET_CROSS_REFERENCE = 6;
+  GET_EXPORTED_KEYS = 7;
+  GET_FUNCTION_COLUMNS = 8;
+  GET_FUNCTIONS = 9;
+  GET_IMPORTED_KEYS = 10;
+  GET_INDEX_INFO = 11;
+  GET_PRIMARY_KEYS = 12;
+  GET_PROCEDURE_COLUMNS = 13;
+  GET_PROCEDURES = 14;
+  GET_PSEUDO_COLUMNS = 15;
+  GET_SCHEMAS = 16;
+  GET_SCHEMAS_WITH_ARGS = 17;
+  GET_SUPER_TABLES = 18;
+  GET_SUPER_TYPES = 19;
+  GET_TABLE_PRIVILEGES = 20;
+  GET_TABLES = 21;
+  GET_TABLE_TYPES = 22;
+  GET_TYPE_INFO = 23;
+  GET_UDTS = 24;
+  GET_VERSION_COLUMNS = 25;
+}
+
+// Represents the breadth of arguments to DatabaseMetaData functions
+message MetaDataOperationArgument {
+  enum ArgumentType {
+    STRING = 0;
+    BOOL = 1;
+    INT = 2;
+    REPEATED_STRING = 3;
+    REPEATED_INT = 4;
+    NULL = 5;
+  }
+    
+  string string_value = 1;
+  bool bool_value = 2;
+  sint32 int_value = 3;
+  repeated string string_array_values = 4;
+  repeated sint32 int_array_values = 5;
+  ArgumentType type = 6;
+}
+
+enum StateType {
+  SQL = 0;
+  METADATA = 1;
+}
+
+message QueryState {
+  StateType type = 1;
+  string sql = 2;
+  MetaDataOperation op = 3;
+  repeated MetaDataOperationArgument args = 4;
+  bool has_args = 5;
+  bool has_sql = 6;
+  bool has_op = 7;
+}

--- a/avatica/src/main/protobuf/requests.proto
+++ b/avatica/src/main/protobuf/requests.proto
@@ -127,3 +127,10 @@ message ExecuteRequest {
 }
 
 
+message SyncResultsRequest {
+  string connection_id = 1;
+  uint32 statement_id = 2;
+  QueryState state = 3;
+  uint64 offset = 4;
+}
+ 

--- a/avatica/src/main/protobuf/responses.proto
+++ b/avatica/src/main/protobuf/responses.proto
@@ -34,6 +34,7 @@ message ResultSetResponse {
 // Response to PrepareAndExecuteRequest
 message ExecuteResponse {
   repeated ResultSetResponse results = 1;
+  bool missing_statement = 2; // Did the request fail because of no-cached statement
 }
 
 // Response to PrepareRequest
@@ -44,6 +45,8 @@ message PrepareResponse {
 // Response to FetchRequest
 message FetchResponse {
   Frame frame = 1;
+  bool missing_statement = 2; // Did the request fail because of no-cached statement
+  bool missing_results = 3; // Did the request fail because of a cached-statement w/o ResultSet
 }
 
 // Response to CreateStatementRequest
@@ -89,4 +92,9 @@ message ErrorResponse {
   Severity severity = 3;
   uint32 error_code = 4; // numeric identifier for error
   string sql_state = 5; // five-character standard-defined value
+}
+
+message SyncResultsResponse {
+  bool missing_statement = 1; // Server doesn't have the statement with the ID from the request
+  bool more_results = 2; // Should the client fetch() to get more results
 }

--- a/avatica/src/test/java/org/apache/calcite/avatica/AvaticaConnectionTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/AvaticaConnectionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Properties;
+
+/**
+ * Tests for AvaticaConnection
+ */
+public class AvaticaConnectionTest {
+
+  @Test
+  public void testNumExecuteRetries() {
+    AvaticaConnection statement = Mockito.mock(AvaticaConnection.class);
+
+    Mockito.when(statement.getNumStatementRetries(Mockito.any(Properties.class)))
+      .thenCallRealMethod();
+
+    // Bad argument should throw an exception
+    try {
+      statement.getNumStatementRetries(null);
+      Assert.fail("Calling getNumStatementRetries with a null object should throw an exception");
+    } catch (NullPointerException e) {
+      // Pass
+    }
+
+    Properties props = new Properties();
+
+    // Verify the default value
+    Assert.assertEquals(Long.valueOf(AvaticaConnection.NUM_EXECUTE_RETRIES_DEFAULT).longValue(),
+        statement.getNumStatementRetries(props));
+
+    // Set a non-default value
+    props.setProperty(AvaticaConnection.NUM_EXECUTE_RETRIES_KEY, "10");
+
+    // Verify that we observe that value
+    Assert.assertEquals(10, statement.getNumStatementRetries(props));
+  }
+
+}
+
+// End AvaticaStatementTest.java

--- a/avatica/src/test/java/org/apache/calcite/avatica/QueryStateTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/QueryStateTest.java
@@ -1,0 +1,510 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.apache.calcite.avatica.remote.MetaDataOperation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that {@link QueryState} properly retains the necessary state to recreate
+ * a {@link ResultSet}.
+ */
+public class QueryStateTest {
+
+  private Connection conn;
+  private DatabaseMetaData metadata;
+  private Statement statement;
+
+
+  @Before
+  public void setup() throws Exception {
+    conn = Mockito.mock(Connection.class);
+    metadata = Mockito.mock(DatabaseMetaData.class);
+    statement = Mockito.mock(Statement.class);
+
+    Mockito.when(conn.getMetaData()).thenReturn(metadata);
+  }
+
+  @Test
+  public void testMetadataGetAttributes() throws Exception {
+    final String catalog = "catalog";
+    final String schemaPattern = null;
+    final String typeNamePattern = "%";
+    final String attributeNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_ATTRIBUTES, catalog, schemaPattern,
+        typeNamePattern, attributeNamePattern);
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getAttributes(catalog, schemaPattern, typeNamePattern,
+        attributeNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetBestRowIdentifier() throws Exception {
+    final String catalog = "catalog";
+    final String schema = null;
+    final String table = "table";
+    final int scope = 1;
+    final boolean nullable = true;
+
+    QueryState state = new QueryState(MetaDataOperation.GET_BEST_ROW_IDENTIFIER, new Object[] {
+      catalog,
+      schema,
+      table,
+      scope,
+      nullable
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getBestRowIdentifier(catalog, schema, table, scope, nullable);
+  }
+
+  @Test
+  public void testMetadataGetCatalogs() throws Exception {
+    QueryState state = new QueryState(MetaDataOperation.GET_CATALOGS, new Object[0]);
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getCatalogs();
+  }
+
+  @Test
+  public void testMetadataGetColumnPrivileges() throws Exception {
+    final String catalog = null;
+    final String schema = "schema";
+    final String table = "table";
+    final String columnNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_COLUMN_PRIVILEGES, new Object[] {
+      catalog,
+      schema,
+      table,
+      columnNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getColumnPrivileges(catalog, schema, table, columnNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetColumns() throws Exception {
+    final String catalog = null;
+    final String schemaPattern = "%";
+    final String tableNamePattern = "%";
+    final String columnNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_COLUMNS, new Object[] {
+      catalog,
+      schemaPattern,
+      tableNamePattern,
+      columnNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getColumns(catalog, schemaPattern, tableNamePattern,
+        columnNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetCrossReference() throws Exception {
+    final String parentCatalog = null;
+    final String parentSchema = null;
+    final String parentTable = "%";
+    final String foreignCatalog = null;
+    final String foreignSchema = null;
+    final String foreignTable = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_CROSS_REFERENCE, new Object[] {
+      parentCatalog,
+      parentSchema,
+      parentTable,
+      foreignCatalog,
+      foreignSchema,
+      foreignTable
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getCrossReference(parentCatalog, parentSchema, parentTable,
+        foreignCatalog, foreignSchema, foreignTable);
+  }
+
+  @Test
+  public void testMetadataGetExportedKeys() throws Exception {
+    final String catalog = "";
+    final String schema = null;
+    final String table = "mytable";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_EXPORTED_KEYS, new Object[] {
+      catalog,
+      schema,
+      table
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getExportedKeys(catalog, schema, table);
+  }
+
+  @Test
+  public void testMetadataGetFunctionColumns() throws Exception {
+    final String catalog = null;
+    final String schemaPattern = "%";
+    final String functionNamePattern = "%";
+    final String columnNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_FUNCTION_COLUMNS, new Object[] {
+      catalog,
+      schemaPattern,
+      functionNamePattern,
+      columnNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getFunctionColumns(catalog, schemaPattern, functionNamePattern,
+        columnNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetFunctions() throws Exception {
+    final String catalog = null;
+    final String schemaPattern = "%";
+    final String functionNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_FUNCTIONS, new Object[] {
+      catalog,
+      schemaPattern,
+      functionNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getFunctions(catalog, schemaPattern, functionNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetImportedKeys() throws Exception {
+    final String catalog = "";
+    final String schema = null;
+    final String table = "my_table";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_IMPORTED_KEYS, new Object[] {
+      catalog,
+      schema,
+      table
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getImportedKeys(catalog, schema, table);
+  }
+
+  @Test
+  public void testMetadataGetIndexInfo() throws Exception {
+    final String catalog = "";
+    final String schema = null;
+    final String table = "my_table";
+    final boolean unique = true;
+    final boolean approximate = true;
+
+    QueryState state = new QueryState(MetaDataOperation.GET_INDEX_INFO, new Object[] {
+      catalog,
+      schema,
+      table,
+      unique,
+      approximate
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getIndexInfo(catalog, schema, table, unique, approximate);
+  }
+
+  @Test
+  public void testMetadataGetPrimaryKeys() throws Exception {
+    final String catalog = "";
+    final String schema = null;
+    final String table = "my_table";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_PRIMARY_KEYS, new Object[] {
+      catalog,
+      schema,
+      table
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getPrimaryKeys(catalog, schema, table);
+  }
+
+  @Test
+  public void testMetadataGetProcedureColumns() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String procedureNamePattern = "%";
+    final String columnNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_PROCEDURE_COLUMNS, new Object[] {
+      catalog,
+      schemaPattern,
+      procedureNamePattern,
+      columnNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getProcedureColumns(catalog, schemaPattern, procedureNamePattern,
+        columnNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetProcedures() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String procedureNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_PROCEDURES, new Object[] {
+      catalog,
+      schemaPattern,
+      procedureNamePattern,
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getProcedures(catalog, schemaPattern, procedureNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetPseudoColumns() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String tableNamePattern = "%";
+    final String columnNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_PSEUDO_COLUMNS, new Object[] {
+      catalog,
+      schemaPattern,
+      tableNamePattern,
+      columnNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getPseudoColumns(catalog, schemaPattern, tableNamePattern,
+        columnNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetSchemas() throws Exception {
+    QueryState state = new QueryState(MetaDataOperation.GET_SCHEMAS, new Object[0]);
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getSchemas();
+  }
+
+  @Test
+  public void testMetadataGetSchemasWithArgs() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+
+    QueryState state = new QueryState(MetaDataOperation.GET_SCHEMAS_WITH_ARGS, new Object[] {
+      catalog,
+      schemaPattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getSchemas(catalog, schemaPattern);
+  }
+
+  @Test
+  public void testMetadataGetSuperTables() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String tableNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_SUPER_TABLES, new Object[] {
+      catalog,
+      schemaPattern,
+      tableNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getSuperTables(catalog, schemaPattern, tableNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetSuperTypes() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String tableNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_SUPER_TYPES, new Object[] {
+      catalog,
+      schemaPattern,
+      tableNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getSuperTypes(catalog, schemaPattern, tableNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetTablePrivileges() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String tableNamePattern = "%";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_TABLE_PRIVILEGES, new Object[] {
+      catalog,
+      schemaPattern,
+      tableNamePattern
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getTablePrivileges(catalog, schemaPattern, tableNamePattern);
+  }
+
+  @Test
+  public void testMetadataGetTables() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String tableNamePattern = "%";
+    final String[] types = new String[] {"VIEW", "TABLE"};
+
+    QueryState state = new QueryState(MetaDataOperation.GET_TABLES, new Object[] {
+      catalog,
+      schemaPattern,
+      tableNamePattern,
+      types
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getTables(catalog, schemaPattern, tableNamePattern, types);
+  }
+
+  @Test
+  public void testMetadataGetTableTypes() throws Exception {
+    QueryState state = new QueryState(MetaDataOperation.GET_TABLE_TYPES, new Object[0]);
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getTableTypes();
+  }
+
+  @Test
+  public void testMetadataGetTypeInfo() throws Exception {
+    QueryState state = new QueryState(MetaDataOperation.GET_TYPE_INFO, new Object[0]);
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getTypeInfo();
+  }
+
+  @Test
+  public void testMetadataGetUDTs() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String typeNamePattern = "%";
+    final int[] types = new int[] {1, 2};
+
+    QueryState state = new QueryState(MetaDataOperation.GET_UDTS, new Object[] {
+      catalog,
+      schemaPattern,
+      typeNamePattern,
+      types
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getUDTs(catalog, schemaPattern, typeNamePattern, types);
+  }
+
+  @Test
+  public void testMetadataGetVersionColumns() throws Exception {
+    final String catalog = "";
+    final String schemaPattern = null;
+    final String table = "my_table";
+
+    QueryState state = new QueryState(MetaDataOperation.GET_VERSION_COLUMNS, new Object[] {
+      catalog,
+      schemaPattern,
+      table
+    });
+
+    state.invoke(conn, statement);
+
+    Mockito.verify(metadata).getVersionColumns(catalog, schemaPattern, table);
+  }
+
+  @Test
+  public void testSerialization() throws Exception {
+    final String catalog = "catalog";
+    final String schema = null;
+    final String table = "table";
+    final int scope = 1;
+    final boolean nullable = true;
+
+    QueryState state = new QueryState(MetaDataOperation.GET_BEST_ROW_IDENTIFIER, new Object[] {
+      catalog,
+      schema,
+      table,
+      scope,
+      nullable
+    });
+
+    assertEquals(state, QueryState.fromProto(state.toProto()));
+
+    final String schemaPattern = null;
+    final String typeNamePattern = "%";
+    final int[] types = new int[] {1, 2};
+
+    state = new QueryState(MetaDataOperation.GET_UDTS, new Object[] {
+      catalog,
+      schemaPattern,
+      typeNamePattern,
+      types
+    });
+
+    assertEquals(state, QueryState.fromProto(state.toProto()));
+
+    state = new QueryState("SELECT * FROM foo");
+
+    assertEquals(state, QueryState.fromProto(state.toProto()));
+  }
+
+}

--- a/avatica/src/test/java/org/apache/calcite/avatica/QueryStateTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/QueryStateTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
 import java.sql.Statement;
 
 import static org.junit.Assert.assertEquals;

--- a/avatica/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests for the HTTP transport.
+ */
+public class AvaticaHttpClientTest {
+  private static final String REQUEST =
+      "{\"request\":\"createStatement\",\"connectionId\":\"8f3f28ee-d0bb-4cdb-a4b1-8f6e8476c534\"}";
+  private static final String RESPONSE =
+      "{\"response\":\"createStatement\",\"connectionId\":"
+          + "\"8f3f28ee-d0bb-4cdb-a4b1-8f6e8476c534\",\"statementId\":1608176856}";
+
+  @Test
+  public void testRetryOnUnavailable() throws Exception {
+    // HTTP-503, try again
+    URL url = new URL("http://127.0.0.1:8765");
+    final HttpURLConnection cnxn = Mockito.mock(HttpURLConnection.class);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ByteArrayInputStream bais = new ByteArrayInputStream(RESPONSE.getBytes(StandardCharsets.UTF_8));
+
+    // Create the HTTP client
+    AvaticaHttpClientImpl client = new AvaticaHttpClientImpl(url) {
+      @Override HttpURLConnection openConnection() throws IOException {
+        return cnxn;
+      }
+    };
+
+    // HTTP 503 then 200
+    Mockito.when(cnxn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_UNAVAILABLE,
+        HttpURLConnection.HTTP_OK);
+
+    Mockito.when(cnxn.getOutputStream()).thenReturn(baos);
+    Mockito.when(cnxn.getInputStream()).thenReturn(bais);
+
+    byte[] response = client.send(REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    assertArrayEquals(RESPONSE.getBytes(StandardCharsets.UTF_8), response);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testServerError() throws Exception {
+    // HTTP 500 should error out
+    URL url = new URL("http://127.0.0.1:8765");
+    final HttpURLConnection cnxn = Mockito.mock(HttpURLConnection.class);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    // Create the HTTP client
+    AvaticaHttpClientImpl client = new AvaticaHttpClientImpl(url) {
+      @Override HttpURLConnection openConnection() throws IOException {
+        return cnxn;
+      }
+    };
+
+    // HTTP 500
+    Mockito.when(cnxn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_INTERNAL_ERROR);
+
+    Mockito.when(cnxn.getOutputStream()).thenReturn(baos);
+
+    // Should throw an RTE
+    client.send(REQUEST.getBytes(StandardCharsets.UTF_8));
+  }
+
+}

--- a/avatica/src/test/java/org/apache/calcite/avatica/remote/MetaDataOperationTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/remote/MetaDataOperationTest.java
@@ -16,24 +16,20 @@
  */
 package org.apache.calcite.avatica.remote;
 
-import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
- * Implementation of {@link org.apache.calcite.avatica.remote.Service}
- * that translates requests into JSON and sends them to a remote server,
- * usually an HTTP server.
+ * Tests for {@link MetaDataOperation}
  */
-public class RemoteService extends JsonService {
-  private final AvaticaHttpClient client;
+public class MetaDataOperationTest {
 
-  public RemoteService(AvaticaHttpClient client) {
-    this.client = client;
+  @Test
+  public void testProtobufSerialization() {
+    for (MetaDataOperation metadataOp : MetaDataOperation.values()) {
+      assertEquals(metadataOp, MetaDataOperation.fromProto(metadataOp.toProto()));
+    }
   }
 
-  @Override public String apply(String request) {
-    byte[] response = client.send(request.getBytes(StandardCharsets.UTF_8));
-    return new String(response, StandardCharsets.UTF_8);
-  }
 }
-
-// End RemoteService.java

--- a/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufHandlerTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/remote/ProtobufHandlerTest.java
@@ -84,7 +84,7 @@ public class ProtobufHandlerTest {
     frameRows.add(new Object[] {true, "my_string"});
 
     Meta.Frame frame = Frame.create(0, true, frameRows);
-    FetchResponse response = new FetchResponse(frame);
+    FetchResponse response = new FetchResponse(frame, false, false);
 
     when(translation.parseRequest(serializedRequest)).thenReturn(request);
     when(service.apply(request)).thenReturn(response);

--- a/avatica/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
+++ b/avatica/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
@@ -111,6 +111,10 @@ public class JsonHandlerTest {
       return null;
     }
 
+    @Override public SyncResultsResponse apply(SyncResultsRequest request) {
+      return null;
+    }
+
     @Override public ExecuteResponse apply(ExecuteRequest request) {
       return null;
     }
@@ -145,7 +149,7 @@ public class JsonHandlerTest {
               RANDOM.nextInt(), false, signature, Meta.Frame.EMPTY, -1L);
 
       return new Service.ExecuteResponse(
-          Collections.singletonList(resultSetResponse));
+          Collections.singletonList(resultSetResponse), false);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteJdbc41Factory.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteJdbc41Factory.java
@@ -24,6 +24,7 @@ import org.apache.calcite.avatica.AvaticaPreparedStatement;
 import org.apache.calcite.avatica.AvaticaResultSetMetaData;
 import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.QueryState;
 import org.apache.calcite.avatica.UnregisteredDriver;
 
 import java.io.InputStream;
@@ -90,7 +91,7 @@ public class CalciteJdbc41Factory extends CalciteFactory {
         resultSetConcurrency, resultSetHoldability);
   }
 
-  public CalciteResultSet newResultSet(AvaticaStatement statement,
+  public CalciteResultSet newResultSet(AvaticaStatement statement, QueryState state,
       Meta.Signature signature, TimeZone timeZone, Meta.Frame firstFrame) {
     final ResultSetMetaData metaData =
         newResultSetMetaData(statement, signature);

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -25,6 +25,8 @@ import org.apache.calcite.avatica.AvaticaUtils;
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.MetaImpl;
+import org.apache.calcite.avatica.NoSuchStatementException;
+import org.apache.calcite.avatica.QueryState;
 import org.apache.calcite.avatica.remote.TypedValue;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Enumerator;
@@ -528,7 +530,13 @@ public class CalciteMetaImpl extends MetaImpl {
         "TABLE_TYPE");
   }
 
-  @Override public Iterable<Object> createIterable(StatementHandle handle,
+  @Override public Iterable<Object> createIterable(StatementHandle handle, QueryState state,
+      Signature signature, List<TypedValue> parameterValues, Frame firstFrame) {
+    // Drop QueryState
+    return _createIterable(handle, signature, parameterValues, firstFrame);
+  }
+
+  Iterable<Object> _createIterable(StatementHandle handle,
       Signature signature, List<TypedValue> parameterValues, Frame firstFrame) {
     try {
       //noinspection unchecked
@@ -584,7 +592,7 @@ public class CalciteMetaImpl extends MetaImpl {
     final Iterator<Object> iterator;
     if (stmt.getResultSet() == null) {
       final Iterable<Object> iterable =
-          createIterable(h, signature, null, null);
+          _createIterable(h, signature, null, null);
       iterator = iterable.iterator();
       stmt.setResultSet(iterator);
     } else {
@@ -606,7 +614,7 @@ public class CalciteMetaImpl extends MetaImpl {
     final Iterator<Object> iterator;
 
     final Iterable<Object> iterable =
-        createIterable(h, signature, parameterValues, null);
+        _createIterable(h, signature, parameterValues, null);
     iterator = iterable.iterator();
     stmt.setResultSet(iterator);
 
@@ -732,6 +740,13 @@ public class CalciteMetaImpl extends MetaImpl {
     public void remove() {
       throw new UnsupportedOperationException();
     }
+  }
+
+  @Override
+  public boolean syncResults(StatementHandle h, QueryState state, long offset)
+      throws NoSuchStatementException {
+    // Doesn't have application in Calcite itself.
+    throw new UnsupportedOperationException();
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteResultSet.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteResultSet.java
@@ -46,7 +46,7 @@ public class CalciteResultSet extends AvaticaResultSet {
       CalcitePrepare.CalciteSignature calciteSignature,
       ResultSetMetaData resultSetMetaData, TimeZone timeZone,
       Meta.Frame firstFrame) {
-    super(statement, calciteSignature, resultSetMetaData, timeZone, firstFrame);
+    super(statement, null, calciteSignature, resultSetMetaData, timeZone, firstFrame);
   }
 
   @Override protected CalciteResultSet execute() throws SQLException {

--- a/src/main/config/checkstyle/checker.xml
+++ b/src/main/config/checkstyle/checker.xml
@@ -90,10 +90,6 @@ limitations under the License.
     </module>
       <!-- Switch statements should be complete and with independent cases -->
     <module name="FallThrough"/>
-    <!-- For hadoop_yarn profile, some YARN exceptions aren't loading in checkstyle -->
-    <module name="RedundantThrows">
-        <property name="suppressLoadErrors" value="true" />
-    </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
       <!-- Only one statement per line allowed -->


### PR DESCRIPTION
Prelim patch for CALCITE-903. Change the client to retry when 1) statements are not cached and 2) the backing ResultSet for a cached-statement is missing.

Desperately needs unit tests and doc updates for recommended deploys using generic load-balancers (e.g. haproxy).