### PR TITLE
[CALCITE-1603] Support TUMBLE in the GROUP BY clause.

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -654,6 +654,11 @@ public interface CalciteResource {
   @BaseMessage("SELECT must have a FROM clause")
   ExInst<SqlValidatorException> selectMissingFrom();
 
+  @BaseMessage("Group function ''{0}'' can only appear in GROUP BY clause")
+  ExInst<SqlValidatorException> groupFunctionMustAppearInGroupByClause(String funcName);
+
+  @BaseMessage("Call to auxiliary group function ''{0}'' must have matching call to group function ''{1}'' in GROUP BY clause")
+  ExInst<SqlValidatorException> auxiliaryWithoutMatchingGroupCall(String func1, String func2);
 }
 
 // End CalciteResource.java

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -773,6 +773,19 @@ public enum SqlKind {
   /** The {@code ROW_NUMBER} window function. */
   CUME_DIST,
 
+  // Group functions
+
+  /** The {@code TUMBLE} group function. */
+  TUMBLE,
+
+  /** The {@code TUMBLE_START} auxiliary function of
+   * the {@link #TUMBLE} function. */
+  TUMBLE_START,
+
+  /** The {@code TUMBLE_END} auxiliary function of
+   * the {@link #TUMBLE} function. */
+  TUMBLE_END,
+
   // DDL and session control statements follow. The list is not exhaustive: feel
   // free to add more.
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -792,6 +792,32 @@ public abstract class SqlOperator {
   }
 
   /**
+   * Returns whether this is a group function.
+   *
+   * <p>Group functions can only appear in the GROUP BY clause.
+   *
+   * <p>Examples are {@code HOP}, {@code TUMBLE}, {@code SESSION}.
+   *
+   * <p>Group functions have auxiliary functions, e.g. {@code HOP_START}, but
+   * these are not group functions.
+   */
+  public boolean isGroup() {
+    return false;
+  }
+
+  /**
+   * Returns whether this is an group auxiliary function.
+   *
+   * <p>Examples are {@code HOP_START} and {@code HOP_END} (both auxiliary to
+   * {@code HOP}).
+   *
+   * @see #isGroup()
+   */
+  public boolean isGroupAuxiliary() {
+    return false;
+  }
+
+  /**
    * Accepts a {@link SqlVisitor}, visiting each operand of a call. Returns
    * null.
    *

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupFunction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.validate.SqlMonotonicity;
+
+/**
+ * SQL function that computes keys by which rows can be partitioned and
+ * aggregated.
+ *
+ * <p>Group functions always occur in the GROUP BY clause. They often have
+ * auxiliary functions that access information about the group. For example,
+ * {@code HOP} is a group function, and its auxiliary functions are
+ * {@code HOP_START} and {@code HOP_END}. Here they are used in a streaming
+ * query:
+ *
+ * <blockquote><pre>
+ * SELECT STREAM HOP_START(rowtime, INTERVAL '1' HOUR),
+ *   HOP_END(rowtime, INTERVAL '1' HOUR),
+ *   MIN(unitPrice)
+ * FROM Orders
+ * GROUP BY HOP(rowtime, INTERVAL '1' HOUR), productId
+ * </pre></blockquote>
+ */
+class SqlGroupFunction extends SqlFunction {
+  private final SqlGroupFunction groupFunction;
+
+  /** Creates a SqlGroupFunction.
+   *
+   * @param kind Kind; also determines function name
+   * @param groupFunction Group function, if this is an auxiliary;
+   *                      null, if this is a group function
+   * @param operandTypeChecker Operand type checker
+   */
+  SqlGroupFunction(SqlKind kind, SqlGroupFunction groupFunction,
+      SqlOperandTypeChecker operandTypeChecker) {
+    super(kind.name(), kind, ReturnTypes.ARG0, null,
+        operandTypeChecker, SqlFunctionCategory.SYSTEM);
+    this.groupFunction = groupFunction;
+    if (groupFunction != null) {
+      assert groupFunction.groupFunction == null;
+    }
+  }
+
+  /** Creates an auxiliary function from this group function. */
+  SqlGroupFunction auxiliary(SqlKind kind) {
+    return new SqlGroupFunction(kind, this, getOperandTypeChecker());
+  }
+
+  @Override public boolean isGroup() {
+    // Auxiliary functions are not group functions
+    return groupFunction == null;
+  }
+
+  @Override public boolean isGroupAuxiliary() {
+    return groupFunction != null;
+  }
+
+  @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
+    // Monotonic iff its first argument is, but not strict.
+    //
+    // Note: This strategy happens to works for all current group functions
+    // (HOP, TUMBLE, SESSION). When there are exceptions to this rule, we'll
+    // make the method abstract.
+    return call.getOperandMonotonicity(0).unstrict();
+  }
+}
+
+// End SqlGroupFunction.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1760,6 +1760,19 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
         }
       };
 
