### PR TITLE
[CALCITE-1173] HTTP Basic and Digest authentication support

### DIFF
--- a/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -35,6 +35,10 @@ public interface ConnectionConfig {
   String serialization();
   /** @see BuiltInConnectionProperty#AUTHENTICATION */
   String authentication();
+  /** @see BuiltInConnectionProperty#AVATICA_USER */
+  String avaticaUser();
+  /** @see BuiltInConnectionProperty#AVATICA_PASSWORD */
+  String avaticaPassword();
   AvaticaHttpClientFactory httpClientFactory();
   String httpClientClass();
 }

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -56,6 +56,14 @@ public class ConnectionConfigImpl implements ConnectionConfig {
     return BuiltInConnectionProperty.AUTHENTICATION.wrap(properties).getString();
   }
 
+  public String avaticaUser() {
+    return BuiltInConnectionProperty.AVATICA_USER.wrap(properties).getString();
+  }
+
+  public String avaticaPassword() {
+    return BuiltInConnectionProperty.AVATICA_PASSWORD.wrap(properties).getString();
+  }
+
   public AvaticaHttpClientFactory httpClientFactory() {
     return BuiltInConnectionProperty.HTTP_CLIENT_FACTORY.wrap(properties)
         .getPlugin(AvaticaHttpClientFactory.class, null);

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/AuthenticationType.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/AuthenticationType.java
@@ -14,13 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.calcite.avatica.server;
+package org.apache.calcite.avatica.remote;
 
 /**
- * An enumeration for support types of authentication for the {@link HttpServer}.
+ * An enumeration for support types of authentication for the HttpServer.
  */
 public enum AuthenticationType {
   NONE,
+  BASIC,
+  DIGEST,
   SPNEGO;
 }
 

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/Service.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/Service.java
@@ -1706,15 +1706,7 @@ public interface Service {
       Map<String, String> infoAsString = new HashMap<>();
       for (Map.Entry<Object, Object> entry : props.entrySet()) {
         // Determine if this is a property we want to forward to the server
-        boolean localProperty = false;
-        for (BuiltInConnectionProperty prop : BuiltInConnectionProperty.values()) {
-          if (prop.camelName().equals(entry.getKey())) {
-            localProperty = true;
-            break;
-          }
-        }
-
-        if (!localProperty) {
+        if (!BuiltInConnectionProperty.isLocalProperty(entry.getKey())) {
           infoAsString.put(entry.getKey().toString(), entry.getValue().toString());
         }
       }

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/remote/UsernamePasswordAuthenticateable.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/remote/UsernamePasswordAuthenticateable.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.remote;
+
+/**
+ * Interface that allows configuration of a username and password with some HTTP authentication.
+ */
+public interface UsernamePasswordAuthenticateable {
+
+  /**
+   * Sets the username, password and method to be used for authentication.
+   *
+   * @param authType Type of authentication
+   * @param username Username
+   * @param password Password
+   */
+  void setUsernamePassword(AuthenticationType authType, String username, String password);
+
+}
+
+// End UsernamePasswordAuthenticateable.java

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/AbstractAvaticaHandler.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/AbstractAvaticaHandler.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.avatica.server;
 
 import org.apache.calcite.avatica.AvaticaSeverity;
+import org.apache.calcite.avatica.remote.AuthenticationType;
 import org.apache.calcite.avatica.remote.Service.ErrorResponse;
 
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -54,12 +55,14 @@ public abstract class AbstractAvaticaHandler extends AbstractHandler
   public boolean isUserPermitted(AvaticaServerConfiguration serverConfig,
       HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Make sure that we drop any unauthenticated users out first.
-    if (null != serverConfig && AuthenticationType.SPNEGO == serverConfig.getAuthenticationType()) {
-      String remoteUser = request.getRemoteUser();
-      if (null == remoteUser) {
-        response.setStatus(HttpURLConnection.HTTP_UNAUTHORIZED);
-        response.getOutputStream().write(UNAUTHORIZED_ERROR.serialize().toByteArray());
-        return false;
+    if (null != serverConfig) {
+      if (AuthenticationType.SPNEGO == serverConfig.getAuthenticationType()) {
+        String remoteUser = request.getRemoteUser();
+        if (null == remoteUser) {
+          response.setStatus(HttpURLConnection.HTTP_UNAUTHORIZED);
+          response.getOutputStream().write(UNAUTHORIZED_ERROR.serialize().toByteArray());
+          return false;
+        }
       }
     }
 

--- a/avatica/server/src/main/java/org/apache/calcite/avatica/server/AvaticaServerConfiguration.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/server/AvaticaServerConfiguration.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.avatica.server;
 
+import org.apache.calcite.avatica.remote.AuthenticationType;
+
 import java.util.concurrent.Callable;
 
 /**
@@ -43,6 +45,34 @@ public interface AvaticaServerConfiguration {
    * @return A Kerberos principal, or null if not applicable.
    */
   String getKerberosPrincipal();
+
+  /**
+   * Returns the array of allowed roles for login. Only applicable when
+   * {@link #getAuthenticationType()} returns {@link AuthenticationType#BASIC} or
+   * {@link AuthenticationType#DIGEST}.
+   *
+   * @return An array of allowed login roles, or null.
+   */
+  String[] getAllowedRoles();
+
+  /**
+   * Returns the name of the realm to use in coordination with the properties files specified
+   * by {@link #getHashLoginServiceProperties()}. Only applicable when
+   * {@link #getAuthenticationType()} returns {@link AuthenticationType#BASIC} or
+   * {@link AuthenticationType#DIGEST}.
+   *
+   * @return A realm for the HashLoginService, or null.
+   */
+  String getHashLoginServiceRealm();
+
+  /**
+   * Returns the path to a properties file that contains users and realms. Only applicable when
+   * {@link #getAuthenticationType()} returns {@link AuthenticationType#BASIC} or
+   * {@link AuthenticationType#DIGEST}.
+   *
+   * @return A realm for the HashLoginService, or null.
+   */
+  String getHashLoginServiceProperties();
 
   /**
    * Returns true if the Avatica server should run user requests at that remote user. Otherwise,

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.avatica.server;
 
+import org.apache.calcite.avatica.remote.AuthenticationType;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/BasicAuthHttpServerTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/BasicAuthHttpServerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.apache.calcite.avatica.ConnectionSpec;
+import org.apache.calcite.avatica.jdbc.JdbcMeta;
+import org.apache.calcite.avatica.remote.Driver;
+import org.apache.calcite.avatica.remote.LocalService;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for HTTP Basic authentication.
+ */
+public class BasicAuthHttpServerTest extends HttpAuthBase {
+
+  private static final ConnectionSpec CONNECTION_SPEC = ConnectionSpec.HSQLDB;
+  private static HttpServer server;
+  private static String url;
+
+  @BeforeClass public static void startServer() throws Exception {
+    final String userPropertiesFile = BasicAuthHttpServerTest.class
+        .getResource("/auth-users.properties").getFile();
+    assertNotNull("Could not find properties file for basic auth users", userPropertiesFile);
+
+    // Create a LocalService around HSQLDB
+    final JdbcMeta jdbcMeta = new JdbcMeta(CONNECTION_SPEC.url,
+        CONNECTION_SPEC.username, CONNECTION_SPEC.password);
+    LocalService service = new LocalService(jdbcMeta);
+
+    server = new HttpServer.Builder()
+        .withBasicAuthentication(userPropertiesFile, new String[] { "users" })
+        .withHandler(service, Driver.Serialization.PROTOBUF)
+        .withPort(0)
+        .build();
+    server.start();
+
+    url = "jdbc:avatica:remote:url=http://localhost:" + server.getPort()
+        + ";authentication=BASIC;serialization=PROTOBUF";
+
+    // Create and grant permissions to our users
+    createHsqldbUsers();
+  }
+
+  @AfterClass public static void stopServer() throws Exception {
+    if (null != server) {
+      server.stop();
+    }
+  }
+
+  @Test public void testDisallowedAvaticaAllowedDbUser() throws Exception {
+    // Allowed by avatica and hsqldb
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER2");
+    props.put("avatica_password", "foo");
+    props.put("user", "USER2");
+    props.put("password", "password2");
+
+    try {
+      readWriteData(url, "INVALID_AVATICA_USER_VALID_DB_USER", props);
+      fail("Expected an exception");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("HTTP/401"));
+    }
+  }
+
+  @Test public void testDisallowedAvaticaNoDbUser() throws Exception {
+    // Allowed by avatica and hsqldb
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER2");
+    props.put("avatica_password", "password2");
+
+    readWriteData(url, "INVALID_AVATICA_USER_NO_DB_USER", props);
+  }
+
+  @Test public void testValidUser() throws Exception {
+    // Allowed by avatica and hsqldb
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER2");
+    props.put("avatica_password", "password2");
+    props.put("user", "USER2");
+    props.put("password", "password2");
+
+    readWriteData(url, "VALID_USER", props);
+  }
+
+  @Test public void testInvalidUser() throws Exception {
+    // Denied by avatica
+    final Properties props = new Properties();
+    props.put("user", "foo");
+    props.put("password", "bar");
+
+    try {
+      readWriteData(url, "INVALID_USER", props);
+      fail("Expected an exception");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("HTTP/401"));
+    }
+  }
+
+  @Test public void testUserWithDisallowedRole() throws Exception {
+    // Disallowed by avatica
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER4");
+    props.put("avatica_password", "password4");
+
+    try {
+      readWriteData(url, "DISALLOWED_AVATICA_USER", props);
+      fail("Expected an exception");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("HTTP/403"));
+    }
+  }
+
+  @Test public void testDisallowedDbUser() throws Exception {
+    // Disallowed by hsqldb, allowed by avatica
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER1");
+    props.put("avatica_password", "password1");
+    props.put("user", "USER1");
+    props.put("password", "password1");
+
+    try {
+      readWriteData(url, "DISALLOWED_DB_USER", props);
+      fail("Expected an exception");
+    } catch (RuntimeException e) {
+      assertEquals("Remote driver error: RuntimeException: "
+          + "java.sql.SQLInvalidAuthorizationSpecException: invalid authorization specification"
+          + " - not found: USER1"
+          + " -> SQLInvalidAuthorizationSpecException: invalid authorization specification - "
+          + "not found: USER1"
+          + " -> HsqlException: invalid authorization specification - not found: USER1",
+          e.getMessage());
+    }
+  }
+}
+
+// End BasicAuthHttpServerTest.java

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/DigestAuthHttpServerTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/DigestAuthHttpServerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.apache.calcite.avatica.ConnectionSpec;
+import org.apache.calcite.avatica.jdbc.JdbcMeta;
+import org.apache.calcite.avatica.remote.Driver;
+import org.apache.calcite.avatica.remote.LocalService;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for HTTP Digest authentication.
+ */
+public class DigestAuthHttpServerTest extends HttpAuthBase {
+
+  private static final ConnectionSpec CONNECTION_SPEC = ConnectionSpec.HSQLDB;
+  private static HttpServer server;
+  private static String url;
+
+  @BeforeClass public static void startServer() throws Exception {
+    final String userPropertiesFile = BasicAuthHttpServerTest.class
+        .getResource("/auth-users.properties").getFile();
+    assertNotNull("Could not find properties file for digest auth users", userPropertiesFile);
+
+    // Create a LocalService around HSQLDB
+    final JdbcMeta jdbcMeta = new JdbcMeta(CONNECTION_SPEC.url,
+        CONNECTION_SPEC.username, CONNECTION_SPEC.password);
+    LocalService service = new LocalService(jdbcMeta);
+
+    server = new HttpServer.Builder()
+        .withDigestAuthentication(userPropertiesFile, new String[] { "users" })
+        .withHandler(service, Driver.Serialization.PROTOBUF)
+        .withPort(0)
+        .build();
+    server.start();
+
+    url = "jdbc:avatica:remote:url=http://localhost:" + server.getPort()
+        + ";authentication=DIGEST;serialization=PROTOBUF";
+
+    // Create and grant permissions to our users
+    createHsqldbUsers();
+  }
+
+  @AfterClass public static void stopServer() throws Exception {
+    if (null != server) {
+      server.stop();
+    }
+  }
+
+  @Test public void testValidUser() throws Exception {
+    // Valid both with avatica and hsqldb
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER2");
+    props.put("avatica_password", "password2");
+    props.put("user", "USER2");
+    props.put("password", "password2");
+
+    readWriteData(url, "VALID_USER", props);
+  }
+
+  @Test public void testInvalidAvaticaValidDb() throws Exception {
+    // Valid both with avatica and hsqldb
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER2");
+    props.put("avatica_password", "foobar");
+    props.put("user", "USER2");
+    props.put("password", "password2");
+
+    try {
+      readWriteData(url, "INVALID_AVATICA_VALID_DB", props);
+      fail("Expected a failure");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("HTTP/401"));
+    }
+  }
+
+  @Test public void testValidAvaticaNoDb() throws Exception {
+    // Valid both with avatica and hsqldb
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER2");
+    props.put("avatica_password", "password2");
+
+    readWriteData(url, "VALID_AVATICA_NO_DB", props);
+  }
+
+  @Test public void testInvalidAvaticaNoDb() throws Exception {
+    // Valid both with avatica and hsqldb
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER2");
+    props.put("avatica_password", "foobar");
+
+    try {
+      readWriteData(url, "INVALID_AVATICA_NO_DB", props);
+      fail("Expected a failure");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("HTTP/401"));
+    }
+  }
+
+  @Test public void testInvalidUser() throws Exception {
+    // Invalid avatica user
+    final Properties props = new Properties();
+    props.put("avatica_user", "foo");
+    props.put("avatica_password", "bar");
+
+    try {
+      readWriteData(url, "INVALID_USER", props);
+      fail("Expected a failure");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("HTTP/401"));
+    }
+  }
+
+  @Test public void testUserWithDisallowedRole() throws Exception {
+    // User 4 is disallowed in avatica due to its roles
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER4");
+    props.put("avatica_password", "password4");
+
+    try {
+      readWriteData(url, "DISALLOWED_USER", props);
+      fail("Expected a failure");
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(), containsString("HTTP/403"));
+    }
+  }
+
+  @Test public void testAllowedAvaticaDisabledHsqldbUser() throws Exception {
+    // Valid Avatica user, but an invalid database user
+    final Properties props = new Properties();
+    props.put("avatica_user", "USER1");
+    props.put("avatica_password", "password1");
+    props.put("user", "USER1");
+    props.put("password", "password1");
+
+    try {
+      readWriteData(url, "DISALLOWED_HSQLDB_USER", props);
+      fail("Expected a failure");
+    } catch (RuntimeException e) {
+      assertEquals("Remote driver error: RuntimeException: "
+          + "java.sql.SQLInvalidAuthorizationSpecException: invalid authorization specification"
+          + " - not found: USER1"
+          + " -> SQLInvalidAuthorizationSpecException: invalid authorization specification - "
+          + "not found: USER1"
+          + " -> HsqlException: invalid authorization specification - not found: USER1",
+          e.getMessage());
+    }
+  }
+}
+
+// End DigestAuthHttpServerTest.java

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpAuthBase.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpAuthBase.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+import org.apache.calcite.avatica.ConnectionSpec;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Common test logic for HTTP basic and digest auth
+ */
+public class HttpAuthBase {
+
+  static boolean userExists(Statement stmt, String user) throws SQLException {
+    ResultSet results = stmt.executeQuery(
+        "SELECT * FROM INFORMATION_SCHEMA.SYSTEM_USERS WHERE USER_NAME = '" + user + "'");
+    return results.next();
+  }
+
+  static void createHsqldbUsers() throws SQLException {
+    try (Connection conn = DriverManager.getConnection(ConnectionSpec.HSQLDB.url,
+        ConnectionSpec.HSQLDB.username, ConnectionSpec.HSQLDB.password);
+        Statement stmt = conn.createStatement()) {
+      for (int i = 2; i <= 5; i++) {
+        // Users 2-5 exist (not user1)
+        final String username = "USER" + i;
+        final String password = "password" + i;
+        if (userExists(stmt, username)) {
+          stmt.execute("DROP USER " + username);
+        }
+        stmt.execute("CREATE USER " + username + " PASSWORD '" + password + "'");
+        // Grant permission to the user we create (defined in the scottdb hsqldb impl)
+        stmt.execute("GRANT DBA TO " + username);
+      }
+    }
+  }
+
+  void readWriteData(String url, String tableName, Properties props) throws Exception {
+    try (Connection conn = DriverManager.getConnection(url, props);
+        Statement stmt = conn.createStatement()) {
+      assertFalse(stmt.execute("DROP TABLE IF EXISTS " + tableName));
+      assertFalse(stmt.execute("CREATE TABLE " + tableName + " (pk integer, msg varchar(10))"));
+
+      assertEquals(1, stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(1, 'abcd')"));
+      assertEquals(1, stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(2, 'bcde')"));
+      assertEquals(1, stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(3, 'cdef')"));
+
+      ResultSet results = stmt.executeQuery("SELECT count(1) FROM " + tableName);
+      assertNotNull(results);
+      assertTrue(results.next());
+      assertEquals(3, results.getInt(1));
+    }
+  }
+}
+
+// End HttpAuthBase.java

--- a/avatica/server/src/test/resources/auth-users.properties
+++ b/avatica/server/src/test/resources/auth-users.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+USER1: password1,role1,users
+USER2: password2,role2,users
+USER3: password3,role3,users
+USER4: password4,role4,admins
+USER5: password5,role5,admins

--- a/avatica/site/_docs/client_reference.md
+++ b/avatica/site/_docs/client_reference.md
@@ -35,7 +35,13 @@ As a reminder, the JDBC connection URL for Avatica is:
 
 The following are a list of supported options:
 
-**url**
+{% comment %}
+It's a shame that we have to embed HTML to get the anchors but the normal
+header tags from kramdown screw up the definition list. We lose the pretty
+on-hover images for the permalink, but oh well.
+{% endcomment %}
+
+<strong><a name="url" href="#url">url</a></strong>
 
 : _Description_: This property is a URL which refers to the location of the
   Avatica Server which the driver will communicate with.
@@ -46,7 +52,7 @@ The following are a list of supported options:
 : _Required_: Yes.
 
 
-**serialization**
+<strong><a name="serialization" href="#serialization">serialization</a></strong>
 
 : _Description_: Avatica supports multiple types of serialization mechanisms
   to format data between the client and server. This property is used to ensure
@@ -58,19 +64,19 @@ The following are a list of supported options:
 : _Required_: No.
 
 
-**authentication**
+<strong><a name="authentication" href="#authentication">authentication</a></strong>
 
 : _Description_: Avatica clients can specify the means in which it authenticates
-  with the Avatica server. Presently, the only form of authentication is SPNEGO
-  which enables Kerberos authentication. Clients who want to use a specific form
-  of authentication should specify the appropriate value in this property.
+  with the Avatica server. Clients who want to use a specific form
+  of authentication should specify the appropriate value in this property. Valid
+  values for this property are presently: `NONE`, `BASIC`, `DIGEST`, and `SPNEGO`.
 
-: _Default_: `null` (implying "no authentication").
+: _Default_: `null` (implying "no authentication", equivalent to `NONE`).
 
 : _Required_: No.
 
 
-**timeZone**
+<strong><a name="timeZone" href="#timeZone">timeZone</a></strong>
 
 : _Description_: The timezone that will be used for dates and times. Valid values for this
   property are defined by [RFC 822](https://www.ietf.org/rfc/rfc0822.txt), for
@@ -83,7 +89,7 @@ The following are a list of supported options:
 : _Required_: No.
 
 
-**httpclient_factory**
+<strong><a name="httpclient-factory" href="#httpclient-factory">httpclient_factory</a></strong>
 
 : _Description_: The Avatica client is a "fancy" HTTP client. As such, there are
   many libraries and APIs available for making HTTP calls. To determine which implementation
@@ -95,13 +101,33 @@ The following are a list of supported options:
 : _Required_: No.
 
 
-**httpclient_impl**
+<strong><a name="httpclient-impl" href="#httpclient-impl">httpclient_impl</a></strong>
 
 : _Description_: When using the default `AvaticaHttpClientFactoryImpl` HTTP client factory
   implementation, this factory should choose the correct client implementation for the
   given client configuration. This property can be used to override the specific HTTP
   client implementation. If it is not provided, the `AvaticaHttpClientFactoryImpl` will
   automatically choose the HTTP client implementation.
+
+: _Default_: `null`.
+
+: _Required_: No.
+
+<strong><a name="avatica-user" href="#avatica-user">avatica_user</a></strong>
+
+: _Description_: This is the username used by an Avatica client to identify itself
+  to the Avatica server. It is unique to the traditional "user" JDBC property. It
+  is only necessary if Avatica is configured for HTTP Basic or Digest authentication.
+
+: _Default_: `null`.
+
+: _Required_: No.
+
+<strong><a name="avatica-password" href="#avatica-password">avatica_password</a></strong>
+
+: _Description_: This is the password used by an Avatica client to identify itself
+  to the Avatica server. It is unique to the traditional "password" JDBC property. It
+  is only necessary if Avatica is configured for HTTP Basic or Digest authentication.
 
 : _Default_: `null`.
 

--- a/avatica/site/_docs/security.md
+++ b/avatica/site/_docs/security.md
@@ -3,6 +3,11 @@ layout: docs
 title: Security
 sidebar_title: Security
 permalink: /docs/security.html
+auth_types:
+  - { name: "HTTP Basic", anchor: "http-basic-authentication" }
+  - { name: "HTTP Digest", anchor: "http-digest-authentication" }
+  - { name: "Kerberos with SPNEGO", anchor: "kerberos-with-spnego-authentication" }
+  - { name: "Client implementation", anchor: "client-implementation" }
 ---
 <!--
 {% comment %}
@@ -30,16 +35,107 @@ for limit what actions clients are allowed to perform.
 Similarly, Avatica must limit what users are allowed to connect and interact
 with the server. Avatica must primarily deal with authentication while authorization
 is deferred to the underlying database. By default, Avatica provides no authentication.
-Avatica does have the ability to perform client authentication using Kerberos.
+Avatica does have the ability to perform client authentication using Kerberos,
+HTTP Basic, and HTTP Digest.
 
-## Kerberos-based authentication
+The authentication and authorization provided by Avatica are designed for use
+*instead* of the authentication and authorization provided by the underlying database.
+The typical `user` and `password` JDBC properties are **always** passed through to
+the Avatica server which will cause the server to enforce those credentials. As such,
+Avatica's authentication types mentioned here only have relevance when the underlying database's authentication
+and authorization features are not used. (The Kerberos/SPNEGO integration is one difference as the impersonation feature
+is specifically designed to allow the Kerberos identity to be passed to the database -
+new advanced implementations could also follow this same approach if desired).
+
+## Table of Contents
+<ul>
+  {% for item in page.auth_types %}<li><a href="#{{ item.anchor }}">{{ item.name }}</a></li>{% endfor %}
+</ul>
+
+
+## HTTP Basic Authentication
+
+Avatica supports authentication over [HTTP Basic](https://en.wikipedia.org/wiki/Basic_access_authentication).
+This is simple username-password based authentication which is ultimately insecure when
+operating over an untrusted network. Basic authentication is only secure when the transport
+is encrypted (e.g. TLS) as the credentials are passed in the clear. This authentication is
+supplementary to the provided JDBC authentication. If credentials are passed to the database
+already, this authentication is unnecessary.
+
+### Enabling Basic Authentication
+
+{% highlight java %}
+String propertiesFile = "/path/to/jetty-users.properties";
+// All roles allowed
+String[] allowedRoles = new String[]  {"*"};
+// Only specific roles are allowed
+allowedRoles = new String[] { "users", "admins" };
+HttpServer server = new HttpServer.Builder()
+    .withPort(8765)
+    .withHandler(new LocalService(), Driver.Serialization.PROTOBUF)
+    .withBasicAuthentication(propertiesFile, allowedRoles)
+    .build();
+{% endhighlight %}
+
+The properties file must be in a form consumable by Jetty. Each line in this
+file is of the form: `username: password[,rolename ...]`
+
+For example:
+
+{% highlight properties %}
+bob: b0b5pA55w0rd,users
+steve: 5teve5pA55w0rd,users
+alice: Al1cepA55w0rd,admins
+{% endhighlight %}
+
+Passwords can also be obfuscated as MD5 hashes or oneway cryptography ("CRYPT").
+For more information, see the [official Jetty documentation](http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html).
+
+## HTTP Digest Authentication
+
+Avatica also supports [HTTP Digest](https://en.wikipedia.org/wiki/Digest_access_authentication).
+This is desirable for Avatica as it does not require the use of TLS to secure communication
+between the Avatica client and server. It is configured very similarly to HTTP Basic
+authentication. This authentication is supplementary to the provided JDBC authentication.
+If credentials are passed to the database already, this authentication is unnecessary.
+
+### Enabling Digest Authentication
+
+{% highlight java %}
+String propertiesFile = "/path/to/jetty-users.properties";
+// All roles allowed
+String[] allowedRoles = new String[]  {"*"};
+// Only specific roles are allowed
+allowedRoles = new String[] { "users", "admins" };
+HttpServer server = new HttpServer.Builder()
+    .withPort(8765)
+    .withHandler(new LocalService(), Driver.Serialization.PROTOBUF)
+    .withDigestAuthentication(propertiesFile, allowedRoles)
+    .build();
+{% endhighlight %}
+
+The properties file must be in a form consumable by Jetty. Each line in this
+file is of the form: `username: password[,rolename ...]`
+
+For example:
+
+{% highlight properties %}
+bob: b0b5pA55w0rd,users
+steve: 5teve5pA55w0rd,users
+alice: Al1cepA55w0rd,admins
+{% endhighlight %}
+
+Passwords can also be obfuscated as MD5 hashes or oneway cryptography ("CRYPT").
+For more information, see the [official Jetty documentation](http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html).
+
+## Kerberos with SPNEGO Authentication
 
 Because Avatica operates over an HTTP interface, the simple and protected GSSAPI
 negotiation mechanism ([SPNEGO](https://en.wikipedia.org/wiki/SPNEGO)) is a logical
 choice. This mechanism makes use of the "HTTP Negotiate" authentication extension to
 communicate with the Kerberos Key Distribution Center (KDC) to authenticate a client.
 
-## Enabling SPNEGO/Kerberos Authentication in servers
+### Enabling SPNEGO/Kerberos Authentication in servers
 
 The Avatica server can operate either by performing the login using
 a JAAS configuration file or login programmatically. By default, authenticated clients
@@ -50,7 +146,7 @@ As a note, it is required that the Kerberos principal in use by the Avatica serv
 **must** have an primary of `HTTP` (where Kerberos principals are of the form
 `primary[/instance]@REALM`). This is specified by [RFC-4559](https://tools.ietf.org/html/rfc4559).
 
-### Programmatic Login
+#### Programmatic Login
 
 This approach requires no external file configurations and only requires a
 keytab file for the principal.
@@ -65,7 +161,7 @@ HttpServer server = new HttpServer.Builder()
     .build();
 {% endhighlight %}
 
-### JAAS Configuration File Login
+#### JAAS Configuration File Login
 
 A JAAS configuration file can be set via the system property `java.security.auth.login.config`.
 The user must set this property when launching their Java application invoking the Avatica server.
@@ -94,7 +190,7 @@ com.sun.security.jgss.accept  {
 
 Ensure the `keyTab` and `principal` attributes are set correctly for your system.
 
-## Impersonation
+### Impersonation
 
 Impersonation is a feature of the Avatica server which allows the Avatica clients
 to execute the server-side calls (e.g. the underlying JDBC calls). Because the details
@@ -137,9 +233,21 @@ public class PhoenixDoAsCallback implements DoAsRemoteUserCallback {
 ## Client implementation
 
 Many HTTP client libraries, such as [Apache Commons HttpComponents](https://hc.apache.org/), already have
-support for performing SPNEGO authentication. When in doubt, refer to one of
+support for performing Basic, Digest, and SPNEGO authentication. When in doubt, refer to one of
 these implementations as it is likely correct.
 
-For information on building this by hand, consult [RFC-4559](https://tools.ietf.org/html/rfc4559)
-which describes how the authentication handshake, through use of the "WWW-authenticate"
+### SPNEGO
+
+For information on building SPNEGO support by hand, consult [RFC-4559](https://tools.ietf.org/html/rfc4559)
+which describes how the authentication handshake, through use of the "WWW-authenticate=Negotiate"
 HTTP header, is used to authenticate a client.
+
+### Password-based
+
+For both HTTP Basic and Digest authentication, the [avatica_user]({{site.baseurl}}/docs/client_reference.html#avatica-user)
+and [avatica_password]({{site.baseurl}}/docs/client_reference.html#avatica-password)
+properties are used to identify the client with the server. If the underlying database
+(the JDBC driver inside the Avatica server) require their own user and password combination,
+these are set via the traditional "user" and "password" properties in the Avatica
+JDBC driver. This also implies that adding HTTP-level authentication in Avatica is likely
+superfluous.

--- a/avatica/src/main/config/checkstyle/suppressions.xml
+++ b/avatica/src/main/config/checkstyle/suppressions.xml
@@ -29,6 +29,7 @@ limitations under the License.
   <suppress checks=".*" files="release.properties"/>
   <suppress checks=".*" files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]apache[/\\]calcite[/\\]avatica[/\\]proto"/>
   <suppress checks=".*" files="log4j.properties"/>
+  <suppress checks=".*" files="auth-users.properties"/>
 
   <!-- This file triggers https://github.com/checkstyle/checkstyle/issues/92,
        through no fault of its own. -->


### PR DESCRIPTION
Adds support for HTTP basic and digest auth. New builder
methods on HttpServer, and new client implementations.

Additional docs outlining use.