### PR TITLE
SortCollapseRule for collapsing nested sorts.

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -91,6 +91,7 @@ import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.rel.rules.ProjectTableScanRule;
 import org.apache.calcite.rel.rules.ProjectWindowTransposeRule;
 import org.apache.calcite.rel.rules.ReduceExpressionsRule;
+import org.apache.calcite.rel.rules.SortCollapseRule;
 import org.apache.calcite.rel.rules.SortJoinTransposeRule;
 import org.apache.calcite.rel.rules.SortProjectTransposeRule;
 import org.apache.calcite.rel.rules.SortUnionTransposeRule;
@@ -237,7 +238,8 @@ public class CalcitePrepareImpl implements CalcitePrepare {
           JoinPushThroughJoinRule.LEFT,
           SortProjectTransposeRule.INSTANCE,
           SortJoinTransposeRule.INSTANCE,
-          SortUnionTransposeRule.INSTANCE);
+          SortUnionTransposeRule.INSTANCE,
+          SortCollapseRule.INSTANCE);
 
   private static final List<RelOptRule> CONSTANT_REDUCTION_RULES =
       ImmutableList.of(

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortCollapseRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortCollapseRule.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rex.RexLiteral;
+
+/**
+ * Collapses two adjacent Sort operations together. Useful for queries like
+ * {@code SELECT * FROM (SELECT DISTINCT dim2 FROM foo ORDER BY dim2) LIMIT 10}.
+ */
+public class SortCollapseRule extends RelOptRule {
+  public static final SortCollapseRule INSTANCE = new SortCollapseRule();
+
+  public SortCollapseRule() {
+    super(operand(Sort.class, operand(Sort.class, any())));
+  }
+
+  @Override public void onMatch(final RelOptRuleCall call) {
+    // First is the inner sort, second is the outer sort.
+    final Sort first = call.rel(1);
+    final Sort second = call.rel(0);
+
+    if (second.collation.getFieldCollations().isEmpty()) {
+      // Add up the offsets.
+      final int firstOffset = first.offset != null ? RexLiteral.intValue(first.offset) : 0;
+      final int secondOffset = second.offset != null ? RexLiteral.intValue(second.offset) : 0;
+
+      final int fetch;
+
+      if (first.fetch == null && second.fetch == null) {
+        // Neither has a limit => no limit overall.
+        fetch = -1;
+      } else if (first.fetch == null) {
+        // Outer limit only.
+        fetch = RexLiteral.intValue(second.fetch);
+      } else if (second.fetch == null) {
+        // Inner limit only.
+        fetch = Math.max(0, RexLiteral.intValue(first.fetch) - secondOffset);
+      } else {
+        fetch = Math.max(
+            0,
+            Math.min(
+                RexLiteral.intValue(first.fetch) - secondOffset,
+                RexLiteral.intValue(second.fetch))
+        );
+      }
+
+      final RelNode combined = call
+          .builder()
+          .push(first.getInput())
+          .sortLimit(firstOffset + secondOffset, fetch, first.getChildExps())
+          .build();
+
+      call.transformTo(combined);
+    }
+  }
+}
+// End SortCollapseRule.java

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortCollapseRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortCollapseRule.java
@@ -59,8 +59,7 @@ public class SortCollapseRule extends RelOptRule {
             0,
             Math.min(
                 RexLiteral.intValue(first.fetch) - secondOffset,
-                RexLiteral.intValue(second.fetch))
-        );
+                RexLiteral.intValue(second.fetch)));
       }
 
       final RelNode combined = call

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -81,6 +81,7 @@ import org.apache.calcite.rel.rules.SemiJoinJoinTransposeRule;
 import org.apache.calcite.rel.rules.SemiJoinProjectTransposeRule;
 import org.apache.calcite.rel.rules.SemiJoinRemoveRule;
 import org.apache.calcite.rel.rules.SemiJoinRule;
+import org.apache.calcite.rel.rules.SortCollapseRule;
 import org.apache.calcite.rel.rules.SortJoinTransposeRule;
 import org.apache.calcite.rel.rules.SortProjectTransposeRule;
 import org.apache.calcite.rel.rules.SortUnionTransposeRule;
