### PR TITLE
[CALCITE-1216] Add new rule to substitute Filter On Scan by possible Materialized View

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
@@ -234,6 +234,15 @@ public class EnumerableTableScan
     return new EnumerableTableScan(getCluster(), traitSet, table, elementType);
   }
 
+  @Override public boolean equals(Object obj) {
+    return obj instanceof EnumerableTableScan
+        && this.table.equals(((EnumerableTableScan) obj).getTable());
+  }
+
+  @Override public int hashCode() {
+    return this.table.hashCode();
+  }
+
   public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
     // Note that representation is ARRAY. This assumes that the table
     // returns a Object[] for each record. Actually a Table<T> can

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1616,7 +1616,7 @@ public class SubstitutionVisitor {
     @Override public boolean equals(Object obj) {
       return obj == this
           || obj instanceof MutableScan
-          && rel == ((MutableScan) obj).rel;
+          && rel.equals(((MutableScan) obj).rel);
     }
 
     @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -84,6 +84,7 @@ import org.apache.calcite.rel.rules.JoinAssociateRule;
 import org.apache.calcite.rel.rules.JoinCommuteRule;
 import org.apache.calcite.rel.rules.JoinPushExpressionsRule;
 import org.apache.calcite.rel.rules.JoinPushThroughJoinRule;
+import org.apache.calcite.rel.rules.MaterializedViewFilterScanRule;
 import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
 import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.rel.rules.ProjectTableScanRule;
@@ -491,7 +492,9 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     for (RelOptRule rule : DEFAULT_RULES) {
       planner.addRule(rule);
     }
-
+    if (prepareContext.config().materializationsEnabled()) {
+      planner.addRule(MaterializedViewFilterScanRule.INSTANCE);
+    }
     if (ENABLE_BINDABLE) {
       for (RelOptRule rule : Bindables.RULES) {
         planner.addRule(rule);

--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -205,6 +205,16 @@ public class RelOptTableImpl implements Prepare.PreparingTable {
     throw new RuntimeException("Cannot extend " + table); // TODO: user error
   }
 
+  @Override public boolean equals(Object obj) {
+    return obj instanceof RelOptTableImpl
+        && this.rowType.equals(((RelOptTableImpl) obj).getRowType())
+        && this.table == ((RelOptTableImpl) obj).table;
+  }
+
+  @Override public int hashCode() {
+    return (this.table == null)
+        ? super.hashCode() : this.table.hashCode();
+  }
   public double getRowCount() {
     if (rowCount != null) {
       return rowCount;

--- a/core/src/main/java/org/apache/calcite/rel/rules/MaterializedViewFilterScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MaterializedViewFilterScanRule.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.MaterializedViewSubstitutionVisitor;
+import org.apache.calcite.plan.RelOptMaterialization;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.TableScan;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Planner rule that converts
+ * a {@link org.apache.calcite.rel.core.Filter}
+ * on a {@link org.apache.calcite.rel.core.TableScan}
+ * to a {@link org.apache.calcite.rel.core.Filter} on Materialized View
+ */
+public class MaterializedViewFilterScanRule extends RelOptRule {
+  public static final MaterializedViewFilterScanRule INSTANCE =
+      new MaterializedViewFilterScanRule();
+
+  private final HepProgram program = new HepProgramBuilder()
+      .addRuleInstance(FilterProjectTransposeRule.INSTANCE)
+      .addRuleInstance(ProjectMergeRule.INSTANCE)
+      .build();
+
+  //~ Constructors -----------------------------------------------------------
+
+  /** Creates a MaterializedViewFilterScanRule. */
+  protected MaterializedViewFilterScanRule() {
+    super(operand(Filter.class, operand(TableScan.class, null, none())),
+        "MaterializedViewFilterScanRule");
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  public void onMatch(RelOptRuleCall call) {
+    final Filter filter = call.rel(0);
+    final TableScan scan = call.rel(1);
+    apply(call, filter, scan);
+  }
+
+  protected void apply(RelOptRuleCall call, Filter filter, TableScan scan) {
+    RelOptPlanner planner = call.getPlanner();
+    List<RelOptMaterialization> materializations =
+        (planner instanceof VolcanoPlanner)
+            ? ((VolcanoPlanner) planner).getMaterialization()
+            : ImmutableList.<RelOptMaterialization>of();
+    if (!materializations.isEmpty()) {
+      RelNode root = filter.copy(filter.getTraitSet(),
+          Collections.singletonList((RelNode) scan));
+      List<RelOptMaterialization> applicableMaterializations =
+          VolcanoPlanner.getApplicableMaterializations(root, materializations);
+      for (RelOptMaterialization materialization : applicableMaterializations) {
+        if (RelOptUtil.areRowTypesEqual(scan.getRowType(),
+            materialization.queryRel.getRowType(), false)) {
+          RelNode target = materialization.queryRel;
+          final HepPlanner hepPlanner =
+              new HepPlanner(program, planner.getContext());
+          hepPlanner.setRoot(target);
+          target = hepPlanner.findBestExp();
+          List<RelNode> subs = new MaterializedViewSubstitutionVisitor(target, root)
+              .go(materialization.tableRel);
+          for (RelNode s : subs) {
+            call.transformTo(s);
+          }
+        }
+      }
+    }
+  }
+}
+
+// End MaterializedViewFilterScanRule.java


### PR DESCRIPTION
This will allow join queries with filter to be optimized by Materialised Views. It waits for predicate tot be pushed across join onto table scan, and then check if it can possible do any substitution for it.

1. New rule might be bit on expensive side but we haven't hit any performance issues till now.
2. Have a found a bug (not related to current changes) while writing test cases for this. Will look into it in different diff.
