### PR TITLE
[CALCITE-1148] Fix RelTrait conversion (e.g. distribution, collation), new tests

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableConvention.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableConvention.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.RelTraitSet;
 
 /**
  * Family of calling conventions that return results as an
@@ -54,6 +55,14 @@ public enum EnumerableConvention implements Convention {
   }
 
   public void register(RelOptPlanner planner) {}
+
+  public boolean canConvertConvention(Convention toConvention) {
+    return false;
+  }
+
+  public boolean useAbstractConvertersForConversion(RelTraitSet fromTraits, RelTraitSet toTraits) {
+    return false;
+  }
 }
 
 // End EnumerableConvention.java

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcConvention.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcConvention.java
@@ -20,6 +20,7 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.rules.FilterSetOpTransposeRule;
 import org.apache.calcite.rel.rules.ProjectRemoveRule;
 import org.apache.calcite.sql.SqlDialect;
@@ -60,6 +61,15 @@ public class JdbcConvention extends Convention.Impl {
   public static JdbcConvention of(SqlDialect dialect, Expression expression,
       String name) {
     return new JdbcConvention(dialect, expression, name);
+  }
+
+  @Override public boolean canConvertConvention(Convention toConvention) {
+    return false;
+  }
+
+  @Override public boolean useAbstractConvertersForConversion(
+      RelTraitSet fromTraits, RelTraitSet toTraits) {
+    return false;
   }
 
   @Override public void register(RelOptPlanner planner) {

--- a/core/src/main/java/org/apache/calcite/interpreter/BindableConvention.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/BindableConvention.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.RelTraitSet;
 
 /**
  * Calling convention that returns results as an
@@ -59,6 +60,14 @@ public enum BindableConvention implements Convention {
   }
 
   public void register(RelOptPlanner planner) {}
+
+  public boolean canConvertConvention(Convention toConvention) {
+    return false;
+  }
+
+  public boolean useAbstractConvertersForConversion(RelTraitSet fromTraits, RelTraitSet toTraits) {
+    return false;
+  }
 }
 
 // End BindableConvention.java

--- a/core/src/main/java/org/apache/calcite/interpreter/InterpretableConvention.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/InterpretableConvention.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.RelTraitSet;
 
 /**
  * Calling convention that returns results as an
@@ -53,6 +54,14 @@ public enum InterpretableConvention implements Convention {
   }
 
   public void register(RelOptPlanner planner) {}
+
+  public boolean canConvertConvention(Convention toConvention) {
+    return false;
+  }
+
+  public boolean useAbstractConvertersForConversion(RelTraitSet fromTraits, RelTraitSet toTraits) {
+    return false;
+  }
 }
 
 // End InterpretableConvention.java

--- a/core/src/main/java/org/apache/calcite/plan/Convention.java
+++ b/core/src/main/java/org/apache/calcite/plan/Convention.java
@@ -38,6 +38,28 @@ public interface Convention extends RelTrait {
   String getName();
 
   /**
+   * Checks whether we should convert from this convention to toConvention.
+   * Used by ConventionTraitDef.
+   *
+   * @param toConvention desired convention to convert to
+   * @return true if we should convert from this convention to toConvention
+   */
+  boolean canConvertConvention(Convention toConvention);
+
+  /**
+   * Checks whether we should convert from this trait set to the other trait set.
+   * The convention decides whether it wants to handle other trait conversions, e.g.
+   * collation, distribution, etc..  For a given convention, we will only add abstract converters
+   * to handle the trait (convention, collation, distribution, etc.) conversions if this function
+   * returns true.
+   *
+   * @param fromTraits Relnode's traits that we are converting from
+   * @param toTraits Target traits
+   * @return true if we should add converters
+   */
+  boolean useAbstractConvertersForConversion(RelTraitSet fromTraits, RelTraitSet toTraits);
+
+  /**
    * Default implementation.
    */
   class Impl implements Convention {
@@ -69,6 +91,15 @@ public interface Convention extends RelTrait {
 
     public RelTraitDef getTraitDef() {
       return ConventionTraitDef.INSTANCE;
+    }
+
+    public boolean canConvertConvention(Convention toConvention) {
+      return false;
+    }
+
+    public boolean useAbstractConvertersForConversion(
+        RelTraitSet fromTraits, RelTraitSet toTraits) {
+      return false;
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
@@ -195,8 +195,8 @@ public class ConventionTraitDef extends RelTraitDef<Convention> {
       Convention fromConvention,
       Convention toConvention) {
     ConversionData conversionData = getConversionData(planner);
-    return conversionData.getShortestPath(fromConvention, toConvention)
-        != null;
+    return fromConvention.canConvertConvention(toConvention)
+        || conversionData.getShortestPath(fromConvention, toConvention) != null;
   }
 
   private ConversionData getConversionData(RelOptPlanner planner) {

--- a/core/src/main/java/org/apache/calcite/plan/RelTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTraitDef.java
@@ -177,6 +177,23 @@ public abstract class RelTraitDef<T extends RelTrait> {
       T toTrait);
 
   /**
+   * Tests whether the given RelTrait can be converted to another RelTrait.
+   *
+   * @param planner   the planner requesting the conversion test
+   * @param fromTrait the RelTrait to convert from
+   * @param toTrait   the RelTrait to convert to
+   * @param fromRel   the RelNode to convert from (with fromTrait)
+   * @return true if fromTrait can be converted to toTrait
+   */
+  public boolean canConvert(
+      RelOptPlanner planner,
+      T fromTrait,
+      T toTrait,
+      RelNode fromRel) {
+    return canConvert(planner, fromTrait, toTrait);
+  }
+
+  /**
    * Provides notification of the registration of a particular
    * {@link ConverterRule} with a {@link RelOptPlanner}. The default
    * implementation does nothing.

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -710,25 +710,6 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     }
   }
 
-  public boolean canConvert(RelTraitSet fromTraits, RelTraitSet toTraits) {
-    assert fromTraits.size() >= toTraits.size();
-
-    boolean canConvert = true;
-    for (int i = 0; (i < toTraits.size()) && canConvert; i++) {
-      RelTrait fromTrait = fromTraits.getTrait(i);
-      RelTrait toTrait = toTraits.getTrait(i);
-
-      assert fromTrait.getTraitDef() == toTrait.getTraitDef();
-      assert traitDefs.contains(fromTrait.getTraitDef());
-      assert traitDefs.contains(toTrait.getTraitDef());
-
-      canConvert =
-          fromTrait.getTraitDef().canConvert(this, fromTrait, toTrait);
-    }
-
-    return canConvert;
-  }
-
   public RelNode changeTraits(final RelNode rel, RelTraitSet toTraits) {
     assert !rel.getTraitSet().equals(toTraits);
     assert toTraits.allSimple();

--- a/core/src/main/java/org/apache/calcite/rel/RelCollationTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollationTraitDef.java
@@ -82,9 +82,21 @@ public class RelCollationTraitDef extends RelTraitDef<RelCollation> {
   }
 
   public boolean canConvert(
-      RelOptPlanner planner, RelCollation fromTrait, RelCollation toTrait) {
+       RelOptPlanner planner, RelCollation fromTrait, RelCollation toTrait) {
+    return false;
+  }
+
+  @Override public boolean canConvert(
+      RelOptPlanner planner, RelCollation fromTrait, RelCollation toTrait, RelNode fromRel) {
+    // Should return true only if we can convert.  In this case, we can only convert if the
+    // fromTrait (the child/input) has fields that the toTrait wants to sort.
+    for (RelFieldCollation field : toTrait.getFieldCollations()) {
+      int index = field.getFieldIndex();
+      if (index >= fromRel.getRowType().getFieldCount()) {
+        return false;
+      }
+    }
     return true;
   }
 }
-
 // End RelCollationTraitDef.java

--- a/core/src/test/java/org/apache/calcite/plan/volcano/CollationConversionTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/CollationConversionTest.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan.volcano;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.AbstractConverter.ExpandConversionRule;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollationImpl;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexNode;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PHYS_CALLING_CONVENTION;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.TestLeafRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.TestSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.newCluster;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for {@link org.apache.calcite.rel.RelCollationTraitDef}.
+ */
+public class CollationConversionTest {
+
+  public TestRelCollationImpl leafCollation =
+      new TestRelCollationImpl(ImmutableList.of(new RelFieldCollation(0, Direction.CLUSTERED)));
+
+  public TestRelCollationImpl rootCollation =
+      new TestRelCollationImpl(ImmutableList.of(new RelFieldCollation(0)));
+
+  public TestRelCollationTraitDef collationTraitDef = new TestRelCollationTraitDef();
+
+  @Test public void testCollationConversion() {
+    VolcanoPlanner planner = new VolcanoPlanner();
+    planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+    planner.addRelTraitDef(collationTraitDef);
+
+    planner.addRule(new SingleNodeRule());
+    planner.addRule(new LeafTraitRule());
+    planner.addRule(ExpandConversionRule.INSTANCE);
+
+    RelOptCluster cluster = newCluster(planner);
+    NoneLeafRel leafRel = new NoneLeafRel(cluster, "a");
+    NoneSingleRel singleRel = new NoneSingleRel(cluster, leafRel);
+    RelNode convertedRel =
+        planner.changeTraits(singleRel,
+            cluster.traitSetOf(PHYS_CALLING_CONVENTION).plus(rootCollation));
+    planner.setRoot(convertedRel);
+    RelNode result = planner.chooseDelegate().findBestExp();
+    assertTrue(result instanceof RootSingleRel);
+    assertTrue(result.getTraitSet().contains(rootCollation));
+    assertTrue(result.getTraitSet().contains(PHYS_CALLING_CONVENTION));
+
+    RelNode child = result.getInput(0);
+    assertTrue(child instanceof PhysicalSort);
+    assertTrue(result.getTraitSet().contains(rootCollation));
+    assertTrue(child.getTraitSet().contains(PHYS_CALLING_CONVENTION));
+
+    RelNode grandChild = child.getInput(0);
+    assertTrue(grandChild instanceof LeafRel);
+    assertTrue(grandChild.getTraitSet().contains(leafCollation));
+    assertTrue(child.getTraitSet().contains(PHYS_CALLING_CONVENTION));
+  }
+
+  /**
+   * Converts a NoneSingleRel to RootSingleRel
+   */
+  class SingleNodeRule extends RelOptRule {
+    SingleNodeRule() {
+      super(operand(NoneSingleRel.class, any()));
+    }
+
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    public void onMatch(RelOptRuleCall call) {
+      NoneSingleRel singleRel = call.rel(0);
+      RelNode childRel = singleRel.getInput();
+      RelNode physInput =
+          convert(childRel,
+              singleRel.getTraitSet()
+                  .replace(PHYS_CALLING_CONVENTION)
+                  .plus(rootCollation));
+      call.transformTo(
+          new RootSingleRel(
+              singleRel.getCluster(),
+              physInput));
+    }
+  }
+
+  /**
+   * RootSingleRel: Root node with physical convention and rootCollation trait.
+   */
+  class RootSingleRel extends TestSingleRel {
+    RootSingleRel(
+        RelOptCluster cluster,
+        RelNode child) {
+      super(
+          cluster,
+          cluster.traitSetOf(PHYS_CALLING_CONVENTION).plus(rootCollation),
+          child);
+    }
+
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      return new RootSingleRel(getCluster(), sole(inputs));
+    }
+  }
+
+  /**
+   * Converts a NoneLeafRel (with none convention) to LeafRel (with physical convention)
+   */
+  class LeafTraitRule extends RelOptRule {
+    LeafTraitRule() {
+      super(operand(NoneLeafRel.class, any()));
+    }
+
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    public void onMatch(RelOptRuleCall call) {
+      NoneLeafRel leafRel = call.rel(0);
+      call.transformTo(new LeafRel(leafRel.getCluster(), leafRel.getLabel()));
+    }
+  }
+
+  /**
+   * SingletonLeafRel:  leaf node with physical convention and leafCollation trait
+   */
+  class LeafRel extends TestLeafRel {
+    LeafRel(
+        RelOptCluster cluster,
+        String label) {
+      super(
+          cluster,
+          cluster.traitSetOf(PHYS_CALLING_CONVENTION).plus(leafCollation),
+          label);
+    }
+
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      return new LeafRel(getCluster(), getLabel());
+    }
+  }
+
+  /**
+   * NoneLeafRel:  leaf node with none convention and leafCollation trait
+   */
+  class NoneLeafRel extends TestLeafRel {
+    protected NoneLeafRel(
+        RelOptCluster cluster,
+        String label) {
+      super(
+          cluster,
+          cluster.traitSetOf(Convention.NONE).plus(leafCollation),
+          label);
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(Convention.NONE, leafCollation);
+      assert inputs.isEmpty();
+      return this;
+    }
+  }
+
+  /**
+   * NoneSingleRel:  a single relNode with none convention and leafCollation trait
+   */
+  class NoneSingleRel extends TestSingleRel {
+    protected NoneSingleRel(
+        RelOptCluster cluster,
+        RelNode child) {
+      super(
+          cluster,
+          cluster.traitSetOf(Convention.NONE).plus(leafCollation),
+          child);
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(Convention.NONE, leafCollation);
+      return new NoneSingleRel(getCluster(), sole(inputs));
+    }
+  }
+
+  /**
+   * Dummy collation trait implementation for the test
+   */
+  public class TestRelCollationImpl extends RelCollationImpl {
+
+    public TestRelCollationImpl(ImmutableList<RelFieldCollation> fieldCollations) {
+      super(fieldCollations);
+    }
+
+    @Override public RelTraitDef getTraitDef() {
+      return collationTraitDef;
+    }
+  }
+
+  /**
+   * Dummy collation trait def implementation for the test (uses the PhysicalSort below)
+   */
+  public class TestRelCollationTraitDef extends RelTraitDef<RelCollation> {
+    public Class<RelCollation> getTraitClass() {
+      return RelCollation.class;
+    }
+
+    public String getSimpleName() {
+      return "testsort";
+    }
+
+    @Override public boolean multiple() {
+      return true;
+    }
+
+    public RelCollation getDefault() {
+      return leafCollation;
+    }
+
+    public RelNode convert(
+        RelOptPlanner planner,
+        RelNode rel,
+        RelCollation toCollation,
+        boolean allowInfiniteCostConverters) {
+      if (toCollation.getFieldCollations().isEmpty()) {
+        // An empty sort doesn't make sense.
+        return null;
+      }
+
+      final Sort sort = new PhysicalSort(rel.getCluster(),
+          rel.getTraitSet().replace(toCollation), rel, toCollation, null, null);
+      return sort;
+    }
+
+    public boolean canConvert(
+        RelOptPlanner planner, RelCollation fromTrait, RelCollation toTrait) {
+      return true;
+    }
+  }
+
+  /**
+   * Physical Sort RelNode (not logical)
+   */
+  public class PhysicalSort extends Sort {
+    public PhysicalSort(
+        RelOptCluster cluster,
+        RelTraitSet traits,
+        RelNode child,
+        RelCollation collation,
+        RexNode offset,
+        RexNode fetch) {
+      super(cluster, traits, child, collation, offset, fetch);
+
+    }
+
+    @Override public Sort copy(
+        RelTraitSet traitSet,
+        RelNode newInput,
+        RelCollation newCollation,
+        RexNode offset,
+        RexNode fetch) {
+      return new PhysicalSort(getCluster(), traitSet, newInput, newCollation, offset, fetch);
+    }
+
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+  }
+}
+// End CollationConversionTest.java

--- a/core/src/test/java/org/apache/calcite/plan/volcano/ComboRuleTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/ComboRuleTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan.volcano;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.GoodSingleRule;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.NoneLeafRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.NoneSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PHYS_CALLING_CONVENTION;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PhysLeafRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PhysSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.TestSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.newCluster;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit test for {@link VolcanoPlanner}
+ */
+public class ComboRuleTest {
+
+  @Test public void testCombo() {
+    VolcanoPlanner planner = new VolcanoPlanner();
+    planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+
+    planner.addRule(new ComboRule());
+    planner.addRule(new AddIntermediateNodeRule());
+    planner.addRule(new GoodSingleRule());
+
+    RelOptCluster cluster = newCluster(planner);
+    NoneLeafRel leafRel =
+        new NoneLeafRel(
+            cluster,
+            "a");
+    NoneSingleRel singleRel =
+        new NoneSingleRel(
+            cluster,
+            leafRel);
+    NoneSingleRel singleRel2 =
+        new NoneSingleRel(
+            cluster,
+            singleRel);
+    RelNode convertedRel =
+        planner.changeTraits(
+            singleRel2,
+            cluster.traitSetOf(PHYS_CALLING_CONVENTION));
+    planner.setRoot(convertedRel);
+    RelNode result = planner.chooseDelegate().findBestExp();
+    assertTrue(result instanceof IntermediateNode);
+  }
+
+  /**
+   * Intermediate node, the cost decreases as it is pushed up the tree
+   * (more children it has, cheaper it gets)
+   */
+  private static class IntermediateNode extends TestSingleRel {
+
+    private final int numNodesBelow;
+
+    IntermediateNode(RelOptCluster cluster, RelNode child, int numNodesBelow) {
+      super(cluster, cluster.traitSetOf(PHYS_CALLING_CONVENTION), child);
+      this.numNodesBelow = numNodesBelow;
+    }
+
+    public int getNumNodesBelow() { return numNodesBelow; }
+
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeCost(100, 100, 100).multiplyBy(1.0 / numNodesBelow);
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(PHYS_CALLING_CONVENTION);
+      return new IntermediateNode(getCluster(), sole(inputs), numNodesBelow);
+    }
+  }
+
+  /**
+   * Rule that adds an intermediate node above the PhysLeafRel
+   */
+  private static class AddIntermediateNodeRule extends RelOptRule {
+    AddIntermediateNodeRule() {
+      super(operand(NoneLeafRel.class, any()));
+    }
+
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    public void onMatch(RelOptRuleCall call) {
+      NoneLeafRel leaf = call.rel(0);
+
+      RelNode physLeaf = new PhysLeafRel(leaf.getCluster(), leaf.getLabel());
+      RelNode intermediateNode = new IntermediateNode(physLeaf.getCluster(), physLeaf, 1);
+
+      call.transformTo(intermediateNode);
+    }
+  }
+
+  /**
+   * Matches PhysSingleRel-IntermediateNode-Any and converts to Intermediate-PhysSingleRel-Any
+   */
+  private static class ComboRule extends RelOptRule {
+    ComboRule() {
+      super(createOperand());
+    }
+
+    private static RelOptRuleOperand createOperand() {
+      RelOptRuleOperand input = operand(RelNode.class, any());
+      input = operand(IntermediateNode.class, some(input));
+      input = operand(PhysSingleRel.class, some(input));
+      return input;
+    }
+
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    @Override public boolean matches(RelOptRuleCall call) {
+      if (call.rels.length < 3) {
+        return false;
+      }
+
+      if (call.rel(0) instanceof PhysSingleRel
+          && call.rel(1) instanceof IntermediateNode
+          && call.rel(2) instanceof RelNode) {
+        return true;
+      }
+      return false;
+    }
+
+    @Override public void onMatch(RelOptRuleCall call) {
+      List<RelNode> newInputs = new ArrayList<>(1);
+      newInputs.add(call.rel(2));
+      IntermediateNode oldInter = call.rel(1);
+      RelNode physRel = call.rel(0).copy(call.rel(0).getTraitSet(), newInputs);
+      RelNode converted = new IntermediateNode(
+          physRel.getCluster(),
+          physRel,
+          oldInter.getNumNodesBelow() + 1);
+      call.transformTo(converted);
+    }
+  }
+}
+// End ComboRuleTest.java

--- a/core/src/test/java/org/apache/calcite/plan/volcano/PlannerTestCommon.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/PlannerTestCommon.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.plan.volcano;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+
+import java.util.List;
+
+/**
+ * Common set of classes and utility methods for the tests in this package
+ */
+public class PlannerTestCommon {
+
+  private PlannerTestCommon() {}
+
+  /**
+   * Private calling convention representing a physical implementation.
+   */
+  public static final Convention PHYS_CALLING_CONVENTION
+    = new Convention.Impl("PHYS", RelNode.class) {
+      @Override public boolean canConvertConvention(Convention toConvention) {
+        return true;
+      }
+
+      @Override public boolean useAbstractConvertersForConversion(
+          RelTraitSet fromTraits, RelTraitSet toTraits) {
+        return true;
+      }
+    };
+
+  public static RelOptCluster newCluster(VolcanoPlanner planner) {
+    final RelDataTypeFactory typeFactory =
+        new SqlTypeFactoryImpl(org.apache.calcite.rel.type.RelDataTypeSystem.DEFAULT);
+    return RelOptCluster.create(planner, new RexBuilder(typeFactory));
+  }
+
+  /** Leaf relational expression. */
+  abstract static class TestLeafRel extends AbstractRelNode {
+    private String label;
+
+    protected TestLeafRel(
+        RelOptCluster cluster,
+        RelTraitSet traits,
+        String label) {
+      super(cluster, traits);
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    // implement RelNode
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeInfiniteCost();
+    }
+
+    // implement RelNode
+    protected RelDataType deriveRowType() {
+      final RelDataTypeFactory typeFactory = getCluster().getTypeFactory();
+      return typeFactory.builder()
+          .add("this", typeFactory.createJavaType(Void.TYPE))
+          .build();
+    }
+
+    public RelWriter explainTerms(RelWriter pw) {
+      return super.explainTerms(pw).item("label", label);
+    }
+  }
+
+  /** Relational expression with one input. */
+  abstract static class TestSingleRel extends SingleRel {
+    protected TestSingleRel(
+        RelOptCluster cluster,
+        RelTraitSet traits,
+        RelNode child) {
+      super(cluster, traits, child);
+    }
+
+    // implement RelNode
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeInfiniteCost();
+    }
+
+    // implement RelNode
+    protected RelDataType deriveRowType() {
+      return getInput().getRowType();
+    }
+  }
+
+  /** Relational expression with one input and convention NONE. */
+  static class NoneSingleRel extends TestSingleRel {
+    protected NoneSingleRel(
+        RelOptCluster cluster,
+        RelNode child) {
+      super(
+          cluster,
+          cluster.traitSetOf(Convention.NONE),
+          child);
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(Convention.NONE);
+      return new NoneSingleRel(getCluster(), sole(inputs));
+    }
+  }
+
+  /** Relational expression with zero inputs and convention NONE. */
+  static class NoneLeafRel extends TestLeafRel {
+    protected NoneLeafRel(
+        RelOptCluster cluster,
+        String label) {
+      super(
+          cluster,
+          cluster.traitSetOf(Convention.NONE),
+          label);
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(Convention.NONE);
+      assert inputs.isEmpty();
+      return this;
+    }
+  }
+
+  /** Relational expression with zero inputs and convention PHYS. */
+  static class PhysLeafRel extends TestLeafRel {
+    PhysLeafRel(
+        RelOptCluster cluster,
+        String label) {
+      super(
+          cluster,
+          cluster.traitSetOf(PHYS_CALLING_CONVENTION),
+          label);
+    }
+
+    // implement RelNode
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(PHYS_CALLING_CONVENTION);
+      assert inputs.isEmpty();
+      return this;
+    }
+  }
+
+  /** Relational expression with one input and convention PHYS. */
+  static class PhysSingleRel extends TestSingleRel {
+    PhysSingleRel(
+        RelOptCluster cluster,
+        RelNode child) {
+      super(
+          cluster,
+          cluster.traitSetOf(PHYS_CALLING_CONVENTION),
+          child);
+    }
+
+    // implement RelNode
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(PHYS_CALLING_CONVENTION);
+      return new PhysSingleRel(
+          getCluster(),
+          sole(inputs));
+    }
+  }
+
+  /** Planner rule that converts {@link NoneLeafRel} to PHYS
+   * convention. */
+  static class PhysLeafRule extends RelOptRule {
+    PhysLeafRule() {
+      super(operand(NoneLeafRel.class, any()));
+    }
+
+    // implement RelOptRule
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    // implement RelOptRule
+    public void onMatch(RelOptRuleCall call) {
+      NoneLeafRel leafRel = call.rel(0);
+      call.transformTo(
+          new PhysLeafRel(
+              leafRel.getCluster(),
+              leafRel.getLabel()));
+    }
+  }
+
+  /** Planner rule that matches a {@link NoneSingleRel} and succeeds. */
+  static class GoodSingleRule extends RelOptRule {
+    GoodSingleRule() {
+      super(operand(NoneSingleRel.class, any()));
+    }
+
+    // implement RelOptRule
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    // implement RelOptRule
+    public void onMatch(RelOptRuleCall call) {
+      NoneSingleRel singleRel = call.rel(0);
+      RelNode childRel = singleRel.getInput();
+      RelNode physInput =
+          convert(
+              childRel,
+              singleRel.getTraitSet().replace(PHYS_CALLING_CONVENTION));
+      call.transformTo(
+          new PhysSingleRel(
+              singleRel.getCluster(),
+              physInput));
+    }
+  }
+}
+// End PlannerTestCommon.java

