### PR TITLE
[CALCITE-1005] handle null in RelMdMaxRowCount.getRowCount

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
@@ -99,8 +99,11 @@ public class RelMdMaxRowCount {
     if (rel.getGroupSet().isEmpty()) {
       return 1D;
     }
-    return RelMetadataQuery.getMaxRowCount(rel.getInput())
-        * rel.getGroupSets().size();
+    final Double inputCt = RelMetadataQuery.getMaxRowCount(rel.getInput());
+    if (inputCt == null) {
+      return null;
+    }
+    return inputCt * rel.getGroupSets().size();
   }
 
   public Double getMaxRowCount(Join rel) {


### PR DESCRIPTION
I tested the fix outside of the calcite repo, but I wasn't able to reproduce with a calcite test.