### PR TITLE
[CALCITE-1200] Handle null equality join condition as IS NOT DISTINCT…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/JoinInfo.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/JoinInfo.java
@@ -56,9 +56,10 @@ public abstract class JoinInfo {
   public static JoinInfo of(RelNode left, RelNode right, RexNode condition) {
     final List<Integer> leftKeys = new ArrayList<Integer>();
     final List<Integer> rightKeys = new ArrayList<Integer>();
+    final List<Boolean> filterNulls = new ArrayList<Boolean>();
     RexNode remaining =
         RelOptUtil.splitJoinCondition(left, right, condition, leftKeys,
-            rightKeys);
+            rightKeys, filterNulls);
     if (remaining.isAlwaysTrue()) {
       return new EquiJoinInfo(ImmutableIntList.copyOf(leftKeys),
           ImmutableIntList.copyOf(rightKeys));

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
@@ -168,9 +168,10 @@ public class AggregateJoinTransposeRule extends RelOptRule {
     // Split join condition
     final List<Integer> leftKeys = Lists.newArrayList();
     final List<Integer> rightKeys = Lists.newArrayList();
+    final List<Boolean> filterNulls = Lists.newArrayList();
     RexNode nonEquiConj =
         RelOptUtil.splitJoinCondition(join.getLeft(), join.getRight(),
-            join.getCondition(), leftKeys, rightKeys);
+            join.getCondition(), leftKeys, rightKeys, filterNulls);
     // If it contains non-equi join conditions, we bail out
     if (!nonEquiConj.isAlwaysTrue()) {
       return;


### PR DESCRIPTION
… FROM in RelOptUtil.splitJoinCondition

@julianhyde Could you please review the patch? 

I haven't added all the tests that I want to add. I added few tests to see if that is the correct way to test. If it looks good, I will add more tests (mainly involving multiple join conditions and join conditions with non-equi-join components)