### PR TITLE
CALCITE-958: fix for table function overloading failing when using named parameters

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlCallBinding.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCallBinding.java
@@ -121,7 +121,7 @@ public class SqlCallBinding extends SqlOperatorBinding {
   /** Returns the operands to a call permuted into the same order as the
    * formal parameters of the function. */
   public List<SqlNode> operands() {
-    if (hasAssignment()) {
+    if (hasAssignment() && !(call.getOperator() instanceof SqlUnresolvedFunction)) {
       return permutedOperands(call);
     } else {
       final List<SqlNode> operandList = call.getOperandList();

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -525,6 +525,8 @@ public class JdbcTest {
         connection.unwrap(CalciteConnection.class);
     SchemaPlus rootSchema = calciteConnection.getRootSchema();
     SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
+    final TableFunction table1 = TableFunctionImpl.create(MAZE_METHOD);
+    schema.add("Maze", table1);
     final TableFunction table2 = TableFunctionImpl.create(MAZE2_METHOD);
     schema.add("Maze", table2);
     final TableFunction table3 = TableFunctionImpl.create(MAZE3_METHOD);
@@ -534,17 +536,22 @@ public class JdbcTest {
     ResultSet resultSet = connection.createStatement().executeQuery(sql);
     final String result = "S=abcde\n"
         + "S=xyz\n";
-    assertThat(CalciteAssert.toString(resultSet), equalTo(result));
+    assertThat(CalciteAssert.toString(resultSet), equalTo(result + "S=generate(w=5, h=3, s=1)\n"));
 
     final String sql2 = "select *\n"
         + "from table(\"s\".\"Maze\"(WIDTH => 5, HEIGHT => 3, SEED => 1))";
     resultSet = connection.createStatement().executeQuery(sql2);
-    assertThat(CalciteAssert.toString(resultSet), equalTo(result));
+    assertThat(CalciteAssert.toString(resultSet), equalTo(result + "S=generate2(w=5, h=3, s=1)\n"));
 
     final String sql3 = "select *\n"
         + "from table(\"s\".\"Maze\"(HEIGHT => 3, WIDTH => 5))";
     resultSet = connection.createStatement().executeQuery(sql3);
-    assertThat(CalciteAssert.toString(resultSet), equalTo(result));
+    assertThat(CalciteAssert.toString(resultSet), equalTo(result + "S=generate2(w=5, h=3, s=null)\n"));
+
+    final String sql4 = "select *\n"
+        + "from table(\"s\".\"Maze\"(FOO => 'a'))";
+    resultSet = connection.createStatement().executeQuery(sql4);
+    assertThat(CalciteAssert.toString(resultSet), equalTo(result + "S=generate3(foo=a)\n"));
   }
 
   /**
@@ -7393,20 +7400,26 @@ public class JdbcTest {
   public static class MazeTable extends AbstractTable
       implements ScannableTable {
 
+    private final String content;
+
+    public MazeTable(String content) {
+      this.content = content;
+    }
+
     public static ScannableTable generate(int width, int height, int seed) {
-      return new MazeTable();
+      return new MazeTable(String.format("generate(w=%d, h=%d, s=%d)", width, height, seed));
     }
 
     public static ScannableTable generate2(
         @Parameter(name = "WIDTH") int width,
         @Parameter(name = "HEIGHT") int height,
         @Parameter(name = "SEED", optional = true) Integer seed) {
-      return new MazeTable();
+      return new MazeTable(String.format("generate2(w=%d, h=%d, s=%d)", width, height, seed));
     }
 
     public static ScannableTable generate3(
         @Parameter(name = "FOO") String foo) {
-      return new MazeTable();
+      return new MazeTable(String.format("generate3(foo=%s)", foo));
     }
 
     public RelDataType getRowType(RelDataTypeFactory typeFactory) {
@@ -7416,7 +7429,7 @@ public class JdbcTest {
     }
 
     public Enumerable<Object[]> scan(DataContext root) {
-      Object[][] rows = {{"abcde"}, {"xyz"}};
+      Object[][] rows = {{"abcde"}, {"xyz"}, {content}};
       return Linq4j.asEnumerable(rows);
     }
   }


### PR DESCRIPTION
We get a NullPointerException when more than one function with the same name is returned.
There is a different code path when only one function is returned.
```
java.sql.SQLException: Error while executing SQL "select *
from table("s"."Maze"(WIDTH => 5, HEIGHT => 3, SEED => 1))": null
	at org.apache.calcite.avatica.Helper.createException(Helper.java:52)
	at org.apache.calcite.avatica.Helper.createException(Helper.java:41)
	at org.apache.calcite.avatica.AvaticaStatement.executeInternal(AvaticaStatement.java:143)
	at org.apache.calcite.avatica.AvaticaStatement.executeQuery(AvaticaStatement.java:186)
	at org.apache.calcite.test.JdbcTest.testMultipleScannableTableFunctionWithNamedParameters(JdbcTest.java:541)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
Caused by: java.lang.NullPointerException
	at org.apache.calcite.sql.SqlFunction.getParamNames(SqlFunction.java:171)
	at org.apache.calcite.sql.SqlCallBinding.permutedOperands(SqlCallBinding.java:158)
	at org.apache.calcite.sql.SqlCallBinding.operands(SqlCallBinding.java:125)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.inferUnknownTypes(SqlValidatorImpl.java:1630)
	at org.apache.calcite.sql.validate.ProcedureNamespace.validateImpl(ProcedureNamespace.java:52)
	at org.apache.calcite.sql.validate.AbstractNamespace.validate(AbstractNamespace.java:86)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateNamespace(SqlValidatorImpl.java:842)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateQuery(SqlValidatorImpl.java:828)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateFrom(SqlValidatorImpl.java:2743)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateFrom(SqlValidatorImpl.java:2728)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateSelect(SqlValidatorImpl.java:2946)
	at org.apache.calcite.sql.validate.SelectNamespace.validateImpl(SelectNamespace.java:60)
	at org.apache.calcite.sql.validate.AbstractNamespace.validate(AbstractNamespace.java:86)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateNamespace(SqlValidatorImpl.java:842)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateQuery(SqlValidatorImpl.java:828)
	at org.apache.calcite.sql.SqlSelect.validate(SqlSelect.java:207)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateScopedExpression(SqlValidatorImpl.java:802)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validate(SqlValidatorImpl.java:516)
	at org.apache.calcite.sql2rel.SqlToRelConverter.convertQuery(SqlToRelConverter.java:569)
	at org.apache.calcite.prepare.Prepare.prepareSql(Prepare.java:224)
	at org.apache.calcite.prepare.Prepare.prepareSql(Prepare.java:190)
	at org.apache.calcite.prepare.CalcitePrepareImpl.prepare2_(CalcitePrepareImpl.java:727)
	at org.apache.calcite.prepare.CalcitePrepareImpl.prepare_(CalcitePrepareImpl.java:587)
	at org.apache.calcite.prepare.CalcitePrepareImpl.prepareSql(CalcitePrepareImpl.java:557)
	at org.apache.calcite.jdbc.CalciteConnectionImpl.parseQuery(CalciteConnectionImpl.java:212)
	at org.apache.calcite.jdbc.CalciteMetaImpl.prepareAndExecute(CalciteMetaImpl.java:573)
	at org.apache.calcite.avatica.AvaticaConnection.prepareAndExecuteInternal(AvaticaConnection.java:571)
	at org.apache.calcite.avatica.AvaticaStatement.executeInternal(AvaticaStatement.java:135)
	... 25 more
```