### PR TITLE
[CALCITE-1568] Upgrade mockito to 2.5.5

### DIFF
--- a/avatica/core/pom.xml
+++ b/avatica/core/pom.xml
@@ -79,7 +79,7 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/AvaticaConnectionTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/AvaticaConnectionTest.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.avatica;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -30,12 +29,9 @@ public class AvaticaConnectionTest {
 
   @Test
   public void testNumExecuteRetries() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     AvaticaConnection statement = Mockito.mock(AvaticaConnection.class);
 
-    Mockito.when(statement.getNumStatementRetries(Mockito.any(Properties.class)))
+    Mockito.when(statement.getNumStatementRetries(Mockito.nullable(Properties.class)))
       .thenCallRealMethod();
 
     // Bad argument should throw an exception

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/AvaticaStatementTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/AvaticaStatementTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.avatica;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,9 +33,6 @@ public class AvaticaStatementTest {
   private AvaticaStatement statement;
 
   @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     statement = mock(AvaticaStatement.class);
   }
 

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/QueryStateTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/QueryStateTest.java
@@ -18,7 +18,6 @@ package org.apache.calcite.avatica;
 
 import org.apache.calcite.avatica.remote.MetaDataOperation;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,9 +42,6 @@ public class QueryStateTest {
 
   @Before
   public void setup() throws Exception {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     conn = Mockito.mock(Connection.class);
     metadata = Mockito.mock(DatabaseMetaData.class);
     statement = Mockito.mock(Statement.class);

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/remote/AbstractHandlerTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/remote/AbstractHandlerTest.java
@@ -22,8 +22,6 @@ import org.apache.calcite.avatica.remote.Service.ErrorResponse;
 import org.apache.calcite.avatica.remote.Service.Request;
 import org.apache.calcite.avatica.remote.Service.Response;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -46,11 +44,6 @@ public class AbstractHandlerTest {
     PrintWriter pw = new PrintWriter(sw);
     Objects.requireNonNull(e).printStackTrace(pw);
     return sw.toString();
-  }
-
-  @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
   }
 
   @Test public void testExceptionUnwrappingWithoutContext() {
@@ -111,7 +104,7 @@ public class AbstractHandlerTest {
     // Deserialize it back into a POJO
     Mockito.when(handler.decode(Mockito.anyString())).thenReturn(request);
     // Construct the Response for that Request
-    Mockito.when(request.accept(Mockito.any(Service.class))).thenReturn(response);
+    Mockito.when(request.accept(Mockito.nullable(Service.class))).thenReturn(response);
     // Throw an IOException when serializing the Response.
     Mockito.when(handler.encode(response)).thenThrow(exception);
     Mockito.when(handler.convertToErrorResponse(exception)).thenCallRealMethod();

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaCommonsHttpClientImplTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaCommonsHttpClientImplTest.java
@@ -23,8 +23,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.StringEntity;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -42,11 +40,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Test class for {@link AvaticaCommonsHttpClientImpl}
  */
 public class AvaticaCommonsHttpClientImplTest {
-
-  @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-  }
 
   @Test public void testRetryOnHttp503() throws Exception {
     final byte[] requestBytes = "fake_request".getBytes(UTF_8);

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.avatica.remote;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -39,11 +37,6 @@ public class AvaticaHttpClientTest {
   private static final String RESPONSE =
       "{\"response\":\"createStatement\",\"connectionId\":"
           + "\"8f3f28ee-d0bb-4cdb-a4b1-8f6e8476c534\",\"statementId\":1608176856}";
-
-  @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-  }
 
   @Test
   public void testRetryOnUnavailable() throws Exception {

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/remote/KerberosConnectionTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/remote/KerberosConnectionTest.java
@@ -18,8 +18,6 @@ package org.apache.calcite.avatica.remote;
 
 import org.apache.calcite.avatica.remote.KerberosConnection.RenewalTask;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -36,6 +34,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,11 +42,6 @@ import static org.mockito.Mockito.when;
  * Test case for KerberosConnection
  */
 public class KerberosConnectionTest {
-
-  @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-  }
 
   @Test(expected = NullPointerException.class) public void testNullArgs() {
     new KerberosConnection(null, null);
@@ -75,7 +69,7 @@ public class KerberosConnectionTest {
     LoginContext context = mock(LoginContext.class);
 
     // Call the real login(LoginContext, Configuration, Subject) method
-    when(krbUtil.login(any(LoginContext.class), any(Configuration.class), any(Subject.class)))
+    when(krbUtil.login(nullable(LoginContext.class), any(Configuration.class), any(Subject.class)))
         .thenCallRealMethod();
     // Return a fake LoginContext
     when(krbUtil.createLoginContext(conf)).thenReturn(context);

--- a/avatica/core/src/test/java/org/apache/calcite/avatica/remote/ProtobufHandlerTest.java
+++ b/avatica/core/src/test/java/org/apache/calcite/avatica/remote/ProtobufHandlerTest.java
@@ -28,7 +28,6 @@ import org.apache.calcite.avatica.remote.Service.FetchRequest;
 import org.apache.calcite.avatica.remote.Service.FetchResponse;
 import org.apache.calcite.avatica.remote.Service.RpcMetadataResponse;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -55,9 +54,6 @@ public class ProtobufHandlerTest {
 
   @Before
   public void setupMocks() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     // Mocks
     service = Mockito.mock(Service.class);
     translation = Mockito.mock(ProtobufTranslation.class);

--- a/avatica/metrics-dropwizardmetrics3/pom.xml
+++ b/avatica/metrics-dropwizardmetrics3/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardHistogramTest.java
+++ b/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardHistogramTest.java
@@ -18,7 +18,6 @@ package org.apache.calcite.avatica.metrics.dropwizard3;
 
 import com.codahale.metrics.Histogram;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -31,9 +30,6 @@ public class DropwizardHistogramTest {
   private Histogram histogram;
 
   @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     this.histogram = Mockito.mock(Histogram.class);
   }
 

--- a/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardMeterTest.java
+++ b/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardMeterTest.java
@@ -18,7 +18,6 @@ package org.apache.calcite.avatica.metrics.dropwizard3;
 
 import com.codahale.metrics.Meter;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -31,9 +30,6 @@ public class DropwizardMeterTest {
   private Meter meter;
 
   @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     this.meter = Mockito.mock(Meter.class);
   }
 

--- a/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardMetricsSystemTest.java
+++ b/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardMetricsSystemTest.java
@@ -25,7 +25,6 @@ import org.apache.calcite.avatica.metrics.Timer.Context;
 
 import com.codahale.metrics.MetricRegistry;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,9 +44,6 @@ public class DropwizardMetricsSystemTest {
   private DropwizardMetricsSystem metrics;
 
   @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     mockRegistry = mock(MetricRegistry.class);
     metrics = new DropwizardMetricsSystem(mockRegistry);
   }

--- a/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardTimerTest.java
+++ b/avatica/metrics-dropwizardmetrics3/src/test/java/org/apache/calcite/avatica/metrics/dropwizard3/DropwizardTimerTest.java
@@ -21,7 +21,6 @@ import org.apache.calcite.avatica.metrics.dropwizard3.DropwizardTimer.Dropwizard
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -35,9 +34,6 @@ public class DropwizardTimerTest {
   private Context context;
 
   @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     this.timer = Mockito.mock(Timer.class);
     this.context = Mockito.mock(Context.class);
   }

--- a/avatica/metrics/pom.xml
+++ b/avatica/metrics/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/avatica/metrics/src/test/java/org/apache/calcite/avatica/metrics/MetricsSystemLoaderTest.java
+++ b/avatica/metrics/src/test/java/org/apache/calcite/avatica/metrics/MetricsSystemLoaderTest.java
@@ -19,8 +19,6 @@ package org.apache.calcite.avatica.metrics;
 import org.apache.calcite.avatica.metrics.noop.NoopMetricsSystem;
 import org.apache.calcite.avatica.metrics.noop.NoopMetricsSystemConfiguration;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -34,11 +32,6 @@ import static org.junit.Assert.assertEquals;
  * Test class for {@link MetricsSystemLoader}.
  */
 public class MetricsSystemLoaderTest {
-
-  @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-  }
 
   @Test public void testSingleInstance() {
     final List<MetricsSystemFactory> factories =

--- a/avatica/pom.xml
+++ b/avatica/pom.xml
@@ -81,7 +81,7 @@ limitations under the License.
     <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
     <maven-scm-provider.version>1.9.4</maven-scm-provider.version>
     <maven-shade-plugin.version>2.1</maven-shade-plugin.version>
-    <mockito-all.version>1.10.19</mockito-all.version>
+    <mockito.version>2.5.5</mockito.version>
     <protobuf.version>3.1.0</protobuf.version>
     <scott-data-hsqldb.version>0.1</scott-data-hsqldb.version>
     <servlet.version>3.0.1</servlet.version>
@@ -249,8 +249,8 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${mockito-all.version}</version>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/avatica/server/pom.xml
+++ b/avatica/server/pom.xml
@@ -119,7 +119,7 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/jdbc/JdbcMetaTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/jdbc/JdbcMetaTest.java
@@ -23,7 +23,6 @@ import org.apache.calcite.avatica.Meta.StatementHandle;
 
 import com.google.common.cache.Cache;
 
-import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -58,9 +57,6 @@ public class JdbcMetaTest {
   }
 
   @Test public void testPrepareSetsMaxRows() throws Exception {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     final String id = UUID.randomUUID().toString();
     final String sql = "SELECT * FROM FOO";
     final int maxRows = 500;
@@ -93,9 +89,6 @@ public class JdbcMetaTest {
   }
 
   @Test public void testPrepareAndExecuteSetsMaxRows() throws Exception {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     final String id = UUID.randomUUID().toString();
     final int statementId = 12345;
     final String sql = "SELECT * FROM FOO";

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/jdbc/StatementInfoTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/jdbc/StatementInfoTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.avatica.jdbc;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -37,11 +35,6 @@ import static org.junit.Assert.assertTrue;
  * Tests covering {@link StatementInfo}.
  */
 public class StatementInfoTest {
-
-  @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-  }
 
   @Test
   public void testLargeOffsets() throws Exception {

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
@@ -20,7 +20,6 @@ import org.apache.calcite.avatica.remote.AuthenticationType;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,10 +31,10 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /**
  * Test class for logic common to all {@link AvaticaHandler}'s.
@@ -48,9 +47,6 @@ public class AbstractAvaticaHandlerTest {
   private HttpServletResponse response;
 
   @Before public void setup() throws Exception {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     handler = mock(AbstractAvaticaHandler.class);
     config = mock(AvaticaServerConfiguration.class);
     request = mock(HttpServletRequest.class);

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/HandlerFactoryTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/HandlerFactoryTest.java
@@ -20,7 +20,6 @@ import org.apache.calcite.avatica.remote.Driver.Serialization;
 import org.apache.calcite.avatica.remote.Service;
 
 import org.eclipse.jetty.server.Handler;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -37,9 +36,6 @@ public class HandlerFactoryTest {
 
   @Before
   public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     this.factory = new HandlerFactory();
     this.service = Mockito.mock(Service.class);
   }

--- a/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpServerBuilderTest.java
+++ b/avatica/server/src/test/java/org/apache/calcite/avatica/server/HttpServerBuilderTest.java
@@ -19,8 +19,6 @@ package org.apache.calcite.avatica.server;
 import org.apache.calcite.avatica.remote.Driver.Serialization;
 import org.apache.calcite.avatica.remote.Service;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -31,10 +29,6 @@ import static org.junit.Assert.assertNull;
  * Test class for {@link HttpServer}.
  */
 public class HttpServerBuilderTest {
-  @Before public void setup() {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-  }
 
   @Test public void extraAllowedRolesConfigured() {
     final String[] extraRoles = new String[] {"BAR.COM"};

--- a/avatica/tck/src/main/java/org/apache/calcite/avatica/tck/tests/BaseTckTest.java
+++ b/avatica/tck/src/main/java/org/apache/calcite/avatica/tck/tests/BaseTckTest.java
@@ -19,7 +19,6 @@ package org.apache.calcite.avatica.tck.tests;
 import org.apache.calcite.avatica.tck.TestRunner;
 
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -36,9 +35,6 @@ public abstract class BaseTckTest {
   protected Connection connection;
 
   @Before public void initializeConnection() throws Exception {
-    // Disabled on JDK9 due to Mockito bug; see [CALCITE-1567].
-    Assume.assumeTrue(System.getProperty("java.version").compareTo("9") < 0);
-
     connection = TestRunner.getConnection();
   }
 


### PR DESCRIPTION
Includes a partial revert of 5c6a94f4beb10fd73adc324ca9f906a9a5970d8c
which undoes the test ignore on jdk9.