### PR TITLE
CALCITE-1433: Add missing dependencies to avatica-server

### DIFF
--- a/avatica/server/pom.xml
+++ b/avatica/server/pom.xml
@@ -40,6 +40,10 @@ limitations under the License.
       <artifactId>avatica-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.calcite.avatica</groupId>
+      <artifactId>avatica-metrics</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
@@ -69,6 +73,11 @@ limitations under the License.
       <groupId>org.apache.calcite.avatica</groupId>
       <artifactId>avatica-core</artifactId>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Adds some missing direct dependencies to avatica-server caught by
maven-dependency-plugin analyze goal