### PR TITLE
CALCITE-1453 Support ANY type with binary compare / arithmetic operators

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -1636,6 +1636,7 @@ public class RexImpTable {
             SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
             SqlStdOperatorTable.GREATER_THAN,
             SqlStdOperatorTable.GREATER_THAN_OR_EQUAL);
+    public static final String METHOD_POSTFIX_FOR_ANY_TYPE = "Any";
 
     private final ExpressionType expressionType;
     private final String backupMethodName;
@@ -1664,31 +1665,22 @@ public class RexImpTable {
       //   ignore_null
       //     return x == null ? y : y == null ? x : x OP y
       if (backupMethodName != null) {
+        RelDataType leftType = call.getOperands().get(0).getType();
+        RelDataType rightType = call.getOperands().get(1).getType();
+
+        if (leftType.getSqlTypeName().equals(SqlTypeName.ANY)
+            || rightType.getSqlTypeName().equals(SqlTypeName.ANY)) {
+          // one or both of parameter(s) is(are) ANY type
+          return callBackupMethodAnyType(translator, call, expressions);
+        }
+
         Type type0 = expressions.get(0).getType();
         Type type1 = expressions.get(1).getType();
         final SqlBinaryOperator op = (SqlBinaryOperator) call.getOperator();
-
-        if (type0 == Object.class || type1 == Object.class) {
-          // one or both of parameter(s) is(are) ANY type
-          final Primitive primitive0 = Primitive.of(type0);
-          final Primitive primitive1 = Primitive.of(type1);
-          Expression expression0 = expressions.get(0);
-          Expression expression1 = expressions.get(1);
-
-          if (primitive0 != null) {
-            expression0 = Expressions.box(expression0, primitive0);
-          }
-          if (primitive1 != null) {
-            expression1 = Expressions.box(expression1, primitive1);
-          }
-
-          return Expressions.call(SqlFunctions.class, backupMethodName, expression0, expression1);
-        } else {
-          final Primitive primitive = Primitive.ofBoxOr(type0);
-          if (primitive == null || type1 == BigDecimal.class
-              || COMPARISON_OPERATORS.contains(op) && !COMP_OP_TYPES.contains(primitive)) {
-            return Expressions.call(SqlFunctions.class, backupMethodName, expressions);
-          }
+        final Primitive primitive = Primitive.ofBoxOr(type0);
+        if (primitive == null || type1 == BigDecimal.class
+            || COMPARISON_OPERATORS.contains(op) && !COMP_OP_TYPES.contains(primitive)) {
+          return Expressions.call(SqlFunctions.class, backupMethodName, expressions);
         }
       }
 
@@ -1697,6 +1689,29 @@ public class RexImpTable {
       return Types.castIfNecessary(returnType,
           Expressions.makeBinary(expressionType, expressions.get(0),
               expressions.get(1)));
+    }
+
+    private Expression callBackupMethodAnyType(RexToLixTranslator translator, RexCall call,
+        List<Expression> expressions) {
+      String backupMethodNameForAnyType = backupMethodName + METHOD_POSTFIX_FOR_ANY_TYPE;
+      Type type0 = expressions.get(0).getType();
+      Type type1 = expressions.get(1).getType();
+
+      // one or both of parameter(s) is(are) ANY type
+      final Primitive primitive0 = Primitive.of(type0);
+      final Primitive primitive1 = Primitive.of(type1);
+      Expression expression0 = expressions.get(0);
+      Expression expression1 = expressions.get(1);
+
+      if (primitive0 != null) {
+        expression0 = Expressions.box(expression0, primitive0);
+      }
+      if (primitive1 != null) {
+        expression1 = Expressions.box(expression1, primitive1);
+      }
+
+      return Expressions.call(SqlFunctions.class, backupMethodNameForAnyType,
+          expression0, expression1);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -360,7 +360,7 @@ public class SqlFunctions {
       // The result of SqlFunctions.eq(BigDecimal, BigDecimal) is making more sense than
       // BigDecimal.equals(BigDecimal).
       // So if both of types are BigDecimal, we just use SqlFunctions.eq(BigDecimal, BigDecimal).
-      if (bothParametersAssignable(b0, b1, BigDecimal.class)) {
+      if (BigDecimal.class.isAssignableFrom(b0.getClass())) {
         return eq((BigDecimal) b0, (BigDecimal) b1);
       } else {
         return b0.equals(b1);
@@ -416,7 +416,7 @@ public class SqlFunctions {
   /** SQL &lt; operator applied to Object values. */
   public static boolean lt(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && bothParametersAssignable(b0, b1, Comparable.class)) {
+        && Comparable.class.isAssignableFrom(b0.getClass())) {
       return ((Comparable) b0).compareTo(b1) < 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return lt(toBigDecimal((Number) b0), toBigDecimal((Number) b1));
@@ -451,7 +451,7 @@ public class SqlFunctions {
   /** SQL &le; operator applied to Object values. */
   public static boolean le(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && bothParametersAssignable(b0, b1, Comparable.class)) {
+        && Comparable.class.isAssignableFrom(b0.getClass())) {
       return ((Comparable) b0).compareTo(b1) <= 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return le(toBigDecimal((Number) b0), toBigDecimal((Number) b1));
@@ -486,7 +486,7 @@ public class SqlFunctions {
   /** SQL &gt; operator applied to Object values. */
   public static boolean gt(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && bothParametersAssignable(b0, b1, Comparable.class)) {
+        && Comparable.class.isAssignableFrom(b0.getClass())) {
       return ((Comparable) b0).compareTo(b1) > 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return gt(toBigDecimal((Number) b0), toBigDecimal((Number) b1));
@@ -521,7 +521,7 @@ public class SqlFunctions {
   /** SQL &ge; operator applied to Object values. */
   public static boolean ge(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && bothParametersAssignable(b0, b1, Comparable.class)) {
+        && Comparable.class.isAssignableFrom(b0.getClass())) {
       return ((Comparable) b0).compareTo(b1) >= 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return ge(toBigDecimal((Number) b0), toBigDecimal((Number) b1));

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -356,6 +356,12 @@ public class SqlFunctions {
   /** SQL = operator applied to Object values (including String; neither
    * side may be null). */
   public static boolean eq(Object b0, Object b1) {
+    return b0.equals(b1);
+  }
+
+  /** SQL = operator applied to Object values (either or both operands is(are) ANY type; neither
+   * side may be null). */
+  public static boolean eqAny(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())) {
       // The result of SqlFunctions.eq(BigDecimal, BigDecimal) is making more sense than
       // BigDecimal.equals(BigDecimal).
@@ -390,6 +396,12 @@ public class SqlFunctions {
     return !eq(b0, b1);
   }
 
+  /** SQL &lt;&gt; operator applied to Object values (either or both operands is(are) ANY type;
+   * including String; neither side may be null). */
+  public static boolean neAny(Object b0, Object b1) {
+    return !eqAny(b0, b1);
+  }
+
   // <
 
   /** SQL &lt; operator applied to boolean values. */
@@ -413,7 +425,7 @@ public class SqlFunctions {
   }
 
   /** SQL &lt; operator applied to Object values. */
-  public static boolean lt(Object b0, Object b1) {
+  public static boolean ltAny(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
         && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) < 0;
@@ -447,8 +459,8 @@ public class SqlFunctions {
     return b0.compareTo(b1) <= 0;
   }
 
-  /** SQL &le; operator applied to Object values. */
-  public static boolean le(Object b0, Object b1) {
+  /** SQL &le; operator applied to Object values. (either or both operands is(are) ANY type) */
+  public static boolean leAny(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
         && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) <= 0;
@@ -482,8 +494,8 @@ public class SqlFunctions {
     return b0.compareTo(b1) > 0;
   }
 
-  /** SQL &gt; operator applied to Object values. */
-  public static boolean gt(Object b0, Object b1) {
+  /** SQL &gt; operator applied to Object values. (either or both operands is(are) ANY type) */
+  public static boolean gtAny(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
         && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) > 0;
@@ -517,8 +529,8 @@ public class SqlFunctions {
     return b0.compareTo(b1) >= 0;
   }
 
-  /** SQL &ge; operator applied to Object values. */
-  public static boolean ge(Object b0, Object b1) {
+  /** SQL &ge; operator applied to Object values. (either or both operands is(are) ANY type) */
+  public static boolean geAny(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
         && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) >= 0;
@@ -573,8 +585,9 @@ public class SqlFunctions {
     return (b0 == null || b1 == null) ? null : b0.add(b1);
   }
 
-  /** SQL <code>+</code> operator applied to Object values. */
-  public static Object plus(Object b0, Object b1) {
+  /** SQL <code>+</code> operator applied to Object values.
+   * (either or both operands is(are) ANY type) */
+  public static Object plusAny(Object b0, Object b1) {
     if (b0 == null || b1 == null) {
       return null;
     }
@@ -630,8 +643,9 @@ public class SqlFunctions {
     return (b0 == null || b1 == null) ? null : b0.subtract(b1);
   }
 
-  /** SQL <code>-</code> operator applied to Object values. */
-  public static Object minus(Object b0, Object b1) {
+  /** SQL <code>-</code> operator applied to Object values.
+   * (either or both operands is(are) ANY type) */
+  public static Object minusAny(Object b0, Object b1) {
     if (b0 == null || b1 == null) {
       return null;
     }
@@ -689,8 +703,9 @@ public class SqlFunctions {
         : b0.divide(b1, MathContext.DECIMAL64);
   }
 
-  /** SQL <code>/</code> operator applied to Object values. */
-  public static Object divide(Object b0, Object b1) {
+  /** SQL <code>/</code> operator applied to Object values.
+   * (either or both operands is(are) ANY type) */
+  public static Object divideAny(Object b0, Object b1) {
     if (b0 == null || b1 == null) {
       return null;
     }
@@ -756,8 +771,9 @@ public class SqlFunctions {
     return (b0 == null || b1 == null) ? null : b0.multiply(b1);
   }
 
-  /** SQL <code>*</code> operator applied to Object values. */
-  public static Object multiply(Object b0, Object b1) {
+  /** SQL <code>*</code> operator applied to Object values.
+   * (either or both operands is(are) ANY type) */
+  public static Object multiplyAny(Object b0, Object b1) {
     if (b0 == null || b1 == null) {
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -360,7 +360,7 @@ public class SqlFunctions {
       // The result of SqlFunctions.eq(BigDecimal, BigDecimal) is making more sense than
       // BigDecimal.equals(BigDecimal).
       // So if both of types are BigDecimal, we just use SqlFunctions.eq(BigDecimal, BigDecimal).
-      if (BigDecimal.class.isAssignableFrom(b0.getClass())) {
+      if (BigDecimal.class.isInstance(b0)) {
         return eq((BigDecimal) b0, (BigDecimal) b1);
       } else {
         return b0.equals(b1);
@@ -374,8 +374,7 @@ public class SqlFunctions {
   }
 
   private static boolean bothParametersAssignable(Object b0, Object b1, Class clazz) {
-    return clazz.isAssignableFrom(b0.getClass())
-        && clazz.isAssignableFrom(b1.getClass());
+    return clazz.isInstance(b0) && clazz.isInstance(b1);
   }
 
   // <>
@@ -416,7 +415,7 @@ public class SqlFunctions {
   /** SQL &lt; operator applied to Object values. */
   public static boolean lt(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && Comparable.class.isAssignableFrom(b0.getClass())) {
+        && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) < 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return lt(toBigDecimal((Number) b0), toBigDecimal((Number) b1));
@@ -451,7 +450,7 @@ public class SqlFunctions {
   /** SQL &le; operator applied to Object values. */
   public static boolean le(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && Comparable.class.isAssignableFrom(b0.getClass())) {
+        && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) <= 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return le(toBigDecimal((Number) b0), toBigDecimal((Number) b1));
@@ -486,7 +485,7 @@ public class SqlFunctions {
   /** SQL &gt; operator applied to Object values. */
   public static boolean gt(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && Comparable.class.isAssignableFrom(b0.getClass())) {
+        && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) > 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return gt(toBigDecimal((Number) b0), toBigDecimal((Number) b1));
@@ -521,7 +520,7 @@ public class SqlFunctions {
   /** SQL &ge; operator applied to Object values. */
   public static boolean ge(Object b0, Object b1) {
     if (b0.getClass().equals(b1.getClass())
-        && Comparable.class.isAssignableFrom(b0.getClass())) {
+        && Comparable.class.isInstance(b0)) {
       return ((Comparable) b0).compareTo(b1) >= 0;
     } else if (bothParametersAssignable(b0, b1, Number.class)) {
       return ge(toBigDecimal((Number) b0), toBigDecimal((Number) b1));

--- a/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
@@ -161,7 +161,7 @@ public class SqlDataTypeSpec extends SqlNode {
   /** Returns a copy of this data type specification with a given
    * nullability. */
   public SqlDataTypeSpec withNullable(Boolean nullable) {
-    if (nullable.equals(this.nullable)) {
+    if (Objects.equals(nullable, this.nullable)) {
       return this;
     }
     return new SqlDataTypeSpec(collectionsTypeName, typeName, precision, scale,

--- a/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
@@ -18,7 +18,6 @@ package org.apache.calcite.sql;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
@@ -162,7 +161,7 @@ public class SqlDataTypeSpec extends SqlNode {
   /** Returns a copy of this data type specification with a given
    * nullability. */
   public SqlDataTypeSpec withNullable(Boolean nullable) {
-    if (SqlFunctions.eq(nullable, this.nullable)) {
+    if (nullable.equals(this.nullable)) {
       return this;
     }
     return new SqlDataTypeSpec(collectionsTypeName, typeName, precision, scale,

--- a/core/src/test/java/org/apache/calcite/test/CollectionTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/CollectionTypeTest.java
@@ -168,24 +168,52 @@ public class CollectionTypeTest {
 
     final Statement statement = connection.createStatement();
 
-    // Since the value type is ANY, we need to wrap the value to CAST in order to
-    // compare with literal. if it doesn't, Exception is thrown at Runtime.
-    // This is only occurred with primitive type because of providing overloaded methods
-    try {
-      final String sql = "select \"ID\", \"MAPFIELD\"['c'] AS \"MAPFIELD_C\","
-          + " \"NESTEDMAPFIELD\", \"ARRAYFIELD\" "
-          + "from \"s\".\"nested\" "
-          + "where \"NESTEDMAPFIELD\"['a']['b'] = 2 AND \"ARRAYFIELD\"[2] = 200";
-      statement.executeQuery(sql);
+    // placing literal earlier than ANY type is intended: do not modify
+    final String sql = "select \"ID\", \"MAPFIELD\"['c'] AS \"MAPFIELD_C\","
+        + " \"NESTEDMAPFIELD\", \"ARRAYFIELD\" "
+        + "from \"s\".\"nested\" "
+        + "where \"NESTEDMAPFIELD\"['a']['b'] = 2 AND 200.0 = \"ARRAYFIELD\"[2]";
 
-      fail("Without CAST, comparing result of ITEM() and primitive type should throw Exception "
-          + "in Runtime");
-    } catch (SQLException e) {
-      Throwable e2 = e.getCause();
-      assertThat(e2, is(instanceOf(RuntimeException.class)));
-      Throwable e3 = e2.getCause();
-      assertThat(e3, is(instanceOf(NoSuchMethodException.class)));
-    }
+    final ResultSet resultSet = statement.executeQuery(sql);
+    final List<String> resultStrings = CalciteAssert.toList(resultSet);
+    assertThat(resultStrings.size(), is(1));
+
+    // JDBC doesn't support Map / Nested Map so just relying on string representation
+    String expectedRow = "ID=2; MAPFIELD_C=4; NESTEDMAPFIELD={a={b=2, c=4}}; "
+        + "ARRAYFIELD=[100, 200, 300]";
+    assertThat(resultStrings.get(0), is(expectedRow));
+  }
+
+
+  @Test public void testArithmeticToAnyTypeWithoutCast() throws Exception {
+    Connection connection = setupConnectionWithNestedAnyTypeTable();
+
+    final Statement statement = connection.createStatement();
+
+    // placing literal earlier than ANY type is intended: do not modify
+    final String sql = "select \"ID\", \"MAPFIELD\"['c'] AS \"MAPFIELD_C\","
+        + " \"NESTEDMAPFIELD\", \"ARRAYFIELD\" "
+        + "from \"s\".\"nested\" "
+        + "where \"NESTEDMAPFIELD\"['a']['b'] + 1.0 = 3 "
+        + "AND \"NESTEDMAPFIELD\"['a']['b'] * 2.0 = 4 "
+        + "AND \"NESTEDMAPFIELD\"['a']['b'] > 1"
+        + "AND \"NESTEDMAPFIELD\"['a']['b'] >= 2"
+        + "AND 100.1 <> \"ARRAYFIELD\"[2] - 100.0"
+        + "AND 100.0 = \"ARRAYFIELD\"[2] / 2"
+        + "AND 99.9 < \"ARRAYFIELD\"[2] / 2"
+        + "AND 100.0 <= \"ARRAYFIELD\"[2] / 2"
+        + "AND '200' <> \"STRINGARRAYFIELD\"[1]"
+        + "AND '200' = \"STRINGARRAYFIELD\"[2]"
+        + "AND '100' < \"STRINGARRAYFIELD\"[2]";
+
+    final ResultSet resultSet = statement.executeQuery(sql);
+    final List<String> resultStrings = CalciteAssert.toList(resultSet);
+    assertThat(resultStrings.size(), is(1));
+
+    // JDBC doesn't support Map / Nested Map so just relying on string representation
+    String expectedRow = "ID=2; MAPFIELD_C=4; NESTEDMAPFIELD={a={b=2, c=4}}; "
+        + "ARRAYFIELD=[100, 200, 300]";
+    assertThat(resultStrings.get(0), is(expectedRow));
   }
 
   @Test public void testAccessNonExistKeyFromMapWithAnyType() throws Exception {
@@ -313,6 +341,7 @@ public class CollectionTypeTest {
 
   private static Object[][] setupNestedRecords() {
     List<Integer> ints = Arrays.asList(100, 200, 300);
+    List<String> strings = Arrays.asList("100", "200", "300");
 
     Object[][] records = new Object[5][];
 
@@ -322,7 +351,7 @@ public class CollectionTypeTest {
       map.put("c", i * i);
       Map<String, Map<String, Integer>> mm = new HashMap<>();
       mm.put("a", map);
-      records[i] = new Object[] {i, map, mm, ints};
+      records[i] = new Object[] {i, map, mm, ints, strings};
     }
 
     return records;
@@ -333,24 +362,28 @@ public class CollectionTypeTest {
   public static class NestedCollectionTable implements ScannableTable {
     public RelDataType getRowType(RelDataTypeFactory typeFactory) {
 
-      RelDataType nullableKeyType = typeFactory
+      RelDataType nullableVarcharType = typeFactory
           .createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
-      RelDataType nullableValueType = typeFactory
+      RelDataType nullableIntegerType = typeFactory
           .createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
       RelDataType nullableMapType = typeFactory
-          .createTypeWithNullability(typeFactory.createMapType(nullableKeyType, nullableValueType),
+          .createTypeWithNullability(
+              typeFactory.createMapType(nullableVarcharType, nullableIntegerType),
               true);
       return typeFactory.builder()
           .add("ID", SqlTypeName.INTEGER)
           .add("MAPFIELD",
               typeFactory.createTypeWithNullability(
-                typeFactory.createMapType(nullableKeyType, nullableValueType), true))
+                typeFactory.createMapType(nullableVarcharType, nullableIntegerType), true))
           .add("NESTEDMAPFIELD", typeFactory
               .createTypeWithNullability(
-                  typeFactory.createMapType(nullableKeyType, nullableMapType), true))
+                  typeFactory.createMapType(nullableVarcharType, nullableMapType), true))
           .add("ARRAYFIELD", typeFactory
               .createTypeWithNullability(
-                  typeFactory.createArrayType(nullableValueType, -1L), true))
+                  typeFactory.createArrayType(nullableIntegerType, -1L), true))
+          .add("STRINGARRAYFIELD", typeFactory
+              .createTypeWithNullability(
+                  typeFactory.createArrayType(nullableVarcharType, -1L), true))
           .build();
     }
 
@@ -380,6 +413,7 @@ public class CollectionTypeTest {
           .add("MAPFIELD", SqlTypeName.ANY)
           .add("NESTEDMAPFIELD", SqlTypeName.ANY)
           .add("ARRAYFIELD", SqlTypeName.ANY)
+          .add("STRINGARRAYFIELD", SqlTypeName.ANY)
           .build();
     }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -62,10 +62,13 @@ import static org.apache.calcite.runtime.SqlFunctions.upper;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -613,6 +616,262 @@ public class SqlFunctionsTest {
     assertThat(floorMod(1, 3), equalTo(1L));
     assertThat(floorMod(-1, 3), equalTo(2L));
   }
+
+  @Test public void testEqWithAny() {
+    // Non-numeric same type equality check
+    assertTrue(SqlFunctions.eqAny("hello", "hello"));
+
+    // Numeric types equality check
+    assertTrue(SqlFunctions.eqAny(1, 1L));
+    assertTrue(SqlFunctions.eqAny(1, 1.0D));
+    assertTrue(SqlFunctions.eqAny(1L, 1.0D));
+    assertTrue(SqlFunctions.eqAny(new BigDecimal(1L), 1));
+    assertTrue(SqlFunctions.eqAny(new BigDecimal(1L), 1L));
+    assertTrue(SqlFunctions.eqAny(new BigDecimal(1L), 1.0D));
+    assertTrue(SqlFunctions.eqAny(new BigDecimal(1L), new BigDecimal(1.0D)));
+
+    // Non-numeric different type equality check
+    assertFalse(SqlFunctions.eqAny("2", 2));
+  }
+
+  @Test public void testNeWithAny() {
+    // Non-numeric same type inequality check
+    assertTrue(SqlFunctions.neAny("hello", "world"));
+
+    // Numeric types inequality check
+    assertTrue(SqlFunctions.neAny(1, 2L));
+    assertTrue(SqlFunctions.neAny(1, 2.0D));
+    assertTrue(SqlFunctions.neAny(1L, 2.0D));
+    assertTrue(SqlFunctions.neAny(new BigDecimal(2L), 1));
+    assertTrue(SqlFunctions.neAny(new BigDecimal(2L), 1L));
+    assertTrue(SqlFunctions.neAny(new BigDecimal(2L), 1.0D));
+    assertTrue(SqlFunctions.neAny(new BigDecimal(2L), new BigDecimal(1.0D)));
+
+    // Non-numeric different type inequality check
+    assertTrue(SqlFunctions.neAny("2", 2));
+  }
+
+  @Test public void testLtWithAny() {
+    // Non-numeric same type "less then" check
+    assertTrue(SqlFunctions.ltAny("apple", "banana"));
+
+    // Numeric types "less than" check
+    assertTrue(SqlFunctions.ltAny(1, 2L));
+    assertTrue(SqlFunctions.ltAny(1, 2.0D));
+    assertTrue(SqlFunctions.ltAny(1L, 2.0D));
+    assertTrue(SqlFunctions.ltAny(new BigDecimal(1L), 2));
+    assertTrue(SqlFunctions.ltAny(new BigDecimal(1L), 2L));
+    assertTrue(SqlFunctions.ltAny(new BigDecimal(1L), 2.0D));
+    assertTrue(SqlFunctions.ltAny(new BigDecimal(1L), new BigDecimal(2.0D)));
+
+    // Non-numeric different type but both implements Comparable
+    // "less than" check
+    try {
+      assertFalse(SqlFunctions.ltAny("1", new Long(2L)));
+      fail("'lt' on non-numeric different type is not possible");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
+  }
+
+
+  @Test public void testLeWithAny() {
+    // Non-numeric same type "less or equal" check
+    assertTrue(SqlFunctions.leAny("apple", "banana"));
+    assertTrue(SqlFunctions.leAny("apple", "apple"));
+
+    // Numeric types "less or equal" check
+    assertTrue(SqlFunctions.leAny(1, 2L));
+    assertTrue(SqlFunctions.leAny(1, 1L));
+    assertTrue(SqlFunctions.leAny(1, 2.0D));
+    assertTrue(SqlFunctions.leAny(1, 1.0D));
+    assertTrue(SqlFunctions.leAny(1L, 2.0D));
+    assertTrue(SqlFunctions.leAny(1L, 1.0D));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), 2));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), 1));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), 2L));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), 1L));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), 2.0D));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), 1.0D));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), new BigDecimal(2.0D)));
+    assertTrue(SqlFunctions.leAny(new BigDecimal(1L), new BigDecimal(1.0D)));
+
+    // Non-numeric different type but both implements Comparable
+    // "less or equal" check
+    try {
+      assertFalse(SqlFunctions.leAny("2", new Long(2L)));
+      fail("'le' on non-numeric different type is not possible");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
+  }
+
+  @Test public void testGtWithAny() {
+    // Non-numeric same type "greater then" check
+    assertTrue(SqlFunctions.gtAny("banana", "apple"));
+
+    // Numeric types "greater than" check
+    assertTrue(SqlFunctions.gtAny(2, 1L));
+    assertTrue(SqlFunctions.gtAny(2, 1.0D));
+    assertTrue(SqlFunctions.gtAny(2L, 1.0D));
+    assertTrue(SqlFunctions.gtAny(new BigDecimal(2L), 1));
+    assertTrue(SqlFunctions.gtAny(new BigDecimal(2L), 1L));
+    assertTrue(SqlFunctions.gtAny(new BigDecimal(2L), 1.0D));
+    assertTrue(SqlFunctions.gtAny(new BigDecimal(2L), new BigDecimal(1.0D)));
+
+    // Non-numeric different type but both implements Comparable
+    // "greater than" check
+    try {
+      assertFalse(SqlFunctions.gtAny("2", new Long(1L)));
+      fail("'gt' on non-numeric different type is not possible");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
+  }
+
+  @Test public void testGeWithAny() {
+    // Non-numeric same type "greater or equal" check
+    assertTrue(SqlFunctions.geAny("banana", "apple"));
+    assertTrue(SqlFunctions.geAny("apple", "apple"));
+
+    // Numeric types "greater or equal" check
+    assertTrue(SqlFunctions.geAny(2, 1L));
+    assertTrue(SqlFunctions.geAny(1, 1L));
+    assertTrue(SqlFunctions.geAny(2, 1.0D));
+    assertTrue(SqlFunctions.geAny(1, 1.0D));
+    assertTrue(SqlFunctions.geAny(2L, 1.0D));
+    assertTrue(SqlFunctions.geAny(1L, 1.0D));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(2L), 1));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(1L), 1));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(2L), 1L));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(1L), 1L));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(2L), 1.0D));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(1L), 1.0D));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(2L), new BigDecimal(1.0D)));
+    assertTrue(SqlFunctions.geAny(new BigDecimal(1L), new BigDecimal(1.0D)));
+
+    // Non-numeric different type but both implements Comparable
+    // "greater or equal" check
+    try {
+      assertFalse(SqlFunctions.geAny("2", new Long(2L)));
+      fail("'ge' on non-numeric different type is not possible");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test public void testPlusAny() {
+    // null parameters
+    assertNull(SqlFunctions.plusAny(null, null));
+    assertNull(SqlFunctions.plusAny(null, 1));
+    assertNull(SqlFunctions.plusAny(1, null));
+
+    // Numeric types
+    assertThat(SqlFunctions.plusAny(2, 1L), equalTo((Object) new BigDecimal(3)));
+    assertThat(SqlFunctions.plusAny(2, 1.0D), equalTo((Object) new BigDecimal(3)));
+    assertThat(SqlFunctions.plusAny(2L, 1.0D), equalTo((Object) new BigDecimal(3)));
+    assertThat(SqlFunctions.plusAny(new BigDecimal(2L), 1),
+        equalTo((Object) new BigDecimal(3)));
+    assertThat(SqlFunctions.plusAny(new BigDecimal(2L), 1L),
+        equalTo((Object) new BigDecimal(3)));
+    assertThat(SqlFunctions.plusAny(new BigDecimal(2L), 1.0D),
+        equalTo((Object) new BigDecimal(3)));
+    assertThat(SqlFunctions.plusAny(new BigDecimal(2L), new BigDecimal(1.0D)),
+        equalTo((Object) new BigDecimal(3)));
+
+    // Non-numeric type
+    try {
+      SqlFunctions.plusAny("2", new Long(2L));
+      fail("'plus' on non-numeric type is not possible");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test public void testMinusAny() {
+    // null parameters
+    assertNull(SqlFunctions.minusAny(null, null));
+    assertNull(SqlFunctions.minusAny(null, 1));
+    assertNull(SqlFunctions.minusAny(1, null));
+
+    // Numeric types
+    assertThat(SqlFunctions.minusAny(2, 1L), equalTo((Object) new BigDecimal(1)));
+    assertThat(SqlFunctions.minusAny(2, 1.0D), equalTo((Object) new BigDecimal(1)));
+    assertThat(SqlFunctions.minusAny(2L, 1.0D), equalTo((Object) new BigDecimal(1)));
+    assertThat(SqlFunctions.minusAny(new BigDecimal(2L), 1),
+        equalTo((Object) new BigDecimal(1)));
+    assertThat(SqlFunctions.minusAny(new BigDecimal(2L), 1L),
+        equalTo((Object) new BigDecimal(1)));
+    assertThat(SqlFunctions.minusAny(new BigDecimal(2L), 1.0D),
+        equalTo((Object) new BigDecimal(1)));
+    assertThat(SqlFunctions.minusAny(new BigDecimal(2L), new BigDecimal(1.0D)),
+        equalTo((Object) new BigDecimal(1)));
+
+    // Non-numeric type
+    try {
+      SqlFunctions.minusAny("2", new Long(2L));
+      fail("'minus' on non-numeric type is not possible");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test public void testMultiplyAny() {
+    // null parameters
+    assertNull(SqlFunctions.multiplyAny(null, null));
+    assertNull(SqlFunctions.multiplyAny(null, 1));
+    assertNull(SqlFunctions.multiplyAny(1, null));
+
+    // Numeric types
+    assertThat(SqlFunctions.multiplyAny(2, 1L), equalTo((Object) new BigDecimal(2)));
+    assertThat(SqlFunctions.multiplyAny(2, 1.0D), equalTo((Object) new BigDecimal(2)));
+    assertThat(SqlFunctions.multiplyAny(2L, 1.0D), equalTo((Object) new BigDecimal(2)));
+    assertThat(SqlFunctions.multiplyAny(new BigDecimal(2L), 1),
+        equalTo((Object) new BigDecimal(2)));
+    assertThat(SqlFunctions.multiplyAny(new BigDecimal(2L), 1L),
+        equalTo((Object) new BigDecimal(2)));
+    assertThat(SqlFunctions.multiplyAny(new BigDecimal(2L), 1.0D),
+        equalTo((Object) new BigDecimal(2)));
+    assertThat(SqlFunctions.multiplyAny(new BigDecimal(2L), new BigDecimal(1.0D)),
+        equalTo((Object) new BigDecimal(2)));
+
+    // Non-numeric type
+    try {
+      SqlFunctions.multiplyAny("2", new Long(2L));
+      fail("'multiply' on non-numeric type is not possible");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test public void testDivideAny() {
+    // null parameters
+    assertNull(SqlFunctions.divideAny(null, null));
+    assertNull(SqlFunctions.divideAny(null, 1));
+    assertNull(SqlFunctions.divideAny(1, null));
+
+    // Numeric types
+    assertThat(SqlFunctions.divideAny(5, 2L), equalTo((Object) new BigDecimal(2.5)));
+    assertThat(SqlFunctions.divideAny(5, 2.0D), equalTo((Object) new BigDecimal(2.5)));
+    assertThat(SqlFunctions.divideAny(5L, 2.0D), equalTo((Object) new BigDecimal(2.5)));
+    assertThat(SqlFunctions.divideAny(new BigDecimal(5L), 2),
+        equalTo((Object) new BigDecimal(2.5)));
+    assertThat(SqlFunctions.divideAny(new BigDecimal(5L), 2L),
+        equalTo((Object) new BigDecimal(2.5)));
+    assertThat(SqlFunctions.divideAny(new BigDecimal(5L), 2.0D),
+        equalTo((Object) new BigDecimal(2.5)));
+    assertThat(SqlFunctions.divideAny(new BigDecimal(5L), new BigDecimal(2.0D)),
+        equalTo((Object) new BigDecimal(2.5)));
+
+    // Non-numeric type
+    try {
+      SqlFunctions.divideAny("5", new Long(2L));
+      fail("'divide' on non-numeric type is not possible");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
 }
 
 // End SqlFunctionsTest.java


### PR DESCRIPTION
ANY type is represented as Object. There's no enough overloaded backup methods
for compare / arithmetic operators so if the type of one or two parameter(s)
is(are) ANY, it can't find the matched method.

This patch adds overloaded methods for compare / arithmetic operators which
parameters are (Object, Object). And if either parameter is ANY, it boxes
primitive type parameter so that it can be matched to Object, Object.

Newly added overloaded methods are smart that they can handle different Number
types for parameters, while implementation gets some downsides:
1. requires converting to BigDecimal
2. the result of arithmetic is also BigDecimal

If we want to minimize the result type of of arithmetic (or converting to BigDecimal is not acceptable), we could have arithmetic result type matrix (do we have this?), and convert the result to desired type.
