### PR TITLE
[CALCITE-1461] Hard coded class name in JaninoRelMetadataProvider breaks shading

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -228,7 +228,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
           .append(";\n");
     }
     buff.append("  }\n")
-        .append("  public org.apache.calcite.rel.metadata.MetadataDef getDef() {\n")
+        .append("  public ").append(MetadataDef.class.getName()).append(" getDef() {\n")
         .append("    return ")
         .append(def.metadataClass.getName())
         .append(".DEF;\n")
@@ -239,8 +239,8 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
           .append(" ")
           .append(method.e.getName())
           .append("(\n")
-          .append("      org.apache.calcite.rel.RelNode r,\n")
-          .append("      org.apache.calcite.rel.metadata.RelMetadataQuery mq");
+          .append("      ").append(RelNode.class.getName()).append(" r,\n")
+          .append("      ").append(RelMetadataQuery.class.getName()).append(" mq");
       paramList(buff, method.e)
           .append(") {\n");
       buff.append("    final java.util.List key = ")
@@ -299,8 +299,8 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
           .append(" ")
           .append(method.e.getName())
           .append("_(\n")
-          .append("      org.apache.calcite.rel.RelNode r,\n")
-          .append("      org.apache.calcite.rel.metadata.RelMetadataQuery mq");
+          .append("      ").append(RelNode.class.getName()).append(" r,\n")
+          .append("      ").append(RelMetadataQuery.class.getName()).append(" mq");
       paramList(buff, method.e)
           .append(") {\n");
       buff.append("    switch (relClasses.indexOf(r.getClass())) {\n");


### PR DESCRIPTION
In `JaninoRelMetadataProvider.load3`, the generated class string contains some hard coded Calcite's classes, such as `org.apache.calcite.rel.metadata.MetadataDef`. After shading Calcite, the `MetadataDef` can not be found in the shaded classes. And a compile error will be thrown.

So it's better to use `MetadataDef.class.getName()` instead of hard code string.