### PR TITLE
[CALCITE-991] Create separate FunctionCategories for table functions and macros

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1928,13 +1928,13 @@ void ColumnType(List<SqlNode> list) :
 SqlNode TableFunctionCall(SqlParserPos pos) :
 {
     SqlNode call;
-    SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+    SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION;
 }
 {
     [
         <SPECIFIC>
         {
-            funcType = SqlFunctionCategory.USER_DEFINED_SPECIFIC_FUNCTION;
+            funcType = SqlFunctionCategory.USER_DEFINED_TABLE_SPECIFIC_FUNCTION;
         }
     ]
     {

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -60,6 +60,7 @@ import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -233,6 +234,18 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
       return;
     }
     final Collection<Function> functions = getFunctionsFrom(opName.names);
+    for (Iterator<Function> iterator = functions.iterator(); iterator.hasNext();) {
+      Function function = iterator.next();
+      if (function instanceof TableMacro || function instanceof TableFunction) {
+        if (category == null || !category.isTableFunction()) {
+          iterator.remove();
+        }
+      } else {
+        if (category != null && category.isTableFunction()) {
+          iterator.remove();
+        }
+      }
+    }
     if (functions.isEmpty()) {
       return;
     }

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -339,11 +339,7 @@ public class RelJson {
           map.put("type", toJson(node.getType()));
         }
         if (call.getOperator() instanceof SqlFunction) {
-          switch (((SqlFunction) call.getOperator()).getFunctionType()) {
-          case USER_DEFINED_CONSTRUCTOR:
-          case USER_DEFINED_FUNCTION:
-          case USER_DEFINED_PROCEDURE:
-          case USER_DEFINED_SPECIFIC_FUNCTION:
+          if (((SqlFunction) call.getOperator()).getFunctionType().isUserdefined()) {
             map.put("class", call.getOperator().getClass().getName());
           }
         }

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -339,7 +339,7 @@ public class RelJson {
           map.put("type", toJson(node.getType()));
         }
         if (call.getOperator() instanceof SqlFunction) {
-          if (((SqlFunction) call.getOperator()).getFunctionType().isUserdefined()) {
+          if (((SqlFunction) call.getOperator()).getFunctionType().isUserDefined()) {
             map.put("class", call.getOperator().getClass().getName());
           }
         }

--- a/core/src/main/java/org/apache/calcite/sql/SqlFunctionCategory.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunctionCategory.java
@@ -31,12 +31,53 @@ public enum SqlFunctionCategory {
   USER_DEFINED_PROCEDURE("UDP", "User-defined procedure"),
   USER_DEFINED_CONSTRUCTOR("UDC", "User-defined constructor"),
   USER_DEFINED_SPECIFIC_FUNCTION("UDF_SPECIFIC",
-      "User-defined function with SPECIFIC name");
+      "User-defined function with SPECIFIC name"),
+  USER_DEFINED_TABLE_FUNCTION("TABLE_UDF", "User-defined table function"),
+  USER_DEFINED_TABLE_SPECIFIC_FUNCTION("TABLE_UDF_SPECIFIC",
+      "User-defined table function with SPECIFIC name");
 
   SqlFunctionCategory(String abbrev, String description) {
     Util.discard(abbrev);
     Util.discard(description);
   }
+
+  public final boolean isUserdefined() {
+    return isOneOf(
+        USER_DEFINED_FUNCTION,
+        USER_DEFINED_PROCEDURE,
+        USER_DEFINED_CONSTRUCTOR,
+        USER_DEFINED_SPECIFIC_FUNCTION,
+        USER_DEFINED_TABLE_FUNCTION,
+        USER_DEFINED_TABLE_SPECIFIC_FUNCTION);
+  }
+
+  public final boolean isTableFunction() {
+    return isOneOf(
+        USER_DEFINED_TABLE_FUNCTION,
+        USER_DEFINED_TABLE_SPECIFIC_FUNCTION);
+  }
+
+  public final boolean isSpecific() {
+    return isOneOf(
+        USER_DEFINED_SPECIFIC_FUNCTION,
+        USER_DEFINED_TABLE_SPECIFIC_FUNCTION);
+  }
+
+  public final boolean isUnresolvedUserDefinedFunction() {
+    return isOneOf(
+        USER_DEFINED_FUNCTION,
+        USER_DEFINED_TABLE_FUNCTION);
+  }
+
+  public final boolean isOneOf(SqlFunctionCategory... categories) {
+    for (SqlFunctionCategory category : categories) {
+      if (category == this) {
+        return true;
+      }
+    }
+    return false;
+  }
+
 }
 
 // End SqlFunctionCategory.java

--- a/core/src/main/java/org/apache/calcite/sql/SqlFunctionCategory.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunctionCategory.java
@@ -41,7 +41,7 @@ public enum SqlFunctionCategory {
     Util.discard(description);
   }
 
-  public final boolean isUserdefined() {
+  public final boolean isUserDefined() {
     return isOneOf(
         USER_DEFINED_FUNCTION,
         USER_DEFINED_PROCEDURE,
@@ -63,7 +63,7 @@ public enum SqlFunctionCategory {
         USER_DEFINED_TABLE_SPECIFIC_FUNCTION);
   }
 
-  public final boolean isUnresolvedUserDefinedFunction() {
+  public final boolean isUserDefinedNotSpecificFunction() {
     return isOneOf(
         USER_DEFINED_FUNCTION,
         USER_DEFINED_TABLE_FUNCTION);

--- a/core/src/main/java/org/apache/calcite/sql/SqlFunctionCategory.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunctionCategory.java
@@ -18,66 +18,76 @@ package org.apache.calcite.sql;
 
 import org.apache.calcite.util.Util;
 
+import static org.apache.calcite.sql.SqlFunctionCategoryProperty.FUNCTION;
+import static org.apache.calcite.sql.SqlFunctionCategoryProperty.SPECIFIC;
+import static org.apache.calcite.sql.SqlFunctionCategoryProperty.TABLE_FUNCTION;
+import static org.apache.calcite.sql.SqlFunctionCategoryProperty.USER_DEFINED;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Enumeration of the categories of
  * SQL-invoked routines.
  */
 public enum SqlFunctionCategory {
-  STRING("STRING", "String function"),
-  NUMERIC("NUMERIC", "Numeric function"),
-  TIMEDATE("TIMEDATE", "Time and date function"),
-  SYSTEM("SYSTEM", "System function"),
-  USER_DEFINED_FUNCTION("UDF", "User-defined function"),
-  USER_DEFINED_PROCEDURE("UDP", "User-defined procedure"),
-  USER_DEFINED_CONSTRUCTOR("UDC", "User-defined constructor"),
-  USER_DEFINED_SPECIFIC_FUNCTION("UDF_SPECIFIC",
-      "User-defined function with SPECIFIC name"),
-  USER_DEFINED_TABLE_FUNCTION("TABLE_UDF", "User-defined table function"),
+  STRING("STRING", "String function", FUNCTION),
+  NUMERIC("NUMERIC", "Numeric function", FUNCTION),
+  TIMEDATE("TIMEDATE", "Time and date function", FUNCTION),
+  SYSTEM("SYSTEM", "System function", FUNCTION),
+  USER_DEFINED_FUNCTION("UDF", "User-defined function", USER_DEFINED, FUNCTION),
+  USER_DEFINED_PROCEDURE("UDP", "User-defined procedure", USER_DEFINED),
+  USER_DEFINED_CONSTRUCTOR("UDC", "User-defined constructor", USER_DEFINED),
+  USER_DEFINED_SPECIFIC_FUNCTION(
+      "UDF_SPECIFIC", "User-defined function with SPECIFIC name", USER_DEFINED, SPECIFIC, FUNCTION),
+  USER_DEFINED_TABLE_FUNCTION(
+      "TABLE_UDF", "User-defined table function", USER_DEFINED, TABLE_FUNCTION),
   USER_DEFINED_TABLE_SPECIFIC_FUNCTION("TABLE_UDF_SPECIFIC",
-      "User-defined table function with SPECIFIC name");
+      "User-defined table function with SPECIFIC name", USER_DEFINED, TABLE_FUNCTION, SPECIFIC);
 
-  SqlFunctionCategory(String abbrev, String description) {
+  private final boolean userDefined;
+  private final boolean tableFunction;
+  private final boolean specific;
+  private final boolean function;
+
+  SqlFunctionCategory(String abbrev, String description, SqlFunctionCategoryProperty... types) {
     Util.discard(abbrev);
     Util.discard(description);
+    Set<SqlFunctionCategoryProperty> typeSet = new HashSet<>(Arrays.asList(types));
+    this.userDefined = typeSet.contains(USER_DEFINED);
+    this.tableFunction = typeSet.contains(TABLE_FUNCTION);
+    this.specific = typeSet.contains(SPECIFIC);
+    this.function = typeSet.contains(FUNCTION);
   }
 
-  public final boolean isUserDefined() {
-    return isOneOf(
-        USER_DEFINED_FUNCTION,
-        USER_DEFINED_PROCEDURE,
-        USER_DEFINED_CONSTRUCTOR,
-        USER_DEFINED_SPECIFIC_FUNCTION,
-        USER_DEFINED_TABLE_FUNCTION,
-        USER_DEFINED_TABLE_SPECIFIC_FUNCTION);
+  public boolean isUserDefined() {
+    return userDefined;
   }
 
-  public final boolean isTableFunction() {
-    return isOneOf(
-        USER_DEFINED_TABLE_FUNCTION,
-        USER_DEFINED_TABLE_SPECIFIC_FUNCTION);
+  public boolean isTableFunction() {
+    return tableFunction;
   }
 
-  public final boolean isSpecific() {
-    return isOneOf(
-        USER_DEFINED_SPECIFIC_FUNCTION,
-        USER_DEFINED_TABLE_SPECIFIC_FUNCTION);
+  public boolean isFunction() {
+    return function;
   }
 
-  public final boolean isUserDefinedNotSpecificFunction() {
-    return isOneOf(
-        USER_DEFINED_FUNCTION,
-        USER_DEFINED_TABLE_FUNCTION);
+  public boolean isSpecific() {
+    return specific;
   }
 
-  public final boolean isOneOf(SqlFunctionCategory... categories) {
-    for (SqlFunctionCategory category : categories) {
-      if (category == this) {
-        return true;
-      }
-    }
-    return false;
+  public boolean isUserDefinedNotSpecificFunction() {
+    return userDefined && (function || tableFunction) && !specific;
   }
 
+}
+
+/**
+ * Properties of a SqlFunctionCategory
+ */
+enum SqlFunctionCategoryProperty {
+  USER_DEFINED, TABLE_FUNCTION, SPECIFIC, FUNCTION;
 }
 
 // End SqlFunctionCategory.java

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -263,8 +263,7 @@ public abstract class SqlUtil {
     if (operator instanceof SqlFunction) {
       SqlFunction function = (SqlFunction) operator;
 
-      switch (function.getFunctionType()) {
-      case USER_DEFINED_SPECIFIC_FUNCTION:
+      if (function.getFunctionType().isSpecific()) {
         writer.keyword("SPECIFIC");
       }
       SqlIdentifier id = function.getSqlIdentifier();

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlAbstractParserImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlAbstractParserImpl.java
@@ -363,7 +363,7 @@ public abstract class SqlAbstractParserImpl {
     /// name when regenerating SQL).
     if (funName.isSimple()) {
       final List<SqlOperator> list = Lists.newArrayList();
-      opTab.lookupOperatorOverloads(funName, null, SqlSyntax.FUNCTION, list);
+      opTab.lookupOperatorOverloads(funName, funcType, SqlSyntax.FUNCTION, list);
       if (list.size() == 1) {
         fun = list.get(0);
       }

--- a/core/src/main/java/org/apache/calcite/sql/util/ListSqlOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/util/ListSqlOperatorTable.java
@@ -69,8 +69,7 @@ public class ListSqlOperatorTable implements SqlOperatorTable {
       } else {
         functionCategory = SqlFunctionCategory.SYSTEM;
       }
-      if (category != functionCategory
-          && category != SqlFunctionCategory.USER_DEFINED_FUNCTION) {
+      if (category != functionCategory && !category.isUnresolvedUserDefinedFunction()) {
         continue;
       }
       operatorList.add(operator);

--- a/core/src/main/java/org/apache/calcite/sql/util/ListSqlOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/util/ListSqlOperatorTable.java
@@ -69,7 +69,7 @@ public class ListSqlOperatorTable implements SqlOperatorTable {
       } else {
         functionCategory = SqlFunctionCategory.SYSTEM;
       }
-      if (category != functionCategory && !category.isUnresolvedUserDefinedFunction()) {
+      if (category != functionCategory && !category.isUserDefinedNotSpecificFunction()) {
         continue;
       }
       operatorList.add(operator);

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
@@ -25,12 +25,12 @@ import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.util.Util;
 
-import static org.apache.calcite.sql.SqlKind.QUERY;
-import static org.apache.calcite.sql.SqlSyntax.FUNCTION;
-
 import com.google.common.collect.Lists;
 
 import java.util.List;
+
+import static org.apache.calcite.sql.SqlKind.QUERY;
+import static org.apache.calcite.sql.SqlSyntax.FUNCTION;
 
 /**
  * Visitor which looks for an aggregate function inside a tree of
@@ -113,7 +113,7 @@ class AggFinder extends SqlBasicVisitor<Void> {
     // User-defined function may not be resolved yet.
     if (operator instanceof SqlFunction) {
       SqlFunction sqlFunction = (SqlFunction) operator;
-      if (sqlFunction.getFunctionType().isUnresolvedUserDefinedFunction()) {
+      if (sqlFunction.getFunctionType().isUserDefinedNotSpecificFunction()) {
         final List<SqlOperator> list = Lists.newArrayList();
         opTab.lookupOperatorOverloads(sqlFunction.getSqlIdentifier(),
             sqlFunction.getFunctionType(), FUNCTION, list);

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
@@ -18,14 +18,15 @@ package org.apache.calcite.sql.validate;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
-import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
-import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.util.Util;
+
+import static org.apache.calcite.sql.SqlKind.QUERY;
+import static org.apache.calcite.sql.SqlSyntax.FUNCTION;
 
 import com.google.common.collect.Lists;
 
@@ -110,22 +111,23 @@ class AggFinder extends SqlBasicVisitor<Void> {
       }
     }
     // User-defined function may not be resolved yet.
-    if (operator instanceof SqlFunction
-        && ((SqlFunction) operator).getFunctionType()
-        == SqlFunctionCategory.USER_DEFINED_FUNCTION) {
-      final List<SqlOperator> list = Lists.newArrayList();
-      opTab.lookupOperatorOverloads(((SqlFunction) operator).getSqlIdentifier(),
-          SqlFunctionCategory.USER_DEFINED_FUNCTION, SqlSyntax.FUNCTION, list);
-      for (SqlOperator sqlOperator : list) {
-        if (sqlOperator.isAggregator()) {
-          // If nested aggregates disallowed or found aggregate at invalid level
-          if (aggregate) {
-            throw new Util.FoundOne(call);
+    if (operator instanceof SqlFunction) {
+      SqlFunction sqlFunction = (SqlFunction) operator;
+      if (sqlFunction.getFunctionType().isUnresolvedUserDefinedFunction()) {
+        final List<SqlOperator> list = Lists.newArrayList();
+        opTab.lookupOperatorOverloads(sqlFunction.getSqlIdentifier(),
+            sqlFunction.getFunctionType(), FUNCTION, list);
+        for (SqlOperator sqlOperator : list) {
+          if (sqlOperator.isAggregator()) {
+            // If nested aggregates disallowed or found aggregate at invalid level
+            if (aggregate) {
+              throw new Util.FoundOne(call);
+            }
           }
         }
       }
     }
-    if (call.isA(SqlKind.QUERY)) {
+    if (call.isA(QUERY)) {
       // don't traverse into queries
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
@@ -47,9 +47,25 @@ public class SqlUserDefinedFunction extends SqlFunction {
       SqlOperandTypeChecker operandTypeChecker,
       List<RelDataType> paramTypes,
       Function function) {
+    this(opName,
+        returnTypeInference,
+        operandTypeInference,
+        operandTypeChecker,
+        paramTypes,
+        function,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION);
+  }
+
+  public SqlUserDefinedFunction(SqlIdentifier opName,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeInference operandTypeInference,
+      SqlOperandTypeChecker operandTypeChecker,
+      List<RelDataType> paramTypes,
+      Function function,
+      SqlFunctionCategory category) {
     super(Util.last(opName.names), opName, SqlKind.OTHER_FUNCTION,
         returnTypeInference, operandTypeInference, operandTypeChecker,
-        paramTypes, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+        paramTypes, category);
     this.function = function;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
@@ -56,7 +56,7 @@ public class SqlUserDefinedFunction extends SqlFunction {
         SqlFunctionCategory.USER_DEFINED_FUNCTION);
   }
 
-  public SqlUserDefinedFunction(SqlIdentifier opName,
+  protected SqlUserDefinedFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       SqlOperandTypeChecker operandTypeChecker,

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
@@ -19,6 +19,7 @@ package org.apache.calcite.sql.validate;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.TableFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
@@ -42,7 +43,7 @@ public class SqlUserDefinedTableFunction extends SqlUserDefinedFunction {
       List<RelDataType> paramTypes,
       TableFunction function) {
     super(opName, returnTypeInference, operandTypeInference, operandTypeChecker,
-        paramTypes, function);
+        paramTypes, function, SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
@@ -70,7 +70,7 @@ public class SqlUserDefinedTableMacro extends SqlFunction {
     super(Util.last(opName.names), opName, SqlKind.OTHER_FUNCTION,
         returnTypeInference, operandTypeInference, operandTypeChecker,
         Preconditions.checkNotNull(paramTypes),
-        SqlFunctionCategory.USER_DEFINED_FUNCTION);
+        SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
     this.tableMacro = tableMacro;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -720,12 +720,11 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
           // for leaves, it's usually safe to assume that
           // no transformation is required
           rewriteGeneric(p);
+        } else {
+          throw Util.newInternal(
+              "no '" + visitMethodName + "' method found for class "
+              + p.getClass().getName());
         }
-      }
-      if (!found) {
-        throw Util.newInternal(
-            "no '" + visitMethodName + "' method found for class "
-            + p.getClass().getName());
       }
     }
   }

--- a/core/src/test/java/org/apache/calcite/prepare/LookupOperatorOverloadsTest.java
+++ b/core/src/test/java/org/apache/calcite/prepare/LookupOperatorOverloadsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.prepare;
 
+
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.CalcitePrepare;
@@ -42,8 +43,17 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.calcite.sql.SqlFunctionCategory.USER_DEFINED_CONSTRUCTOR;
+import static org.apache.calcite.sql.SqlFunctionCategory.USER_DEFINED_FUNCTION;
+import static org.apache.calcite.sql.SqlFunctionCategory.USER_DEFINED_PROCEDURE;
+import static org.apache.calcite.sql.SqlFunctionCategory.USER_DEFINED_SPECIFIC_FUNCTION;
+import static org.apache.calcite.sql.SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION;
+import static org.apache.calcite.sql.SqlFunctionCategory.USER_DEFINED_TABLE_SPECIFIC_FUNCTION;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import static java.util.Arrays.asList;
 
 /**
  * Test for lookupOperatorOverloads() in {@link CalciteCatalogReader}
@@ -57,6 +67,64 @@ public class LookupOperatorOverloadsTest {
       assertTrue(op instanceof SqlUserDefinedTableFunction);
       assertTrue(name.equals(op.getName()));
     }
+  }
+
+  @Test
+  public void testIsUserDefined() throws SQLException {
+    List<SqlFunctionCategory> cats = new ArrayList<>();
+    for (SqlFunctionCategory sqlFunctionCategory : SqlFunctionCategory.values()) {
+      if (sqlFunctionCategory.isUserDefined()) {
+        cats.add(sqlFunctionCategory);
+      }
+    }
+    assertEquals(
+        asList(
+            USER_DEFINED_FUNCTION,
+            USER_DEFINED_PROCEDURE,
+            USER_DEFINED_CONSTRUCTOR,
+            USER_DEFINED_SPECIFIC_FUNCTION,
+            USER_DEFINED_TABLE_FUNCTION,
+            USER_DEFINED_TABLE_SPECIFIC_FUNCTION),
+        cats);
+  }
+
+  @Test
+  public void testIsTableFunction() throws SQLException {
+    List<SqlFunctionCategory> cats = new ArrayList<>();
+    for (SqlFunctionCategory sqlFunctionCategory : SqlFunctionCategory.values()) {
+      if (sqlFunctionCategory.isTableFunction()) {
+        cats.add(sqlFunctionCategory);
+      }
+    }
+    assertEquals(
+        asList(USER_DEFINED_TABLE_FUNCTION, USER_DEFINED_TABLE_SPECIFIC_FUNCTION),
+        cats);
+  }
+
+  @Test
+  public void testIsSpecific() throws SQLException {
+    List<SqlFunctionCategory> cats = new ArrayList<>();
+    for (SqlFunctionCategory sqlFunctionCategory : SqlFunctionCategory.values()) {
+      if (sqlFunctionCategory.isSpecific()) {
+        cats.add(sqlFunctionCategory);
+      }
+    }
+    assertEquals(
+        asList(USER_DEFINED_SPECIFIC_FUNCTION, USER_DEFINED_TABLE_SPECIFIC_FUNCTION),
+        cats);
+  }
+
+  @Test
+  public void testIsUserDefinedNotSpecificFunction() throws SQLException {
+    List<SqlFunctionCategory> cats = new ArrayList<>();
+    for (SqlFunctionCategory sqlFunctionCategory : SqlFunctionCategory.values()) {
+      if (sqlFunctionCategory.isUserDefinedNotSpecificFunction()) {
+        cats.add(sqlFunctionCategory);
+      }
+    }
+    assertEquals(
+        asList(USER_DEFINED_FUNCTION, USER_DEFINED_TABLE_FUNCTION),
+        cats);
   }
 
   @Test

--- a/core/src/test/java/org/apache/calcite/prepare/LookupOperatorOverloadsTest.java
+++ b/core/src/test/java/org/apache/calcite/prepare/LookupOperatorOverloadsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.prepare;
+
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.TableFunction;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.TableFunctionImpl;
+import org.apache.calcite.server.CalciteServerStatement;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlUserDefinedTableFunction;
+import org.apache.calcite.util.Smalls;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for lookupOperatorOverloads() in {@link CalciteCatalogReader}
+ */
+public class LookupOperatorOverloadsTest {
+
+  private void functionTypeChecker(int size, String name, List<SqlOperator> operatorList) {
+    assertEquals(operatorList.size(), size);
+
+    for (SqlOperator op : operatorList) {
+      assertTrue(op instanceof SqlUserDefinedTableFunction);
+      assertTrue(name.equals(op.getName()));
+    }
+  }
+
+  @Test
+  public void test() throws SQLException {
+    final String schemaName = "MySchema";
+    final String funcName = "MyFUNC";
+    final String anotherName = "AnotherFunc";
+
+    Connection connection = DriverManager.getConnection("jdbc:calcite:");
+    CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
+    SchemaPlus rootSchema = calciteConnection.getRootSchema();
+    SchemaPlus schema = rootSchema.add(schemaName, new AbstractSchema());
+    final TableFunction table = TableFunctionImpl.create(Smalls.MAZE_METHOD);
+    schema.add(funcName, table);
+    schema.add(anotherName, table);
+    final TableFunction table2 = TableFunctionImpl.create(Smalls.MAZE3_METHOD);
+    schema.add(funcName, table2);
+
+    final CalciteServerStatement statement =
+            connection.createStatement().unwrap(CalciteServerStatement.class);
+    final CalcitePrepare.Context prepareContext = statement.createPrepareContext();
+    final JavaTypeFactory typeFactory = prepareContext.getTypeFactory();
+    CalciteCatalogReader reader =
+            new CalciteCatalogReader(prepareContext.getRootSchema(), false, null, typeFactory);
+
+    List<SqlOperator> operatorList = new ArrayList<>();
+    SqlIdentifier myFuncIdentifier = new SqlIdentifier(
+            Lists.newArrayList(schemaName, funcName), null, SqlParserPos.ZERO, null);
+    reader.lookupOperatorOverloads(
+            myFuncIdentifier, SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION,
+            SqlSyntax.FUNCTION, operatorList);
+    functionTypeChecker(2, funcName, operatorList);
+
+    operatorList.clear();
+    reader.lookupOperatorOverloads(
+            myFuncIdentifier, SqlFunctionCategory.USER_DEFINED_FUNCTION,
+            SqlSyntax.FUNCTION, operatorList);
+    functionTypeChecker(0, null, operatorList);
+
+    operatorList.clear();
+    SqlIdentifier anotherFuncIdentifier = new SqlIdentifier(
+            Lists.newArrayList(schemaName, anotherName), null, SqlParserPos.ZERO, null);
+    reader.lookupOperatorOverloads(
+            anotherFuncIdentifier, SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION,
+            SqlSyntax.FUNCTION, operatorList);
+    functionTypeChecker(1, anotherName, operatorList);
+  }
+}
+// End LookupOperatorOverloadsTest.java

--- a/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
@@ -24,6 +24,7 @@ import org.apache.calcite.plan.RelWriterTest;
 import org.apache.calcite.plan.volcano.TraitPropagationTest;
 import org.apache.calcite.plan.volcano.VolcanoPlannerTest;
 import org.apache.calcite.plan.volcano.VolcanoPlannerTraitTest;
+import org.apache.calcite.prepare.LookupOperatorOverloadsTest;
 import org.apache.calcite.rel.RelCollationTest;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverterTest;
 import org.apache.calcite.rex.RexBuilderTest;
@@ -119,6 +120,7 @@ import org.junit.runners.Suite;
     ChunkListTest.class,
     FrameworksTest.class,
     EnumerableCorrelateTest.class,
+    LookupOperatorOverloadsTest.class,
 
     // slow tests (above 1s)
     UdfTest.class,


### PR DESCRIPTION
This prevents collisions between Drill Table macros and regular functions.
https://github.com/apache/drill/pull/246