@@ -503,6 +504,32 @@ public class RelOptRulesTest extends RelOptTestBase {
         + "select b.name from dept b\n"
         + "order by name limit 0";
     checkPlanning(program, sql);
+  }
+
+  @Test public void testSortCollapse() {
+    final HepProgram preProgram =
+        HepProgram.builder()
+                  .addRuleInstance(ProjectRemoveRule.INSTANCE)
+                  .build();
+    final HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(SortCollapseRule.INSTANCE)
+        .build();
+
+    checkPlanning(tester, preProgram, new HepPlanner(program),
+                  "select * from (select distinct deptno from emp order by deptno) limit 1");
+  }
+
+  @Test public void testSortCollapse2() {
+    final HepProgram preProgram =
+        HepProgram.builder()
+                  .addRuleInstance(ProjectRemoveRule.INSTANCE)
+                  .build();
+    final HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(SortCollapseRule.INSTANCE)
+        .build();
+
+    checkPlanning(tester, preProgram, new HepPlanner(program),
+                  "select * from (select distinct deptno from emp order by deptno limit 3 offset 1) limit 3 offset 1");
   }
 
   @Test public void testSemiJoinRuleExists() {

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -545,6 +545,26 @@ public class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  @Test public void testSortCollapse3() {
+    final HepProgram preProgram =
+        HepProgram.builder()
+            .addRuleInstance(ProjectRemoveRule.INSTANCE)
+            .build();
+    final HepProgram program =
+        HepProgram.builder()
+            .addRuleInstance(SortCollapseRule.INSTANCE)
+            .build();
+    final String sql = "select * from (\n"
+                       + "select distinct deptno from emp\n"
+                       + "order by deptno desc\n"
+                       + "limit 3 offset 1)\n"
+                       + "limit 3 offset 1";
+    sql(sql)
+        .withPre(preProgram)
+        .with(program)
+        .check();
+  }
+
   @Test public void testSemiJoinRuleExists() {
     final HepProgram preProgram =
         HepProgram.builder()

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -509,27 +509,40 @@ public class RelOptRulesTest extends RelOptTestBase {
   @Test public void testSortCollapse() {
     final HepProgram preProgram =
         HepProgram.builder()
-                  .addRuleInstance(ProjectRemoveRule.INSTANCE)
-                  .build();
-    final HepProgram program = new HepProgramBuilder()
-        .addRuleInstance(SortCollapseRule.INSTANCE)
-        .build();
-
-    checkPlanning(tester, preProgram, new HepPlanner(program),
-                  "select * from (select distinct deptno from emp order by deptno) limit 1");
+            .addRuleInstance(ProjectRemoveRule.INSTANCE)
+            .build();
+    final HepProgram program =
+        HepProgram.builder()
+            .addRuleInstance(SortCollapseRule.INSTANCE)
+            .build();
+    final String sql = "select * from (\n"
+                       + "select distinct deptno from emp\n"
+                       + "order by deptno)\n"
+                       + "limit 1";
+    sql(sql)
+        .withPre(preProgram)
+        .with(program)
+        .check();
   }
 
   @Test public void testSortCollapse2() {
     final HepProgram preProgram =
         HepProgram.builder()
-                  .addRuleInstance(ProjectRemoveRule.INSTANCE)
-                  .build();
-    final HepProgram program = new HepProgramBuilder()
-        .addRuleInstance(SortCollapseRule.INSTANCE)
-        .build();
-
-    checkPlanning(tester, preProgram, new HepPlanner(program),
-                  "select * from (select distinct deptno from emp order by deptno limit 3 offset 1) limit 3 offset 1");
+            .addRuleInstance(ProjectRemoveRule.INSTANCE)
+            .build();
+    final HepProgram program =
+        HepProgram.builder()
+            .addRuleInstance(SortCollapseRule.INSTANCE)
+            .build();
+    final String sql = "select * from (\n"
+                       + "select distinct deptno from emp\n"
+                       + "order by deptno\n"
+                       + "limit 3 offset 1)\n"
+                       + "limit 3 offset 1";
+    sql(sql)
+        .withPre(preProgram)
+        .with(program)
+        .check();
   }
 
   @Test public void testSemiJoinRuleExists() {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5587,6 +5587,50 @@ LogicalProject(EMPNO=[$0], D=[$9])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testSortCollapse">
+        <Resource name="sql">
+            <![CDATA[select * from (select distinct deptno from emp order by deptno) limit 1]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalSort(fetch=[1])
+  LogicalSort(sort0=[$0], dir0=[ASC])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalSort(sort0=[$0], dir0=[ASC], fetch=[1])
+  LogicalAggregate(group=[{0}])
+    LogicalProject(DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSortCollapse2">
+        <Resource name="sql">
+            <![CDATA[select * from (select distinct deptno from emp order by deptno limit 3 offset 1) limit 3 offset 1]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalSort(offset=[1], fetch=[3])
+  LogicalSort(sort0=[$0], dir0=[ASC], offset=[1], fetch=[3])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalSort(sort0=[$0], dir0=[ASC], offset=[2], fetch=[2])
+  LogicalAggregate(group=[{0}])
+    LogicalProject(DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testSortJoinTranspose2">
         <Resource name="sql">
             <![CDATA[select * from sales.emp e right join (

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5631,6 +5631,32 @@ LogicalSort(sort0=[$0], dir0=[ASC], offset=[2], fetch=[2])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testSortCollapse3">
+        <Resource name="sql">
+            <![CDATA[select * from (
+select distinct deptno from emp
+order by deptno desc
+limit 3 offset 1)
+limit 3 offset 1]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalSort(offset=[1], fetch=[3])
+  LogicalSort(sort0=[$0], dir0=[DESC], offset=[1], fetch=[3])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalSort(sort0=[$0], dir0=[DESC], offset=[2], fetch=[2])
+  LogicalAggregate(group=[{0}])
+    LogicalProject(DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testSortJoinTranspose2">
         <Resource name="sql">
             <![CDATA[select * from sales.emp e right join (


### PR DESCRIPTION
Useful for subqueries like `SELECT * FROM (...) LIMIT X`, where the inner
query might have an order by or limit.