### PR TITLE
[CALCITE-1288] Avoid doing the same join twice if count(distinct) exists

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2382,6 +2382,15 @@ public class RelOptRulesTest extends RelOptTestBase {
     checkSubQuery(sql).check();
   }
 
+  @Test public void testDistinctNonDistinctAggregates() {
+    final HepProgram program = HepProgram.builder()
+            .addRuleInstance(AggregateExpandDistinctAggregatesRule.JOIN)
+            .build();
+    checkPlanning(program, "select emp.empno, count(*), avg(distinct dept.deptno)\n"
+            + " from sales.emp emp inner join sales.dept dept\n"
+            + " on emp.deptno = dept.deptno\n"
+            + " group by emp.empno");
+  }
 }
 
 // End RelOptRulesTest.java

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5333,4 +5333,31 @@ LogicalProject(EMPNO=[$0])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testDistinctNonDistinctAggregates">
+        <Resource name="sql">
+            <![CDATA[select emp.empno, count(*), avg(distinct dept.deptno)
+from sales.emp emp inner join sales.dept dept
+on emp.deptno = dept.deptno
+group by emp.empno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[AVG(DISTINCT $1)])
+  LogicalProject(EMPNO=[$0], DEPTNO0=[$9])
+    LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($2)], EXPR$2=[AVG($1)])
+  LogicalAggregate(group=[{0, 1}], EXPR$1=[COUNT()])
+    LogicalProject(EMPNO=[$0], DEPTNO0=[$9])
+      LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
This change will allow AggregateExpandDistictAggregatesRule JOIN instance to generates multi-phases aggregates when we see a query with one distinct and one or more non-distinct aggregates 