### PR TITLE
[CALCITE-936] Make HttpServer to be configurable

### DIFF
--- a/avatica-server/src/main/java/org/apache/calcite/avatica/server/HttpServer.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/server/HttpServer.java
@@ -37,6 +37,10 @@ public class HttpServer {
   private int port = -1;
   private final Handler handler;
 
+  public HttpServer(Handler handler) {
+    this(0, handler);
+  }
+
   public HttpServer(int port, Handler handler) {
     this.port = port;
     this.handler = handler;

--- a/avatica-server/src/main/java/org/apache/calcite/avatica/server/HttpServer.java
+++ b/avatica-server/src/main/java/org/apache/calcite/avatica/server/HttpServer.java
@@ -52,10 +52,8 @@ public class HttpServer {
     server = new Server(threadPool);
     server.manage(threadPool);
 
-    final ServerConnector connector = new ServerConnector(server);
-    connector.setIdleTimeout(60 * 1000);
-    connector.setSoLingerTime(-1);
-    connector.setPort(port);
+    final ServerConnector connector = configureConnector(new ServerConnector(server), port);
+
     server.setConnectors(new Connector[] { connector });
 
     final HandlerList handlerList = new HandlerList();
@@ -69,6 +67,19 @@ public class HttpServer {
     port = connector.getLocalPort();
 
     LOG.info("Service listening on port " + getPort() + ".");
+  }
+
+  /**
+   * Configure server connector if needed.
+   *
+   * @param connector connector to be configured
+   * @param port port number handed over in constructor
+   */
+  protected ServerConnector configureConnector(ServerConnector connector, int port) {
+    connector.setIdleTimeout(60 * 1000);
+    connector.setSoLingerTime(-1);
+    connector.setPort(port);
+    return connector;
   }
 
   public void stop() {

--- a/site/_docs/avatica_overview.md
+++ b/site/_docs/avatica_overview.md
@@ -39,6 +39,22 @@ objects to/from JSON.
 
 Avatica-Server is a Java implementation of Avatica RPC.
 It embeds the Jetty HTTP server.
+Connector in HTTP server can be configured if needed by extending
+org.apache.calcite.avatica.server.HttpServer class and overriding configureConnector() method.
+For example, user can set "requestHeaderSize" by,
+
+{% highlight java %}
+HttpServer server = new HttpServer(handler) {
+  @Override
+  protected ServerConnector configureConnector(ServerConnector connector, int port) {
+    HttpConnectionFactory factory =
+        (HttpConnectionFactory)connector.getDefaultConnectionFactory();
+    factory.getHttpConfiguration().setRequestHeaderSize(64 << 10);
+    return super.configureConnector(connector, port);
+  }
+};
+server.start();
+{% endhighlight %}
 
 Core concepts:
 


### PR DESCRIPTION
We met a case to increase "requestHeaderSize" but currently it's not possible.