### PR TITLE
[CALCITE-1390] Copy the properties passed in to the DriverManager bef…

### DIFF
--- a/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectStringParser.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/ConnectStringParser.java
@@ -120,7 +120,7 @@ public class ConnectStringParser {
   /**
    * Parses the connect string into a Properties object. Note that the string
    * can only be parsed once. Subsequent calls return empty/unchanged
-   * Properties.
+   * Properties. The original <code>props</code> argument is not altered.
    *
    * @param props optional properties object, may be <code>null</code>
    *
@@ -130,15 +130,18 @@ public class ConnectStringParser {
    *
    * @throws SQLException error parsing name-value pairs
    */
-  Properties parseInternal(Properties props)
+  Properties parseInternal(final Properties props)
       throws SQLException {
+    final Properties newProps;
     if (props == null) {
-      props = new Properties();
+      newProps = new Properties();
+    } else {
+      newProps = (Properties) props.clone();
     }
     while (i < n) {
-      parsePair(props);
+      parsePair(newProps);
     }
-    return props;
+    return newProps;
   }
 
   /**

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
@@ -725,6 +725,16 @@ public class RemoteMetaTest {
     }
   }
 
+  @Test public void testDriverProperties() throws Exception {
+    final Properties props = new Properties();
+    props.setProperty("foo", "bar");
+    final Properties originalProps = (Properties) props.clone();
+    try (final Connection conn = DriverManager.getConnection(url, props)) {
+      // The contents of the two properties objects should not have changed after connecting.
+      assertEquals(props, originalProps);
+    }
+  }
+
   /** Factory that provides a {@link JdbcMeta}. */
   public static class FullyRemoteJdbcMetaFactory implements Meta.Factory {
 


### PR DESCRIPTION
…ore modifying

The Avatica driver does additional processing of the Properties object
which is passed in via the DriverManager call. We should make a copy
of the Properties when instantiating the Driver instead of directly
modifying the Properties passed-in.