### PR TITLE
CALCITE-1384 Extension point for ALTER statements

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -170,6 +170,16 @@ limitations under the License.
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+          <excludes>${project.build.directory}/generated-test-sources/javacc</excludes>
+          <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/javacc</generatedTestSourcesDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>
@@ -188,6 +198,22 @@ limitations under the License.
             </goals>
             <configuration>
               <sourceDirectory>${project.build.directory}/generated-sources/fmpp</sourceDirectory>
+              <includes>
+                <include>**/Parser.jj</include>
+              </includes>
+              <lookAhead>2</lookAhead>
+              <isStatic>false</isStatic>
+            </configuration>
+          </execution>
+          <execution>
+            <id>javacc-test</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>javacc</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.build.directory}/generated-test-sources/fmpp</sourceDirectory>
+              <outputDirectory>${project.build.directory}/generated-test-sources/javacc</outputDirectory>
               <includes>
                 <include>**/Parser.jj</include>
               </includes>
@@ -444,13 +470,25 @@ limitations under the License.
           <plugin>
             <groupId>com.googlecode.fmpp-maven-plugin</groupId>
             <artifactId>fmpp-maven-plugin</artifactId>
-            <configuration>
-              <cfgFile>src/main/codegen/config.fmpp</cfgFile>
-              <templateDirectory>src/main/codegen/templates</templateDirectory>
-            </configuration>
             <executions>
               <execution>
+                <configuration>
+                  <cfgFile>src/main/codegen/config.fmpp</cfgFile>
+                  <templateDirectory>src/main/codegen/templates</templateDirectory>
+                </configuration>
                 <id>generate-fmpp-sources</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+              </execution>
+              <execution>
+                <configuration>
+                  <cfgFile>src/test/codegen/config.fmpp</cfgFile>
+                  <templateDirectory>src/main/codegen/templates</templateDirectory>
+                  <outputDirectory>${project.build.directory}/generated-test-sources/fmpp</outputDirectory>
+                </configuration>
+                <id>generate-fmpp-test-sources</id>
                 <phase>validate</phase>
                 <goals>
                   <goal>generate</goal>

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -70,6 +70,10 @@ data: {
     dataTypeParserMethods: [
     ]
 
+    # List of methods for parsing extensions to ALTER SYSTEM calls
+    alterStatementParserMethods: [
+    ]
+
     # List of files in @includes directory that have parser method
     # implementations for parsing custom SQL statements, literals or types
     # given as part of "statementParserMethods", "literalParserMethods" or

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -41,6 +41,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.sql.JoinConditionType;
 import org.apache.calcite.sql.JoinType;
+import org.apache.calcite.sql.SqlAlter;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
@@ -924,6 +925,8 @@ SqlNode SqlStmt() :
 {
     (
         stmt = SqlSetOption()
+        |
+        stmt = SqlAlter()
         |
         stmt = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
         |
@@ -2965,21 +2968,17 @@ SqlCall SequenceExpression() :
 }
 
 /**
- * Parses an expression for setting or resetting an option in SQL, such as QUOTED_IDENTIFIERS,
- * or explain plan level (physical/logical).
+ * Parses "SET <NAME> = VALUE" or "RESET <NAME>", without a leading
+ * "ALTER <SCOPE>".
  */
 SqlSetOption SqlSetOption() :
 {
     SqlParserPos pos = null;
-    String scope = null;
     SqlIdentifier name;
     SqlNode val = null;
+    SqlSetOption setOption = null;
 }
 {
-    (
-        <ALTER> { pos = getPos(); }
-        scope = Scope()
-    )?
     (
         <SET> {
             pos = pos == null ? getPos() : pos;
@@ -2996,6 +2995,9 @@ SqlSetOption SqlSetOption() :
                 val = new SqlIdentifier(token.image.toUpperCase(), getPos());
             }
         )
+        {
+            setOption = new SqlSetOption(pos.plus(getPos()), null, name, val);
+        }
     |
         <RESET> {
             pos = pos == null ? getPos() : pos;
@@ -3007,9 +3009,44 @@ SqlSetOption SqlSetOption() :
                 name = new SqlIdentifier(token.image.toUpperCase(), getPos());
             }
         )
+        {
+            setOption = new SqlSetOption(pos.plus(getPos()), null, name, val);
+        }
     )
     {
-        return new SqlSetOption(pos.plus(getPos()), scope, name, val);
+        return setOption;
+    }
+}
+
+/**
+ * Parses an expression for setting or resetting an option in SQL, such as QUOTED_IDENTIFIERS,
+ * or explain plan level (physical/logical).
+ */
+SqlAlter SqlAlter() :
+{
+    SqlParserPos pos = null;
+    String scope = null;
+    SqlIdentifier name;
+    SqlNode val = null;
+    SqlAlter alterNode = null;
+}
+{
+    (
+        <ALTER> { pos = getPos(); }
+        scope = Scope()
+    )
+    (
+        alterNode = SqlSetOption()
+
+  <#-- additional literal parser methods are included here -->
+  <#list parser.alterStatementParserMethods as method>
+    |
+        alterNode = ${method}
+  </#list>
+    )
+    {
+        alterNode.setScope(scope);
+        return alterNode;
     }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlAlter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAlter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Base class for an ALTER statements parse tree nodes. The portion of the
+ * statement covered by this class is "ALTER &lt;SCOPE&gt;. Subclasses handle
+ * whatever comes after the scope.
+ */
+public abstract class SqlAlter extends SqlCall {
+
+  /** Scope of the operation. Values "SYSTEM" and "SESSION" are typical. */
+  String scope;
+
+  public SqlAlter(SqlParserPos pos) {
+    this(pos, null);
+  }
+
+  public SqlAlter(SqlParserPos pos, String scope) {
+    super(pos);
+    this.scope = scope;
+  }
+
+  @Override public final void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (scope != null) {
+      writer.keyword("ALTER");
+      writer.keyword(scope);
+    }
+    unparseAlterOperation(writer, leftPrec, rightPrec);
+  }
+
+  protected abstract void unparseAlterOperation(SqlWriter writer, int leftPrec, int rightPrec);
+
+  public String getScope() {
+    return scope;
+  }
+
+  public void setScope(String scope) {
+    this.scope = scope;
+  }
+
+}
+
+// End SqlAlter.java

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetOption.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetOption.java
@@ -58,7 +58,7 @@ import java.util.List;
  * <li><code>ALTER SESSION RESET ALL</code></li>
  * </ul>
  */
