### PR TITLE
[CALCITE-1595] NPE in SqlTypeUtil

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -512,22 +512,25 @@ public class RelBuilder {
   }
 
   /** Creates a call to a scalar operator. */
-  public RexNode call(SqlOperator operator, RexNode... operands) {
+  private RexNode call(SqlOperator operator, List<RexNode> operands) {
     final RexBuilder builder = cluster.getRexBuilder();
-    final List<RexNode> operandList = ImmutableList.copyOf(operands);
-    final RelDataType type = builder.deriveReturnType(operator, operandList);
+    final RelDataType type = builder.deriveReturnType(operator, operands);
     if (type == null) {
       throw new IllegalArgumentException("cannot derive type: " + operator
-          + "; operands: " + Lists.transform(operandList, FN_TYPE));
+                                         + "; operands: " + Lists.transform(operands, FN_TYPE));
     }
-    return builder.makeCall(type, operator, operandList);
+    return builder.makeCall(type, operator, operands);
+  }
+
+  /** Creates a call to a scalar operator. */
+  public RexNode call(SqlOperator operator, RexNode... operands) {
+    return call(operator, ImmutableList.copyOf(operands));
   }
 
   /** Creates a call to a scalar operator. */
   public RexNode call(SqlOperator operator,
       Iterable<? extends RexNode> operands) {
-    return cluster.getRexBuilder().makeCall(operator,
-        ImmutableList.copyOf(operands));
+    return call(operator, ImmutableList.copyOf(operands));
   }
 
   /** Creates an AND. */


### PR DESCRIPTION
Make both versions of RelBuilder.call() use the same type validation