### PR TITLE
[CALCITE-1295] ReduceExpressionRule should not reduce AS operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
@@ -1010,6 +1010,11 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
         callConstancy = Constancy.NON_CONSTANT;
       }
 
+      // we will not reduce AS operator
+      if (call.getOperator() == SqlStdOperatorTable.AS) {
+        callConstancy = Constancy.NON_CONSTANT;
+      }
+
       // Row operator itself can't be reduced to a literal, but if
       // the operands are constants, we still want to reduce those
       if ((callConstancy == Constancy.REDUCIBLE_CONSTANT)


### PR DESCRIPTION
In extremely rare cases, if we build relation tree ourselves through RelBuilder.

```
relBuilder.push(
        LogicalProject.create(relBuilder.peek(),
          Lists.newArrayList(relBuilder.alias(relBuilder.literal(true), "_c0")),
          Lists.newArrayList("_c0")))
```

Then we may have AS(true, $1) in the expressions, and AS(true, $1) can satisfy ReduceExpressionRule, but AS call do not exist in `RexImpTable.INSTANCE`, so it throws this :

```
java.lang.RuntimeException: cannot translate call AS($t0, $t1)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translateCall(RexToLixTranslator.java:533)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translate0(RexToLixTranslator.java:507)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translate(RexToLixTranslator.java:219)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translate0(RexToLixTranslator.java:472)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translate(RexToLixTranslator.java:219)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translate(RexToLixTranslator.java:214)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translateList(RexToLixTranslator.java:700)
	at org.apache.calcite.adapter.enumerable.RexToLixTranslator.translateProjects(RexToLixTranslator.java:189)
	at org.apache.calcite.rex.RexExecutorImpl.compile(RexExecutorImpl.java:80)
	at org.apache.calcite.rex.RexExecutorImpl.compile(RexExecutorImpl.java:59)
	at org.apache.calcite.rex.RexExecutorImpl.reduce(RexExecutorImpl.java:118)
	at org.apache.calcite.rel.rules.ReduceExpressionsRule.reduceExpressionsInternal(ReduceExpressionsRule.java:544)
	at org.apache.calcite.rel.rules.ReduceExpressionsRule.reduceExpressions(ReduceExpressionsRule.java:455)
	at org.apache.calcite.rel.rules.ReduceExpressionsRule.reduceExpressions(ReduceExpressionsRule.java:438)
```