### PR TITLE
[CALCITE-1150] Add dynamic record type and dynamic star for schema-on…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/DynamicRecordType.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/DynamicRecordType.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.type;
+
+
+/**
+ * Specific type of RelRecordType that corresponds to a dynamic table,
+ * where columns are created as they are requested.
+ */
+public abstract class DynamicRecordType extends RelDataTypeImpl {
+
+  // The prefix string for dynamic star column name
+  public static final String DYNAMIC_STAR_PREFIX = "**";
+
+  public boolean isDynamicStruct() {
+    return true;
+  }
+
+  /**
+   * Returns true if the column name starts with DYNAMIC_STAR_PREFIX.
+   */
+  public static boolean isDynamicStarColName(String name) {
+    return name.startsWith(DYNAMIC_STAR_PREFIX);
+  }
+
+}
+
+// End DynamicRecordType.java

--- a/core/src/main/java/org/apache/calcite/rel/type/DynamicRecordTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/DynamicRecordTypeImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.rel.type;
+
+import org.apache.calcite.sql.type.SqlTypeExplicitPrecedenceList;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Pair;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Implementation of RelDataType for dynamic table. It's used in
+ * Sql validation phase, where field list is mutable for getField() call.
+ *
+ * <p>After Sql validation, a normal RelDataTypeImpl with immutable field list
+ * would take place of DynamicRecordTypeImpl instance for dynamic table. </p>
+ */
+public class DynamicRecordTypeImpl extends DynamicRecordType {
+
+  private final RelDataTypeFactory typeFactory;
+  private final RelDataTypeHolder holder;
+
+  public DynamicRecordTypeImpl(RelDataTypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+    this.holder = new RelDataTypeHolder();
+    this.holder.setRelDataTypeFactory(typeFactory);
+    computeDigest();
+  }
+
+  public List<RelDataTypeField> getFieldList() {
+    return holder.getFieldList(typeFactory);
+  }
+
+  public int getFieldCount() {
+    return holder.getFieldCount();
+  }
+
+  public RelDataTypeField getField(String fieldName, boolean caseSensitive, boolean elideRecord) {
+    Pair<RelDataTypeField, Boolean> pair = holder.getFieldOrInsert(typeFactory, fieldName,
+        caseSensitive);
+    // If a new field is added, we should re-compute the digest.
+    if (pair.right) {
+      computeDigest();
+    }
+
+    return pair.left;
+  }
+
+  public List<String> getFieldNames() {
+    return holder.getFieldNames();
+  }
+
+  public SqlTypeName getSqlTypeName() {
+    return SqlTypeName.ROW;
+  }
+
+  public RelDataTypePrecedenceList getPrecedenceList() {
+    return new SqlTypeExplicitPrecedenceList(Collections.<SqlTypeName>emptyList());
+  }
+
+  protected void generateTypeString(StringBuilder sb, boolean withDetail) {
+    sb.append("(DynamicRecordRow" + getFieldNames() + ")");
+  }
+
+  public boolean isStruct() {
+    return true;
+  }
+
+  public RelDataTypeFamily getFamily() {
+    return getSqlTypeName().getFamily();
+  }
+
+}
+
+// End DynamicRecordTypeImpl.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataType.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataType.java
@@ -227,6 +227,11 @@ public interface RelDataType /*extends Type*/ {
    * applied to values of this type
    */
   RelDataTypeComparability getComparability();
+
+  /**
+   *@return whether it has dynamic structure (for "schema-on-read" table)
+   */
+  boolean isDynamicStruct();
 }
 
 // End RelDataType.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeField.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeField.java
@@ -50,6 +50,11 @@ public interface RelDataTypeField extends Map.Entry<String, RelDataType> {
    * @return field type
    */
   RelDataType getType();
+
+  /**
+   * Returns true if this is a dynamic star field.
+   */
+  boolean isDynamicStar();
 }
 
 // End RelDataTypeField.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFieldImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFieldImpl.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.rel.type;
 
