### PR TITLE
CALCITE-1812 Reuse RelMetadataQuery in planner, make it availale via RelOptRuleCall

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
@@ -90,7 +90,7 @@ public class EnumerableCalc extends Calc implements EnumerableRel {
   public static EnumerableCalc create(final RelNode input,
       final RexProgram program) {
     final RelOptCluster cluster = input.getCluster();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet = cluster.traitSet()
         .replace(EnumerableConvention.INSTANCE)
         .replaceIfs(RelCollationTraitDef.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilter.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilter.java
@@ -54,7 +54,7 @@ public class EnumerableFilter
   public static EnumerableFilter create(final RelNode input,
       RexNode condition) {
     final RelOptCluster cluster = input.getCluster();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet =
         cluster.traitSetOf(EnumerableConvention.INSTANCE)
             .replaceIfs(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimit.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimit.java
@@ -64,7 +64,7 @@ public class EnumerableLimit extends SingleRel implements EnumerableRel {
   public static EnumerableLimit create(final RelNode input, RexNode offset,
       RexNode fetch) {
     final RelOptCluster cluster = input.getCluster();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet =
         cluster.traitSetOf(EnumerableConvention.INSTANCE)
             .replaceIfs(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -90,7 +90,7 @@ public class EnumerableMergeJoin extends EquiJoin implements EnumerableRel {
     final RelOptCluster cluster = right.getCluster();
     RelTraitSet traitSet = cluster.traitSet();
     if (traitSet.isEnabled(RelCollationTraitDef.INSTANCE)) {
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
       final List<RelCollation> collations =
           RelMdCollation.mergeJoin(mq, left, right, leftKeys, rightKeys);
       traitSet = traitSet.replace(collations);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
@@ -69,7 +69,7 @@ public class EnumerableProject extends Project implements EnumerableRel {
   public static EnumerableProject create(final RelNode input,
       final List<? extends RexNode> projects, RelDataType rowType) {
     final RelOptCluster cluster = input.getCluster();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet =
         cluster.traitSet().replace(EnumerableConvention.INSTANCE)
             .replaceIfs(RelCollationTraitDef.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableValues.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableValues.java
@@ -58,7 +58,7 @@ public class EnumerableValues extends Values implements EnumerableRel {
   public static EnumerableValues create(RelOptCluster cluster,
       final RelDataType rowType,
       final ImmutableList<ImmutableList<RexLiteral>> tuples) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet =
         cluster.traitSetOf(EnumerableConvention.INSTANCE)
             .replaceIfs(RelCollationTraitDef.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -269,7 +269,7 @@ public class Bindables {
     public static BindableFilter create(final RelNode input,
         RexNode condition) {
       final RelOptCluster cluster = input.getCluster();
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
       final RelTraitSet traitSet =
           cluster.traitSetOf(BindableConvention.INSTANCE)
               .replaceIfs(RelCollationTraitDef.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -73,6 +73,8 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
 
   private RexExecutor executor;
 
+  private RelMetadataQuery mq;
+
   //~ Constructors -----------------------------------------------------------
 
   /**
@@ -423,6 +425,17 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
             return clazz.isAssignableFrom(input);
           }
         });
+  }
+
+  public RelMetadataQuery getMetadataQuery() {
+    if (mq == null) {
+      mq = RelMetadataQuery.instance();
+    }
+    return mq;
+  }
+
+  public void invalidateMetadataQuery() {
+    mq = null;
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
@@ -132,7 +132,7 @@ public class ConventionTraitDef extends RelTraitDef<Convention> {
       RelNode rel,
       Convention toConvention,
       boolean allowInfiniteCostConverters) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = planner.getMetadataQuery();
     final ConversionData conversionData = getConversionData(planner);
 
     final Convention fromConvention = rel.getConvention();

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
@@ -333,6 +333,15 @@ public interface RelOptPlanner {
   /** Called when a relational expression is copied to a similar expression. */
   void onCopy(RelNode rel, RelNode newRel);
 
+  /** Gets the current RelMetadataQuery */
+  RelMetadataQuery getMetadataQuery();
+
+  /**
+   * Should be called whenever the current RelMetadataQuery becomes obsolete.
+   * Typically invoked from {@link RelOptRuleCall#transformTo}
+   */
+  void invalidateMetadataQuery();
+
   /** @deprecated Use {@link RexExecutor} */
   @Deprecated // to be removed before 2.0
   interface Executor extends RexExecutor {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
@@ -18,6 +18,7 @@ package org.apache.calcite.plan;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.trace.CalciteTrace;
 
@@ -188,6 +189,14 @@ public abstract class RelOptRuleCall {
    */
   public RelOptPlanner getPlanner() {
     return planner;
+  }
+
+  /**
+   * Returns the current RelMetadataQuery to be used by Rule.onMatch
+   * @return mq
+   */
+  public RelMetadataQuery getMetadataQuery() {
+    return planner.getMetadataQuery();
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -3424,6 +3424,7 @@ public abstract class RelOptUtil {
     final RexBuilder rexBuilder = r.getCluster().getRexBuilder();
     final RelDataType rowType = r.getRowType();
     final List<RexNode> list = new ArrayList<>();
+    final RelMetadataQuery mq = r.getCluster().getPlanner().getMetadataQuery();
     for (RelDataTypeField field : rowType.getFieldList()) {
       if (field.getType().isNullable()) {
         list.add(
@@ -3435,8 +3436,7 @@ public abstract class RelOptUtil {
       // All columns are declared NOT NULL.
       return false;
     }
-    final RelOptPredicateList predicates =
-        RelMetadataQuery.instance().getPulledUpPredicates(r);
+    final RelOptPredicateList predicates = mq.getPulledUpPredicates(r);
     if (predicates.pulledUpPredicates.isEmpty()) {
       // We have no predicates, so cannot deduce that any of the fields
       // declared NULL are really NOT NULL.

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -640,7 +640,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
       bestRel = call.getResults().get(0);
     } else {
       RelOptCost bestCost = null;
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = getMetadataQuery();
       for (RelNode rel : call.getResults()) {
         RelOptCost thisCost = getCost(rel, mq);
         if (LOGGER.isTraceEnabled()) {
@@ -939,7 +939,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
 
     assertNoCycles();
 
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = getMetadataQuery();
     final StringBuilder sb = new StringBuilder();
     sb.append("\nBreadth-first from root:  {\n");
     for (HepRelVertex vertex : BreadthFirstIterator.of(graph, root)) {

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRuleCall.java
@@ -56,6 +56,7 @@ public class HepRuleCall extends RelOptRuleCall {
     final RelNode rel0 = rels[0];
     RelOptUtil.verifyTypeEquivalence(rel0, rel, rel0);
     results.add(rel);
+    getPlanner().invalidateMetadataQuery();
   }
 
   List<RelNode> getResults() {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -354,7 +354,7 @@ class RelSet {
 
     // Make sure the cost changes as a result of merging are propagated.
     final Set<RelSubset> activeSet = new HashSet<>();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = planner.getMetadataQuery();
     for (RelNode parentRel : getParentRels()) {
       final RelSubset parentSubset = planner.getSubset(parentRel);
       parentSubset.propagateCostImprovements(

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -126,7 +126,7 @@ public class RelSubset extends AbstractRelNode {
    */
   private void computeBestCost(RelOptPlanner planner) {
     bestCost = planner.getCostFactory().makeInfiniteCost();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = planner.getMetadataQuery();
     for (RelNode rel : getRels()) {
       final RelOptCost cost = planner.getCost(rel, mq);
       if (cost.isLt(bestCost)) {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -388,7 +388,7 @@ class RuleQueue {
       // The root always has importance = 1
       importance = 1.0;
     } else {
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = planner.getMetadataQuery();
 
       // The importance of a subset is the max of its importance to its
       // parents

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -888,7 +888,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
    * Checks internal consistency.
    */
   protected void validate() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = getMetadataQuery();
     for (RelSet set : allSets) {
       if (set.equivalentSet != null) {
         throw new AssertionError(
@@ -1169,7 +1169,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
    * @see #normalizePlan(String)
    */
   public void dump(PrintWriter pw) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = getMetadataQuery();
     pw.println("Root: " + root.getDescription());
     pw.println("Original rel:");
     pw.println(originalRootString);
@@ -1653,7 +1653,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     // 100. We think this happens because the back-links to parents are
     // not established. So, give the subset another change to figure out
     // its cost.
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = getMetadataQuery();
     subset.propagateCostImprovements(this, mq, rel, new HashSet<RelSubset>());
 
     return subset;

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -133,6 +133,7 @@ public class VolcanoRuleCall extends RelOptRuleCall {
             entry.getKey(), entry.getValue(), this);
       }
       volcanoPlanner.ensureRegistered(rel, rels[0], this);
+      getPlanner().invalidateMetadataQuery();
 
       if (volcanoPlanner.listener != null) {
         RelOptListener.RuleProductionEvent event =

--- a/core/src/main/java/org/apache/calcite/rel/core/Union.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Union.java
@@ -53,8 +53,7 @@ public abstract class Union extends SetOp {
   //~ Methods ----------------------------------------------------------------
 
   @Override public double estimateRowCount(RelMetadataQuery mq) {
-    double dRows = RelMdUtil.getUnionAllRowCount(RelMetadataQuery.instance(),
-        this);
+    double dRows = RelMdUtil.getUnionAllRowCount(mq, this);
     if (!all) {
       dRows *= 0.5;
     }
@@ -63,7 +62,7 @@ public abstract class Union extends SetOp {
 
   @Deprecated // to be removed before 2.0
   public static double estimateRowCount(RelNode rel) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = rel.getCluster().getPlanner().getMetadataQuery();
     return RelMdUtil.getUnionAllRowCount(mq, (Union) rel);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelWriterImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelWriterImpl.java
@@ -41,7 +41,6 @@ public class RelWriterImpl implements RelWriter {
   private final boolean withIdPrefix;
   protected final Spacer spacer = new Spacer();
   private final List<Pair<String, Object>> values = new ArrayList<>();
-  protected final RelMetadataQuery mq = RelMetadataQuery.instance();
 
   //~ Constructors -----------------------------------------------------------
 
@@ -62,7 +61,7 @@ public class RelWriterImpl implements RelWriter {
   protected void explain_(RelNode rel,
       List<Pair<String, Object>> values) {
     List<RelNode> inputs = rel.getInputs();
-
+    final RelMetadataQuery mq = rel.getCluster().getPlanner().getMetadataQuery();
     if (!mq.isVisibleInExplain(rel, detailLevel)) {
       // render children in place of this, at same level
       explainInputs(inputs);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
@@ -91,7 +91,7 @@ public final class LogicalCalc extends Calc {
   public static LogicalCalc create(final RelNode input,
       final RexProgram program) {
     final RelOptCluster cluster = input.getCluster();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet = cluster.traitSet()
         .replace(Convention.NONE)
         .replaceIfs(RelCollationTraitDef.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -107,7 +107,7 @@ public final class LogicalFilter extends Filter {
   public static LogicalFilter create(final RelNode input, RexNode condition,
       ImmutableSet<CorrelationId> variablesSet) {
     final RelOptCluster cluster = input.getCluster();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE)
         .replaceIfs(RelCollationTraitDef.INSTANCE,
             new Supplier<List<RelCollation>>() {

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -107,7 +107,7 @@ public final class LogicalProject extends Project {
   public static LogicalProject create(final RelNode input,
       final List<? extends RexNode> projects, RelDataType rowType) {
     final RelOptCluster cluster = input.getCluster();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet =
         cluster.traitSet().replace(Convention.NONE)
             .replaceIfs(

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
@@ -82,7 +82,7 @@ public class LogicalValues extends Values {
   public static LogicalValues create(RelOptCluster cluster,
       final RelDataType rowType,
       final ImmutableList<ImmutableList<RexLiteral>> tuples) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getPlanner().getMetadataQuery();
     final RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE)
         .replaceIfs(
             RelCollationTraitDef.INSTANCE, new Supplier<List<RelCollation>>() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
@@ -81,7 +81,7 @@ public class AggregateFilterTransposeRule extends RelOptRule {
     final ImmutableBitSet newGroupSet =
         aggregate.getGroupSet().union(filterColumns);
     final RelNode input = filter.getInput();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final Boolean unique = mq.areColumnsUnique(input, newGroupSet);
     if (unique != null && unique) {
       // The input is already unique on the grouping columns, so there's little

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
@@ -156,7 +156,7 @@ public class AggregateJoinTransposeRule extends RelOptRule {
 
     // Do the columns used by the join appear in the output of the aggregate?
     final ImmutableBitSet aggregateColumns = aggregate.getGroupSet();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final ImmutableBitSet keyColumns = keyColumns(aggregateColumns,
         mq.getPulledUpPredicates(join).pulledUpPredicates);
     final ImmutableBitSet joinColumns =

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
@@ -106,7 +106,7 @@ public class AggregateProjectPullUpConstantsRule extends RelOptRule {
     }
 
     final RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final RelOptPredicateList predicates =
         mq.getPulledUpPredicates(aggregate.getInput());
     if (predicates == null) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
@@ -61,7 +61,7 @@ public class AggregateRemoveRule extends RelOptRule {
     if (!aggregate.getAggCallList().isEmpty() || aggregate.indicator) {
       return;
     }
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     if (!SqlFunctions.isTrue(mq.areColumnsUnique(input, aggregate.getGroupSet()))) {
       return;
     }

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
@@ -116,7 +116,7 @@ public class AggregateStarTableRule extends RelOptRule {
     final RelBuilder relBuilder = call.builder();
     final CalciteSchema.TableEntry tableEntry = pair.left;
     final TileKey tileKey = pair.right;
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final double rowCount = aggregate.estimateRowCount(mq);
     final Table aggregateTable = tableEntry.getTable();
     final RelDataType aggregateTableRowType =

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
@@ -116,7 +116,7 @@ public class AggregateUnionTransposeRule extends RelOptRule {
     // create corresponding aggregates on top of each union child
     final RelBuilder relBuilder = call.builder();
     int transformCount = 0;
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     for (RelNode input : union.getInputs()) {
       boolean alreadyUnique =
           RelMdUtil.areColumnsDefinitelyUnique(mq, input,

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinPushTransitivePredicatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinPushTransitivePredicatesRule.java
@@ -59,7 +59,7 @@ public class JoinPushTransitivePredicatesRule extends RelOptRule {
 
   @Override public void onMatch(RelOptRuleCall call) {
     Join join = call.rel(0);
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     RelOptPredicateList preds = mq.getPulledUpPredicates(join);
 
     if (preds.leftInferredPredicates.isEmpty()

--- a/core/src/main/java/org/apache/calcite/rel/rules/LoptMultiJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/LoptMultiJoin.java
@@ -701,7 +701,7 @@ public class LoptMultiJoin {
     // First, locate the originating column for all simple column
     // references in the left factor.
     final RelNode left = getJoinFactor(leftFactor);
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = left.getCluster().getPlanner().getMetadataQuery();
     final Map<Integer, Integer> leftFactorColMapping = new HashMap<>();
     for (int i = 0; i < left.getRowType().getFieldCount(); i++) {
       final RelColumnOrigin colOrigin = mq.getColumnOrigin(left, i);

--- a/core/src/main/java/org/apache/calcite/rel/rules/LoptOptimizeJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/LoptOptimizeJoinRule.java
@@ -88,12 +88,13 @@ public class LoptOptimizeJoinRule extends RelOptRule {
   public void onMatch(RelOptRuleCall call) {
     final MultiJoin multiJoinRel = call.rel(0);
     final LoptMultiJoin multiJoin = new LoptMultiJoin(multiJoinRel);
+    final RelMetadataQuery mq = call.getMetadataQuery();
 
-    findRemovableOuterJoins(multiJoin);
+    findRemovableOuterJoins(mq, multiJoin);
 
     final RexBuilder rexBuilder = multiJoinRel.getCluster().getRexBuilder();
     final LoptSemiJoinOptimizer semiJoinOpt =
-        new LoptSemiJoinOptimizer(multiJoin, rexBuilder);
+        new LoptSemiJoinOptimizer(call.getMetadataQuery(), multiJoin, rexBuilder);
 
     // determine all possible semijoins
     semiJoinOpt.makePossibleSemiJoins(multiJoin);
@@ -116,9 +117,9 @@ public class LoptOptimizeJoinRule extends RelOptRule {
 
     multiJoin.setFactorWeights();
 
-    findRemovableSelfJoins(multiJoin);
+    findRemovableSelfJoins(mq, multiJoin);
 
-    findBestOrderings(call.builder(), multiJoin, semiJoinOpt, call);
+    findBestOrderings(mq, call.builder(), multiJoin, semiJoinOpt, call);
   }
 
   /**
@@ -128,7 +129,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    *
    * @param multiJoin join factors being optimized
    */
-  private void findRemovableOuterJoins(LoptMultiJoin multiJoin) {
+  private void findRemovableOuterJoins(RelMetadataQuery mq, LoptMultiJoin multiJoin) {
     final List<Integer> removalCandidates = new ArrayList<>();
     for (int factIdx = 0;
         factIdx < multiJoin.getNumJoinFactors();
@@ -209,7 +210,6 @@ public class LoptOptimizeJoinRule extends RelOptRule {
         // part of an equality join condition, nulls are filtered out
         // by the join.  So, it's ok if there are nulls in the join
         // keys.
-        final RelMetadataQuery mq = RelMetadataQuery.instance();
         if (RelMdUtil.areColumnsDefinitelyUniqueWhenNullsFiltered(mq,
             multiJoin.getJoinFactor(factIdx), joinKeys)) {
           multiJoin.addRemovableOuterJoinFactor(factIdx);
@@ -286,9 +286,9 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    *
    * @param multiJoin join factors being optimized
    */
-  private void findRemovableSelfJoins(LoptMultiJoin multiJoin) {
+  private void findRemovableSelfJoins(RelMetadataQuery mq, LoptMultiJoin multiJoin) {
     // Candidates for self-joins must be simple factors
-    Map<Integer, RelOptTable> simpleFactors = getSimpleFactors(multiJoin);
+    Map<Integer, RelOptTable> simpleFactors = getSimpleFactors(mq, multiJoin);
 
     // See if a simple factor is repeated and therefore potentially is
     // part of a self-join.  Restrict each factor to at most one
@@ -332,6 +332,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
       }
       if ((selfJoinFilters.size() > 0)
           && isSelfJoinFilterUnique(
+            mq,
             multiJoin,
             factor1,
             factor2,
@@ -351,7 +352,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @return map consisting of the simple factors and the tables they
    * correspond
    */
-  private Map<Integer, RelOptTable> getSimpleFactors(LoptMultiJoin multiJoin) {
+  private Map<Integer, RelOptTable> getSimpleFactors(RelMetadataQuery mq, LoptMultiJoin multiJoin) {
     final Map<Integer, RelOptTable> returnList = new HashMap<>();
 
     // Loop through all join factors and locate the ones where each
@@ -361,7 +362,6 @@ public class LoptOptimizeJoinRule extends RelOptRule {
     if (multiJoin.getMultiJoinRel().isFullOuterJoin()) {
       return returnList;
     }
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     for (int factIdx = 0; factIdx < multiJoin.getNumJoinFactors(); factIdx++) {
       if (multiJoin.isNullGenerating(factIdx)
           || (multiJoin.getJoinRemovalFactor(factIdx) != null)) {
@@ -389,6 +389,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @return true if the criteria are met
    */
   private boolean isSelfJoinFilterUnique(
+      RelMetadataQuery mq,
       LoptMultiJoin multiJoin,
       int leftFactor,
       int rightFactor,
@@ -422,7 +423,6 @@ public class LoptOptimizeJoinRule extends RelOptRule {
                 rightRel.getRowType().getFieldList(),
                 adjustments));
 
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     return areSelfJoinKeysUnique(mq, leftRel, rightRel, joinFilters);
   }
 
@@ -435,6 +435,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @param call RelOptRuleCall associated with this rule
    */
   private void findBestOrderings(
+      RelMetadataQuery mq,
       RelBuilder relBuilder,
       LoptMultiJoin multiJoin,
       LoptSemiJoinOptimizer semiJoinOpt,
@@ -452,6 +453,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
       }
       LoptJoinTree joinTree =
           createOrdering(
+              mq,
               relBuilder,
               multiJoin,
               semiJoinOpt,
@@ -563,6 +565,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @return computed cardinality
    */
   private Double computeJoinCardinality(
+      RelMetadataQuery mq,
       LoptMultiJoin multiJoin,
       LoptSemiJoinOptimizer semiJoinOpt,
       LoptJoinTree joinTree,
@@ -605,7 +608,6 @@ public class LoptOptimizeJoinRule extends RelOptRule {
     if (joinKeys.isEmpty()) {
       return null;
     } else {
-      final RelMetadataQuery mq = semiJoinOpt.mq;
       return mq.getDistinctRowCount(semiJoinOpt.getChosenSemiJoin(factor),
           joinKeys.build(), null);
     }
@@ -667,6 +669,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * firstFactor to appear as the first factor in the join
    */
   private LoptJoinTree createOrdering(
+      RelMetadataQuery mq,
       RelBuilder relBuilder,
       LoptMultiJoin multiJoin,
       LoptSemiJoinOptimizer semiJoinOpt,
@@ -698,6 +701,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
         } else {
           nextFactor =
               getBestNextFactor(
+                  mq,
                   multiJoin,
                   factorsToAdd,
                   factorsAdded,
@@ -718,6 +722,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
       factorsNeeded.and(factorsAdded);
       joinTree =
           addFactorToTree(
+              mq,
               relBuilder,
               multiJoin,
               semiJoinOpt,
@@ -751,6 +756,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @return index of the best factor to add next
    */
   private int getBestNextFactor(
+      RelMetadataQuery mq,
       LoptMultiJoin multiJoin,
       BitSet factorsToAdd,
       BitSet factorsAdded,
@@ -801,6 +807,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
           && ((dimWeight > bestWeight) || (dimWeight == bestWeight))) {
         cardinality =
             computeJoinCardinality(
+              mq,
                 multiJoin,
                 semiJoinOpt,
                 joinTree,
@@ -860,6 +867,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * add the factor; otherwise, null is returned
    */
   private LoptJoinTree addFactorToTree(
+      RelMetadataQuery mq,
       RelBuilder relBuilder,
       LoptMultiJoin multiJoin,
       LoptSemiJoinOptimizer semiJoinOpt,
@@ -868,7 +876,6 @@ public class LoptOptimizeJoinRule extends RelOptRule {
       BitSet factorsNeeded,
       List<RexNode> filtersToAdd,
       boolean selfJoin) {
-    final RelMetadataQuery mq = semiJoinOpt.mq;
 
     // if the factor corresponds to the null generating factor in an outer
     // join that can be removed, then create a replacement join
@@ -914,6 +921,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
     final List<RexNode> tmpFilters = new ArrayList<>(filtersToAdd);
     LoptJoinTree topTree =
         addToTop(
+            mq,
             relBuilder,
             multiJoin,
             semiJoinOpt,
@@ -923,6 +931,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
             selfJoin);
     LoptJoinTree pushDownTree =
         pushDownFactor(
+            mq,
             relBuilder,
             multiJoin,
             semiJoinOpt,
@@ -1013,6 +1022,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * returned
    */
   private LoptJoinTree pushDownFactor(
+      RelMetadataQuery mq,
       RelBuilder relBuilder,
       LoptMultiJoin multiJoin,
       LoptSemiJoinOptimizer semiJoinOpt,
@@ -1082,6 +1092,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
     LoptJoinTree subTree = (childNo == 0) ? left : right;
     subTree =
         addFactorToTree(
+            mq,
             relBuilder,
             multiJoin,
             semiJoinOpt,
@@ -1136,6 +1147,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
 
     // create the new join tree with the factor pushed down
     return createJoinSubtree(
+        mq,
         relBuilder,
         multiJoin,
         left,
@@ -1162,6 +1174,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @return new join tree
    */
   private LoptJoinTree addToTop(
+      RelMetadataQuery mq,
       RelBuilder relBuilder,
       LoptMultiJoin multiJoin,
       LoptSemiJoinOptimizer semiJoinOpt,
@@ -1214,6 +1227,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
     }
 
     return createJoinSubtree(
+        mq,
         relBuilder,
         multiJoin,
         joinTree,
@@ -1723,6 +1737,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @return created LogicalJoin
    */
   private LoptJoinTree createJoinSubtree(
+      RelMetadataQuery mq,
       RelBuilder relBuilder,
       LoptMultiJoin multiJoin,
       LoptJoinTree left,
@@ -1736,7 +1751,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
         multiJoin.getMultiJoinRel().getCluster().getRexBuilder();
 
     // swap the inputs if beneficial
-    if (swapInputs(multiJoin, left, right, selfJoin)) {
+    if (swapInputs(mq, multiJoin, left, right, selfJoin)) {
       LoptJoinTree tmp = right;
       right = left;
       left = tmp;
@@ -1850,6 +1865,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * @return true if swapping should be done
    */
   private boolean swapInputs(
+      RelMetadataQuery mq,
       LoptMultiJoin multiJoin,
       LoptJoinTree left,
       LoptJoinTree right,
@@ -1861,7 +1877,6 @@ public class LoptOptimizeJoinRule extends RelOptRule {
           ((LoptJoinTree.Leaf) left.getFactorTree()).getId());
     }
 
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final Double leftRowCount = mq.getRowCount(left.getJoinTree());
     final Double rightRowCount = mq.getRowCount(right.getJoinTree());
 
@@ -1994,7 +2009,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
     }
 
     // Make sure the join is between the same simple factor
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = joinRel.getCluster().getPlanner().getMetadataQuery();
     final RelOptTable leftTable = mq.getTableOrigin(left);
     if (leftTable == null) {
       return false;

--- a/core/src/main/java/org/apache/calcite/rel/rules/LoptSemiJoinOptimizer.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/LoptSemiJoinOptimizer.java
@@ -61,9 +61,7 @@ public class LoptSemiJoinOptimizer {
 
   private final RexBuilder rexBuilder;
 
-  /** Not thread-safe. But should be OK, because an optimizer is only used
-   * from within one thread.*/
-  final RelMetadataQuery mq = RelMetadataQuery.instance();
+  private final RelMetadataQuery mq;
 
   /**
    * Semijoins corresponding to each join factor, if they are going to be
@@ -85,10 +83,12 @@ public class LoptSemiJoinOptimizer {
   //~ Constructors -----------------------------------------------------------
 
   public LoptSemiJoinOptimizer(
+      RelMetadataQuery mq,
       LoptMultiJoin multiJoin,
       RexBuilder rexBuilder) {
     // there are no semijoins yet, so initialize to the original
     // factors
+    this.mq = mq;
     int nJoinFactors = multiJoin.getNumJoinFactors();
     chosenSemiJoins = new RelNode[nJoinFactors];
     for (int i = 0; i < nJoinFactors; i++) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinOptimizeBushyRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinOptimizeBushyRule.java
@@ -88,7 +88,7 @@ public class MultiJoinOptimizeBushyRule extends RelOptRule {
     final MultiJoin multiJoinRel = call.rel(0);
     final RexBuilder rexBuilder = multiJoinRel.getCluster().getRexBuilder();
     final RelBuilder relBuilder = call.builder();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
 
     final LoptMultiJoin multiJoin = new LoptMultiJoin(multiJoinRel);
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
@@ -143,7 +143,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
           Lists.newArrayList(filter.getCondition());
       RexNode newConditionExp;
       boolean reduced;
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = call.getMetadataQuery();
       final RelOptPredicateList predicates =
           mq.getPulledUpPredicates(filter.getInput());
       if (reduceExpressions(filter, expList, predicates, true)) {
@@ -259,7 +259,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
 
     @Override public void onMatch(RelOptRuleCall call) {
       final Project project = call.rel(0);
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = call.getMetadataQuery();
       final RelOptPredicateList predicates =
           mq.getPulledUpPredicates(project.getInput());
       final List<RexNode> expList =
@@ -291,7 +291,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
       final Join join = call.rel(0);
       final List<RexNode> expList = Lists.newArrayList(join.getCondition());
       final int fieldCount = join.getLeft().getRowType().getFieldCount();
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = call.getMetadataQuery();
       final RelOptPredicateList leftPredicates =
           mq.getPulledUpPredicates(join.getLeft());
       final RelOptPredicateList rightPredicates =

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
@@ -62,7 +62,7 @@ public class SortJoinTransposeRule extends RelOptRule {
   @Override public boolean matches(RelOptRuleCall call) {
     final Sort sort = call.rel(0);
     final Join join = call.rel(1);
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final JoinInfo joinInfo = JoinInfo.of(
         join.getLeft(), join.getRight(), join.getCondition());
 
@@ -117,7 +117,7 @@ public class SortJoinTransposeRule extends RelOptRule {
     // We create a new sort operator on the corresponding input
     final RelNode newLeftInput;
     final RelNode newRightInput;
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     if (join.getJoinType() == JoinRelType.LEFT) {
       // If the input is already sorted and we are not reducing the number of tuples,
       // we bail out

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortUnionTransposeRule.java
@@ -94,7 +94,7 @@ public class SortUnionTransposeRule extends RelOptRule {
     // Thus we use 'ret' as a flag to identify if we have finished pushing the
     // sort past a union.
     boolean ret = true;
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     for (RelNode input : union.getInputs()) {
       if (!RelMdUtil.checkInputForCollationAndLimit(mq, input,
           sort.getCollation(), sort.offset, sort.fetch)) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -157,7 +157,7 @@ public abstract class SubQueryRemoveRule extends RelOptRule {
     switch (e.getKind()) {
     case SCALAR_QUERY:
       builder.push(e.rel);
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = e.rel.getCluster().getPlanner().getMetadataQuery();
       final Boolean unique = mq.areColumnsUnique(builder.peek(),
           ImmutableBitSet.of());
       if (unique == null || !unique) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionPullUpConstantsRule.java
@@ -68,7 +68,7 @@ public class UnionPullUpConstantsRule extends RelOptRule {
     }
 
     final RexBuilder rexBuilder = union.getCluster().getRexBuilder();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final RelOptPredicateList predicates = mq.getPulledUpPredicates(union);
     if (predicates == null) {
       return;

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -1883,7 +1883,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
         // The join filters out the nulls.  So, it's ok if there are
         // nulls in the join keys.
-        final RelMetadataQuery mq = RelMetadataQuery.instance();
+        final RelMetadataQuery mq = call.getMetadataQuery();
         if (!RelMdUtil.areColumnsDefinitelyUniqueWhenNullsFiltered(mq, right,
             rightJoinKeys)) {
           SQL2REL_LOGGER.debug("{} are not unique keys for {}",
@@ -2097,7 +2097,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
         // The join filters out the nulls.  So, it's ok if there are
         // nulls in the join keys.
-        final RelMetadataQuery mq = RelMetadataQuery.instance();
+        final RelMetadataQuery mq = call.getMetadataQuery();
         if (!RelMdUtil.areColumnsDefinitelyUniqueWhenNullsFiltered(mq, left,
             correlatedInputRefJoinKeys)) {
           SQL2REL_LOGGER.debug("{} are not unique keys for {}",
@@ -2175,7 +2175,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
         // leftInput contains unique keys
         // i.e. each row is distinct and can group by on all the left
         // fields
-        final RelMetadataQuery mq = RelMetadataQuery.instance();
+        final RelMetadataQuery mq = call.getMetadataQuery();
         if (!RelMdUtil.areColumnsDefinitelyUnique(mq, left, allCols)) {
           SQL2REL_LOGGER.debug("There are no unique keys for {}", left);
           return;

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
@@ -187,7 +187,7 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
     final ImmutableBitSet.Builder fieldsUsedBuilder = fieldsUsed.rebuild();
 
     // Fields that define the collation cannot be discarded.
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = rel.getCluster().getPlanner().getMetadataQuery();
     final ImmutableList<RelCollation> collations = mq.collations(input);
     for (RelCollation collation : collations) {
       for (RelFieldCollation fieldCollation : collation.getFieldCollations()) {

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -999,7 +999,7 @@ public class RelBuilder {
         ImmutableBitSet.of(registerExpressions(extraNodes, groupKey_.nodes));
   label:
     if (Iterables.isEmpty(aggCalls) && !groupKey_.indicator) {
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = peek().getCluster().getPlanner().getMetadataQuery();
       if (groupSet.isEmpty()) {
         final Double minRowCount = mq.getMinRowCount(peek());
         if (minRowCount == null || minRowCount < 1D) {


### PR DESCRIPTION
RelMetadataQuery instance is held by planner and carried by the call to the rule. Most places the RMQ was needed in onMatch, where the call is available, or on a method called form onMatch where it could easily be passed as parameter. LoptMultiJoin functions needed RMQ and I had to pass the parameter to several functions.
Since RelNode can get the planner (via cluster) de-facto any reference to a RelNode can retrieve the needed RMQ. I used this in places where the call was not available. This includes also the deprecated functions like getRows.