### PR TITLE
[CALCITE-1615] Support HOP and SESSION in the GROUP BY clause

### DIFF
--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -50,6 +50,8 @@ data: {
 
     # List of keywords from "keywords" section that are not reserved.
     nonReservedKeywords: [
+      "HOP", "HOP_END", "HOP_START", "SESSION_END", "SESSION_START",
+      "TUMBLE", "TUMBLE_END", "TUMBLE_START"
     ]
 
     # List of methods for parsing custom SQL statements.

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -5757,6 +5757,9 @@ String CommonNonReservedKeyWord() :
         | <GOTO>
         | <GRANTED>
         | <HIERARCHY>
+        | <HOP : "HOP" >
+        | <HOP_END : "HOP_END">
+        | <HOP_START : "HOP_START">
         | <IMMEDIATE>
         | <IMPLEMENTATION>
         | <INCLUDING>
@@ -5857,6 +5860,8 @@ String CommonNonReservedKeyWord() :
         | <SERVER>
         | <SERVER_NAME>
         | <SESSION>
+        | <SESSION_END : "SESSION_END">
+        | <SESSION_START : "SESSION_START">
         | <SETS>
         | <SIMPLE>
         | <SIZE>
@@ -5933,6 +5938,9 @@ String CommonNonReservedKeyWord() :
         | <TRIGGER_CATALOG>
         | <TRIGGER_NAME>
         | <TRIGGER_SCHEMA>
+        | <TUMBLE : "TUMBLE" >
+        | <TUMBLE_END : "TUMBLE_END">
+        | <TUMBLE_START : "TUMBLE_START">
         | <TYPE>
         | <UNBOUNDED>
         | <UNCOMMITTED>

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -786,6 +786,28 @@ public enum SqlKind {
    * the {@link #TUMBLE} function. */
   TUMBLE_END,
 
+  /** The {@code HOP} group function. */
+  HOP,
+
+  /** The {@code HOP_START} auxiliary function of
+   * the {@link #HOP} function. */
+  HOP_START,
+
+  /** The {@code HOP_END} auxiliary function of
+   * the {@link #HOP} function. */
+  HOP_END,
+
+  /** The {@code SESSION} group function. */
+  SESSION,
+
+  /** The {@code SESSION_START} auxiliary function of
+   * the {@link #SESSION} function. */
+  SESSION_START,
+
+  /** The {@code SESSION_END} auxiliary function of
+   * the {@link #SESSION} function. */
+  SESSION_END,
+
   // DDL and session control statements follow. The list is not exhaustive: feel
   // free to add more.
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1856,6 +1856,28 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlFunction TUMBLE_END =
       TUMBLE.auxiliary(SqlKind.TUMBLE_END);
 
+  public static final SqlGroupFunction HOP =
+      new SqlGroupFunction(SqlKind.HOP, null,
+          OperandTypes.or(OperandTypes.DATETIME_INTERVAL_INTERVAL,
+              OperandTypes.DATETIME_INTERVAL_INTERVAL_TIME));
+
+  public static final SqlFunction HOP_START =
+      HOP.auxiliary(SqlKind.HOP_START);
+
+  public static final SqlFunction HOP_END =
+      HOP.auxiliary(SqlKind.HOP_END);
+
+  public static final SqlGroupFunction SESSION =
+      new SqlGroupFunction(SqlKind.SESSION, null,
+          OperandTypes.or(OperandTypes.DATETIME_INTERVAL,
+              OperandTypes.DATETIME_INTERVAL_TIME));
+
+  public static final SqlFunction SESSION_START =
+      SESSION.auxiliary(SqlKind.SESSION_START);
+
+  public static final SqlFunction SESSION_END =
+      SESSION.auxiliary(SqlKind.SESSION_END);
+
   //~ Methods ----------------------------------------------------------------
 
   /**
@@ -1879,6 +1901,12 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
     case TUMBLE_START:
     case TUMBLE_END:
       return TUMBLE;
+    case HOP_START:
+    case HOP_END:
+      return HOP;
+    case SESSION_START:
+    case SESSION_END:
+      return SESSION;
     default:
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -564,7 +564,8 @@ public class SqlValidatorUtil {
   /** Analyzes an expression in a GROUP BY clause.
    *
    * <p>It may be an expression, an empty list (), or a call to
-   * {@code GROUPING SETS}, {@code CUBE}, {@code ROLLUP} or {@code TUMBLE}.
+   * {@code GROUPING SETS}, {@code CUBE}, {@code ROLLUP},
+   * {@code TUMBLE}, {@code HOP} or {@code SESSION}.
    *
    * <p>Each group item produces a list of group sets, which are written to
    * {@code topBuilder}. To find the grouping sets of the query, we will take
@@ -600,7 +601,9 @@ public class SqlValidatorUtil {
         return;
       }
       // fall through
+    case HOP:
     case TUMBLE:
+    case SESSION:
     case GROUPING_SETS:
     default:
       builder = ImmutableList.builder();
@@ -728,7 +731,9 @@ public class SqlValidatorUtil {
     }
 
     switch (expr.getKind()) {
+    case HOP:
     case TUMBLE:
+    case SESSION:
       groupAnalyzer.extraExprs.add(expr);
       break;
     }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8859,6 +8859,39 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "  tumble(timestamp '1990-03-04 12:34:56', interval '2' hour)^")
         .fails(STR_AGG_REQUIRES_MONO);
   }
+
+  @Test public void testStreamHop() {
+    // HOP
+    sql("select stream\n"
+        + "  hop_start(rowtime, interval '1' hour, interval '3' hour) as rowtime,\n"
+        + "  count(*) as c\n"
+        + "from orders\n"
+        + "group by hop(rowtime, interval '1' hour, interval '3' hour)").ok();
+    sql("select stream\n"
+        + "  ^hop_start(rowtime, interval '1' hour, interval '2' hour)^,\n"
+        + "  count(*) as c\n"
+        + "from orders\n"
+        + "group by hop(rowtime, interval '1' hour, interval '3' hour)")
+        .fails("Call to auxiliary group function 'HOP_START' must have "
+            + "matching call to group function 'HOP' in GROUP BY clause");
+    // HOP with align
+    sql("select stream\n"
+        + "  hop_start(rowtime, interval '1' hour, interval '3' hour,\n"
+        + "    time '12:34:56') as rowtime,\n"
+        + "  count(*) as c\n"
+        + "from orders\n"
+        + "group by hop(rowtime, interval '1' hour, interval '3' hour,\n"
+        + "    time '12:34:56')").ok();
+  }
+
+  @Test public void testStreamSession() {
+    // SESSION
+    sql("select stream session_start(rowtime, interval '1' hour) as rowtime,\n"
+        + "  session_end(rowtime, interval '1' hour),\n"
+        + "  count(*) as c\n"
+        + "from orders\n"
+        + "group by session(rowtime, interval '1' hour)").ok();
+  }
 }
 
 // End SqlValidatorTest.java

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2415,6 +2415,41 @@ LogicalDelta
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testHopTable">
+        <Resource name="sql">
+            <![CDATA[select stream hop_start(rowtime, interval '1' hour, interval '3' hour) as rowtime,
+count(*) as c
+from orders
+group by hop(rowtime, interval '1' hour, interval '3' hour)]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalDelta
+  LogicalProject(ROWTIME=[HOP_START($0, 3600000, 10800000)], C=[$1])
+    LogicalAggregate(group=[{0}], C=[COUNT()])
+      LogicalProject($f0=[HOP($0, 3600000, 10800000)])
+        LogicalTableScan(table=[[STREAM_JOINS, ORDERS]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSessionTable">
+        <Resource name="sql">
+            <![CDATA[select stream session_start(rowtime, interval '1' hour) as rowtime,
+session_end(rowtime, interval '1' hour),
+count(*) as c
+from orders
+group by session(rowtime, interval '1' hour)]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalDelta
+  LogicalProject(ROWTIME=[SESSION_START($0, 3600000)], EXPR$1=[SESSION_END($0, 3600000)], C=[$1])
+    LogicalAggregate(group=[{0}], C=[COUNT()])
+      LogicalProject($f0=[SESSION($0, 3600000)])
+        LogicalTableScan(table=[[STREAMS, ORDERS]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testGroupByCaseIn">
         <Resource name="sql">
             <![CDATA[select

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -439,6 +439,9 @@ GRANTED,
 **HAVING**,
 HIERARCHY,
 **HOLD**,
+HOP,
+HOP_END,
+HOP_START,
 **HOUR**,
 **IDENTITY**,
 IMMEDIATE,
@@ -656,6 +659,8 @@ SERIALIZABLE,
 SERVER,
 SERVER_NAME,
 SESSION,
+SESSION_END,
+SESSION_START,
 **SESSION_USER**,
 **SET**,
 SETS,
@@ -771,6 +776,9 @@ TRIGGER_NAME,
 TRIGGER_SCHEMA,
 **TRIM**,
 **TRUE**,
+TUMBLE,
+TUMBLE_END,
+TUMBLE_START,
 TYPE,
 **UESCAPE**,
 UNBOUNDED,
@@ -1278,6 +1286,26 @@ Not implemented:
 | GROUPING(expression) | Returns 1 if expression is rolled up in the current row's grouping set, 0 otherwise
 | GROUP_ID()           | Returns an integer that uniquely identifies the combination of grouping keys
 | GROUPING_ID(expression [, expression ] * ) | Returns a bit vector of the given grouping expressions
+
+### Grouped window functions
+
+| Operator syntax      | Description
+|:-------------------- |:-----------
+| TUMBLE(dateTime, interval [, time ]) | Indicate a tumbling window of *interval* for *dateTime*. The window is aligned at *time*.
+| HOP(dateTime, slide, size, [, time ]) | Indicate a hopping window for *dateTime*. The window covers rows within the interval of *size*. It shifts for every *slide* and is aligned at *time*.
+| SESSION(dateTime, interval, [, time]) | Indicate a session window of *interval* for *dateTime*. The window is aligned at *time*.
+
+### Grouped auxiliary functions
+
+| Operator syntax      | Description
+|:-------------------- |:-----------
+| TUMBLE_START(expression, interval [, time ]) | Return the value of the *expression* at the beginning of the window.
+| TUMBLE_END(expression, interval [, time ]) | Return the value of the *expression* at the end of the window.
+| HOP_START(expression, slide, size, [, time ]) | Return the value of the *expression* at the beginning of the window.
+| HOP_END(expression, slide, size, [, time ]) | Return the value of the *expression* at the end of the window.
+| SESSION_START(expression, interval, [, time]) | Return the value of the *expression* at the beginning of the window.
+| SESSION_END(expression, interval, [, time]) | Return the value of the *expression* at the end of the window.
+
 
 ### User-defined functions
 


### PR DESCRIPTION
This PR enables Calcite to parse the `HOP` and `SESSION` windows. Similar to CALCITE-1603, it does not implement the runtime of the windows.

The code is derived from https://github.com/julianhyde/calcite/commits/768-hop