### PR TITLE
[CALCITE-1572] Fix nullable check in JdbcSchema

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
@@ -283,7 +283,7 @@ public class JdbcSchema implements Schema {
       }
       RelDataType sqlType =
           sqlType(typeFactory, dataType, precision, scale, typeString);
-      boolean nullable = resultSet.getBoolean(11);
+      boolean nullable = resultSet.getInt(11) != 0;
       fieldInfo.add(columnName, sqlType).nullable(nullable);
     }
     resultSet.close();

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
@@ -283,7 +283,7 @@ public class JdbcSchema implements Schema {
       }
       RelDataType sqlType =
           sqlType(typeFactory, dataType, precision, scale, typeString);
-      boolean nullable = resultSet.getInt(11) != 0;
+      boolean nullable = resultSet.getInt(11) != DatabaseMetaData.columnNoNulls;
       fieldInfo.add(columnName, sqlType).nullable(nullable);
     }
     resultSet.close();

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -827,6 +827,17 @@ public class JdbcAdapterTest {
     });
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-1572">[CALCITE-1572]
+   * JdbcSchema throws exception when detecting nullable columns</a>. */
+  @Test public void testColumnNullability() throws Exception {
+    final String sql = "select * from \"foodmart\".\"employee\" limit 10";
+    CalciteAssert.model(JdbcTest.FOODMART_MODEL)
+        .query(sql)
+        .runs()
+        .returnsCount(10);
+  }
+
   /** Acquires a lock, and releases it when closed. */
   static class LockWrapper implements AutoCloseable {
     private final Lock lock;


### PR DESCRIPTION
Fix an issue raised when JdbcSchema checking column nullability. It will raise exception when connecting to Presto.

Test plan:
  Manually tested with MySQL and Presto connections.