### PR TITLE
CALCITE-1668: RexUtil.simplify handle literal comparison simplification

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1669,9 +1669,44 @@ public class RexUtil {
     final List<RexNode> operands = new ArrayList<>(e.operands);
     simplifyList(rexBuilder, operands);
     if (operands.equals(e.operands)) {
-      return e;
+      return simplifyLiteralComparison(rexBuilder, e);
     }
     return rexBuilder.makeCall(e.op, operands);
+  }
+
+  /**
+   * Simplifies comparison of literal expression
+   */
+  private static RexNode simplifyLiteralComparison(RexBuilder rexBuilder, RexCall e) {
+    if (2 == e.operands.size()) {
+      RexNode firstOperand = e.operands.get(0);
+      RexNode secondOperand = e.operands.get(1);
+      if (firstOperand.getType().equals(secondOperand.getType())
+              && firstOperand.isA(SqlKind.LITERAL) && secondOperand.isA(SqlKind.LITERAL)) {
+        Comparable firstValue = ((RexLiteral) firstOperand).getValue();
+        Comparable secondValue = ((RexLiteral) secondOperand).getValue();
+        if (firstValue != null && secondValue != null) {
+          // Use .compareTo instead of .equals() because we want to compare value
+          // BigDecimal checks scale too with .equals
+          int comparisonResult = firstValue.compareTo(secondValue);
+          switch (e.getKind()) {
+          case EQUALS:
+            return rexBuilder.makeLiteral(comparisonResult == 0);
+          case GREATER_THAN:
+            return rexBuilder.makeLiteral(comparisonResult > 0);
+          case GREATER_THAN_OR_EQUAL:
+            return rexBuilder.makeLiteral(comparisonResult >= 0);
+          case LESS_THAN:
+            return rexBuilder.makeLiteral(comparisonResult < 0);
+          case LESS_THAN_OR_EQUAL:
+            return rexBuilder.makeLiteral(comparisonResult <= 0);
+          case NOT_EQUALS:
+            return rexBuilder.makeLiteral(comparisonResult != 0);
+          }
+        }
+      }
+    }
+    return e;
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -1309,6 +1309,71 @@ public class RexProgramTest {
         "1970-01-01 00:00:00"); // different from Hive
   }
 
+  @Test public void testSimplifyLiterals() {
+    final RexLiteral literalAbc = rexBuilder.makeLiteral("abc");
+    final RexLiteral literalDef = rexBuilder.makeLiteral("def");
+
+    final RexLiteral literalZero = rexBuilder.makeExactLiteral(BigDecimal.ZERO);
+    final RexLiteral literalOne = rexBuilder.makeExactLiteral(BigDecimal.ONE);
+    final RexLiteral literalOneDotZero = rexBuilder.makeExactLiteral(new BigDecimal(1.0));
+
+    // Check string comparison
+    checkSimplify(eq(literalAbc, literalAbc), "true");
+    checkSimplify(eq(literalAbc, literalDef), "false");
+    checkSimplify(ne(literalAbc, literalAbc), "false");
+    checkSimplify(ne(literalAbc, literalDef), "true");
+    checkSimplify(gt(literalAbc, literalDef), "false");
+    checkSimplify(gt(literalDef, literalAbc), "true");
+    checkSimplify(gt(literalDef, literalDef), "false");
+    checkSimplify(ge(literalAbc, literalDef), "false");
+    checkSimplify(ge(literalDef, literalAbc), "true");
+    checkSimplify(ge(literalDef, literalDef), "true");
+    checkSimplify(lt(literalAbc, literalDef), "true");
+    checkSimplify(lt(literalAbc, literalDef), "true");
+    checkSimplify(lt(literalDef, literalDef), "false");
+    checkSimplify(le(literalAbc, literalDef), "true");
+    checkSimplify(le(literalDef, literalAbc), "false");
+    checkSimplify(le(literalDef, literalDef), "true");
+
+    // Check whole number comparison
+    checkSimplify(eq(literalZero, literalOne), "false");
+    checkSimplify(eq(literalOne, literalZero), "false");
+    checkSimplify(ne(literalZero, literalOne), "true");
+    checkSimplify(ne(literalOne, literalZero), "true");
+    checkSimplify(gt(literalZero, literalOne), "false");
+    checkSimplify(gt(literalOne, literalZero), "true");
+    checkSimplify(gt(literalOne, literalOne), "false");
+    checkSimplify(ge(literalZero, literalOne), "false");
+    checkSimplify(ge(literalOne, literalZero), "true");
+    checkSimplify(ge(literalOne, literalOne), "true");
+    checkSimplify(lt(literalZero, literalOne), "true");
+    checkSimplify(lt(literalOne, literalZero), "false");
+    checkSimplify(lt(literalOne, literalOne), "false");
+    checkSimplify(le(literalZero, literalOne), "true");
+    checkSimplify(le(literalOne, literalZero), "false");
+    checkSimplify(le(literalOne, literalOne), "true");
+
+    // Check decimal equality comparison
+    checkSimplify(eq(literalOne, literalOneDotZero), "true");
+    checkSimplify(eq(literalOneDotZero, literalOne), "true");
+    checkSimplify(ne(literalOne, literalOneDotZero), "false");
+    checkSimplify(ne(literalOneDotZero, literalOne), "false");
+
+    // Check different types shouldn't change simplification
+    checkSimplifyUnchanged(eq(literalZero, literalAbc));
+    checkSimplifyUnchanged(eq(literalAbc, literalZero));
+    checkSimplifyUnchanged(ne(literalZero, literalAbc));
+    checkSimplifyUnchanged(ne(literalAbc, literalZero));
+    checkSimplifyUnchanged(gt(literalZero, literalAbc));
+    checkSimplifyUnchanged(gt(literalAbc, literalZero));
+    checkSimplifyUnchanged(ge(literalZero, literalAbc));
+    checkSimplifyUnchanged(ge(literalAbc, literalZero));
+    checkSimplifyUnchanged(lt(literalZero, literalAbc));
+    checkSimplifyUnchanged(lt(literalAbc, literalZero));
+    checkSimplifyUnchanged(le(literalZero, literalAbc));
+    checkSimplifyUnchanged(le(literalAbc, literalZero));
+  }
+
   private Calendar cal(int y, int m, int d, int h, int mm, int s) {
     final Calendar c = Calendar.getInstance(DateTimeUtils.GMT_ZONE);
     c.set(Calendar.YEAR, y);


### PR DESCRIPTION
Add ability to optimize out things like 1 = 0 or 1 = 1 by converting to a literal boolean TRUE or FALSE.

Supersedes PR #376 