### PR TITLE
CALCITE-1408: Throw SQLException if accessor cannot convert to the requested type

### DIFF
--- a/avatica/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/avatica/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -33,6 +33,7 @@ import java.sql.Clob;
 import java.sql.Date;
 import java.sql.NClob;
 import java.sql.Ref;
+import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Struct;
@@ -279,137 +280,137 @@ public abstract class AbstractCursor implements Cursor {
       this.getter = getter;
     }
 
-    public boolean wasNull() {
+    public boolean wasNull() throws SQLException {
       return getter.wasNull();
     }
 
-    public String getString() {
+    public String getString() throws SQLException {
       final Object o = getObject();
       return o == null ? null : o.toString();
     }
 
-    public boolean getBoolean() {
+    public boolean getBoolean() throws SQLException {
       return getLong() != 0L;
     }
 
-    public byte getByte() {
+    public byte getByte() throws SQLException {
       return (byte) getLong();
     }
 
-    public short getShort() {
+    public short getShort() throws SQLException {
       return (short) getLong();
     }
 
-    public int getInt() {
+    public int getInt() throws SQLException {
       return (int) getLong();
     }
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       throw cannotConvert("long");
     }
 
-    public float getFloat() {
+    public float getFloat() throws SQLException {
       return (float) getDouble();
     }
 
-    public double getDouble() {
+    public double getDouble() throws SQLException {
       throw cannotConvert("double");
     }
 
-    public BigDecimal getBigDecimal() {
+    public BigDecimal getBigDecimal() throws SQLException {
       throw cannotConvert("BigDecimal");
     }
 
-    public BigDecimal getBigDecimal(int scale) {
+    public BigDecimal getBigDecimal(int scale) throws SQLException {
       throw cannotConvert("BigDecimal with scale");
     }
 
-    public byte[] getBytes() {
+    public byte[] getBytes() throws SQLException {
       throw cannotConvert("byte[]");
     }
 
-    public InputStream getAsciiStream() {
+    public InputStream getAsciiStream() throws SQLException {
       throw cannotConvert("InputStream (ascii)");
     }
 
-    public InputStream getUnicodeStream() {
+    public InputStream getUnicodeStream() throws SQLException {
       throw cannotConvert("InputStream (unicode)");
     }
 
-    public InputStream getBinaryStream() {
+    public InputStream getBinaryStream() throws SQLException {
       throw cannotConvert("InputStream (binary)");
     }
 
-    public Object getObject() {
+    public Object getObject() throws SQLException {
       return getter.getObject();
     }
 
-    public Reader getCharacterStream() {
+    public Reader getCharacterStream() throws SQLException {
       throw cannotConvert("Reader");
     }
 
-    private RuntimeException cannotConvert(String targetType) {
-      return new RuntimeException("cannot convert to " + targetType + " ("
+    private SQLException cannotConvert(String targetType) throws SQLException {
+      return new SQLDataException("cannot convert to " + targetType + " ("
           + this + ")");
     }
 
-    public Object getObject(Map<String, Class<?>> map) {
+    public Object getObject(Map<String, Class<?>> map) throws SQLException {
       throw cannotConvert("Object (with map)");
     }
 
-    public Ref getRef() {
+    public Ref getRef() throws SQLException {
       throw cannotConvert("Ref");
     }
 
-    public Blob getBlob() {
+    public Blob getBlob() throws SQLException {
       throw cannotConvert("Blob");
     }
 
-    public Clob getClob() {
+    public Clob getClob() throws SQLException {
       throw cannotConvert("Clob");
     }
 
-    public Array getArray() {
+    public Array getArray() throws SQLException {
       throw cannotConvert("Array");
     }
 
-    public Struct getStruct() {
+    public Struct getStruct() throws SQLException {
       throw cannotConvert("Struct");
     }
 
-    public Date getDate(Calendar calendar) {
+    public Date getDate(Calendar calendar) throws SQLException {
       throw cannotConvert("Date");
     }
 
-    public Time getTime(Calendar calendar) {
+    public Time getTime(Calendar calendar) throws SQLException {
       throw cannotConvert("Time");
     }
 
-    public Timestamp getTimestamp(Calendar calendar) {
+    public Timestamp getTimestamp(Calendar calendar) throws SQLException {
       throw cannotConvert("Timestamp");
     }
 
-    public URL getURL() {
+    public URL getURL() throws SQLException {
       throw cannotConvert("URL");
     }
 
-    public NClob getNClob() {
+    public NClob getNClob() throws SQLException {
       throw cannotConvert("NClob");
     }
 
-    public SQLXML getSQLXML() {
+    public SQLXML getSQLXML() throws SQLException {
       throw cannotConvert("SQLXML");
     }
 
-    public String getNString() {
+    public String getNString() throws SQLException {
       throw cannotConvert("NString");
     }
 
-    public Reader getNCharacterStream() {
+    public Reader getNCharacterStream() throws SQLException {
       throw cannotConvert("NCharacterStream");
     }
 
-    public <T> T getObject(Class<T> type) {
+    public <T> T getObject(Class<T> type) throws SQLException {
       throw cannotConvert("Object (with type)");
     }
   }
@@ -423,7 +424,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public BigDecimal getBigDecimal(int scale) {
+    public BigDecimal getBigDecimal(int scale) throws SQLException {
       final long v = getLong();
       if (v == 0 && getter.wasNull()) {
         return null;
@@ -431,7 +432,7 @@ public abstract class AbstractCursor implements Cursor {
       return BigDecimal.valueOf(v).setScale(scale, RoundingMode.DOWN);
     }
 
-    public BigDecimal getBigDecimal() {
+    public BigDecimal getBigDecimal() throws SQLException {
       final long val = getLong();
       if (val == 0 && getter.wasNull()) {
         return null;
@@ -439,15 +440,15 @@ public abstract class AbstractCursor implements Cursor {
       return BigDecimal.valueOf(val);
     }
 
-    public double getDouble() {
+    public double getDouble() throws SQLException {
       return getLong();
     }
 
-    public float getFloat() {
+    public float getFloat() throws SQLException {
       return getLong();
     }
 
-    public abstract long getLong();
+    public abstract long getLong() throws SQLException;
   }
 
   /**
@@ -459,12 +460,12 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public boolean getBoolean() {
+    public boolean getBoolean() throws SQLException {
       Boolean o = (Boolean) getObject();
       return o != null && o;
     }
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       return getBoolean() ? 1 : 0;
     }
   }
@@ -478,12 +479,12 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public byte getByte() {
+    public byte getByte() throws SQLException {
       Byte o = (Byte) getObject();
       return o == null ? 0 : o;
     }
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       return getByte();
     }
   }
@@ -497,12 +498,12 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public short getShort() {
+    public short getShort() throws SQLException {
       Short o = (Short) getObject();
       return o == null ? 0 : o;
     }
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       return getShort();
     }
   }
@@ -516,12 +517,12 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public int getInt() {
+    public int getInt() throws SQLException {
       Integer o = (Integer) super.getObject();
       return o == null ? 0 : o;
     }
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       return getInt();
     }
   }
@@ -535,7 +536,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       Long o = (Long) super.getObject();
       return o == null ? 0 : o;
     }
@@ -550,7 +551,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public BigDecimal getBigDecimal(int scale) {
+    public BigDecimal getBigDecimal(int scale) throws SQLException {
       final double v = getDouble();
       if (v == 0d && getter.wasNull()) {
         return null;
@@ -558,7 +559,7 @@ public abstract class AbstractCursor implements Cursor {
       return BigDecimal.valueOf(v).setScale(scale, RoundingMode.DOWN);
     }
 
-    public BigDecimal getBigDecimal() {
+    public BigDecimal getBigDecimal() throws SQLException {
       final double v = getDouble();
       if (v == 0 && getter.wasNull()) {
         return null;
@@ -566,9 +567,9 @@ public abstract class AbstractCursor implements Cursor {
       return BigDecimal.valueOf(v);
     }
 
-    public abstract double getDouble();
+    public abstract double getDouble() throws SQLException;
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       return (long) getDouble();
     }
   }
@@ -582,12 +583,12 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public float getFloat() {
+    public float getFloat() throws SQLException {
       Float o = (Float) getObject();
       return o == null ? 0f : o;
     }
 
-    public double getDouble() {
+    public double getDouble() throws SQLException {
       return getFloat();
     }
   }
@@ -601,7 +602,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public double getDouble() {
+    public double getDouble() throws SQLException {
       Double o = (Double) getObject();
       return o == null ? 0d : o;
     }
@@ -616,39 +617,39 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    protected abstract Number getNumber();
+    protected abstract Number getNumber() throws SQLException;
 
-    public double getDouble() {
+    public double getDouble() throws SQLException {
       Number number = getNumber();
       return number == null ? 0d : number.doubleValue();
     }
 
-    public float getFloat() {
+    public float getFloat() throws SQLException {
       Number number = getNumber();
       return number == null ? 0f : number.floatValue();
     }
 
-    public long getLong() {
+    public long getLong() throws SQLException {
       Number number = getNumber();
       return number == null ? 0L : number.longValue();
     }
 
-    public int getInt() {
+    public int getInt() throws SQLException {
       Number number = getNumber();
       return number == null ? 0 : number.intValue();
     }
 
-    public short getShort() {
+    public short getShort() throws SQLException {
       Number number = getNumber();
       return number == null ? 0 : number.shortValue();
     }
 
-    public byte getByte() {
+    public byte getByte() throws SQLException {
       Number number = getNumber();
       return number == null ? 0 : number.byteValue();
     }
 
-    public boolean getBoolean() {
+    public boolean getBoolean() throws SQLException {
       Number number = getNumber();
       return number != null && number.doubleValue() != 0;
     }
@@ -663,15 +664,15 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    protected Number getNumber() {
+    protected Number getNumber() throws SQLException {
       return (Number) getObject();
     }
 
-    public BigDecimal getBigDecimal(int scale) {
+    public BigDecimal getBigDecimal(int scale) throws SQLException {
       return (BigDecimal) getObject();
     }
 
-    public BigDecimal getBigDecimal() {
+    public BigDecimal getBigDecimal() throws SQLException {
       return (BigDecimal) getObject();
     }
   }
@@ -692,11 +693,11 @@ public abstract class AbstractCursor implements Cursor {
       this.scale = scale;
     }
 
-    protected Number getNumber() {
+    protected Number getNumber() throws SQLException {
       return (Number) super.getObject();
     }
 
-    public BigDecimal getBigDecimal(int scale) {
+    public BigDecimal getBigDecimal(int scale) throws SQLException {
       Number n = getNumber();
       if (n == null) {
         return null;
@@ -708,7 +709,7 @@ public abstract class AbstractCursor implements Cursor {
       return decimal;
     }
 
-    public BigDecimal getBigDecimal() {
+    public BigDecimal getBigDecimal() throws SQLException {
       return getBigDecimal(scale);
     }
   }
@@ -723,11 +724,11 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    public String getString() {
+    public String getString() throws SQLException {
       return (String) getObject();
     }
 
-    @Override public byte[] getBytes() {
+    @Override public byte[] getBytes() throws SQLException {
       return super.getBytes();
     }
   }
@@ -744,7 +745,7 @@ public abstract class AbstractCursor implements Cursor {
       this.spacer = new Spacer(length);
     }
 
-    public String getString() {
+    public String getString() throws SQLException {
       String s = super.getString();
       if (s == null) {
         return null;
@@ -762,7 +763,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter, length);
     }
 
-    public String getString() {
+    public String getString() throws SQLException {
       Character s = (Character) super.getObject();
       if (s == null) {
         return null;
@@ -783,7 +784,7 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     //FIXME: Protobuf gets byte[]
-    @Override public byte[] getBytes() {
+    @Override public byte[] getBytes() throws SQLException {
       Object obj = getObject();
       if (null == obj) {
         return null;
@@ -799,7 +800,7 @@ public abstract class AbstractCursor implements Cursor {
       }
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       Object o = getObject();
       if (null == o) {
         return null;
@@ -823,11 +824,11 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    @Override public Object getObject() {
+    @Override public Object getObject() throws SQLException {
       return super.getObject();
     }
 
-    @Override public byte[] getBytes() {
+    @Override public byte[] getBytes() throws SQLException {
       // JSON sends this as a base64-enc string, protobuf can do binary.
       Object obj = getObject();
 
@@ -839,7 +840,7 @@ public abstract class AbstractCursor implements Cursor {
       return getBase64Decoded();
     }
 
-    private byte[] getBase64Decoded() {
+    private byte[] getBase64Decoded() throws SQLException {
       final String string = super.getString();
       if (null == string) {
         return null;
@@ -848,7 +849,7 @@ public abstract class AbstractCursor implements Cursor {
       return ByteString.parseBase64(string);
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final byte[] bytes = getBase64Decoded();
       if (null == bytes) {
         return null;
@@ -871,11 +872,11 @@ public abstract class AbstractCursor implements Cursor {
       this.localCalendar = localCalendar;
     }
 
-    @Override public Object getObject() {
+    @Override public Object getObject() throws SQLException {
       return getDate(localCalendar);
     }
 
-    @Override public Date getDate(Calendar calendar) {
+    @Override public Date getDate(Calendar calendar) throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -883,7 +884,7 @@ public abstract class AbstractCursor implements Cursor {
       return longToDate(v.longValue() * DateTimeUtils.MILLIS_PER_DAY, calendar);
     }
 
-    @Override public Timestamp getTimestamp(Calendar calendar) {
+    @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -892,7 +893,7 @@ public abstract class AbstractCursor implements Cursor {
           calendar);
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -914,11 +915,11 @@ public abstract class AbstractCursor implements Cursor {
       this.localCalendar = localCalendar;
     }
 
-    @Override public Object getObject() {
+    @Override public Object getObject() throws SQLException {
       return getTime(localCalendar);
     }
 
-    @Override public Time getTime(Calendar calendar) {
+    @Override public Time getTime(Calendar calendar) throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -926,7 +927,7 @@ public abstract class AbstractCursor implements Cursor {
       return intToTime(v.intValue(), calendar);
     }
 
-    @Override public Timestamp getTimestamp(Calendar calendar) {
+    @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -934,7 +935,7 @@ public abstract class AbstractCursor implements Cursor {
       return longToTimestamp(v.longValue(), calendar);
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -956,11 +957,11 @@ public abstract class AbstractCursor implements Cursor {
       this.localCalendar = localCalendar;
     }
 
-    @Override public Object getObject() {
+    @Override public Object getObject() throws SQLException {
       return getTimestamp(localCalendar);
     }
 
-    @Override public Timestamp getTimestamp(Calendar calendar) {
+    @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -968,7 +969,7 @@ public abstract class AbstractCursor implements Cursor {
       return longToTimestamp(v.longValue(), calendar);
     }
 
-    @Override public Date getDate(Calendar calendar) {
+    @Override public Date getDate(Calendar calendar) throws SQLException {
       final Timestamp timestamp  = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
@@ -976,7 +977,7 @@ public abstract class AbstractCursor implements Cursor {
       return new Date(timestamp.getTime());
     }
 
-    @Override public Time getTime(Calendar calendar) {
+    @Override public Time getTime(Calendar calendar) throws SQLException {
       final Timestamp timestamp  = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
@@ -986,7 +987,7 @@ public abstract class AbstractCursor implements Cursor {
               DateTimeUtils.MILLIS_PER_DAY));
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
@@ -1005,7 +1006,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    @Override public Date getDate(Calendar calendar) {
+    @Override public Date getDate(Calendar calendar) throws SQLException {
       java.sql.Date date = (Date) getObject();
       if (date == null) {
         return null;
@@ -1018,7 +1019,7 @@ public abstract class AbstractCursor implements Cursor {
       return date;
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final int v = getInt();
       if (v == 0 && wasNull()) {
         return null;
@@ -1026,7 +1027,7 @@ public abstract class AbstractCursor implements Cursor {
       return dateAsString(v, null);
     }
 
-    @Override public long getLong() {
+    @Override public long getLong() throws SQLException {
       Date date = getDate(null);
       return date == null
           ? 0L
@@ -1044,7 +1045,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    @Override public Time getTime(Calendar calendar) {
+    @Override public Time getTime(Calendar calendar) throws SQLException {
       Time date  = (Time) getObject();
       if (date == null) {
         return null;
@@ -1057,7 +1058,7 @@ public abstract class AbstractCursor implements Cursor {
       return date;
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final int v = getInt();
       if (v == 0 && wasNull()) {
         return null;
@@ -1065,7 +1066,7 @@ public abstract class AbstractCursor implements Cursor {
       return timeAsString(v, null);
     }
 
-    @Override public long getLong() {
+    @Override public long getLong() throws SQLException {
       Time time = getTime(null);
       return time == null ? 0L
           : (time.getTime() % DateTimeUtils.MILLIS_PER_DAY);
@@ -1082,7 +1083,7 @@ public abstract class AbstractCursor implements Cursor {
       super(getter);
     }
 
-    @Override public Timestamp getTimestamp(Calendar calendar) {
+    @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
       Timestamp timestamp  = (Timestamp) getObject();
       if (timestamp == null) {
         return null;
@@ -1095,7 +1096,7 @@ public abstract class AbstractCursor implements Cursor {
       return timestamp;
     }
 
-    @Override public Date getDate(Calendar calendar) {
+    @Override public Date getDate(Calendar calendar) throws SQLException {
       final Timestamp timestamp  = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
@@ -1103,7 +1104,7 @@ public abstract class AbstractCursor implements Cursor {
       return new Date(timestamp.getTime());
     }
 
-    @Override public Time getTime(Calendar calendar) {
+    @Override public Time getTime(Calendar calendar) throws SQLException {
       final Timestamp timestamp  = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
@@ -1113,7 +1114,7 @@ public abstract class AbstractCursor implements Cursor {
               DateTimeUtils.MILLIS_PER_DAY));
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final long v = getLong();
       if (v == 0 && wasNull()) {
         return null;
@@ -1121,7 +1122,7 @@ public abstract class AbstractCursor implements Cursor {
       return timestampAsString(v, null);
     }
 
-    @Override public long getLong() {
+    @Override public long getLong() throws SQLException {
       Timestamp timestamp = getTimestamp(null);
       return timestamp == null ? 0 : timestamp.getTime();
     }
@@ -1141,7 +1142,7 @@ public abstract class AbstractCursor implements Cursor {
       this.localCalendar = localCalendar;
     }
 
-    @Override public Timestamp getTimestamp(Calendar calendar) {
+    @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
       java.util.Date date  = (java.util.Date) getObject();
       if (date == null) {
         return null;
@@ -1153,7 +1154,7 @@ public abstract class AbstractCursor implements Cursor {
       return new Timestamp(v);
     }
 
-    @Override public Date getDate(Calendar calendar) {
+    @Override public Date getDate(Calendar calendar) throws SQLException {
       final Timestamp timestamp  = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
@@ -1161,7 +1162,7 @@ public abstract class AbstractCursor implements Cursor {
       return new Date(timestamp.getTime());
     }
 
-    @Override public Time getTime(Calendar calendar) {
+    @Override public Time getTime(Calendar calendar) throws SQLException {
       final Timestamp timestamp  = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
@@ -1171,7 +1172,7 @@ public abstract class AbstractCursor implements Cursor {
               DateTimeUtils.MILLIS_PER_DAY));
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       java.util.Date date  = (java.util.Date) getObject();
       if (date == null) {
         return null;
@@ -1179,7 +1180,7 @@ public abstract class AbstractCursor implements Cursor {
       return timestampAsString(date.getTime(), null);
     }
 
-    @Override public long getLong() {
+    @Override public long getLong() throws SQLException {
       Timestamp timestamp = getTimestamp(localCalendar);
       return timestamp == null ? 0 : timestamp.getTime();
     }
@@ -1197,7 +1198,7 @@ public abstract class AbstractCursor implements Cursor {
       this.range = range;
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final int v = getInt();
       if (v == 0 && wasNull()) {
         return null;
@@ -1221,7 +1222,7 @@ public abstract class AbstractCursor implements Cursor {
       this.scale = scale;
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final long v = getLong();
       if (v == 0 && wasNull()) {
         return null;
@@ -1250,7 +1251,7 @@ public abstract class AbstractCursor implements Cursor {
       this.factory = factory;
     }
 
-    @Override public Object getObject() {
+    @Override public Object getObject() throws SQLException {
       final Object object = super.getObject();
       if (object == null || object instanceof List) {
         return object;
@@ -1260,7 +1261,7 @@ public abstract class AbstractCursor implements Cursor {
       return AvaticaUtils.primitiveList(object);
     }
 
-    @Override public Array getArray() {
+    @Override public Array getArray() throws SQLException {
       final List list = (List) getObject();
       if (list == null) {
         return null;
@@ -1268,7 +1269,7 @@ public abstract class AbstractCursor implements Cursor {
       return new ArrayImpl(list, this);
     }
 
-    @Override public String getString() {
+    @Override public String getString() throws SQLException {
       final Array array = getArray();
       return array == null ? null : array.toString();
     }
@@ -1286,11 +1287,11 @@ public abstract class AbstractCursor implements Cursor {
       this.fieldAccessors = fieldAccessors;
     }
 
-    @Override public Object getObject() {
+    @Override public Object getObject() throws SQLException {
       return getStruct();
     }
 
-    @Override public Struct getStruct() {
+    @Override public Struct getStruct() throws SQLException {
       final Object o = super.getObject();
       if (o == null) {
         return null;

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
@@ -1,0 +1,1093 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.apache.calcite.avatica.ColumnMetaData.AvaticaType;
+import org.apache.calcite.avatica.remote.TypedValue;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLDataException;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+
+/**
+ * Test {@code ResultSet#getXXX} conversions
+ *
+ */
+@RunWith(Parameterized.class)
+public class AvaticaResultSetConversionsTest {
+  /**
+   * A fake test driver for test.
+   */
+  private static final class TestDriver extends UnregisteredDriver {
+
+    @Override protected DriverVersion createDriverVersion() {
+      return new DriverVersion("test", "test 0.0.0", "test", "test 0.0.0", false, 0, 0, 0, 0);
+    }
+
+    @Override protected String getConnectStringPrefix() {
+      return "jdbc:test";
+    }
+
+    @Override public Meta createMeta(AvaticaConnection connection) {
+      return new TestMetaImpl(connection);
+    }
+  }
+
+  /**
+   * Fake meta implementation for test driver.
+   */
+  public static final class TestMetaImpl extends MetaImpl {
+    public TestMetaImpl(AvaticaConnection connection) {
+      super(connection);
+    }
+
+    @Override public StatementHandle prepare(ConnectionHandle ch, String sql, long maxRowCount) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public ExecuteResult prepareAndExecute(StatementHandle h, String sql,
+        long maxRowCount, PrepareCallback callback) throws NoSuchStatementException {
+      throw new UnsupportedOperationException();
+    }
+
+    private static ColumnMetaData columnMetaData(String name, int ordinal, AvaticaType type,
+        int columnNullable) {
+      return new ColumnMetaData(
+          ordinal, false, true, false, false,
+          columnNullable,
+          true, -1, name, name, null,
+          0, 0, null, null, type, true, false, false,
+          type.columnClassName());
+    }
+
+    @Override public ExecuteResult prepareAndExecute(StatementHandle h, String sql,
+        long maxRowCount, int maxRowsInFirstFrame, PrepareCallback callback)
+        throws NoSuchStatementException {
+      assertEquals("SELECT * FROM TABLE", sql);
+      List<ColumnMetaData> columns = Arrays
+          .asList(
+              columnMetaData("bool", 0,
+                  ColumnMetaData.scalar(Types.BOOLEAN, "BOOLEAN",
+                      ColumnMetaData.Rep.PRIMITIVE_BOOLEAN),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("byte", 1,
+                  ColumnMetaData.scalar(Types.TINYINT, "TINYINT",
+                      ColumnMetaData.Rep.PRIMITIVE_BYTE),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("short", 2,
+                  ColumnMetaData.scalar(Types.SMALLINT, "SMALLINT",
+                      ColumnMetaData.Rep.PRIMITIVE_SHORT),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("int", 3,
+                  ColumnMetaData.scalar(Types.INTEGER, "INTEGER", ColumnMetaData.Rep.PRIMITIVE_INT),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("long", 4,
+                  ColumnMetaData.scalar(Types.BIGINT, "BIGINT", ColumnMetaData.Rep.PRIMITIVE_LONG),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("float", 5,
+                  ColumnMetaData.scalar(Types.REAL, "REAL", ColumnMetaData.Rep.FLOAT),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("double", 6,
+                  ColumnMetaData.scalar(Types.FLOAT, "FLOAT", ColumnMetaData.Rep.DOUBLE),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("string", 7,
+                  ColumnMetaData.scalar(Types.VARCHAR, "VARCHAR", ColumnMetaData.Rep.STRING),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("date", 8,
+                  ColumnMetaData.scalar(Types.DATE, "DATE", ColumnMetaData.Rep.JAVA_SQL_DATE),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("time", 9,
+                  ColumnMetaData.scalar(Types.TIME, "TIME", ColumnMetaData.Rep.JAVA_SQL_TIME),
+                  DatabaseMetaData.columnNoNulls),
+              columnMetaData("timestamp", 10,
+                  ColumnMetaData.scalar(Types.TIMESTAMP, "TIMESTAMP",
+                      ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP),
+                  DatabaseMetaData.columnNoNulls)
+      );
+
+      List<Object> row = Collections.<Object>singletonList(
+        new Object[] {
+          true, (byte) 1, (short) 2, 3, 4L, 5.0f, 6.0d, "testvalue",
+          new Date(1476130718123L), new Time(1476130718123L), new Timestamp(1476130718123L)
+        });
+
+      CursorFactory factory = CursorFactory.deduce(columns, null);
+      Frame frame = new Frame(0, true, row);
+
+      Signature signature = Signature.create(columns, sql,
+          Collections.<AvaticaParameter>emptyList(), factory, StatementType.SELECT);
+      try {
+        synchronized (callback.getMonitor()) {
+          callback.clear();
+          callback.assign(signature, frame, -1);
+        }
+        callback.execute();
+      } catch (SQLException e) {
+        throw new RuntimeException();
+      }
+      MetaResultSet rs = MetaResultSet.create(h.connectionId, 0, false, signature, null);
+      return new ExecuteResult(Collections.singletonList(rs));
+    }
+
+    @Override public ExecuteBatchResult prepareAndExecuteBatch(StatementHandle h,
+        List<String> sqlCommands) throws NoSuchStatementException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public ExecuteBatchResult executeBatch(StatementHandle h,
+        List<List<TypedValue>> parameterValues) throws NoSuchStatementException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public Frame fetch(StatementHandle h, long offset, int fetchMaxRowCount)
+        throws NoSuchStatementException, MissingResultsException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public ExecuteResult execute(StatementHandle h, List<TypedValue> parameterValues,
+        long maxRowCount) throws NoSuchStatementException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public ExecuteResult execute(StatementHandle h, List<TypedValue> parameterValues,
+        int maxRowsInFirstFrame) throws NoSuchStatementException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public void closeStatement(StatementHandle h) {
+    }
+
+    @Override public boolean syncResults(StatementHandle sh, QueryState state, long offset)
+        throws NoSuchStatementException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public void commit(ConnectionHandle ch) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public void rollback(ConnectionHandle ch) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Base accessor test helper
+   */
+  private static class AccessorTestHelper {
+    protected final int ordinal;
+
+    protected AccessorTestHelper(int ordinal) {
+      this.ordinal = ordinal;
+    }
+
+    public void testGetString(ResultSet resultSet) throws SQLException {
+      resultSet.getString(ordinal);
+    }
+
+    public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getBoolean(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetByte(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getByte(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetShort(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getShort(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetInt(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getInt(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetLong(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getLong(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetFloat(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getFloat(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetDouble(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getDouble(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getBigDecimal(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetBytes(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getBytes(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetAsciiStream(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getAsciiStream(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetBinaryStream(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getBinaryStream(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetObject(ResultSet resultSet) throws SQLException {
+      resultSet.getObject(ordinal);
+    }
+
+    public void testGetCharacterStream(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getCharacterStream(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetObject(ResultSet resultSet, Map<String, Class<?>> map) throws SQLException {
+      try {
+        resultSet.getObject(ordinal, map);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetRef(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getRef(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetBlob(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getBlob(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetClob(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getBlob(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetArray(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getArray(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetDate(ResultSet resultSet, Calendar calendar) throws SQLException {
+      try {
+        resultSet.getDate(ordinal, calendar);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetTime(ResultSet resultSet, Calendar calendar) throws SQLException {
+      try {
+        resultSet.getTime(ordinal, calendar);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetTimestamp(ResultSet resultSet, Calendar calendar) throws SQLException {
+      try {
+        resultSet.getTimestamp(ordinal, calendar);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void getURL(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getURL(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetNClob(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getNClob(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetSQLXML(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getSQLXML(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetNString(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getNString(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+
+    public void testGetNCharacterStream(ResultSet resultSet) throws SQLException {
+      try {
+        resultSet.getNCharacterStream(ordinal);
+        fail("Was expecting to throw SQLDataException");
+      } catch (SQLDataException e) {
+        // success
+      }
+    }
+  }
+
+  /**
+   * accessor test helper for the boolean column
+   */
+  private static final class BooleanAccesorTestHelper extends AccessorTestHelper {
+    private BooleanAccesorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("true", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) 1, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 1, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(1, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(1L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      assertEquals(BigDecimal.ONE, resultSet.getBigDecimal(ordinal));
+    }
+
+    @Override public void testGetFloat(ResultSet resultSet) throws SQLException {
+      assertEquals(1.0f, resultSet.getFloat(ordinal), 0);
+    }
+
+    @Override public void testGetDouble(ResultSet resultSet) throws SQLException {
+      assertEquals(1.0d, resultSet.getDouble(ordinal), 0);
+    }
+  }
+
+  /**
+   * accessor test helper for the byte column
+   */
+  private static final class ByteAccesorTestHelper extends AccessorTestHelper {
+    private ByteAccesorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("1", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) 1, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 1, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(1, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(1L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      assertEquals(BigDecimal.ONE, resultSet.getBigDecimal(ordinal));
+    }
+
+    @Override public void testGetFloat(ResultSet resultSet) throws SQLException {
+      assertEquals(1.0f, resultSet.getFloat(ordinal), 0);
+    }
+
+    @Override public void testGetDouble(ResultSet resultSet) throws SQLException {
+      assertEquals(1.0d, resultSet.getDouble(ordinal), 0);
+    }
+  }
+
+  /**
+   * accessor test helper for the short column
+   */
+  private static final class ShortAccessorTestHelper extends AccessorTestHelper {
+    private ShortAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("2", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) 2, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 2, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(2, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(2L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      assertEquals(new BigDecimal(2), resultSet.getBigDecimal(ordinal));
+    }
+
+    @Override public void testGetFloat(ResultSet resultSet) throws SQLException {
+      assertEquals(2.0f, resultSet.getFloat(ordinal), 0);
+    }
+
+    @Override public void testGetDouble(ResultSet resultSet) throws SQLException {
+      assertEquals(2.0d, resultSet.getDouble(ordinal), 0);
+    }
+  }
+
+  /**
+   * accessor test helper for the int column
+   */
+  private static final class IntAccessorTestHelper extends AccessorTestHelper {
+    private IntAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("3", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) 3, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 3, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(3, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(3L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      assertEquals(new BigDecimal(3), resultSet.getBigDecimal(ordinal));
+    }
+
+    @Override public void testGetFloat(ResultSet resultSet) throws SQLException {
+      assertEquals(3.0f, resultSet.getFloat(ordinal), 0);
+    }
+
+    @Override public void testGetDouble(ResultSet resultSet) throws SQLException {
+      assertEquals(3.0d, resultSet.getDouble(ordinal), 0);
+    }
+  }
+
+  /**
+   * accessor test helper for the long column
+   */
+  private static final class LongAccessorTestHelper extends AccessorTestHelper {
+    private LongAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("4", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) 4, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 4, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(4, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(4L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      assertEquals(new BigDecimal(4), resultSet.getBigDecimal(ordinal));
+    }
+
+    @Override public void testGetFloat(ResultSet resultSet) throws SQLException {
+      assertEquals(4.0f, resultSet.getFloat(ordinal), 0);
+    }
+
+    @Override public void testGetDouble(ResultSet resultSet) throws SQLException {
+      assertEquals(4.0d, resultSet.getDouble(ordinal), 0);
+    }
+  }
+
+  /**
+   * accessor test helper for the float column
+   */
+  private static final class FloatAccessorTestHelper extends AccessorTestHelper {
+    private FloatAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("5.0", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) 5, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 5, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(5, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(5L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      assertEquals(new BigDecimal(5).setScale(1), resultSet.getBigDecimal(ordinal));
+    }
+
+    @Override public void testGetFloat(ResultSet resultSet) throws SQLException {
+      assertEquals(5.0f, resultSet.getFloat(ordinal), 0);
+    }
+
+    @Override public void testGetDouble(ResultSet resultSet) throws SQLException {
+      assertEquals(5.0d, resultSet.getDouble(ordinal), 0);
+    }
+  }
+
+  /**
+   * accessor test helper for the double column
+   */
+  private static final class DoubleAccessorTestHelper extends AccessorTestHelper {
+    private DoubleAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("6.0", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) 6, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 6, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(6, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(6L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDecimal(ResultSet resultSet) throws SQLException {
+      assertEquals(new BigDecimal(6).setScale(1), resultSet.getBigDecimal(ordinal));
+    }
+
+    @Override public void testGetFloat(ResultSet resultSet) throws SQLException {
+      assertEquals(6.0f, resultSet.getFloat(ordinal), 0);
+    }
+
+    @Override public void testGetDouble(ResultSet resultSet) throws SQLException {
+      assertEquals(6.0d, resultSet.getDouble(ordinal), 0);
+    }
+  }
+
+  /**
+   * accessor test helper for the date column
+   */
+  private static final class DateAccessorTestHelper extends AccessorTestHelper {
+    private DateAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("2016-10-10", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) -68, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 17084, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(17084, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(17084, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDate(ResultSet resultSet, Calendar calendar) throws SQLException {
+      assertEquals(new Date(1476130718123L), resultSet.getDate(ordinal, calendar));
+    }
+  }
+
+  /**
+   * accessor test helper for the time column
+   */
+  private static final class TimeAccessorTestHelper extends AccessorTestHelper {
+    private TimeAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("20:18:38", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) -85, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) -20053, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(73118123, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(73118123, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetTime(ResultSet resultSet, Calendar calendar) throws SQLException {
+      assertEquals(new Time(1476130718123L), resultSet.getTime(ordinal, calendar));
+    }
+  }
+
+  /**
+   * accessor test helper for the timestamp column
+   */
+  private static final class TimestampAccessorTestHelper extends AccessorTestHelper {
+    private TimestampAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("2016-10-10 20:18:38", resultSet.getString(ordinal));
+    }
+
+    @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
+      assertEquals(true, resultSet.getBoolean(ordinal));
+    }
+
+    @Override public void testGetByte(ResultSet resultSet) throws SQLException {
+      assertEquals((byte) -85, resultSet.getByte(ordinal));
+    }
+
+    @Override public void testGetShort(ResultSet resultSet) throws SQLException {
+      assertEquals((short) 16811, resultSet.getShort(ordinal));
+    }
+
+    @Override public void testGetInt(ResultSet resultSet) throws SQLException {
+      assertEquals(-1338031701, resultSet.getInt(ordinal));
+    }
+
+    @Override public void testGetLong(ResultSet resultSet) throws SQLException {
+      assertEquals(1476130718123L, resultSet.getLong(ordinal));
+    }
+
+    @Override public void testGetDate(ResultSet resultSet, Calendar calendar) throws SQLException {
+      assertEquals(new Date(1476130718123L), resultSet.getDate(ordinal, calendar));
+    }
+
+    @Override public void testGetTime(ResultSet resultSet, Calendar calendar) throws SQLException {
+      // how come both are different? DST...
+      //assertEquals(new Time(1476130718123L), resultSet.getTime(ordinal, calendar));
+      assertEquals(new Time(73118123L), resultSet.getTime(ordinal, calendar));
+    }
+
+    @Override public void testGetTimestamp(ResultSet resultSet, Calendar calendar)
+        throws SQLException {
+      assertEquals(new Timestamp(1476130718123L), resultSet.getTimestamp(ordinal, calendar));
+    }
+  }
+
+  /**
+   * accessor test helper for the string column
+   */
+  private static final class StringAccessorTestHelper extends AccessorTestHelper {
+    private StringAccessorTestHelper(int ordinal) {
+      super(ordinal);
+    }
+
+    @Override public void testGetString(ResultSet resultSet) throws SQLException {
+      assertEquals("testvalue", resultSet.getString(ordinal));
+    }
+  }
+
+  private static final Calendar DEFAULT_CALENDAR = Calendar
+      .getInstance(TimeZone.getTimeZone("GMT"));
+
+  private static Connection connection = null;
+  private static ResultSet resultSet = null;
+
+  @BeforeClass
+  public static void executeQuery() throws SQLException {
+    Properties properties = new Properties();
+    properties.setProperty("timeZone", "GMT");
+
+    connection = new TestDriver().connect("jdbc:test", properties);
+    resultSet = connection.createStatement().executeQuery("SELECT * FROM TABLE");
+    resultSet.next(); // move to the first record
+  }
+
+  @AfterClass
+  public static void cleanupQuery() throws SQLException {
+    if (resultSet != null) {
+      resultSet.close();
+    }
+
+    if (connection != null) {
+      connection.close();
+    }
+  }
+
+  @Parameters
+  public static Collection<AccessorTestHelper> data() {
+    return Arrays.<AccessorTestHelper>asList(
+        new BooleanAccesorTestHelper(1),
+        new ByteAccesorTestHelper(2),
+        new ShortAccessorTestHelper(3),
+        new IntAccessorTestHelper(4),
+        new LongAccessorTestHelper(5),
+        new FloatAccessorTestHelper(6),
+        new DoubleAccessorTestHelper(7),
+        new StringAccessorTestHelper(8),
+        new DateAccessorTestHelper(9),
+        new TimeAccessorTestHelper(10),
+        new TimestampAccessorTestHelper(11));
+  }
+
+  private final AccessorTestHelper testHelper;
+
+  public AvaticaResultSetConversionsTest(AccessorTestHelper testHelper) {
+    this.testHelper = testHelper;
+  }
+
+  @Test
+  public void testGetString() throws SQLException {
+    testHelper.testGetString(resultSet);
+  }
+
+  @Test
+  public void testGetBoolean() throws SQLException {
+    testHelper.testGetBoolean(resultSet);
+  }
+
+  @Test
+  public void testGetByte() throws SQLException {
+    testHelper.testGetByte(resultSet);
+  }
+
+  @Test
+  public void testGetShort() throws SQLException {
+    testHelper.testGetShort(resultSet);
+  }
+
+  @Test
+  public void testGetInt() throws SQLException {
+    testHelper.testGetInt(resultSet);
+  }
+
+  @Test
+  public void testGetLong() throws SQLException {
+    testHelper.testGetLong(resultSet);
+  }
+
+  @Test
+  public void testGetFloat() throws SQLException {
+    testHelper.testGetFloat(resultSet);
+  }
+
+  @Test
+  public void testGetDouble() throws SQLException {
+    testHelper.testGetDouble(resultSet);
+  }
+
+  @Test
+  public void testGetDecimal() throws SQLException {
+    testHelper.testGetDecimal(resultSet);
+  }
+
+  @Test
+  public void testGetBytes() throws SQLException {
+    testHelper.testGetBytes(resultSet);
+  }
+
+  @Test
+  public void testGetAsciiStream() throws SQLException {
+    testHelper.testGetAsciiStream(resultSet);
+  }
+
+  @Test
+  public void testGetBinaryStream() throws SQLException {
+    testHelper.testGetBinaryStream(resultSet);
+  }
+
+  @Test
+  public void testGetObject() throws SQLException {
+    testHelper.testGetObject(resultSet);
+  }
+
+  @Test
+  public void testGetCharacterStream() throws SQLException {
+    testHelper.testGetCharacterStream(resultSet);
+  }
+
+  @Test
+  public void testGetObjectWithMap() throws SQLException {
+    testHelper.testGetObject(resultSet, Collections.<String, Class<?>>emptyMap());
+  }
+
+  @Test
+  public void testGetRef() throws SQLException {
+    testHelper.testGetRef(resultSet);
+  }
+
+  @Test
+  public void testGetBlob() throws SQLException {
+    testHelper.testGetBlob(resultSet);
+  }
+
+  @Test
+  public void testGetClob() throws SQLException {
+    testHelper.testGetClob(resultSet);
+  }
+
+  @Test
+  public void testGetArray() throws SQLException {
+    testHelper.testGetArray(resultSet);
+  }
+
+  @Test
+  public void testGetDate() throws SQLException {
+    testHelper.testGetDate(resultSet, DEFAULT_CALENDAR);
+  }
+
+  @Test
+  public void testGetTime() throws SQLException {
+    testHelper.testGetTime(resultSet, DEFAULT_CALENDAR);
+  }
+
+  @Test
+  public void testGetTimestamp() throws SQLException {
+    testHelper.testGetTimestamp(resultSet, DEFAULT_CALENDAR);
+  }
+
+  @Test
+  public void getURL() throws SQLException {
+    testHelper.getURL(resultSet);
+  }
+
+  @Test
+  public void testGetNClob() throws SQLException {
+    testHelper.testGetNClob(resultSet);
+  }
+
+  @Test
+  public void testGetSQLXML() throws SQLException {
+    testHelper.testGetSQLXML(resultSet);
+  }
+
+  @Test
+  public void testGetNString() throws SQLException {
+    testHelper.testGetNString(resultSet);
+  }
+
+  @Test
+  public void testGetNCharacterStream() throws SQLException {
+    testHelper.testGetNCharacterStream(resultSet);
+  }
+}
+
+// End AvaticaResultSetConversionsTest.java

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/util/NumberAccessorTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/util/NumberAccessorTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.SQLException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 public class NumberAccessorTest {
 
   @Test
-  public void testBigDecimalZeroScale() {
+  public void testBigDecimalZeroScale() throws SQLException {
     final BigDecimal orig = new BigDecimal(BigInteger.valueOf(137L), 1);
     NumberAccessor accessor = new AbstractCursor.NumberAccessor(
         new Getter() {


### PR DESCRIPTION
Instead of throwing a generic RuntimeException if user tries to access a column
with an invalid type (like accessing a VARCHAR column as a long), throw SQLException
instead which is what is expected by users.