### PR TITLE
[CALCITE-1558] fix field mapping for converting an aggregate to a two…

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3047,6 +3047,32 @@ public class RelOptRulesTest extends RelOptTestBase {
         .build();
     sql(sql).with(program).check();
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-1558">[CALCITE-1558]
+   * Converting an aggregate to a two-level aggregates</a>
+   */
+  @Test public void testDistinctNonDistinctAggregatesWithGrouping1() {
+    final String sql = ""
+        + "SELECT deptno, SUM(deptno), SUM(DISTINCT sal), MAX(deptno), MAX(comm)\n"
+        + "FROM emp\n"
+        + "GROUP BY deptno";
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(AggregateExpandDistinctAggregatesRule.JOIN)
+        .build();
+    sql(sql).with(program).check();
+  }
+
+  @Test public void testDistinctNonDistinctAggregatesWithGrouping2() {
+    final String sql = ""
+            + "SELECT deptno, COUNT(deptno), SUM(DISTINCT sal)\n"
+            + "FROM emp\n"
+            + "GROUP BY deptno";
+    HepProgram program = new HepProgramBuilder()
+            .addRuleInstance(AggregateExpandDistinctAggregatesRule.JOIN)
+            .build();
+    sql(sql).with(program).check();
+  }
 }
 
 // End RelOptRulesTest.java

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6622,4 +6622,48 @@ LogicalProject(SAL=[$5])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testDistinctNonDistinctAggregatesWithGrouping1">
+        <Resource name="sql">
+            <![CDATA[SELECT deptno, SUM(deptno), SUM(DISTINCT sal), MAX(deptno), MAX(comm)
+FROM emp
+GROUP BY deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($0)], EXPR$2=[SUM(DISTINCT $1)], EXPR$3=[MAX($0)], EXPR$4=[MAX($2)])
+  LogicalProject(DEPTNO=[$7], SAL=[$5], COMM=[$6])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($2)], EXPR$2=[SUM($1)], EXPR$3=[MAX($3)], EXPR$4=[MAX($4)])
+  LogicalAggregate(group=[{0, 1}], EXPR$1=[SUM($0)], EXPR$3=[MAX($0)], EXPR$4=[MAX($2)])
+    LogicalProject(DEPTNO=[$7], SAL=[$5], COMM=[$6])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDistinctNonDistinctAggregatesWithGrouping2">
+        <Resource name="sql">
+            <![CDATA[SELECT deptno, SUM(deptno), SUM(DISTINCT sal)
+FROM emp
+GROUP BY deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[SUM(DISTINCT $1)])
+  LogicalProject(DEPTNO=[$7], SAL=[$5])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($2)], EXPR$2=[SUM($1)])
+  LogicalAggregate(group=[{0, 1}], EXPR$1=[COUNT()])
+    LogicalProject(DEPTNO=[$7], SAL=[$5])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
fix field mapping for converting an aggregate to a two-level aggregates in the following cases:

// Equivalent SQL:
// SELECT deptno, COUNT(deptno), SUM(DISTINCT sal)
// FROM emp
// GROUP BY deptno

// SELECT deptno, SUM(cnt), SUM(sal)
// FROM
// SELECT deptno, COUNT(deptno) AS cnt, sal
// FROM emp
// GROUP BY deptno, sal
// GROUP BY deptno

or a more complex case:

// Equivalent SQL:
// SELECT deptno, SUM(deptno), SUM(DISTINCT sal), MAX(deptno), MAX(comm)
// FROM emp
// GROUP BY deptno

// SELECT deptno, SUM(sumOfInnerComm), SUM(sal), MAX(maxOfInnerDeptno), MAX(maxOfInnerComm)
// FROM
// SELECT deptno, sal, SUM(deptno) as sumOfInnerDeptno, MAX(deptno) as maxOfInnerDeptno, MAX(comm) AS maxOfInnerComm
// FROM emp
// GROUP BY deptno, sal
// GROUP BY deptno