### PR TITLE
CALCITE-1419 Fix JDBC LTRIM, RTRIM, LOCATE with 3 params

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4067,6 +4067,10 @@ SqlNode BuiltinFunctionCall() :
         e = AtomicRowExpression() { args = startList(e); }
         <IN>
         e = Expression(ExprContext.ACCEPT_SUBQUERY) { args.add(e);}
+        [
+            <FOR>
+            e = Expression(ExprContext.ACCEPT_SUBQUERY) { args.add(e); }
+        ]
         <RPAREN>
         {
             return SqlStdOperatorTable.POSITION.createCall(

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1322,6 +1322,25 @@ public class SqlFunctions {
     return s.indexOf(seek) + 1;
   }
 
+  /** SQL {@code POSITION(seek IN string FOR integer)} function. */
+  public static int position(String seek, String s, int for_) {
+    if ((for_ - 1) >= s.length()) {
+      return seek.length() == 0 ? s.length() : 0;
+    }
+
+    return s.indexOf(seek, for_ - 1) + 1;
+  }
+
+  /** SQL {@code POSITION(seek IN string FOR integer)} function. */
+  public static int position(ByteString seek, ByteString s, int for_) {
+    if ((for_ - 1) >= s.length()) {
+      return seek.length() == 0 ? s.length() : 0;
+    }
+
+    // ByteString doesn't have substring(ByteString, int), so apply substring and find from there
+    return position(s.substring(for_ - 1), seek);
+  }
+
   /** Helper for rounding. Truncate(12345, 1000) returns 12000. */
   public static long round(long v, long x) {
     return truncate(v + x / 2, x);

--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -674,7 +674,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
               assert 1 == operands.length;
               return super.createCall(pos,
                   SqlTrimFunction.Flag.LEADING.symbol(SqlParserPos.ZERO),
-                  SqlLiteral.createCharString(" ", null),
+                  SqlLiteral.createCharString(" ", SqlParserPos.ZERO),
                   operands[0]);
             }
           });
@@ -686,7 +686,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
               assert 1 == operands.length;
               return super.createCall(pos,
                   SqlTrimFunction.Flag.TRAILING.symbol(SqlParserPos.ZERO),
-                  SqlLiteral.createCharString(" ", null),
+                  SqlLiteral.createCharString(" ", SqlParserPos.ZERO),
                   operands[0]);
             }
           });

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlPositionFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlPositionFunction.java
@@ -24,6 +24,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 
 /**
  * The <code>POSITION</code> function.
@@ -35,13 +36,18 @@ public class SqlPositionFunction extends SqlFunction {
   // params are all same character set, like OVERLAY does implicitly
   // as part of rtiDyadicStringSumPrecision
 
+  private static final SqlOperandTypeChecker OTC_CUSTOM =
+      OperandTypes.or(
+          OperandTypes.STRING_SAME_SAME,
+          OperandTypes.STRING_SAME_SAME_INTEGER);
+
   public SqlPositionFunction() {
     super(
         "POSITION",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.INTEGER_NULLABLE,
         null,
-        OperandTypes.STRING_SAME_SAME,
+        OTC_CUSTOM,
         SqlFunctionCategory.NUMERIC);
   }
 
@@ -56,21 +62,42 @@ public class SqlPositionFunction extends SqlFunction {
     call.operand(0).unparse(writer, leftPrec, rightPrec);
     writer.sep("IN");
     call.operand(1).unparse(writer, leftPrec, rightPrec);
+    if (3 == call.operandCount()) {
+      writer.sep("FOR");
+      call.operand(2).unparse(writer, leftPrec, rightPrec);
+    }
     writer.endFunCall(frame);
   }
 
   public String getSignatureTemplate(final int operandsCount) {
-    assert operandsCount == 2;
-    return "{0}({1} IN {2})";
+    switch (operandsCount) {
+    case 2:
+      return "{0}({1} IN {2})";
+    case 3:
+      return "{0}({1} IN {2} FOR {3})";
+    }
+    assert false;
+    return null;
   }
 
   public boolean checkOperandTypes(
       SqlCallBinding callBinding,
       boolean throwOnFailure) {
     // check that the two operands are of same type.
-    return OperandTypes.SAME_SAME.checkOperandTypes(
-        callBinding, throwOnFailure)
-        && super.checkOperandTypes(callBinding, throwOnFailure);
+    switch (callBinding.getOperandCount()) {
+    case 2:
+      return OperandTypes.SAME_SAME.checkOperandTypes(
+          callBinding, throwOnFailure)
+          && super.checkOperandTypes(callBinding, throwOnFailure);
+
+    case 3:
+      return OperandTypes.SAME_SAME_INTEGER.checkOperandTypes(
+          callBinding, throwOnFailure)
+          && super.checkOperandTypes(callBinding, throwOnFailure);
+    }
+
+    assert false;
+    return false;
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -326,6 +326,9 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker SAME_SAME =
       new SameOperandTypeChecker(2);
 
+  public static final SqlSingleOperandTypeChecker SAME_SAME_INTEGER =
+      new SameOperandTypeExceptLastOperandChecker(3, "INTEGER");
+
   /**
    * Operand type-checking strategy where three operands must all be in the
    * same type family.
@@ -388,6 +391,13 @@ public abstract class OperandTypes {
   STRING_STRING_INTEGER_INTEGER =
       family(SqlTypeFamily.STRING, SqlTypeFamily.STRING,
           SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER);
+
+  /**
+   * Operand type-checking strategy where two operands must both be in the
+   * same string type family and last type is INTEGER.
+   */
+  public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_INTEGER =
+      OperandTypes.and(STRING_STRING_INTEGER, SAME_SAME_INTEGER);
 
   public static final SqlSingleOperandTypeChecker ANY =
       family(SqlTypeFamily.ANY);

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -1689,21 +1689,16 @@ public abstract class SqlOperatorBaseTest {
         4,
         "INTEGER NOT NULL");
 
