### PR TITLE
[CALCITE-1582] RelToSqlConverter doesn't handle cartesian join

### DIFF
--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -306,6 +306,14 @@ public class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  @Test public void testCartesianProduct() {
+    String query = "select * from \"department\" , \"employee\"";
+    String expected = "SELECT *\n"
+        + "FROM \"foodmart\".\"department\",\n"
+        + "\"foodmart\".\"employee\"";
+    sql(query).ok(expected);
+  }
+
   @Test public void testSimpleIn() {
     String query = "select * from \"department\" where \"department_id\" in (\n"
         + "  select \"department_id\" from \"employee\"\n"


### PR DESCRIPTION
It remains that `RelBuilder.join()` accepts an empty join condition. Perhaps this should only be allowed when join type = INNER to indicate a cartesian join?