### PR TITLE
[CALCITE-1159] Kerberos-based client authentication via SPNEGO

### DIFF
--- a/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.avatica;
 
+import org.apache.calcite.avatica.Meta.ExecuteBatchResult;
 import org.apache.calcite.avatica.Meta.MetaResultSet;
 import org.apache.calcite.avatica.remote.Service.ErrorResponse;
 import org.apache.calcite.avatica.remote.Service.OpenConnectionRequest;
@@ -505,6 +506,25 @@ public abstract class AvaticaConnection implements Connection {
     return statement.openResultSet;
   }
 
+  /** Executes a batch update using an {@link AvaticaPreparedStatement}.
+   *
+   * @param pstmt The prepared statement.
+   * @return An array of update counts containing one element for each command in the batch.
+   */
+  protected int[] executeBatchUpdateInternal(AvaticaPreparedStatement pstmt) throws SQLException {
+    try {
+      // Get the handle from the statement
+      Meta.StatementHandle handle = pstmt.handle;
+      // Execute it against meta
+      final Meta.ExecuteBatchResult executeBatchResult =
+          meta.executeBatch(handle, pstmt.getParameterValueBatch());
+      // Send back just the update counts
+      return executeBatchResult.updateCounts;
+    } catch (Exception e) {
+      throw helper.createException(e.getMessage(), e);
+    }
+  }
+
   /** Returns whether a a statement is capable of updates and if so,
    * and the statement's {@code updateCount} is still -1, proceeds to
    * get updateCount value from statement's resultSet.
@@ -579,6 +599,11 @@ public abstract class AvaticaConnection implements Connection {
           }
         };
     return meta.prepareAndExecute(statement.handle, sql, maxRowCount, callback);
+  }
+
+  protected ExecuteBatchResult prepareAndUpdateBatch(final AvaticaStatement statement,
+      final List<String> queries) throws NoSuchStatementException, SQLException {
+    return meta.prepareAndExecuteBatch(statement.handle, queries);
   }
 
   protected ResultSet createResultSet(Meta.MetaResultSet metaResultSet, QueryState state)

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaPreparedStatement.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaPreparedStatement.java
@@ -35,6 +35,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
@@ -52,6 +53,7 @@ public abstract class AvaticaPreparedStatement
   private final ResultSetMetaData resultSetMetaData;
   private Calendar calendar;
   protected final TypedValue[] slots;
+  protected final List<List<TypedValue>> parameterValueBatch;
 
   /**
    * Creates an AvaticaPreparedStatement.
@@ -75,10 +77,25 @@ public abstract class AvaticaPreparedStatement
     this.slots = new TypedValue[signature.parameters.size()];
     this.resultSetMetaData =
         connection.factory.newResultSetMetaData(this, signature);
+    this.parameterValueBatch = new ArrayList<>();
   }
 
   @Override protected List<TypedValue> getParameterValues() {
     return Arrays.asList(slots);
+  }
+
+  /** Returns a copy of the current parameter values.
+   * @return A copied list of the parameter values
+   */
+  protected List<TypedValue> copyParameterValues() {
+    // For implementing batch update, we need to make a copy of slots, not just a thin reference
+    // to it as as list. Otherwise, subsequent setFoo(..) calls will alter the underlying array
+    // and modify our cached TypedValue list.
+    List<TypedValue> copy = new ArrayList<>(slots.length);
+    for (TypedValue value : slots) {
+      copy.add(value);
+    }
+    return copy;
   }
 
   /** Returns a calendar in the connection's time zone, creating one the first
@@ -101,6 +118,10 @@ public abstract class AvaticaPreparedStatement
       calendar = Calendar.getInstance(connection.getTimeZone());
     }
     return calendar;
+  }
+
+  protected List<List<TypedValue>> getParameterValueBatch() {
+    return this.parameterValueBatch;
   }
 
   // implement PreparedStatement
@@ -213,7 +234,21 @@ public abstract class AvaticaPreparedStatement
   }
 
   public void addBatch() throws SQLException {
-    throw connection.helper.unsupported();
+    // Need to copy the parameterValues into a new list, not wrap the array in a list
+    // as getParameterValues does.
+    this.parameterValueBatch.add(copyParameterValues());
+  }
+
+  @Override public int[] executeBatch() throws SQLException {
+    // Overriding the implementation in AvaticaStatement.
+    try {
+      final int[] updateCounts = getConnection().executeBatchUpdateInternal(this);
+      return updateCounts;
+    } finally {
+      // If we failed to send this batch, that's a problem for the user to handle, not us.
+      // Make sure we always clear the statements we collected to submit in one RPC.
+      this.parameterValueBatch.clear();
+    }
   }
 
   public void setCharacterStream(int parameterIndex, Reader reader, int length)

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -24,6 +24,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -67,6 +68,8 @@ public abstract class AvaticaStatement
 
   private Meta.Signature signature;
 
+  private final List<String> batchedSql;
+
   protected void setSignature(Meta.Signature signature) {
     this.signature = signature;
   }
@@ -109,6 +112,7 @@ public abstract class AvaticaStatement
     }
     connection.statementMap.put(h.id, this);
     this.handle = h;
+    this.batchedSql = new ArrayList<>();
   }
 
   /** Returns the identifier of the statement, unique within its connection. */
@@ -146,6 +150,25 @@ public abstract class AvaticaStatement
 
     throw new RuntimeException("Failed to successfully execute query after "
         + connection.maxRetriesPerExecute + " attempts.");
