### PR TITLE
[CALCITE-1415] Add sub-query support for RelStructuredTypeFlattener

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -27,6 +27,7 @@ import org.apache.calcite.rel.core.Collect;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Sample;
 import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Uncollect;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalCalc;
@@ -39,7 +40,6 @@ import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
 import org.apache.calcite.rel.logical.LogicalTableModify;
-import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.stream.LogicalChi;
@@ -57,6 +57,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
@@ -124,7 +125,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
   //~ Instance fields --------------------------------------------------------
 
   private final RexBuilder rexBuilder;
-  private final RewriteRelVisitor visitor;
+  private final boolean restructure;
 
   private final Map<RelNode, RelNode> oldToNewRelMap = Maps.newHashMap();
   private RelNode currentRel;
@@ -137,10 +138,11 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
 
   public RelStructuredTypeFlattener(
       RexBuilder rexBuilder,
-      RelOptTable.ToRelContext toRelContext) {
+      RelOptTable.ToRelContext toRelContext,
+      boolean restructure) {
     this.rexBuilder = rexBuilder;
-    this.visitor = new RewriteRelVisitor();
     this.toRelContext = toRelContext;
+    this.restructure = restructure;
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -168,8 +170,9 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
     }
   }
 
-  public RelNode rewrite(RelNode root, boolean restructure) {
+  public RelNode rewrite(RelNode root) {
     // Perform flattening.
+    final RewriteRelVisitor visitor = new RewriteRelVisitor();
     visitor.visit(root, 0, null);
     RelNode flattened = getNewForOldRel(root);
     flattenedRootType = flattened.getRowType();
@@ -648,7 +651,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
         || (call.isA(SqlKind.NEW_SPECIFICATION));
   }
 
-  public void rewriteRel(LogicalTableScan rel) {
+  public void rewriteRel(TableScan rel) {
     RelNode newRel = rel.getTable().toRel(toRelContext);
     if (!SqlTypeUtil.isFlat(rel.getRowType())) {
       final List<Pair<RexNode, String>> flattenedExpList = Lists.newArrayList();
@@ -767,7 +770,11 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
           iInput += getNewForOldInput(inputRef.getIndex());
           return new RexInputRef(iInput, fieldType);
         } else if (refExp instanceof RexCorrelVariable) {
-          return fieldAccess;
+          RelDataType refType =
+              SqlTypeUtil.flattenRecordType(
+                  rexBuilder.getTypeFactory(), refExp.getType(), null);
+          refExp = rexBuilder.makeCorrel(refType, ((RexCorrelVariable) refExp).id);
+          return rexBuilder.makeFieldAccess(refExp, iInput);
         } else if (refExp.isA(SqlKind.CAST)) {
           // REVIEW jvs 27-Feb-2005:  what about a cast between
           // different user-defined types (once supported)?
@@ -810,6 +817,14 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
           rexBuilder,
           rexCall.getOperator(),
           rexCall.getOperands());
+    }
+
+    @Override public RexNode visitSubQuery(RexSubQuery subQuery) {
+      subQuery = (RexSubQuery) super.visitSubQuery(subQuery);
+      RelStructuredTypeFlattener flattener =
+          new RelStructuredTypeFlattener(rexBuilder, toRelContext, restructure);
+      RelNode rel = flattener.rewrite(subQuery.rel);
+      return subQuery.clone(rel);
     }
 
     private RexNode flattenComparison(

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -452,8 +452,8 @@ public class SqlToRelConverter {
       RelNode rootRel,
       boolean restructure) {
     RelStructuredTypeFlattener typeFlattener =
-        new RelStructuredTypeFlattener(rexBuilder, createToRelContext());
-    return typeFlattener.rewrite(rootRel, restructure);
+        new RelStructuredTypeFlattener(rexBuilder, createToRelContext(), restructure);
+    return typeFlattener.rewrite(rootRel);
   }
 
   /**
@@ -2242,12 +2242,16 @@ public class SqlToRelConverter {
         }
       }
 
+      RexFieldAccess topLevelFieldAccess = fieldAccess;
+      while (topLevelFieldAccess.getReferenceExpr() instanceof RexFieldAccess) {
+        topLevelFieldAccess = (RexFieldAccess) topLevelFieldAccess.getReferenceExpr();
+      }
       final RelDataTypeField field = foundNs.getRowType().getFieldList()
-          .get(fieldAccess.getField().getIndex() - namespaceOffset);
+          .get(topLevelFieldAccess.getField().getIndex() - namespaceOffset);
       int pos = namespaceOffset + field.getIndex();
 
       assert field.getType()
-          == lookup.getFieldAccess(correlName).getField().getType();
+          == topLevelFieldAccess.getField().getType();
 
       assert pos != -1;
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2401,6 +2401,48 @@ public class RelOptRulesTest extends RelOptTestBase {
     checkSubQuery(sql).check();
   }
 
+  @Test public void testStructTypeInNonCorrelatedSubQuery() {
+    final String sql = "select *\n"
+        + "from struct.t t1\n"
+        + "where c0 in (\n"
+        + "  select f1.c0 from struct.t t2)";
+    final HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(SubQueryRemoveRule.PROJECT)
+        .addRuleInstance(SubQueryRemoveRule.FILTER)
+        .addRuleInstance(SubQueryRemoveRule.JOIN)
+        .build();
+    final Tester tester = this.tester.withTrim(true).withExpand(false);
+    checkPlanning(tester, null, new HepPlanner(program), sql);
+  }
+
+  @Test public void testStructTypeInCorrelatedSubQuery() {
+    final String sql = "select *\n"
+        + "from struct.t t1\n"
+        + "where c0 = (\n"
+        + "  select max(f1.c0) from struct.t t2 where t1.k0 = t2.k0)";
+    final HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(SubQueryRemoveRule.PROJECT)
+        .addRuleInstance(SubQueryRemoveRule.FILTER)
+        .addRuleInstance(SubQueryRemoveRule.JOIN)
+        .build();
+    final Tester tester = this.tester.withTrim(true).withExpand(false);
+    checkPlanning(tester, null, new HepPlanner(program), sql);
+  }
+
+  @Test public void testStructTypeInCorrelatedSubQuery2() {
+    final String sql = "select *\n"
+        + "from struct.t t1\n"
+        + "where c0 in (\n"
+        + "  select f1.c0 from struct.t t2 where t1.c2 = t2.c2)";
+    final HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(SubQueryRemoveRule.PROJECT)
+        .addRuleInstance(SubQueryRemoveRule.FILTER)
+        .addRuleInstance(SubQueryRemoveRule.JOIN)
+        .build();
+    final Tester tester = this.tester.withTrim(true).withExpand(false);
+    checkPlanning(tester, null, new HepPlanner(program), sql);
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-434">[CALCITE-434]
    * Converting predicates on date dimension columns into date ranges</a>,

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1125,6 +1125,112 @@ LogicalProject(EMPNO=[$0])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testStructTypeInNonCorrelatedSubQuery">
+        <Resource name="sql">
+            <![CDATA[select *
+from struct.t t1
+where c0 in (
+  select f1.c0 from struct.t t2)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(K0=[$0], C1=[$1], C0=[$2], C10=[$3], C00=[$4], C2=[$5], A0=[$6], C3=[$7], A00=[$8])
+  LogicalFilter(condition=[IN($2, {
+LogicalProject(C0=[$4])
+  LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+    LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+})])
+    LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+      LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(K0=[$0], C1=[$1], C0=[$2], C10=[$3], C00=[$4], C2=[$5], A0=[$6], C3=[$7], A00=[$8])
+  LogicalProject(K0=[$0], C1=[$1], C0=[$2], C13=[$3], C04=[$4], C2=[$5], A0=[$6], C3=[$7], A08=[$8])
+    LogicalJoin(condition=[=($2, $9)], joinType=[inner])
+      LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+        LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+      LogicalAggregate(group=[{0}])
+        LogicalProject(C0=[$4])
+          LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+            LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testStructTypeInCorrelatedSubQuery">
+        <Resource name="sql">
+            <![CDATA[select *
+from struct.t t1
+where c0 = (
+  select max(f1.c0) from struct.t t2 where t1.k0 = t2.k0)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(K0=[$0], C1=[$1], C0=[$2], C10=[$3], C00=[$4], C2=[$5], A0=[$6], C3=[$7], A00=[$8])
+  LogicalFilter(condition=[=($2, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject($f0=[$4])
+    LogicalFilter(condition=[=($cor0.K0_0, $0)])
+      LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+        LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+}))], variablesSet=[[$cor0]])
+    LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+      LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(K0=[$0], C1=[$1], C0=[$2], C10=[$3], C00=[$4], C2=[$5], A0=[$6], C3=[$7], A00=[$8])
+  LogicalProject(K0=[$0], C1=[$1], C0=[$2], C13=[$3], C04=[$4], C2=[$5], A0=[$6], C3=[$7], A08=[$8])
+    LogicalFilter(condition=[=($2, $9)])
+      LogicalCorrelate(correlation=[$cor0], joinType=[LEFT], requiredColumns=[{0}])
+        LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+          LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+        LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+          LogicalProject($f0=[$4])
+            LogicalFilter(condition=[=($cor0.K0_0, $0)])
+              LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+                LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testStructTypeInCorrelatedSubQuery2">
+        <Resource name="sql">
+            <![CDATA[select *
+from struct.t t1
+where c0 in (
+  select f1.c0 from struct.t t2 where t1.c2 = t2.c2)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(K0=[$0], C1=[$1], C0=[$2], C10=[$3], C00=[$4], C2=[$5], A0=[$6], C3=[$7], A00=[$8])
+  LogicalFilter(condition=[IN($2, {
+LogicalProject(C0=[$4])
+  LogicalFilter(condition=[=($cor0.C2_5, $5)])
+    LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+      LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+})], variablesSet=[[$cor0]])
+    LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+      LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(K0=[$0], C1=[$1], C0=[$2], C10=[$3], C00=[$4], C2=[$5], A0=[$6], C3=[$7], A00=[$8])
+  LogicalProject(K0=[$0], C1=[$1], C0=[$2], C13=[$3], C04=[$4], C2=[$5], A0=[$6], C3=[$7], A08=[$8])
+    LogicalFilter(condition=[=($2, $9)])
+      LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{5}])
+        LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+          LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+        LogicalAggregate(group=[{0}])
+          LogicalProject(C0=[$4])
+            LogicalFilter(condition=[=($cor0.C2_5, $5)])
+              LogicalProject(K0=[$0], C1=[$1], C0=[$2.C0], C13=[$2.C1], C04=[$3.C0], C2=[$3.C2], A0=[$3.A0], C3=[$4.C3], A08=[$4.A0])
+                LogicalTableScan(table=[[CATALOG, STRUCT, T]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testExtractYearMonthToRange">
         <Resource name="sql">
             <![CDATA[select *


### PR DESCRIPTION
@julianhyde Could you please review this? The changes include:
1. Handle RexSubQuery in RelStructuredTypeFlattener.
2. Enable structured type field access on correlate variables in RelStructuredTypeFlattener.RewriteRexShuttle.
3. Bug fix for structured type field access on correlate variables in SqlToRelConverter.getCorrelationUse(),

So after the fix, structured types can work well if "expand" is turned off in SqlToRelConverter.