### PR TITLE
CALCITE-1442: Fix SqlIntervalQualifier#getFractionalSecondPrecisionPreservingDefault()

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
@@ -248,7 +248,7 @@ public class SqlIntervalQualifier extends SqlNode {
     if (useDefaultFractionalSecondPrecision()) {
       return RelDataType.PRECISION_NOT_SPECIFIED;
     } else {
-      return startPrecision;
+      return fractionalSecondPrecision;
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -527,6 +527,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     checkExpType(
         "CASE 1 WHEN 1 THEN cast(null as integer) WHEN 2 THEN cast(cast(null as tinyint) as integer) END",
         "INTEGER");
+    checkExpType(
+        "CASE 1 WHEN 1 THEN INTERVAL '12 3:4:5.6' DAY TO SECOND(6) WHEN 2 THEN INTERVAL '12 3:4:5.6' DAY TO SECOND(9) END",
+        "INTERVAL DAY TO SECOND(9)");
   }
 
   @Test public void testCaseExpressionFails() {


### PR DESCRIPTION
Change the field returned by getFractionalSecondPrecisionPreservingDefault()
from startPrecision to fractionalSecondPrecision