### PR TITLE
[CALCITE-750] Support for nested aggregates within window aggregates.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.sql.util.SqlVisitor;
 import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 
 import static org.apache.calcite.util.Static.RESOURCE;
@@ -67,8 +68,16 @@ public class SqlOverOperator extends SqlBinaryOperator {
     if (!aggCall.getOperator().isAggregator()) {
       throw validator.newValidationError(aggCall, RESOURCE.overNonAggregate());
     }
+    // Enable nested aggregates with window aggregates (OVER operator)
+    if (validator instanceof SqlValidatorImpl) {
+      ((SqlValidatorImpl) validator).enableNestedAggregates();
+    }
     validator.validateWindow(call.operand(1), scope, aggCall);
     validator.validateAggregateParams(aggCall, null, scope);
+    // Disable nested aggregates post validation
+    if (validator instanceof SqlValidatorImpl) {
+      ((SqlValidatorImpl) validator).disableNestedAggregates();
+    }
   }
 
   public RelDataType deriveType(

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
@@ -29,6 +29,8 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.Lists;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 
 /**
@@ -38,8 +40,17 @@ import java.util.List;
 class AggFinder extends SqlBasicVisitor<Void> {
   //~ Instance fields --------------------------------------------------------
 
+  // Maximum allowed nesting level of aggregates
+  private static final int MAX_AGG_LEVEL = 2;
   private final SqlOperatorTable opTab;
   private final boolean over;
+
+  private boolean nestedAgg;                        // Allow nested aggregates
+
+  // Stores aggregate nesting level while visiting the tree to keep track of
+  // nested aggregates within window aggregates. An explicit stack is used
+  // instead of recursion to obey the SqlVisitor interface
+  private Deque<Integer> aggLevelStack;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -53,9 +64,49 @@ class AggFinder extends SqlBasicVisitor<Void> {
   AggFinder(SqlOperatorTable opTab, boolean over) {
     this.opTab = opTab;
     this.over = over;
+    this.nestedAgg = false;
+    this.aggLevelStack = new ArrayDeque<Integer>();
   }
 
   //~ Methods ----------------------------------------------------------------
+
+  /**
+   * Allows nested aggregates within window aggregates
+   */
+  public void enableNestedAggregates()  {
+    this.nestedAgg = true;
+    this.aggLevelStack.clear();
+  }
+
+  /**
+   * Disallows nested aggregates within window aggregates
+   */
+  public void disableNestedAggregates()  {
+    this.nestedAgg = false;
+    this.aggLevelStack.clear();
+  }
+
+  public void addAggLevel(int aggLevel) {
+    aggLevelStack.push(aggLevel);
+  }
+
+  public void removeAggLevel() {
+    if (!aggLevelStack.isEmpty()) {
+      aggLevelStack.pop();
+    }
+  }
+
+  public int getAggLevel() {
+    if (!aggLevelStack.isEmpty()) {
+      return aggLevelStack.peek();
+    } else {
+      return -1;
+    }
+  }
+
+  public boolean isEmptyAggLevel() {
+    return aggLevelStack.isEmpty();
+  }
 
   /**
    * Finds an aggregate.
@@ -87,8 +138,21 @@ class AggFinder extends SqlBasicVisitor<Void> {
 
   public Void visit(SqlCall call) {
     final SqlOperator operator = call.getOperator();
+    final int parAggLevel = this.getAggLevel(); //parent aggregate nesting level
+    // If nested aggregates disallowed or found an aggregate at invalid level
     if (operator.isAggregator()) {
-      throw new Util.FoundOne(call);
+      if (!nestedAgg || (parAggLevel + 1) > MAX_AGG_LEVEL) {
+        throw new Util.FoundOne(call);
+      } else {
+        if (parAggLevel >= 0) {
+          this.addAggLevel(parAggLevel + 1);
+        }
+      }
+    } else {
+      // Add the parent aggregate level before visiting its children
+      if (parAggLevel >= 0) {
+        this.addAggLevel(parAggLevel);
+      }
     }
     // User-defined function may not be resolved yet.
     if (operator instanceof SqlFunction
@@ -99,7 +163,14 @@ class AggFinder extends SqlBasicVisitor<Void> {
           SqlFunctionCategory.USER_DEFINED_FUNCTION, SqlSyntax.FUNCTION, list);
       for (SqlOperator sqlOperator : list) {
         if (sqlOperator.isAggregator()) {
-          throw new Util.FoundOne(call);
+          // If nested aggregates disallowed or found aggregate at invalid level
+          if (!nestedAgg || (parAggLevel + 1) > MAX_AGG_LEVEL) {
+            throw new Util.FoundOne(call);
+          } else {
+            if (parAggLevel >= 0) {
+              this.addAggLevel(parAggLevel + 1);
+            }
+          }
         }
       }
     }
@@ -115,7 +186,12 @@ class AggFinder extends SqlBasicVisitor<Void> {
         return null;
       }
     }
-    return super.visit(call);
+    super.visit(call);
+    // Remove the parent aggregate level after visiting its children
+    if (parAggLevel >= 0) {
+      this.removeAggLevel();
+    }
+    return null;
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -271,6 +271,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   // if it's OK to expand the signature of that method.
   private boolean validatingSqlMerge;
 
+  private boolean nestedAgg;                        // Allow nested aggregates
+
   //~ Constructors -----------------------------------------------------------
 
   /**
@@ -303,6 +305,20 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   }
 
   //~ Methods ----------------------------------------------------------------
+
+  /**
+   * Allows nested aggregates within window aggregates
+   */
+  public void enableNestedAggregates() {
+    this.nestedAgg = true;
+  }
+
+  /**
+   * Disallows nested aggregates within window aggregates
+   */
+  public void disableNestedAggregates() {
+    this.nestedAgg = false;
+  }
 
   public SqlConformance getConformance() {
     return conformance;
@@ -4102,6 +4118,19 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // we see it, we'll report the error for the SUM (not the MAX).
     // For more than one level of nesting, the error which results
     // depends on the traversal order for validation.
+
+    // For window function agg(expr), expr can contain an aggregate function
+    // For example, AVG(2*MAX(x)) OVER (partition by y) GROUP BY y is legal; Only
+    // one level of nesting is allowed since non-window aggregates cannot nest aggregates.
+    aggOrOverFinder.disableNestedAggregates();
+
+    // Store nesting level of each aggregate. If an aggregate is found at an invalid
+    // nesting level, throw an assert.
+    if (nestedAgg) {
+      aggOrOverFinder.enableNestedAggregates();
+      aggOrOverFinder.addAggLevel(1);
+    }
+
     for (SqlNode param : aggCall.getOperandList()) {
       if (aggOrOverFinder.findAgg(param) != null) {
         throw newValidationError(aggCall, RESOURCE.nestedAggIllegal());
@@ -4111,6 +4140,13 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       if (aggOrOverFinder.findAgg(filter) != null) {
         throw newValidationError(filter, RESOURCE.aggregateInFilterIllegal());
       }
+    }
+    // Disallow nested aggregates post call to this function
+    if (nestedAgg) {
+      aggOrOverFinder.removeAggLevel();
+      // Assert we don't have dangling items left in the stack
+      assert aggOrOverFinder.isEmptyAggLevel();
+      aggOrOverFinder.disableNestedAggregates();
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2521,11 +2521,15 @@ public class SqlToRelConverter {
       // agg converter knows which aggregations are required
 
       selectList.accept(aggConverter);
+      // Assert we don't have dangling items left in the stack
+      assert aggConverter.isEmptyAggLevel();
       for (SqlNode expr : orderExprList) {
         expr.accept(aggConverter);
+        assert aggConverter.isEmptyAggLevel();
       }
       if (having != null) {
         having.accept(aggConverter);
+        assert aggConverter.isEmptyAggLevel();
       }
 
       // compute inputs to the aggregator
@@ -4449,6 +4453,15 @@ public class SqlToRelConverter {
     private final Map<AggregateCall, RexNode> aggCallMapping =
         Maps.newHashMap();
 
+    // Minimum allowed nesting level for converting aggregates within the
+    // OVER operator
+    private static final int MIN_AGG_LEVEL = 1;
+
+    // Stores aggregate nesting level while visiting the tree to keep track of
+    // nested aggregates within window aggregates. An explicit stack is used
+    // instead of recursion to obey the SqlVisitor interface
+    private Deque<Integer> aggLevelStack = new ArrayDeque<Integer>();
+
     /**
      * Creates an AggConverter.
      *
@@ -4549,7 +4562,30 @@ public class SqlToRelConverter {
       return null;
     }
 
+    public void addAggLevel(int aggLevel) {
+      aggLevelStack.push(aggLevel);
+    }
+
+    public void removeAggLevel() {
+      if (!aggLevelStack.isEmpty()) {
+        aggLevelStack.pop();
+      }
+    }
+
+    public int getAggLevel() {
+      if (!aggLevelStack.isEmpty()) {
+        return aggLevelStack.peek();
+      } else {
+        return -1;
+      }
+    }
+
+    public boolean isEmptyAggLevel() {
+      return aggLevelStack.isEmpty();
+    }
+
     public Void visit(SqlCall call) {
+      int parAggLevel;                                 //parent aggregate nesting level
       switch (call.getKind()) {
       case FILTER:
         translateAgg((SqlCall) call.operand(0), call.operand(1), call);
@@ -4560,18 +4596,40 @@ public class SqlToRelConverter {
         return null;
       }
       // ignore window aggregates and ranking functions (associated with OVER operator)
+      // However, do not ignore nested window aggregates
       if (call.getOperator().getKind() == SqlKind.OVER) {
-        return null;
+        if (call.operand(0).getKind() == SqlKind.RANK) {
+          return null;
+        }
+        // Track aggregate nesting levels only within an OVER operator.
+        this.addAggLevel(0);
       }
+
+      parAggLevel = this.getAggLevel();
+      // Do not translate the top level window aggregate. Only do so for
+      // nested aggregates, if present
       if (call.getOperator().isAggregator()) {
-        translateAgg(call, null, call);
-        return null;
+        if (parAggLevel < 0
+            || (parAggLevel + 1) > MIN_AGG_LEVEL) {
+          translateAgg(call, null, call);
+          return null;
+        } else if (parAggLevel >= 0) {
+          // Add the parent aggregate level before visiting its children
+          this.addAggLevel(parAggLevel + 1);
+        }
+      } else if (call.getOperator().getKind() != SqlKind.OVER
+                 && parAggLevel >= 0) {
+        this.addAggLevel(parAggLevel);
       }
       for (SqlNode operand : call.getOperandList()) {
         // Operands are occasionally null, e.g. switched CASE arg 0.
         if (operand != null) {
           operand.accept(this);
         }
+      }
+      // Remove the parent aggregate level after visiting its children
+      if (parAggLevel >= 0) {
+        this.removeAggLevel();
       }
       return null;
     }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2314,6 +2314,17 @@ public class RelOptRulesTest extends RelOptTestBase {
     checkSubQuery(sql).check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-750">[CALCITE-750]
+   * Support nested aggregates - allows only one level nesting of aggregates
+   * under window aggregates i.e. window_agg(standard_agg) </a>. */
+  @Test public void testNestedAggregates() {
+    final HepProgram program = HepProgram.builder()
+                    .addRuleInstance(ProjectToWindowRule.PROJECT)
+                    .build();
+    checkPlanning(program, "SELECT avg(sum(sal) + 2*min(empno) + 3*avg(empno)) "
+            + "over (partition by deptno) from emp group by deptno");
+  }
 }
 
 // End RelOptRulesTest.java

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -6334,10 +6334,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "select sum(^max(min(empno))^) from emp",
         ERR_NESTED_AGG);
 
-    // in OVER clause
-    checkFails(
-        "select ^sum(max(empno)) OVER^ (order by deptno ROWS 2 PRECEDING) from emp",
-        ERR_NESTED_AGG);
+    // in OVER clause - this should be OK
+    check("select ^sum(max(empno)) OVER^ (order by deptno ROWS 2 PRECEDING) from emp");
+
+    // in OVER clause with more than one level of nesting
+    checkFails("select ^avg(sum(min(sal))) OVER^ (partition by deptno) from emp"
+          + " group by deptno", ERR_NESTED_AGG);
 
     // OVER in clause
     checkFails(

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5218,4 +5218,31 @@ LogicalProject(EMPNO=[$0])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testNestedAggregates">
+        <Resource name="sql">
+            <![CDATA[SELECT avg(sum(sal) + 2*min(empno) + 3*avg(empno))) over
+    (partition by deptno)
+    from emp
+    group by deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EXPR$0=[CAST(/(SUM(+(+($1, *(2, $2)), *(3, $3))) OVER (PARTITION BY $0 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), COUNT(+(+($1, *(2, $2)), *(3, $3))) OVER (PARTITION BY $0 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))):INTEGER NOT NULL])
+  LogicalAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[MIN($2)], agg#2=[AVG($2)])
+    LogicalProject(DEPTNO=[$7], SAL=[$5], EMPNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EXPR$0=[CAST(/($0, $1)):INTEGER NOT NULL])
+  LogicalProject($0=[$2], $1=[$3])
+    LogicalWindow(window#0=[window(partition {0} order by [] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [SUM($1), COUNT($1)])])
+      LogicalProject(DEPTNO=[$0], $1=[+(+($1, *(2, $2)), *(3, $3))])
+        LogicalAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[MIN($2)], agg#2=[AVG($2)])
+          LogicalProject(DEPTNO=[$7], SAL=[$5], EMPNO=[$0])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+          </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
We needed some sort of context to propagate along with the SqlCall - parentOperator in SqlBasicCall does that. We investigated the scopes particularly the AggregatingSelectScope but felt the intent of the scope was different and the SqlBasicCall was the best place to carry the context around. Also, it was easier to implement it that way. Please suggest if there is a better way to do it!

The changes will allow arbitrary expressions involving one level of nested aggregates (please see the testcase).