### PR TITLE
[CALCITE-1699] Statement may be null

### DIFF
--- a/avatica/server/src/main/java/org/apache/calcite/avatica/jdbc/StatementInfo.java
+++ b/avatica/server/src/main/java/org/apache/calcite/avatica/jdbc/StatementInfo.java
@@ -20,7 +20,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
-import java.util.Objects;
 
 /**
  * All we know about a statement. Encapsulates a {@link ResultSet}.
@@ -37,7 +36,8 @@ public class StatementInfo {
   private boolean resultsInitialized = false;
 
   public StatementInfo(Statement statement) {
-    this.statement = Objects.requireNonNull(statement);
+    // May be null
+    this.statement = statement;
   }
 
   // Visible for testing


### PR DESCRIPTION
When the ResultSet that generated the Statement
was created from a DatabaseMetaData call, the Statement
may be null.