### PR TITLE
Append schema to SQL

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -16,10 +16,6 @@
  */
 package org.apache.calcite.adapter.jdbc;
 
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.java.AbstractQueryableTable;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
@@ -49,6 +45,10 @@ import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.util.SqlString;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -150,6 +150,7 @@ class JdbcTable extends AbstractQueryableTable
     else if(jdbcSchemaName != null){
       strings.add(jdbcSchemaName);
     }
+
     strings.add(jdbcTableName);
     return new SqlIdentifier(strings, SqlParserPos.ZERO);
   }

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -16,6 +16,10 @@
  */
 package org.apache.calcite.adapter.jdbc;
 
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.java.AbstractQueryableTable;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
@@ -45,10 +49,6 @@ import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.util.SqlString;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
-
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -146,6 +146,9 @@ class JdbcTable extends AbstractQueryableTable
     }
     if (jdbcSchema.schema != null) {
       strings.add(jdbcSchema.schema);
+    }
+    else if(jdbcSchemaName != null){
+      strings.add(jdbcSchemaName);
     }
     strings.add(jdbcTableName);
     return new SqlIdentifier(strings, SqlParserPos.ZERO);


### PR DESCRIPTION
In some testing we've been doing with Drill, the drill fork of calcite isn't appending the database schema to the SQL which results in mydb.table, not mydb.myschema.table and queries fail. I've sent them a PR and don't see a fix here either, so here is the same fix.