### PR TITLE
CALCITE-1418 Fix binary version of SUBSTRING() functions

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -587,8 +587,6 @@ public class RexLiteral extends RexNode {
       return null;
     }
     switch (typeName) {
-    case BINARY:
-      return ((ByteBuffer) value).array();
     case CHAR:
       return ((NlsString) value).getValue();
     case DECIMAL:

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -124,6 +124,16 @@ public class SqlFunctions {
     return s.substring(from - 1);
   }
 
+  /** SQL SUBSTRING(binary FROM ... FOR ...) function. */
+  public static ByteString substring(ByteString b, int from, int for_) {
+    return b.substring(from - 1, Math.min(from - 1 + for_, b.length()));
+  }
+
+  /** SQL SUBSTRING(binary FROM ...) function. */
+  public static ByteString substring(ByteString b, int from) {
+    return b.substring(from - 1);
+  }
+
   /** SQL UPPER(string) function. */
   public static String upper(String s) {
     return s.toUpperCase();

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4118,6 +4118,13 @@ public abstract class SqlOperatorBaseTest {
     tester.checkString(
         "substring('abc' from 2)", "bc", "VARCHAR(3) NOT NULL");
 
+    tester.checkString(
+        "substring(x'aabbcc' from 1 for 2)",
+        "aabb",
+        "VARBINARY(3) NOT NULL");
+    tester.checkString(
+        "substring(x'aabbcc' from 2)", "bbcc", "VARBINARY(3) NOT NULL");
+
     if (Bug.FRG296_FIXED) {
       // substring regexp not supported yet
       tester.checkString(


### PR DESCRIPTION
SqlFunctions doesn't have overloaded version of substring() which receives ByteString.
Hence calling SUBSTRING(binary FROM integer) and SUBSTRING(binary FROM integer FOR integer) will fail.

This patch adds SqlFunctions.substring(ByteString, int[, int]), and relevant test.
Also fix RexLiteral since now ByteString is used for representing binary literal.