### PR TITLE
CALCITE-993: Predicate Pull up above Project enhancement

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -34,6 +34,7 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
@@ -339,7 +340,7 @@ public class RelMdPredicates {
   }
 
   /**
-   * Is this RexCall a deterministic function over literals
+   * Is this expression a deterministic function over literals
    *
    * @param expr
    * @return TRUE if expr is deterministic and all args are constants; FALSE
@@ -360,6 +361,11 @@ public class RelMdPredicates {
       @Override
       public Void visitInputRef(RexInputRef inputRef) {
         throw new Util.FoundOne(inputRef);
+      }
+
+      @Override
+      public Void visitCorrelVariable(RexCorrelVariable correlVariable) {
+        throw new Util.FoundOne(correlVariable);
       }
 
       @Override

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1270,14 +1270,14 @@ public class RelMetadataTest extends SqlToRelTestBase {
   }
 
   @Test public void testPullUpPredicatesFromProject() {
-    final String sql = "select deptno, mgr, x, 'y' as y from (\n"
-        + "  select deptno, mgr, cast(null as integer) as x\n"
+    final String sql = "select deptno, mgr, x, 'y' as y, z from (\n"
+        + "  select deptno, mgr, cast(null as integer) as x, cast('1' as int) as z\n"
         + "  from emp\n"
         + "  where mgr is null and deptno < 10)";
     final RelNode rel = convertSql(sql);
     RelOptPredicateList list = RelMetadataQuery.getPulledUpPredicates(rel);
     assertThat(list.pulledUpPredicates.toString(),
-        is("[IS NULL($1), <($0, 10), IS NULL($2), =($3, 'y')]"));
+        is("[IS NULL($1), <($0, 10), IS NULL($2), =($4, CAST('1'):INTEGER NOT NULL), =($3, 'y')]"));
   }
 
   /** Custom metadata interface. */


### PR DESCRIPTION
Currently RelMDPredicates doesn't pull deterministic expressions with literals in it.
This patch tries to address that.
Ex: select r1.x from (select cast('10' as int) as x, y from r1 where y<10)r1 join r2 on r1.x=r2.x;