### PR TITLE
[CALCITE-1434] AggregateFunctionImpl doesnt work if the class implements a generic interface

### DIFF
--- a/core/src/main/java/org/apache/calcite/schema/impl/ReflectiveFunctionBase.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ReflectiveFunctionBase.java
@@ -82,7 +82,7 @@ public abstract class ReflectiveFunctionBase implements Function {
    */
   static Method findMethod(Class<?> clazz, String name) {
     for (Method method : clazz.getMethods()) {
-      if (method.getName().equals(name)) {
+      if (method.getName().equals(name) && !method.isBridge()) {
         return method;
       }
     }

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -440,6 +440,60 @@ public class UdfTest {
         "Caused by: java.lang.RuntimeException: In user-defined aggregate class 'org.apache.calcite.util.Smalls$SumFunctionBadIAdd', first parameter to 'add' method must be the accumulator (the return type of the 'init' method)");
   }
 
+  @Test public void testUserDefinedAggregateFunctionImplmentsInterface() {
+    final String empDept = JdbcTest.EmpDeptTableFactory.class.getName();
+    final String mySum3 = Smalls.MySum3.class.getName();
+    final CalciteAssert.AssertThat with = CalciteAssert.model("{\n"
+            + "  version: '1.0',\n"
+            + "   schemas: [\n"
+            + "     {\n"
+            + "       name: 'adhoc',\n"
+            + "       tables: [\n"
+            + "         {\n"
+            + "           name: 'EMPLOYEES',\n"
+            + "           type: 'custom',\n"
+            + "           factory: '" + empDept + "',\n"
+            + "           operand: {'foo': true, 'bar': 345}\n"
+            + "         }\n"
+            + "       ],\n"
+            + "       functions: [\n"
+            + "         {\n"
+            + "           name: 'MY_SUM3',\n"
+            + "           className: '" + mySum3 + "'\n"
+            + "         }\n"
+            + "       ]\n"
+            + "     }\n"
+            + "   ]\n"
+            + "}")
+            .withDefaultSchema("adhoc");
+
+    with.query("select my_sum3(\"deptno\") as p from EMPLOYEES\n")
+            .returns("P=50\n");
+    with.withDefaultSchema(null)
+            .query(
+                    "select \"adhoc\".my_sum3(\"deptno\") as p from \"adhoc\".EMPLOYEES\n")
+            .returns("P=50\n");
+    with.query("select my_sum3(\"empid\"), \"deptno\" as p from EMPLOYEES\n")
+            .throws_(
+                    "Expression 'deptno' is not being grouped");
+    with.query("select my_sum3(\"deptno\") as p from EMPLOYEES\n")
+            .returns("P=50\n");
+    with.query("select my_sum3(\"name\") as p from EMPLOYEES\n")
+            .throws_(
+                    "Cannot apply 'MY_SUM3' to arguments of type 'MY_SUM3(<JAVATYPE(CLASS JAVA.LANG.STRING)>)'. Supported form(s): 'MY_SUM3(<NUMERIC>)");
+    with.query("select my_sum3(\"deptno\", 1) as p from EMPLOYEES\n")
+            .throws_(
+                    "No match found for function signature MY_SUM3(<NUMERIC>, <NUMERIC>)");
+    with.query("select my_sum3() as p from EMPLOYEES\n")
+            .throws_(
+                    "No match found for function signature MY_SUM3()");
+    with.query("select \"deptno\", my_sum3(\"deptno\") as p from EMPLOYEES\n"
+            + "group by \"deptno\"")
+            .returnsUnordered(
+                    "deptno=20; P=20",
+                    "deptno=10; P=30");
+  }
+
   private static CalciteAssert.AssertThat withBadUdf(Class clazz) {
     final String empDept = JdbcTest.EmpDeptTableFactory.class.getName();
     final String className = clazz.getName();

--- a/core/src/test/java/org/apache/calcite/util/Smalls.java
+++ b/core/src/test/java/org/apache/calcite/util/Smalls.java
@@ -469,6 +469,38 @@ public class Smalls {
     }
   }
 
+  /** A generic interface for defining user defined aggregate functions */
+  private interface UDAF<A, V, R> {
+    A init();
+
+    A add(A accumulator, V val);
+
+    A merge(A accumulator1, A accumulator2);
+
+    R result(A accumulator);
+  }
+
+  /**
+   * Example of user-defined aggregate function that implements a generic interface.
+   */
+  public static class MySum3 implements UDAF<Integer, Integer, Integer> {
+    @Override public Integer init() {
+      return 0;
+    }
+
+    @Override public Integer add(Integer accumulator, Integer val) {
+      return accumulator + val;
+    }
+
+    @Override public Integer merge(Integer accumulator1, Integer accumulator2) {
+      return accumulator1 + accumulator2;
+    }
+
+    @Override public Integer result(Integer accumulator) {
+      return accumulator;
+    }
+  }
+
   /** Example of a user-defined aggregate function (UDAF), whose methods are
    * static. */
   public static class MyStaticSumFunction {


### PR DESCRIPTION
Skip bridge methods in ReflectiveFunctionBase.findMethod so that user defined aggregate functions can implement generic interfaces.