### PR TITLE
[CALCITE-1309] Support LATERAL TABLE

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1802,10 +1802,16 @@ SqlNode TableRef() :
             tableRef = unnestOp.createCall(pos.plus(getPos()), args.toArray());
         }
     |
+        { boolean isLateral = false; }
+        [<LATERAL> { isLateral = true;} ]
         <TABLE> { pos = getPos(); } <LPAREN>
         tableRef = TableFunctionCall(pos)
         <RPAREN>
         {
+            if (isLateral) {
+                tableRef = SqlStdOperatorTable.LATERAL.createCall(
+                    getPos(), tableRef);
+            }
         }
     |
         tableRef = ExtendedTableRef()

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -876,7 +876,7 @@ public enum SqlKind {
       EnumSet.complementOf(
           concat(
               EnumSet.of(AS, ARGUMENT_ASSIGNMENT, DEFAULT,
-                  DESCENDING, CUBE, ROLLUP, GROUPING_SETS, EXTEND,
+                  DESCENDING, CUBE, ROLLUP, GROUPING_SETS, EXTEND, LATERAL,
                   SELECT, JOIN, OTHER_FUNCTION, CAST, TRIM, FLOOR, CEIL,
                   TIMESTAMP_ADD, TIMESTAMP_DIFF,
                   LITERAL_CHAIN, JDBC_FN, PRECEDING, FOLLOWING, ORDER_BY,

--- a/core/src/main/java/org/apache/calcite/sql/SqlLateralOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLateralOperator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+
+
+/**
+ * An operator describing a LATERAL specification.
+ */
+public class SqlLateralOperator extends SqlSpecialOperator {
+  //~ Constructors -----------------------------------------------------------
+
+  public SqlLateralOperator(
+      String name,
+      SqlKind kind,
+      int pred,
+      boolean isLeftAssoc,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeInference operandTypeInference,
+      SqlOperandTypeChecker operandTypeChecker) {
+    super(
+        name,
+        kind,
+        pred,
+        isLeftAssoc,
+        returnTypeInference,
+        operandTypeInference,
+        operandTypeChecker);
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  public void unparse(
+      SqlWriter writer,
+      SqlCall call,
+      int leftPrec,
+      int rightPrec) {
+    if (call.operandCount() > 0
+            && call.getOperandList().get(0).getKind() == SqlKind.COLLECTION_TABLE) {
+      // do not create ( ) around the following TABLE clause
+      writer.print(getName());
+      writer.print(" ");
+      final SqlWriter.Frame frame =
+              writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL);
+      final SqlLiteral quantifier = call.getFunctionQuantifier();
+      if (quantifier != null) {
+        quantifier.unparse(writer, 0, 0);
+      }
+      if (call.operandCount() == 0) {
+        switch (call.getOperator().getSyntax()) {
+        case FUNCTION_STAR:
+          writer.sep("*");
+        }
+      }
+      for (SqlNode operand : call.getOperandList()) {
+        writer.sep(",");
+        operand.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    } else {
+      SqlUtil.unparseFunctionSyntax(this, writer, call);
+    }
+  }
+}
+
+// End SqlLateralOperator.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -26,9 +26,9 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFilterOperator;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlFunctionalOperator;
 import org.apache.calcite.sql.SqlInternalOperator;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLateralOperator;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperator;
@@ -993,7 +993,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
    * The <code>LATERAL</code> operator.
    */
   public static final SqlSpecialOperator LATERAL =
-      new SqlFunctionalOperator(
+      new SqlLateralOperator(
           "LATERAL",
           SqlKind.LATERAL,
           200,

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -189,7 +189,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   /**
    * The name-resolution scope of a LATERAL TABLE clause.
    */
-  private SqlValidatorScope tableScope = null;
+  private TableScope tableScope = null;
 
   /**
    * Maps a {@link SqlNode node} to the
@@ -1968,6 +1968,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       return newNode;
 
     case LATERAL:
+      if (tableScope != null) {
+        tableScope.meetLateral();
+      }
       return registerFrom(
           parentScope,
           usingScope,

--- a/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
@@ -29,6 +29,10 @@ class TableScope extends ListScope {
 
   private final SqlNode node;
 
+  // The expression inside the LATERAL can only see tables before it in the FROM clause.
+  // We use this flag to indicate whether current table is before LATERAL.
+  private boolean beforeLateral;
+
   //~ Constructors -----------------------------------------------------------
 
   /**
@@ -39,14 +43,25 @@ class TableScope extends ListScope {
   TableScope(SqlValidatorScope parent, SqlNode node) {
     super(parent);
     this.node = node;
+    this.beforeLateral = true;
   }
 
   //~ Methods ----------------------------------------------------------------
+
+
+  @Override public void addChild(SqlValidatorNamespace ns, String alias) {
+    if (beforeLateral) {
+      super.addChild(ns, alias);
+    }
+  }
 
   public SqlNode getNode() {
     return node;
   }
 
+  public void meetLateral() {
+    this.beforeLateral = false;
+  }
 }
 
 // End TableScope.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
@@ -19,12 +19,12 @@ package org.apache.calcite.sql.validate;
 import org.apache.calcite.sql.SqlNode;
 
 /**
- * The name-resolution scope of a LATERAL TABLE clause. The objects visible are those in
- * the parameters found on the left side of the LATERAL TABLE clause, and objects
- * inherited from the parent scope.
+ * The name-resolution scope of a LATERAL TABLE clause.
  *
+ * <p>The objects visible are those in the parameters found on the left side of
+ * the LATERAL TABLE clause, and objects inherited from the parent scope.
  */
-public class TableScope extends ListScope {
+class TableScope extends ListScope {
   //~ Instance fields --------------------------------------------------------
 
   private final SqlNode node;
@@ -36,9 +36,7 @@ public class TableScope extends ListScope {
    *
    * @param parent   Parent scope, or null
    */
-  TableScope(
-      SqlValidatorScope parent,
-      SqlNode node) {
+  TableScope(SqlValidatorScope parent, SqlNode node) {
     super(parent);
     this.node = node;
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.validate;
+
+import org.apache.calcite.sql.SqlNode;
+
+/**
+ * The name-resolution scope of a LATERAL TABLE clause. The objects visible are those in
+ * the parameters found on the left side of the LATERAL TABLE clause, and objects
+ * inherited from the parent scope.
+ *
+ */
+public class TableScope extends ListScope {
+  //~ Instance fields --------------------------------------------------------
+
+  private final SqlNode node;
+
+  //~ Constructors -----------------------------------------------------------
+
+  /**
+   * Creates a scope corresponding to a LATERAL TABLE clause.
+   *
+   * @param parent   Parent scope, or null
+   */
+  TableScope(
+      SqlValidatorScope parent,
+      SqlNode node) {
+    super(parent);
+    this.node = node;
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  public SqlNode getNode() {
+    return node;
+  }
+
+}
+
+// End TableScope.java

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2735,11 +2735,30 @@ public class SqlParserTest {
   }
 
   @Test public void testCollectionTableWithLateral() {
-    check(
-        "select * from dept, lateral table(ramp(dept.deptno))",
-        "SELECT *\n"
-                + "FROM `DEPT`,\n"
-                + "(LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`))))");
+    final String sql = "select * from dept, lateral table(ramp(dept.deptno))";
+    final String expected = "SELECT *\n"
+        + "FROM `DEPT`,\n"
+        + "LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`)))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCollectionTableWithLateral2() {
+    final String sql = "select * from dept as d\n"
+        + "cross join lateral table(ramp(dept.deptno)) as r";
+    final String expected = "SELECT *\n"
+        + "FROM `DEPT` AS `D`\n"
+        + "CROSS JOIN LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`))) AS `R`";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCollectionTableWithLateral3() {
+    // LATERAL before first table in FROM clause doesn't achieve anything, but
+    // it's valid.
+    final String sql = "select * from lateral table(ramp(dept.deptno)), dept";
+    final String expected = "SELECT *\n"
+        + "FROM LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`))),\n"
+        + "`DEPT`";
+    sql(sql).ok(expected);
   }
 
   @Test public void testIllegalCursors() {

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2734,6 +2734,14 @@ public class SqlParserTest {
             + "FROM `EMPS`))), (ROW(`EMPNO`, `NAME`))))");
   }
 
+  @Test public void testCollectionTableWithLateral() {
+    check(
+        "select * from dept, lateral table(ramp(dept.deptno))",
+        "SELECT *\n"
+                + "FROM `DEPT`,\n"
+                + "(LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`))))");
+  }
+
   @Test public void testIllegalCursors() {
     checkFails(
         "select ^cursor^(select * from emps) from emps",

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2738,7 +2738,7 @@ public class SqlParserTest {
     final String sql = "select * from dept, lateral table(ramp(dept.deptno))";
     final String expected = "SELECT *\n"
         + "FROM `DEPT`,\n"
-        + "LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`)))";
+        + "LATERAL TABLE(`RAMP`(`DEPT`.`DEPTNO`))";
     sql(sql).ok(expected);
   }
 
@@ -2747,7 +2747,7 @@ public class SqlParserTest {
         + "cross join lateral table(ramp(dept.deptno)) as r";
     final String expected = "SELECT *\n"
         + "FROM `DEPT` AS `D`\n"
-        + "CROSS JOIN LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`))) AS `R`";
+        + "CROSS JOIN LATERAL TABLE(`RAMP`(`DEPT`.`DEPTNO`)) AS `R`";
     sql(sql).ok(expected);
   }
 
@@ -2756,7 +2756,7 @@ public class SqlParserTest {
     // it's valid.
     final String sql = "select * from lateral table(ramp(dept.deptno)), dept";
     final String expected = "SELECT *\n"
-        + "FROM LATERAL(TABLE(`RAMP`(`DEPT`.`DEPTNO`))),\n"
+        + "FROM LATERAL TABLE(`RAMP`(`DEPT`.`DEPTNO`)),\n"
         + "`DEPT`";
     sql(sql).ok(expected);
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -736,6 +736,14 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql("select * from table(ramp(3))").ok();
   }
 
+  @Test public void testCollectionTableWithLateral() {
+    sql("select * from dept, lateral table(ramp(dept.deptno))").ok();
+  }
+
+  @Test public void testCollectionTableWithLateral2() {
+    sql("select * from dept, lateral table(ramp(deptno))").ok();
+  }
+
   @Test public void testSample() {
     final String sql =
         "select * from emp tablesample substitute('DATASET1') where empno > 5";

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7042,6 +7042,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "No match found for function signature NONEXISTENTRAMP\\(<CHARACTER>\\)");
   }
 
+  @Test public void testCollectionTableWithLateral() {
+    checkResultType(
+        "select * from dept, lateral table(ramp(dept.deptno))",
+        "RecordType(INTEGER NOT NULL DEPTNO, VARCHAR(10) NOT NULL NAME, INTEGER NOT NULL I) NOT NULL");
+  }
+
   @Test public void testCollectionTableWithCursorParam() {
     checkResultType(
         "select * from table(dedup(cursor(select * from emp),'ename'))",

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -624,6 +624,32 @@ LogicalProject(I=[$0])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testCollectionTableWithLateral">
+        <Resource name="sql">
+            <![CDATA[select * from dept, lateral table(ramp(dept.deptno))]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0], NAME=[$1], I=[$2])
+  LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.DEPTNO)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testCollectionTableWithLateral2">
+        <Resource name="sql">
+            <![CDATA[select * from dept, lateral table(ramp(deptno))]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0], NAME=[$1], I=[$2])
+  LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.DEPTNO)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testInValueListShort">
         <Resource name="sql">
             <![CDATA[select empno from emp where deptno in (10, 20)]]>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -117,6 +117,32 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[SUM(DISTINCT $1)], EXPR$
             <![CDATA[select deptno, sum(sal), sum(distinct sal), count(*) from emp group by deptno]]>
         </Resource>
     </TestCase>
+    <TestCase name="testCollectionTableWithLateral">
+        <Resource name="sql">
+            <![CDATA[select * from dept, lateral table(ramp(dept.deptno))]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0], NAME=[$1], I=[$2])
+  LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.DEPTNO)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testCollectionTableWithLateral2">
+        <Resource name="sql">
+            <![CDATA[select * from dept, lateral table(ramp(deptno))]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0], NAME=[$1], I=[$2])
+  LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.DEPTNO)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testCorrelatedSubQueryInAggregate">
         <Resource name="sql">
             <![CDATA[SELECT SUM(
@@ -621,32 +647,6 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
             <![CDATA[
 LogicalProject(I=[$0])
   LogicalTableFunctionScan(invocation=[RAMP(3)], rowType=[RecordType(INTEGER I)])
-]]>
-        </Resource>
-    </TestCase>
-    <TestCase name="testCollectionTableWithLateral">
-        <Resource name="sql">
-            <![CDATA[select * from dept, lateral table(ramp(dept.deptno))]]>
-        </Resource>
-        <Resource name="plan">
-            <![CDATA[
-LogicalProject(DEPTNO=[$0], NAME=[$1], I=[$2])
-  LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{0}])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-    LogicalTableFunctionScan(invocation=[RAMP($cor0.DEPTNO)], rowType=[RecordType(INTEGER I)])
-]]>
-        </Resource>
-    </TestCase>
-    <TestCase name="testCollectionTableWithLateral2">
-        <Resource name="sql">
-            <![CDATA[select * from dept, lateral table(ramp(deptno))]]>
-        </Resource>
-        <Resource name="plan">
-            <![CDATA[
-LogicalProject(DEPTNO=[$0], NAME=[$1], I=[$2])
-  LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{0}])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-    LogicalTableFunctionScan(invocation=[RAMP($cor0.DEPTNO)], rowType=[RecordType(INTEGER I)])
 ]]>
         </Resource>
     </TestCase>


### PR DESCRIPTION
This is an initial PR for supporting LATERAL TABLE.  It support to query like this:


```sql
SELECT MyTable.*, t.s  FROM MyTable, LATERAL TABLE(split(MyTable.a)) AS t(s)
``` 

All the tests have passed, **EXCEPT** `org.apache.calcite.sql.parser.SqlUnParserTest.testCollectionTableWithLateral`. I understand the reason is that it doesn't know how to parse `LATERAL(TABLE(...))`. I've tried many ways to solve it, but more errors occurred. 



Hi @julianhyde , it would be great if you can help me. 