### PR TITLE
[CALCITE-553] Enable compiler profiles by default

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -416,8 +416,9 @@ limitations under the License.
       the same contents -->
       <id>generate-version-properties</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
-        <file><missing>target/classes/org-apache-calcite-jdbc.properties</missing></file>
+        <property>
+          <name>!skipGenerate</name>
+        </property>
       </activation>
       <build>
         <resources>
@@ -435,8 +436,9 @@ limitations under the License.
       -->
       <id>generate-parser</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
-        <file><missing>target/generated-sources/fmpp/javacc/Parser.jj</missing></file>
+        <property>
+          <name>!skipGenerate</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -62,6 +62,22 @@ $ cd calcite
 $ mvn install
 {% endhighlight %}
 
+Calcite includes a number of machine-generated codes. By default, these are
+regenerated on every build, but this has the negative side-effect of causing
+a re-compilation of the entire project when the non-machine-generated code
+has not changed. To make sure incremental compilation still works as intended,
+provide the `skipGenerate` command line option with your maven command.
+If you invoke the `clean` lifecycle phase, you must not specify the
+`skipGenerate` option as it will not recompile the necessary code for the build
+to succeed.
+
+{% highlight bash %}
+$ mvn clean
+$ mvn package
+... hacks ...
+$ mvn package -DskipGenerate
+{% endhighlight %}
+
 [Running tests](#running-tests) describes how to run more or fewer
 tests.
 
@@ -71,9 +87,7 @@ The test suite will run by default when you build, unless you specify
 `-DskipTests`:
 
 {% highlight bash %}
-# Note: "mvn clean install" does not work; use "mvn clean" then "mvn install"
-$ mvn clean
-$ mvn -DskipTests install
+$ mvn -DskipTests clean install
 $ mvn test
 {% endhighlight %}
 

--- a/site/develop/index.md
+++ b/site/develop/index.md
@@ -52,13 +52,6 @@ $ cd calcite
 $ mvn install
 {% endhighlight %}
 
-If you need to re-build from scratch, clean and install as two separate steps:
-
-{% highlight bash %}
-$ mvn clean
-$ mvn install
-{% endhighlight %}
-
 The HOWTO describes how to
 [build from a source distribution]({{ site.baseurl }}/docs/howto.html#building-from-a-source-distribution),
 [run more or fewer tests]({{ site.baseurl }}/docs/howto.html#running-tests) and


### PR DESCRIPTION
A number of profiles were conditionally enabled by default
in an attempt to make incremental compilation work. The
implementation ended up breaking standard maven convention
such as the inclusion of the "clean" lifecycle phase with
another lifecycle phase such as "package".

The profiles can still be disabled on the command line by
users who wish to do so (and know they haven't updated the
files).