### PR TITLE
CALCITE-1407: MetaImpl#fieldMetaData(Class<?>) sets wrong ordinal

### DIFF
--- a/avatica/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
@@ -235,7 +235,7 @@ public abstract class MetaImpl implements Meta {
         scalarType.columnClassName());
   }
 
-  protected static ColumnMetaData.StructType fieldMetaData(Class clazz) {
+  protected static ColumnMetaData.StructType fieldMetaData(Class<?> clazz) {
     final List<ColumnMetaData> list = new ArrayList<ColumnMetaData>();
     for (Field field : clazz.getFields()) {
       if (Modifier.isPublic(field.getModifiers())
@@ -243,7 +243,7 @@ public abstract class MetaImpl implements Meta {
         list.add(
             columnMetaData(
                 AvaticaUtils.camelToUpper(field.getName()),
-                list.size() + 1, field.getType()));
+                list.size(), field.getType()));
       }
     }
     return ColumnMetaData.struct(list);


### PR DESCRIPTION
Method org.apache.calcite.avatica.MetaImpl#fieldMetaData(Class) creates Column
metadata info from a metadata class. At the same time, the method provides the
column ordinal, which is starts at 1, whereas ColumnMetadata ordinal starts at
0 (according to field comment and usage inside avatica).