### PR TITLE
[CALCITE-1235] Push down LIMIT in unfiltered Cassandra queries

### DIFF
--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraLimit.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraLimit.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.cassandra;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+
+import java.util.List;
+
+/**
+ * Implementation of limits in Cassandra.
+ */
+public class CassandraLimit extends SingleRel implements CassandraRel {
+  public final RexNode fetch;
+
+  public CassandraLimit(RelOptCluster cluster, RelTraitSet traitSet,
+      RelNode input, RexNode fetch) {
+    super(cluster, traitSet, input);
+    this.fetch = fetch;
+    assert getConvention() == input.getConvention();
+  }
+
+  @Override public RelOptCost computeSelfCost(RelOptPlanner planner,
+      RelMetadataQuery mq) {
+    // We do this so we get the limit for free
+    return planner.getCostFactory().makeZeroCost();
+  }
+
+  @Override public CassandraLimit copy(RelTraitSet traitSet, List<RelNode> newInputs) {
+    return new CassandraLimit(getCluster(), traitSet, sole(newInputs), fetch);
+  }
+
+  public void implement(Implementor implementor) {
+    implementor.visitChild(0, getInput());
+    implementor.setLimit(RexLiteral.intValue(fetch));
+  }
+
+  public RelWriter explainTerms(RelWriter pw) {
+    super.explainTerms(pw);
+    pw.itemIf("fetch", fetch, fetch != null);
+    return pw;
+  }
+}
+
+// End CassandraLimit.java

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraMethod.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraMethod.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public enum CassandraMethod {
   CASSANDRA_QUERYABLE_QUERY(CassandraTable.CassandraQueryable.class, "query",
-      List.class, List.class, List.class, List.class, Integer.class);
+      List.class, List.class, List.class, List.class, Integer.class, Integer.class);
 
   public final Method method;
 

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraMethod.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraMethod.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public enum CassandraMethod {
   CASSANDRA_QUERYABLE_QUERY(CassandraTable.CassandraQueryable.class, "query",
-      List.class, List.class, List.class, List.class, String.class);
+      List.class, List.class, List.class, List.class, Integer.class);
 
   public final Method method;
 

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRel.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRel.java
@@ -39,7 +39,7 @@ public interface CassandraRel extends RelNode {
   class Implementor {
     final Map<String, String> selectFields = new LinkedHashMap<String, String>();
     final List<String> whereClause = new ArrayList<String>();
-    String limitValue = null;
+    int limitValue = -1;
     final List<String> order = new ArrayList<String>();
 
     RelOptTable table;
@@ -63,7 +63,7 @@ public interface CassandraRel extends RelNode {
       order.addAll(newOrder);
     }
 
-    public void setLimit(String limit) {
+    public void setLimit(int limit) {
       limitValue = limit;
     }
 

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRel.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRel.java
@@ -39,7 +39,8 @@ public interface CassandraRel extends RelNode {
   class Implementor {
     final Map<String, String> selectFields = new LinkedHashMap<String, String>();
     final List<String> whereClause = new ArrayList<String>();
-    int limitValue = -1;
+    int offset = 0;
+    int fetch = -1;
     final List<String> order = new ArrayList<String>();
 
     RelOptTable table;
@@ -61,10 +62,6 @@ public interface CassandraRel extends RelNode {
 
     public void addOrder(List<String> newOrder) {
       order.addAll(newOrder);
-    }
-
-    public void setLimit(int limit) {
-      limitValue = limit;
     }
 
     public void visitChild(int ordinal, RelNode input) {

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
@@ -279,8 +279,8 @@ public class CassandraRules {
     private static final Predicate<Sort> SORT_PREDICATE =
         new Predicate<Sort>() {
           public boolean apply(Sort input) {
-            // CQL has no support for offsets
-            return input.offset == null;
+            // Limits are handled by CassandraLimit
+            return input.offset == null && input.fetch == null;
           }
         };
     private static final Predicate<CassandraFilter> FILTER_PREDICATE =
@@ -306,7 +306,7 @@ public class CassandraRules {
               .replace(sort.getCollation());
       return new CassandraSort(sort.getCluster(), traitSet,
           convert(sort.getInput(), traitSet.replace(RelCollations.EMPTY)),
-          sort.getCollation(), sort.fetch);
+          sort.getCollation());
     }
 
     public boolean matches(RelOptRuleCall call) {

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
@@ -304,7 +304,7 @@ public class CassandraRules {
               .replace(sort.getCollation());
       return new CassandraSort(sort.getCluster(), traitSet,
           convert(sort.getInput(), traitSet.replace(RelCollations.EMPTY)),
-          sort.getCollation(), filter.getImplicitCollation(), sort.fetch);
+          sort.getCollation(), sort.fetch);
     }
 
     public boolean matches(RelOptRuleCall call) {

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
@@ -402,7 +402,7 @@ public class CassandraRules {
       final RelTraitSet traitSet =
           limit.getTraitSet().replace(CassandraRel.CONVENTION);
       return new CassandraLimit(limit.getCluster(), traitSet,
-        convert(limit.getInput(), CassandraRel.CONVENTION), limit.fetch);
+        convert(limit.getInput(), CassandraRel.CONVENTION), limit.offset, limit.fetch);
     }
 
     /** @see org.apache.calcite.rel.convert.ConverterRule */

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
@@ -26,7 +26,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 
 import java.util.ArrayList;
@@ -38,8 +37,8 @@ import java.util.List;
  */
 public class CassandraSort extends Sort implements CassandraRel {
   public CassandraSort(RelOptCluster cluster, RelTraitSet traitSet,
-      RelNode child, RelCollation collation, RexNode fetch) {
-    super(cluster, traitSet, child, collation, null, fetch);
+      RelNode child, RelCollation collation) {
+    super(cluster, traitSet, child, collation, null, null);
 
     assert getConvention() == CassandraRel.CONVENTION;
     assert getConvention() == child.getConvention();
@@ -50,18 +49,14 @@ public class CassandraSort extends Sort implements CassandraRel {
     RelOptCost cost = super.computeSelfCost(planner, mq);
     if (!collation.getFieldCollations().isEmpty()) {
       return cost.multiplyBy(0.05);
-    } else if (fetch == null) {
-      return cost;
     } else {
-      // We do this so we get the limit for free
-      return planner.getCostFactory().makeZeroCost();
+      return cost;
     }
   }
 
   @Override public Sort copy(RelTraitSet traitSet, RelNode input,
       RelCollation newCollation, RexNode offset, RexNode fetch) {
-    return new CassandraSort(getCluster(), traitSet, input, collation,
-        fetch);
+    return new CassandraSort(getCluster(), traitSet, input, collation);
   }
 
   public void implement(Implementor implementor) {
@@ -83,9 +78,6 @@ public class CassandraSort extends Sort implements CassandraRel {
       }
 
       implementor.addOrder(fieldOrder);
-    }
-    if (fetch != null) {
-      implementor.setLimit(RexLiteral.intValue(fetch));
     }
   }
 }

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
@@ -85,7 +85,7 @@ public class CassandraSort extends Sort implements CassandraRel {
       implementor.addOrder(fieldOrder);
     }
     if (fetch != null) {
-      implementor.setLimit(((RexLiteral) fetch).getValue().toString());
+      implementor.setLimit(RexLiteral.intValue(fetch));
     }
   }
 }

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
@@ -37,13 +37,9 @@ import java.util.List;
  * relational expression in Cassandra.
  */
 public class CassandraSort extends Sort implements CassandraRel {
-  private final RelCollation implicitCollation;
-
   public CassandraSort(RelOptCluster cluster, RelTraitSet traitSet,
-      RelNode child, RelCollation collation, RelCollation implicitCollation, RexNode fetch) {
+      RelNode child, RelCollation collation, RexNode fetch) {
     super(cluster, traitSet, child, collation, null, fetch);
-
-    this.implicitCollation = implicitCollation;
 
     assert getConvention() == CassandraRel.CONVENTION;
     assert getConvention() == child.getConvention();
@@ -64,7 +60,7 @@ public class CassandraSort extends Sort implements CassandraRel {
 
   @Override public Sort copy(RelTraitSet traitSet, RelNode input,
       RelCollation newCollation, RexNode offset, RexNode fetch) {
-    return new CassandraSort(getCluster(), traitSet, input, collation, implicitCollation,
+    return new CassandraSort(getCluster(), traitSet, input, collation,
         fetch);
   }
 

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTable.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTable.java
@@ -99,7 +99,7 @@ public class CassandraTable extends AbstractQueryableTable
   public Enumerable<Object> query(final Session session) {
     return query(session, Collections.<Map.Entry<String, Class>>emptyList(),
         Collections.<Map.Entry<String, String>>emptyList(),
-        Collections.<String>emptyList(), Collections.<String>emptyList(), null);
+        Collections.<String>emptyList(), Collections.<String>emptyList(), -1);
   }
 
   /** Executes a CQL query on the underlying table.
@@ -111,7 +111,7 @@ public class CassandraTable extends AbstractQueryableTable
    */
   public Enumerable<Object> query(final Session session, List<Map.Entry<String, Class>> fields,
         final List<Map.Entry<String, String>> selectFields, List<String> predicates,
-        List<String> order, String limit) {
+        List<String> order, Integer limit) {
     // Build the type of the resulting row based on the provided fields
     final RelDataTypeFactory typeFactory =
         new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
@@ -181,7 +181,7 @@ public class CassandraTable extends AbstractQueryableTable
     if (!order.isEmpty()) {
       queryBuilder.append(Util.toString(order, " ORDER BY ", ", ", ""));
     }
-    if (limit != null) {
+    if (limit >= 0) {
       queryBuilder.append(" LIMIT " + limit);
     }
     queryBuilder.append(" ALLOW FILTERING");
@@ -238,7 +238,7 @@ public class CassandraTable extends AbstractQueryableTable
     @SuppressWarnings("UnusedDeclaration")
     public Enumerable<Object> query(List<Map.Entry<String, Class>> fields,
         List<Map.Entry<String, String>> selectFields, List<String> predicates,
-        List<String> order, String limit) {
+        List<String> order, Integer limit) {
       return getTable().query(getSession(), fields, selectFields, predicates,
           order, limit);
     }

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTable.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTable.java
@@ -99,7 +99,7 @@ public class CassandraTable extends AbstractQueryableTable
   public Enumerable<Object> query(final Session session) {
     return query(session, Collections.<Map.Entry<String, Class>>emptyList(),
         Collections.<Map.Entry<String, String>>emptyList(),
-        Collections.<String>emptyList(), Collections.<String>emptyList(), -1);
+        Collections.<String>emptyList(), Collections.<String>emptyList(), 0, -1);
   }
 
   /** Executes a CQL query on the underlying table.
@@ -111,7 +111,7 @@ public class CassandraTable extends AbstractQueryableTable
    */
   public Enumerable<Object> query(final Session session, List<Map.Entry<String, Class>> fields,
         final List<Map.Entry<String, String>> selectFields, List<String> predicates,
-        List<String> order, Integer limit) {
+        List<String> order, final Integer offset, final Integer fetch) {
     // Build the type of the resulting row based on the provided fields
     final RelDataTypeFactory typeFactory =
         new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
@@ -181,7 +181,10 @@ public class CassandraTable extends AbstractQueryableTable
     if (!order.isEmpty()) {
       queryBuilder.append(Util.toString(order, " ORDER BY ", ", ", ""));
     }
-    if (limit >= 0) {
+
+    int limit = offset;
+    if (fetch >= 0) { limit += fetch; }
+    if (limit > 0) {
       queryBuilder.append(" LIMIT " + limit);
     }
     queryBuilder.append(" ALLOW FILTERING");
@@ -191,7 +194,12 @@ public class CassandraTable extends AbstractQueryableTable
     return new AbstractEnumerable<Object>() {
       public Enumerator<Object> enumerator() {
         final ResultSet results = session.execute(query);
-        return new CassandraEnumerator(results, resultRowType);
+        // Skip results until we get to the right offset
+        int skip = 0;
+        Enumerator<Object> enumerator = new CassandraEnumerator(results, resultRowType);
+        while (skip < offset && enumerator.moveNext()) { skip++; }
+
+        return enumerator;
       }
     };
   }
@@ -239,9 +247,9 @@ public class CassandraTable extends AbstractQueryableTable
     @SuppressWarnings("UnusedDeclaration")
     public Enumerable<Object> query(List<Map.Entry<String, Class>> fields,
         List<Map.Entry<String, String>> selectFields, List<String> predicates,
-        List<String> order, Integer limit) {
+        List<String> order, Integer offset, Integer fetch) {
       return getTable().query(getSession(), fields, selectFields, predicates,
-          order, limit);
+          order, offset, fetch);
     }
   }
 }

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTable.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTable.java
@@ -186,6 +186,7 @@ public class CassandraTable extends AbstractQueryableTable
     }
     queryBuilder.append(" ALLOW FILTERING");
     final String query = queryBuilder.toString();
+    System.out.println(query);
 
     return new AbstractEnumerable<Object>() {
       public Enumerator<Object> enumerator() {

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraToEnumerableConverter.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraToEnumerableConverter.java
@@ -112,14 +112,17 @@ public class CassandraToEnumerableConverter
     final Expression order =
         list.append("order",
             constantArrayList(cassandraImplementor.order, String.class));
-    final Expression limit =
-        list.append("limit",
-            Expressions.constant(cassandraImplementor.limitValue));
+    final Expression offset =
+        list.append("offset",
+            Expressions.constant(cassandraImplementor.offset));
+    final Expression fetch =
+        list.append("fetch",
+            Expressions.constant(cassandraImplementor.fetch));
     Expression enumerable =
         list.append("enumerable",
             Expressions.call(table,
                 CassandraMethod.CASSANDRA_QUERYABLE_QUERY.method, fields,
-                selectFields, predicates, order, limit));
+                selectFields, predicates, order, offset, fetch));
     if (CalcitePrepareImpl.DEBUG) {
       System.out.println("Cassandra: " + predicates);
     }

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterIT.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterIT.java
@@ -103,11 +103,12 @@ public class CassandraAdapterIT {
     CalciteAssert.that()
         .enable(enabled())
         .with(TWISSANDRA)
-        .query("select \"tweet_id\" from \"userline\" where \"username\" = '!PUBLIC!' limit 1")
-        .returns("tweet_id=f3c329de-d05b-11e5-b58b-90e2ba530b12\n")
+        .query("select \"tweet_id\" from \"userline\" where \"username\" = '!PUBLIC!' limit 2")
+        .returns("tweet_id=f3c329de-d05b-11e5-b58b-90e2ba530b12\n"
+               + "tweet_id=f3dbb03a-d05b-11e5-b58b-90e2ba530b12\n")
         .explainContains("PLAN=CassandraToEnumerableConverter\n"
-                + "  CassandraProject(tweet_id=[$2])\n"
-                + "    CassandraSort(fetch=[1])\n"
+                + "  CassandraLimit(fetch=[2])\n"
+                + "    CassandraProject(tweet_id=[$2])\n"
                 + "      CassandraFilter(condition=[=(CAST($0):VARCHAR(8) CHARACTER SET \"ISO-8859-1\" COLLATE \"ISO-8859-1$en_US$primary\", '!PUBLIC!')])\n");
   }
 
@@ -133,7 +134,7 @@ public class CassandraAdapterIT {
         .enable(enabled())
         .with(TWISSANDRA)
         .query("select \"tweet_id\" from \"userline\" where \"username\" = '!PUBLIC!' limit 8")
-        .explainContains("CassandraSort(fetch=[8])\n");
+        .explainContains("CassandraLimit(fetch=[8])\n");
   }
 
   @Test public void testMaterializedView() {

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterIT.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterIT.java
@@ -147,6 +147,17 @@ public class CassandraAdapterIT {
                        + "    CassandraSort(sort0=[$1], dir0=[DESC])");
   }
 
+  @Test public void testSortOffset() {
+    CalciteAssert.that()
+        .enable(enabled())
+        .with(TWISSANDRA)
+        .query("select \"tweet_id\" from \"userline\" where "
+             + "\"username\"='!PUBLIC!' limit 2 offset 1")
+        .explainContains("CassandraLimit(offset=[1], fetch=[2])")
+        .returns("tweet_id=f3dbb03a-d05b-11e5-b58b-90e2ba530b12\n"
+               + "tweet_id=f3e4182e-d05b-11e5-b58b-90e2ba530b12\n");
+  }
+
   @Test public void testMaterializedView() {
     CalciteAssert.that()
         .enable(enabled())

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterIT.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterIT.java
@@ -137,6 +137,16 @@ public class CassandraAdapterIT {
         .explainContains("CassandraLimit(fetch=[8])\n");
   }
 
+  @Test public void testSortLimit() {
+    CalciteAssert.that()
+        .enable(enabled())
+        .with(TWISSANDRA)
+        .query("select * from \"userline\" where \"username\"='!PUBLIC!' "
+             + "order by \"time\" desc limit 10")
+        .explainContains("  CassandraLimit(fetch=[10])\n"
+                       + "    CassandraSort(sort0=[$1], dir0=[DESC])");
+  }
+
   @Test public void testMaterializedView() {
     CalciteAssert.that()
         .enable(enabled())


### PR DESCRIPTION
I'd appreciate someone if someone could review this before I merge to see if maybe there's a better way to accomplish what I'm trying to do. In the current version of the Cassandra adapter, some overly specific matching is necessary to push down sorts because information is needed from other parts of the operator tree. This means that the current match rule will only pushes down LIMIT if the query has a filter.

This patch adds two additional rules to help deal with LIMIT. The first pushes down `EnumerableLimit` and the second eliminates redundant adjacent `CassandraSort` operators which can now occur because one rule matches `EnumerableLimit` and the other matches `Sort`. They both can be handled by a single instance of operator so this makes the plan simpler.