### PR TITLE
Implement simplify literal comparison

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1628,9 +1628,40 @@ public class RexUtil {
     final List<RexNode> operands = new ArrayList<>(e.operands);
     simplifyList(rexBuilder, operands);
     if (operands.equals(e.operands)) {
-      return e;
+      return simplifyLiteralComparison(rexBuilder, e);
     }
     return rexBuilder.makeCall(e.op, operands);
+  }
+
+  /**
+   * Simplifies comparison of literal expression
+   */
+  public static RexNode simplifyLiteralComparison(RexBuilder rexBuilder, RexCall e) {
+    if (2 == e.operands.size()) {
+      RexNode firstOperand = e.operands.get(0);
+      RexNode secondOperand = e.operands.get(1);
+      if (firstOperand.isA(SqlKind.LITERAL) && secondOperand.isA(SqlKind.LITERAL)) {
+        Comparable firstValue = ((RexLiteral) firstOperand).getValue();
+        Comparable secondValue = ((RexLiteral) secondOperand).getValue();
+        if (firstValue != null && secondValue != null) {
+          switch (e.getKind()) {
+          case EQUALS:
+            return rexBuilder.makeLiteral(firstValue.equals(secondValue));
+          case GREATER_THAN:
+            return rexBuilder.makeLiteral(firstValue.compareTo(secondValue) > 0);
+          case GREATER_THAN_OR_EQUAL:
+            return rexBuilder.makeLiteral(firstValue.compareTo(secondValue) >= 0);
+          case LESS_THAN:
+            return rexBuilder.makeLiteral(firstValue.compareTo(secondValue) < 0);
+          case LESS_THAN_OR_EQUAL:
+            return rexBuilder.makeLiteral(firstValue.compareTo(secondValue) <= 0);
+          case NOT_EQUALS:
+            return rexBuilder.makeLiteral(!firstValue.equals(secondValue));
+          }
+        }
+      }
+    }
+    return e;
   }
 
   /**


### PR DESCRIPTION
Add ability to optimize out things like 1 = 0 or 1 = 1 by converting to a literal boolean TRUE or FALSE.

There are two failed tests with this change:
```
Failed tests:
  CalciteSqlOperatorTest>SqlOperatorBaseTest.testEqualsOperator:1981 expected:<[true]> but was:<[false]>
  RelOptRulesTest.testTransitiveInferenceConstantEquiPredicate:2326->transitiveInference:2235 planBefore expected:<...[inner])
    Logical[Filter(condition=[=(1, 1)])
      Logical]TableScan(table=[[CA...> but was:<...[inner])
    Logical[]TableScan(table=[[CA...>
```

The first one is trying to say that 1 = 1.0. I'm not sure how to work around that yet.

The second one the filter is now optimized out since a simple Filter(TRUE) is useless so it would generate a more optimal plan without the Filter.