### PR TITLE
[CALCITE-1238] Fix unparsing LIMIT without ORDER BY after validation

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -229,7 +229,7 @@ public class SqlSelectOperator extends SqlOperator {
       }
       writer.endList(windowFrame);
     }
-    if (select.orderBy != null) {
+    if ((select.orderBy != null) && !SqlNodeList.isEmptyList(select.orderBy)) {
       writer.sep("ORDER BY");
       final SqlWriter.Frame orderFrame =
           writer.startList(SqlWriter.FrameTypeEnum.ORDER_BY_LIST);

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7027,6 +7027,43 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             + "FROM `DEPT`");
   }
 
+  @Test public void testRewriteWithLimitWithoutOrderBy() {
+    SqlValidator validator = tester.getValidator();
+    validator.setIdentifierExpansion(false);
+    tester.checkRewrite(
+        validator,
+        "select name from dept limit 2",
+        "SELECT `NAME`\n"
+            + "FROM `DEPT`\n"
+            + "FETCH NEXT 2 ROWS ONLY");
+  }
+
+  @Test public void testRewriteWithOffsetWithoutOrderBy() {
+    SqlValidator validator = tester.getValidator();
+    validator.setIdentifierExpansion(false);
+    tester.checkRewrite(
+        validator,
+        "select name from dept offset 2",
+        "SELECT `NAME`\n"
+            + "FROM `DEPT`\n"
+            + "OFFSET 2 ROWS");
+  }
+
+  @Test public void testRewriteWithUnionFetchWithoutOrderBy() {
+    SqlValidator validator = tester.getValidator();
+    validator.setIdentifierExpansion(false);
+    tester.checkRewrite(
+        validator,
+        "select name from dept union all select name from dept limit 2",
+        "SELECT *\n"
+            + "FROM (SELECT `NAME`\n"
+            + "FROM `DEPT`\n"
+            + "UNION ALL\n"
+            + "SELECT `NAME`\n"
+            + "FROM `DEPT`)\n"
+            + "FETCH NEXT 2 ROWS ONLY");
+  }
+
   @Test public void testRewriteWithIdentifierExpansion() {
     SqlValidator validator = tester.getValidator();
     validator.setIdentifierExpansion(true);


### PR DESCRIPTION
When unparsing ORDER BY in SqlSelectOperator, also check that the nodes list is non-empty.
Otherwise, invalid SQL can be built from an AST validated from a query with a LIMIT/FETCH
clause but no ORDER BY clause.