### PR TITLE
[CALCITE-1153] Invalid cast created during SQL Join in Oracle

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -465,6 +465,7 @@ public class SqlDialect {
     case HSQLDB:
     case PHOENIX:
     case POSTGRESQL:
+    case ORACLE:
       return false;
     default:
       return true;

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -289,9 +289,9 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     registerOp(SqlStdOperatorTable.FLOOR, floorCeilConvertlet);
     registerOp(SqlStdOperatorTable.CEIL, floorCeilConvertlet);
 
-    registerOp(SqlStdOperatorTable.TIMESTAMP_ADD,
-        new TimestampAddConvertlet());
-    registerOp(SqlStdOperatorTable.TIMESTAMP_DIFF, new TimestampDiffConvertlet());
+    registerOp(SqlStdOperatorTable.TIMESTAMP_ADD, new TimestampAddConvertlet());
+    registerOp(SqlStdOperatorTable.TIMESTAMP_DIFF,
+        new TimestampDiffConvertlet());
 
     // Convert "element(<expr>)" to "$element_slice(<expr>)", if the
     // expression is a multiset of scalars.
@@ -1364,7 +1364,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
   private class TimestampDiffConvertlet implements SqlRexConvertlet {
     public RexNode convertCall(SqlRexContext cx, SqlCall call) {
       // TIMESTAMPDIFF(unit, t1, t2)
-      //    => (t1 - t2) UNIT
+      //    => (t2 - t1) UNIT
       final RexBuilder rexBuilder = cx.getRexBuilder();
       final SqlLiteral unitLiteral = call.operand(0);
       final TimeUnit unit = unitLiteral.symbolValue(TimeUnit.class);
@@ -1375,8 +1375,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       return divide(cx.getRexBuilder(),
           rexBuilder.makeCast(intType,
               rexBuilder.makeCall(SqlStdOperatorTable.MINUS_DATE,
-                  cx.convertExpression(call.operand(1)),
                   cx.convertExpression(call.operand(2)),
+                  cx.convertExpression(call.operand(1)),
                   cx.getRexBuilder().makeIntervalLiteral(qualifier))),
           unit.multiplier);
     }

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4624,11 +4624,11 @@ public abstract class SqlOperatorBaseTest {
     tester.checkScalar("timestampdiff(HOUR, "
         + "timestamp '2016-02-24 12:42:25', "
         + "timestamp '2016-02-24 15:42:25')",
-        "-3", "INTEGER NOT NULL");
+        "3", "INTEGER NOT NULL");
     tester.checkScalar("timestampdiff(MICROSECOND, "
         + "timestamp '2016-02-24 12:42:25', "
         + "timestamp '2016-02-24 12:42:20')",
-        "5000000", "INTEGER NOT NULL");
+        "-5000000", "INTEGER NOT NULL");
     if (!INTERVAL) {
       return;
     }

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1042,8 +1042,8 @@ Not implemented:
 | {fn CURTIME()}  | Equivalent to `LOCALTIME`
 | {fn NOW()}      | Equivalent to `LOCALTIMESTAMP`
 | {fn QUARTER(date)} | Equivalent to `EXTRACT(QUARTER FROM date)`. Returns an integer between 1 and 4.
-| {fn TIMESTAMPADD(interval, count, timestamp)} | Adds an interval to a timestamp
-| {fn TIMESTAMPDIFF(interval, timestamp, timestamp)} | Subtracts two timestamps
+| {fn TIMESTAMPADD(timeUnit, count, timestamp)} | Adds an interval of *count* *timeUnit*s to a timestamp
+| {fn TIMESTAMPDIFF(timeUnit, timestamp1, timestamp2)} | Subtracts *timestamp1* from *timestamp2* and returns the result in *timeUnit*s
 
 Not implemented:
 


### PR DESCRIPTION
Removes 'character set'  from the datatype definition for Oracle dialect