### PR TITLE
[CALCITE-1025] Add support for HTTP Basic auth (for proxies) in Avati…

### DIFF
--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -79,7 +79,7 @@ public abstract class AvaticaConnection implements Connection {
   protected final UnregisteredDriver driver;
   protected final AvaticaFactory factory;
   final String url;
-  protected final Properties info;
+  private final Properties info;
   protected final Meta meta;
   protected final AvaticaDatabaseMetaData metaData;
   public final Helper helper = Helper.INSTANCE;
@@ -128,7 +128,7 @@ public abstract class AvaticaConnection implements Connection {
    * almost certainly subclass {@link ConnectionConfig} with their own
    * properties. */
   public ConnectionConfig config() {
-    return new ConnectionConfigImpl(info);
+    return new ConnectionConfigImpl(getInfo());
   }
 
   /**
@@ -136,7 +136,7 @@ public abstract class AvaticaConnection implements Connection {
    */
   public void openConnection() {
     // Open the connection on the server
-    this.meta.openConnection(handle, OpenConnectionRequest.serializeProperties(info));
+    this.meta.openConnection(handle, OpenConnectionRequest.serializeProperties(getInfo()));
   }
 
   // Connection methods
@@ -679,6 +679,10 @@ public abstract class AvaticaConnection implements Connection {
       // Shouldn't ever happen.
       throw new IllegalStateException();
     }
+  }
+
+  public Properties getInfo() {
+    return info;
   }
 }
 

--- a/avatica/src/main/java/org/apache/calcite/avatica/AvaticaDatabaseMetaData.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/AvaticaDatabaseMetaData.java
@@ -88,7 +88,7 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public String getUserName() throws SQLException {
-    return connection.info.getProperty("user");
+    return connection.getInfo().getProperty("user");
   }
 
   public boolean isReadOnly() throws SQLException {

--- a/avatica/src/main/java/org/apache/calcite/avatica/remote/Driver.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/remote/Driver.java
@@ -124,13 +124,15 @@ public class Driver extends UnregisteredDriver {
    */
   AvaticaHttpClient getHttpClient(AvaticaConnection connection, ConnectionConfig config) {
     URL url;
+    Properties props = connection.getInfo();
+
     try {
       url = new URL(config.url());
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }
 
-    return new AvaticaHttpClientImpl(url);
+    return new AvaticaHttpClientImpl(url, props);
   }
 
   @Override public Connection connect(String url, Properties info)

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -135,7 +135,7 @@ abstract class CalciteConnectionImpl
   }
 
   public CalciteConnectionConfig config() {
-    return new CalciteConnectionConfigImpl(info);
+    return new CalciteConnectionConfigImpl(getInfo());
   }
 
   /** Called after the constructor has completed and the model has been
@@ -229,7 +229,7 @@ abstract class CalciteConnectionImpl
   }
 
   public Properties getProperties() {
-    return info;
+    return getInfo();
   }
 
   // QueryProvider methods


### PR DESCRIPTION
Implementation of the feature request from CALCITE-1025 JIRA.  If a username/password are supplied, this code creates an HTTP BASIC header and adds the credentials to the HTTP request.  This allows Calcite / Avatica based drivers (like the Phoenix "thin" driver) to pass through HTTP proxies like Knox. 
