### PR TITLE
[CALCITE-1264] Fix Litmus argument interpolation

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Litmus.java
+++ b/core/src/main/java/org/apache/calcite/util/Litmus.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.util;
 
+import org.slf4j.helpers.MessageFormatter;
+
 /**
  * Callback to be called when a test for validity succeeds or fails.
  */
@@ -24,7 +26,8 @@ public interface Litmus {
    * an {@link java.lang.AssertionError} on failure. */
   Litmus THROW = new Litmus() {
     public boolean fail(String message, Object... args) {
-      final String s = message == null ? null : String.format(message, args);
+      final String s = message == null
+          ? null : MessageFormatter.arrayFormat(message, args).getMessage();
       throw new AssertionError(s);
     }
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -127,7 +127,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
     }
     final String signature = signature();
     if (!isValidSignature(signature)) {
-      return litmus.fail("invalid signature [%s]", signature);
+      return litmus.fail("invalid signature [{}]", signature);
     }
     if (rels.isEmpty()) {
       return litmus.fail("must have at least one rel");
@@ -161,7 +161,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
         if (r instanceof Filter) {
           final Filter filter = (Filter) r;
           if (!isValidFilter(filter.getCondition())) {
-            return litmus.fail("invalid filter [%s]", filter.getCondition());
+            return litmus.fail("invalid filter [{}]", filter.getCondition());
           }
         }
       }


### PR DESCRIPTION
Arguments to litmus.fail were not being output, but displayed as "{}".