### PR TITLE
[CALCITE-1433] Fix missing avatica test-jar dependency

### DIFF
--- a/avatica/pom.xml
+++ b/avatica/pom.xml
@@ -158,7 +158,7 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>org.apache.calcite.avatica</groupId>
-        <artifactId>avatica</artifactId>
+        <artifactId>avatica-core</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
       </dependency>

--- a/avatica/server/pom.xml
+++ b/avatica/server/pom.xml
@@ -67,7 +67,7 @@ limitations under the License.
     <!-- test dependencies -->
     <dependency>
       <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica</artifactId>
+      <artifactId>avatica-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
During CALCITE-1224, some artifacts have been renamed. Fix avatica-server
module to use the new artifact name.