### PR TITLE
[CALCITE-998] fixed exception when calling stddev

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
@@ -397,7 +397,8 @@ public class AggregateReduceFunctionsRule extends RelOptRule {
             oldAggRel.getGroupCount(),
             oldAggRel.getInput(),
             null,
-            null);
+            null,
+            ImmutableIntList.of(argOrdinal));
     final RexNode sumArgSquared =
         rexBuilder.addAggCall(sumArgSquaredAggCall,
             nGroups,

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -1689,6 +1689,11 @@ public class JdbcTest {
         .returnsUnordered("deptno=20");
   }
 
+  @Test public void testStddev() throws Exception {
+    withEmpDept("select stddev_samp(deptno) as s from emp")
+            .returns("S=19\n");
+  }
+
   /** Tests a date literal against a JDBC data source. */
   @Test public void testJdbcDate() {
     CalciteAssert.that()


### PR DESCRIPTION
it was trying to get the type for the new input column (X*X) from the old table which did not have it - causing an index exception -  I have made it use the original columns (X) type instead (as X*X will have the same type as X)