### PR TITLE
[CALCITE-1301] Add cancel flag to AvaticaStatement

### DIFF
--- a/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -49,6 +49,7 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Implementation of JDBC connection
@@ -662,6 +663,13 @@ public abstract class AvaticaConnection implements Connection {
 
   private Meta.ConnectionProperties sync() {
     return meta.connectionSync(handle, new ConnectionPropertiesImpl());
+  }
+
+  /** Returns or creates a slot whose state can be changed to cancel a
+   * statement. */
+  public AtomicBoolean getCancelFlag(Meta.StatementHandle h)
+      throws NoSuchStatementException {
+    return new AtomicBoolean();
   }
 
   /** A way to call package-protected methods. But only a sub-class of

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
@@ -69,6 +69,7 @@ public class AvaticaResultSet implements ResultSet, ArrayImpl.Factory {
   private long timeoutMillis;
   private Cursor timeoutCursor;
 
+  /** Creates an {@link AvaticaResultSet}. */
   public AvaticaResultSet(AvaticaStatement statement,
       QueryState state,
       Meta.Signature signature,
@@ -148,7 +149,7 @@ public class AvaticaResultSet implements ResultSet, ArrayImpl.Factory {
    * Sets the timeout that this result set will wait for a row from the
    * underlying iterator.
    *
-   * <p>Not a JDBC method.</p>
+   * <p>Not a JDBC method.
    *
    * @param timeoutMillis Timeout in milliseconds. Must be greater than zero.
    */
@@ -166,9 +167,14 @@ public class AvaticaResultSet implements ResultSet, ArrayImpl.Factory {
 */
   }
 
-  // not JDBC
+  /** Sets the flag to indicate that cancel has been requested.
+   *
+   * <p>The implementation should check this flag periodically and cease
+   * processing.
+   *
+   * <p>Not a JDBC method. */
   protected void cancel() {
-    throw new UnsupportedOperationException(); // TODO:
+    statement.cancelFlag.compareAndSet(false, true);
   }
 
   /**
@@ -214,6 +220,9 @@ public class AvaticaResultSet implements ResultSet, ArrayImpl.Factory {
     // TODO: for timeout, see IteratorResultSet.next
     if (isClosed()) {
       throw new SQLException("next() called on closed cursor");
+    }
+    if (statement.cancelFlag.get()) {
+      throw new SQLException("Statement canceled");
     }
     if (cursor.next()) {
       ++row;

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Implementation of {@link java.sql.Statement}
@@ -42,6 +43,9 @@ public abstract class AvaticaStatement
   /** Statement id; unique within connection. */
   public Meta.StatementHandle handle;
   protected boolean closed;
+
+  /** Support for {@link #cancel()} method. */
+  protected final AtomicBoolean cancelFlag;
 
   /**
    * Support for {@link #closeOnCompletion()} method.
@@ -113,6 +117,11 @@ public abstract class AvaticaStatement
     connection.statementMap.put(h.id, this);
     this.handle = h;
     this.batchedSql = new ArrayList<>();
+    try {
+      this.cancelFlag = connection.getCancelFlag(h);
+    } catch (NoSuchStatementException e) {
+      throw new AssertionError("no statement", e);
+    }
   }
 
   /** Returns the identifier of the statement, unique within its connection. */
@@ -320,6 +329,8 @@ public abstract class AvaticaStatement
     if (openResultSet != null) {
       openResultSet.cancel();
     }
+    // If there is an open result set, it probably just set the same flag.
+    cancelFlag.compareAndSet(false, true);
   }
 
   public SQLWarning getWarnings() throws SQLException {

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaUtils.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/AvaticaUtils.java
@@ -95,6 +95,38 @@ public class AvaticaUtils {
   }
 
   /**
+   * Use this method to flag temporary code.
+   *
+   * <p>Example #1:
+   * <blockquote><pre>
+   * if (AvaticaUtils.remark("baz fixed") == null) {
+   *   baz();
+   * }</pre></blockquote>
+   *
+   * <p>Example #2:
+   * <blockquote><pre>
+   * /&#42;&#42; &#64;see AvaticaUtils#remark Remove before checking in &#42;/
+   * void uselessMethod() {}
+   * </pre></blockquote>
+   */
+  public static <T> T remark(T remark) {
+    return remark;
+  }
+
+  /**
+   * Use this method to flag code that should be re-visited after upgrading
+   * a component.
+   *
+   * <p>If the intended change is that a class or member be removed, flag
+   * instead using a {@link Deprecated} annotation followed by a comment such as
+   * "to be removed before 2.0".
+   */
+  public static boolean upgrade(String remark) {
+    discard(remark);
+    return false;
+  }
+
+  /**
    * Adapts a primitive array into a {@link List}. For example,
    * {@code asList(new double[2])} returns a {@code List&lt;Double&gt;}.
    */

--- a/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionProperty.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectionProperty.java
@@ -57,6 +57,24 @@ public interface ConnectionProperty {
     ENUM,
     PLUGIN;
 
+    /** Deduces the class of a property of this type, given the default value
+     * and the user-specified value class (each of which may be null, unless
+     * this is an enum or a plugin). */
+    public Class deduceValueClass(Object defaultValue, Class valueClass) {
+      if (valueClass != null) {
+        return valueClass;
+      }
+      if (defaultValue != null) {
+        final Class<?> c = defaultValue.getClass();
+        if (c.isAnonymousClass()) {
+          // for default values that are anonymous enums
+          return c.getSuperclass();
+        }
+        return c;
+      }
+      return defaultValueClass();
+    }
+
     /** Returns whether a default value and value types are valid for this
      * kind of property. */
     public boolean valid(Object defaultValue, Class clazz) {


### PR DESCRIPTION
Allow connection properties that are enums to declare their value
type. (Extends the work done in [CALCITE-1263].)