### PR TITLE
[Calcite-1010] Extending RelToSqlConverter to support FETCH/LIMIT and OFFSET and UTs for them

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -147,8 +147,7 @@ public class SqlDialect {
   public SqlDialect(
       DatabaseProduct databaseProduct,
       String databaseProductName,
-      String identifierQuoteString,
-      NullCollation nullCollation) {
+      String identifierQuoteString, NullCollation nullCollation) {
     Preconditions.checkNotNull(this.nullCollation = nullCollation);
     Preconditions.checkNotNull(databaseProductName);
     this.databaseProduct = Preconditions.checkNotNull(databaseProduct);
@@ -609,21 +608,12 @@ public class SqlDialect {
     private String databaseProductName;
     private String quoteString;
     private final NullCollation nullCollation;
-    private final boolean useFetch;
-    private final boolean useOffset;
 
     DatabaseProduct(String databaseProductName, String quoteString,
-                    NullCollation nullCollation) {
-      this(databaseProductName, quoteString, nullCollation, true, true);
-    }
-
-    DatabaseProduct(String databaseProductName, String quoteString,
-        NullCollation nullCollation, boolean useFetch, boolean useOffset) {
+        NullCollation nullCollation) {
       this.databaseProductName = databaseProductName;
       this.quoteString = quoteString;
       this.nullCollation = nullCollation;
-      this.useFetch = useFetch;
-      this.useOffset = useOffset;
     }
 
     /**
@@ -640,7 +630,8 @@ public class SqlDialect {
     public SqlDialect getDialect() {
       if (dialect == null) {
         dialect =
-            new SqlDialect(this, databaseProductName, quoteString, nullCollation);
+            new SqlDialect(this, databaseProductName, quoteString,
+                nullCollation);
       }
       return dialect;
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -236,6 +236,26 @@ public class SqlSelectOperator extends SqlOperator {
       unparseListClause(writer, select.orderBy);
       writer.endList(orderFrame);
     }
+    if (select.offset != null) {
+      final SqlWriter.Frame offsetFrame =
+          writer.startList(SqlWriter.FrameTypeEnum.OFFSET);
+      writer.newlineAndIndent();
+      writer.keyword("OFFSET");
+      select.offset.unparse(writer, -1, -1);
+      writer.keyword("ROWS");
+      writer.endList(offsetFrame);
+    }
+    if (select.fetch != null) {
+      final SqlWriter.Frame fetchFrame =
+          writer.startList(SqlWriter.FrameTypeEnum.FETCH);
+      writer.newlineAndIndent();
+      writer.keyword("FETCH");
+      writer.keyword("NEXT");
+      select.fetch.unparse(writer, -1, -1);
+      writer.keyword("ROWS");
+      writer.keyword("ONLY");
+      writer.endList(fetchFrame);
+    }
     writer.endList(selectFrame);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -236,12 +236,7 @@ public class SqlSelectOperator extends SqlOperator {
       unparseListClause(writer, select.orderBy);
       writer.endList(orderFrame);
     }
-    if (select.offset != null) {
-      writer.offset(select.offset);
-    }
-    if (select.fetch != null) {
-      writer.fetch(select.fetch);
-    }
+    writer.fetchOffset(select.fetch, select.offset);
     writer.endList(selectFrame);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -237,24 +237,10 @@ public class SqlSelectOperator extends SqlOperator {
       writer.endList(orderFrame);
     }
     if (select.offset != null) {
-      final SqlWriter.Frame offsetFrame =
-          writer.startList(SqlWriter.FrameTypeEnum.OFFSET);
-      writer.newlineAndIndent();
-      writer.keyword("OFFSET");
-      select.offset.unparse(writer, -1, -1);
-      writer.keyword("ROWS");
-      writer.endList(offsetFrame);
+      writer.offset(select.offset);
     }
     if (select.fetch != null) {
-      final SqlWriter.Frame fetchFrame =
-          writer.startList(SqlWriter.FrameTypeEnum.FETCH);
-      writer.newlineAndIndent();
-      writer.keyword("FETCH");
-      writer.keyword("NEXT");
-      select.fetch.unparse(writer, -1, -1);
-      writer.keyword("ROWS");
-      writer.keyword("ONLY");
-      writer.endList(fetchFrame);
+      writer.fetch(select.fetch);
     }
     writer.endList(selectFrame);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -310,6 +310,16 @@ public interface SqlWriter {
   void identifier(String name);
 
   /**
+   * Prints fetch clause
+   */
+  void fetch(SqlNode fetch);
+
+  /**
+   * Prints offset clause
+   */
+  void offset(SqlNode offset);
+
+  /**
    * Prints a new line, and indents.
    */
   void newlineAndIndent();

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -310,14 +310,9 @@ public interface SqlWriter {
   void identifier(String name);
 
   /**
-   * Prints fetch clause
+   * Prints offset/fetch clause
    */
-  void fetch(SqlNode fetch);
-
-  /**
-   * Prints offset clause
-   */
-  void offset(SqlNode offset);
+  void fetchOffset(SqlNode fetch, SqlNode offset);
 
   /**
    * Prints a new line, and indents.

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -902,6 +902,38 @@ public class SqlPrettyWriter implements SqlWriter {
     setNeedWhitespace(true);
   }
 
+  public void offset(SqlNode offset) {
+    final SqlWriter.Frame offsetFrame =
+        this.startList(SqlWriter.FrameTypeEnum.OFFSET);
+    this.newlineAndIndent();
+    if (dialect.isUseOffsetOnly()) {
+      this.keyword("OFFSET");
+      offset.unparse(this, -1, -1);
+      this.keyword("ROWS");
+    } else {
+      this.keyword("OFFSET");
+      offset.unparse(this, -1, -1);
+    }
+    this.endList(offsetFrame);
+  }
+
+  public void fetch(SqlNode fetch) {
+    final SqlWriter.Frame fetchFrame =
+        this.startList(SqlWriter.FrameTypeEnum.FETCH);
+    this.newlineAndIndent();
+    if (dialect.isUseFetch()) {
+      this.keyword("FETCH");
+      this.keyword("NEXT");
+      fetch.unparse(this, -1, -1);
+      this.keyword("ROWS");
+      this.keyword("ONLY");
+    } else {
+      this.keyword("LIMIT");
+      fetch.unparse(this, -1, -1);
+    }
+    this.endList(fetchFrame);
+  }
+
   public Frame startFunCall(String funName) {
     keyword(funName);
     setNeedWhitespace(false);

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -902,36 +902,49 @@ public class SqlPrettyWriter implements SqlWriter {
     setNeedWhitespace(true);
   }
 
-  public void offset(SqlNode offset) {
-    final SqlWriter.Frame offsetFrame =
-        this.startList(SqlWriter.FrameTypeEnum.OFFSET);
-    this.newlineAndIndent();
-    if (dialect.isUseOffsetOnly()) {
-      this.keyword("OFFSET");
-      offset.unparse(this, -1, -1);
-      this.keyword("ROWS");
-    } else {
-      this.keyword("OFFSET");
-      offset.unparse(this, -1, -1);
+  public void fetchOffset(SqlNode fetch, SqlNode offset) {
+    if (fetch == null && offset == null) {
+      return;
     }
-    this.endList(offsetFrame);
-  }
-
-  public void fetch(SqlNode fetch) {
-    final SqlWriter.Frame fetchFrame =
-        this.startList(SqlWriter.FrameTypeEnum.FETCH);
-    this.newlineAndIndent();
-    if (dialect.isUseFetch()) {
-      this.keyword("FETCH");
-      this.keyword("NEXT");
-      fetch.unparse(this, -1, -1);
-      this.keyword("ROWS");
-      this.keyword("ONLY");
-    } else {
-      this.keyword("LIMIT");
-      fetch.unparse(this, -1, -1);
+    if (dialect.supportsOffsetFetch()) {
+      if (offset != null) {
+        this.newlineAndIndent();
+        final Frame offsetFrame =
+            this.startList(FrameTypeEnum.OFFSET);
+        this.keyword("OFFSET");
+        offset.unparse(this, -1, -1);
+        this.keyword("ROWS");
+        this.endList(offsetFrame);
+      }
+      if (fetch != null) {
+        this.newlineAndIndent();
+        final Frame fetchFrame =
+            this.startList(FrameTypeEnum.FETCH);
+        this.keyword("FETCH");
+        this.keyword("NEXT");
+        fetch.unparse(this, -1, -1);
+        this.keyword("ROWS");
+        this.keyword("ONLY");
+        this.endList(fetchFrame);
+      }
+    } else { // If dialect does not support OFFSET/FETCH clause then use LIMIT/OFFSET
+      if (fetch != null) {
+        this.newlineAndIndent();
+        final Frame fetchFrame =
+            this.startList(FrameTypeEnum.FETCH);
+        this.keyword("LIMIT");
+        fetch.unparse(this, -1, -1);
+        this.endList(fetchFrame);
+      }
+      if (offset != null) {
+        this.newlineAndIndent();
+        final Frame offsetFrame =
+            this.startList(FrameTypeEnum.OFFSET);
+        this.keyword("OFFSET");
+        offset.unparse(this, -1, -1);
+        this.endList(offsetFrame);
+      }
     }
-    this.endList(fetchFrame);
   }
 
   public Frame startFunCall(String funName) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -268,7 +268,7 @@ public class RelToSqlConverterTest {
             + "ORDER BY \"net_weight\", \"gross_weight\" DESC, \"low_fat\"");
   }
 
-  @Ignore
+  @Ignore("Need to fix this by enhancing dialects")
   @Test
   public void testSelectQueryWithLimitClause() {
     String query = "select \"product_id\"  from \"product\" limit 100 offset 10";
@@ -277,6 +277,43 @@ public class RelToSqlConverterTest {
         "SELECT \"product_id\"\n"
             + "FROM \"foodmart\".\"product\"\n"
             + "LIMIT 100 OFFSET 10");
+  }
+
+  @Test
+  public void testSelectQueryWithLimitClauseWithoutOrder() {
+    String query = "select \"product_id\"  from \"product\" limit 100 offset 10";
+    checkRel2Sql(this.logicalPlanner,
+        query,
+        "SELECT \"product_id\"\n"
+            + "FROM \"foodmart\".\"product\"\n"
+            + "OFFSET 10 ROWS\n"
+            + "FETCH NEXT 100 ROWS ONLY");
+  }
+
+  @Test
+  public void testSelectQueryWithLimitOffsetClause() {
+    String query = "select \"product_id\"  from \"product\" order by \"net_weight\" asc"
+        + " limit 100 offset 10";
+    checkRel2Sql(this.logicalPlanner,
+        query,
+        "SELECT \"product_id\", \"net_weight\"\n"
+            + "FROM \"foodmart\".\"product\"\n"
+            + "ORDER BY \"net_weight\"\n"
+            + "OFFSET 10 ROWS\n"
+            + "FETCH NEXT 100 ROWS ONLY");
+  }
+
+  @Test
+  public void testSelectQueryWithFetchOffsetClause() {
+    String query = "select \"product_id\"  from \"product\" order by \"product_id\""
+        + " offset 10 rows fetch next 100 rows only";
+    checkRel2Sql(this.logicalPlanner,
+        query,
+        "SELECT \"product_id\"\n"
+            + "FROM \"foodmart\".\"product\"\n"
+            + "ORDER BY \"product_id\"\n"
+            + "OFFSET 10 ROWS\n"
+            + "FETCH NEXT 100 ROWS ONLY");
   }
 
   @Test

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -277,7 +277,7 @@ public class RelToSqlConverterTest {
     String query = "select \"product_id\"  from \"product\" limit 100 offset 10";
     checkRel2Sql(this.logicalPlanner,
         query,
-        "SELECT product_id\nFROM foodmart.product\nOFFSET 10\nLIMIT 100",
+        "SELECT product_id\nFROM foodmart.product\nLIMIT 100\nOFFSET 10",
         SqlDialect.DatabaseProduct.HIVE.getDialect());
   }
 


### PR DESCRIPTION
1. ReltoSqlConverter is extended to support FETCH/LIMIT and OFFSET/OFFSET ONLY
2. Changes made to SqlDialect and SqlWriter to support LIMIT/OFFSET while printing SqlNode
Tests: https://travis-ci.org/qubole/incubator-calcite/builds/96717101