### PR TITLE
[CALCITE-1346] Invalid nested window aggregates query with alias

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2509,8 +2509,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // Also when nested window aggregates are present
     for (SqlNode node : select.getSelectList()) {
       if (node instanceof SqlCall) {
-        SqlCall call = (SqlCall) node;
-        if (call.getOperator().getKind() == SqlKind.OVER
+        SqlCall call = (SqlCall) overFinder.findAgg(node);
+        if (call != null
+            && call.getOperator().getKind() == SqlKind.OVER
             && call.getOperandList().size() != 0) {
           if (call.operand(0) instanceof SqlCall
               && isNestedAggregateWindow((SqlCall) call.operand(0))) {


### PR DESCRIPTION
A case was missed in CALCITE-1327, CALCITE-1340. The OVER clause is only check for in the top level of the select item. Instead we should use the overFinder.