### PR TITLE
[CALCITE-980] Fix AND and OR implementation in Enumerable convention

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -798,6 +798,17 @@ public class ReflectiveSchemaTest {
     public final BitSet bitSet = new BitSet(0);
   }
 
+  /** Table that has integer and string fields */
+  public static class IntAndString {
+    public final int id;
+    public final String value;
+
+    public IntAndString(int id, String value) {
+      this.id = id;
+      this.value = value;
+    }
+  }
+
   /** Object whose fields are relations. Called "catch-all" because it's OK
    * if tests add new fields. */
   public static class CatchallSchema {
@@ -841,6 +852,13 @@ public class ReflectiveSchemaTest {
 
     public final IntHolder[] primesCustomBoxed =
         new IntHolder[]{new IntHolder(1), new IntHolder(3), new IntHolder(5)};
+
+    public final IntAndString[] nullables = new IntAndString[] {
+      new IntAndString(1, "A"), new IntAndString(2, "B"), new IntAndString(2, "C"),
+      new IntAndString(3, null)};
+
+    public final IntAndString[] bools = new IntAndString[] {
+      new IntAndString(1, "T"), new IntAndString(2, "F"), new IntAndString(3, null)};
   }
 
   /**

--- a/core/src/test/resources/sql/conditions.oq
+++ b/core/src/test/resources/sql/conditions.oq
@@ -1,0 +1,259 @@
+# conditions.oq - conditions
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+!use catchall
+!set outputformat mysql
+
+# OR test
+
+with tmp(a, b) as (
+  values (1, 1), (1, 0), (1, cast(null as int))
+       , (0, 1), (0, 0), (0, cast(null as int))
+       , (cast(null as int), 1), (cast(null as int), 0), (cast(null as int), cast(null as int)))
+select *
+  from tmp
+ where a = 1 or b = 1
+ order by 1, 2;
+
++---+---+
+| A | B |
++---+---+
+| 0 | 1 |
+| 1 | 0 |
+| 1 | 1 |
+| 1 |   |
+|   | 1 |
++---+---+
+(5 rows)
+
+!ok
+
+with tmp(a, b) as (
+  values (1, 1), (1, 0), (1, cast(null as int))
+       , (0, 1), (0, 0), (0, cast(null as int))
+       , (cast(null as int), 1), (cast(null as int), 0), (cast(null as int), cast(null as int)))
+select *
+  from tmp
+ where not (a = 1 or b = 1)
+ order by 1, 2;
+
++---+---+
+| A | B |
++---+---+
+| 0 | 0 |
++---+---+
+(1 row)
+
+!ok
+
+# AND test
+
+with tmp(a, b) as (
+  values (1, 1), (1, 0), (1, cast(null as int))
+       , (0, 1), (0, 0), (0, cast(null as int))
+       , (cast(null as int), 1), (cast(null as int), 0), (cast(null as int), cast(null as int)))
+select *
+  from tmp
+ where a = 1 AND b = 1
+ order by 1, 2;
+
++---+---+
+| A | B |
++---+---+
+| 1 | 1 |
++---+---+
+(1 row)
+
+!ok
+
+with tmp(a, b) as (
+  values (1, 1), (1, 0), (1, cast(null as int))
+       , (0, 1), (0, 0), (0, cast(null as int))
+       , (cast(null as int), 1), (cast(null as int), 0), (cast(null as int), cast(null as int)))
+select *
+  from tmp
+ where not (a = 1 AND b = 1)
+ order by 1, 2;
+
++---+---+
+| A | B |
++---+---+
+| 0 | 0 |
+| 0 | 1 |
+| 0 |   |
+| 1 | 0 |
+|   | 0 |
++---+---+
+(5 rows)
+
+!ok
+
+# Test cases for CALCITE-980
+
+select "value" from "nullables" a where "value" = 'A' or "value" = 'B' order by 1;
+
++-------+
+| value |
++-------+
+| A     |
+| B     |
++-------+
+(2 rows)
+
+!ok
+
+select "value" from "nullables" a where not ("value" = 'A' or "value" = 'B') order by 1;
+
++-------+
+| value |
++-------+
+| C     |
++-------+
+(1 row)
+
+!ok
+
+select "value" from "nullables" a where not (not ("value" = 'A' or "value" = 'B')) order by 1;
+
++-------+
+| value |
++-------+
+| A     |
+| B     |
++-------+
+(2 rows)
+
+!ok
+
+select "value" from "nullables" a where "value" = 'A' and "value" = 'B' order by 1;
+
++-------+
+| value |
++-------+
++-------+
+(0 rows)
+
+!ok
+
+select "value" from "nullables" a where not ("value" = 'A' and "value" = 'B') order by 1;
+
++-------+
+| value |
++-------+
+| A     |
+| B     |
+| C     |
++-------+
+(3 rows)
+
+!ok
+
+select "value" from "nullables" a where not (not ("value" = 'A' and "value" = 'B')) order by 1;
+
++-------+
+| value |
++-------+
++-------+
+(0 rows)
+
+!ok
+
+select "value" from "nullables" a
+ where case when not ("value" = 'A' or "value" = 'B') then 1 else 0 end = 1
+ order by 1;
+
++-------+
+| value |
++-------+
+| C     |
++-------+
+(1 row)
+
+!ok
+
+select "value" from "nullables" a
+ where
+   case when not ("value"='A' or "value"='B')
+     then
+       case when ("value"='A' or "value"='B') then 1 else 2 end
+     else 0
+   end = 2
+ order by 1;
+
++-------+
+| value |
++-------+
+| C     |
++-------+
+(1 row)
+
+!ok
+
+select "value" from "nullables" a
+ where
+   case when not ("value"='A' or "value"='B')
+     then
+       case when not /* <--diff from above */ ("value"='A' or "value"='B') then 1 else 2 end
+     else 0
+   end = 1 /* <- diff from above*/
+ order by 1;
+
++-------+
+| value |
++-------+
+| C     |
++-------+
+(1 row)
+
+!ok
+
+select "value" from "nullables" a
+ where
+   case when not ("value"='A' or "value"='B')
+     then
+       case when not ("value"='A' or "value"='B') then 1 else 2 end
+     else 0
+   end = 0 /* <- diff from above*/
+ order by 1;
+
++-------+
+| value |
++-------+
+| A     |
+| B     |
+|       |
++-------+
+(3 rows)
+
+!ok
+
+select "value" from "nullables" a
+ where
+   case when not ("value"='A' or "value"='B')
+     then
+       case when not ("value"='A' or "value"='B') then 1 else 2 end
+     else 0
+   end = 2 /* <- diff from above*/
+ order by 1;
+
++-------+
+| value |
++-------+
++-------+
+(0 rows)
+
+!ok


### PR DESCRIPTION
The PR seems to fix null semantics handling for OR and AND.
For `not (c='a' and c='b')` it generates the following code:
```java
/* 113 */ while (inputEnumerator.moveNext()) {
/* 114 */   final String current = inputEnumerator.current() == null ? (String) null
                                   : inputEnumerator.current().toString();
/* 115 */   if (!(current == null || org.apache.calcite.runtime.SqlFunctions.eq(current, "a")
              || (current == null || org.apache.calcite.runtime.SqlFunctions.eq(current, "b")))) {
/* 116 */     return true;
/* 117 */   }
/* 118 */ }
```
