### PR TITLE
CALCITE-1310: Infer between operator operand type by the first known …

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
@@ -31,6 +31,7 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.apache.calcite.sql.type.ComparableOperandTypeChecker;
+import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeUtil;
@@ -115,7 +116,7 @@ public class SqlBetweenOperator extends SqlInfixOperator {
         SqlKind.BETWEEN,
         30,
         null,
-        null, OTC_CUSTOM);
+            InferTypes.FIRST_KNOWN, OTC_CUSTOM);
     this.flag = flag;
     this.negated = negated;
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -6571,6 +6571,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select deptno from emp\n"
         + "group by deptno, case when deptno = ? then 1 else 2 end").ok();
     sql("select 1 from emp having sum(sal) < ?").ok();
+    sql("select * from emp where deptno between ? and ?").ok();
+    sql("select * from emp where ? between deptno and ?").ok();
+    sql("select * from emp where ? between ? and deptno").ok();
   }
 
   @Test public void testUnnest() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-1310

By setting the default constructor parameter with InferTypes.FIRST_KNOWN, we could infer the operand type by known one.