### PR TITLE
CALCITE-1738 Handle CAST nodes in DruidDateTimeUtils

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
@@ -501,6 +501,10 @@ public class RexImplicationCheckerTest {
           calendar, timeDataType.getPrecision());
     }
 
+    public RexNode cast(RelDataType type, RexNode exp) {
+      return rexBuilder.makeCast(type, exp, true);
+    }
+
     void checkImplies(RexNode node1, RexNode node2) {
       final String message =
           node1 + " does not imply " + node2 + " when it should";

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.trace.CalciteTrace;
 
@@ -243,12 +244,31 @@ public class DruidDateTimeUtils {
   }
 
   private static Calendar literalValue(RexNode node) {
-    if (node instanceof RexLiteral) {
+    switch(node.getKind()) {
+    case LITERAL:
+      assert node instanceof RexLiteral;
       Object value = ((RexLiteral) node).getValue();
       if (value instanceof  Calendar) {
         return (Calendar) value;
       }
-      return null;
+      break;
+    case CAST:
+      // Normally all CAST are eliminated by now by constant reduction
+      // When HiveExecutor is used there may be a nullability-only cast
+      // from TIMESTMAP NOT NULL literal to TIMESTAMP literal
+      // We can handle that case by traversing the dummy CAST
+      assert node instanceof RexCall;
+      final RexCall call = (RexCall) node;
+      final RexNode operand = call.getOperands().get(0);
+      final RelDataType callType = call.getType();
+      final RelDataType operandType = operand.getType();
+      if (operand.getKind() == SqlKind.LITERAL
+        && callType.getSqlTypeName() == SqlTypeName.TIMESTAMP
+        && callType.isNullable()
+        && operandType.getSqlTypeName() == SqlTypeName.TIMESTAMP
+        && !operandType.isNullable()) {
+        return literalValue(operand);
+      }
     }
     return null;
   }

--- a/druid/src/test/java/org/apache/calcite/test/DruidDateRangeRulesTest.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidDateRangeRulesTest.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.rules.DateRangeRules;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.test.RexImplicationCheckerTest.Fixture;
+import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
@@ -41,6 +42,23 @@ import static org.junit.Assert.assertThat;
 
 /** Unit tests for {@link DateRangeRules} algorithms. */
 public class DruidDateRangeRulesTest {
+
+  @Test public void testFilterWithCast() {
+    final Fixture2 f = new Fixture2();
+    Calendar from = Util.calendar();
+    from.clear();
+    from.set(2010, Calendar.JANUARY, 1);
+    Calendar to = Util.calendar();
+    to.clear();
+    to.set(2011, Calendar.JANUARY, 1);
+
+    // dt >= 2010-01-01 AND dt < 2011-01-01
+    checkDateRangeNoSimplify(f,
+      f.and(
+        f.ge(f.dt, f.cast(f.timeStampDataType, f.timestampLiteral(from))),
+        f.lt(f.dt, f.cast(f.timeStampDataType, f.timestampLiteral(to)))),
+      is("[2010-01-01T00:00:00.000/2011-01-01T00:00:00.000]"));
+  }
 
   @Test public void testExtractYearAndMonthFromDateColumn() {
     final Fixture2 f = new Fixture2();
@@ -114,6 +132,30 @@ public class DruidDateRangeRulesTest {
             f.eq(f.exMonthTs, f.literal(2)), f.eq(f.exDayTs, f.literal(29))),
         is("[2012-02-29T00:00:00.000/2012-03-01T00:00:00.000, "
             + "2016-02-29T00:00:00.000/2016-03-01T00:00:00.000]"));
+  }
+
+  // For testFilterWithCAST we need to no simplify the expression, which would
+  // remove the CAST, in order to match the way expressions are presented when
+  // HiveRexExecutorImpl is used in Hive
+  private void checkDateRangeNoSimplify(Fixture f, RexNode e, Matcher<String> intervalMatcher) {
+    final Map<String, RangeSet<Calendar>> operandRanges = new HashMap<>();
+    // We rely on the collection being sorted (so YEAR comes before MONTH
+    // before HOUR) and unique. A predicate on MONTH is not useful if there is
+    // no predicate on YEAR. Then when we apply the predicate on DAY it doesn't
+    // generate hundreds of ranges we'll later throw away.
+    final List<TimeUnitRange> timeUnits =
+        Ordering.natural().sortedCopy(DateRangeRules.extractTimeUnits(e));
+    for (TimeUnitRange timeUnit : timeUnits) {
+      e = e.accept(
+          new DateRangeRules.ExtractShuttle(f.rexBuilder, timeUnit,
+              operandRanges));
+    }
+    List<LocalInterval> intervals =
+        DruidDateTimeUtils.createInterval(f.timeStampDataType, e);
+    if (intervals == null) {
+      throw new AssertionError("null interval");
+    }
+    assertThat(intervals.toString(), intervalMatcher);
   }
 
   private void checkDateRange(Fixture f, RexNode e, Matcher<String> intervalMatcher) {


### PR DESCRIPTION
This adds handling of the way literal timestamps make it to DruidDateTimeUtil when used from Hive, as a `CAST(timestampLiteral as TIMESTAMP)`.