-public class SqlSetOption extends SqlCall {
+public class SqlSetOption extends SqlAlter {
   public static final SqlSpecialOperator OPERATOR =
       new SqlSpecialOperator("SET_OPTION", SqlKind.SET_OPTION) {
         @Override public SqlCall createCall(SqlLiteral functionQualifier,
@@ -69,9 +69,6 @@ public class SqlSetOption extends SqlCall {
               (SqlIdentifier) operands[1], operands[2]);
         }
       };
-
-  /** Scope of the assignment. Values "SYSTEM" and "SESSION" are typical. */
-  String scope;
 
   /** Name of the option as an {@link org.apache.calcite.sql.SqlIdentifier}
    * with one or more parts.*/
@@ -94,7 +91,7 @@ public class SqlSetOption extends SqlCall {
    */
   public SqlSetOption(SqlParserPos pos, String scope, SqlIdentifier name,
       SqlNode value) {
-    super(pos);
+    super(pos, scope);
     this.scope = scope;
     this.name = name;
     this.value = value;
@@ -141,11 +138,7 @@ public class SqlSetOption extends SqlCall {
     }
   }
 
-  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    if (scope != null) {
-      writer.keyword("ALTER");
-      writer.keyword(scope);
-    }
+  @Override protected void unparseAlterOperation(SqlWriter writer, int leftPrec, int rightPrec) {
     if (value != null) {
       writer.keyword("SET");
     } else {
@@ -172,14 +165,6 @@ public class SqlSetOption extends SqlCall {
 
   public void setName(SqlIdentifier name) {
     this.name = name;
-  }
-
-  public String getScope() {
-    return scope;
-  }
-
-  public void setScope(String scope) {
-    this.scope = scope;
   }
 
   public SqlNode getValue() {

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data: {
+    parser: {
+      # Generated parser implementation class package and name
+      package: "org.apache.calcite.sql.parser.extension",
+      class: "ExtensionSqlParserImpl",
+
+      # List of import statements.
+      imports: [
+        "org.apache.calcite.sql.parser.extension.SqlUploadJarNode"
+      ]
+
+      # List of keywords.
+      keywords: [
+        "UPLOAD"
+        "JAR"
+      ]
+
+      # List of keywords from "keywords" section that are not reserved.
+      nonReservedKeywords: [
+      ]
+
+      # List of methods for parsing custom SQL statements.
+      statementParserMethods: [
+      ]
+
+      # List of methods for parsing custom literals.
+      # Example: ParseJsonLiteral().
+      literalParserMethods: [
+      ]
+
+      # List of methods for parsing custom data types.
+      dataTypeParserMethods: [
+      ]
+
+      # List of methods for parsing extensions to ALTER SYSTEM calls
+      alterStatementParserMethods: [
+        "SqlUploadJarNode()"
+      ]
+
+      # List of files in @includes directory that have parser method
+      # implementations for custom SQL statements, literals or types
+      # given as part of "statementParserMethods", "literalParserMethods" or
+      # "dataTypeParserMethods".
+      implementationFiles: [
+        "parserImpls.ftl"
+      ]
+
+      includeCompoundIdentifier: true
+      includeBraces: true
+      includeAdditionalDeclarations: false
+
+    }
+}
+freemarkerLinks: {
+    includes: includes/
+}

--- a/core/src/test/codegen/includes/compoundIdentifier.ftl
+++ b/core/src/test/codegen/includes/compoundIdentifier.ftl
@@ -1,0 +1,34 @@
+<#--
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
+
+<#--
+  Add implementations of additional parser statements, literals or
+  data types.
+
+  Example of SqlShowTables() implementation:
+  SqlNode SqlShowTables()
+  {
+    ...local variables...
+  }
+  {
+    <SHOW> <TABLES>
+    ...
+    {
+      return SqlShowTables(...)
+    }
+  }
+-->

--- a/core/src/test/codegen/includes/parserImpls.ftl
+++ b/core/src/test/codegen/includes/parserImpls.ftl
@@ -1,0 +1,38 @@
+<#--
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
+
+
+SqlAlter SqlUploadJarNode() :
+{
+    SqlParserPos pos;
+    SqlNode jarPath;
+    List<SqlNode> jarPathsList;
+}
+{
+    <UPLOAD>  { pos = getPos(); } <JAR>
+    jarPath = StringLiteral() {
+        jarPathsList = startList(jarPath);
+    }
+    (
+        <COMMA> jarPath = StringLiteral() {
+            jarPathsList.add(jarPath);
+        }
+    ) *
+    {
+        return new SqlUploadJarNode(pos.plus(getPos()), jarPathsList);
+    }
+}

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -22,6 +22,7 @@ import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSetOption;
+import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
@@ -64,10 +65,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * A <code>SqlParserTest</code> is a unit-test for
  * {@link SqlParser the SQL parser}.
+ *
+ * To reuse this test for an extension parser, implement the
+ * {@link #parserImplFactory()} method to return the extension parser
+ * implementation.
  */
 public class SqlParserTest {
   //~ Static fields/initializers ---------------------------------------------
@@ -543,9 +549,18 @@ public class SqlParserTest {
     return new Sql(sql);
   }
 
-  private SqlParser getSqlParser(String sql) {
+  /**
+   * Implementors of custom parsing logic who want to reuse this test should
+   * override this method with the factory for their extension parser.
+   */
+  protected SqlParserImplFactory parserImplFactory() {
+    return SqlParserImpl.FACTORY;
+  }
+
+  protected SqlParser getSqlParser(String sql) {
     return SqlParser.create(sql,
         SqlParser.configBuilder()
+            .setParserFactory(parserImplFactory())
             .setQuoting(quoting)
             .setUnquotedCasing(unquotedCasing)
             .setQuotedCasing(quotedCasing)
@@ -6681,6 +6696,7 @@ public class SqlParserTest {
    * non-reserved keyword list in the parser.
    */
   @Test public void testNoUnintendedNewReservedKeywords() {
+    assumeTrue(isNotSubclass()); // This shouldn't run for subclasses
     final SqlAbstractParserImpl.Metadata metadata =
         getSqlParser("").getMetadata();
 
@@ -6706,6 +6722,7 @@ public class SqlParserTest {
   /** Generates a copy of {@code reference.md} with the current set of key
    * words. Fails if the copy is different from the original. */
   @Test public void testGenerateKeyWords() throws IOException {
+    assumeTrue(isNotSubclass()); // This shouldn't run for subclasses
     // inUrl = "file:/home/x/calcite/core/target/test-classes/hsqldb-model.json"
     String path = "hsqldb-model.json";
     final URL inUrl = SqlParserTest.class.getResource("/" + path);
@@ -6908,8 +6925,7 @@ public class SqlParserTest {
   }
 
   @Test public void testSqlOptions() throws SqlParseException {
-    SqlNode node =
-        SqlParser.create("alter system set schema = true").parseStmt();
+    SqlNode node = getSqlParser("alter system set schema = true").parseStmt();
     SqlSetOption opt = (SqlSetOption) node;
     assertThat(opt.getScope(), equalTo("SYSTEM"));
     SqlPrettyWriter writer = new SqlPrettyWriter(SqlDialect.CALCITE);
@@ -6941,7 +6957,7 @@ public class SqlParserTest {
         .ok("SET `APPROX` = -12.3450")
         .node(isDdl());
 
-    node = SqlParser.create("reset schema").parseStmt();
+    node = getSqlParser("reset schema").parseStmt();
     opt = (SqlSetOption) node;
     assertThat(opt.getScope(), equalTo(null));
     writer = new SqlPrettyWriter(SqlDialect.CALCITE);
@@ -7113,6 +7129,10 @@ public class SqlParserTest {
 
       SqlValidatorTestCase.checkEx(thrown, expectedMsgPattern, sap);
     }
+  }
+
+  private boolean isNotSubclass() {
+    return this.getClass().equals(SqlParserTest.class);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/parser/extension/ExtensionSqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/extension/ExtensionSqlParserTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.parser.extension;
+
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParserImplFactory;
+import org.apache.calcite.sql.parser.SqlParserTest;
+
+import org.junit.Test;
+
+/**
+ * Testing for extension functionality of the base SQL parser impl.
+ *
+ * This test runs all test cases of the base {@link SqlParserTest}, as well
+ * as verifying specific extension points.
+ */
+public class ExtensionSqlParserTest extends SqlParserTest {
+
+  @Override protected SqlParserImplFactory parserImplFactory() {
+    return ExtensionSqlParserImpl.FACTORY;
+  }
+
+  @Test
+  public void testAlterSystemExtension() throws SqlParseException {
+    check("alter system upload jar '/path/to/jar'",
+      "ALTER SYSTEM UPLOAD JAR '/path/to/jar'");
+  }
+
+  @Test
+  public void testAlterSystemExtensionWithoutAlter() throws SqlParseException {
+    // We need to include the scope for custom alter operations
+    checkFails("^upload^ jar '/path/to/jar'",
+      "(?s).*Encountered \"upload\" at .*");
+  }
+}
+
+// End ExtensionSqlParserTest.java

--- a/core/src/test/java/org/apache/calcite/sql/parser/extension/SqlUploadJarNode.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/extension/SqlUploadJarNode.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.parser.extension;
+
+import org.apache.calcite.sql.SqlAlter;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.List;
+
+/**
+ * Simple test example of a custom alter system call.
+ */
+public class SqlUploadJarNode extends SqlAlter {
+  public static final SqlOperator OPERATOR = new SqlSpecialOperator("UPLOAD JAR",
+    SqlKind.OTHER_DDL);
+  private final List<SqlNode> jarPaths;
+
+  public SqlUploadJarNode(SqlParserPos pos, List<SqlNode> jarPaths) {
+    super(pos);
+    this.jarPaths = jarPaths;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return jarPaths;
+  }
+
+  @Override protected void unparseAlterOperation(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("UPLOAD");
+    writer.keyword("JAR");
+    SqlWriter.Frame frame = writer.startList("", "");
+    for (SqlNode jarPath : jarPaths) {
+      jarPath.unparse(writer, leftPrec, rightPrec);
+    }
+    writer.endList(frame);
+  }
+}
+
+// End SqlUploadJarNode.java

--- a/pom.xml
+++ b/pom.xml
@@ -633,6 +633,18 @@ limitations under the License.
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>add-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-test-sources/javacc</source>
+              </sources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
Add a parser extension point for parsing of ALTER statements.

The main content of this commit is the addition of an initial
test setup to allow testing parsing extension points within
Calcite itself. This involves the addition of test-specific
parser templates and building of a test-specific parser.