### PR TITLE
[CALCITE-1780][core] Add [required Order] and [requiresOver] paramete…

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -330,7 +330,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
     } else if (function instanceof AggregateFunction) {
       return new SqlUserDefinedAggFunction(name,
           infer((AggregateFunction) function), InferTypes.explicit(argTypes),
-          typeChecker, (AggregateFunction) function);
+          typeChecker, (AggregateFunction) function, false, false);
     } else if (function instanceof TableMacro) {
       return new SqlUserDefinedTableMacro(name, ReturnTypes.CURSOR,
           InferTypes.explicit(argTypes), typeChecker, paramTypes,

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedAggFunction.java
@@ -46,10 +46,13 @@ public class SqlUserDefinedAggFunction extends SqlAggFunction {
   public SqlUserDefinedAggFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
-      SqlOperandTypeChecker operandTypeChecker, AggregateFunction function) {
+      SqlOperandTypeChecker operandTypeChecker,
+      AggregateFunction function,
+      boolean requiresOrder,
+      boolean requiresOver) {
     super(Util.last(opName.names), opName, SqlKind.OTHER_FUNCTION,
         returnTypeInference, operandTypeInference, operandTypeChecker,
-        SqlFunctionCategory.USER_DEFINED_FUNCTION, false, false);
+        SqlFunctionCategory.USER_DEFINED_FUNCTION, requiresOrder, requiresOver);
     this.function = function;
   }
 


### PR DESCRIPTION
Currently org.apache.calcite.sql.validate.SqlUserDefinedAggFunction calls the constructor of SqlAggFunction:
```

Protected SqlAggFunction (
       String name,
       SqlIdentifier sqlIdentifier,
       SqlKind kind,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       SqlOperandTypeChecker operandTypeChecker,
       SqlFunctionCategory funcType,
       Boolean requiresOrder,
       Boolean requiresOver) 
```
The requiresOrder = false, requiresOver = false. as follow:

```
Public SqlUserDefinedAggFunction (SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       SqlOperandTypeChecker operandTypeChecker, AggregateFunction function) {
     Super (Util.last (opName.names), opName, SqlKind.OTHER_FUNCTION,
         ReturnTypeInference, operandTypeInference, operandTypeChecker,
         SqlFunctionCategory.USER_DEFINED_FUNCTION, false, false);
     This.function = function;
   } 
```
In this PR. add `required Order` and `requiresOver` parameters to the constructor of `SqlUserDefinedAggregate Function`.