+import org.apache.calcite.sql.type.SqlTypeName;
+
 import java.io.Serializable;
 
 /**
@@ -99,6 +101,11 @@ public class RelDataTypeFieldImpl implements RelDataTypeField, Serializable {
   public String toString() {
     return "#" + index + ": " + name + " " + type;
   }
+
+  public boolean isDynamicStar() {
+    return type.getSqlTypeName() == SqlTypeName.DYNAMIC_STAR;
+  }
+
 }
 
 // End RelDataTypeFieldImpl.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeHolder.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeHolder.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.rel.type;
+
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Holding the expandable list of fields for dynamic table.
+ */
+public class RelDataTypeHolder {
+  List<RelDataTypeField> fields = new ArrayList<>();
+
+  private RelDataTypeFactory typeFactory;
+
+  public List<RelDataTypeField> getFieldList(RelDataTypeFactory typeFactory) {
+    return fields;
+  }
+
+  public int getFieldCount() {
+    return fields.size();
+  }
+
+  /**
+   * Get field if exists, otherwise inserts a new field. The new field by default will have "any"
+   * type, except for the dynamic star field.
+   *
+   * @param typeFactory RelDataTypeFactory
+   * @param fieldName Request field name
+   * @param caseSensitive Case Sensitive
+   * @return A pair of RelDataTypeField and Boolean. Boolean indicates whether a new field is added
+   * to this holder.
+   */
+  public Pair<RelDataTypeField, Boolean> getFieldOrInsert(RelDataTypeFactory typeFactory,
+      String fieldName, boolean caseSensitive) {
+
+    // First check if this field name exists in our field list
+    for (RelDataTypeField f : fields) {
+      if (Util.matches(caseSensitive, f.getName(), fieldName)) {
+        return Pair.of(f, false);
+      }
+    }
+
+    final SqlTypeName typeName = DynamicRecordType.isDynamicStarColName(fieldName)
+        ? SqlTypeName.DYNAMIC_STAR : SqlTypeName.ANY;
+
+    // This field does not exist in our field list add it
+    RelDataTypeField newField = new RelDataTypeFieldImpl(
+        fieldName,
+        fields.size(),
+        typeFactory.createTypeWithNullability(typeFactory.createSqlType(typeName), true));
+
+    // Add the name to our list of field names
+    fields.add(newField);
+
+    return Pair.of(newField, true);
+  }
+
+  public List<String> getFieldNames() {
+    List<String> fieldNames = new ArrayList<>();
+    for (RelDataTypeField f : fields) {
+      fieldNames.add(f.getName());
+    }
+
+    return fieldNames;
+  }
+
+  public void setRelDataTypeFactory(RelDataTypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+  }
+
+}
+
+// End RelDataTypeHolder.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -107,6 +107,15 @@ public abstract class RelDataTypeImpl
             fieldName, -1, lastField.getType());
       }
     }
+
+    // a dynamic * field will match any field name.
+    for (RelDataTypeField field : fieldList) {
+      if (field.isDynamicStar()) {
+        // the requested field could be in the unresolved star
+        return field;
+      }
+    }
+
     return null;
   }
 
@@ -388,6 +397,10 @@ public abstract class RelDataTypeImpl
     // Even in a case-insensitive connection, the name must be precisely
     // "_extra".
     return rowType.getField("_extra", true, false);
+  }
+
+  public boolean isDynamicStruct() {
+    return false;
   }
 
   /** Work space for {@link RelDataTypeImpl#getFieldRecurse}. */

--- a/core/src/main/java/org/apache/calcite/sql/SqlIdentifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIdentifier.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql;
 
