### PR TITLE
[CALCITE-1245] Allow RelBuilder scan to take multiple arguments

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/PigRelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/PigRelBuilder.java
@@ -49,8 +49,12 @@ public class PigRelBuilder extends RelBuilder {
         relBuilder.relOptSchema);
   }
 
-  @Override public PigRelBuilder scan(String tableName) {
-    return (PigRelBuilder) super.scan(tableName);
+  @Override public PigRelBuilder scan(String... tableNames) {
+    return (PigRelBuilder) super.scan(tableNames);
+  }
+
+  @Override public PigRelBuilder scan(Iterable<String> tableNames) {
+    return (PigRelBuilder) super.scan(tableNames);
   }
 
   /** Loads a data set.

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -64,6 +64,7 @@ import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -663,21 +664,34 @@ public class RelBuilder {
   /** Creates a {@link org.apache.calcite.rel.core.TableScan} of the table
    * with a given name.
    *
-   * <p>Throws if the table does not exist within the current schema.
+   * <p>Throws if the table does not exist.
    *
    * <p>Returns this builder.
    *
-   * @param tableName Name of table
+   * @param tableNames Name of table (can optionally be qualified)
    */
-  public RelBuilder scan(String tableName) {
-    final RelOptTable relOptTable =
-        relOptSchema.getTableForMember(ImmutableList.of(tableName));
+  public RelBuilder scan(Iterable<String> tableNames) {
+    final List<String> names = ImmutableList.copyOf(tableNames);
+    final RelOptTable relOptTable = relOptSchema.getTableForMember(names);
     if (relOptTable == null) {
-      throw Static.RESOURCE.tableNotFound(tableName).ex();
+      throw Static.RESOURCE.tableNotFound(Joiner.on(".").join(names)).ex();
     }
     final RelNode scan = scanFactory.createScan(cluster, relOptTable);
     push(scan);
     return this;
+  }
+
+  /** Creates a {@link org.apache.calcite.rel.core.TableScan} of the table
+   * with a given name.
+   *
+   * <p>Throws if the table does not exist.
+   *
+   * <p>Returns this builder.
+   *
+   * @param tableNames Name of table (can optionally be qualified)
+   */
+  public RelBuilder scan(String... tableNames) {
+    return scan(ImmutableList.copyOf(tableNames));
   }
 
   /** Creates a {@link org.apache.calcite.rel.core.Filter} of an array of

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -121,6 +121,18 @@ public class RelBuilderTest {
         is("LogicalTableScan(table=[[scott, EMP]])\n"));
   }
 
+  @Test public void testScanQualifiedTable() {
+    // Equivalent SQL:
+    //   SELECT *
+    //   FROM "scott"."emp"
+    final RelNode root =
+        RelBuilder.create(config().build())
+            .scan("scott", "EMP")
+            .build();
+    assertThat(str(root),
+        is("LogicalTableScan(table=[[scott, EMP]])\n"));
+  }
+
   @Test public void testScanInvalidTable() {
     // Equivalent SQL:
     //   SELECT *
@@ -133,6 +145,36 @@ public class RelBuilderTest {
       fail("expected error, got " + root);
     } catch (Exception e) {
       assertThat(e.getMessage(), is("Table 'ZZZ' not found"));
+    }
+  }
+
+  @Test public void testScanInvalidSchema() {
+    // Equivalent SQL:
+    //   SELECT *
+    //   FROM "zzz"."emp"
+    try {
+      final RelNode root =
+          RelBuilder.create(config().build())
+              .scan("ZZZ", "EMP") // the table exists, but the schema does not
+              .build();
+      fail("expected error, got " + root);
+    } catch (Exception e) {
+      assertThat(e.getMessage(), is("Table 'ZZZ.EMP' not found"));
+    }
+  }
+
+  @Test public void testScanInvalidQualifiedTable() {
+    // Equivalent SQL:
+    //   SELECT *
+    //   FROM "scott"."zzz"
+    try {
+      final RelNode root =
+          RelBuilder.create(config().build())
+              .scan("scott", "ZZZ") // the schema is valid, but the table does not exist
+              .build();
+      fail("expected error, got " + root);
+    } catch (Exception e) {
+      assertThat(e.getMessage(), is("Table 'scott.ZZZ' not found"));
     }
   }
 


### PR DESCRIPTION
RelBuilder scan now implements two interfaces:

1. `scan(String... tableNames)`
2. `scan(Iterable<String> tableNames)`

which allows RelBuilder to be used in queries across datasources, where the subschema name is required.