--- a/core/src/test/java/org/apache/calcite/plan/volcano/TraitConversionTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/TraitConversionTest.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.plan.volcano;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.AbstractConverter.ExpandConversionRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PHYS_CALLING_CONVENTION;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.TestLeafRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.TestSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.newCluster;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit test for {@link org.apache.calcite.rel.RelDistributionTraitDef}.
+ */
+public class TraitConversionTest {
+
+  final ConvertRelDistributionTraitDef newTraitDefInstance = new ConvertRelDistributionTraitDef();
+  public SimpleDistribution simpleDistributionAny = new SimpleDistribution("ANY");
+  public SimpleDistribution simpleDistributionRandom = new SimpleDistribution("RANDOM");
+  public SimpleDistribution simpleDistributionSingleton = new SimpleDistribution("SINGLETON");
+
+  @Test public void testTraitConversion() {
+    VolcanoPlanner planner = new VolcanoPlanner();
+    planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+    planner.addRelTraitDef(newTraitDefInstance);
+
+    planner.addRule(new RandomSingleTraitRule());
+    planner.addRule(new SingleLeafTraitRule());
+    planner.addRule(ExpandConversionRule.INSTANCE);
+
+    RelOptCluster cluster = newCluster(planner);
+    NoneLeafRel leafRel = new NoneLeafRel(cluster, "a");
+    NoneSingleRel singleRel = new NoneSingleRel(cluster, leafRel);
+    RelNode convertedRel =
+        planner.changeTraits(singleRel,
+            cluster.traitSetOf(PHYS_CALLING_CONVENTION));
+    planner.setRoot(convertedRel);
+    RelNode result = planner.chooseDelegate().findBestExp();
+
+    assertTrue(result instanceof RandomSingleRel);
+    assertTrue(result.getTraitSet().contains(PHYS_CALLING_CONVENTION));
+    assertTrue(result.getTraitSet().contains(simpleDistributionRandom));
+
+    RelNode child = result.getInput(0);
+    assertTrue(child instanceof BridgeRel);
+    assertTrue(child.getTraitSet().contains(PHYS_CALLING_CONVENTION));
+    assertTrue(child.getTraitSet().contains(simpleDistributionRandom));
+
+    RelNode grandChild = child.getInput(0);
+    assertTrue(grandChild instanceof SingletonLeafRel);
+    assertTrue(grandChild.getTraitSet().contains(PHYS_CALLING_CONVENTION));
+    assertTrue(grandChild.getTraitSet().contains(simpleDistributionSingleton));
+  }
+
+  /**
+   * Converts a NoneSingleRel (none convention, distribution any) to RandomSingleRel
+   * (physical convention, distribution random)
+   */
+  class RandomSingleTraitRule extends RelOptRule {
+    RandomSingleTraitRule() {
+      super(operand(NoneSingleRel.class, any()));
+    }
+
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    public void onMatch(RelOptRuleCall call) {
+      NoneSingleRel singleRel = call.rel(0);
+      RelNode childRel = singleRel.getInput();
+      RelNode physInput =
+          convert(childRel,
+              singleRel.getTraitSet()
+                  .replace(PHYS_CALLING_CONVENTION)
+                  .plus(simpleDistributionRandom));
+      call.transformTo(
+          new RandomSingleRel(
+              singleRel.getCluster(),
+              physInput));
+    }
+  }
+
+  /**
+   * RandomSingleRel:  Rel with physical convention and random distribution
+   */
+  class RandomSingleRel extends TestSingleRel {
+    RandomSingleRel(
+        RelOptCluster cluster,
+        RelNode child) {
+      super(
+          cluster,
+          cluster.traitSetOf(PHYS_CALLING_CONVENTION).plus(simpleDistributionRandom),
+          child);
+    }
+
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+
+    public RelNode copy(
+        RelTraitSet traitSet,
+        List<RelNode> inputs) {
+      return new RandomSingleRel(getCluster(), sole(inputs));
+    }
+  }
+
+  /**
+   * Converts NoneLeafRel (none convention, any distribution) to SingletonLeafRel
+   * (physical convention, singleton distribution)
+   */
+  class SingleLeafTraitRule extends RelOptRule {
+    SingleLeafTraitRule() {
+      super(operand(NoneLeafRel.class, any()));
+    }
+
+    public Convention getOutConvention() {
+      return PHYS_CALLING_CONVENTION;
+    }
+
+    public void onMatch(RelOptRuleCall call) {
+      NoneLeafRel leafRel = call.rel(0);
+      call.transformTo(
+          new SingletonLeafRel(leafRel.getCluster(), leafRel.getLabel()));
+    }
+  }
+
+  /**
+   * SingletonLeafRel (with singleton distribution, physical convention)
+   */
+  class SingletonLeafRel extends TestLeafRel {
+    SingletonLeafRel(
+        RelOptCluster cluster,
+        String label) {
+      super(
+          cluster,
+          cluster.traitSetOf(PHYS_CALLING_CONVENTION).plus(simpleDistributionSingleton),
+          label);
+    }
+
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      return new SingletonLeafRel(getCluster(), getLabel());
+    }
+  }
+
+  /**
+   * Bridges the SimpleDistribution, difference between SingletonLeafRel and RandomSingleRel
+   */
+  class BridgeRel extends TestSingleRel {
+    BridgeRel(
+        RelOptCluster cluster,
+        RelNode child) {
+      super(
+          cluster,
+          cluster.traitSetOf(PHYS_CALLING_CONVENTION).plus(simpleDistributionRandom),
+          child);
+    }
+
+    public RelOptCost computeSelfCost(
+        RelOptPlanner planner,
+        RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      return new BridgeRel(getCluster(), sole(inputs));
+    }
+  }
+
+  /**
+   * Dummy distribution for test (simplified version of RelDistribution)
+   */
+  public class SimpleDistribution implements RelTrait {
+
+    private final String name;
+
+    public SimpleDistribution(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    @Override public String toString() {
+      return getName();
+    }
+
+    @Override public RelTraitDef getTraitDef() {
+      return newTraitDefInstance;
+    }
+
+    @Override public boolean satisfies(RelTrait trait) {
+      if (trait == this || trait == simpleDistributionAny) {
+        return true;
+      }
+
+      return false;
+    }
+
+    @Override public void register(RelOptPlanner planner) {}
+  }
+
+  /**
+   * Dummy distribution trait def for test (handles conversion of SimpleDistribution)
+   */
+  public class ConvertRelDistributionTraitDef extends RelTraitDef<SimpleDistribution> {
+
+    private ConvertRelDistributionTraitDef() {}
+
+    @Override public Class<SimpleDistribution> getTraitClass() {
+      return SimpleDistribution.class;
+    }
+
+    @Override public String toString() {
+      return getSimpleName();
+    }
+
+    @Override public String getSimpleName() {
+      return "ConvertRelDistributionTraitDef";
+    }
+
+    @Override public RelNode convert(
+        RelOptPlanner planner,
+        RelNode rel,
+        SimpleDistribution toTrait,
+        boolean allowInfiniteCostConverters) {
+      if (toTrait == simpleDistributionAny) {
+        return rel;
+      }
+
+      return new BridgeRel(rel.getCluster(), rel);
+    }
+
+    @Override public boolean canConvert(
+        RelOptPlanner planner,
+        SimpleDistribution fromTrait,
+        SimpleDistribution toTrait) {
+
+      if ((fromTrait == toTrait)
+          || (toTrait == simpleDistributionAny)
+          || (fromTrait == simpleDistributionSingleton
+          && toTrait == simpleDistributionRandom)) {
+        return true;
+      }
+
+      return false;
+    }
+
+    @Override public SimpleDistribution getDefault() {
+      return simpleDistributionAny;
+    }
+  }
+
+  /**
+   * NoneLeafRel (any distribution and none convention)
+   */
+  class NoneLeafRel extends TestLeafRel {
+    protected NoneLeafRel(
+        RelOptCluster cluster,
+        String label) {
+      super(
+          cluster,
+          cluster.traitSetOf(Convention.NONE),
+          label);
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(Convention.NONE, simpleDistributionAny);
+      assert inputs.isEmpty();
+      return this;
+    }
+  }
+
+  /**
+   * NoneSingleRel (any distribution and none convention)
+   */
+  class NoneSingleRel extends TestSingleRel {
+    protected NoneSingleRel(
+        RelOptCluster cluster,
+        RelNode child) {
+      super(
+          cluster,
+          cluster.traitSetOf(Convention.NONE),
+          child);
+    }
+
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert traitSet.comprises(Convention.NONE, simpleDistributionAny);
+      return new NoneSingleRel(
+          getCluster(),
+          sole(inputs));
+    }
+  }
+}
+// End TraitConversionTest.java

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
@@ -20,28 +20,17 @@ import org.apache.calcite.adapter.enumerable.EnumerableConvention;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptListener;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelWriter;
-import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.logical.LogicalProject;
-import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.ProjectRemoveRule;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeSystem;
-import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
-import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
@@ -54,7 +43,18 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.GoodSingleRule;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.NoneLeafRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.NoneSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PHYS_CALLING_CONVENTION;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PhysLeafRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PhysLeafRule;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.PhysSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.TestSingleRel;
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.newCluster;
+
 import static org.hamcrest.CoreMatchers.equalTo;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -64,30 +64,11 @@ import static org.junit.Assert.assertTrue;
  * Unit test for {@link VolcanoPlanner the optimizer}.
  */
 public class VolcanoPlannerTest {
-  //~ Static fields/initializers ---------------------------------------------
-
-  /**
-   * Private calling convention representing a physical implementation.
-   */
-  private static final Convention PHYS_CALLING_CONVENTION =
-      new Convention.Impl(
-          "PHYS",
-          RelNode.class);
-
-  //~ Constructors -----------------------------------------------------------
 
   public VolcanoPlannerTest() {
   }
 
   //~ Methods ----------------------------------------------------------------
-
-  static RelOptCluster newCluster(VolcanoPlanner planner) {
-    final RelDataTypeFactory typeFactory =
-        new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
-    return RelOptCluster.create(planner,
-        new RexBuilder(typeFactory));
-  }
-
   /**
    * Tests transformation of a leaf from NONE to PHYS.
    */
@@ -479,149 +460,6 @@ public class VolcanoPlannerTest {
 
   //~ Inner Classes ----------------------------------------------------------
 
-  /** Leaf relational expression. */
-  private abstract static class TestLeafRel extends AbstractRelNode {
-    private String label;
-
-    protected TestLeafRel(
-        RelOptCluster cluster,
-        RelTraitSet traits,
-        String label) {
-      super(cluster, traits);
-      this.label = label;
-    }
-
-    public String getLabel() {
-      return label;
-    }
-
-    // implement RelNode
-    public RelOptCost computeSelfCost(RelOptPlanner planner,
-        RelMetadataQuery mq) {
-      return planner.getCostFactory().makeInfiniteCost();
-    }
-
-    // implement RelNode
-    protected RelDataType deriveRowType() {
-      final RelDataTypeFactory typeFactory = getCluster().getTypeFactory();
-      return typeFactory.builder()
-          .add("this", typeFactory.createJavaType(Void.TYPE))
-          .build();
-    }
-
-    public RelWriter explainTerms(RelWriter pw) {
-      return super.explainTerms(pw)
-          .item("label", label);
-    }
-  }
-
-  /** Relational expression with one input. */
-  private abstract static class TestSingleRel extends SingleRel {
-    protected TestSingleRel(
-        RelOptCluster cluster,
-        RelTraitSet traits,
-        RelNode child) {
-      super(cluster, traits, child);
-    }
-
-    // implement RelNode
-    public RelOptCost computeSelfCost(RelOptPlanner planner,
-        RelMetadataQuery mq) {
-      return planner.getCostFactory().makeInfiniteCost();
-    }
-
-    // implement RelNode
-    protected RelDataType deriveRowType() {
-      return getInput().getRowType();
-    }
-  }
-
-  /** Relational expression with one input and convention NONE. */
-  private static class NoneSingleRel extends TestSingleRel {
-    protected NoneSingleRel(
-        RelOptCluster cluster,
-        RelNode child) {
-      super(
-          cluster,
-          cluster.traitSetOf(Convention.NONE),
-          child);
-    }
-
-    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-      assert traitSet.comprises(Convention.NONE);
-      return new NoneSingleRel(
-          getCluster(),
-          sole(inputs));
-    }
-  }
-
-  /** Relational expression with zero inputs and convention NONE. */
-  private static class NoneLeafRel extends TestLeafRel {
-    protected NoneLeafRel(
-        RelOptCluster cluster,
-        String label) {
-      super(
-          cluster,
-          cluster.traitSetOf(Convention.NONE),
-          label);
-    }
-
-    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-      assert traitSet.comprises(Convention.NONE);
-      assert inputs.isEmpty();
-      return this;
-    }
-  }
-
-  /** Relational expression with zero inputs and convention PHYS. */
-  private static class PhysLeafRel extends TestLeafRel {
-    PhysLeafRel(
-        RelOptCluster cluster,
-        String label) {
-      super(
-          cluster,
-          cluster.traitSetOf(PHYS_CALLING_CONVENTION),
-          label);
-    }
-
-    // implement RelNode
-    public RelOptCost computeSelfCost(RelOptPlanner planner,
-        RelMetadataQuery mq) {
-      return planner.getCostFactory().makeTinyCost();
-    }
-
-    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-      assert traitSet.comprises(PHYS_CALLING_CONVENTION);
-      assert inputs.isEmpty();
-      return this;
-    }
-  }
-
-  /** Relational expression with one input and convention PHYS. */
-  private static class PhysSingleRel extends TestSingleRel {
-    PhysSingleRel(
-        RelOptCluster cluster,
-        RelNode child) {
-      super(
-          cluster,
-          cluster.traitSetOf(PHYS_CALLING_CONVENTION),
-          child);
-    }
-
-    // implement RelNode
-    public RelOptCost computeSelfCost(RelOptPlanner planner,
-        RelMetadataQuery mq) {
-      return planner.getCostFactory().makeTinyCost();
-    }
-
-    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-      assert traitSet.comprises(PHYS_CALLING_CONVENTION);
-      return new PhysSingleRel(
-          getCluster(),
-          sole(inputs));
-    }
-  }
-
   /** Converter from PHYS to ENUMERABLE convention. */
   class PhysToIteratorConverter extends ConverterImpl {
     public PhysToIteratorConverter(
@@ -639,54 +477,6 @@ public class VolcanoPlannerTest {
       return new PhysToIteratorConverter(
           getCluster(),
           sole(inputs));
-    }
-  }
-
-  /** Planner rule that converts {@link NoneLeafRel} to PHYS
-   * convention. */
-  private static class PhysLeafRule extends RelOptRule {
-    PhysLeafRule() {
-      super(operand(NoneLeafRel.class, any()));
-    }
-
-    // implement RelOptRule
-    public Convention getOutConvention() {
-      return PHYS_CALLING_CONVENTION;
-    }
-
-    // implement RelOptRule
-    public void onMatch(RelOptRuleCall call) {
-      NoneLeafRel leafRel = call.rel(0);
-      call.transformTo(
-          new PhysLeafRel(
-              leafRel.getCluster(),
-              leafRel.getLabel()));
-    }
-  }
-
-  /** Planner rule that matches a {@link NoneSingleRel} and succeeds. */
-  private static class GoodSingleRule extends RelOptRule {
-    GoodSingleRule() {
-      super(operand(NoneSingleRel.class, any()));
-    }
-
-    // implement RelOptRule
-    public Convention getOutConvention() {
-      return PHYS_CALLING_CONVENTION;
-    }
-
-    // implement RelOptRule
-    public void onMatch(RelOptRuleCall call) {
-      NoneSingleRel singleRel = call.rel(0);
-      RelNode childRel = singleRel.getInput();
-      RelNode physInput =
-          convert(
-              childRel,
-              singleRel.getTraitSet().replace(PHYS_CALLING_CONVENTION));
-      call.transformTo(
-          new PhysSingleRel(
-              singleRel.getCluster(),
-              physInput));
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
@@ -49,6 +49,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.apache.calcite.plan.volcano.PlannerTestCommon.newCluster;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -119,7 +121,7 @@ public class VolcanoPlannerTraitTest {
     planner.addRule(new PhysLeafRule());
     planner.addRule(new IterSingleRule());
 
-    RelOptCluster cluster = VolcanoPlannerTest.newCluster(planner);
+    RelOptCluster cluster = newCluster(planner);
 
     NoneLeafRel noneLeafRel =
         RelOptUtil.addTrait(
@@ -170,7 +172,7 @@ public class VolcanoPlannerTraitTest {
     planner.addRule(new IterSingleRule());
     planner.addRule(new IterSinglePhysMergeRule());
 
-    RelOptCluster cluster = VolcanoPlannerTest.newCluster(planner);
+    RelOptCluster cluster = newCluster(planner);
 
     NoneLeafRel noneLeafRel =
         RelOptUtil.addTrait(
@@ -207,7 +209,7 @@ public class VolcanoPlannerTraitTest {
     planner.addRule(new PhysLeafRule());
     planner.addRule(new IterSingleRule2());
 
-    RelOptCluster cluster = VolcanoPlannerTest.newCluster(planner);
+    RelOptCluster cluster = newCluster(planner);
 
     NoneLeafRel noneLeafRel =
         RelOptUtil.addTrait(

--- a/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
@@ -21,6 +21,9 @@ import org.apache.calcite.jdbc.CalciteRemoteDriverTest;
 import org.apache.calcite.plan.RelOptPlanReaderTest;
 import org.apache.calcite.plan.RelOptUtilTest;
 import org.apache.calcite.plan.RelWriterTest;
+import org.apache.calcite.plan.volcano.CollationConversionTest;
+import org.apache.calcite.plan.volcano.ComboRuleTest;
+import org.apache.calcite.plan.volcano.TraitConversionTest;
 import org.apache.calcite.plan.volcano.TraitPropagationTest;
 import org.apache.calcite.plan.volcano.VolcanoPlannerTest;
 import org.apache.calcite.plan.volcano.VolcanoPlannerTraitTest;
@@ -102,6 +105,9 @@ import org.junit.runners.Suite;
     RexBuilderTest.class,
     SqlTypeFactoryTest.class,
     SqlValidatorUtilTest.class,
+    CollationConversionTest.class,
+    TraitConversionTest.class,
+    ComboRuleTest.class,
 
     // medium tests (above 0.1s)
     SqlParserTest.class,

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -103,20 +103,20 @@ public class JdbcAdapterTest {
             + "from scott.emp e inner join scott.dept d \n"
             + "on e.deptno = d.deptno")
         .explainContains("PLAN=JdbcToEnumerableConverter\n"
-            + "  JdbcProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$2], DNAME=[$4])\n"
-            + "    JdbcJoin(condition=[=($2, $3)], joinType=[inner])\n"
-            + "      JdbcProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])\n"
-            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
+            + "  JdbcProject(EMPNO=[$2], ENAME=[$3], DEPTNO=[$4], DNAME=[$1])\n"
+            + "    JdbcJoin(condition=[=($4, $0)], joinType=[inner])\n"
             + "      JdbcProject(DEPTNO=[$0], DNAME=[$1])\n"
-            + "        JdbcTableScan(table=[[SCOTT, DEPT]])")
+            + "        JdbcTableScan(table=[[SCOTT, DEPT]])\n"
+            + "      JdbcProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])\n"
+            + "        JdbcTableScan(table=[[SCOTT, EMP]])")
         .runs()
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
-        .planHasSql("SELECT \"t\".\"EMPNO\", \"t\".\"ENAME\", "
-            + "\"t\".\"DEPTNO\", \"t0\".\"DNAME\"\n"
-            + "FROM (SELECT \"EMPNO\", \"ENAME\", \"DEPTNO\"\n"
-            + "FROM \"SCOTT\".\"EMP\") AS \"t\"\n"
-            + "INNER JOIN (SELECT \"DEPTNO\", \"DNAME\"\n"
-            + "FROM \"SCOTT\".\"DEPT\") AS \"t0\" "
+        .planHasSql("SELECT \"t0\".\"EMPNO\", \"t0\".\"ENAME\", "
+            + "\"t0\".\"DEPTNO\", \"t\".\"DNAME\"\n"
+            + "FROM (SELECT \"DEPTNO\", \"DNAME\"\n"
+            + "FROM \"SCOTT\".\"DEPT\") AS \"t\"\n"
+            + "INNER JOIN (SELECT \"EMPNO\", \"ENAME\", \"DEPTNO\"\n"
+            + "FROM \"SCOTT\".\"EMP\") AS \"t0\" "
             + "ON \"t\".\"DEPTNO\" = \"t0\".\"DEPTNO\"");
   }
 
@@ -129,17 +129,19 @@ public class JdbcAdapterTest {
             + "from scott.emp e inner join scott.salgrade s \n"
             + "on e.sal > s.losal and e.sal < s.hisal")
         .explainContains("PLAN=JdbcToEnumerableConverter\n"
-            + "  JdbcProject(EMPNO=[$0], ENAME=[$1], GRADE=[$3])\n"
-            + "    JdbcJoin(condition=[AND(>($2, $4), <($2, $5))], joinType=[inner])\n"
+            + "  JdbcProject(EMPNO=[$3], ENAME=[$4], GRADE=[$0])\n"
+            + "    JdbcJoin(condition=[AND(>($5, $1), <($5, $2))], joinType=[inner])\n"
+            + "      JdbcTableScan(table=[[SCOTT, SALGRADE]])\n"
             + "      JdbcProject(EMPNO=[$0], ENAME=[$1], SAL=[$5])\n"
-            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
-            + "      JdbcTableScan(table=[[SCOTT, SALGRADE]])")
+            + "        JdbcTableScan(table=[[SCOTT, EMP]])")
         .runs()
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
         .planHasSql("SELECT \"t\".\"EMPNO\", \"t\".\"ENAME\", "
-            + "\"SALGRADE\".\"GRADE\"\n"
-            + "FROM (SELECT \"EMPNO\", \"ENAME\", \"SAL\"\nFROM \"SCOTT\".\"EMP\") AS \"t\"\n"
-            + "INNER JOIN \"SCOTT\".\"SALGRADE\" ON \"t\".\"SAL\" > \"SALGRADE\".\"LOSAL\" AND \"t\".\"SAL\" < \"SALGRADE\".\"HISAL\"");
+            + "\"SALGRADE\".\"GRADE\"\nFROM \"SCOTT\".\"SALGRADE\"\n"
+            + "INNER JOIN (SELECT \"EMPNO\", \"ENAME\", \"SAL\"\n"
+            + "FROM \"SCOTT\".\"EMP\") AS \"t\" "
+            + "ON \"SALGRADE\".\"LOSAL\" < \"t\".\"SAL\" "
+            + "AND \"SALGRADE\".\"HISAL\" > \"t\".\"SAL\"");
   }
 
   @Test public void testNonEquiJoinReverseConditionPlan() {
@@ -148,18 +150,18 @@ public class JdbcAdapterTest {
             + "from scott.emp e inner join scott.salgrade s \n"
             + "on s.losal <= e.sal and s.hisal >= e.sal")
         .explainContains("PLAN=JdbcToEnumerableConverter\n"
-            + "  JdbcProject(EMPNO=[$0], ENAME=[$1], GRADE=[$3])\n"
-            + "    JdbcJoin(condition=[AND(<=($4, $2), >=($5, $2))], joinType=[inner])\n"
+            + "  JdbcProject(EMPNO=[$3], ENAME=[$4], GRADE=[$0])\n"
+            + "    JdbcJoin(condition=[AND(<=($1, $5), >=($2, $5))], joinType=[inner])\n"
+            + "      JdbcTableScan(table=[[SCOTT, SALGRADE]])\n"
             + "      JdbcProject(EMPNO=[$0], ENAME=[$1], SAL=[$5])\n"
-            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
-            + "      JdbcTableScan(table=[[SCOTT, SALGRADE]])")
+            + "        JdbcTableScan(table=[[SCOTT, EMP]])")
         .runs()
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
         .planHasSql("SELECT \"t\".\"EMPNO\", \"t\".\"ENAME\", "
-            + "\"SALGRADE\".\"GRADE\"\n"
-            + "FROM (SELECT \"EMPNO\", \"ENAME\", \"SAL\"\n"
-            + "FROM \"SCOTT\".\"EMP\") AS \"t\"\n"
-            + "INNER JOIN \"SCOTT\".\"SALGRADE\" ON \"t\".\"SAL\" >= \"SALGRADE\".\"LOSAL\" AND \"t\".\"SAL\" <= \"SALGRADE\".\"HISAL\"");
+            + "\"SALGRADE\".\"GRADE\"\nFROM \"SCOTT\".\"SALGRADE\"\n"
+            + "INNER JOIN (SELECT \"EMPNO\", \"ENAME\", \"SAL\"\n"
+            + "FROM \"SCOTT\".\"EMP\") AS \"t\" "
+            + "ON \"SALGRADE\".\"LOSAL\" <= \"t\".\"SAL\" AND \"SALGRADE\".\"HISAL\" >= \"t\".\"SAL\"");
   }
 
   @Test public void testMixedJoinPlan() {
@@ -168,20 +170,21 @@ public class JdbcAdapterTest {
             + "from scott.emp e inner join scott.emp m on  \n"
             + "e.mgr = m.empno and e.sal > m.sal")
         .explainContains("PLAN=JdbcToEnumerableConverter\n"
-            + "  JdbcProject(EMPNO=[$0], ENAME=[$1], EMPNO0=[$0], ENAME0=[$1])\n"
-            + "    JdbcJoin(condition=[AND(=($2, $4), >($3, $5))], joinType=[inner])\n"
-            + "      JdbcProject(EMPNO=[$0], ENAME=[$1], MGR=[$3], SAL=[$5])\n"
-            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
+            + "  JdbcProject(EMPNO=[$2], ENAME=[$3], EMPNO0=[$2], ENAME0=[$3])\n"
+            + "    JdbcJoin(condition=[AND(=($4, $0), >($5, $1))], joinType=[inner])\n"
             + "      JdbcProject(EMPNO=[$0], SAL=[$5])\n"
+            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
+            + "      JdbcProject(EMPNO=[$0], ENAME=[$1], MGR=[$3], SAL=[$5])\n"
             + "        JdbcTableScan(table=[[SCOTT, EMP]])")
         .runs()
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
-        .planHasSql("SELECT \"t\".\"EMPNO\", \"t\".\"ENAME\", "
-            + "\"t\".\"EMPNO\" AS \"EMPNO0\", \"t\".\"ENAME\" AS \"ENAME0\"\n"
-            + "FROM (SELECT \"EMPNO\", \"ENAME\", \"MGR\", \"SAL\"\n"
+        .planHasSql("SELECT \"t0\".\"EMPNO\", \"t0\".\"ENAME\", "
+            + "\"t0\".\"EMPNO\" AS \"EMPNO0\", \"t0\".\"ENAME\" AS \"ENAME0\"\n"
+            + "FROM (SELECT \"EMPNO\", \"SAL\"\n"
             + "FROM \"SCOTT\".\"EMP\") AS \"t\"\n"
-            + "INNER JOIN (SELECT \"EMPNO\", \"SAL\"\n"
-            + "FROM \"SCOTT\".\"EMP\") AS \"t0\" ON \"t\".\"MGR\" = \"t0\".\"EMPNO\" AND \"t\".\"SAL\" > \"t0\".\"SAL\"");
+            + "INNER JOIN (SELECT \"EMPNO\", \"ENAME\", \"MGR\", \"SAL\"\n"
+            + "FROM \"SCOTT\".\"EMP\") AS \"t0\" "
+            + "ON \"t\".\"EMPNO\" = \"t0\".\"MGR\" AND \"t\".\"SAL\" < \"t0\".\"SAL\"");
   }
 
   @Test public void testMixedJoinWithOrPlan() {
@@ -190,20 +193,22 @@ public class JdbcAdapterTest {
             + "from scott.emp e inner join scott.emp m on  \n"
             + "e.mgr = m.empno and (e.sal > m.sal or m.hiredate > e.hiredate)")
         .explainContains("PLAN=JdbcToEnumerableConverter\n"
-            + "  JdbcProject(EMPNO=[$0], ENAME=[$1], EMPNO0=[$0], ENAME0=[$1])\n"
-            + "    JdbcJoin(condition=[AND(=($2, $5), OR(>($4, $7), >($6, $3)))], joinType=[inner])\n"
-            + "      JdbcProject(EMPNO=[$0], ENAME=[$1], MGR=[$3], HIREDATE=[$4], SAL=[$5])\n"
-            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
+            + "  JdbcProject(EMPNO=[$3], ENAME=[$4], EMPNO0=[$3], ENAME0=[$4])\n"
+            + "    JdbcJoin(condition=[AND(=($5, $0), OR(>($7, $2), >($1, $6)))], joinType=[inner])\n"
             + "      JdbcProject(EMPNO=[$0], HIREDATE=[$4], SAL=[$5])\n"
+            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
+            + "      JdbcProject(EMPNO=[$0], ENAME=[$1], MGR=[$3], HIREDATE=[$4], SAL=[$5])\n"
             + "        JdbcTableScan(table=[[SCOTT, EMP]])")
         .runs()
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
-        .planHasSql("SELECT \"t\".\"EMPNO\", \"t\".\"ENAME\", "
-            + "\"t\".\"EMPNO\" AS \"EMPNO0\", \"t\".\"ENAME\" AS \"ENAME0\"\n"
-            + "FROM (SELECT \"EMPNO\", \"ENAME\", \"MGR\", \"HIREDATE\", \"SAL\"\n"
+        .planHasSql("SELECT \"t0\".\"EMPNO\", \"t0\".\"ENAME\", "
+            + "\"t0\".\"EMPNO\" AS \"EMPNO0\", \"t0\".\"ENAME\" AS \"ENAME0\"\n"
+            + "FROM (SELECT \"EMPNO\", \"HIREDATE\", \"SAL\"\n"
             + "FROM \"SCOTT\".\"EMP\") AS \"t\"\n"
-            + "INNER JOIN (SELECT \"EMPNO\", \"HIREDATE\", \"SAL\"\n"
-            + "FROM \"SCOTT\".\"EMP\") AS \"t0\" ON \"t\".\"MGR\" = \"t0\".\"EMPNO\" AND (\"t\".\"SAL\" > \"t0\".\"SAL\" OR \"t\".\"HIREDATE\" < \"t0\".\"HIREDATE\")");
+            + "INNER JOIN (SELECT \"EMPNO\", \"ENAME\", \"MGR\", \"HIREDATE\", \"SAL\"\n"
+            + "FROM \"SCOTT\".\"EMP\") AS \"t0\" "
+            + "ON \"t\".\"EMPNO\" = \"t0\".\"MGR\" "
+            + "AND (\"t\".\"SAL\" < \"t0\".\"SAL\" OR \"t\".\"HIREDATE\" > \"t0\".\"HIREDATE\")");
   }
 
   @Test public void testJoin3TablesPlan() {
@@ -240,20 +245,19 @@ public class JdbcAdapterTest {
             + "from scott.emp e,scott.dept d \n"
             + "where e.deptno = d.deptno")
         .explainContains("PLAN=JdbcToEnumerableConverter\n"
-            + "  JdbcProject(EMPNO=[$2], ENAME=[$3], DEPTNO=[$0], DNAME=[$1])\n"
-            + "    JdbcJoin(condition=[=($4, $0)], joinType=[inner])\n"
-            + "      JdbcProject(DEPTNO=[$0], DNAME=[$1])\n"
-            + "        JdbcTableScan(table=[[SCOTT, DEPT]])\n"
+            + "  JdbcProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$3], DNAME=[$4])\n"
+            + "    JdbcJoin(condition=[=($2, $3)], joinType=[inner])\n"
             + "      JdbcProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])\n"
-            + "        JdbcTableScan(table=[[SCOTT, EMP]])")
+            + "        JdbcTableScan(table=[[SCOTT, EMP]])\n"
+            + "      JdbcProject(DEPTNO=[$0], DNAME=[$1])\n"
+            + "        JdbcTableScan(table=[[SCOTT, DEPT]])")
         .runs()
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
-        .planHasSql("SELECT \"t0\".\"EMPNO\", \"t0\".\"ENAME\", "
-            + "\"t\".\"DEPTNO\", \"t\".\"DNAME\"\n"
-            + "FROM (SELECT \"DEPTNO\", \"DNAME\"\n"
-            + "FROM \"SCOTT\".\"DEPT\") AS \"t\"\n"
-            + "INNER JOIN (SELECT \"EMPNO\", \"ENAME\", \"DEPTNO\"\n"
-            + "FROM \"SCOTT\".\"EMP\") AS \"t0\" ON \"t\".\"DEPTNO\" = \"t0\".\"DEPTNO\"");
+        .planHasSql("SELECT \"t\".\"EMPNO\", \"t\".\"ENAME\", "
+            + "\"t0\".\"DEPTNO\", \"t0\".\"DNAME\"\n"
+            + "FROM (SELECT \"EMPNO\", \"ENAME\", \"DEPTNO\"\nFROM \"SCOTT\".\"EMP\") AS \"t\"\n"
+            + "INNER JOIN (SELECT \"DEPTNO\", \"DNAME\"\n"
+            + "FROM \"SCOTT\".\"DEPT\") AS \"t0\" ON \"t\".\"DEPTNO\" = \"t0\".\"DEPTNO\"");
   }
 
   // JdbcJoin not used for this
@@ -280,22 +284,22 @@ public class JdbcAdapterTest {
             + "where e.deptno = d.deptno \n"
             + "and e.deptno=20")
         .explainContains("PLAN=JdbcToEnumerableConverter\n"
-            + "  JdbcProject(EMPNO=[$2], ENAME=[$3], DEPTNO=[$0], DNAME=[$1])\n"
-            + "    JdbcJoin(condition=[=($4, $0)], joinType=[inner])\n"
-            + "      JdbcProject(DEPTNO=[$0], DNAME=[$1])\n"
-            + "        JdbcTableScan(table=[[SCOTT, DEPT]])\n"
+            + "  JdbcProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$3], DNAME=[$4])\n"
+            + "    JdbcJoin(condition=[=($2, $3)], joinType=[inner])\n"
             + "      JdbcProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])\n"
             + "        JdbcFilter(condition=[=(CAST($7):INTEGER, 20)])\n"
-            + "          JdbcTableScan(table=[[SCOTT, EMP]])")
+            + "          JdbcTableScan(table=[[SCOTT, EMP]])\n"
+            + "      JdbcProject(DEPTNO=[$0], DNAME=[$1])\n"
+            + "        JdbcTableScan(table=[[SCOTT, DEPT]])")
         .runs()
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
-        .planHasSql("SELECT \"t1\".\"EMPNO\", \"t1\".\"ENAME\", "
-            + "\"t\".\"DEPTNO\", \"t\".\"DNAME\"\n"
-            + "FROM (SELECT \"DEPTNO\", \"DNAME\"\n"
-            + "FROM \"SCOTT\".\"DEPT\") AS \"t\"\n"
-            + "INNER JOIN (SELECT \"EMPNO\", \"ENAME\", \"DEPTNO\"\n"
+        .planHasSql("SELECT \"t0\".\"EMPNO\", \"t0\".\"ENAME\", "
+            + "\"t1\".\"DEPTNO\", \"t1\".\"DNAME\"\n"
+            + "FROM (SELECT \"EMPNO\", \"ENAME\", \"DEPTNO\"\n"
             + "FROM \"SCOTT\".\"EMP\"\n"
-            + "WHERE CAST(\"DEPTNO\" AS INTEGER) = 20) AS \"t1\" ON \"t\".\"DEPTNO\" = \"t1\".\"DEPTNO\"");
+            + "WHERE CAST(\"DEPTNO\" AS INTEGER) = 20) AS \"t0\"\n"
+            + "INNER JOIN (SELECT \"DEPTNO\", \"DNAME\"\n"
+            + "FROM \"SCOTT\".\"DEPT\") AS \"t1\" ON \"t0\".\"DEPTNO\" = \"t1\".\"DEPTNO\"");
   }
 
   /** Test case for

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -1941,6 +1941,7 @@ public class JdbcTest {
     //   12    36
     //   13   116 - OOM did not complete
     checkJoinNWay(1);
+    checkJoinNWay(3);
     checkJoinNWay(6);
   }
 


### PR DESCRIPTION
Summary of the fixes.
1) In RelSet.getOrCreateSubset(), only add AbstractConverters if RelTraitDef can convert.  This means that the difference should be of size 1 (i.e. only one trait is different as RelTraitDef defines canConvert() and convert() on only one RelTrait), and RelTraitDef.canConvert() should return true.  This cuts back on the number of AbstractConverters added signifincantly if RelTraitDef.canConvert() is written properly.

2) In RelCollationTraitDef, canConvert() should really only return true if there is a need for conversion.  If the fromTrait already satisfies toTrait, there is no need to change it.  Perhaps "canConvert()" should be named "shouldConvert()", but I left the name as it is.  Without this change, many of the JdbcTests (joins) were taking a lot longer to plan or go on infinite-planning-state.

3)  Remaining changes are test changes.