### PR TITLE
CALCITE-1447: Support INTERSECT DISTINCT, address julian's comments

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -46,6 +46,7 @@ import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.rules.AggregateProjectPullUpConstantsRule;
 import org.apache.calcite.rel.rules.DateRangeRules;
 import org.apache.calcite.rel.rules.FilterMergeRule;
+import org.apache.calcite.rel.rules.IntersectToDistinctRule;
 import org.apache.calcite.rel.rules.MultiJoin;
 import org.apache.calcite.rel.rules.ProjectToWindowRule;
 import org.apache.calcite.rel.rules.PruneEmptyRules;
@@ -1755,6 +1756,7 @@ public abstract class RelOptUtil {
     planner.addRule(ProjectToWindowRule.PROJECT);
     planner.addRule(FilterMergeRule.INSTANCE);
     planner.addRule(DateRangeRules.FILTER_INSTANCE);
+    planner.addRule(IntersectToDistinctRule.INSTANCE);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/rules/IntersectToDistinctRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/IntersectToDistinctRule.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Intersect;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.logical.LogicalIntersect;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Planner rule that translates a distinct
+ * {@link org.apache.calcite.rel.core.Intersect}
+ * (<code>all</code> = <code>false</code>)
+ * into a group of operators composed of
+ * {@link org.apache.calcite.rel.core.Union} {@link org.apache.calcite.rel.core.Aggregate}, etc.
+ * <p> Rewrite: (GB-Union All-GB)-GB-UDTF (on all attributes)
+ * Example: R1 Intersect All R2
+ * R3 = GB(R1 on all attributes + count(*) as c) union all GB(R2 on all attributes + count(*) as c)
+ * R4 = GB(R3 on all attributes + count(c) as cnt  + min(c) as m)
+ * Note that we do not need min(c) in intersect distinct
+ * R5 = Fil ( cnt == #branch )
+ * If it is intersect all then
+ * R6 = UDTF (R5) which will explode the tuples based on min(c).
+ * R7 = Proj(R6 on all attributes)
+ * Else
+ * R6 = Proj(R5 on all attributes)
+ * @see org.apache.calcite.rel.rules.UnionToDistinctRule
+ */
+public class IntersectToDistinctRule extends RelOptRule {
+  public static final IntersectToDistinctRule INSTANCE =
+          new IntersectToDistinctRule(LogicalIntersect.class, RelFactories.LOGICAL_BUILDER);
+
+  //~ Constructors -----------------------------------------------------------
+
+  /**
+   * Creates a IntersectToDistinctRule.
+   */
+  public IntersectToDistinctRule(Class<? extends Intersect> intersectClazz,
+                                 RelBuilderFactory relBuilderFactory) {
+    super(operand(intersectClazz, any()), relBuilderFactory, null);
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  public void onMatch(RelOptRuleCall call) {
+    final Intersect intersect = call.rel(0);
+    if (intersect.all) {
+      return; // nothing to do
+    }
+    final RelDataTypeFactory typeFactory = intersect.getCluster().getTypeFactory();
+    final int inputCount = intersect.getInputs().size();
+    final RexBuilder rexBuilder = intersect.getCluster().getRexBuilder();
+    final RelDataType bigintType = typeFactory.createSqlType(
+            org.apache.calcite.sql.type.SqlTypeName.BIGINT);
+    final RelBuilder unionBuilder = call.builder();
+
+    // 1st level GB: create a GB (col0, col1, count() as c) for each branch
+    for (int index = 0; index < inputCount; index++) {
+      RelNode input = intersect.getInputs().get(index);
+      final List<Integer> groupSetPositions = Lists.newArrayList();
+      for (int cInd = 0; cInd < input.getRowType().getFieldList().size(); cInd++) {
+        groupSetPositions.add(cInd);
+      }
+
+      final RelBuilder relBuilder = call.builder();
+
+      // groupSetPosition includes all the positions
+      final ImmutableBitSet groupSet = ImmutableBitSet.of(groupSetPositions);
+
+      List<AggregateCall> aggregateCalls = Lists.newArrayList();
+
+      final List<Integer> argList = Lists.newArrayList();
+      AggregateCall aggregateCall = AggregateCall.create(
+              SqlStdOperatorTable.COUNT,
+              false,
+              argList,
+              -1,
+              bigintType,
+              null);
+
+      aggregateCalls.add(aggregateCall);
+
+      relBuilder.push(input);
+      relBuilder.aggregate(
+              relBuilder.groupKey(groupSet, false, null), aggregateCalls);
+      unionBuilder.push(relBuilder.build());
+    }
+
+    // create a union above all the branches
+    unionBuilder.union(true, inputCount);
+    RelNode union = unionBuilder.build();
+
+    // 2nd level GB: create a GB (col0, col1, count(c)) for each branch
+    final List<Integer> groupSetPositions = Lists.newArrayList();
+    // the index of c is union.getRowType().getFieldList().size() - 1
+    for (int index = 0; index < union.getRowType().getFieldList().size() - 1; index++) {
+      groupSetPositions.add(index);
+    }
+    final List<Integer> argList = Lists.newArrayList();
+    AggregateCall aggregateCall = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            argList,
+            -1,
+            bigintType,
+            null);
+    List<AggregateCall> aggregateCalls = Lists.newArrayList();
+    aggregateCalls.add(aggregateCall);
+
+    final ImmutableBitSet groupSet = ImmutableBitSet.of(groupSetPositions);
+    final RelBuilder relBuilder = call.builder();
+    relBuilder.push(union);
+    relBuilder.aggregate(
+            relBuilder.groupKey(groupSet, false, null), aggregateCalls);
+    RelNode aggregateRel = relBuilder.build();
+
+    // add a filter count(c) = #branches
+    int countInd = union.getRowType().getFieldList().size() - 1;
+    List<RexNode> childRexNodeLst = new ArrayList<RexNode>();
+    RexInputRef ref = rexBuilder.makeInputRef(aggregateRel, countInd);
+    RexLiteral literal = rexBuilder.makeBigintLiteral(new BigDecimal(inputCount));
+    childRexNodeLst.add(ref);
+    childRexNodeLst.add(literal);
+    RexNode factoredFilterExpr = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, childRexNodeLst);
+
+    relBuilder.push(aggregateRel);
+    relBuilder.filter(factoredFilterExpr);
+    RelNode filterRel = relBuilder.build();
+
+    List<RexNode> originalInputRefs = Lists.transform(filterRel.getRowType().getFieldList(),
+            new Function<RelDataTypeField, RexNode>() {
+        @Override public RexNode apply(RelDataTypeField input) {
+          return new RexInputRef(input.getIndex(), input.getType());
+        }
+      });
+    List<RexNode> copyInputRefs = new ArrayList<>();
+    for (int i = 0; i < originalInputRefs.size() - 1; i++) {
+      copyInputRefs.add(originalInputRefs.get(i));
+    }
+    relBuilder.push(filterRel);
+    relBuilder.project(copyInputRefs);
+
+    // the schema for intersect distinct is like this
+    // R3 on all attributes + count(c) as cnt
+    // finally add a project to project out the last column
+    call.transformTo(relBuilder.build());
+  }
+}
+
+// End IntersectToDistinctRule.java

--- a/core/src/test/java/org/apache/calcite/test/JdbcFrontLinqBackTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcFrontLinqBackTest.java
@@ -162,7 +162,6 @@ public class JdbcFrontLinqBackTest {
   /**
    * Tests INTERSECT.
    */
-  @Ignore
   @Test public void testIntersect() {
     hr()
         .query("select substring(\"name\" from 1 for 1) as x\n"

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -56,6 +56,7 @@ import org.apache.calcite.rel.rules.FilterMergeRule;
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
 import org.apache.calcite.rel.rules.FilterSetOpTransposeRule;
 import org.apache.calcite.rel.rules.FilterToCalcRule;
+import org.apache.calcite.rel.rules.IntersectToDistinctRule;
 import org.apache.calcite.rel.rules.JoinAddRedundantSemiJoinRule;
 import org.apache.calcite.rel.rules.JoinCommuteRule;
 import org.apache.calcite.rel.rules.JoinExtractFilterRule;
@@ -877,6 +878,22 @@ public class RelOptRulesTest extends RelOptTestBase {
         + "select * from emp where deptno = 20\n"
         + "intersect\n"
         + "select * from emp where deptno = 30\n";
+    sql(sql).with(program).check();
+  }
+
+  /** Tests {@link org.apache.calcite.rel.rules.IntersectToDistinctRule}, which rewrites an
+   * {@link Intersect} operators with 3 inputs. */
+  @Test public void testIntersectToDistinct() throws Exception {
+    HepProgram program = new HepProgramBuilder()
+            .addRuleInstance(UnionMergeRule.INTERSECT_INSTANCE)
+            .addRuleInstance(IntersectToDistinctRule.INSTANCE)
+            .build();
+
+    final String sql = "select * from emp where deptno = 10\n"
+            + "intersect\n"
+            + "select * from emp where deptno = 20\n"
+            + "intersect\n"
+            + "select * from emp where deptno = 30\n";
     sql(sql).with(program).check();
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -767,7 +767,8 @@ LogicalProject(EXPR$0=[$0], EXPR$1=[$1])
     <TestCase name="testEmptyMinus">
         <Resource name="sql">
             <![CDATA[select * from (values (30, 3)) as t (x, y) where x > 30except
-select * from (values (20, 2))except
+select * from (values (20, 2))
+except
 select * from (values (40, 4))]]>
         </Resource>
         <Resource name="planBefore">
@@ -1379,6 +1380,51 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], BIRTHDATE=[$9])
   LogicalFilter(condition=[AND(>=(Reinterpret($9), 2014-01-01), <(Reinterpret($9), 2015-01-01))])
     LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testIntersectToDistinct">
+        <Resource name="sql">
+            <![CDATA[select * from emp where deptno = 10
+intersect
+select * from emp where deptno = 20
+intersect
+select * from emp where deptno = 30
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalIntersect(all=[false])
+  LogicalIntersect(all=[false])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+      LogicalFilter(condition=[=($7, 10)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+      LogicalFilter(condition=[=($7, 20)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[=($7, 30)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[=($9, 3)])
+    LogicalAggregate(group=[{0, 1, 2, 3, 4, 5, 6, 7, 8}], agg#0=[COUNT()])
+      LogicalUnion(all=[true])
+        LogicalAggregate(group=[{0, 1, 2, 3, 4, 5, 6, 7, 8}], agg#0=[COUNT()])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+            LogicalFilter(condition=[=($7, 10)])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalAggregate(group=[{0, 1, 2, 3, 4, 5, 6, 7, 8}], agg#0=[COUNT()])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+            LogicalFilter(condition=[=($7, 20)])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalAggregate(group=[{0, 1, 2, 3, 4, 5, 6, 7, 8}], agg#0=[COUNT()])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+            LogicalFilter(condition=[=($7, 30)])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -5950,9 +5996,9 @@ LogicalProject(EMPNO=[$0])
     <TestCase name="testDistinctNonDistinctAggregates">
         <Resource name="sql">
             <![CDATA[select emp.empno, count(*), avg(distinct dept.deptno)
-from sales.emp emp inner join sales.dept dept
-on emp.deptno = dept.deptno
-group by emp.empno]]>
+ from sales.emp emp inner join sales.dept dept
+ on emp.deptno = dept.deptno
+ group by emp.empno]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[


### PR DESCRIPTION
address most of Julian's comments:
Please add necessary markup around javadoc so that it stays formatted when converted to html
Remove the deprecated constructor - this is a new class
Add a @see in UnionToDistinctRule
I think you should change count(1) to count(*). It's the same (because 1 is not null) but doesn't entail a project. Then, I don't think the lower Aggregate calls need a count at all.
Make relBuilder final. It's safe to re-use the RelBuilder.
Sorry to be pedantic, but can you rename numBranches to inputCount? Consistent with terminology and naming elsewhere.
Can you enable JdbcFrontLinqBackTest.testIntersect. With your changes, I think it should pass!

One item not addressed : Can you inline your calls to makeBigintLiteral. (We ought to have deprecated that method, but let's not start using it.)

It seems that RexLiteral is private and I can not directly create it.