-    // only the 2 arg version of locate is implemented
-    if (false) {
-      tester.checkScalar(
-          "{fn LOCATE(string1, string2[, start])}",
-          null,
-          "");
-    }
+    tester.checkScalar(
+        "{fn LOCATE('ha', 'alphabet', 6)}",
+        0,
+        "INTEGER NOT NULL");
 
-    // ltrim is implemented but has a bug in arg checking
-    if (false) {
-      tester.checkScalar(
-          "{fn LTRIM(' xxx  ')}",
-          "xxx",
-          "VARCHAR(6)");
-    }
+    tester.checkScalar(
+        "{fn LTRIM(' xxx  ')}",
+        "xxx  ",
+        "VARCHAR(6) NOT NULL");
+
     if (false) {
       tester.checkScalar("{fn REPEAT(string, count)}", null, "");
     }
@@ -1717,13 +1712,11 @@ public abstract class SqlOperatorBaseTest {
       tester.checkScalar("{fn RIGHT(string, count)}", null, "");
     }
 
-    // rtrim is implemented but has a bug in arg checking
-    if (false) {
-      tester.checkScalar(
-          "{fn RTRIM(' xxx  ')}",
-          "xxx",
-          "VARCHAR(6)");
-    }
+    tester.checkScalar(
+        "{fn RTRIM(' xxx  ')}",
+        " xxx",
+        "VARCHAR(6) NOT NULL");
+
     if (false) {
       tester.checkScalar("{fn SOUNDEX(string)}", null, "");
     }
@@ -3554,6 +3547,15 @@ public abstract class SqlOperatorBaseTest {
     tester.setFor(SqlStdOperatorTable.POSITION);
     tester.checkScalarExact("position('b' in 'abc')", "2");
     tester.checkScalarExact("position('' in 'abc')", "1");
+    tester.checkScalarExact("position('b' in 'abc' FOR 3)", "0");
+    tester.checkScalarExact("position('b' in 'abc' FOR 5)", "0");
+    tester.checkScalarExact("position('' in 'abc' FOR 10)", "3");
+
+    tester.checkScalarExact("position(x'bb' in x'aabbcc')", "2");
+    tester.checkScalarExact("position(x'' in x'aabbcc')", "1");
+    tester.checkScalarExact("position(x'bb' in x'aabbcc' FOR 3)", "0");
+    tester.checkScalarExact("position(x'bb' in x'aabbcc' FOR 5)", "0");
+    tester.checkScalarExact("position(x'' in x'aabbcc' FOR 10)", "3");
 
     // FRG-211
     tester.checkScalarExact("position('tra' in 'fdgjklewrtra')", "10");

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -732,9 +732,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   @Test public void testPosition() {
     checkExp("position('mouse' in 'house')");
     checkExp("position(x'11' in x'100110')");
+    checkExp("position(x'11' in x'100110' FOR 10)");
     checkExp("position(x'abcd' in x'')");
     checkExpType("position('mouse' in 'house')", "INTEGER NOT NULL");
     checkWholeExpFails("position(x'1234' in '110')",
+        "Parameters must be of the same type");
+    checkWholeExpFails("position(x'1234' in '110' for 3)",
         "Parameters must be of the same type");
   }
 
@@ -1149,9 +1152,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     checkWholeExpFails("{fn insert('','',1,2)}", "(?s).*.*");
     checkWholeExpFails("{fn insert('','',1)}", "(?s).*4.*");
 
-    // TODO: this is legal JDBC syntax, but the 3 ops call is not
-    // implemented
-    checkWholeExpFails("{fn locate('','',1)}", ANY);
+    checkExp("{fn locate('','',1)}");
     checkWholeExpFails(
         "{fn log10('1')}",
         "(?s).*Cannot apply.*fn LOG10..<CHAR.1.>.*");

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -920,6 +920,7 @@ The operator precedence and associativity, highest to lowest.
 | UPPER(string)              | Returns a character string converted to upper case
 | LOWER(string)              | Returns a character string converted to lower case
 | POSITION(string1 IN string2) | Returns the position of the first occurrence of *string1* in *string2*
+| POSITION(string1 IN string2 FOR integer) | Returns the position of the first occurrence of *string1* in *string2* starting at a given point.
 | TRIM( { BOTH &#124; LEADING &#124; TRAILING } string1 FROM string2) | Removes the longest string containing only the characters in *string1* from the start/end/both ends of *string1*
 | OVERLAY(string1 PLACING string2 FROM integer [ FOR integer2 ]) | Replaces a substring of *string1* with *string2*
 | SUBSTRING(string FROM integer)  | Returns a substring of a character string starting at a given point.


### PR DESCRIPTION
* For fixing LOCATE with 3 params easily, modify POSITION to also have optional third parameter
  * POSITION(string IN string FOR integer)
* Add newly added POSITION to SQL reference page

Btw, since Avatica seems to be treated as individual project, while implementing `SqlFunctions.position(ByteString, ByteString, int)` I just apply substring and seek from the result of substring, instead of adding  `ByteString.substring(ByteString, int)` to ByteString. 
IMO, we can address this to Avatica later, and use that method after Avatica is released.