### PR TITLE
[CALCITE-1060] Tests: initialize DriverManager before registering AlternatingDriver

### DIFF
--- a/avatica-server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
+++ b/avatica-server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
@@ -68,6 +68,10 @@ public class AlternatingRemoteMetaTest {
 
   static {
     try {
+      // Force DriverManager initialization before we hit AlternatingDriver->Driver.<clinit>
+      // Otherwise Driver.<clinit> -> DriverManager.registerDriver -> scan service provider files
+      // causes a deadlock (see CALCITE-1060)
+      DriverManager.getDrivers();
       DriverManager.registerDriver(new AlternatingDriver());
     } catch (SQLException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Early DriverManager initialization is required to prevent
`Driver.<clinit>` -> `DriverManager.findServiceProviders` -> `Class.forName("Driver")`
deadlock.

Note: proper resolution might need to add an entry for `AlternatingDriver` to the service manifest