### PR TITLE
[CALCITE-1551] fix for: RelBuilder's project() doesn't preserve alias

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/PigRelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/PigRelBuilder.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -36,6 +37,8 @@ import java.util.List;
  * Extension to {@link RelBuilder} for Pig relational operators.
  */
 public class PigRelBuilder extends RelBuilder {
+  private String lastAlias;
+
   private PigRelBuilder(Context context,
       RelOptCluster cluster,
       RelOptSchema relOptSchema) {
@@ -50,10 +53,12 @@ public class PigRelBuilder extends RelBuilder {
   }
 
   @Override public PigRelBuilder scan(String... tableNames) {
+    lastAlias = null;
     return (PigRelBuilder) super.scan(tableNames);
   }
 
   @Override public PigRelBuilder scan(Iterable<String> tableNames) {
+    lastAlias = null;
     return (PigRelBuilder) super.scan(tableNames);
   }
 
@@ -141,7 +146,7 @@ public class PigRelBuilder extends RelBuilder {
           cluster.getRexBuilder().makeCall(peek(1, 0).getRowType(),
               SqlStdOperatorTable.ROW, fields());
       aggregate(groupKey.e,
-          aggregateCall(SqlStdOperatorTable.COLLECT, false, null, null, row));
+          aggregateCall(SqlStdOperatorTable.COLLECT, false, null, getAlias(), row));
       if (groupKey.i < n - 1) {
         push(r);
         List<RexNode> predicates = new ArrayList<>();
@@ -152,6 +157,25 @@ public class PigRelBuilder extends RelBuilder {
       }
     }
     return this;
+  }
+
+  String getAlias() {
+    if (lastAlias != null) {
+      return lastAlias;
+    } else {
+      RelNode top = peek();
+      if (top instanceof TableScan) {
+        return Util.last(top.getTable().getQualifiedName());
+      } else {
+        return null;
+      }
+    }
+  }
+
+  /** Retain alias for naming of aggregates. */
+  @Override public RelBuilder as(final String alias) {
+    lastAlias = alias;
+    return super.as(alias);
   }
 
   /** Partitioner for group and join */

--- a/core/src/main/java/org/apache/calcite/tools/PigRelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/PigRelBuilder.java
@@ -135,14 +135,13 @@ public class PigRelBuilder extends RelBuilder {
       if (groupKey.i < n - 1) {
         r = build();
       }
-      String alias = getAlias();
       // Create a ROW to pass to COLLECT. Interestingly, this is not allowed
       // by standard SQL; see [CALCITE-877] Allow ROW as argument to COLLECT.
       final RexNode row =
           cluster.getRexBuilder().makeCall(peek(1, 0).getRowType(),
               SqlStdOperatorTable.ROW, fields());
       aggregate(groupKey.e,
-          aggregateCall(SqlStdOperatorTable.COLLECT, false, null, alias, row));
+          aggregateCall(SqlStdOperatorTable.COLLECT, false, null, null, row));
       if (groupKey.i < n - 1) {
         push(r);
         List<RexNode> predicates = new ArrayList<>();

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -39,6 +39,7 @@ import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;
@@ -57,7 +58,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
-import org.apache.calcite.util.CompositeList;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
@@ -76,12 +76,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import java.math.BigDecimal;
 import java.util.AbstractList;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -222,6 +224,13 @@ public class RelBuilder {
   public RelBuilder push(RelNode node) {
     stack.push(new Frame(node));
     return this;
+  }
+
+  /**
+   * Adds a rel node to the top of the stack while preserving the field names & aliases. */
+  private void replaceTop(RelNode node) {
+    final Frame frame = stack.pop();
+    stack.push(new Frame(node, frame.fields));
   }
 
   /** Pushes a collection of relational expressions. */
@@ -405,28 +414,23 @@ public class RelBuilder {
   public RexNode field(int inputCount, String alias, String fieldName) {
     Preconditions.checkNotNull(alias);
     Preconditions.checkNotNull(fieldName);
-    final List<String> aliases = new ArrayList<>();
+    final List<String> fields = new ArrayList<>();
     for (int inputOrdinal = 0; inputOrdinal < inputCount; ++inputOrdinal) {
       final Frame frame = peek_(inputOrdinal);
-      int offset = 0; // relative to this frame
-      for (Pair<String, RelDataType> pair : frame.right) {
-        if (pair.left != null && pair.left.equals(alias)) {
-          int i = pair.right.getFieldNames().indexOf(fieldName);
-          if (i >= 0) {
-            return field(inputCount, inputCount - 1 - inputOrdinal,
-                offset + i);
-          } else {
-            throw new IllegalArgumentException("no field '" + fieldName
-                + "' in relation '" + alias
-                + "'; fields are: " + pair.right.getFieldNames());
-          }
+      for (int i = 0; i < frame.fields.size(); ++i) {
+        // check for alias match
+        if (frame.fields.get(i).left.contains(alias)
+            // and field name match
+            && frame.fields.get(i).right.getName().equals(fieldName)) {
+          return field(inputCount, inputCount - 1 - inputOrdinal, i);
         }
-        aliases.add(pair.left);
-        offset += pair.right.getFieldCount();
+        fields.add(
+            String.format("{aliases=%s,fieldName=%s}",
+                          frame.fields.get(i).left,
+                          frame.fields.get(i).right.getName()));
       }
     }
-    throw new IllegalArgumentException("no relation with alias '" + alias
-        + "'; aliases are: " + aliases);
+    throw new IllegalArgumentException("no aliased field found; fields are: " + fields);
   }
 
   /** Returns a reference to a given field of a record-valued expression. */
@@ -476,7 +480,7 @@ public class RelBuilder {
   public ImmutableList<RexNode> fields(List<? extends Number> ordinals) {
     final ImmutableList.Builder<RexNode> nodes = ImmutableList.builder();
     for (Number ordinal : ordinals) {
-      RexNode node = field(1, 0, ordinal.intValue(), true);
+      RexNode node = field(1, 0, ordinal.intValue(), false);
       nodes.add(node);
     }
     return nodes.build();
@@ -796,7 +800,7 @@ public class RelBuilder {
     if (!x.isAlwaysTrue()) {
       final Frame frame = stack.pop();
       final RelNode filter = filterFactory.createFilter(frame.rel, x);
-      stack.push(new Frame(filter, frame.right));
+      stack.push(new Frame(filter, frame.fields));
     }
     return this;
   }
@@ -856,16 +860,42 @@ public class RelBuilder {
       boolean force) {
     final List<String> names = new ArrayList<>();
     final List<RexNode> exprList = new ArrayList<>();
+    final Iterator<String> nameIterator = fieldNames.iterator();
     for (RexNode node : nodes) {
       if (simplify) {
         node = RexUtil.simplifyPreservingType(getRexBuilder(), node);
       }
       exprList.add(node);
-    }
-    final Iterator<String> nameIterator = fieldNames.iterator();
-    for (RexNode node : nodes) {
-      final String name = nameIterator.hasNext() ? nameIterator.next() : null;
+      String name = nameIterator.hasNext() ? nameIterator.next() : null;
       names.add(name != null ? name : inferAlias(exprList, node));
+    }
+    final Frame frame = stack.peek();
+    ImmutableList.Builder<Pair<Set<String>, RelDataTypeField>> fields = ImmutableList.builder();
+    final Set<String> uniqueNameList =
+        getTypeFactory().getTypeSystem().isSchemaCaseSensitive()
+        ? new HashSet<String>()
+        : new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    // calculate final names and build field list
+    for (int i = 0; i < names.size(); ++i) {
+      RexNode node = exprList.get(i);
+      String name = names.get(i);
+      Pair<Set<String>, RelDataTypeField> field = null;
+      if (name == null || uniqueNameList.contains(name)) {
+        int j = 0;
+        do {
+          name = SqlValidatorUtil.F_SUGGESTER.apply(name, j++, i);
+        } while (uniqueNameList.contains(name));
+        names.set(i, name);
+      }
+      RelDataTypeField fieldType = new RelDataTypeFieldImpl(name, i, node.getType());
+      if (node.getKind() == SqlKind.INPUT_REF) {
+        // preserve rel aliases for INPUT_REF fields
+        field = Pair.of(frame.fields.get(((RexInputRef) node).getIndex()).left, fieldType);
+      } else {
+        field = Pair.of((Set<String>) new HashSet<String>(), fieldType);
+      }
+      uniqueNameList.add(name);
+      fields.add(field);
     }
     final RelDataType inputRowType = peek().getRowType();
     if (!force && RexUtil.isIdentity(exprList, inputRowType)) {
@@ -874,20 +904,16 @@ public class RelBuilder {
         return this;
       } else {
         // create "virtual" row type for project only rename fields
-        final Frame frame = stack.pop();
-        final RelDataType rowType =
-            RexUtil.createStructType(cluster.getTypeFactory(), exprList,
-                names, SqlValidatorUtil.F_SUGGESTER);
-        stack.push(
-            new Frame(frame.rel,
-                ImmutableList.of(Pair.of(frame.right.get(0).left, rowType))));
+        stack.pop();
+        stack.push(new Frame(frame.rel, fields.build()));
         return this;
       }
     }
     final RelNode project =
-        projectFactory.createProject(build(), ImmutableList.copyOf(exprList),
+        projectFactory.createProject(frame.rel, ImmutableList.copyOf(exprList),
             names);
-    push(project);
+    stack.pop();
+    stack.push(new Frame(project, fields.build()));
     return this;
   }
 
@@ -906,7 +932,7 @@ public class RelBuilder {
     switch (expr.getKind()) {
     case INPUT_REF:
       final RexInputRef ref = (RexInputRef) expr;
-      return peek(0).getRowType().getFieldNames().get(ref.getIndex());
+      return stack.peek().fields.get(ref.getIndex()).getValue().getName();
     case CAST:
       return inferAlias(exprList, ((RexCall) expr).getOperands().get(0));
     case AS:
@@ -980,7 +1006,8 @@ public class RelBuilder {
     if (extraNodes.size() > inputRowType.getFieldCount()) {
       project(extraNodes);
     }
-    final RelNode r = build();
+    final Frame frame = stack.pop();
+    final RelNode r = frame.rel;
     final List<AggregateCall> aggregateCalls = new ArrayList<>();
     for (AggCall aggCall : aggCalls) {
       final AggregateCall aggregateCall;
@@ -1004,7 +1031,41 @@ public class RelBuilder {
     }
     RelNode aggregate = aggregateFactory.createAggregate(r,
         groupKey_.indicator, groupSet, groupSets, aggregateCalls);
-    push(aggregate);
+
+    // build field list
+    ImmutableList.Builder<Pair<Set<String>, RelDataTypeField>> fields = ImmutableList.builder();
+    int i = 0;
+    // first, group fields
+    for (Integer groupField : groupSet.asList()) {
+      RexNode node = extraNodes.get(groupField);
+      if (node.getKind() == SqlKind.INPUT_REF) {
+        fields.add(frame.fields.get(((RexInputRef) node).getIndex()));
+      } else {
+        String name = aggregate.getRowType().getFieldNames().get(i);
+        RelDataTypeField fieldType = new RelDataTypeFieldImpl(name, i, node.getType());
+        fields.add(Pair.<Set<String>, RelDataTypeField>of(new HashSet<String>(), fieldType));
+      }
+      i++;
+    }
+    // second, indicator fields (copy from aggregate rel type)
+    if (groupKey_.indicator) {
+      for (int j = 0; j < groupSet.cardinality(); ++j) {
+        RelDataTypeField fieldType =
+            new RelDataTypeFieldImpl(aggregate.getRowType().getFieldNames().get(i), i,
+                                     aggregate.getRowType().getFieldList().get(i).getType());
+        fields.add(Pair.<Set<String>, RelDataTypeField>of(new HashSet<String>(), fieldType));
+        i++;
+      }
+    }
+    // third, aggregate fields. retain `i' as field index
+    for (int j = 0; j < aggregateCalls.size(); ++j) {
+      AggregateCall call = aggregateCalls.get(j);
+      RelDataTypeField fieldType =
+          new RelDataTypeFieldImpl(aggregate.getRowType().getFieldNames().get(i + j),
+                                   i + j, call.getType());
+      fields.add(Pair.<Set<String>, RelDataTypeField>of(new HashSet<String>(), fieldType));
+    }
+    stack.push(new Frame(aggregate, fields.build()));
     return this;
   }
 
@@ -1169,10 +1230,10 @@ public class RelBuilder {
       join = joinFactory.createJoin(left.rel, right.rel, condition,
           variablesSet, joinType, false);
     }
-    final List<Pair<String, RelDataType>> pairs = new ArrayList<>();
-    pairs.addAll(left.right);
-    pairs.addAll(right.right);
-    stack.push(new Frame(join, ImmutableList.copyOf(pairs)));
+    ImmutableList.Builder<Pair<Set<String>, RelDataTypeField>> fields = ImmutableList.builder();
+    fields.addAll(left.fields);
+    fields.addAll(right.fields);
+    stack.push(new Frame(join, fields.build()));
     filter(postCondition);
     return this;
   }
@@ -1200,10 +1261,9 @@ public class RelBuilder {
   /** Creates a {@link org.apache.calcite.rel.core.SemiJoin}. */
   public RelBuilder semiJoin(Iterable<? extends RexNode> conditions) {
     final Frame right = stack.pop();
-    final Frame left = stack.pop();
     final RelNode semiJoin =
-        semiJoinFactory.createSemiJoin(left.rel, right.rel, and(conditions));
-    stack.push(new Frame(semiJoin, left.right));
+        semiJoinFactory.createSemiJoin(peek(), right.rel, and(conditions));
+    replaceTop(semiJoin);
     return this;
   }
 
@@ -1213,11 +1273,20 @@ public class RelBuilder {
   }
 
   /** Assigns a table alias to the top entry on the stack. */
-  public RelBuilder as(String alias) {
+  public RelBuilder as(final String alias) {
     final Frame pair = stack.pop();
+    List<Pair<Set<String>, RelDataTypeField>> newFields =
+        Lists.transform(pair.fields, new Function<Pair<Set<String>, RelDataTypeField>,
+                                                  Pair<Set<String>, RelDataTypeField>>() {
+          public Pair<Set<String>, RelDataTypeField> apply(final Pair<Set<String>,
+                                                                      RelDataTypeField> field) {
+            field.left.add(alias);
+            return field;
+          }
+        });
     stack.push(
         new Frame(pair.rel,
-            ImmutableList.of(Pair.of(alias, pair.right.get(0).right))));
+                  ImmutableList.copyOf(newFields)));
     return this;
   }
 
@@ -1449,12 +1518,11 @@ public class RelBuilder {
       if (top instanceof Sort) {
         final Sort sort2 = (Sort) top;
         if (sort2.offset == null && sort2.fetch == null) {
-          stack.pop();
-          push(sort2.getInput());
+          replaceTop(sort2.getInput());
           final RelNode sort =
-              sortFactory.createSort(build(), sort2.collation,
+              sortFactory.createSort(peek(), sort2.collation,
                   offsetNode, fetchNode);
-          push(sort);
+          replaceTop(sort);
           return this;
         }
       }
@@ -1463,12 +1531,11 @@ public class RelBuilder {
         if (project.getInput() instanceof Sort) {
           final Sort sort2 = (Sort) project.getInput();
           if (sort2.offset == null && sort2.fetch == null) {
-            stack.pop();
-            push(sort2.getInput());
+            replaceTop(sort2.getInput());
             final RelNode sort =
-                sortFactory.createSort(build(), sort2.collation,
+                sortFactory.createSort(peek(), sort2.collation,
                     offsetNode, fetchNode);
-            push(sort);
+            replaceTop(sort);
             project(project.getProjects());
             return this;
           }
@@ -1479,9 +1546,9 @@ public class RelBuilder {
       project(extraNodes);
     }
     final RelNode sort =
-        sortFactory.createSort(build(), RelCollations.of(fieldCollations),
+        sortFactory.createSort(peek(), RelCollations.of(fieldCollations),
             offsetNode, fetchNode);
-    push(sort);
+    replaceTop(sort);
     if (addedFields) {
       project(originalExtraNodes);
     }
@@ -1560,13 +1627,6 @@ public class RelBuilder {
     stack.clear();
   }
 
-  protected String getAlias() {
-    final Frame frame = stack.peek();
-    return frame.right.size() == 1
-        ? frame.right.get(0).left
-        : null;
-  }
-
   /** Information necessary to create a call to an aggregate function.
    *
    * @see RelBuilder#aggregateCall */
@@ -1642,23 +1702,29 @@ public class RelBuilder {
    * <p>Describes a previously created relational expression and
    * information about how table aliases map into its row type. */
   private static class Frame {
-    static final Function<Pair<String, RelDataType>, List<RelDataTypeField>> FN =
-        new Function<Pair<String, RelDataType>, List<RelDataTypeField>>() {
-          public List<RelDataTypeField> apply(Pair<String, RelDataType> input) {
-            return input.right.getFieldList();
+    static final Function<Pair<Set<String>, RelDataTypeField>, RelDataTypeField> FN =
+        new Function<Pair<Set<String>, RelDataTypeField>, RelDataTypeField>() {
+          public RelDataTypeField apply(Pair<Set<String>, RelDataTypeField> input) {
+            return input.right;
           }
         };
 
     final RelNode rel;
-    final ImmutableList<Pair<String, RelDataType>> right;
+    final ImmutableList<Pair<Set<String>, RelDataTypeField>> fields;
 
-    private Frame(RelNode rel, ImmutableList<Pair<String, RelDataType>> pairs) {
+    private Frame(RelNode rel, ImmutableList<Pair<Set<String>, RelDataTypeField>> fields) {
       this.rel = rel;
-      this.right = pairs;
+      this.fields = fields;
     }
 
     private Frame(RelNode rel) {
-      this(rel, ImmutableList.of(Pair.of(deriveAlias(rel), rel.getRowType())));
+      String tableAlias = deriveAlias(rel);
+      ImmutableList.Builder<Pair<Set<String>, RelDataTypeField>> builder = ImmutableList.builder();
+      for (RelDataTypeField field : rel.getRowType().getFieldList()) {
+        builder.add(Pair.<Set<String>, RelDataTypeField>of(Sets.newHashSet(tableAlias), field));
+      }
+      this.rel = rel;
+      this.fields = builder.build();
     }
 
     private static String deriveAlias(RelNode rel) {
@@ -1672,7 +1738,7 @@ public class RelBuilder {
     }
 
     List<RelDataTypeField> fields() {
-      return CompositeList.ofCopy(Iterables.transform(right, FN));
+      return Lists.transform(fields, FN);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -882,8 +882,11 @@ public class RelBuilder {
       Pair<Set<String>, RelDataTypeField> field = null;
       if (name == null || uniqueNameList.contains(name)) {
         int j = 0;
+        if (name == null) {
+          j = i;
+        }
         do {
-          name = SqlValidatorUtil.F_SUGGESTER.apply(name, j++, i);
+          name = SqlValidatorUtil.F_SUGGESTER.apply(name, j, j++);
         } while (uniqueNameList.contains(name));
         names.set(i, name);
       }

--- a/core/src/test/java/org/apache/calcite/test/PigRelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/PigRelBuilderTest.java
@@ -100,7 +100,7 @@ public class PigRelBuilderTest {
         .group(null, null, -1, builder.groupKey("DEPTNO", "JOB").alias("e"))
         .build();
     final String plan = ""
-        + "LogicalAggregate(group=[{2, 7}], EMP=[COLLECT($8)])\n"
+        + "LogicalAggregate(group=[{2, 7}], agg#0=[COLLECT($8)])\n"
         + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n"
         + "    LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(str(root), is(plan));
@@ -118,8 +118,8 @@ public class PigRelBuilderTest {
             builder.groupKey("DEPTNO").alias("d"))
         .build();
     final String plan = "LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
-        + "  LogicalAggregate(group=[{0}], EMP=[COLLECT($8)])\n"
-        + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n      LogicalTableScan(table=[[scott, EMP]])\n  LogicalAggregate(group=[{0}], DEPT=[COLLECT($3)])\n"
+        + "  LogicalAggregate(group=[{0}], agg#0=[COLLECT($8)])\n"
+        + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n      LogicalTableScan(table=[[scott, EMP]])\n  LogicalAggregate(group=[{0}], agg#0=[COLLECT($3)])\n"
         + "    LogicalProject(DEPTNO=[$0], DNAME=[$1], LOC=[$2], $f3=[ROW($0, $1, $2)])\n"
         + "      LogicalTableScan(table=[[scott, DEPT]])\n";
     assertThat(str(root), is(plan));

--- a/core/src/test/java/org/apache/calcite/test/PigRelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/PigRelBuilderTest.java
@@ -100,7 +100,7 @@ public class PigRelBuilderTest {
         .group(null, null, -1, builder.groupKey("DEPTNO", "JOB").alias("e"))
         .build();
     final String plan = ""
-        + "LogicalAggregate(group=[{2, 7}], agg#0=[COLLECT($8)])\n"
+        + "LogicalAggregate(group=[{2, 7}], EMP=[COLLECT($8)])\n"
         + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n"
         + "    LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(str(root), is(plan));
@@ -118,8 +118,9 @@ public class PigRelBuilderTest {
             builder.groupKey("DEPTNO").alias("d"))
         .build();
     final String plan = "LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
-        + "  LogicalAggregate(group=[{0}], agg#0=[COLLECT($8)])\n"
-        + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n      LogicalTableScan(table=[[scott, EMP]])\n  LogicalAggregate(group=[{0}], agg#0=[COLLECT($3)])\n"
+        + "  LogicalAggregate(group=[{0}], EMP=[COLLECT($8)])\n"
+        + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n"
+        + "      LogicalTableScan(table=[[scott, EMP]])\n  LogicalAggregate(group=[{0}], DEPT=[COLLECT($3)])\n"
         + "    LogicalProject(DEPTNO=[$0], DNAME=[$1], LOC=[$2], $f3=[ROW($0, $1, $2)])\n"
         + "      LogicalTableScan(table=[[scott, DEPT]])\n";
     assertThat(str(root), is(plan));

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -367,7 +367,7 @@ public class RelBuilderTest {
     // Note: AS(COMM, C) becomes just $6
     assertThat(str(root),
         is(
-            "LogicalProject(DEPTNO=[$7], COMM=[CAST($6):SMALLINT NOT NULL], $f2=[20], COMM3=[$6], C=[$6])\n"
+            "LogicalProject(DEPTNO=[$7], COMM=[CAST($6):SMALLINT NOT NULL], $f2=[20], COMM0=[$6], C=[$6])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n"));
   }
 
@@ -400,7 +400,7 @@ public class RelBuilderTest {
         is("LogicalProject(DEPTNO=[$7], COMM=[CAST($6):SMALLINT NOT NULL],"
                 + " $f2=[OR(=($7, 20), AND(null, =($7, 10), IS NULL($6),"
                 + " IS NULL($7)), =($7, 30))], n2=[IS NULL($2)],"
-                + " nn2=[IS NOT NULL($3)], $f5=[20], COMM6=[$6], C=[$6])\n"
+                + " nn2=[IS NOT NULL($3)], $f5=[20], COMM0=[$6], C=[$6])\n"
                 + "  LogicalTableScan(table=[[scott, EMP]])\n"));
   }
 
@@ -1188,7 +1188,7 @@ public class RelBuilderTest {
     final String expected = ""
                             + "LogicalProject(DEPTNO=[$0], EMPNO=[$2])\n"
                             + "  LogicalFilter(condition=[>($0, 100)])\n"
-                            + "    LogicalProject(DEPTNO=[$16], DEPTNO1=[$16], EMPNO=[$8], MGR=[$3])\n"
+                            + "    LogicalProject(DEPTNO=[$16], DEPTNO0=[$16], EMPNO=[$8], MGR=[$3])\n"
                             + "      LogicalJoin(condition=[true], joinType=[inner])\n"
                             + "        LogicalTableScan(table=[[scott, EMP]])\n"
                             + "        LogicalJoin(condition=[true], joinType=[inner])\n"

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -47,6 +47,7 @@ import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 
 import org.junit.Test;
 
@@ -428,7 +429,7 @@ public class RelBuilderTest {
             .project(builder.field("a"),
                 builder.field("t1", "c"))
             .build();
-    final String expected = "LogicalProject(DEPTNO=[$0], LOC=[$2])\n"
+    final String expected = "LogicalProject(a=[$0], c=[$2])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
     assertThat(str(root), is(expected));
   }
@@ -446,15 +447,17 @@ public class RelBuilderTest {
                 builder.call(SqlStdOperatorTable.EQUALS,
                     builder.field("a"),
                     builder.literal(20)))
-            .aggregate(builder.groupKey(0, 1, 2))
+            .aggregate(builder.groupKey(0, 1, 2),
+                       builder.aggregateCall(SqlStdOperatorTable.SUM,
+                                             false, null, null,
+                                             builder.field(0)))
             .project(builder.field("c"),
                 builder.field("a"))
             .build();
     final String expected = "LogicalProject(c=[$2], a=[$0])\n"
-        + "  LogicalAggregate(group=[{3, 4, 5}])\n"
-        + "    LogicalProject(DEPTNO=[$0], DNAME=[$1], LOC=[$2], a=[$0], b=[$1], c=[$2])\n"
-        + "      LogicalFilter(condition=[=($0, 20)])\n"
-        + "        LogicalTableScan(table=[[scott, DEPT]])\n";
+                            + "  LogicalAggregate(group=[{0, 1, 2}], agg#0=[SUM($0)])\n"
+                            + "    LogicalFilter(condition=[=($0, 20)])\n"
+                            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
     assertThat(str(root), is(expected));
   }
 
@@ -1036,25 +1039,189 @@ public class RelBuilderTest {
     final RelBuilder builder = RelBuilder.create(config().build());
     RelNode root =
         builder.scan("EMP")
-            .as("e")
-            .scan("EMP")
-            .as("m")
-            .scan("DEPT")
-            .join(JoinRelType.INNER)
-            .join(JoinRelType.INNER)
-            .filter(
-                builder.equals(builder.field("e", "DEPTNO"),
-                    builder.field("DEPT", "DEPTNO")),
-                builder.equals(builder.field("m", "EMPNO"),
-                    builder.field("e", "MGR")))
-            .build();
+               .as("e")
+               .scan("EMP")
+               .as("m")
+               .scan("DEPT")
+               .join(JoinRelType.INNER)
+               .join(JoinRelType.INNER)
+               .filter(
+                   builder.equals(builder.field("e", "DEPTNO"),
+                                  builder.field("DEPT", "DEPTNO")),
+                   builder.equals(builder.field("m", "EMPNO"),
+                                  builder.field("e", "MGR")))
+               .build();
     final String expected = ""
-        + "LogicalFilter(condition=[AND(=($7, $16), =($8, $3))])\n"
-        + "  LogicalJoin(condition=[true], joinType=[inner])\n"
-        + "    LogicalTableScan(table=[[scott, EMP]])\n"
-        + "    LogicalJoin(condition=[true], joinType=[inner])\n"
-        + "      LogicalTableScan(table=[[scott, EMP]])\n"
-        + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+                            + "LogicalFilter(condition=[AND(=($7, $16), =($8, $3))])\n"
+                            + "  LogicalJoin(condition=[true], joinType=[inner])\n"
+                            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+                            + "    LogicalJoin(condition=[true], joinType=[inner])\n"
+                            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+                            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(str(root), is(expected));
+  }
+
+  @Test public void testAliasSort() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+               .as("e")
+               .sort(0)
+               .project(builder.field("e", "EMPNO"))
+               .build();
+    final String expected = ""
+                            + "LogicalProject(EMPNO=[$0])\n"
+                            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
+                            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(str(root), is(expected));
+  }
+
+  @Test public void testAliasLimit() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+               .as("e")
+               .sort(1)
+               .sortLimit(10, 20) // aliases were lost here if preceded by sort()
+               .project(builder.field("e", "EMPNO"))
+               .build();
+    final String expected = ""
+                            + "LogicalProject(EMPNO=[$0])\n"
+                            + "  LogicalSort(sort0=[$1], dir0=[ASC], offset=[10], fetch=[20])\n"
+                            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(str(root), is(expected));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-1551">[CALCITE-1551]
+   * RelBuilder's project() doesn't preserve alias</a> */
+  @Test public void testAliasProject() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+               .as("EMP_alias")
+               .project(builder.field("DEPTNO"),
+                        builder.literal(20))
+               .project(builder.field("EMP_alias", "DEPTNO"))
+               .build();
+    assertThat(str(root),
+               is(
+                   "LogicalProject(DEPTNO=[$0])\n"
+                   + "  LogicalProject(DEPTNO=[$7], $f1=[20])\n"
+                   + "    LogicalTableScan(table=[[scott, EMP]])\n"));
+  }
+
+  @Test public void testAliasAggregate() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+               .as("EMP_alias")
+               .project(builder.field("DEPTNO"),
+                        builder.literal(20))
+               .aggregate(builder.groupKey(builder.field("EMP_alias", "DEPTNO")),
+                          builder.aggregateCall(SqlStdOperatorTable.SUM, false, null, null,
+                                                builder.field(1)))
+               .project(builder.alias(builder.field(1), "sum"),
+                        builder.field("EMP_alias", "DEPTNO"))
+               .build();
+    assertThat(str(root),
+               is(
+                   "LogicalProject(sum=[$1], DEPTNO=[$0])\n"
+                   + "  LogicalAggregate(group=[{0}], agg#0=[SUM($1)])\n"
+                   + "    LogicalProject(DEPTNO=[$7], $f1=[20])\n"
+                   + "      LogicalTableScan(table=[[scott, EMP]])\n"));
+  }
+
+  /**
+   * Test that a projection retains field names after a join.
+   */
+  @Test public void testProjectJoin() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+               .as("e")
+               .scan("DEPT")
+               .join(JoinRelType.INNER)
+               .project(
+                   builder.field("DEPT", "DEPTNO"),
+                   builder.field(0),
+                   builder.field("e", "MGR"))
+               // essentially a no-op, was previously throwing exception due to
+               // project() using join-renamed fields
+               .project(
+                   builder.field("DEPT", "DEPTNO"),
+                   builder.field(1),
+                   builder.field("e", "MGR"))
+               .build();
+    final String expected = ""
+                            + "LogicalProject(DEPTNO=[$8], EMPNO=[$0], MGR=[$3])\n"
+                            + "  LogicalJoin(condition=[true], joinType=[inner])\n"
+                            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+                            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(str(root), is(expected));
+  }
+
+  @Test public void testMultiLevelAlias() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+               .as("e")
+               .scan("EMP")
+               .as("m")
+               .scan("DEPT")
+               .join(JoinRelType.INNER)
+               .join(JoinRelType.INNER)
+               .project(
+                   builder.field("DEPT", "DEPTNO"),
+                   builder.field(16),
+                   builder.field("m", "EMPNO"),
+                   builder.field("e", "MGR"))
+               .as("all")
+               .filter(
+                   builder.call(SqlStdOperatorTable.GREATER_THAN,
+                                builder.field("DEPT", "DEPTNO"),
+                                builder.literal(100)))
+               .project(
+                   builder.field("DEPT", "DEPTNO"),
+                   builder.field("all", "EMPNO"))
+               .build();
+    final String expected = ""
+                            + "LogicalProject(DEPTNO=[$0], EMPNO=[$2])\n"
+                            + "  LogicalFilter(condition=[>($0, 100)])\n"
+                            + "    LogicalProject(DEPTNO=[$16], DEPTNO1=[$16], EMPNO=[$8], MGR=[$3])\n"
+                            + "      LogicalJoin(condition=[true], joinType=[inner])\n"
+                            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+                            + "        LogicalJoin(condition=[true], joinType=[inner])\n"
+                            + "          LogicalTableScan(table=[[scott, EMP]])\n"
+                            + "          LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(str(root), is(expected));
+  }
+
+  @Test public void testUnionAlias() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+               .as("e1")
+               .project(builder.field("EMPNO"),
+                        builder.call(SqlStdOperatorTable.CONCAT,
+                                     builder.field("ENAME"),
+                                     builder.literal("-1")))
+               .scan("EMP")
+               .as("e2")
+               .project(builder.field("EMPNO"),
+                        builder.call(SqlStdOperatorTable.CONCAT,
+                                     builder.field("ENAME"),
+                                     builder.literal("-2")))
+               .union(false) // aliases lost here
+               .project(builder.fields(Lists.newArrayList(1, 0)))
+               .build();
+    final String expected = ""
+                            + "LogicalProject($f1=[$1], EMPNO=[$0])\n"
+                            + "  LogicalUnion(all=[false])\n"
+                            + "    LogicalProject(EMPNO=[$0], $f1=[||($1, '-1')])\n"
+                            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+                            + "    LogicalProject(EMPNO=[$0], $f1=[||($1, '-2')])\n"
+                            + "      LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(str(root), is(expected));
   }
 

--- a/core/src/test/java/org/apache/calcite/test/StreamTest.java
+++ b/core/src/test/java/org/apache/calcite/test/StreamTest.java
@@ -286,7 +286,7 @@ public class StreamTest {
             + "  LogicalProject(ROWTIME=[$0], ORDERID=[$1], SUPPLIERID=[$5])\n"
             + "    LogicalProject(ROWTIME=[$0], ID=[$1], PRODUCT=[$2], UNITS=[$3], ID0=[$5], SUPPLIER=[$6])\n"
             + "      LogicalJoin(condition=[=($4, $5)], joinType=[inner])\n"
-            + "        LogicalProject(ROWTIME=[$0], ID=[$1], PRODUCT=[$2], UNITS=[$3], PRODUCT4=[CAST($2):VARCHAR(32) CHARACTER SET \"ISO-8859-1\" COLLATE \"ISO-8859-1$en_US$primary\" NOT NULL])\n"
+            + "        LogicalProject(ROWTIME=[$0], ID=[$1], PRODUCT=[$2], UNITS=[$3], PRODUCT0=[CAST($2):VARCHAR(32) CHARACTER SET \"ISO-8859-1\" COLLATE \"ISO-8859-1$en_US$primary\" NOT NULL])\n"
             + "          LogicalTableScan(table=[[STREAM_JOINS, ORDERS]])\n"
             + "        LogicalTableScan(table=[[STREAM_JOINS, PRODUCTS]])\n")
         .explainContains(""

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5318,7 +5318,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
         <Resource name="planAfter">
             <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[$SUM0($4)])
-  LogicalProject(JOB=[$0], EXPR$0=[$1], NAME=[$2], EXPR$00=[$3], $f4=[*($1, $3)])
+  LogicalProject(JOB=[$0], EXPR$0=[$1], NAME=[$2], EXPR$03=[$3], $f4=[*($1, $3)])
     LogicalJoin(condition=[=($0, $2)], joinType=[inner])
       LogicalAggregate(group=[{2}], EXPR$0=[COUNT()])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -5777,7 +5777,7 @@ LogicalProject(DEPTNO=[$7])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
     LogicalJoin(condition=[true], joinType=[left])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalJoin(condition=[=($7, $11)], joinType=[inner])
@@ -5842,7 +5842,7 @@ LogicalFilter(condition=[<($0, 20)])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
     LogicalJoin(condition=[true], joinType=[left])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalJoin(condition=[true], joinType=[inner])
@@ -5907,8 +5907,8 @@ LogicalProject(DEPTNO=[$7])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
-    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10], $f0=[$11])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10], $f0=[$11])
       LogicalJoin(condition=[<($11, $12)], joinType=[left])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
         LogicalJoin(condition=[true], joinType=[left])
@@ -6007,7 +6007,7 @@ LogicalProject(EMPNO=[$0], DEPTNO=[$7])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
     LogicalJoin(condition=[true], joinType=[left])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalJoin(condition=[AND(=($0, $11), =($9, $12))], joinType=[inner])

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1221,11 +1221,11 @@ LogicalProject(X=[$0], Y=[$1])
             <![CDATA[
 LogicalProject(EXPR$0=[CAST($1):VARCHAR(128) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL], EXPR$1=[CAST($2):INTEGER NOT NULL])
   LogicalFilter(condition=[=(CAST(CAST($4):VARCHAR(1) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL):VARCHAR(7) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL, 'Manager')])
-    LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO0=[$10], SLACKER=[$11])
+    LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO1=[$10], SLACKER=[$11])
       LogicalJoin(condition=[=($2, $12)], joinType=[inner])
-        LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO2=[CAST($0):INTEGER NOT NULL])
+        LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[CAST($0):INTEGER NOT NULL])
           LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[CAST($7):INTEGER NOT NULL])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[CAST($7):INTEGER NOT NULL])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -1233,11 +1233,11 @@ LogicalProject(EXPR$0=[CAST($1):VARCHAR(128) CHARACTER SET "ISO-8859-1" COLLATE 
             <![CDATA[
 LogicalProject(EXPR$0=[CAST($1):VARCHAR(128) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL], EXPR$1=[$2])
   LogicalFilter(condition=[=(CAST(CAST($4):VARCHAR(1) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL):VARCHAR(7) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary" NOT NULL, 'Manager')])
-    LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO0=[$10], SLACKER=[$11])
+    LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO1=[$10], SLACKER=[$11])
       LogicalJoin(condition=[=($2, $12)], joinType=[inner])
-        LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO2=[$0])
+        LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[$0])
           LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$7])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$7])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -5318,7 +5318,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
         <Resource name="planAfter">
             <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[$SUM0($4)])
-  LogicalProject(JOB=[$0], EXPR$0=[$1], NAME=[$2], EXPR$03=[$3], $f4=[*($1, $3)])
+  LogicalProject(JOB=[$0], EXPR$0=[$1], NAME=[$2], EXPR$00=[$3], $f4=[*($1, $3)])
     LogicalJoin(condition=[=($0, $2)], joinType=[inner])
       LogicalAggregate(group=[{2}], EXPR$0=[COUNT()])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -5777,7 +5777,7 @@ LogicalProject(DEPTNO=[$7])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
     LogicalJoin(condition=[true], joinType=[left])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalJoin(condition=[=($7, $11)], joinType=[inner])
@@ -5842,7 +5842,7 @@ LogicalFilter(condition=[<($0, 20)])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
     LogicalJoin(condition=[true], joinType=[left])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalJoin(condition=[true], joinType=[inner])
@@ -5907,8 +5907,8 @@ LogicalProject(DEPTNO=[$7])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
-    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10], $f0=[$11])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10], $f0=[$11])
       LogicalJoin(condition=[<($11, $12)], joinType=[left])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
         LogicalJoin(condition=[true], joinType=[left])
@@ -6007,7 +6007,7 @@ LogicalProject(EMPNO=[$0], DEPTNO=[$7])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9], NAME=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
     LogicalJoin(condition=[true], joinType=[left])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalJoin(condition=[AND(=($0, $11), =($9, $12))], joinType=[inner])

--- a/piglet/src/test/java/org/apache/calcite/test/PigletTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigletTest.java
@@ -135,7 +135,7 @@ public class PigletTest {
     final String s = "A = LOAD 'EMP';\n"
         + "B = GROUP A BY DEPTNO;";
     final String expected = ""
-        + "LogicalAggregate(group=[{7}], agg#0=[COLLECT($8)])\n"
+        + "LogicalAggregate(group=[{7}], A=[COLLECT($8)])\n"
         + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n"
         + "    LogicalTableScan(table=[[scott, EMP]])\n";
     pig(s).explainContains(expected);

--- a/piglet/src/test/java/org/apache/calcite/test/PigletTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigletTest.java
@@ -135,7 +135,7 @@ public class PigletTest {
     final String s = "A = LOAD 'EMP';\n"
         + "B = GROUP A BY DEPTNO;";
     final String expected = ""
-        + "LogicalAggregate(group=[{7}], A=[COLLECT($8)])\n"
+        + "LogicalAggregate(group=[{7}], agg#0=[COLLECT($8)])\n"
         + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[ROW($0, $1, $2, $3, $4, $5, $6, $7)])\n"
         + "    LogicalTableScan(table=[[scott, EMP]])\n";
     pig(s).explainContains(expected);


### PR DESCRIPTION
This is accomplished by changing the structure of the Frame in
RelBuilder to include alias and field information for all fields in the
relnode irrespective of their origin. Rel aliases also preserved on
group keys through aggregate operations.

General approach:
* Each `Frame` now maintains a list of fields, each field having a set of rel aliases by which it can be referred to. I renamed `Frame.right` to `Frame.fields` and the type is now `Pair<Set<String>, RelDataTypeField>`.
* `RelBuilder.field(alias, fieldName)` modified slightly to check aliases and field name equality. Code is simpler now as there is an entry for each field.
* `RelBuilder.project()` modified to build a field list preserving any aliases linked by `RexInputRef` nodes.
* `RelBuilder.filter()`, sort, sortLimit modified to retain the existing set of aliases & fields.
* `RelBuilder.aggregate()` modified to retain aliases of group keys which are `RexInputRef` nodes.

A few notes about the patch:
* Changed `PigRelBuilder` to use a `null` alias for the `aggregateCall()`. It was previously taken from the (first) rel alias which doesn't seem to have any utility. If this needs to do something else, I'll gladly change it.
* `RelBuilder.field(ordinals)` uses a special version of `field()` which may assign an alias. I didn't understand the original intention of this in 2193c6e6e88873dc4b63d8572eebeaa51c795c6c. I'm no longer using that `alias` argument and everything seems to work well without it. Is it ok to remove?