+import org.apache.calcite.rel.type.DynamicRecordType;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlVisitor;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
@@ -332,6 +333,11 @@ public class SqlIdentifier extends SqlNode {
   }
 
   public SqlMonotonicity getMonotonicity(SqlValidatorScope scope) {
+    // for "star" column, whether it's static or dynamic return not_monotonic directly.
+    if (Util.last(names).equals("") || DynamicRecordType.isDynamicStarColName(Util.last(names))) {
+      return SqlMonotonicity.NOT_MONOTONIC;
+    }
+
     // First check for builtin functions which don't have parentheses,
     // like "LOCALTIME".
     final SqlValidator validator = scope.getValidator();

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -104,6 +104,7 @@ class SqlItemOperator extends SqlSpecialOperator {
       return OperandTypes.family(
           operandType.getKeyType().getSqlTypeName().getFamily());
     case ANY:
+    case DYNAMIC_STAR:
       return OperandTypes.or(
           OperandTypes.family(SqlTypeFamily.INTEGER),
           OperandTypes.family(SqlTypeFamily.CHARACTER));
@@ -128,6 +129,7 @@ class SqlItemOperator extends SqlSpecialOperator {
       return typeFactory.createTypeWithNullability(operandType.getValueType(),
           true);
     case ANY:
+    case DYNAMIC_STAR:
       return typeFactory.createTypeWithNullability(
           typeFactory.createSqlType(SqlTypeName.ANY), true);
     default:

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -85,7 +85,9 @@ public enum SqlTypeName {
   CURSOR(PrecScale.NO_NO, false, ExtraSqlTypes.REF_CURSOR,
       SqlTypeFamily.CURSOR),
   COLUMN_LIST(PrecScale.NO_NO, false, Types.OTHER + 2,
-      SqlTypeFamily.COLUMN_LIST);
+      SqlTypeFamily.COLUMN_LIST),
+  DYNAMIC_STAR(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES, true,
+      Types.JAVA_OBJECT, SqlTypeFamily.ANY);
 
   public static final int MAX_DATETIME_PRECISION = 3;
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/OrderByScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/OrderByScope.java
@@ -73,7 +73,10 @@ public class OrderByScope extends DelegatingScope {
       final SqlValidatorNamespace selectNs =
           validator.getNamespace(select);
       final RelDataType rowType = selectNs.getRowType();
-      if (validator.catalogReader.field(rowType, name) != null) {
+
+      final RelDataTypeField field = validator.catalogReader.field(rowType, name);
+      if (field != null && !field.isDynamicStar()) {
+        // if identifier is resolved to a dynamic star, use super.fullyQualify() for such case.
         return SqlQualified.create(this, 1, selectNs, identifier);
       }
     }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -660,6 +660,13 @@ public class SqlValidatorUtil {
     }
 
     public SqlNode visit(SqlIdentifier id) {
+      // First check for builtin functions which don't have parentheses,
+      // like "LOCALTIME".
+      final SqlCall call = SqlUtil.makeCall(getScope().getValidator().getOperatorTable(), id);
+      if (call != null) {
+        return call;
+      }
+
       return getScope().fullyQualify(id).identifier;
     }
 

--- a/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
@@ -271,7 +271,7 @@ public class CalciteRemoteDriverTest {
   @Test public void testRemoteTypeInfo() throws Exception {
     CalciteAssert.hr().with(REMOTE_CONNECTION_FACTORY)
         .metaData(GET_TYPEINFO)
-        .returns(CalciteAssert.checkResultCount(30));
+        .returns(CalciteAssert.checkResultCount(31));
   }
 
   @Test public void testRemoteTableTypes() throws Exception {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
@@ -575,7 +575,7 @@ public abstract class SqlToRelTestBase {
         RelDataTypeFactory typeFactory) {
       return new FarragoTestValidator(
           getOperatorTable(),
-          createCatalogReader(typeFactory),
+          catalogReader,
           typeFactory,
           getConformance());
     }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -3954,7 +3954,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     winSql("select *\n"
         + " from emp\n"
         + " join dept on emp.deptno = dept.deptno\n"
-        + " and ^sum(sal) over (partition by deptno\n"
+        + " and ^sum(sal) over (partition by emp.deptno\n"
         + "    order by empno\n"
         + "    rows 3 preceding)^ = dept.deptno + 40\n"
         + "order by deptno")
@@ -5932,7 +5932,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     // Group by
     checkFails(
         "select 1 from emp group by deptno order by ^empno^",
-        "Expression 'EMP\\.EMPNO' is not being grouped");
+        "Expression 'EMPNO' is not being grouped");
 
     // order by can contain aggregate expressions
     check("select empno from emp "
@@ -5943,7 +5943,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
     checkFails(
         "select sum(sal) from emp having count(*) > 3 order by ^empno^",
-        "Expression 'EMP\\.EMPNO' is not being grouped");
+        "Expression 'EMPNO' is not being grouped");
 
     check("select sum(sal) from emp having count(*) > 3 order by sum(deptno)");
 
@@ -5951,11 +5951,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
     checkFails(
         "select distinct deptno from emp group by deptno order by ^empno^",
-        "Expression 'EMP\\.EMPNO' is not in the select clause");
+        "Expression 'EMPNO' is not in the select clause");
 
     checkFails(
         "select distinct deptno from emp group by deptno order by deptno, ^empno^",
-        "Expression 'EMP\\.EMPNO' is not in the select clause");
+        "Expression 'EMPNO' is not in the select clause");
 
     check("select distinct deptno from emp group by deptno order by deptno");
 
@@ -5987,7 +5987,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     checkFails(
         "select distinct cast(empno as bigint) "
             + "from emp order by ^empno^",
-        "Expression 'EMP\\.EMPNO' is not in the select clause");
+        "Expression 'EMPNO' is not in the select clause");
     checkFails(
         "select distinct cast(empno as bigint) "
             + "from emp order by ^emp.empno^",
@@ -6073,10 +6073,10 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "Aggregate expression is illegal in ORDER BY clause of non-aggregating SELECT");
     checkFails("SELECT DISTINCT deptno from emp\n"
         + "GROUP BY deptno ORDER BY deptno, ^sum(empno)^",
-        "Expression 'SUM\\(`EMP`\\.`EMPNO`\\)' is not in the select clause");
+        "Expression 'SUM\\(`EMPNO`\\)' is not in the select clause");
     checkFails("SELECT DISTINCT deptno, min(empno) from emp\n"
         + "GROUP BY deptno ORDER BY deptno, ^sum(empno)^",
-        "Expression 'SUM\\(`EMP`\\.`EMPNO`\\)' is not in the select clause");
+        "Expression 'SUM\\(`EMPNO`\\)' is not in the select clause");
     check("SELECT DISTINCT deptno, sum(empno) from emp\n"
         + "GROUP BY deptno ORDER BY deptno, sum(empno)");
   }