+  }
+
+  /**
+   * Executes a collection of updates in a single batch RPC.
+   *
+   * @return an array of integers mapping to the update count per SQL command.
+   */
+  protected int[] executeBatchInternal() throws SQLException {
+    for (int i = 0; i < connection.maxRetriesPerExecute; i++) {
+      try {
+        Meta.ExecuteBatchResult result = connection.prepareAndUpdateBatch(this, batchedSql);
+        return result.updateCounts;
+      } catch (NoSuchStatementException e) {
+        resetStatement();
+      }
+    }
+
+    throw new RuntimeException("Failed to successfully execute batch update after "
+        +  connection.maxRetriesPerExecute + " attempts");
   }
 
   protected void resetStatement() {
@@ -359,7 +382,7 @@ public abstract class AvaticaStatement
   }
 
   public void addBatch(String sql) throws SQLException {
-    throw connection.helper.unsupported();
+    this.batchedSql.add(Objects.requireNonNull(sql));
   }
 
   public void clearBatch() throws SQLException {
@@ -367,7 +390,13 @@ public abstract class AvaticaStatement
   }
 
   public int[] executeBatch() throws SQLException {
-    throw connection.helper.unsupported();
+    try {
+      return executeBatchInternal();
+    } finally {
+      // If we failed to send this batch, that's a problem for the user to handle, not us.
+      // Make sure we always clear the statements we collected to submit in one RPC.
+      this.batchedSql.clear();
+    }
   }
 
   public AvaticaConnection getConnection() {

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
@@ -44,6 +44,9 @@ public enum BuiltInConnectionProperty implements ConnectionProperty {
   /** Serialization used over remote connections */
   SERIALIZATION("serialization", Type.STRING, "json", false),
 
+  /** The type of authentication to be used */
+  AUTHENTICATION("authentication", Type.STRING, null, false),
+
   /** Factory for constructing http clients. */
   HTTP_CLIENT_FACTORY("httpclient_factory", Type.PLUGIN,
       AvaticaHttpClientFactoryImpl.class.getName(), false),

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -52,6 +52,10 @@ public class ConnectionConfigImpl implements ConnectionConfig {
     return BuiltInConnectionProperty.SERIALIZATION.wrap(properties).getString();
   }
 
+  public String authentication() {
+    return BuiltInConnectionProperty.AUTHENTICATION.wrap(properties).getString();
+  }
+
   public AvaticaHttpClientFactory httpClientFactory() {
     return BuiltInConnectionProperty.HTTP_CLIENT_FACTORY.wrap(properties)
         .getPlugin(AvaticaHttpClientFactory.class, null);

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/Meta.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/Meta.java
@@ -228,6 +228,24 @@ public interface Meta {
   ExecuteResult prepareAndExecute(StatementHandle h, String sql,
       long maxRowCount, PrepareCallback callback) throws NoSuchStatementException;
 
+  /** Prepares a statement and then executes a number of SQL commands in one pass.
+   *
+   * @param h Statement handle
+   * @param sqlCommands SQL commands to run
+   * @return An array of update counts containing one element for each command in the batch.
+   */
+  ExecuteBatchResult prepareAndExecuteBatch(StatementHandle h, List<String> sqlCommands)
+      throws NoSuchStatementException;
+
+  /** Executes a collection of bound parameter values on a prepared statement.
+   *
+   * @param h Statement handle
+   * @param parameterValues A collection of list of typed values, one list per batch
+   * @return An array of update counts containing one element for each command in the batch.
+   */
+  ExecuteBatchResult executeBatch(StatementHandle h, List<List<TypedValue>> parameterValues)
+      throws NoSuchStatementException;
+
   /** Returns a frame of rows.
    *
    * <p>The frame describes whether there may be another frame. If there is not
@@ -421,6 +439,17 @@ public interface Meta {
 
     public ExecuteResult(List<MetaResultSet> resultSets) {
       this.resultSets = resultSets;
+    }
+  }
+
+  /**
+   * Response from a collection of SQL commands or parameter values in a single batch.
+   */
+  class ExecuteBatchResult {
+    public final int[] updateCounts;
+
+    public ExecuteBatchResult(int[] updateCounts) {
+      this.updateCounts = Objects.requireNonNull(updateCounts);
     }
   }
 

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/proto/Requests.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/proto/Requests.java
@@ -12035,6 +12035,2381 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface PrepareAndExecuteBatchRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:PrepareAndExecuteBatchRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
+
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    int getStatementId();
+
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    com.google.protobuf.ProtocolStringList
+        getSqlCommandsList();
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    int getSqlCommandsCount();
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    java.lang.String getSqlCommands(int index);
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getSqlCommandsBytes(int index);
+  }
+  /**
+   * Protobuf type {@code PrepareAndExecuteBatchRequest}
+   *
+   * <pre>
+   * Request to prepare and execute a collection of sql statements.
+   * </pre>
+   */
+  public  static final class PrepareAndExecuteBatchRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:PrepareAndExecuteBatchRequest)
+      PrepareAndExecuteBatchRequestOrBuilder {
+    // Use PrepareAndExecuteBatchRequest.newBuilder() to construct.
+    private PrepareAndExecuteBatchRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private PrepareAndExecuteBatchRequest() {
+      connectionId_ = "";
+      statementId_ = 0;
+      sqlCommands_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private PrepareAndExecuteBatchRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              String s = input.readStringRequireUtf8();
+
+              connectionId_ = s;
+              break;
+            }
+            case 16: {
+
+              statementId_ = input.readUInt32();
+              break;
+            }
+            case 26: {
+              String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                sqlCommands_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              sqlCommands_.add(s);
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+          sqlCommands_ = sqlCommands_.getUnmodifiableView();
+        }
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_PrepareAndExecuteBatchRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_PrepareAndExecuteBatchRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest.class, org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        connectionId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STATEMENT_ID_FIELD_NUMBER = 2;
+    private int statementId_;
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    public int getStatementId() {
+      return statementId_;
+    }
+
+    public static final int SQL_COMMANDS_FIELD_NUMBER = 3;
+    private com.google.protobuf.LazyStringList sqlCommands_;
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getSqlCommandsList() {
+      return sqlCommands_;
+    }
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    public int getSqlCommandsCount() {
+      return sqlCommands_.size();
+    }
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    public java.lang.String getSqlCommands(int index) {
+      return sqlCommands_.get(index);
+    }
+    /**
+     * <code>repeated string sql_commands = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getSqlCommandsBytes(int index) {
+      return sqlCommands_.getByteString(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getConnectionIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        output.writeUInt32(2, statementId_);
+      }
+      for (int i = 0; i < sqlCommands_.size(); i++) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 3, sqlCommands_.getRaw(i));
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(2, statementId_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < sqlCommands_.size(); i++) {
+          dataSize += computeStringSizeNoTag(sqlCommands_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getSqlCommandsList().size();
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code PrepareAndExecuteBatchRequest}
+     *
+     * <pre>
+     * Request to prepare and execute a collection of sql statements.
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:PrepareAndExecuteBatchRequest)
+        org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_PrepareAndExecuteBatchRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_PrepareAndExecuteBatchRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest.class, org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        connectionId_ = "";
+
+        statementId_ = 0;
+
+        sqlCommands_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_PrepareAndExecuteBatchRequest_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest build() {
+        org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest buildPartial() {
+        org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest result = new org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        result.connectionId_ = connectionId_;
+        result.statementId_ = statementId_;
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          sqlCommands_ = sqlCommands_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        }
+        result.sqlCommands_ = sqlCommands_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest other) {
+        if (other == org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
+        if (other.getStatementId() != 0) {
+          setStatementId(other.getStatementId());
+        }
+        if (!other.sqlCommands_.isEmpty()) {
+          if (sqlCommands_.isEmpty()) {
+            sqlCommands_ = other.sqlCommands_;
+            bitField0_ = (bitField0_ & ~0x00000004);
+          } else {
+            ensureSqlCommandsIsMutable();
+            sqlCommands_.addAll(other.sqlCommands_);
+          }
+          onChanged();
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          connectionId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int statementId_ ;
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public int getStatementId() {
+        return statementId_;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder setStatementId(int value) {
+        
+        statementId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder clearStatementId() {
+        
+        statementId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList sqlCommands_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureSqlCommandsIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          sqlCommands_ = new com.google.protobuf.LazyStringArrayList(sqlCommands_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getSqlCommandsList() {
+        return sqlCommands_.getUnmodifiableView();
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public int getSqlCommandsCount() {
+        return sqlCommands_.size();
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public java.lang.String getSqlCommands(int index) {
+        return sqlCommands_.get(index);
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getSqlCommandsBytes(int index) {
+        return sqlCommands_.getByteString(index);
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public Builder setSqlCommands(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureSqlCommandsIsMutable();
+        sqlCommands_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public Builder addSqlCommands(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureSqlCommandsIsMutable();
+        sqlCommands_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public Builder addAllSqlCommands(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureSqlCommandsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, sqlCommands_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public Builder clearSqlCommands() {
+        sqlCommands_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string sql_commands = 3;</code>
+       */
+      public Builder addSqlCommandsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureSqlCommandsIsMutable();
+        sqlCommands_.add(value);
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:PrepareAndExecuteBatchRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:PrepareAndExecuteBatchRequest)
+    private static final org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest();
+    }
+
+    public static org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<PrepareAndExecuteBatchRequest>
+        PARSER = new com.google.protobuf.AbstractParser<PrepareAndExecuteBatchRequest>() {
+      public PrepareAndExecuteBatchRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new PrepareAndExecuteBatchRequest(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<PrepareAndExecuteBatchRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<PrepareAndExecuteBatchRequest> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface UpdateBatchOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:UpdateBatch)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> 
+        getParameterValuesList();
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index);
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    int getParameterValuesCount();
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+        getParameterValuesOrBuilderList();
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code UpdateBatch}
+   *
+   * <pre>
+   * Each command is a list of TypedValues
+   * </pre>
+   */
+  public  static final class UpdateBatch extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:UpdateBatch)
+      UpdateBatchOrBuilder {
+    // Use UpdateBatch.newBuilder() to construct.
+    private UpdateBatch(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private UpdateBatch() {
+      parameterValues_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private UpdateBatch(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                parameterValues_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.TypedValue>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              parameterValues_.add(input.readMessage(org.apache.calcite.avatica.proto.Common.TypedValue.parser(), extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          parameterValues_ = java.util.Collections.unmodifiableList(parameterValues_);
+        }
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_UpdateBatch_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_UpdateBatch_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Requests.UpdateBatch.class, org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder.class);
+    }
+
+    public static final int PARAMETER_VALUES_FIELD_NUMBER = 1;
+    private java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> parameterValues_;
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> getParameterValuesList() {
+      return parameterValues_;
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    public java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+        getParameterValuesOrBuilderList() {
+      return parameterValues_;
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    public int getParameterValuesCount() {
+      return parameterValues_.size();
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index) {
+      return parameterValues_.get(index);
+    }
+    /**
+     * <code>repeated .TypedValue parameter_values = 1;</code>
+     */
+    public org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
+        int index) {
+      return parameterValues_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < parameterValues_.size(); i++) {
+        output.writeMessage(1, parameterValues_.get(i));
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < parameterValues_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, parameterValues_.get(i));
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Requests.UpdateBatch prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code UpdateBatch}
+     *
+     * <pre>
+     * Each command is a list of TypedValues
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:UpdateBatch)
+        org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_UpdateBatch_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_UpdateBatch_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Requests.UpdateBatch.class, org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Requests.UpdateBatch.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getParameterValuesFieldBuilder();
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        if (parameterValuesBuilder_ == null) {
+          parameterValues_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          parameterValuesBuilder_.clear();
+        }
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_UpdateBatch_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatch getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Requests.UpdateBatch.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatch build() {
+        org.apache.calcite.avatica.proto.Requests.UpdateBatch result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatch buildPartial() {
+        org.apache.calcite.avatica.proto.Requests.UpdateBatch result = new org.apache.calcite.avatica.proto.Requests.UpdateBatch(this);
+        int from_bitField0_ = bitField0_;
+        if (parameterValuesBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            parameterValues_ = java.util.Collections.unmodifiableList(parameterValues_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.parameterValues_ = parameterValues_;
+        } else {
+          result.parameterValues_ = parameterValuesBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Requests.UpdateBatch) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Requests.UpdateBatch)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.UpdateBatch other) {
+        if (other == org.apache.calcite.avatica.proto.Requests.UpdateBatch.getDefaultInstance()) return this;
+        if (parameterValuesBuilder_ == null) {
+          if (!other.parameterValues_.isEmpty()) {
+            if (parameterValues_.isEmpty()) {
+              parameterValues_ = other.parameterValues_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureParameterValuesIsMutable();
+              parameterValues_.addAll(other.parameterValues_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.parameterValues_.isEmpty()) {
+            if (parameterValuesBuilder_.isEmpty()) {
+              parameterValuesBuilder_.dispose();
+              parameterValuesBuilder_ = null;
+              parameterValues_ = other.parameterValues_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              parameterValuesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getParameterValuesFieldBuilder() : null;
+            } else {
+              parameterValuesBuilder_.addAllMessages(other.parameterValues_);
+            }
+          }
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Requests.UpdateBatch parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Requests.UpdateBatch) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> parameterValues_ =
+        java.util.Collections.emptyList();
+      private void ensureParameterValuesIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          parameterValues_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Common.TypedValue>(parameterValues_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> parameterValuesBuilder_;
+
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue> getParameterValuesList() {
+        if (parameterValuesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(parameterValues_);
+        } else {
+          return parameterValuesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public int getParameterValuesCount() {
+        if (parameterValuesBuilder_ == null) {
+          return parameterValues_.size();
+        } else {
+          return parameterValuesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue getParameterValues(int index) {
+        if (parameterValuesBuilder_ == null) {
+          return parameterValues_.get(index);
+        } else {
+          return parameterValuesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder setParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue value) {
+        if (parameterValuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureParameterValuesIsMutable();
+          parameterValues_.set(index, value);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder setParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          parameterValuesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder addParameterValues(org.apache.calcite.avatica.proto.Common.TypedValue value) {
+        if (parameterValuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(value);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder addParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue value) {
+        if (parameterValuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(index, value);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder addParameterValues(
+          org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(builderForValue.build());
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder addParameterValues(
+          int index, org.apache.calcite.avatica.proto.Common.TypedValue.Builder builderForValue) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder addAllParameterValues(
+          java.lang.Iterable<? extends org.apache.calcite.avatica.proto.Common.TypedValue> values) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, parameterValues_);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder clearParameterValues() {
+        if (parameterValuesBuilder_ == null) {
+          parameterValues_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public Builder removeParameterValues(int index) {
+        if (parameterValuesBuilder_ == null) {
+          ensureParameterValuesIsMutable();
+          parameterValues_.remove(index);
+          onChanged();
+        } else {
+          parameterValuesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder getParameterValuesBuilder(
+          int index) {
+        return getParameterValuesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder getParameterValuesOrBuilder(
+          int index) {
+        if (parameterValuesBuilder_ == null) {
+          return parameterValues_.get(index);  } else {
+          return parameterValuesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public java.util.List<? extends org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+           getParameterValuesOrBuilderList() {
+        if (parameterValuesBuilder_ != null) {
+          return parameterValuesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(parameterValues_);
+        }
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder addParameterValuesBuilder() {
+        return getParameterValuesFieldBuilder().addBuilder(
+            org.apache.calcite.avatica.proto.Common.TypedValue.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public org.apache.calcite.avatica.proto.Common.TypedValue.Builder addParameterValuesBuilder(
+          int index) {
+        return getParameterValuesFieldBuilder().addBuilder(
+            index, org.apache.calcite.avatica.proto.Common.TypedValue.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .TypedValue parameter_values = 1;</code>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Common.TypedValue.Builder> 
+           getParameterValuesBuilderList() {
+        return getParameterValuesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder> 
+          getParameterValuesFieldBuilder() {
+        if (parameterValuesBuilder_ == null) {
+          parameterValuesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.calcite.avatica.proto.Common.TypedValue, org.apache.calcite.avatica.proto.Common.TypedValue.Builder, org.apache.calcite.avatica.proto.Common.TypedValueOrBuilder>(
+                  parameterValues_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          parameterValues_ = null;
+        }
+        return parameterValuesBuilder_;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:UpdateBatch)
+    }
+
+    // @@protoc_insertion_point(class_scope:UpdateBatch)
+    private static final org.apache.calcite.avatica.proto.Requests.UpdateBatch DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Requests.UpdateBatch();
+    }
+
+    public static org.apache.calcite.avatica.proto.Requests.UpdateBatch getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<UpdateBatch>
+        PARSER = new com.google.protobuf.AbstractParser<UpdateBatch>() {
+      public UpdateBatch parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new UpdateBatch(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<UpdateBatch> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<UpdateBatch> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Requests.UpdateBatch getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ExecuteBatchRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ExecuteBatchRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
+
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    int getStatementId();
+
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    java.util.List<org.apache.calcite.avatica.proto.Requests.UpdateBatch> 
+        getUpdatesList();
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    org.apache.calcite.avatica.proto.Requests.UpdateBatch getUpdates(int index);
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    int getUpdatesCount();
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    java.util.List<? extends org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder> 
+        getUpdatesOrBuilderList();
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder getUpdatesOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code ExecuteBatchRequest}
+   */
+  public  static final class ExecuteBatchRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ExecuteBatchRequest)
+      ExecuteBatchRequestOrBuilder {
+    // Use ExecuteBatchRequest.newBuilder() to construct.
+    private ExecuteBatchRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private ExecuteBatchRequest() {
+      connectionId_ = "";
+      statementId_ = 0;
+      updates_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private ExecuteBatchRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              String s = input.readStringRequireUtf8();
+
+              connectionId_ = s;
+              break;
+            }
+            case 16: {
+
+              statementId_ = input.readUInt32();
+              break;
+            }
+            case 26: {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                updates_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Requests.UpdateBatch>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              updates_.add(input.readMessage(org.apache.calcite.avatica.proto.Requests.UpdateBatch.parser(), extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+          updates_ = java.util.Collections.unmodifiableList(updates_);
+        }
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteBatchRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteBatchRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest.class, org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        connectionId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STATEMENT_ID_FIELD_NUMBER = 2;
+    private int statementId_;
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    public int getStatementId() {
+      return statementId_;
+    }
+
+    public static final int UPDATES_FIELD_NUMBER = 3;
+    private java.util.List<org.apache.calcite.avatica.proto.Requests.UpdateBatch> updates_;
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    public java.util.List<org.apache.calcite.avatica.proto.Requests.UpdateBatch> getUpdatesList() {
+      return updates_;
+    }
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    public java.util.List<? extends org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder> 
+        getUpdatesOrBuilderList() {
+      return updates_;
+    }
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    public int getUpdatesCount() {
+      return updates_.size();
+    }
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    public org.apache.calcite.avatica.proto.Requests.UpdateBatch getUpdates(int index) {
+      return updates_.get(index);
+    }
+    /**
+     * <code>repeated .UpdateBatch updates = 3;</code>
+     *
+     * <pre>
+     * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+     * </pre>
+     */
+    public org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder getUpdatesOrBuilder(
+        int index) {
+      return updates_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getConnectionIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        output.writeUInt32(2, statementId_);
+      }
+      for (int i = 0; i < updates_.size(); i++) {
+        output.writeMessage(3, updates_.get(i));
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(2, statementId_);
+      }
+      for (int i = 0; i < updates_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, updates_.get(i));
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code ExecuteBatchRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ExecuteBatchRequest)
+        org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteBatchRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteBatchRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest.class, org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getUpdatesFieldBuilder();
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        connectionId_ = "";
+
+        statementId_ = 0;
+
+        if (updatesBuilder_ == null) {
+          updates_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          updatesBuilder_.clear();
+        }
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Requests.internal_static_ExecuteBatchRequest_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest build() {
+        org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest buildPartial() {
+        org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest result = new org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        result.connectionId_ = connectionId_;
+        result.statementId_ = statementId_;
+        if (updatesBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            updates_ = java.util.Collections.unmodifiableList(updates_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.updates_ = updates_;
+        } else {
+          result.updates_ = updatesBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest other) {
+        if (other == org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
+        if (other.getStatementId() != 0) {
+          setStatementId(other.getStatementId());
+        }
+        if (updatesBuilder_ == null) {
+          if (!other.updates_.isEmpty()) {
+            if (updates_.isEmpty()) {
+              updates_ = other.updates_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensureUpdatesIsMutable();
+              updates_.addAll(other.updates_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.updates_.isEmpty()) {
+            if (updatesBuilder_.isEmpty()) {
+              updatesBuilder_.dispose();
+              updatesBuilder_ = null;
+              updates_ = other.updates_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              updatesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getUpdatesFieldBuilder() : null;
+            } else {
+              updatesBuilder_.addAllMessages(other.updates_);
+            }
+          }
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          connectionId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int statementId_ ;
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public int getStatementId() {
+        return statementId_;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder setStatementId(int value) {
+        
+        statementId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder clearStatementId() {
+        
+        statementId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<org.apache.calcite.avatica.proto.Requests.UpdateBatch> updates_ =
+        java.util.Collections.emptyList();
+      private void ensureUpdatesIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          updates_ = new java.util.ArrayList<org.apache.calcite.avatica.proto.Requests.UpdateBatch>(updates_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Requests.UpdateBatch, org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder, org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder> updatesBuilder_;
+
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Requests.UpdateBatch> getUpdatesList() {
+        if (updatesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(updates_);
+        } else {
+          return updatesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public int getUpdatesCount() {
+        if (updatesBuilder_ == null) {
+          return updates_.size();
+        } else {
+          return updatesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatch getUpdates(int index) {
+        if (updatesBuilder_ == null) {
+          return updates_.get(index);
+        } else {
+          return updatesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder setUpdates(
+          int index, org.apache.calcite.avatica.proto.Requests.UpdateBatch value) {
+        if (updatesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureUpdatesIsMutable();
+          updates_.set(index, value);
+          onChanged();
+        } else {
+          updatesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder setUpdates(
+          int index, org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder builderForValue) {
+        if (updatesBuilder_ == null) {
+          ensureUpdatesIsMutable();
+          updates_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          updatesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder addUpdates(org.apache.calcite.avatica.proto.Requests.UpdateBatch value) {
+        if (updatesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureUpdatesIsMutable();
+          updates_.add(value);
+          onChanged();
+        } else {
+          updatesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder addUpdates(
+          int index, org.apache.calcite.avatica.proto.Requests.UpdateBatch value) {
+        if (updatesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureUpdatesIsMutable();
+          updates_.add(index, value);
+          onChanged();
+        } else {
+          updatesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder addUpdates(
+          org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder builderForValue) {
+        if (updatesBuilder_ == null) {
+          ensureUpdatesIsMutable();
+          updates_.add(builderForValue.build());
+          onChanged();
+        } else {
+          updatesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder addUpdates(
+          int index, org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder builderForValue) {
+        if (updatesBuilder_ == null) {
+          ensureUpdatesIsMutable();
+          updates_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          updatesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder addAllUpdates(
+          java.lang.Iterable<? extends org.apache.calcite.avatica.proto.Requests.UpdateBatch> values) {
+        if (updatesBuilder_ == null) {
+          ensureUpdatesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, updates_);
+          onChanged();
+        } else {
+          updatesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder clearUpdates() {
+        if (updatesBuilder_ == null) {
+          updates_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          updatesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public Builder removeUpdates(int index) {
+        if (updatesBuilder_ == null) {
+          ensureUpdatesIsMutable();
+          updates_.remove(index);
+          onChanged();
+        } else {
+          updatesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder getUpdatesBuilder(
+          int index) {
+        return getUpdatesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder getUpdatesOrBuilder(
+          int index) {
+        if (updatesBuilder_ == null) {
+          return updates_.get(index);  } else {
+          return updatesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public java.util.List<? extends org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder> 
+           getUpdatesOrBuilderList() {
+        if (updatesBuilder_ != null) {
+          return updatesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(updates_);
+        }
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder addUpdatesBuilder() {
+        return getUpdatesFieldBuilder().addBuilder(
+            org.apache.calcite.avatica.proto.Requests.UpdateBatch.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder addUpdatesBuilder(
+          int index) {
+        return getUpdatesFieldBuilder().addBuilder(
+            index, org.apache.calcite.avatica.proto.Requests.UpdateBatch.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .UpdateBatch updates = 3;</code>
+       *
+       * <pre>
+       * A batch of updates is a list&lt;list&lt;typevalue&gt;&gt;
+       * </pre>
+       */
+      public java.util.List<org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder> 
+           getUpdatesBuilderList() {
+        return getUpdatesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.calcite.avatica.proto.Requests.UpdateBatch, org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder, org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder> 
+          getUpdatesFieldBuilder() {
+        if (updatesBuilder_ == null) {
+          updatesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.calcite.avatica.proto.Requests.UpdateBatch, org.apache.calcite.avatica.proto.Requests.UpdateBatch.Builder, org.apache.calcite.avatica.proto.Requests.UpdateBatchOrBuilder>(
+                  updates_,
+                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  getParentForChildren(),
+                  isClean());
+          updates_ = null;
+        }
+        return updatesBuilder_;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:ExecuteBatchRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:ExecuteBatchRequest)
+    private static final org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest();
+    }
+
+    public static org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ExecuteBatchRequest>
+        PARSER = new com.google.protobuf.AbstractParser<ExecuteBatchRequest>() {
+      public ExecuteBatchRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new ExecuteBatchRequest(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<ExecuteBatchRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ExecuteBatchRequest> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static com.google.protobuf.Descriptors.Descriptor
     internal_static_CatalogsRequest_descriptor;
   private static
@@ -12135,6 +14510,21 @@ package org.apache.calcite.avatica.proto;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_RollbackRequest_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_PrepareAndExecuteBatchRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_PrepareAndExecuteBatchRequest_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_UpdateBatch_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_UpdateBatch_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_ExecuteBatchRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_ExecuteBatchRequest_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -12184,8 +14574,14 @@ package org.apache.calcite.avatica.proto;
       "atement_id\030\002 \001(\r\022\032\n\005state\030\003 \001(\0132\013.QueryS" +
       "tate\022\016\n\006offset\030\004 \001(\004\"&\n\rCommitRequest\022\025\n" +
       "\rconnection_id\030\001 \001(\t\"(\n\017RollbackRequest\022",
-      "\025\n\rconnection_id\030\001 \001(\tB\"\n org.apache.cal" +
-      "cite.avatica.protob\006proto3"
+      "\025\n\rconnection_id\030\001 \001(\t\"b\n\035PrepareAndExec" +
+      "uteBatchRequest\022\025\n\rconnection_id\030\001 \001(\t\022\024" +
+      "\n\014statement_id\030\002 \001(\r\022\024\n\014sql_commands\030\003 \003" +
+      "(\t\"4\n\013UpdateBatch\022%\n\020parameter_values\030\001 " +
+      "\003(\0132\013.TypedValue\"a\n\023ExecuteBatchRequest\022" +
+      "\025\n\rconnection_id\030\001 \001(\t\022\024\n\014statement_id\030\002" +
+      " \001(\r\022\035\n\007updates\030\003 \003(\0132\014.UpdateBatchB\"\n o" +
+      "rg.apache.calcite.avatica.protob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -12320,6 +14716,24 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_RollbackRequest_descriptor,
         new java.lang.String[] { "ConnectionId", });
+    internal_static_PrepareAndExecuteBatchRequest_descriptor =
+      getDescriptor().getMessageTypes().get(19);
+    internal_static_PrepareAndExecuteBatchRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_PrepareAndExecuteBatchRequest_descriptor,
+        new java.lang.String[] { "ConnectionId", "StatementId", "SqlCommands", });
+    internal_static_UpdateBatch_descriptor =
+      getDescriptor().getMessageTypes().get(20);
+    internal_static_UpdateBatch_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_UpdateBatch_descriptor,
+        new java.lang.String[] { "ParameterValues", });
+    internal_static_ExecuteBatchRequest_descriptor =
+      getDescriptor().getMessageTypes().get(21);
+    internal_static_ExecuteBatchRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ExecuteBatchRequest_descriptor,
+        new java.lang.String[] { "ConnectionId", "StatementId", "Updates", });
     org.apache.calcite.avatica.proto.Common.getDescriptor();
   }
 

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/proto/Responses.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/proto/Responses.java
@@ -11607,6 +11607,957 @@ package org.apache.calcite.avatica.proto;
 
   }
 
+  public interface ExecuteBatchResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ExecuteBatchResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    java.lang.String getConnectionId();
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getConnectionIdBytes();
+
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    int getStatementId();
+
+    /**
+     * <code>repeated uint32 update_counts = 3;</code>
+     */
+    java.util.List<java.lang.Integer> getUpdateCountsList();
+    /**
+     * <code>repeated uint32 update_counts = 3;</code>
+     */
+    int getUpdateCountsCount();
+    /**
+     * <code>repeated uint32 update_counts = 3;</code>
+     */
+    int getUpdateCounts(int index);
+
+    /**
+     * <code>optional bool missing_statement = 4;</code>
+     *
+     * <pre>
+     * Did the request fail because of no-cached statement
+     * </pre>
+     */
+    boolean getMissingStatement();
+
+    /**
+     * <code>optional .RpcMetadata metadata = 5;</code>
+     */
+    boolean hasMetadata();
+    /**
+     * <code>optional .RpcMetadata metadata = 5;</code>
+     */
+    org.apache.calcite.avatica.proto.Responses.RpcMetadata getMetadata();
+    /**
+     * <code>optional .RpcMetadata metadata = 5;</code>
+     */
+    org.apache.calcite.avatica.proto.Responses.RpcMetadataOrBuilder getMetadataOrBuilder();
+  }
+  /**
+   * Protobuf type {@code ExecuteBatchResponse}
+   *
+   * <pre>
+   * Response to a batch update request
+   * </pre>
+   */
+  public  static final class ExecuteBatchResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ExecuteBatchResponse)
+      ExecuteBatchResponseOrBuilder {
+    // Use ExecuteBatchResponse.newBuilder() to construct.
+    private ExecuteBatchResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private ExecuteBatchResponse() {
+      connectionId_ = "";
+      statementId_ = 0;
+      updateCounts_ = java.util.Collections.emptyList();
+      missingStatement_ = false;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    }
+    private ExecuteBatchResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry) {
+      this();
+      int mutable_bitField0_ = 0;
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!input.skipField(tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              String s = input.readStringRequireUtf8();
+
+              connectionId_ = s;
+              break;
+            }
+            case 16: {
+
+              statementId_ = input.readUInt32();
+              break;
+            }
+            case 24: {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                updateCounts_ = new java.util.ArrayList<java.lang.Integer>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              updateCounts_.add(input.readUInt32());
+              break;
+            }
+            case 26: {
+              int length = input.readRawVarint32();
+              int limit = input.pushLimit(length);
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004) && input.getBytesUntilLimit() > 0) {
+                updateCounts_ = new java.util.ArrayList<java.lang.Integer>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              while (input.getBytesUntilLimit() > 0) {
+                updateCounts_.add(input.readUInt32());
+              }
+              input.popLimit(limit);
+              break;
+            }
+            case 32: {
+
+              missingStatement_ = input.readBool();
+              break;
+            }
+            case 42: {
+              org.apache.calcite.avatica.proto.Responses.RpcMetadata.Builder subBuilder = null;
+              if (metadata_ != null) {
+                subBuilder = metadata_.toBuilder();
+              }
+              metadata_ = input.readMessage(org.apache.calcite.avatica.proto.Responses.RpcMetadata.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(metadata_);
+                metadata_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new RuntimeException(e.setUnfinishedMessage(this));
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(
+            new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this));
+      } finally {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+          updateCounts_ = java.util.Collections.unmodifiableList(updateCounts_);
+        }
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_ExecuteBatchResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.calcite.avatica.proto.Responses.internal_static_ExecuteBatchResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse.class, org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int CONNECTION_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object connectionId_;
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public java.lang.String getConnectionId() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        connectionId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string connection_id = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getConnectionIdBytes() {
+      java.lang.Object ref = connectionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        connectionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STATEMENT_ID_FIELD_NUMBER = 2;
+    private int statementId_;
+    /**
+     * <code>optional uint32 statement_id = 2;</code>
+     */
+    public int getStatementId() {
+      return statementId_;
+    }
+
+    public static final int UPDATE_COUNTS_FIELD_NUMBER = 3;
+    private java.util.List<java.lang.Integer> updateCounts_;
+    /**
+     * <code>repeated uint32 update_counts = 3;</code>
+     */
+    public java.util.List<java.lang.Integer>
+        getUpdateCountsList() {
+      return updateCounts_;
+    }
+    /**
+     * <code>repeated uint32 update_counts = 3;</code>
+     */
+    public int getUpdateCountsCount() {
+      return updateCounts_.size();
+    }
+    /**
+     * <code>repeated uint32 update_counts = 3;</code>
+     */
+    public int getUpdateCounts(int index) {
+      return updateCounts_.get(index);
+    }
+    private int updateCountsMemoizedSerializedSize = -1;
+
+    public static final int MISSING_STATEMENT_FIELD_NUMBER = 4;
+    private boolean missingStatement_;
+    /**
+     * <code>optional bool missing_statement = 4;</code>
+     *
+     * <pre>
+     * Did the request fail because of no-cached statement
+     * </pre>
+     */
+    public boolean getMissingStatement() {
+      return missingStatement_;
+    }
+
+    public static final int METADATA_FIELD_NUMBER = 5;
+    private org.apache.calcite.avatica.proto.Responses.RpcMetadata metadata_;
+    /**
+     * <code>optional .RpcMetadata metadata = 5;</code>
+     */
+    public boolean hasMetadata() {
+      return metadata_ != null;
+    }
+    /**
+     * <code>optional .RpcMetadata metadata = 5;</code>
+     */
+    public org.apache.calcite.avatica.proto.Responses.RpcMetadata getMetadata() {
+      return metadata_ == null ? org.apache.calcite.avatica.proto.Responses.RpcMetadata.getDefaultInstance() : metadata_;
+    }
+    /**
+     * <code>optional .RpcMetadata metadata = 5;</code>
+     */
+    public org.apache.calcite.avatica.proto.Responses.RpcMetadataOrBuilder getMetadataOrBuilder() {
+      return getMetadata();
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (!getConnectionIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        output.writeUInt32(2, statementId_);
+      }
+      if (getUpdateCountsList().size() > 0) {
+        output.writeRawVarint32(26);
+        output.writeRawVarint32(updateCountsMemoizedSerializedSize);
+      }
+      for (int i = 0; i < updateCounts_.size(); i++) {
+        output.writeUInt32NoTag(updateCounts_.get(i));
+      }
+      if (missingStatement_ != false) {
+        output.writeBool(4, missingStatement_);
+      }
+      if (metadata_ != null) {
+        output.writeMessage(5, getMetadata());
+      }
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getConnectionIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, connectionId_);
+      }
+      if (statementId_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(2, statementId_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < updateCounts_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeUInt32SizeNoTag(updateCounts_.get(i));
+        }
+        size += dataSize;
+        if (!getUpdateCountsList().isEmpty()) {
+          size += 1;
+          size += com.google.protobuf.CodedOutputStream
+              .computeInt32SizeNoTag(dataSize);
+        }
+        updateCountsMemoizedSerializedSize = dataSize;
+      }
+      if (missingStatement_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, missingStatement_);
+      }
+      if (metadata_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(5, getMetadata());
+      }
+      memoizedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code ExecuteBatchResponse}
+     *
+     * <pre>
+     * Response to a batch update request
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ExecuteBatchResponse)
+        org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_ExecuteBatchResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_ExecuteBatchResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse.class, org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse.Builder.class);
+      }
+
+      // Construct using org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        connectionId_ = "";
+
+        statementId_ = 0;
+
+        updateCounts_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        missingStatement_ = false;
+
+        if (metadataBuilder_ == null) {
+          metadata_ = null;
+        } else {
+          metadata_ = null;
+          metadataBuilder_ = null;
+        }
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.calcite.avatica.proto.Responses.internal_static_ExecuteBatchResponse_descriptor;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse getDefaultInstanceForType() {
+        return org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse.getDefaultInstance();
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse build() {
+        org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse buildPartial() {
+        org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse result = new org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        result.connectionId_ = connectionId_;
+        result.statementId_ = statementId_;
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          updateCounts_ = java.util.Collections.unmodifiableList(updateCounts_);
+          bitField0_ = (bitField0_ & ~0x00000004);
+        }
+        result.updateCounts_ = updateCounts_;
+        result.missingStatement_ = missingStatement_;
+        if (metadataBuilder_ == null) {
+          result.metadata_ = metadata_;
+        } else {
+          result.metadata_ = metadataBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse) {
+          return mergeFrom((org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse other) {
+        if (other == org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse.getDefaultInstance()) return this;
+        if (!other.getConnectionId().isEmpty()) {
+          connectionId_ = other.connectionId_;
+          onChanged();
+        }
+        if (other.getStatementId() != 0) {
+          setStatementId(other.getStatementId());
+        }
+        if (!other.updateCounts_.isEmpty()) {
+          if (updateCounts_.isEmpty()) {
+            updateCounts_ = other.updateCounts_;
+            bitField0_ = (bitField0_ & ~0x00000004);
+          } else {
+            ensureUpdateCountsIsMutable();
+            updateCounts_.addAll(other.updateCounts_);
+          }
+          onChanged();
+        }
+        if (other.getMissingStatement() != false) {
+          setMissingStatement(other.getMissingStatement());
+        }
+        if (other.hasMetadata()) {
+          mergeMetadata(other.getMetadata());
+        }
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object connectionId_ = "";
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public java.lang.String getConnectionId() {
+        java.lang.Object ref = connectionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          connectionId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getConnectionIdBytes() {
+        java.lang.Object ref = connectionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          connectionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder clearConnectionId() {
+        
+        connectionId_ = getDefaultInstance().getConnectionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string connection_id = 1;</code>
+       */
+      public Builder setConnectionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        connectionId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int statementId_ ;
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public int getStatementId() {
+        return statementId_;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder setStatementId(int value) {
+        
+        statementId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 statement_id = 2;</code>
+       */
+      public Builder clearStatementId() {
+        
+        statementId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<java.lang.Integer> updateCounts_ = java.util.Collections.emptyList();
+      private void ensureUpdateCountsIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          updateCounts_ = new java.util.ArrayList<java.lang.Integer>(updateCounts_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+      /**
+       * <code>repeated uint32 update_counts = 3;</code>
+       */
+      public java.util.List<java.lang.Integer>
+          getUpdateCountsList() {
+        return java.util.Collections.unmodifiableList(updateCounts_);
+      }
+      /**
+       * <code>repeated uint32 update_counts = 3;</code>
+       */
+      public int getUpdateCountsCount() {
+        return updateCounts_.size();
+      }
+      /**
+       * <code>repeated uint32 update_counts = 3;</code>
+       */
+      public int getUpdateCounts(int index) {
+        return updateCounts_.get(index);
+      }
+      /**
+       * <code>repeated uint32 update_counts = 3;</code>
+       */
+      public Builder setUpdateCounts(
+          int index, int value) {
+        ensureUpdateCountsIsMutable();
+        updateCounts_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated uint32 update_counts = 3;</code>
+       */
+      public Builder addUpdateCounts(int value) {
+        ensureUpdateCountsIsMutable();
+        updateCounts_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated uint32 update_counts = 3;</code>
+       */
+      public Builder addAllUpdateCounts(
+          java.lang.Iterable<? extends java.lang.Integer> values) {
+        ensureUpdateCountsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, updateCounts_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated uint32 update_counts = 3;</code>
+       */
+      public Builder clearUpdateCounts() {
+        updateCounts_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        onChanged();
+        return this;
+      }
+
+      private boolean missingStatement_ ;
+      /**
+       * <code>optional bool missing_statement = 4;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public boolean getMissingStatement() {
+        return missingStatement_;
+      }
+      /**
+       * <code>optional bool missing_statement = 4;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public Builder setMissingStatement(boolean value) {
+        
+        missingStatement_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool missing_statement = 4;</code>
+       *
+       * <pre>
+       * Did the request fail because of no-cached statement
+       * </pre>
+       */
+      public Builder clearMissingStatement() {
+        
+        missingStatement_ = false;
+        onChanged();
+        return this;
+      }
+
+      private org.apache.calcite.avatica.proto.Responses.RpcMetadata metadata_ = null;
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.calcite.avatica.proto.Responses.RpcMetadata, org.apache.calcite.avatica.proto.Responses.RpcMetadata.Builder, org.apache.calcite.avatica.proto.Responses.RpcMetadataOrBuilder> metadataBuilder_;
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public boolean hasMetadata() {
+        return metadataBuilder_ != null || metadata_ != null;
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public org.apache.calcite.avatica.proto.Responses.RpcMetadata getMetadata() {
+        if (metadataBuilder_ == null) {
+          return metadata_ == null ? org.apache.calcite.avatica.proto.Responses.RpcMetadata.getDefaultInstance() : metadata_;
+        } else {
+          return metadataBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public Builder setMetadata(org.apache.calcite.avatica.proto.Responses.RpcMetadata value) {
+        if (metadataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          metadata_ = value;
+          onChanged();
+        } else {
+          metadataBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public Builder setMetadata(
+          org.apache.calcite.avatica.proto.Responses.RpcMetadata.Builder builderForValue) {
+        if (metadataBuilder_ == null) {
+          metadata_ = builderForValue.build();
+          onChanged();
+        } else {
+          metadataBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public Builder mergeMetadata(org.apache.calcite.avatica.proto.Responses.RpcMetadata value) {
+        if (metadataBuilder_ == null) {
+          if (metadata_ != null) {
+            metadata_ =
+              org.apache.calcite.avatica.proto.Responses.RpcMetadata.newBuilder(metadata_).mergeFrom(value).buildPartial();
+          } else {
+            metadata_ = value;
+          }
+          onChanged();
+        } else {
+          metadataBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public Builder clearMetadata() {
+        if (metadataBuilder_ == null) {
+          metadata_ = null;
+          onChanged();
+        } else {
+          metadata_ = null;
+          metadataBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public org.apache.calcite.avatica.proto.Responses.RpcMetadata.Builder getMetadataBuilder() {
+        
+        onChanged();
+        return getMetadataFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      public org.apache.calcite.avatica.proto.Responses.RpcMetadataOrBuilder getMetadataOrBuilder() {
+        if (metadataBuilder_ != null) {
+          return metadataBuilder_.getMessageOrBuilder();
+        } else {
+          return metadata_ == null ?
+              org.apache.calcite.avatica.proto.Responses.RpcMetadata.getDefaultInstance() : metadata_;
+        }
+      }
+      /**
+       * <code>optional .RpcMetadata metadata = 5;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.calcite.avatica.proto.Responses.RpcMetadata, org.apache.calcite.avatica.proto.Responses.RpcMetadata.Builder, org.apache.calcite.avatica.proto.Responses.RpcMetadataOrBuilder> 
+          getMetadataFieldBuilder() {
+        if (metadataBuilder_ == null) {
+          metadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.calcite.avatica.proto.Responses.RpcMetadata, org.apache.calcite.avatica.proto.Responses.RpcMetadata.Builder, org.apache.calcite.avatica.proto.Responses.RpcMetadataOrBuilder>(
+                  getMetadata(),
+                  getParentForChildren(),
+                  isClean());
+          metadata_ = null;
+        }
+        return metadataBuilder_;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return this;
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:ExecuteBatchResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:ExecuteBatchResponse)
+    private static final org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse();
+    }
+
+    public static org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ExecuteBatchResponse>
+        PARSER = new com.google.protobuf.AbstractParser<ExecuteBatchResponse>() {
+      public ExecuteBatchResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        try {
+          return new ExecuteBatchResponse(input, extensionRegistry);
+        } catch (RuntimeException e) {
+          if (e.getCause() instanceof
+              com.google.protobuf.InvalidProtocolBufferException) {
+            throw (com.google.protobuf.InvalidProtocolBufferException)
+                e.getCause();
+          }
+          throw e;
+        }
+      }
+    };
+
+    public static com.google.protobuf.Parser<ExecuteBatchResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ExecuteBatchResponse> getParserForType() {
+      return PARSER;
+    }
+
+    public org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ResultSetResponse_descriptor;
   private static
@@ -11687,6 +12638,11 @@ package org.apache.calcite.avatica.proto;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_RollbackResponse_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_ExecuteBatchResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_ExecuteBatchResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -11734,8 +12690,12 @@ package org.apache.calcite.avatica.proto;
       "\014more_results\030\002 \001(\010\022\036\n\010metadata\030\003 \001(\0132\014." +
       "RpcMetadata\"%\n\013RpcMetadata\022\026\n\016server_add" +
       "ress\030\001 \001(\t\"\020\n\016CommitResponse\"\022\n\020Rollback" +
-      "ResponseB\"\n org.apache.calcite.avatica.p" +
-      "rotob\006proto3"
+      "Response\"\225\001\n\024ExecuteBatchResponse\022\025\n\rcon" +
+      "nection_id\030\001 \001(\t\022\024\n\014statement_id\030\002 \001(\r\022\025",
+      "\n\rupdate_counts\030\003 \003(\r\022\031\n\021missing_stateme" +
+      "nt\030\004 \001(\010\022\036\n\010metadata\030\005 \001(\0132\014.RpcMetadata" +
+      "B\"\n org.apache.calcite.avatica.protob\006pr" +
+      "oto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -11846,6 +12806,12 @@ package org.apache.calcite.avatica.proto;
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_RollbackResponse_descriptor,
         new java.lang.String[] { });
+    internal_static_ExecuteBatchResponse_descriptor =
+      getDescriptor().getMessageTypes().get(16);
+    internal_static_ExecuteBatchResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ExecuteBatchResponse_descriptor,
+        new java.lang.String[] { "ConnectionId", "StatementId", "UpdateCounts", "MissingStatement", "Metadata", });
     org.apache.calcite.avatica.proto.Common.getDescriptor();
   }
 

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/AvaticaCommonsHttpClientSpnegoImpl.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/AvaticaCommonsHttpClientSpnegoImpl.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.KerberosCredentials;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.util.EntityUtils;
+
+import org.ietf.jgss.GSSCredential;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.Principal;
+import java.util.Objects;
+
+/**
+ * Implementation of an AvaticaHttpClient which uses SPNEGO.
+ */
+public class AvaticaCommonsHttpClientSpnegoImpl implements AvaticaHttpClient {
+  private static final Logger LOG = LoggerFactory
+      .getLogger(AvaticaCommonsHttpClientSpnegoImpl.class);
+
+  public static final String CACHED_CONNECTIONS_MAX_KEY = "avatica.http.spnego.max_cached";
+  public static final String CACHED_CONNECTIONS_MAX_DEFAULT = "100";
+  public static final String CACHED_CONNECTIONS_MAX_PER_ROUTE_KEY =
+      "avatica.http.spnego.max_per_route";
+  public static final String CACHED_CONNECTIONS_MAX_PER_ROUTE_DEFAULT = "25";
+
+  private static final boolean USE_CANONICAL_HOSTNAME = true;
+  private static final boolean STRIP_PORT_ON_SERVER_LOOKUP = true;
+
+  final URL url;
+  final HttpHost host;
+  final PoolingHttpClientConnectionManager pool;
+  final Lookup<AuthSchemeProvider> authRegistry;
+  final BasicCredentialsProvider credentialsProvider;
+  final BasicAuthCache authCache;
+  final CloseableHttpClient client;
+
+  /**
+   * Constructs an http client with the expectation that the user is already logged in with their
+   * Kerberos identity via JAAS.
+   *
+   * @param url The URL for the Avatica server
+   */
+  public AvaticaCommonsHttpClientSpnegoImpl(URL url) {
+    this(url, null);
+  }
+
+  /**
+   * Constructs an HTTP client with user specified by the given credentials.
+   *
+   * @param url The URL for the Avatica server
+   * @param credential The GSS credentials
+   */
+  public AvaticaCommonsHttpClientSpnegoImpl(URL url, GSSCredential credential) {
+    this.url = Objects.requireNonNull(url);
+
+    pool = new PoolingHttpClientConnectionManager();
+    // Increase max total connection to 100
+    final String maxCnxns =
+        System.getProperty(CACHED_CONNECTIONS_MAX_KEY, CACHED_CONNECTIONS_MAX_DEFAULT);
+    pool.setMaxTotal(Integer.parseInt(maxCnxns));
+    // Increase default max connection per route to 25
+    final String maxCnxnsPerRoute = System.getProperty(CACHED_CONNECTIONS_MAX_PER_ROUTE_KEY,
+        CACHED_CONNECTIONS_MAX_PER_ROUTE_DEFAULT);
+    pool.setDefaultMaxPerRoute(Integer.parseInt(maxCnxnsPerRoute));
+
+    this.host = new HttpHost(url.getHost(), url.getPort());
+
+    this.authRegistry = RegistryBuilder.<AuthSchemeProvider>create().register(AuthSchemes.SPNEGO,
+        new SPNegoSchemeFactory(STRIP_PORT_ON_SERVER_LOOKUP, USE_CANONICAL_HOSTNAME)).build();
+
+    this.credentialsProvider = new BasicCredentialsProvider();
+    if (null != credential) {
+      // Non-null credential should be used directly with KerberosCredentials.
+      this.credentialsProvider.setCredentials(AuthScope.ANY, new KerberosCredentials(credential));
+    } else {
+      // A null credential implies that the user is logged in via JAAS using the
+      // java.security.auth.login.config system property
+      this.credentialsProvider.setCredentials(AuthScope.ANY, EmptyCredentials.INSTANCE);
+    }
+
+    this.authCache = new BasicAuthCache();
+
+    // A single thread-safe HttpClient, pooling connections via the ConnectionManager
+    this.client = HttpClients.custom()
+        .setDefaultAuthSchemeRegistry(authRegistry)
+        .setConnectionManager(pool).build();
+  }
+
+  @Override public byte[] send(byte[] request) {
+    HttpClientContext context = HttpClientContext.create();
+
+    context.setTargetHost(host);
+    context.setCredentialsProvider(credentialsProvider);
+    context.setAuthSchemeRegistry(authRegistry);
+    context.setAuthCache(authCache);
+
+    ByteArrayEntity entity = new ByteArrayEntity(request, ContentType.APPLICATION_OCTET_STREAM);
+
+    // Create the client with the AuthSchemeRegistry and manager
+    HttpPost post = new HttpPost(toURI(url));
+    post.setEntity(entity);
+
+    try (CloseableHttpResponse response = client.execute(post, context)) {
+      final int statusCode = response.getStatusLine().getStatusCode();
+      if (HttpURLConnection.HTTP_OK == statusCode
+          || HttpURLConnection.HTTP_INTERNAL_ERROR == statusCode) {
+        return EntityUtils.toByteArray(response.getEntity());
+      }
+
+      throw new RuntimeException("Failed to execute HTTP Request, got HTTP/" + statusCode);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      LOG.debug("Failed to execute HTTP request", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static URI toURI(URL url) throws RuntimeException {
+    try {
+      return url.toURI();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * A credentials implementation which returns null.
+   */
+  private static class EmptyCredentials implements Credentials {
+    public static final EmptyCredentials INSTANCE = new EmptyCredentials();
+
+    @Override public String getPassword() {
+      return null;
+    }
+    @Override public Principal getUserPrincipal() {
+      return null;
+    }
+  }
+}
+
+// End AvaticaCommonsHttpClientSpnegoImpl.java

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClientFactoryImpl.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClientFactoryImpl.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 public class AvaticaHttpClientFactoryImpl implements AvaticaHttpClientFactory {
   public static final String HTTP_CLIENT_IMPL_DEFAULT =
       AvaticaCommonsHttpClientImpl.class.getName();
+  public static final String SPNEGO_HTTP_CLIENT_IMPL_DEFAULT =
+      AvaticaCommonsHttpClientSpnegoImpl.class.getName();
 
   // Public for Type.PLUGIN
   public static final AvaticaHttpClientFactoryImpl INSTANCE = new AvaticaHttpClientFactoryImpl();
@@ -48,7 +50,12 @@ public class AvaticaHttpClientFactoryImpl implements AvaticaHttpClientFactory {
   @Override public AvaticaHttpClient getClient(URL url, ConnectionConfig config) {
     String className = config.httpClientClass();
     if (null == className) {
-      className = HTTP_CLIENT_IMPL_DEFAULT;
+      // Provide an implementation that works with SPNEGO if that's the authentication is use.
+      if ("SPNEGO".equalsIgnoreCase(config.authentication())) {
+        className = SPNEGO_HTTP_CLIENT_IMPL_DEFAULT;
+      } else {
+        className = HTTP_CLIENT_IMPL_DEFAULT;
+      }
     }
 
     try {

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/JsonService.java
@@ -222,6 +222,22 @@ public abstract class JsonService extends AbstractService {
       throw handle(e);
     }
   }
+
+  public ExecuteBatchResponse apply(PrepareAndExecuteBatchRequest request) {
+    try {
+      return decode(apply(encode(request)), ExecuteBatchResponse.class);
+    } catch (IOException e) {
+      throw handle(e);
+    }
+  }
+
+  public ExecuteBatchResponse apply(ExecuteBatchRequest request) {
+    try {
+      return decode(apply(encode(request)), ExecuteBatchResponse.class);
+    } catch (IOException e) {
+      throw handle(e);
+    }
+  }
 }
 
 // End JsonService.java

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/ProtobufMeta.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/ProtobufMeta.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.NoSuchStatementException;
+import org.apache.calcite.avatica.proto.Requests;
+
+import java.util.List;
+
+/**
+ * An extension of {@link Meta} which allows for native processing of calls with the Protobuf
+ * API objects instead of the POJOS (to avoid object translation). In the write-path, performing
+ * this conversion tends to represent a signficant portion of execution time. The introduction
+ * of this interface is to serve the purose of gradual migration to Meta implementations that
+ * can naturally function over Protobuf objects instead of the POJOs.
+ */
+public interface ProtobufMeta extends Meta {
+
+  /**
+   * Executes a batch of commands on a prepared statement.
+   *
+   * @param h Statement handle
+   * @param parameterValues A collection of list of typed values, one list per batch
+   * @return An array of update counts containing one element for each command in the batch.
+   */
+  ExecuteBatchResult executeBatchProtobuf(StatementHandle h, List<Requests.UpdateBatch>
+      parameterValues) throws NoSuchStatementException;
+}
+
+// End ProtobufMeta.java

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/ProtobufService.java
@@ -109,6 +109,14 @@ public abstract class ProtobufService extends AbstractService {
     return (RollbackResponse) _apply(request);
   }
 
+  @Override public ExecuteBatchResponse apply(PrepareAndExecuteBatchRequest request) {
+    return (ExecuteBatchResponse) _apply(request);
+  }
+
+  @Override public ExecuteBatchResponse apply(ExecuteBatchRequest request) {
+    return (ExecuteBatchResponse) _apply(request);
+  }
+
   /**
    * Checks if the provided {@link Message} is an instance of the Class given by
    * <code>expectedType</code>. Throws an IllegalArgumentException if the message is not of the

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/ProtobufTranslationImpl.java
@@ -25,9 +25,11 @@ import org.apache.calcite.avatica.proto.Requests.CommitRequest;
 import org.apache.calcite.avatica.proto.Requests.ConnectionSyncRequest;
 import org.apache.calcite.avatica.proto.Requests.CreateStatementRequest;
 import org.apache.calcite.avatica.proto.Requests.DatabasePropertyRequest;
+import org.apache.calcite.avatica.proto.Requests.ExecuteBatchRequest;
 import org.apache.calcite.avatica.proto.Requests.ExecuteRequest;
 import org.apache.calcite.avatica.proto.Requests.FetchRequest;
 import org.apache.calcite.avatica.proto.Requests.OpenConnectionRequest;
+import org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteBatchRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareAndExecuteRequest;
 import org.apache.calcite.avatica.proto.Requests.PrepareRequest;
 import org.apache.calcite.avatica.proto.Requests.RollbackRequest;
@@ -43,6 +45,7 @@ import org.apache.calcite.avatica.proto.Responses.ConnectionSyncResponse;
 import org.apache.calcite.avatica.proto.Responses.CreateStatementResponse;
 import org.apache.calcite.avatica.proto.Responses.DatabasePropertyResponse;
 import org.apache.calcite.avatica.proto.Responses.ErrorResponse;
+import org.apache.calcite.avatica.proto.Responses.ExecuteBatchResponse;
 import org.apache.calcite.avatica.proto.Responses.ExecuteResponse;
 import org.apache.calcite.avatica.proto.Responses.FetchResponse;
 import org.apache.calcite.avatica.proto.Responses.OpenConnectionResponse;
@@ -126,6 +129,12 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
         new RequestTranslator(CommitRequest.parser(), new Service.CommitRequest()));
     reqParsers.put(RollbackRequest.class.getName(),
         new RequestTranslator(RollbackRequest.parser(), new Service.RollbackRequest()));
+    reqParsers.put(PrepareAndExecuteBatchRequest.class.getName(),
+        new RequestTranslator(PrepareAndExecuteBatchRequest.parser(),
+            new Service.PrepareAndExecuteBatchRequest()));
+    reqParsers.put(ExecuteBatchRequest.class.getName(),
+        new RequestTranslator(ExecuteBatchRequest.parser(),
+            new Service.ExecuteBatchRequest()));
 
     REQUEST_PARSERS = Collections.unmodifiableMap(reqParsers);
 
@@ -166,6 +175,8 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
         new ResponseTranslator(CommitResponse.parser(), new Service.CommitResponse()));
     respParsers.put(RollbackResponse.class.getName(),
         new ResponseTranslator(RollbackResponse.parser(), new Service.RollbackResponse()));
+    respParsers.put(ExecuteBatchResponse.class.getName(),
+        new ResponseTranslator(ExecuteBatchResponse.parser(), new Service.ExecuteBatchResponse()));
 
     RESPONSE_PARSERS = Collections.unmodifiableMap(respParsers);
 
@@ -197,6 +208,9 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
     messageClasses.add(TableTypesRequest.class);
     messageClasses.add(TablesRequest.class);
     messageClasses.add(TypeInfoRequest.class);
+    messageClasses.add(PrepareAndExecuteBatchRequest.class);
+    messageClasses.add(ExecuteBatchRequest.class);
+
     messageClasses.add(CloseConnectionResponse.class);
     messageClasses.add(CloseStatementResponse.class);
     messageClasses.add(CommitResponse.class);
@@ -212,6 +226,7 @@ public class ProtobufTranslationImpl implements ProtobufTranslation {
     messageClasses.add(RollbackResponse.class);
     messageClasses.add(RpcMetadata.class);
     messageClasses.add(SyncResultsResponse.class);
+    messageClasses.add(ExecuteBatchResponse.class);
 
     return messageClasses;
   }

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/RemoteMeta.java
@@ -390,6 +390,29 @@ class RemoteMeta extends MetaImpl {
       }
     });
   }
+
+  @Override public ExecuteBatchResult prepareAndExecuteBatch(final StatementHandle h,
+      final List<String> sqlCommands) throws NoSuchStatementException {
+    return connection.invokeWithRetries(new CallableWithoutException<ExecuteBatchResult>() {
+      @Override public ExecuteBatchResult call() {
+        Service.ExecuteBatchResponse response =
+            service.apply(
+                new Service.PrepareAndExecuteBatchRequest(h.connectionId, h.id, sqlCommands));
+        return new ExecuteBatchResult(response.updateCounts);
+      }
+    });
+  }
+
+  @Override public ExecuteBatchResult executeBatch(final StatementHandle h,
+      final List<List<TypedValue>> parameterValues) throws NoSuchStatementException {
+    return connection.invokeWithRetries(new CallableWithoutException<ExecuteBatchResult>() {
+      @Override public ExecuteBatchResult call() {
+        Service.ExecuteBatchResponse response =
+            service.apply(new Service.ExecuteBatchRequest(h.connectionId, h.id, parameterValues));
+        return new ExecuteBatchResult(response.updateCounts);
+      }
+    });
+  }
 }
 
 // End RemoteMeta.java

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/Service.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/Service.java
@@ -2844,7 +2844,6 @@ public interface Service {
           && Objects.equals(connectionId, ((PrepareAndExecuteBatchRequest) o).connectionId)
           && statementId == ((PrepareAndExecuteBatchRequest) o).statementId
           && Objects.equals(sqlCommands, ((PrepareAndExecuteBatchRequest) o).sqlCommands);
-
     }
   }
 
@@ -2852,10 +2851,6 @@ public interface Service {
    * Request object to execute a batch of commands.
    */
   class ExecuteBatchRequest extends Request {
-    private static final FieldDescriptor UPDATE_BATCH_FIELD_DESCRIPTOR = Requests
-        .ExecuteBatchRequest.getDescriptor()
-        .findFieldByNumber(Requests.ExecuteBatchRequest.UPDATES_FIELD_NUMBER);
-
     public final String connectionId;
     public final int statementId;
     // Each update in a batch has a list of TypedValue's
@@ -2933,7 +2928,11 @@ public interface Service {
         }
       }
 
-      return builder.setConnectionId(connectionId).setStatementId(statementId).build();
+      if (null != connectionId) {
+        builder.setConnectionId(connectionId);
+      }
+
+      return builder.setStatementId(statementId).build();
     }
 
     @Override public int hashCode() {

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/Service.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/Service.java
@@ -2216,8 +2216,10 @@ public interface Service {
 
     public static final int UNKNOWN_ERROR_CODE = -1;
     public static final int MISSING_CONNECTION_ERROR_CODE = 1;
+    public static final int UNAUTHORIZED_ERROR_CODE = 2;
 
     public static final String UNKNOWN_SQL_STATE = "00000";
+    public static final String UNAUTHORIZED_SQL_STATE = "00002";
 
     public final List<String> exceptions;
     public final String errorMessage;
@@ -2318,7 +2320,8 @@ public interface Service {
           metadata);
     }
 
-    @Override Responses.ErrorResponse serialize() {
+    // Public so the Jetty handler implementations can use it
+    @Override public Responses.ErrorResponse serialize() {
       Responses.ErrorResponse.Builder builder = Responses.ErrorResponse.newBuilder();
 
       if (null != rpcMetadata) {

--- a/avatica/core/src/main/protobuf/requests.proto
+++ b/avatica/core/src/main/protobuf/requests.proto
@@ -143,3 +143,21 @@ message CommitRequest {
 message RollbackRequest {
   string connection_id = 1;
 }
+
+// Request to prepare and execute a collection of sql statements.
+message PrepareAndExecuteBatchRequest {
+  string connection_id = 1;
+  uint32 statement_id = 2;
+  repeated string sql_commands = 3;
+}
+
+// Each command is a list of TypedValues
+message UpdateBatch {
+  repeated TypedValue parameter_values = 1;
+}
+
+message ExecuteBatchRequest {
+  string connection_id = 1;
+  uint32 statement_id = 2;
+  repeated UpdateBatch updates = 3; // A batch of updates is a list<list<typevalue>>
+}

--- a/avatica/core/src/main/protobuf/responses.proto
+++ b/avatica/core/src/main/protobuf/responses.proto
@@ -124,3 +124,12 @@ message CommitResponse {
 message RollbackResponse {
 
 }
+
+// Response to a batch update request
+message ExecuteBatchResponse {
+  string connection_id = 1;
+  uint32 statement_id = 2;
+  repeated uint32 update_counts = 3;
+  bool missing_statement = 4; // Did the request fail because of no-cached statement
+  RpcMetadata metadata = 5;
+}

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/remote/ExecuteBatchRequestTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/remote/ExecuteBatchRequestTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+import org.apache.calcite.avatica.ColumnMetaData.Rep;
+import org.apache.calcite.avatica.proto.Common;
+import org.apache.calcite.avatica.proto.Requests;
+import org.apache.calcite.avatica.proto.Requests.UpdateBatch;
+import org.apache.calcite.avatica.remote.Service.ExecuteBatchRequest;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for ExecuteBatchRequest
+ */
+public class ExecuteBatchRequestTest {
+
+  private ExecuteBatchRequest identityRequest = new ExecuteBatchRequest();
+  private List<TypedValue> paramValues =
+      Arrays.asList(TypedValue.create(Rep.BOOLEAN.name(), Boolean.TRUE),
+          TypedValue.create(Rep.STRING.name(), "string"));
+
+  @Test public void testConversionFromProtobuf() {
+    ExecuteBatchRequest request = new ExecuteBatchRequest("connectionId", 12345,
+        Arrays.asList(paramValues, paramValues, paramValues));
+
+    assertFalse("A request with the POJO TypedValue list should return false",
+        request.hasProtoUpdateBatches());
+
+    // Everything will be serialized via protobuf
+    Requests.ExecuteBatchRequest protoRequest = request.serialize();
+
+    ExecuteBatchRequest copy = identityRequest.deserialize(protoRequest);
+
+    assertNull("Parameter values (pojo) list should be null", copy.parameterValues);
+    assertTrue("hasProtoUpdateBatches() should return true", copy.hasProtoUpdateBatches());
+    List<UpdateBatch> protoParameterValues = copy.getProtoUpdateBatches();
+    assertNotNull("Protobuf serialized parameterValues should not be null", protoParameterValues);
+
+    assertEquals(request.parameterValues.size(), protoParameterValues.size());
+
+    for (int i = 0; i < request.parameterValues.size(); i++) {
+      List<TypedValue> orig = request.parameterValues.get(i);
+      List<Common.TypedValue> proto = protoParameterValues.get(i).getParameterValuesList();
+      assertEquals("Mismatch in length of TypedValues at index " + i, orig.size(), proto.size());
+
+      // Don't re-test TypedValue serialization
+    }
+
+    // Everything else should be equivalent.
+    assertEquals(request.connectionId, copy.connectionId);
+    assertEquals(request.statementId, copy.statementId);
+  }
+}
+
+// End ExecuteBatchRequestTest.java

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/remote/ProtobufTranslationImplTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/remote/ProtobufTranslationImplTest.java
@@ -44,11 +44,13 @@ import org.apache.calcite.avatica.remote.Service.CreateStatementResponse;
 import org.apache.calcite.avatica.remote.Service.DatabasePropertyRequest;
 import org.apache.calcite.avatica.remote.Service.DatabasePropertyResponse;
 import org.apache.calcite.avatica.remote.Service.ErrorResponse;
+import org.apache.calcite.avatica.remote.Service.ExecuteBatchResponse;
 import org.apache.calcite.avatica.remote.Service.ExecuteResponse;
 import org.apache.calcite.avatica.remote.Service.FetchRequest;
 import org.apache.calcite.avatica.remote.Service.FetchResponse;
 import org.apache.calcite.avatica.remote.Service.OpenConnectionRequest;
 import org.apache.calcite.avatica.remote.Service.OpenConnectionResponse;
+import org.apache.calcite.avatica.remote.Service.PrepareAndExecuteBatchRequest;
 import org.apache.calcite.avatica.remote.Service.PrepareAndExecuteRequest;
 import org.apache.calcite.avatica.remote.Service.PrepareRequest;
 import org.apache.calcite.avatica.remote.Service.PrepareResponse;
@@ -216,6 +218,11 @@ public class ProtobufTranslationImplTest<T> {
     requests.add(new CommitRequest("connectionId"));
     requests.add(new RollbackRequest("connectionId"));
 
+    // ExecuteBatchRequest omitted because of the special protobuf conversion it does
+
+    List<String> commands = Arrays.asList("command1", "command2", "command3");
+    requests.add(new PrepareAndExecuteBatchRequest("connectionId", 12345, commands));
+
     return requests;
   }
 
@@ -350,6 +357,10 @@ public class ProtobufTranslationImplTest<T> {
 
     responses.add(new CommitResponse());
     responses.add(new RollbackResponse());
+
+    int[] updateCounts = new int[]{1, 0, 1, 1};
+    responses.add(
+        new ExecuteBatchResponse("connectionId", 12345, updateCounts, false, rpcMetadata));
 
     return responses;
   }

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
@@ -129,6 +129,14 @@ public class JsonHandlerTest {
     @Override public RollbackResponse apply(RollbackRequest request) {
       return null;
     }
+
+    @Override public ExecuteBatchResponse apply(ExecuteBatchRequest request) {
+      return null;
+    }
+
+    @Override public ExecuteBatchResponse apply(PrepareAndExecuteBatchRequest request) {
+      return null;
+    }
   }
 
   /**

--- a/avatica/pom.xml
+++ b/avatica/pom.xml
@@ -77,6 +77,7 @@ limitations under the License.
     <jcip-annotations.version>1.0-1</jcip-annotations.version>
     <jetty.version>9.2.15.v20160210</jetty.version>
     <junit.version>4.12</junit.version>
+    <kerby.version>1.0.0-RC1</kerby.version>
     <maven-checkstyle-plugin.version>2.12.1</maven-checkstyle-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
 
@@ -204,6 +205,21 @@ limitations under the License.
         <version>${scott-data-hsqldb.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-client</artifactId>
+        <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-core</artifactId>
+        <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-simplekdc</artifactId>
+        <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
@@ -237,6 +253,11 @@ limitations under the License.
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
         <version>${hsqldb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -534,9 +555,6 @@ limitations under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <threadCount>1</threadCount>
-            <perCoreThreadCount>true</perCoreThreadCount>
-            <parallel>both</parallel>
             <argLine>-Xmx1536m -XX:MaxPermSize=256m -Duser.timezone=${user.timezone}</argLine>
           </configuration>
         </plugin>

--- a/avatica/server/pom.xml
+++ b/avatica/server/pom.xml
@@ -53,6 +53,10 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
@@ -76,6 +80,21 @@ limitations under the License.
       <!-- Used in RemoteDriverTest but dependency not detected by maven-dependency-plugin:2.8:analyze -->
       <groupId>net.hydromatic</groupId>
       <artifactId>scott-data-hsqldb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-simplekdc</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -157,7 +176,6 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>${maven-dependency-plugin.version}</version>
         <!-- configurations do not cascade, so all of the definition from
              ../pom.xml:build:plugin-management:plugins:plugin must be repeated in child poms -->
         <executions>

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/AbstractAvaticaHandler.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/AbstractAvaticaHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.apache.calcite.avatica.AvaticaSeverity;
+import org.apache.calcite.avatica.remote.Service.ErrorResponse;
+
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Base-class for Avatica implemented Jetty Handlers.
+ */
+public abstract class AbstractAvaticaHandler extends AbstractHandler
+    implements MetricsAwareAvaticaHandler {
+
+  private static final ErrorResponse UNAUTHORIZED_ERROR = new ErrorResponse(
+      Collections.<String>emptyList(), "User is not authenticated",
+      ErrorResponse.UNAUTHORIZED_ERROR_CODE, ErrorResponse.UNAUTHORIZED_SQL_STATE,
+      AvaticaSeverity.ERROR, null);
+
+  /**
+   * Determines if a request is permitted to be executed. The server may require authentication
+   * and the login mechanism might have failed. This check verifies that only authenticated
+   * users are permitted through when the server is requiring authentication. When a user
+   * is disallowed, a status code and response will be automatically written to the provided
+   * <code>response</code> and the caller should return immediately.
+   *
+   * @param serverConfig The server's configuration
+   * @param request The user's request
+   * @param response The response to the user's request
+   * @return True if request can proceed, false otherwise.
+   */
+  public boolean isUserPermitted(AvaticaServerConfiguration serverConfig,
+      HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Make sure that we drop any unauthenticated users out first.
+    if (null != serverConfig && AuthenticationType.SPNEGO == serverConfig.getAuthenticationType()) {
+      String remoteUser = request.getRemoteUser();
+      if (null == remoteUser) {
+        response.setStatus(HttpURLConnection.HTTP_UNAUTHORIZED);
+        response.getOutputStream().write(UNAUTHORIZED_ERROR.serialize().toByteArray());
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+// End AbstractAvaticaHandler.java

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/AuthenticationType.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/AuthenticationType.java
@@ -14,29 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.calcite.avatica;
-
-import org.apache.calcite.avatica.remote.AvaticaHttpClientFactory;
-import org.apache.calcite.avatica.remote.Service;
+package org.apache.calcite.avatica.server;
 
 /**
- * Connection configuration.
+ * An enumeration for support types of authentication for the {@link HttpServer}.
  */
-public interface ConnectionConfig {
-  /** @see BuiltInConnectionProperty#SCHEMA */
-  String schema();
-  /** @see BuiltInConnectionProperty#TIME_ZONE */
-  String timeZone();
-  /** @see BuiltInConnectionProperty#FACTORY */
-  Service.Factory factory();
-  /** @see BuiltInConnectionProperty#URL */
-  String url();
-  /** @see BuiltInConnectionProperty#SERIALIZATION */
-  String serialization();
-  /** @see BuiltInConnectionProperty#AUTHENTICATION */
-  String authentication();
-  AvaticaHttpClientFactory httpClientFactory();
-  String httpClientClass();
+public enum AuthenticationType {
+  NONE,
+  SPNEGO;
 }
 
-// End ConnectionConfig.java
+// End AuthenticationType.java

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/AvaticaServerConfiguration.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/AvaticaServerConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A generic configuration interface that users can implement to configure the {@link HttpServer}.
+ */
+public interface AvaticaServerConfiguration {
+
+  /**
+   * Returns the type of authentication the {@link HttpServer} should use.
+   * @return An enum corresponding to an authentication mechanism
+   */
+  AuthenticationType getAuthenticationType();
+
+  /**
+   * Returns the Kerberos realm to use for the server's login. Only relevant when
+   * {@link #getAuthenticationType()} returns {@link AuthenticationType#SPNEGO}.
+   *
+   * @return The Kerberos realm for the server login, or null if not applicable.
+   */
+  String getKerberosRealm();
+
+  /**
+   * Returns the Kerberos principal that the Avatica server should log in as.
+   *
+   * @return A Kerberos principal, or null if not applicable.
+   */
+  String getKerberosPrincipal();
+
+  /**
+   * Returns true if the Avatica server should run user requests at that remote user. Otherwise,
+   * all requests are run as the Avatica server user (which is the default).
+   *
+   * @return True if impersonation is enabled, false otherwise.
+   */
+  boolean supportsImpersonation();
+
+  /**
+   * Invokes the given <code>action</code> as the <code>remoteUserName</code>. This will only be
+   * invoked if {@link #supportsImpersonation()} returns <code>true</code>.
+   *
+   * @param remoteUserName The remote user making a request to the Avatica server.
+   * @param remoteAddress The address the remote user is making the request from.
+   * @return The result from the Callable.
+   */
+  <T> T doAsRemoteUser(String remoteUserName, String remoteAddress, Callable<T> action)
+      throws Exception;
+}
+
+// End AvaticaServerConfiguration.java

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/DoAsRemoteUserCallback.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/DoAsRemoteUserCallback.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A callback which the server can invoke to allow implementations to control additional logic
+ * about whether or not a client from a specific host should be run.
+ * <p>For example, complex logic could be supplied to control whether clientA from host1 is
+ * permitted to execute queries. This logic is deferred upon the user to implement.
+ */
+public interface DoAsRemoteUserCallback {
+
+  /**
+   * Invokes the given <code>action</code> as the <code>remoteUserName</code>.
+   *
+   * @param remoteUserName The remote user making a request to the Avatica server.
+   * @param remoteAddress The address the remote user is making the request from.
+   * @param action The operation the Avatica server wants to run as <code>remoteUserName</code>.
+   * @return The result from the Callable.
+   */
+  <T> T doAsRemoteUser(String remoteUserName, String remoteAddress, Callable<T> action)
+      throws Exception;
+
+}
+
+// End DoAsRemoteUserCallback.java

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/HttpServer.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/HttpServer.java
@@ -16,21 +16,42 @@
  */
 package org.apache.calcite.avatica.server;
 
+import org.apache.calcite.avatica.metrics.MetricsSystemConfiguration;
+import org.apache.calcite.avatica.remote.Driver.Serialization;
+import org.apache.calcite.avatica.remote.Service;
 import org.apache.calcite.avatica.remote.Service.RpcMetadataResponse;
 
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.authentication.SpnegoAuthenticator;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
 
 /**
  * Avatica HTTP server.
@@ -44,12 +65,18 @@ public class HttpServer {
   private Server server;
   private int port = -1;
   private final AvaticaHandler handler;
+  private final AvaticaServerConfiguration config;
+  private final Subject subject;
 
   @Deprecated
   public HttpServer(Handler handler) {
     this(wrapJettyHandler(handler));
   }
 
+  /**
+   * Constructs an {@link HttpServer} which binds to an ephemeral port.
+   * @param handler The Handler to run
+   */
   public HttpServer(AvaticaHandler handler) {
     this(0, handler);
   }
@@ -59,9 +86,38 @@ public class HttpServer {
     this(port, wrapJettyHandler(handler));
   }
 
+  /**
+   * Constructs an {@link HttpServer} with no additional configuration.
+   * @param port The listen port
+   * @param handler The Handler to run
+   */
   public HttpServer(int port, AvaticaHandler handler) {
+    this(port, handler, null);
+  }
+
+  /**
+   * Constructs an {@link HttpServer}.
+   * @param port The listen port
+   * @param handler The Handler to run
+   * @param config Optional configuration for the server
+   */
+  public HttpServer(int port, AvaticaHandler handler, AvaticaServerConfiguration config) {
+    this(port, handler, config, null);
+  }
+
+  /**
+   * Constructs an {@link HttpServer}.
+   * @param port The listen port
+   * @param handler The Handler to run
+   * @param config Optional configuration for the server
+   * @param subject The javax.security Subject for the server, or null
+   */
+  public HttpServer(int port, AvaticaHandler handler, AvaticaServerConfiguration config,
+      Subject subject) {
     this.port = port;
     this.handler = handler;
+    this.config = config;
+    this.subject = subject;
   }
 
   private static AvaticaHandler wrapJettyHandler(Handler handler) {
@@ -73,6 +129,20 @@ public class HttpServer {
   }
 
   public void start() {
+    if (null != subject) {
+      // Run the start in the privileged block (as the kerberos-identified user)
+      Subject.doAs(subject, new PrivilegedAction<Void>() {
+        @Override public Void run() {
+          internalStart();
+          return null;
+        }
+      });
+    } else {
+      internalStart();
+    }
+  }
+
+  protected void internalStart() {
     if (server != null) {
       throw new RuntimeException("Server is already started");
     }
@@ -83,11 +153,34 @@ public class HttpServer {
     server.manage(threadPool);
 
     final ServerConnector connector = configureConnector(new ServerConnector(server), port);
+    ConstraintSecurityHandler spnegoHandler = null;
+
+    if (null != this.config) {
+      switch (config.getAuthenticationType()) {
+      case SPNEGO:
+        // Get the Handler for SPNEGO authentication
+        spnegoHandler = configureSpnego(server, connector, this.config);
+        break;
+      default:
+        // Pass
+        break;
+      }
+    }
 
     server.setConnectors(new Connector[] { connector });
 
+    // Default to using the handler that was passed in
     final HandlerList handlerList = new HandlerList();
-    handlerList.setHandlers(new Handler[] { handler, new DefaultHandler() });
+    Handler avaticaHandler = handler;
+
+    // Wrap the provided handler for SPNEGO if we made one
+    if (null != spnegoHandler) {
+      spnegoHandler.setHandler(handler);
+      avaticaHandler = spnegoHandler;
+    }
+
+    handlerList.setHandlers(new Handler[] {avaticaHandler, new DefaultHandler()});
+
     server.setHandler(handlerList);
     try {
       server.start();
@@ -119,6 +212,41 @@ public class HttpServer {
     final int port = connector.getLocalPort();
 
     return new RpcMetadataResponse(String.format("%s:%d", host, port));
+  }
+
+  /**
+   * Configures the <code>connector</code> given the <code>config</code> for using SPNEGO.
+   *
+   * @param connector The connector to configure
+   * @param config The configuration
+   */
+  protected ConstraintSecurityHandler configureSpnego(Server server, ServerConnector connector,
+      AvaticaServerConfiguration config) {
+    final String realm = Objects.requireNonNull(config.getKerberosRealm());
+    final String principal = Objects.requireNonNull(config.getKerberosPrincipal());
+
+    Constraint constraint = new Constraint();
+    constraint.setName(Constraint.__SPNEGO_AUTH);
+    constraint.setRoles(new String[]{realm});
+    // This is telling Jetty to not allow unauthenticated requests through (very important!)
+    constraint.setAuthenticate(true);
+
+    ConstraintMapping cm = new ConstraintMapping();
+    cm.setConstraint(constraint);
+    cm.setPathSpec("/*");
+
+    // A customization of SpnegoLoginService to explicitly set the server's principal, otherwise
+    // we would have to require a custom file to set the server's principal.
+    PropertyBasedSpnegoLoginService spnegoLoginService =
+        new PropertyBasedSpnegoLoginService(realm, principal);
+
+    ConstraintSecurityHandler sh = new ConstraintSecurityHandler();
+    sh.setAuthenticator(new SpnegoAuthenticator());
+    sh.setLoginService(spnegoLoginService);
+    sh.setConstraintMappings(new ConstraintMapping[]{cm});
+    sh.setRealmName(realm);
+
+    return sh;
   }
 
   /**
@@ -162,6 +290,263 @@ public class HttpServer {
 
   public int getPort() {
     return port;
+  }
+
+  /**
+   * Builder class for creating instances of {@link HttpServer}.
+   */
+  public static class Builder {
+    private int port;
+
+    private Service service;
+    private Serialization serialization;
+    private AvaticaHandler handler = null;
+
+    private MetricsSystemConfiguration<?> metricsConfig;
+
+    private AuthenticationType authenticationType = AuthenticationType.NONE;
+
+    private String kerberosPrincipal;
+    private String kerberosRealm;
+    private File keytab;
+
+    private DoAsRemoteUserCallback remoteUserCallback;
+
+    public Builder() {}
+
+    public Builder withPort(int port) {
+      this.port = port;
+      return this;
+    }
+
+    /**
+     * Sets the {@link Service} and {@link Serialization} information necessary to construct
+     * the appropriate {@link AvaticaHandler}.
+     *
+     * @param service The Avatica service
+     * @param serialization The serialization method
+     * @return <code>this</code>
+     */
+    public Builder withHandler(Service service, Serialization serialization) {
+      this.service = Objects.requireNonNull(service);
+      this.serialization = Objects.requireNonNull(serialization);
+      return this;
+    }
+
+    /**
+     * Sets an {@link AvaticaHandler} directly on the builder. Most users will not want to use
+     * this method and should instead use {@link #withHandler(Service, Serialization)}.
+     *
+     * @param handler The handler
+     * @return <code>this</code>
+     */
+    public Builder withHandler(AvaticaHandler handler) {
+      this.handler = Objects.requireNonNull(handler);
+      return this;
+    }
+
+    /**
+     * Sets the given configuration to enable metrics collection in the server.
+     *
+     * @param metricsConfig Configuration object for metrics.
+     * @return <code>this</code>
+     */
+    public Builder withMetricsConfiguration(MetricsSystemConfiguration<?> metricsConfig) {
+      this.metricsConfig = Objects.requireNonNull(metricsConfig);
+      return this;
+    }
+
+    /**
+     * Configures the server to use SPNEGO authentication. This method requires that the
+     * <code>principal</code> contains the Kerberos realm.
+     *
+     * @param principal A kerberos principal with the realm required.
+     * @return <code>this</code>
+     */
+    public Builder withSpnego(String principal) {
+      int index = Objects.requireNonNull(principal).lastIndexOf('@');
+      if (-1 == index) {
+        throw new IllegalArgumentException("Could not find '@' symbol in '" + principal
+            + "' to parse the Kerberos realm from the principal");
+      }
+      final String realm = principal.substring(index + 1);
+      return withSpnego(principal, realm);
+    }
+
+    /**
+     * Configures the server to use SPNEGO authentication. It is required that callers are logged
+     * in via Kerberos already or have provided the necessary configuration to automatically log
+     * in via JAAS (using the <code>java.security.auth.login.config</code> system property) before
+     * starting the {@link HttpServer}.
+     *
+     * @param principal The kerberos principal
+     * @param realm The kerberos realm
+     * @return <code>this</code>
+     */
+    public Builder withSpnego(String principal, String realm) {
+      this.authenticationType = AuthenticationType.SPNEGO;
+      this.kerberosPrincipal = Objects.requireNonNull(principal);
+      this.kerberosRealm = Objects.requireNonNull(realm);
+      return this;
+    }
+
+    /**
+     * Sets a keytab to be used to perform a Kerberos login automatically (without the use of JAAS).
+     *
+     * @param keytab A KeyTab file for the server's login.
+     * @return <code>this</code>
+     */
+    public Builder withAutomaticLogin(File keytab) {
+      this.keytab = Objects.requireNonNull(keytab);
+      return this;
+    }
+
+    /**
+     * Sets a callback implementation to defer the logic on how to run an action as a given user and
+     * if the action should be permitted for that user.
+     *
+     * @param remoteUserCallback User-provided implementation of the callback
+     * @return <code>this</code>
+     */
+    public Builder withImpersonation(DoAsRemoteUserCallback remoteUserCallback) {
+      this.remoteUserCallback = Objects.requireNonNull(remoteUserCallback);
+      return this;
+    }
+
+    /**
+     * Builds the HttpServer instance from <code>this</code>.
+     * @return An HttpServer.
+     */
+    public HttpServer build() {
+      final AvaticaServerConfiguration serverConfig;
+      final Subject subject;
+      switch (authenticationType) {
+      case NONE:
+        serverConfig = null;
+        subject = null;
+        break;
+      case SPNEGO:
+        if (null != keytab) {
+          LOG.debug("Performing Kerberos login with {} as {}", keytab, kerberosPrincipal);
+          subject = loginViaKerberos(this);
+        } else {
+          LOG.debug("Not performing Kerberos login");
+          subject = null;
+        }
+        serverConfig = buildSpnegoConfiguration(this);
+        break;
+      default:
+        throw new IllegalArgumentException("Unhandled AuthenticationType");
+      }
+
+      AvaticaHandler handler = buildHandler(this, serverConfig);
+
+      return new HttpServer(port, handler, serverConfig, subject);
+    }
+
+    /**
+     * Creates the appropriate {@link AvaticaHandler}.
+     *
+     * @param b The {@link Builder}.
+     * @param config The Avatica server configuration
+     * @return An {@link AvaticaHandler}.
+     */
+    private AvaticaHandler buildHandler(Builder b, AvaticaServerConfiguration config) {
+      // The user provided a handler explicitly.
+      if (null != b.handler) {
+        return b.handler;
+      }
+
+      // Normal case, we create the handler for the user.
+      HandlerFactory factory = new HandlerFactory();
+      return factory.getHandler(b.service, b.serialization, b.metricsConfig, config);
+    }
+
+    /**
+     * Builds an {@link AvaticaServerConfiguration} implementation for SPNEGO-based authentication.
+     * @param b The {@link Builder}.
+     * @return A configuration instance.
+     */
+    private AvaticaServerConfiguration buildSpnegoConfiguration(Builder b) {
+      final String principal = b.kerberosPrincipal;
+      final String realm = b.kerberosRealm;
+      final DoAsRemoteUserCallback callback = b.remoteUserCallback;
+      return new AvaticaServerConfiguration() {
+
+        @Override public AuthenticationType getAuthenticationType() {
+          return AuthenticationType.SPNEGO;
+        }
+
+        @Override public String getKerberosRealm() {
+          return realm;
+        }
+
+        @Override public String getKerberosPrincipal() {
+          return principal;
+        }
+
+        @Override public boolean supportsImpersonation() {
+          return null != callback;
+        }
+
+        @Override public <T> T doAsRemoteUser(String remoteUserName, String remoteAddress,
+            Callable<T> action) throws Exception {
+          return callback.doAsRemoteUser(remoteUserName, remoteAddress, action);
+        }
+      };
+    }
+
+    private Subject loginViaKerberos(Builder b) {
+      Set<Principal> principals = new HashSet<Principal>();
+      principals.add(new KerberosPrincipal(b.kerberosPrincipal));
+
+      Subject subject = new Subject(false, principals, new HashSet<Object>(),
+          new HashSet<Object>());
+
+      KeytabJaasConf conf = new KeytabJaasConf(b.kerberosPrincipal, b.keytab.toString());
+      String confName = "NotUsed";
+      try {
+        LoginContext loginContext = new LoginContext(confName, subject, null, conf);
+        loginContext.login();
+        return loginContext.getSubject();
+      } catch (LoginException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * Javax Configuration class which always returns a configuration for our keytab-based
+     * login.
+     */
+    private static class KeytabJaasConf extends javax.security.auth.login.Configuration {
+      private final String principal;
+      private final String keytab;
+
+      private KeytabJaasConf(String principal, String keytab) {
+        this.principal = principal;
+        this.keytab = keytab;
+      }
+
+      @Override public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+        Map<String, String> options = new HashMap<String, String>();
+        options.put("storeKey", "true");
+        options.put("principal", principal);
+        options.put("keyTab", keytab);
+        options.put("doNotPrompt", "true");
+        options.put("useKeyTab", "true");
+        options.put("isInitiator", "false");
+        options.put("debug", System.getProperty("sun.security.krb5.debug", "false").toLowerCase());
+
+        return new AppConfigurationEntry[] {new AppConfigurationEntry(getKrb5LoginModuleName(),
+            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, options)};
+      }
+    }
+
+    private static String getKrb5LoginModuleName() {
+      return System.getProperty("java.vendor").contains("IBM")
+          ? "com.ibm.security.auth.module.Krb5LoginModule"
+          : "com.sun.security.auth.module.Krb5LoginModule";
+    }
   }
 }
 

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/PropertyBasedSpnegoLoginService.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/PropertyBasedSpnegoLoginService.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.eclipse.jetty.security.SpnegoLoginService;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+/**
+ * A customization of {@link SpnegoLoginService} which directly specifies the server's
+ * principal instead of requiring a file to exist. Known to work with Jetty-9.2.x, any other
+ * version would require testing/inspection to ensure the logic is still sound.
+ */
+public class PropertyBasedSpnegoLoginService extends SpnegoLoginService {
+
+  private static final String TARGET_NAME_FIELD_NAME = "_targetName";
+  private final String serverPrincipal;
+
+  public PropertyBasedSpnegoLoginService(String realm, String serverPrincipal) {
+    super(realm);
+    this.serverPrincipal = Objects.requireNonNull(serverPrincipal);
+  }
+
+  @Override protected void doStart() throws Exception {
+    // Override the parent implementation, setting _targetName to be the serverPrincipal
+    // without the need for a one-line file to do the same thing.
+    //
+    // AbstractLifeCycle's doStart() method does nothing, so we aren't missing any extra logic.
+    final Field targetNameField = SpnegoLoginService.class.getDeclaredField(TARGET_NAME_FIELD_NAME);
+    targetNameField.setAccessible(true);
+    targetNameField.set(this, serverPrincipal);
+  }
+}
+
+// End PropertyBasedSpnegoLoginService.java

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/AvaticaSpnegoTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/AvaticaSpnegoTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.apache.calcite.avatica.jdbc.JdbcMeta;
+import org.apache.calcite.avatica.remote.Driver;
+import org.apache.calcite.avatica.remote.LocalService;
+import org.apache.calcite.avatica.server.HttpServer;
+
+import org.apache.kerby.kerberos.kerb.KrbException;
+import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
+import org.apache.kerby.kerberos.kerb.client.KrbConfig;
+import org.apache.kerby.kerberos.kerb.client.KrbConfigKey;
+import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.security.PrivilegedExceptionAction;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.security.auth.Subject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * End to end test case for SPNEGO with Avatica.
+ */
+@RunWith(Parameterized.class)
+public class AvaticaSpnegoTest {
+  private static final Logger LOG = LoggerFactory.getLogger(AvaticaSpnegoTest.class);
+
+  private static final ConnectionSpec CONNECTION_SPEC = ConnectionSpec.HSQLDB;
+
+  private static SimpleKdcServer kdc;
+  private static KrbConfig clientConfig;
+  private static File keytabDir;
+
+  private static int kdcPort;
+  private static File clientKeytab;
+  private static File serverKeytab;
+
+  private static boolean isKdcStarted = false;
+
+  private static void setupKdc() throws Exception {
+    kdc = new SimpleKdcServer();
+    File target = new File(System.getProperty("user.dir"), "target");
+    assertTrue(target.exists());
+
+    File kdcDir = new File(target, AvaticaSpnegoTest.class.getSimpleName());
+    if (kdcDir.exists()) {
+      SpnegoTestUtil.deleteRecursively(kdcDir);
+    }
+    kdcDir.mkdirs();
+    kdc.setWorkDir(kdcDir);
+
+    kdc.setKdcHost(SpnegoTestUtil.KDC_HOST);
+    kdcPort = SpnegoTestUtil.getFreePort();
+    kdc.setAllowTcp(true);
+    kdc.setAllowUdp(false);
+    kdc.setKdcTcpPort(kdcPort);
+
+    LOG.info("Starting KDC server at {}:{}", SpnegoTestUtil.KDC_HOST, kdcPort);
+
+    kdc.init();
+    kdc.start();
+    isKdcStarted = true;
+
+    keytabDir = new File(target, AvaticaSpnegoTest.class.getSimpleName()
+        + "_keytabs");
+    if (keytabDir.exists()) {
+      SpnegoTestUtil.deleteRecursively(keytabDir);
+    }
+    keytabDir.mkdirs();
+    setupServerUser(keytabDir);
+
+    clientConfig = new KrbConfig();
+    clientConfig.setString(KrbConfigKey.KDC_HOST, SpnegoTestUtil.KDC_HOST);
+    clientConfig.setInt(KrbConfigKey.KDC_TCP_PORT, kdcPort);
+    clientConfig.setString(KrbConfigKey.DEFAULT_REALM, SpnegoTestUtil.REALM);
+
+    // Kerby sets "java.security.krb5.conf" for us!
+    System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
+    // System.setProperty("sun.security.spnego.debug", "true");
+    // System.setProperty("sun.security.krb5.debug", "true");
+  }
+
+  @AfterClass public static void stopKdc() throws Exception {
+    if (isKdcStarted) {
+      LOG.info("Stopping KDC on {}", kdcPort);
+      kdc.stop();
+    }
+  }
+
+  private static void setupServerUser(File keytabDir) throws KrbException {
+    // Create the client user
+    String clientPrincipal = SpnegoTestUtil.CLIENT_PRINCIPAL.substring(0,
+        SpnegoTestUtil.CLIENT_PRINCIPAL.indexOf('@'));
+    clientKeytab = new File(keytabDir, clientPrincipal.replace('/', '_') + ".keytab");
+    if (clientKeytab.exists()) {
+      SpnegoTestUtil.deleteRecursively(clientKeytab);
+    }
+    LOG.info("Creating {} with keytab {}", clientPrincipal, clientKeytab);
+    SpnegoTestUtil.setupUser(kdc, clientKeytab, clientPrincipal);
+
+    // Create the server user
+    String serverPrincipal = SpnegoTestUtil.SERVER_PRINCIPAL.substring(0,
+        SpnegoTestUtil.SERVER_PRINCIPAL.indexOf('@'));
+    serverKeytab = new File(keytabDir, serverPrincipal.replace('/', '_') + ".keytab");
+    if (serverKeytab.exists()) {
+      SpnegoTestUtil.deleteRecursively(serverKeytab);
+    }
+    LOG.info("Creating {} with keytab {}", SpnegoTestUtil.SERVER_PRINCIPAL, serverKeytab);
+    SpnegoTestUtil.setupUser(kdc, serverKeytab, SpnegoTestUtil.SERVER_PRINCIPAL);
+  }
+
+  @Parameters public static List<Object[]> parameters() throws Exception {
+    final ArrayList<Object[]> parameters = new ArrayList<>();
+
+    // Start the KDC
+    setupKdc();
+
+    // Create a LocalService around HSQLDB
+    final JdbcMeta jdbcMeta = new JdbcMeta(CONNECTION_SPEC.url,
+        CONNECTION_SPEC.username, CONNECTION_SPEC.password);
+    final LocalService localService = new LocalService(jdbcMeta);
+
+    for (Driver.Serialization serialization : new Driver.Serialization[] {
+      Driver.Serialization.JSON, Driver.Serialization.PROTOBUF}) {
+      // Build and start the server
+      HttpServer httpServer = new HttpServer.Builder()
+          .withPort(0)
+          .withAutomaticLogin(serverKeytab)
+          .withSpnego(SpnegoTestUtil.SERVER_PRINCIPAL, SpnegoTestUtil.REALM)
+          .withHandler(localService, serialization)
+          .build();
+      httpServer.start();
+
+      final String url = "jdbc:avatica:remote:url=http://" + SpnegoTestUtil.KDC_HOST + ":"
+          + httpServer.getPort() + ";authentication=SPNEGO;serialization=" + serialization;
+      LOG.info("JDBC URL {}", url);
+
+      parameters.add(new Object[] {httpServer, url});
+    }
+
+    return parameters;
+  }
+
+  private final HttpServer httpServer;
+  private final String jdbcUrl;
+
+  public AvaticaSpnegoTest(HttpServer httpServer, String jdbcUrl) {
+    this.httpServer = Objects.requireNonNull(httpServer);
+    this.jdbcUrl = Objects.requireNonNull(jdbcUrl);
+  }
+
+  @After public void stopHttpServer() {
+    if (null != httpServer) {
+      httpServer.stop();
+    }
+  }
+
+  @Test public void testAuthenticatedClient() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      final String tableName = "allowed_clients";
+      // Create the subject for the client
+      final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(SpnegoTestUtil.CLIENT_PRINCIPAL,
+          clientKeytab);
+
+      // The name of the principal
+
+      // Run this code, logged in as the subject (the client)
+      Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
+        @Override public Void run() throws Exception {
+          try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+            try (Statement stmt = conn.createStatement()) {
+              assertFalse(stmt.execute("DROP TABLE IF EXISTS " + tableName));
+              assertFalse(stmt.execute("CREATE TABLE " + tableName + "(pk integer)"));
+              assertEquals(1, stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(1)"));
+              assertEquals(1, stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(2)"));
+              assertEquals(1, stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(3)"));
+
+              ResultSet results = stmt.executeQuery("SELECT count(1) FROM " + tableName);
+              assertTrue(results.next());
+              assertEquals(3, results.getInt(1));
+            }
+          }
+          return null;
+        }
+      });
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+}
+
+// End AvaticaSpnegoTest.java

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -24,6 +24,7 @@ import org.apache.calcite.avatica.remote.LocalService;
 import org.apache.calcite.avatica.remote.ProtobufTranslation;
 import org.apache.calcite.avatica.remote.ProtobufTranslationImpl;
 import org.apache.calcite.avatica.remote.Service;
+import org.apache.calcite.avatica.remote.TypedValue;
 
 import com.google.common.cache.Cache;
 
@@ -35,6 +36,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
@@ -49,11 +52,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -61,8 +67,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -74,6 +82,8 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 @NotThreadSafe // for testConnectionIsolation
 public class RemoteDriverTest {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteDriverTest.class);
+
   public static final String LJS =
       LocalJdbcServiceFactory.class.getName();
 
@@ -1022,6 +1032,394 @@ public class RemoteDriverTest {
             + "SPACE,SUBSTR,UCASE"));
     assertThat(metaData.getDefaultTransactionIsolation(),
         equalTo(Connection.TRANSACTION_READ_COMMITTED));
+  }
+
+  @Test public void testBatchExecute() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      eachConnection(
+          new ConnectionFunction() {
+            public void apply(Connection c1) throws Exception {
+              executeBatchUpdate(c1);
+            }
+          }, getLocalConnection());
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  private void executeBatchUpdate(Connection conn) throws Exception {
+    final int numRows = 10;
+    try (Statement stmt = conn.createStatement()) {
+      final String tableName = AvaticaUtils.unique("BATCH_EXECUTE");
+      LOG.info("Creating table {}", tableName);
+      final String createCommand = String.format("create table if not exists %s ("
+          + "id int not null, "
+          + "msg varchar(10) not null)", tableName);
+      assertFalse("Failed to create table", stmt.execute(createCommand));
+
+      final String updatePrefix = String.format("INSERT INTO %s values(", tableName);
+      for (int i = 0; i < numRows;  i++) {
+        stmt.addBatch(updatePrefix + i + ", '" + Integer.toString(i) + "')");
+      }
+
+      int[] updateCounts = stmt.executeBatch();
+      assertEquals("Unexpected number of update counts returned", numRows, updateCounts.length);
+      for (int i = 0; i < updateCounts.length; i++) {
+        assertEquals("Unexpected update count at index " + i, 1, updateCounts[i]);
+      }
+
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " ORDER BY id asc");
+      assertNotNull("ResultSet was null", rs);
+      for (int i = 0; i < numRows; i++) {
+        assertTrue("ResultSet should have a result", rs.next());
+        assertEquals("Wrong integer value for row " + i, i, rs.getInt(1));
+        assertEquals("Wrong string value for row " + i, Integer.toString(i), rs.getString(2));
+      }
+      assertFalse("ResultSet should have no more records", rs.next());
+    }
+  }
+
+  @Test public void testPreparedBatches() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      eachConnection(
+          new ConnectionFunction() {
+            public void apply(Connection c1) throws Exception {
+              executePreparedBatchUpdate(c1);
+            }
+          }, getLocalConnection());
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  private void executePreparedBatchUpdate(Connection conn) throws Exception {
+    final int numRows = 10;
+    final String tableName = AvaticaUtils.unique("PREPARED_BATCH_EXECUTE");
+    LOG.info("Creating table {}", tableName);
+    try (Statement stmt = conn.createStatement()) {
+      final String createCommand = String.format("create table if not exists %s ("
+          + "id int not null, "
+          + "msg varchar(10) not null)", tableName);
+      assertFalse("Failed to create table", stmt.execute(createCommand));
+    }
+
+    final String insertSql = String.format("INSERT INTO %s values(?, ?)", tableName);
+    try (PreparedStatement pstmt = conn.prepareStatement(insertSql)) {
+      // Add batches with the prepared statement
+      for (int i = 0; i < numRows; i++) {
+        pstmt.setInt(1, i);
+        pstmt.setString(2, Integer.toString(i));
+        pstmt.addBatch();
+      }
+
+      int[] updateCounts = pstmt.executeBatch();
+      assertEquals("Unexpected number of update counts returned", numRows, updateCounts.length);
+      for (int i = 0; i < updateCounts.length; i++) {
+        assertEquals("Unexpected update count at index " + i, 1, updateCounts[i]);
+      }
+    }
+
+    try (Statement stmt = conn.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " ORDER BY id asc");
+      assertNotNull("ResultSet was null", rs);
+      for (int i = 0; i < numRows; i++) {
+        assertTrue("ResultSet should have a result", rs.next());
+        assertEquals("Wrong integer value for row " + i, i, rs.getInt(1));
+        assertEquals("Wrong string value for row " + i, Integer.toString(i), rs.getString(2));
+      }
+      assertFalse("ResultSet should have no more records", rs.next());
+    }
+  }
+
+  @Test public void testPreparedInsert() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      eachConnection(
+          new ConnectionFunction() {
+            public void apply(Connection c1) throws Exception {
+              executePreparedInsert(c1);
+            }
+          }, getLocalConnection());
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  private void executePreparedInsert(Connection conn) throws Exception {
+    final int numRows = 10;
+    final String tableName = AvaticaUtils.unique("PREPARED_INSERT_EXECUTE");
+    LOG.info("Creating table {}", tableName);
+    try (Statement stmt = conn.createStatement()) {
+      final String createCommand = String.format("create table if not exists %s ("
+          + "id int not null, "
+          + "msg varchar(10) not null)", tableName);
+      assertFalse("Failed to create table", stmt.execute(createCommand));
+    }
+
+    final String insertSql = String.format("INSERT INTO %s values(?, ?)", tableName);
+    try (PreparedStatement pstmt = conn.prepareStatement(insertSql)) {
+      // Add batches with the prepared statement
+      for (int i = 0; i < numRows; i++) {
+        pstmt.setInt(1, i);
+        pstmt.setString(2, Integer.toString(i));
+        assertEquals(1, pstmt.executeUpdate());
+      }
+    }
+
+    try (Statement stmt = conn.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " ORDER BY id asc");
+      assertNotNull("ResultSet was null", rs);
+      for (int i = 0; i < numRows; i++) {
+        assertTrue("ResultSet should have a result", rs.next());
+        assertEquals("Wrong integer value for row " + i, i, rs.getInt(1));
+        assertEquals("Wrong string value for row " + i, Integer.toString(i), rs.getString(2));
+      }
+      assertFalse("ResultSet should have no more records", rs.next());
+    }
+  }
+
+  @Test public void testPreparedInsertWithNulls() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      eachConnection(
+          new ConnectionFunction() {
+            public void apply(Connection c1) throws Exception {
+              executePreparedInsertWithNulls(c1);
+            }
+          }, getLocalConnection());
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  private void executePreparedInsertWithNulls(Connection conn) throws Exception {
+    final int numRows = 10;
+    final String tableName = AvaticaUtils.unique("PREPARED_INSERT_EXECUTE_NULLS");
+    LOG.info("Creating table {}", tableName);
+    try (Statement stmt = conn.createStatement()) {
+      final String createCommand = String.format("create table if not exists %s ("
+          + "id int not null, "
+          + "msg varchar(10))", tableName);
+      assertFalse("Failed to create table", stmt.execute(createCommand));
+    }
+
+    final String insertSql = String.format("INSERT INTO %s values(?, ?)", tableName);
+    try (PreparedStatement pstmt = conn.prepareStatement(insertSql)) {
+      // Add batches with the prepared statement
+      for (int i = 0; i < numRows; i++) {
+        pstmt.setInt(1, i);
+        // Even inserts are non-null, odd are null
+        if (0 == i % 2) {
+          pstmt.setString(2, Integer.toString(i));
+        } else {
+          pstmt.setNull(2, Types.VARCHAR);
+        }
+        assertEquals(1, pstmt.executeUpdate());
+      }
+    }
+
+    try (Statement stmt = conn.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " ORDER BY id asc");
+      assertNotNull("ResultSet was null", rs);
+      for (int i = 0; i < numRows; i++) {
+        assertTrue("ResultSet should have a result", rs.next());
+        assertEquals("Wrong integer value for row " + i, i, rs.getInt(1));
+        if (0 == i % 2) {
+          assertEquals("Wrong string value for row " + i, Integer.toString(i), rs.getString(2));
+        } else {
+          assertNull("Expected null value for row " + i, rs.getString(2));
+        }
+      }
+      assertFalse("ResultSet should have no more records", rs.next());
+    }
+  }
+
+  @Test public void testBatchInsertWithNulls() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      eachConnection(
+          new ConnectionFunction() {
+            public void apply(Connection c1) throws Exception {
+              executeBatchInsertWithNulls(c1);
+            }
+          }, getLocalConnection());
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  private void executeBatchInsertWithNulls(Connection conn) throws Exception {
+    final int numRows = 10;
+    final String tableName = AvaticaUtils.unique("BATCH_INSERT_EXECUTE_NULLS");
+    LOG.info("Creating table {}", tableName);
+    try (Statement stmt = conn.createStatement()) {
+      final String createCommand = String.format("create table if not exists %s ("
+          + "id int not null, "
+          + "msg varchar(10))", tableName);
+      assertFalse("Failed to create table", stmt.execute(createCommand));
+    }
+
+    final String insertSql = String.format("INSERT INTO %s values(?, ?)", tableName);
+    try (PreparedStatement pstmt = conn.prepareStatement(insertSql)) {
+      // Add batches with the prepared statement
+      for (int i = 0; i < numRows; i++) {
+        pstmt.setInt(1, i);
+        // Even inserts are non-null, odd are null
+        if (0 == i % 2) {
+          pstmt.setString(2, Integer.toString(i));
+        } else {
+          pstmt.setNull(2, Types.VARCHAR);
+        }
+        pstmt.addBatch();
+      }
+      // Verify that all updates were successful
+      int[] updateCounts = pstmt.executeBatch();
+      assertEquals(numRows, updateCounts.length);
+      int[] expectedCounts = new int[numRows];
+      Arrays.fill(expectedCounts, 1);
+      assertArrayEquals(expectedCounts, updateCounts);
+    }
+
+    try (Statement stmt = conn.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " ORDER BY id asc");
+      assertNotNull("ResultSet was null", rs);
+      for (int i = 0; i < numRows; i++) {
+        assertTrue("ResultSet should have a result", rs.next());
+        assertEquals("Wrong integer value for row " + i, i, rs.getInt(1));
+        if (0 == i % 2) {
+          assertEquals("Wrong string value for row " + i, Integer.toString(i), rs.getString(2));
+        } else {
+          assertNull("Expected null value for row " + i, rs.getString(2));
+        }
+      }
+      assertFalse("ResultSet should have no more records", rs.next());
+    }
+  }
+
+  @Test public void preparedStatementParameterCopies() throws Exception {
+    // When implementing the JDBC batch APIs, it's important that we are copying the
+    // TypedValues and caching them in the AvaticaPreparedStatement. Otherwise, when we submit
+    // the batch, the parameter values for the last update added will be reflected in all previous
+    // updates added to the batch.
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      final String tableName = AvaticaUtils.unique("PREPAREDSTATEMENT_VALUES");
+      final Connection conn = getLocalConnection();
+      try (Statement stmt = conn.createStatement()) {
+        final String sql = "CREATE TABLE " + tableName
+            + " (id varchar(1) not null, col1 varchar(1) not null)";
+        assertFalse(stmt.execute(sql));
+      }
+      try (final PreparedStatement pstmt =
+          conn.prepareStatement("INSERT INTO " + tableName + " values(?, ?)")) {
+        pstmt.setString(1, "a");
+        pstmt.setString(2, "b");
+
+        @SuppressWarnings("resource")
+        AvaticaPreparedStatement apstmt = (AvaticaPreparedStatement) pstmt;
+        TypedValue[] slots = apstmt.slots;
+
+        assertEquals("Unexpected number of values", 2, slots.length);
+
+        List<TypedValue> valuesReference = apstmt.getParameterValues();
+        assertEquals(2, valuesReference.size());
+        assertEquals(slots[0], valuesReference.get(0));
+        assertEquals(slots[1], valuesReference.get(1));
+        List<TypedValue> copiedValues = apstmt.copyParameterValues();
+        assertEquals(2, valuesReference.size());
+        assertEquals(slots[0], copiedValues.get(0));
+        assertEquals(slots[1], copiedValues.get(1));
+
+        slots[0] = null;
+        slots[1] = null;
+
+        // Modifications to the array are reflected in the List from getParameterValues()
+        assertNull(valuesReference.get(0));
+        assertNull(valuesReference.get(1));
+        // copyParameterValues() copied the underlying array, so updates to slots is not reflected
+        assertNotNull(copiedValues.get(0));
+        assertNotNull(copiedValues.get(1));
+      }
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  @Test public void testBatchInsertWithDates() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try {
+      eachConnection(
+          new ConnectionFunction() {
+            public void apply(Connection c1) throws Exception {
+              executeBatchInsertWithDates(c1);
+            }
+          }, getLocalConnection());
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
+
+  private void executeBatchInsertWithDates(Connection conn) throws Exception {
+    final Calendar calendar = Calendar.getInstance();
+    long now = calendar.getTime().getTime();
+    final int numRows = 10;
+    final String tableName = AvaticaUtils.unique("BATCH_INSERT_EXECUTE_DATES");
+    LOG.info("Creating table {}", tableName);
+    try (Statement stmt = conn.createStatement()) {
+      final String dropCommand = String.format("drop table if exists %s", tableName);
+      assertFalse("Failed to drop table", stmt.execute(dropCommand));
+      final String createCommand = String.format("create table %s ("
+          + "id char(15) not null, "
+          + "created_date date not null, "
+          + "val_string varchar)", tableName);
+      assertFalse("Failed to create table", stmt.execute(createCommand));
+    }
+
+    final String insertSql = String.format("INSERT INTO %s values(?, ?, ?)", tableName);
+    try (PreparedStatement pstmt = conn.prepareStatement(insertSql)) {
+      // Add batches with the prepared statement
+      for (int i = 0; i < numRows; i++) {
+        pstmt.setString(1, Integer.toString(i));
+        pstmt.setDate(2, new Date(now + i), calendar);
+        pstmt.setString(3, UUID.randomUUID().toString());
+        pstmt.addBatch();
+      }
+      // Verify that all updates were successful
+      int[] updateCounts = pstmt.executeBatch();
+      assertEquals(numRows, updateCounts.length);
+      int[] expectedCounts = new int[numRows];
+      Arrays.fill(expectedCounts, 1);
+      assertArrayEquals(expectedCounts, updateCounts);
+    }
+
+    try (Statement stmt = conn.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " ORDER BY id asc");
+      assertNotNull("ResultSet was null", rs);
+      for (int i = 0; i < numRows; i++) {
+        assertTrue("ResultSet should have a result", rs.next());
+        assertEquals("Wrong value for row " + i, Integer.toString(i), rs.getString(1).trim());
+
+        Date actual = rs.getDate(2);
+        calendar.setTime(actual);
+        int actualDay = calendar.get(Calendar.DAY_OF_MONTH);
+        int actualMonth = calendar.get(Calendar.MONTH);
+        int actualYear = calendar.get(Calendar.YEAR);
+
+        Date expected = new Date(now + i);
+        calendar.setTime(expected);
+        int expectedDay = calendar.get(Calendar.DAY_OF_MONTH);
+        int expectedMonth = calendar.get(Calendar.MONTH);
+        int expectedYear = calendar.get(Calendar.YEAR);
+        assertEquals("Wrong day for row " + i, expectedDay, actualDay);
+        assertEquals("Wrong month for row " + i, expectedMonth, actualMonth);
+        assertEquals("Wrong year for row " + i, expectedYear, actualYear);
+
+        assertNotNull("Non-null string for row " + i, rs.getString(3));
+      }
+      assertFalse("ResultSet should have no more records", rs.next());
+    }
   }
 
   /**

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/SpnegoTestUtil.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/SpnegoTestUtil.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.apache.calcite.avatica.remote.Service.RpcMetadataResponse;
+import org.apache.calcite.avatica.server.AvaticaHandler;
+
+import org.apache.kerby.kerberos.kerb.KrbException;
+import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
+
+import org.eclipse.jetty.security.UserAuthentication;
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+
+import javax.security.auth.login.Configuration;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Utility class for setting up SPNEGO
+ */
+public class SpnegoTestUtil {
+
+  public static final String JGSS_KERBEROS_TICKET_OID = "1.2.840.113554.1.2.2";
+
+  public static final String REALM = "EXAMPLE.COM";
+  public static final String KDC_HOST = "localhost";
+  public static final String CLIENT_PRINCIPAL = "client@" + REALM;
+  public static final String SERVER_PRINCIPAL = "HTTP/" + KDC_HOST + "@" + REALM;
+
+  private SpnegoTestUtil() {}
+
+  public static int getFreePort() throws IOException {
+    ServerSocket s = new ServerSocket(0);
+    try {
+      s.setReuseAddress(true);
+      int port = s.getLocalPort();
+      return port;
+    } finally {
+      if (null != s) {
+        s.close();
+      }
+    }
+  }
+
+  public static void setupUser(SimpleKdcServer kdc, File keytab, String principal)
+      throws KrbException {
+    kdc.createPrincipal(principal);
+    kdc.exportPrincipal(principal, keytab);
+  }
+
+  /**
+   * Recursively deletes a {@link File}.
+   */
+  public static void deleteRecursively(File d) {
+    if (d.isDirectory()) {
+      for (String name : d.list()) {
+        File child = new File(d, name);
+        if (child.isFile()) {
+          child.delete();
+        } else {
+          deleteRecursively(d);
+        }
+      }
+    }
+    d.delete();
+  }
+
+  /**
+   * Creates the SPNEGO JAAS configuration file for the Jetty server
+   */
+  public static void writeSpnegoConf(File configFile, File serverKeytab)
+      throws Exception {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(configFile))) {
+      // Server login
+      writer.write("com.sun.security.jgss.accept {\n");
+      writer.write(" com.sun.security.auth.module.Krb5LoginModule required\n");
+      writer.write(" principal=\"" + SERVER_PRINCIPAL + "\"\n");
+      writer.write(" useKeyTab=true\n");
+      writer.write(" keyTab=\"" + serverKeytab + "\"\n");
+      writer.write(" storeKey=true \n");
+      // Some extra debug information from JAAS
+      //writer.write(" debug=true\n");
+      writer.write(" isInitiator=false;\n");
+      writer.write("};\n");
+    }
+  }
+
+  public static void refreshJaasConfiguration() {
+    // This is *extremely* important to make sure we get the right Configuration instance.
+    // Configuration keeps a static instance of Configuration that it will return once it
+    // has been initialized. We need to nuke that static instance to make sure our
+    // serverSpnegoConfigFile gets read.
+    AccessController.doPrivileged(new PrivilegedAction<Configuration>() {
+      public Configuration run() {
+        return Configuration.getConfiguration();
+      }
+    }).refresh();
+  }
+
+  /**
+   * A simple handler which returns "OK " with the client's authenticated name and HTTP/200 or
+   * HTTP/401 and the message "Not authenticated!".
+   */
+  public static class AuthenticationRequiredAvaticaHandler implements AvaticaHandler {
+    private final Handler handler = new DefaultHandler();
+
+    @Override public void handle(String target, Request baseRequest, HttpServletRequest request,
+        HttpServletResponse response) throws IOException, ServletException {
+      Authentication auth = baseRequest.getAuthentication();
+      if (Authentication.UNAUTHENTICATED == auth) {
+        throw new AssertionError("Unauthenticated users should not reach here!");
+      }
+
+      baseRequest.setHandled(true);
+      UserAuthentication userAuth = (UserAuthentication) auth;
+      UserIdentity userIdentity = userAuth.getUserIdentity();
+      Principal userPrincipal = userIdentity.getUserPrincipal();
+
+      response.getWriter().print("OK " + userPrincipal.getName());
+      response.setStatus(200);
+    }
+
+    @Override public void setServer(Server server) {
+      handler.setServer(server);
+    }
+
+    @Override public Server getServer() {
+      return handler.getServer();
+    }
+
+    @Override public void destroy() {
+      handler.destroy();
+    }
+
+    @Override public void start() throws Exception {
+      handler.start();
+    }
+
+    @Override public void stop() throws Exception {
+      handler.stop();
+    }
+
+    @Override public boolean isRunning() {
+      return handler.isRunning();
+    }
+
+    @Override public boolean isStarted() {
+      return handler.isStarted();
+    }
+
+    @Override public boolean isStarting() {
+      return handler.isStarting();
+    }
+
+    @Override public boolean isStopping() {
+      return handler.isStopping();
+    }
+
+    @Override public boolean isStopped() {
+      return handler.isStopped();
+    }
+
+    @Override public boolean isFailed() {
+      return handler.isFailed();
+    }
+
+    @Override public void addLifeCycleListener(Listener listener) {
+      handler.addLifeCycleListener(listener);
+    }
+
+    @Override public void removeLifeCycleListener(Listener listener) {
+      handler.removeLifeCycleListener(listener);
+    }
+
+    @Override public void setServerRpcMetadata(RpcMetadataResponse metadata) {}
+  }
+}
+
+// End SpnegoTestUtil.java

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for logic common to all {@link AvaticaHandler}'s.
+ */
+public class AbstractAvaticaHandlerTest {
+
+  private AbstractAvaticaHandler handler;
+  private AvaticaServerConfiguration config;
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+
+  @Before public void setup() throws Exception {
+    handler = mock(AbstractAvaticaHandler.class);
+    config = mock(AvaticaServerConfiguration.class);
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+    when(handler.isUserPermitted(config, request, response)).thenCallRealMethod();
+  }
+
+  @Test public void disallowUnauthenticatedUsers() throws Exception {
+    ServletOutputStream os = mock(ServletOutputStream.class);
+
+    when(config.getAuthenticationType()).thenReturn(AuthenticationType.SPNEGO);
+    when(request.getRemoteUser()).thenReturn(null);
+    when(response.getOutputStream()).thenReturn(os);
+
+    assertFalse(handler.isUserPermitted(config, request, response));
+
+    verify(response).setStatus(HttpURLConnection.HTTP_UNAUTHORIZED);
+    // Make sure that the serialized ErrorMessage looks reasonable
+    verify(os).write(argThat(new BaseMatcher<byte[]>() {
+      @Override public void describeTo(Description description) {
+        String desc = "A serialized ErrorMessage which contains 'User is not authenticated'";
+        description.appendText(desc);
+      }
+
+      @Override public boolean matches(Object item) {
+        String msg = new String((byte[]) item);
+        return msg.contains("User is not authenticated");
+      }
+
+      @Override public void describeMismatch(Object item, Description mismatchDescription) {
+        mismatchDescription.appendText("The message should contain 'User is not authenticated'");
+      }
+    }));
+  }
+
+  @Test public void allowAuthenticatedUsers() throws Exception {
+    when(config.getAuthenticationType()).thenReturn(AuthenticationType.SPNEGO);
+    when(request.getRemoteUser()).thenReturn("user1");
+    assertTrue(handler.isUserPermitted(config, request, response));
+  }
+
+  @Test public void allowAllUsersWhenNoAuthenticationIsNeeded() throws Exception {
+    when(config.getAuthenticationType()).thenReturn(AuthenticationType.NONE);
+    when(request.getRemoteUser()).thenReturn(null);
+    assertTrue(handler.isUserPermitted(config, request, response));
+
+    when(request.getRemoteUser()).thenReturn("user1");
+    assertTrue(handler.isUserPermitted(config, request, response));
+  }
+}
+
+// End AbstractAvaticaHandlerTest.java

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpServerSpnegoWithJaasTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpServerSpnegoWithJaasTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.apache.calcite.avatica.SpnegoTestUtil;
+import org.apache.calcite.avatica.remote.AvaticaCommonsHttpClientSpnegoImpl;
+
+import org.apache.kerby.kerberos.kerb.KrbException;
+import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
+import org.apache.kerby.kerberos.kerb.client.KrbConfig;
+import org.apache.kerby.kerberos.kerb.client.KrbConfigKey;
+import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
+
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.Principal;
+import java.security.PrivilegedExceptionAction;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosTicket;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for SPNEGO with Kerberos. Purely testing SPNEGO, not the Avatica "protocol" on top
+ * of that HTTP. This variant of the test requires that the user use JAAS configuration to
+ * perform server-side login.
+ */
+public class HttpServerSpnegoWithJaasTest {
+  private static final Logger LOG = LoggerFactory.getLogger(HttpServerSpnegoWithJaasTest.class);
+
+  private static SimpleKdcServer kdc;
+  private static HttpServer httpServer;
+
+  private static KrbConfig clientConfig;
+
+  private static int kdcPort;
+
+  private static File clientKeytab;
+  private static File serverKeytab;
+
+  private static File serverSpnegoConfigFile;
+
+  private static boolean isKdcStarted = false;
+  private static boolean isHttpServerStarted = false;
+
+  private static URL httpServerUrl;
+
+  @BeforeClass public static void setupKdc() throws Exception {
+    kdc = new SimpleKdcServer();
+    File target = new File(System.getProperty("user.dir"), "target");
+    assertTrue(target.exists());
+
+    File kdcDir = new File(target, HttpServerSpnegoWithJaasTest.class.getSimpleName());
+    if (kdcDir.exists()) {
+      SpnegoTestUtil.deleteRecursively(kdcDir);
+    }
+    kdcDir.mkdirs();
+    kdc.setWorkDir(kdcDir);
+
+    kdc.setKdcHost(SpnegoTestUtil.KDC_HOST);
+    kdcPort = SpnegoTestUtil.getFreePort();
+    kdc.setAllowTcp(true);
+    kdc.setAllowUdp(false);
+    kdc.setKdcTcpPort(kdcPort);
+
+    LOG.info("Starting KDC server at {}:{}", SpnegoTestUtil.KDC_HOST, kdcPort);
+
+    kdc.init();
+    kdc.start();
+    isKdcStarted = true;
+
+    File keytabDir = new File(target, HttpServerSpnegoWithJaasTest.class.getSimpleName()
+        + "_keytabs");
+    if (keytabDir.exists()) {
+      SpnegoTestUtil.deleteRecursively(keytabDir);
+    }
+    keytabDir.mkdirs();
+    setupUsers(keytabDir);
+
+    clientConfig = new KrbConfig();
+    clientConfig.setString(KrbConfigKey.KDC_HOST, SpnegoTestUtil.KDC_HOST);
+    clientConfig.setInt(KrbConfigKey.KDC_TCP_PORT, kdcPort);
+    clientConfig.setString(KrbConfigKey.DEFAULT_REALM, SpnegoTestUtil.REALM);
+
+    serverSpnegoConfigFile = new File(kdcDir, "server-spnego.conf");
+    SpnegoTestUtil.writeSpnegoConf(serverSpnegoConfigFile, serverKeytab);
+
+    // Kerby sets "java.security.krb5.conf" for us!
+    System.setProperty("java.security.auth.login.config", serverSpnegoConfigFile.toString());
+    // http://docs.oracle.com/javase/7/docs/technotes/guides/security/jgss/...
+    //    tutorials/BasicClientServer.html#useSub
+    System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
+    //System.setProperty("sun.security.spnego.debug", "true");
+    //System.setProperty("sun.security.krb5.debug", "true");
+
+    // Create and start an HTTP server configured only to allow SPNEGO requests
+    // We're not using `withAutomaticLogin(File)` which means we're relying on JAAS to log the
+    // server in.
+    httpServer = new HttpServer.Builder()
+        .withPort(0)
+        .withSpnego(SpnegoTestUtil.SERVER_PRINCIPAL, SpnegoTestUtil.REALM)
+        .withHandler(new SpnegoTestUtil.AuthenticationRequiredAvaticaHandler())
+        .build();
+    httpServer.start();
+    isHttpServerStarted = true;
+
+    httpServerUrl = new URL("http://" + SpnegoTestUtil.KDC_HOST + ":" + httpServer.getPort());
+    LOG.info("HTTP server running at {}", httpServerUrl);
+
+    SpnegoTestUtil.refreshJaasConfiguration();
+  }
+
+  @AfterClass public static void stopKdc() throws Exception {
+    if (isHttpServerStarted) {
+      LOG.info("Stopping HTTP server at {}", httpServerUrl);
+      httpServer.stop();
+    }
+
+    if (isKdcStarted) {
+      LOG.info("Stopping KDC on {}", kdcPort);
+      kdc.stop();
+    }
+  }
+
+  private static void setupUsers(File keytabDir) throws KrbException {
+    String clientPrincipal = SpnegoTestUtil.CLIENT_PRINCIPAL.substring(0,
+        SpnegoTestUtil.CLIENT_PRINCIPAL.indexOf('@'));
+    clientKeytab = new File(keytabDir, clientPrincipal.replace('/', '_') + ".keytab");
+    if (clientKeytab.exists()) {
+      SpnegoTestUtil.deleteRecursively(clientKeytab);
+    }
+    LOG.info("Creating {} with keytab {}", clientPrincipal, clientKeytab);
+    SpnegoTestUtil.setupUser(kdc, clientKeytab, clientPrincipal);
+
+    String serverPrincipal = SpnegoTestUtil.SERVER_PRINCIPAL.substring(0,
+        SpnegoTestUtil.SERVER_PRINCIPAL.indexOf('@'));
+    serverKeytab = new File(keytabDir, serverPrincipal.replace('/', '_') + ".keytab");
+    if (serverKeytab.exists()) {
+      SpnegoTestUtil.deleteRecursively(serverKeytab);
+    }
+    LOG.info("Creating {} with keytab {}", SpnegoTestUtil.SERVER_PRINCIPAL, serverKeytab);
+    SpnegoTestUtil.setupUser(kdc, serverKeytab, SpnegoTestUtil.SERVER_PRINCIPAL);
+  }
+
+  @Test public void testNormalClientsDisallowed() throws Exception {
+    LOG.info("Connecting to {}", httpServerUrl.toString());
+    HttpURLConnection conn = (HttpURLConnection) httpServerUrl.openConnection();
+    conn.setRequestMethod("GET");
+    // Authentication should fail because we didn't provide anything
+    assertEquals(401, conn.getResponseCode());
+  }
+
+  @Test public void testAuthenticatedClientsAllowed() throws Exception {
+    // Create the subject for the client
+    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(SpnegoTestUtil.CLIENT_PRINCIPAL,
+        clientKeytab);
+    final Set<Principal> clientPrincipals = clientSubject.getPrincipals();
+    // Make sure the subject has a principal
+    assertFalse(clientPrincipals.isEmpty());
+
+    // Get a TGT for the subject (might have many, different encryption types). The first should
+    // be the default encryption type.
+    Set<KerberosTicket> privateCredentials =
+            clientSubject.getPrivateCredentials(KerberosTicket.class);
+    assertFalse(privateCredentials.isEmpty());
+    KerberosTicket tgt = privateCredentials.iterator().next();
+    assertNotNull(tgt);
+    LOG.info("Using TGT with etype: {}", tgt.getSessionKey().getAlgorithm());
+
+    // The name of the principal
+    final String principalName = clientPrincipals.iterator().next().getName();
+
+    // Run this code, logged in as the subject (the client)
+    byte[] response = Subject.doAs(clientSubject, new PrivilegedExceptionAction<byte[]>() {
+      @Override public byte[] run() throws Exception {
+        // Logs in with Kerberos via GSS
+        GSSManager gssManager = GSSManager.getInstance();
+        Oid oid = new Oid(SpnegoTestUtil.JGSS_KERBEROS_TICKET_OID);
+        GSSName gssClient = gssManager.createName(principalName, GSSName.NT_USER_NAME);
+        GSSCredential credential = gssManager.createCredential(gssClient,
+            GSSCredential.DEFAULT_LIFETIME, oid, GSSCredential.INITIATE_ONLY);
+
+        // Passes the GSSCredential into the HTTP client implementation
+        final AvaticaCommonsHttpClientSpnegoImpl httpClient =
+            new AvaticaCommonsHttpClientSpnegoImpl(httpServerUrl, credential);
+
+        return httpClient.send(new byte[0]);
+      }
+    });
+
+    // We should get a response which is "OK" with our client's name
+    assertNotNull(response);
+    assertEquals("OK " + SpnegoTestUtil.CLIENT_PRINCIPAL, new String(response));
+  }
+}
+
+// End HttpServerSpnegoWithJaasTest.java

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpServerSpnegoWithoutJaasTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpServerSpnegoWithoutJaasTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.apache.calcite.avatica.SpnegoTestUtil;
+import org.apache.calcite.avatica.remote.AvaticaCommonsHttpClientSpnegoImpl;
+
+import org.apache.kerby.kerberos.kerb.KrbException;
+import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
+import org.apache.kerby.kerberos.kerb.client.KrbConfig;
+import org.apache.kerby.kerberos.kerb.client.KrbConfigKey;
+import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
+
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.Principal;
+import java.security.PrivilegedExceptionAction;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosTicket;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for SPNEGO with Kerberos. Purely testing SPNEGO, not the Avatica "protocol" on top
+ * of that HTTP. This variant of the test relies on the "feature" Avatica provides to not require
+ * JAAS configuration by the user.
+ */
+public class HttpServerSpnegoWithoutJaasTest {
+  private static final Logger LOG = LoggerFactory.getLogger(HttpServerSpnegoWithoutJaasTest.class);
+
+  private static SimpleKdcServer kdc;
+  private static HttpServer httpServer;
+
+  private static KrbConfig clientConfig;
+
+  private static int kdcPort;
+
+  private static File clientKeytab;
+  private static File serverKeytab;
+
+  private static boolean isKdcStarted = false;
+  private static boolean isHttpServerStarted = false;
+
+  private static URL httpServerUrl;
+
+  @BeforeClass public static void setupKdc() throws Exception {
+    kdc = new SimpleKdcServer();
+    File target = new File(System.getProperty("user.dir"), "target");
+    assertTrue(target.exists());
+
+    File kdcDir = new File(target, HttpServerSpnegoWithoutJaasTest.class.getSimpleName());
+    if (kdcDir.exists()) {
+      SpnegoTestUtil.deleteRecursively(kdcDir);
+    }
+    kdcDir.mkdirs();
+    kdc.setWorkDir(kdcDir);
+
+    kdc.setKdcHost(SpnegoTestUtil.KDC_HOST);
+    kdcPort = SpnegoTestUtil.getFreePort();
+    kdc.setAllowTcp(true);
+    kdc.setAllowUdp(false);
+    kdc.setKdcTcpPort(kdcPort);
+
+    LOG.info("Starting KDC server at {}:{}", SpnegoTestUtil.KDC_HOST, kdcPort);
+
+    kdc.init();
+    kdc.start();
+    isKdcStarted = true;
+
+    File keytabDir = new File(target, HttpServerSpnegoWithoutJaasTest.class.getSimpleName()
+        + "_keytabs");
+    if (keytabDir.exists()) {
+      SpnegoTestUtil.deleteRecursively(keytabDir);
+    }
+    keytabDir.mkdirs();
+    setupUsers(keytabDir);
+
+    clientConfig = new KrbConfig();
+    clientConfig.setString(KrbConfigKey.KDC_HOST, SpnegoTestUtil.KDC_HOST);
+    clientConfig.setInt(KrbConfigKey.KDC_TCP_PORT, kdcPort);
+    clientConfig.setString(KrbConfigKey.DEFAULT_REALM, SpnegoTestUtil.REALM);
+
+    // Kerby sets "java.security.krb5.conf" for us!
+    System.clearProperty("java.security.auth.login.config");
+    System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
+    //System.setProperty("sun.security.spnego.debug", "true");
+    //System.setProperty("sun.security.krb5.debug", "true");
+
+    // Create and start an HTTP server configured only to allow SPNEGO requests
+    // We use `withAutomaticLogin(File)` here which should invalidate the need to do JAAS config
+    httpServer = new HttpServer.Builder()
+        .withPort(0)
+        .withAutomaticLogin(serverKeytab)
+        .withSpnego(SpnegoTestUtil.SERVER_PRINCIPAL, SpnegoTestUtil.REALM)
+        .withHandler(new SpnegoTestUtil.AuthenticationRequiredAvaticaHandler())
+        .build();
+    httpServer.start();
+    isHttpServerStarted = true;
+
+    httpServerUrl = new URL("http://" + SpnegoTestUtil.KDC_HOST + ":" + httpServer.getPort());
+    LOG.info("HTTP server running at {}", httpServerUrl);
+  }
+
+  @AfterClass public static void stopKdc() throws Exception {
+    if (isHttpServerStarted) {
+      LOG.info("Stopping HTTP server at {}", httpServerUrl);
+      httpServer.stop();
+    }
+
+    if (isKdcStarted) {
+      LOG.info("Stopping KDC on {}", kdcPort);
+      kdc.stop();
+    }
+  }
+
+  private static void setupUsers(File keytabDir) throws KrbException {
+    String clientPrincipal = SpnegoTestUtil.CLIENT_PRINCIPAL.substring(0,
+        SpnegoTestUtil.CLIENT_PRINCIPAL.indexOf('@'));
+    clientKeytab = new File(keytabDir, clientPrincipal.replace('/', '_') + ".keytab");
+    if (clientKeytab.exists()) {
+      SpnegoTestUtil.deleteRecursively(clientKeytab);
+    }
+    LOG.info("Creating {} with keytab {}", clientPrincipal, clientKeytab);
+    SpnegoTestUtil.setupUser(kdc, clientKeytab, clientPrincipal);
+
+    String serverPrincipal = SpnegoTestUtil.SERVER_PRINCIPAL.substring(0,
+        SpnegoTestUtil.SERVER_PRINCIPAL.indexOf('@'));
+    serverKeytab = new File(keytabDir, serverPrincipal.replace('/', '_') + ".keytab");
+    if (serverKeytab.exists()) {
+      SpnegoTestUtil.deleteRecursively(serverKeytab);
+    }
+    LOG.info("Creating {} with keytab {}", SpnegoTestUtil.SERVER_PRINCIPAL, serverKeytab);
+    SpnegoTestUtil.setupUser(kdc, serverKeytab, SpnegoTestUtil.SERVER_PRINCIPAL);
+  }
+
+  @Test public void testNormalClientsDisallowed() throws Exception {
+    LOG.info("Connecting to {}", httpServerUrl.toString());
+    HttpURLConnection conn = (HttpURLConnection) httpServerUrl.openConnection();
+    conn.setRequestMethod("GET");
+    // Authentication should fail because we didn't provide anything
+    assertEquals(401, conn.getResponseCode());
+  }
+
+  @Test public void testAuthenticatedClientsAllowed() throws Exception {
+    // Create the subject for the client
+    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(SpnegoTestUtil.CLIENT_PRINCIPAL,
+        clientKeytab);
+    final Set<Principal> clientPrincipals = clientSubject.getPrincipals();
+    // Make sure the subject has a principal
+    assertFalse(clientPrincipals.isEmpty());
+
+    // Get a TGT for the subject (might have many, different encryption types). The first should
+    // be the default encryption type.
+    Set<KerberosTicket> privateCredentials =
+            clientSubject.getPrivateCredentials(KerberosTicket.class);
+    assertFalse(privateCredentials.isEmpty());
+    KerberosTicket tgt = privateCredentials.iterator().next();
+    assertNotNull(tgt);
+    LOG.info("Using TGT with etype: {}", tgt.getSessionKey().getAlgorithm());
+
+    // The name of the principal
+    final String principalName = clientPrincipals.iterator().next().getName();
+
+    // Run this code, logged in as the subject (the client)
+    byte[] response = Subject.doAs(clientSubject, new PrivilegedExceptionAction<byte[]>() {
+      @Override public byte[] run() throws Exception {
+        // Logs in with Kerberos via GSS
+        GSSManager gssManager = GSSManager.getInstance();
+        Oid oid = new Oid(SpnegoTestUtil.JGSS_KERBEROS_TICKET_OID);
+        GSSName gssClient = gssManager.createName(principalName, GSSName.NT_USER_NAME);
+        GSSCredential credential = gssManager.createCredential(gssClient,
+            GSSCredential.DEFAULT_LIFETIME, oid, GSSCredential.INITIATE_ONLY);
+
+        // Passes the GSSCredential into the HTTP client implementation
+        final AvaticaCommonsHttpClientSpnegoImpl httpClient =
+            new AvaticaCommonsHttpClientSpnegoImpl(httpServerUrl, credential);
+
+        return httpClient.send(new byte[0]);
+      }
+    });
+
+    // We should get a response which is "OK" with our client's name
+    assertNotNull(response);
+    assertEquals("OK " + SpnegoTestUtil.CLIENT_PRINCIPAL, new String(response));
+  }
+}
+
+// End HttpServerSpnegoWithoutJaasTest.java

--- a/avatica/server/src/test/resources/log4j.properties
+++ b/avatica/server/src/test/resources/log4j.properties
@@ -22,3 +22,7 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 # Set the pattern for each log message
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p - %m%n
+
+# Debug for JGSS and Jetty's security (Kerberos/SPNEGO debugging)
+#log4j.logger.sun.security.jgss=DEBUG
+#log4j.logger.org.eclipse.jetty.security=DEBUG

--- a/avatica/site/_data/docs.yml
+++ b/avatica/site/_data/docs.yml
@@ -22,9 +22,11 @@
 
 - title: Reference
   docs:
+  - client_reference
   - json_reference
   - protobuf_reference
   - howto
+  - security
 
 - title: Meta
   docs:

--- a/avatica/site/_docs/client_reference.md
+++ b/avatica/site/_docs/client_reference.md
@@ -1,0 +1,108 @@
+---
+layout: docs
+title: Client Reference
+sidebar_title: Client Reference
+permalink: /docs/client_reference.html
+---
+
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+Avatica provides a reference-implementation client in the form of a Java
+JDBC client that interacts with the Avatica server over HTTP. This client
+can be used just as any other JDBC driver. There are a number of options
+that are available for clients to specify via the JDBC connection URL.
+
+As a reminder, the JDBC connection URL for Avatica is:
+
+  `jdbc:avatica:remote:[option=value[;option=value]]`
+
+The following are a list of supported options:
+
+**url**
+
+: _Description_: This property is a URL which refers to the location of the
+  Avatica Server which the driver will communicate with.
+
+: _Default_: This property's default value is `null`. It is required that the
+  user provides a value for this property.
+
+: _Required_: Yes.
+
+
+**serialization**
+
+: _Description_: Avatica supports multiple types of serialization mechanisms
+  to format data between the client and server. This property is used to ensure
+  that the client and server both use the same serialization mechanism. Valid
+  values presently include `json` and `protobuf`.
+
+: _Default_: `json` is the default value.
+
+: _Required_: No.
+
+
+**authentication**
+
+: _Description_: Avatica clients can specify the means in which it authenticates
+  with the Avatica server. Presently, the only form of authentication is SPNEGO
+  which enables Kerberos authentication. Clients who want to use a specific form
+  of authentication should specify the appropriate value in this property.
+
+: _Default_: `null` (implying "no authentication").
+
+: _Required_: No.
+
+
+**timeZone**
+
+: _Description_: The timezone that will be used for dates and times. Valid values for this
+  property are defined by [RFC 822](https://www.ietf.org/rfc/rfc0822.txt), for
+  example: `GMT`, `GMT-3`, `EST` or `PDT`.
+
+: _Default_: This property's default value is `null` which will cause the Avatica Driver to
+  use the default timezone as specified by the JVM, commonly overriden by the
+  `user.timezone` system property.
+
+: _Required_: No.
+
+
+**httpclient_factory**
+
+: _Description_: The Avatica client is a "fancy" HTTP client. As such, there are
+  many libraries and APIs available for making HTTP calls. To determine which implementation
+  should be used, there is an interface `AvaticaHttpClientFactory` which can be provided
+  to control how the `AvaticaHttpClient` implementation is chosen.
+
+: _Default_: `AvaticaHttpClientFactoryImpl`.
+
+: _Required_: No.
+
+
+**httpclient_impl**
+
+: _Description_: When using the default `AvaticaHttpClientFactoryImpl` HTTP client factory
+  implementation, this factory should choose the correct client implementation for the
+  given client configuration. This property can be used to override the specific HTTP
+  client implementation. If it is not provided, the `AvaticaHttpClientFactoryImpl` will
+  automatically choose the HTTP client implementation.
+
+: _Default_: `null`.
+
+: _Required_: No.

--- a/avatica/site/_docs/json_reference.md
+++ b/avatica/site/_docs/json_reference.md
@@ -13,8 +13,10 @@ requests:
   - { name: "CreateStatementRequest" }
   - { name: "DatabasePropertyRequest" }
   - { name: "ExecuteRequest" }
+  - { name: "ExecuteBatchRequest" }
   - { name: "FetchRequest" }
   - { name: "OpenConnectionRequest" }
+  - { name: "PrepareAndExecuteBatchRequest" }
   - { name: "PrepareAndExecuteRequest" }
   - { name: "PrepareRequest" }
   - { name: "RollbackRequest" }
@@ -49,6 +51,7 @@ responses:
   - { name: "CreateStatementResponse" }
   - { name: "DatabasePropertyResponse" }
   - { name: "ErrorResponse" }
+  - { name: "ExecuteBatchResponse" }
   - { name: "ExecuteResponse" }
   - { name: "FetchResponse" }
   - { name: "OpenConnectionResponse" }
@@ -231,6 +234,26 @@ This request is used to fetch all <a href="#databaseproperty">database propertie
 
 `connectionId` (required string) The identifier of the connection to use when fetching the database properties.
 
+### ExecuteBatchRequest
+
+This request is used to execute a batch of updates on a PreparedStatement.
+
+{% highlight json %}
+{
+  "request": "executeBatch",
+  "connectionId": "000000-0000-0000-00000000",
+  "statementId": 12345,
+  "parameterValues": [ [ TypedValue, TypedValue, ... ], [ TypedValue, TypedValue, ...], ... ]
+}
+{% endhighlight %}
+
+`connectionId` (required string) The identifier of the connection to use when fetching the database properties.
+
+`statementId` (required integer) The identifier of the statement created using the above connection.
+
+`parameterValues` (required array of array) An array of arrays of <a href="#typedvalue">TypedValue</a>'s. Each element
+  in the array is an update to a row, while the outer array represents the entire "batch" of updates.
+
 ### ExecuteRequest
 
 This request is used to execute a PreparedStatement, optionally with values to bind to the parameters in the Statement.
@@ -287,6 +310,25 @@ This request is used to open a new Connection in the Avatica server.
 `connectionId` (required string) The identifier of the connection to open in the server.
 
 `info` (optional string-to-string map) A Map containing properties to include when creating the Connection.
+
+### PrepareAndExecuteBatchRequest
+
+This request is used as short-hand to create a Statement and execute an batch of SQL commands in that Statement.
+
+{% highlight json %}
+{
+  "request": "prepareAndExecuteBatch",
+  "connectionId": "000000-0000-0000-00000000",
+  "statementId": 12345,
+  "sqlCommands", [ "SQL Command", "SQL Command", ... ]
+}
+{% endhighlight %}
+
+`connectionId` (required string) The identifier for the connection to use.
+
+`statementId` (required integer) The identifier for the statement created by the above connection to use.
+
+`sqlCommands` (required array of strings) An array of SQL commands
 
 ### PrepareAndExecuteRequest
 
@@ -559,6 +601,33 @@ A response when an error was caught executing a request. Any request may return 
 `severity` An <a href="#avaticaseverity">AvaticaSeverity</a> object which denotes how critical the error is.
 
 `rpcMetadata` <a href="#rpcmetadata">Server metadata</a> about this call.
+
+### ExecuteBatchResponse
+
+A response to <a href="#executebatchrequest">ExecuteBatchRequest</a> and <a href="#prepareandexecutebatchrequest">PrepareAndExecuteRequest</a>
+which encapsulates the update counts for a batch of updates.
+
+{% highlight json %}
+{
+  "response": "executeBatch",
+  "connectionId": "000000-0000-0000-00000000",
+  "statementId": 12345,
+  "updateCounts": [ 1, 1, 0, 1, ... ],
+  "missingStatement": false,
+  "rpcMetadata": RpcMetadata
+}
+{% endhighlight %}
+
+`connectionId` The identifier for the connection used to create the statement.
+
+`statementId` The identifier for the created statement.
+
+`updateCounts` An array of integers corresponding to each update contained in the batch that was executed.
+
+`missingStatement` True if the operation failed because the Statement is not cached in the server, false otherwise.
+
+`rpcMetadata` <a href="#rpcmetadata">Server metadata</a> about this call.
+
 
 ### ExecuteResponse
 

--- a/avatica/site/_docs/protobuf_reference.md
+++ b/avatica/site/_docs/protobuf_reference.md
@@ -12,9 +12,11 @@ requests:
   - { name: "ConnectionSyncRequest" }
   - { name: "CreateStatementRequest" }
   - { name: "DatabasePropertyRequest" }
+  - { name: "ExecuteBatchRequest" }
   - { name: "ExecuteRequest" }
   - { name: "FetchRequest" }
   - { name: "OpenConnectionRequest" }
+  - { name: "PrepareAndExecuteBatchRequest" }
   - { name: "PrepareAndExecuteRequest" }
   - { name: "PrepareRequest" }
   - { name: "RollbackRequest" }
@@ -43,6 +45,7 @@ miscellaneous:
   - { name: "StatementType" }
   - { name: "Style" }
   - { name: "TypedValue" }
+  - { name: "UpdateBatch" }
   - { name: "WireMessage" }
 responses:
   - { name: "CloseConnectionResponse" }
@@ -52,6 +55,7 @@ responses:
   - { name: "CreateStatementResponse" }
   - { name: "DatabasePropertyResponse" }
   - { name: "ErrorResponse" }
+  - { name: "ExecuteBatchResponse" }
   - { name: "ExecuteResponse" }
   - { name: "FetchResponse" }
   - { name: "OpenConnectionResponse" }
@@ -234,6 +238,24 @@ message DatabasePropertyRequest {
 
 `connection_id` The identifier of the connection to use when fetching the database properties.
 
+### ExecuteBatchRequest
+
+This request is used to execute a batch of updates against a PreparedStatement.
+
+{% highlight protobuf %}
+message ExecuteBatchRequest {
+  string connection_id = 1;
+  uint32 statement_id = 2;
+  repeated UpdateBatch updates = 3;
+}
+{% endhighlight %}
+
+`connection_id` A string which refers to a connection.
+
+`statement_id` An integer which refers to a statement.
+
+`updates` A list of <a href="#updatebatch">UpdateBatch</a>'s; the batch of updates.
+
 ### ExecuteRequest
 
 This request is used to execute a PreparedStatement, optionally with values to bind to the parameters in the Statement.
@@ -290,6 +312,24 @@ message OpenConnectionRequest {
 `connection_id` The identifier of the connection to open in the server.
 
 `info` A Map containing properties to include when creating the Connection.
+
+### PrepareAndExecuteBatchRequest
+
+This request is used as short-hand to create a Statement and execute a batch of updates against that Statement.
+
+{% highlight protobuf %}
+message PrepareAndExecuteBatchRequest {
+  string connection_id = 1;
+  uint32 statement_id = 2;
+  repeated string sql_commands = 3;
+}
+{% endhighlight %}
+
+`connection_id` The identifier for the connection to use.
+
+`statement_id` The identifier for the statement created by the above connection to use.
+
+`sql_commands` A list of SQL commands to execute; a batch.
 
 ### PrepareAndExecuteRequest
 
@@ -551,6 +591,30 @@ message ErrorResponse {
 `sql_state` A five character alphanumeric code for this error.
 
 `severity` An <a href="#avaticaseverity">AvaticaSeverity</a> object which denotes how critical the error is.
+
+`metadata` <a href="#rpcmetadata">Server metadata</a> about this call.
+
+### ExecuteBatchResponse
+
+A response to the <a href="#executebatchrequest">ExecuteBatchRequest</a> and <a href="#prepareandexecutebatchrequest">PrepareAndExecuteBatchRequest</a>.
+
+{% highlight protobuf %}
+message ExecuteBatchResponse {
+  string connection_id = 1;
+  uint32 statement_id = 2;
+  repeated uint32 update_counts = 3;
+  bool missing_statement = 4;
+  RpcMetadata metadata = 5;
+}
+{% endhighlight %}
+
+`connection_id` The ID referring to the connection that was used.
+
+`statment_id` The ID referring to the statement that was used.
+
+`update_counts` An array of integer values corresponding to the update count for each update in the batch.
+
+`missing_statement` A boolean which denotes if the request failed due to a missing statement.
 
 `metadata` <a href="#rpcmetadata">Server metadata</a> about this call.
 
@@ -1164,6 +1228,18 @@ message TypedValue {
 `double_value` A `double` value.
 
 `null` A boolean which denotes if the value was null.
+
+### UpdateBatch
+
+This is a message which serves as a wrapper around a collection of <a href="#typedvalue">TypedValue</a>'s.
+
+{% highlight protobuf %}
+message UpdateBatch {
+  repeated TypedValue parameter_values = 1;
+}
+{% endhighlight %}
+
+`parameter_values` A collection of parameter values for one SQL command update.
 
 ### WireMessage
 

--- a/avatica/site/_docs/security.md
+++ b/avatica/site/_docs/security.md
@@ -1,0 +1,145 @@
+---
+layout: docs
+title: Security
+sidebar_title: Security
+permalink: /docs/security.html
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+Security is an important topic between clients and the Avatica server. Most JDBC
+drivers and databases implement some level of authentication and authorization
+for limit what actions clients are allowed to perform.
+
+Similarly, Avatica must limit what users are allowed to connect and interact
+with the server. Avatica must primarily deal with authentication while authorization
+is deferred to the underlying database. By default, Avatica provides no authentication.
+Avatica does have the ability to perform client authentication using Kerberos.
+
+## Kerberos-based authentication
+
+Because Avatica operates over an HTTP interface, the simple and protected GSSAPI
+negotiation mechanism ([SPNEGO](https://en.wikipedia.org/wiki/SPNEGO)) is a logical
+choice. This mechanism makes use of the "HTTP Negotiate" authentication extension to
+communicate with the Kerberos Key Distribution Center (KDC) to authenticate a client.
+
+## Enabling SPNEGO/Kerberos Authentication in servers
+
+The Avatica server can operate either by performing the login using
+a JAAS configuration file or login programmatically. By default, authenticated clients
+will have queries executed as the Avatica server's kerberos user. [Impersonation](#impersonation)
+is the feature which enables actions to be run in the server as the actual end-user.
+
+As a note, it is required that the Kerberos principal in use by the Avatica server
+**must** have an primary of `HTTP` (where Kerberos principals are of the form
+`primary[/instance]@REALM`). This is specified by [RFC-4559](https://tools.ietf.org/html/rfc4559).
+
+### Programmatic Login
+
+This approach requires no external file configurations and only requires a
+keytab file for the principal.
+
+{% highlight java %}
+HttpServer server = new HttpServer.Builder()
+    .withPort(8765)
+    .withHandler(new LocalService(), Driver.Serialization.PROTOBUF)
+    .withSpnego("HTTP/host.domain.com@DOMAIN.COM")
+    .withAutomaticLogin(
+        new File("/etc/security/keytabs/avatica.spnego.keytab"))
+    .build();
+{% endhighlight %}
+
+### JAAS Configuration File Login
+
+A JAAS configuration file can be set via the system property `java.security.auth.login.config`.
+The user must set this property when launching their Java application invoking the Avatica server.
+The presence of this file will automatically perform login as necessary in the first use
+of the Avatica server. The invocation is nearly the same as the programmatic login.
+
+{% highlight java %}
+HttpServer server = new HttpServer.Builder()
+    .withPort(8765)
+    .withHandler(new LocalService(), Driver.Serialization.PROTOBUF)
+    .withSpnego("HTTP/host.domain.com@DOMAIN.COM")
+    .build();
+{% endhighlight %}
+
+The contents of the JAAS configuration file are very specific:
+
+{% highlight java %}
+com.sun.security.jgss.accept  {
+  com.sun.security.auth.module.Krb5LoginModule required
+  storeKey=true
+  useKeyTab=true
+  keyTab=/etc/security/keytabs/avatica.spnego.keyTab
+  principal=HTTP/host.domain.com@DOMAIN.COM;
+};
+{% endhighlight %}
+
+Ensure the `keyTab` and `principal` attributes are set correctly for your system.
+
+## Impersonation
+
+Impersonation is a feature of the Avatica server which allows the Avatica clients
+to execute the server-side calls (e.g. the underlying JDBC calls). Because the details
+on what it means to execute such an operation are dependent on the actual system, a
+callback is exposed for downstream integrators to implement.
+
+For example, the following is an example for creating an Apache Hadoop `UserGroupInformation`
+"proxy user". This example takes a `UserGroupInformation` object representing the Avatica server's
+identity, creates a "proxy user" with the client's username, and performs the action as that
+client but using the server's identity.
+
+{% highlight java %}
+public class PhoenixDoAsCallback implements DoAsRemoteUserCallback {
+  private final UserGroupInformation serverUgi;
+
+  public PhoenixDoAsCallback(UserGroupInformation serverUgi) {
+    this.serverUgi = Objects.requireNonNull(serverUgi);
+  }
+
+  @Override
+  public <T> T doAsRemoteUser(String remoteUserName, String remoteAddress, final Callable<T> action) throws Exception {
+    // Proxy this user on top of the server's user (the real user)
+    UserGroupInformation proxyUser = UserGroupInformation.createProxyUser(remoteUserName, serverUgi);
+
+    // Check if this user is allowed to be impersonated.
+    // Will throw AuthorizationException if the impersonation as this user is not allowed
+    ProxyUsers.authorize(proxyUser, remoteAddress);
+
+    // Execute the actual call as this proxy user
+    return proxyUser.doAs(new PrivilegedExceptionAction<T>() {
+      @Override
+      public T run() throws Exception {
+        return action.call();
+      }
+    });
+  }
+}
+{% endhighlight %}
+
+## Client implementation
+
+Many HTTP client libraries, such as [Apache Commons HttpComponents](https://hc.apache.org/), already have
+support for performing SPNEGO authentication. When in doubt, refer to one of
+these implementations as it is likely correct.
+
+For information on building this by hand, consult [RFC-4559](https://tools.ietf.org/html/rfc4559)
+which describes how the authentication handshake, through use of the "WWW-authenticate"
+HTTP header, is used to authenticate a client.


### PR DESCRIPTION
A large set of changes, spanning both new APIs for creating
the Avatica HTTP server and new options for clients to use
the new authentication mechanism. Tests are included that
verify end-to-end SPNEGO-based authentication with Kerberos.

Parallel test running has been removed as it has been
problematic with both HSQLDB and now Kerby (the in-memory
KDC implementation).

Docs have also been updated to include details on how downstream
users should create servers and clients as well as RPC-level details.