+  public static final SqlGroupFunction TUMBLE =
+      new SqlGroupFunction(SqlKind.TUMBLE, null,
+          OperandTypes.or(OperandTypes.DATETIME_INTERVAL,
+              OperandTypes.DATETIME_INTERVAL_TIME));
+
+  /** The TUMBLE_START auxiliary function of the TUMBLE group function. */
+  public static final SqlFunction TUMBLE_START =
+      TUMBLE.auxiliary(SqlKind.TUMBLE_START);
+
+  /** The TUMBLE_END auxiliary function of the TUMBLE group function. */
+  public static final SqlFunction TUMBLE_END =
+      TUMBLE.auxiliary(SqlKind.TUMBLE_END);
+
   //~ Methods ----------------------------------------------------------------
 
   /**
@@ -1774,6 +1787,18 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       instance.init();
     }
     return instance;
+  }
+
+  /** Returns the group function for which a given kind is an auxiliary
+   * function, or null if it is not an auxiliary function. */
+  public static SqlGroupFunction auxiliaryToGroup(SqlKind kind) {
+    switch (kind) {
+    case TUMBLE_START:
+    case TUMBLE_END:
+      return TUMBLE;
+    default:
+      return null;
+    }
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -424,6 +424,18 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker DATETIME_INTERVAL =
       family(SqlTypeFamily.DATETIME, SqlTypeFamily.DATETIME_INTERVAL);
 
+  public static final SqlSingleOperandTypeChecker DATETIME_INTERVAL_INTERVAL =
+      family(SqlTypeFamily.DATETIME, SqlTypeFamily.DATETIME_INTERVAL,
+          SqlTypeFamily.DATETIME_INTERVAL);
+
+  public static final SqlSingleOperandTypeChecker DATETIME_INTERVAL_INTERVAL_TIME =
+      family(SqlTypeFamily.DATETIME, SqlTypeFamily.DATETIME_INTERVAL,
+          SqlTypeFamily.DATETIME_INTERVAL, SqlTypeFamily.TIME);
+
+  public static final SqlSingleOperandTypeChecker DATETIME_INTERVAL_TIME =
+      family(SqlTypeFamily.DATETIME, SqlTypeFamily.DATETIME_INTERVAL,
+          SqlTypeFamily.TIME);
+
   public static final SqlSingleOperandTypeChecker INTERVAL_DATETIME =
       family(SqlTypeFamily.DATETIME_INTERVAL, SqlTypeFamily.DATETIME);
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggChecker.java
@@ -16,14 +16,17 @@
  */
 package org.apache.calcite.sql.validate;
 
+import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWindow;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.util.Litmus;
 
@@ -41,6 +44,7 @@ class AggChecker extends SqlBasicVisitor<Void> {
   //~ Instance fields --------------------------------------------------------
 
   private final Deque<SqlValidatorScope> scopes = new ArrayDeque<>();
+  private final List<SqlNode> extraExprs;
   private final List<SqlNode> groupExprs;
   private boolean distinct;
   private SqlValidatorImpl validator;
@@ -60,9 +64,11 @@ class AggChecker extends SqlBasicVisitor<Void> {
   AggChecker(
       SqlValidatorImpl validator,
       AggregatingScope scope,
+      List<SqlNode> extraExprs,
       List<SqlNode> groupExprs,
       boolean distinct) {
     this.validator = validator;
+    this.extraExprs = extraExprs;
     this.groupExprs = groupExprs;
     this.distinct = distinct;
     this.scopes.push(scope);
@@ -73,6 +79,12 @@ class AggChecker extends SqlBasicVisitor<Void> {
   boolean isGroupExpr(SqlNode expr) {
     for (SqlNode groupExpr : groupExprs) {
       if (groupExpr.equalsDeep(expr, Litmus.IGNORE)) {
+        return true;
+      }
+    }
+
+    for (SqlNode extraExpr : extraExprs) {
+      if (extraExpr.equalsDeep(expr, Litmus.IGNORE)) {
         return true;
       }
     }
@@ -167,6 +179,24 @@ class AggChecker extends SqlBasicVisitor<Void> {
       // This call matches an expression in the GROUP BY clause.
       return null;
     }
+
+    final SqlCall groupCall = convertAuxiliaryToGroupCall(call);
+    if (groupCall != null) {
+      if (isGroupExpr(groupCall)) {
+        // This call is an auxiliary function that matches a group call in the
+        // GROUP BY clause.
+        //
+        // For example TUMBLE_START is an auxiliary of the TUMBLE group function, and
+        //   TUMBLE_START(rowtime, INTERVAL '1' HOUR)
+        // matches
+        //   TUMBLE(rowtime, INTERVAL '1' HOUR')
+        return null;
+      }
+      throw validator.newValidationError(groupCall,
+          RESOURCE.auxiliaryWithoutMatchingGroupCall(
+              call.getOperator().getName(), groupCall.getOperator().getName()));
+    }
+
     if (call.isA(SqlKind.QUERY)) {
       // Allow queries for now, even though they may contain
       // references to forbidden columns.
@@ -184,6 +214,16 @@ class AggChecker extends SqlBasicVisitor<Void> {
     // Restore scope.
     scopes.pop();
     return null;
+  }
+
+  private SqlCall convertAuxiliaryToGroupCall(SqlCall call) {
+    SqlOperator op = SqlStdOperatorTable.auxiliaryToGroup(call.getKind());
+    if (op == null) {
+      return null;
+    }
+    final List<SqlNode> list = call.getOperandList();
+    return new SqlBasicCall(op, list.toArray(new SqlNode[list.size()]),
+        call.getParserPosition());
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -229,6 +229,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       new IdentityHashMap<>();
   private final AggFinder aggFinder;
   private final AggFinder aggOrOverFinder;
+  private final AggFinder aggOrOverOrGroupFinder;
+  private final AggFinder groupFinder;
   private final AggFinder overFinder;
   private final SqlConformance conformance;
   private final Map<SqlNode, SqlNode> originalExprs = new HashMap<>();
@@ -280,9 +282,11 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
     rewriteCalls = true;
     expandColumnReferences = true;
-    aggFinder = new AggFinder(opTab, false, true, null);
-    aggOrOverFinder = new AggFinder(opTab, true, true, null);
-    overFinder = new AggFinder(opTab, true, false, aggOrOverFinder);
+    aggFinder = new AggFinder(opTab, false, true, false, null);
+    aggOrOverFinder = new AggFinder(opTab, true, true, false, null);
+    overFinder = new AggFinder(opTab, true, false, false, aggOrOverFinder);
+    groupFinder = new AggFinder(opTab, false, false, true, null);
+    aggOrOverOrGroupFinder = new AggFinder(opTab, true, true, true, null);
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -2574,7 +2578,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   }
 
   protected boolean isNestedAggregateWindow(SqlCall windowFunction) {
-    AggFinder nestedAggFinder = new AggFinder(opTab, false, false, aggFinder);
+    AggFinder nestedAggFinder = new AggFinder(opTab, false, false, false, aggFinder);
     return nestedAggFinder.findAgg(windowFunction) != null;
   }
 
@@ -2976,19 +2980,26 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
    * Throws an error if there is an aggregate or windowed aggregate in the
    * given clause.
    *
-   * @param condition Parse tree
+   * @param aggFinder Finder for the particular kind(s) of aggregate function
+   * @param node      Parse tree
    * @param clause    Name of clause: "WHERE", "GROUP BY", "ON"
    */
-  private void validateNoAggs(SqlNode condition, String clause) {
-    final SqlNode agg = aggOrOverFinder.findAgg(condition);
-    if (agg != null) {
-      if (SqlUtil.isCallTo(agg, SqlStdOperatorTable.OVER)) {
-        throw newValidationError(agg,
-            RESOURCE.windowedAggregateIllegalInClause(clause));
-      } else {
-        throw newValidationError(agg,
-            RESOURCE.aggregateIllegalInClause(clause));
-      }
+  private void validateNoAggs(AggFinder aggFinder, SqlNode node,
+                              String clause) {
+    final SqlCall agg = aggFinder.findAgg(node);
+    if (agg == null) {
+      return;
+    }
+    final SqlOperator op = agg.getOperator();
+    if (op == SqlStdOperatorTable.OVER) {
+      throw newValidationError(agg,
+          RESOURCE.windowedAggregateIllegalInClause(clause));
+    } else if (op.isGroup() || op.isGroupAuxiliary()) {
+      throw newValidationError(agg,
+          RESOURCE.groupFunctionMustAppearInGroupByClause(op.getName()));
+    } else {
+      throw newValidationError(agg,
+          RESOURCE.aggregateIllegalInClause(clause));
     }
   }
 
@@ -3432,7 +3443,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     if (groupList == null) {
       return;
     }
-    validateNoAggs(groupList, "GROUP BY");
+    validateNoAggs(aggOrOverFinder, groupList, "GROUP BY");
     final SqlValidatorScope groupScope = getGroupScope(select);
     inferUnknownTypes(unknownType, groupScope, groupList);
 
@@ -3523,7 +3534,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       SqlValidatorScope scope,
       SqlNode condition,
       String keyword) {
-    validateNoAggs(condition, keyword);
+    validateNoAggs(aggOrOverOrGroupFinder, condition, keyword);
     inferUnknownTypes(
         booleanType,
         scope,
@@ -3612,6 +3623,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     inferUnknownTypes(targetRowType, selectScope, newSelectList);
 
     for (SqlNode selectItem : expandedSelectItems) {
+      validateNoAggs(groupFinder, selectItem, "SELECT");
       validateExpr(selectItem, selectScope);
     }
 

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -64,7 +64,6 @@ import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
-import org.apache.calcite.util.Static;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.Mappings;
@@ -90,6 +89,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import static org.apache.calcite.util.Static.RESOURCE;
 
 /**
  * Builder for relational expressions.
@@ -697,7 +698,7 @@ public class RelBuilder {
       RexNode filter, String alias, Iterable<? extends RexNode> operands) {
     if (filter != null) {
       if (filter.getType().getSqlTypeName() != SqlTypeName.BOOLEAN) {
-        throw Static.RESOURCE.filterMustBeBoolean().ex();
+        throw RESOURCE.filterMustBeBoolean().ex();
       }
       if (filter.getType().isNullable()) {
         filter = call(SqlStdOperatorTable.IS_TRUE, filter);
@@ -755,7 +756,7 @@ public class RelBuilder {
     final List<String> names = ImmutableList.copyOf(tableNames);
     final RelOptTable relOptTable = relOptSchema.getTableForMember(names);
     if (relOptTable == null) {
-      throw Static.RESOURCE.tableNotFound(Joiner.on(".").join(names)).ex();
+      throw RESOURCE.tableNotFound(Joiner.on(".").join(names)).ex();
     }
     final RelNode scan = scanFactory.createScan(cluster, relOptTable);
     push(scan);

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -212,4 +212,6 @@ FilterMustBeBoolean=FILTER expression must be of type BOOLEAN
 CannotStreamResultsForNonStreamingInputs=Cannot stream results of a query with no streaming inputs: ''{0}''. At least one input should be convertible to a stream
 MinusNotAllowed=MINUS is not allowed under the current SQL conformance level
 SelectMissingFrom=SELECT must have a FROM clause
+GroupFunctionMustAppearInGroupByClause=Group function ''{0}'' can only appear in GROUP BY clause
+AuxiliaryWithoutMatchingGroupCall=Call to auxiliary group function ''{0}'' must have matching call to group function ''{1}'' in GROUP BY clause
 # End CalciteResource.properties

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2399,6 +2399,22 @@ LogicalDelta
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testTumbleTable">
+        <Resource name="sql">
+            <![CDATA[select stream tumble_end(rowtime, interval '2' hour) as rowtime, productId
+from orders
+group by tumble(rowtime, interval '2' hour), productId]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalDelta
+  LogicalProject(ROWTIME=[TUMBLE_END($0, 7200000)], PRODUCTID=[$1])
+    LogicalAggregate(group=[{0, 1}])
+      LogicalProject($f0=[TUMBLE($0, 7200000)], PRODUCTID=[$2])
+        LogicalTableScan(table=[[STREAMS, ORDERS]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testGroupByCaseIn">
         <Resource name="sql">
             <![CDATA[select


### PR DESCRIPTION
This PR effectively rebases the patches from the 768-hop branch from Julian to master. It only contains supports for `TUMBLE` / `TUMBLE_START` / `TUMBLE_END` functions.

Sessions and hop windows are quite similar and they can be added later.