### PR TITLE
Calcite 1653 Allow for custom RelOptPlanner.Executor in RexUtil.simplify

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.runtime.PredicateImpl;
 import org.apache.calcite.util.CancelFlag;
 
@@ -70,7 +71,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
   /** External context. Never null. */
   protected final Context context;
 
-  private Executor executor;
+  private RexExecutor executor;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -269,11 +270,11 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
     return ImmutableList.of();
   }
 
-  public void setExecutor(Executor executor) {
+  public void setExecutor(RexExecutor executor) {
     this.executor = executor;
   }
 
-  public Executor getExecutor() {
+  public RexExecutor getExecutor() {
     return executor;
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
@@ -20,8 +20,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.CachingRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
-import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.util.CancelFlag;
 import org.apache.calcite.util.trace.CalciteTrace;
 
@@ -326,21 +325,20 @@ public interface RelOptPlanner {
   RelTraitSet emptyTraitSet();
 
   /** Sets the object that can execute scalar expressions. */
-  void setExecutor(Executor executor);
+  void setExecutor(RexExecutor executor);
 
   /** Returns the executor used to evaluate constant expressions. */
-  Executor getExecutor();
+  RexExecutor getExecutor();
 
   /** Called when a relational expression is copied to a similar expression. */
   void onCopy(RelNode rel, RelNode newRel);
 
-  /** Can reduce expressions, writing a literal for each into a list. */
-  interface Executor {
-    /**
-     * Reduces expressions, and writes their results into {@code reducedValues}.
-     */
-    void reduce(RexBuilder rexBuilder, List<RexNode> constExps,
-        List<RexNode> reducedValues);
+  /**
+   * Can reduce expressions, writing a literal for each into a list.
+   * @deprecated Use {@link RexExecutor} instead.
+   */
+  @Deprecated
+  public interface Executor extends RexExecutor {
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.metadata.CachingRelMetadataProvider;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
@@ -78,7 +79,7 @@ public class PlannerImpl implements Planner {
   private SchemaPlus defaultSchema;
   private JavaTypeFactory typeFactory;
   private RelOptPlanner planner;
-  private RelOptPlanner.Executor executor;
+  private RexExecutor executor;
 
   // set in STATE_4_VALIDATE
   private CalciteSqlValidator validator;

--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.rel.rules;
 
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -38,6 +37,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexDynamicParam;
+import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
@@ -462,7 +462,8 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
     boolean reduced = reduceExpressionsInternal(rel, expList, predicates);
 
     // Simplify preds in place
-    ExprSimplifier simplifier = new ExprSimplifier(rexBuilder, unknownAsFalse);
+    RexExecutor executor = rel.getCluster().getPlanner().getExecutor();
+    ExprSimplifier simplifier = new ExprSimplifier(rexBuilder, unknownAsFalse, executor);
     boolean simplified = false;
     for (int i = 0; i < expList.size(); i++) {
       RexNode expr2 = simplifier.apply(expList.get(i));
@@ -532,7 +533,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
     }
 
     // Compute the values they reduce to.
-    RelOptPlanner.Executor executor =
+    RexExecutor executor =
         rel.getCluster().getPlanner().getExecutor();
     if (executor == null) {
       // Cannot reduce expressions: caller has not set an executor in their

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutor.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutor.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rex;
+
+import java.util.List;
+
+/** Can reduce expressions, writing a literal for each into a list. */
+public interface RexExecutor {
+
+  /**
+   * Reduces expressions, and writes their results into {@code reducedValues}.
+   */
+  void reduce(RexBuilder rexBuilder, List<RexNode> constExps,
+      List<RexNode> reducedValues);
+}
+
+// End RexExecutor.java

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
@@ -28,7 +28,6 @@ import org.apache.calcite.linq4j.tree.IndexExpression;
 import org.apache.calcite.linq4j.tree.MethodCallExpression;
 import org.apache.calcite.linq4j.tree.MethodDeclaration;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -44,7 +43,7 @@ import java.util.List;
 /**
 * Evaluates a {@link RexNode} expression.
 */
-public class RexExecutorImpl implements RelOptPlanner.Executor {
+public class RexExecutorImpl implements RexExecutor {
 
   private final DataContext dataContext;
 

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -18,7 +18,6 @@ package org.apache.calcite.rex;
 
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.linq4j.function.Predicate1;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.Strong;
 import org.apache.calcite.rel.RelCollation;
@@ -74,6 +73,7 @@ import java.util.Set;
  * Utility methods concerning row-expressions.
  */
 public class RexUtil {
+
   private static final Function<? super RexNode, ? extends RexNode> ADD_NOT =
       new Function<RexNode, RexNode>() {
         public RexNode apply(RexNode input) {
@@ -110,9 +110,8 @@ public class RexUtil {
         }
       };
 
-  /** Executor for a bit of constant reduction. Ideally we'd use the user's
-   * preferred executor, but that isn't available. */
-  private static final RelOptPlanner.Executor EXECUTOR =
+  /** Executor for a bit of constant reduction. The user can pass in another executor. */
+  private static final RexExecutor EXECUTOR =
       new RexExecutorImpl(Schemas.createDataContext(null));
 
   private RexUtil() {
@@ -1561,8 +1560,9 @@ public class RexUtil {
    * <p>This is useful if you are simplifying expressions in a
    * {@link Project}. */
   public static RexNode simplifyPreservingType(RexBuilder rexBuilder,
-      RexNode e) {
-    final RexNode e2 = simplify(rexBuilder, e, false);
+      RexNode e,
+      RexExecutor executor) {
+    final RexNode e2 = simplify(rexBuilder, e, false, executor);
     if (e2.getType() == e.getType()) {
       return e2;
     }
@@ -1585,11 +1585,17 @@ public class RexUtil {
    * </ul>
    */
   public static RexNode simplify(RexBuilder rexBuilder, RexNode e) {
-    return simplify(rexBuilder, e, false);
+    return simplify(rexBuilder, e, false, EXECUTOR);
   }
 
   public static RexNode simplify(RexBuilder rexBuilder, RexNode e,
-      boolean unknownAsFalse) {
+    boolean unknownAsFalse) {
+    return simplify(rexBuilder, e, unknownAsFalse, EXECUTOR);
+  }
+
+  public static RexNode simplify(RexBuilder rexBuilder, RexNode e,
+    boolean unknownAsFalse,
+    RexExecutor executor) {
     switch (e.getKind()) {
     case AND:
       return simplifyAnd(rexBuilder, (RexCall) e, unknownAsFalse);
@@ -1600,7 +1606,7 @@ public class RexUtil {
     case CASE:
       return simplifyCase(rexBuilder, (RexCall) e, unknownAsFalse);
     case CAST:
-      return simplifyCast(rexBuilder, (RexCall) e);
+      return simplifyCast(rexBuilder, (RexCall) e, executor);
     case IS_NULL:
     case IS_NOT_NULL:
     case IS_TRUE:
@@ -2197,7 +2203,7 @@ public class RexUtil {
     for (RexNode notDisjunction : notTerms) {
       terms.add(
           simplify(rexBuilder,
-              rexBuilder.makeCall(SqlStdOperatorTable.NOT, notDisjunction), true));
+              rexBuilder.makeCall(SqlStdOperatorTable.NOT, notDisjunction), true, null));
     }
     // The negated terms: only deterministic expressions
     for (String negatedTerm : negatedTerms) {
@@ -2330,7 +2336,8 @@ public class RexUtil {
         && (call.operands.size() - i) % 2 == 1;
   }
 
-  private static RexNode simplifyCast(RexBuilder rexBuilder, RexCall e) {
+  private static RexNode simplifyCast(RexBuilder rexBuilder, RexCall e,
+        RexExecutor executor) {
     final RexNode operand = e.getOperands().get(0);
     switch (operand.getKind()) {
     case LITERAL:
@@ -2355,7 +2362,10 @@ public class RexUtil {
         }
       }
       final List<RexNode> reducedValues = new ArrayList<>();
-      EXECUTOR.reduce(rexBuilder, ImmutableList.<RexNode>of(e), reducedValues);
+      if (executor == null) {
+        executor = EXECUTOR;
+      }
+      executor.reduce(rexBuilder, ImmutableList.<RexNode>of(e), reducedValues);
       return Preconditions.checkNotNull(
           Iterables.getOnlyElement(reducedValues));
     default:
@@ -2923,11 +2933,14 @@ public class RexUtil {
   /** Deep expressions simplifier. */
   public static class ExprSimplifier extends RexShuttle {
     private final RexBuilder rexBuilder;
+    private final RexExecutor executor;
     private final boolean unknownAsFalse;
     private final Map<RexNode, Boolean> unknownAsFalseMap;
 
-    public ExprSimplifier(RexBuilder rexBuilder, boolean unknownAsFalse) {
+    public ExprSimplifier(RexBuilder rexBuilder, boolean unknownAsFalse,
+        RexExecutor executor) {
       this.rexBuilder = rexBuilder;
+      this.executor = executor;
       this.unknownAsFalse = unknownAsFalse;
       this.unknownAsFalseMap = new HashMap<>();
     }
@@ -2952,7 +2965,7 @@ public class RexUtil {
         }
       }
       RexNode node = super.visitCall(call);
-      RexNode simplifiedNode = simplify(rexBuilder, node, unknownAsFalseCall);
+      RexNode simplifiedNode = simplify(rexBuilder, node, unknownAsFalseCall, executor);
       if (node == simplifiedNode) {
         return node;
       }

--- a/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
+++ b/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
@@ -18,9 +18,9 @@ package org.apache.calcite.tools;
 
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.RelOptCostFactory;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -49,7 +49,7 @@ public interface FrameworkConfig {
   /**
    * Returns the executor used to evaluate constant expressions.
    */
-  RelOptPlanner.Executor getExecutor();
+  RexExecutor getExecutor();
 
   /**
    * Returns a list of one or more programs used during the course of query

--- a/core/src/main/java/org/apache/calcite/tools/Frameworks.java
+++ b/core/src/main/java/org/apache/calcite/tools/Frameworks.java
@@ -21,12 +21,12 @@ import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCostFactory;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.prepare.PlannerImpl;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.server.CalciteServerStatement;
 import org.apache.calcite.sql.SqlOperatorTable;
@@ -180,7 +180,7 @@ public class Frameworks {
     private SqlParser.Config parserConfig =
         SqlParser.Config.DEFAULT;
     private SchemaPlus defaultSchema;
-    private RelOptPlanner.Executor executor;
+    private RexExecutor executor;
     private RelOptCostFactory costFactory;
     private RelDataTypeSystem typeSystem = RelDataTypeSystem.DEFAULT;
 
@@ -197,7 +197,7 @@ public class Frameworks {
       return this;
     }
 
-    public ConfigBuilder executor(RelOptPlanner.Executor executor) {
+    public ConfigBuilder executor(RexExecutor executor) {
       Preconditions.checkNotNull(executor);
       this.executor = executor;
       return this;
@@ -281,7 +281,7 @@ public class Frameworks {
     private final SchemaPlus defaultSchema;
     private final RelOptCostFactory costFactory;
     private final RelDataTypeSystem typeSystem;
-    private final RelOptPlanner.Executor executor;
+    private final RexExecutor executor;
 
     public StdFrameworkConfig(Context context,
         SqlRexConvertletTable convertletTable,
@@ -292,7 +292,7 @@ public class Frameworks {
         SchemaPlus defaultSchema,
         RelOptCostFactory costFactory,
         RelDataTypeSystem typeSystem,
-        RelOptPlanner.Executor executor) {
+        RexExecutor executor) {
       this.context = context;
       this.convertletTable = convertletTable;
       this.operatorTable = operatorTable;
@@ -313,7 +313,7 @@ public class Frameworks {
       return defaultSchema;
     }
 
-    public RelOptPlanner.Executor getExecutor() {
+    public RexExecutor getExecutor() {
       return executor;
     }
 

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -864,7 +864,8 @@ public class RelBuilder {
     final Iterator<String> nameIterator = fieldNames.iterator();
     for (RexNode node : nodes) {
       if (simplify) {
-        node = RexUtil.simplifyPreservingType(getRexBuilder(), node);
+        node = RexUtil.simplifyPreservingType(getRexBuilder(), node,
+          cluster.getPlanner().getExecutor());
       }
       exprList.add(node);
       String name = nameIterator.hasNext() ? nameIterator.next() : null;


### PR DESCRIPTION
 Add optional executor to `RexUtil.simplify` and propagate the executor through `ReduceExpressionsRule.reduceExpressions` and `RexUtil$ExprSimplifier`.