@@ -6822,17 +6822,17 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     // similar validation for SELECT DISTINCT and GROUP BY
     checkFails(
         "SELECT deptno FROM emp GROUP BY deptno ORDER BY deptno, ^empno^",
-        "Expression 'EMP\\.EMPNO' is not being grouped");
+        "Expression 'EMPNO' is not being grouped");
     checkFails(
         "SELECT DISTINCT deptno from emp ORDER BY deptno, ^empno^",
-        "Expression 'EMP\\.EMPNO' is not in the select clause");
+        "Expression 'EMPNO' is not in the select clause");
     check("SELECT DISTINCT deptno from emp ORDER BY deptno + 2");
 
     // The ORDER BY clause works on what is projected by DISTINCT - even if
     // GROUP BY is present.
     checkFails(
         "SELECT DISTINCT deptno FROM emp GROUP BY deptno, empno ORDER BY deptno, ^empno^",
-        "Expression 'EMP\\.EMPNO' is not in the select clause");
+        "Expression 'EMPNO' is not in the select clause");
 
     // redundant distinct; same query is in unitsql/optimizer/distinct.sql
     check("select distinct * from (\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -3273,4 +3273,142 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testSelectFromDynamicTable">
+        <Resource name="sql">
+            <![CDATA[select n_nationkey, n_name from SALES.NATION]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(N_NATIONKEY=[$0], N_NAME=[$1])
+  LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSelectStarFromDynamicTable">
+        <Resource name="sql">
+            <![CDATA[select * from SALES.NATION]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(**=[$0])
+  LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testReferDynamicStarInSelectOB">
+        <Resource name="sql">
+            <![CDATA[select n_nationkey, n_name from (select * from SALES.NATION) order by n_regionkey]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(N_NATIONKEY=[$0], N_NAME=[$1])
+  LogicalSort(sort0=[$2], dir0=[ASC])
+    LogicalProject(N_NATIONKEY=[ITEM($0, 'N_NATIONKEY')], N_NAME=[ITEM($0, 'N_NAME')], EXPR$2=[ITEM($0, 'N_REGIONKEY')])
+      LogicalProject(**=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDynamicStarInTableJoin">
+        <Resource name="sql">
+            <![CDATA[select * from (select * from SALES.NATION) T1, (SELECT * from SALES.CUSTOMER) T2 where T1.n_nationkey = T2.c_nationkey ]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(**=[$0], **0=[$1])
+  LogicalFilter(condition=[=(ITEM($0, 'N_NATIONKEY'), ITEM($1, 'C_NATIONKEY'))])
+    LogicalJoin(condition=[true], joinType=[inner])
+      LogicalProject(**=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+      LogicalProject(**=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, CUSTOMER]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testReferDynamicStarInSelectWhereGB">
+        <Resource name="sql">
+            <![CDATA[select n_regionkey, count(*) as cnt from (select * from SALES.NATION) where n_nationkey > 5 group by n_regionkey ]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalAggregate(group=[{0}], CNT=[COUNT()])
+  LogicalProject(N_REGIONKEY=[ITEM($0, 'N_REGIONKEY')])
+    LogicalFilter(condition=[>(CAST(ITEM($0, 'N_NATIONKEY')):INTEGER, 5)])
+      LogicalProject(**=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDynamicStarInJoinAndSubQ">
+        <Resource name="sql">
+            <![CDATA[select * from (select * from SALES.NATION T1, SALES.CUSTOMER T2 where T1.n_nationkey = T2.c_nationkey) ]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(**=[$0], **0=[$1])
+  LogicalProject(**=[$1], **0=[$3])
+    LogicalFilter(condition=[=($0, $2)])
+      LogicalJoin(condition=[true], joinType=[inner])
+        LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+        LogicalTableScan(table=[[CATALOG, SALES, CUSTOMER]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testStarJoinStaticDynTable">
+        <Resource name="sql">
+            <![CDATA[select * from SALES.NATION N, SALES.REGION R where N.n_regionkey = R.r_regionkey ]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(**=[$1], R_REGIONKEY=[$2], R_NAME=[$3], R_COMMENT=[$4])
+  LogicalFilter(condition=[=(CAST($0):INTEGER, $2)])
+    LogicalJoin(condition=[true], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+      LogicalTableScan(table=[[CATALOG, SALES, REGION]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testGrpByColFromStarInSubQuery">
+        <Resource name="sql">
+            <![CDATA[select * from SALES.NATION N, SALES.REGION R where N.n_regionkey = R.r_regionkey ]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalAggregate(group=[{0}])
+  LogicalProject(COL=[ITEM($0, 'N_NATIONKEY')])
+    LogicalProject(**=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDynStarInExistSubQ">
+        <Resource name="sql">
+            <![CDATA[select * from SALES.REGION where exists (select * from SALES.NATION)]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(R_REGIONKEY=[$0], R_NAME=[$1], R_COMMENT=[$2])
+  LogicalFilter(condition=[IS NOT NULL($3)])
+    LogicalJoin(condition=[true], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, REGION]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalProject(**=[$0])
+            LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSelStarOrderBy">
+        <Resource name="sql">
+            <![CDATA[SELECT * from SALES.NATION order by n_nationkey]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(**=[$0])
+  LogicalSort(sort0=[$1], dir0=[ASC])
+    LogicalProject(**=[$0], N_NATIONKEY=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, NATION]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
…-read table

Add dynamic star column and dynamic record type. Use "**" as the dynamic star column name prefix.

Address review comment 1: Remove the code of SqlSelect.isExpand.

Address review comment 2: RelOptTableImpl.toRel() will convert a dynamicRecordType to RelRecordType. This ensure that a immutable record type in sql-to-rel.

Address review comment 5: add isDynamicStruct().

Address review comment7: add unit test for star in exists subquery.

Modify expected error messages for couple of tests in SqlValidatorTest: use original exp in stead of expanded exp in error msg.