### PR TITLE
[CALCITE-1819] - Druid Adapter does not push the boolean operator "<>" as a filter correctly

### DIFF
--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -77,6 +77,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
@@ -1023,21 +1024,21 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
 
         switch (e.getKind()) {
         case EQUALS:
-          return new JsonSelector("selector", dimName, tr(e, posConstant), extractionFunction);
+          return new JsonSelector(dimName, tr(e, posConstant), extractionFunction);
         case NOT_EQUALS:
-          return new JsonCompositeFilter("not",
-              new JsonSelector("selector", dimName, tr(e, posConstant), extractionFunction));
+          return new JsonCompositeFilter(JsonFilter.Type.NOT,
+              new JsonSelector(dimName, tr(e, posConstant), extractionFunction));
         case GREATER_THAN:
-          return new JsonBound("bound", dimName, tr(e, posConstant),
+          return new JsonBound(dimName, tr(e, posConstant),
               true, null, false, numeric, extractionFunction);
         case GREATER_THAN_OR_EQUAL:
-          return new JsonBound("bound", dimName, tr(e, posConstant),
+          return new JsonBound(dimName, tr(e, posConstant),
               false, null, false, numeric, extractionFunction);
         case LESS_THAN:
-          return new JsonBound("bound", dimName, null, false,
+          return new JsonBound(dimName, null, false,
               tr(e, posConstant), true, numeric, extractionFunction);
         case LESS_THAN_OR_EQUAL:
-          return new JsonBound("bound", dimName, null, false,
+          return new JsonBound(dimName, null, false,
               tr(e, posConstant), false, numeric, extractionFunction);
         case IN:
           ImmutableList.Builder<String> listBuilder = ImmutableList.builder();
@@ -1046,9 +1047,9 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
               listBuilder.add(((RexLiteral) rexNode).getValue3().toString());
             }
           }
-          return new JsonInFilter("in", dimName, listBuilder.build(), extractionFunction);
+          return new JsonInFilter(dimName, listBuilder.build(), extractionFunction);
         case BETWEEN:
-          return new JsonBound("bound", dimName, tr(e, 2), false,
+          return new JsonBound(dimName, tr(e, 2), false,
               tr(e, 3), false, numeric, extractionFunction);
         default:
           throw new AssertionError();
@@ -1057,7 +1058,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
       case OR:
       case NOT:
         call = (RexCall) e;
-        return new JsonCompositeFilter(e.getKind().lowerName,
+        return new JsonCompositeFilter(JsonFilter.Type.valueOf(e.getKind().name()),
             translateFilters(call.getOperands()));
       default:
         throw new AssertionError("cannot translate filter: " + e);
@@ -1234,9 +1235,25 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
 
   /** Filter element of a Druid "groupBy" or "topN" query. */
   private abstract static class JsonFilter implements Json {
-    final String type;
+    /**
+     * Supported filter types
+     * */
+    protected enum Type {
+      AND,
+      OR,
+      NOT,
+      SELECTOR,
+      IN,
+      BOUND;
 
-    private JsonFilter(String type) {
+      public String lowercase() {
+        return name().toLowerCase(Locale.ROOT);
+      }
+    }
+
+    final Type type;
+
+    private JsonFilter(Type type) {
       this.type = type;
     }
   }
@@ -1247,9 +1264,9 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
     private final String value;
     private final ExtractionFunction extractionFunction;
 
-    private JsonSelector(String type, String dimension, String value,
+    private JsonSelector(String dimension, String value,
         ExtractionFunction extractionFunction) {
-      super(type);
+      super(Type.SELECTOR);
       this.dimension = dimension;
       this.value = value;
       this.extractionFunction = extractionFunction;
@@ -1257,7 +1274,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
 
     public void write(JsonGenerator generator) throws IOException {
       generator.writeStartObject();
-      generator.writeStringField("type", type);
+      generator.writeStringField("type", type.lowercase());
       generator.writeStringField("dimension", dimension);
       generator.writeStringField("value", value);
       writeFieldIf(generator, "extractionFn", extractionFunction);
@@ -1276,10 +1293,10 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
     private final boolean alphaNumeric;
     private final ExtractionFunction extractionFunction;
 
-    private JsonBound(String type, String dimension, String lower,
+    private JsonBound(String dimension, String lower,
         boolean lowerStrict, String upper, boolean upperStrict,
         boolean alphaNumeric, ExtractionFunction extractionFunction) {
-      super(type);
+      super(Type.BOUND);
       this.dimension = dimension;
       this.lower = lower;
       this.lowerStrict = lowerStrict;
@@ -1291,7 +1308,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
 
     public void write(JsonGenerator generator) throws IOException {
       generator.writeStartObject();
-      generator.writeStringField("type", type);
+      generator.writeStringField("type", type.lowercase());
       generator.writeStringField("dimension", dimension);
       if (lower != null) {
         generator.writeStringField("lower", lower);
@@ -1315,21 +1332,21 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
   private static class JsonCompositeFilter extends JsonFilter {
     private final List<? extends JsonFilter> fields;
 
-    private JsonCompositeFilter(String type,
+    private JsonCompositeFilter(Type type,
         Iterable<? extends JsonFilter> fields) {
       super(type);
       this.fields = ImmutableList.copyOf(fields);
     }
 
-    private JsonCompositeFilter(String type, JsonFilter... fields) {
+    private JsonCompositeFilter(Type type, JsonFilter... fields) {
       this(type, ImmutableList.copyOf(fields));
     }
 
     public void write(JsonGenerator generator) throws IOException {
       generator.writeStartObject();
-      generator.writeStringField("type", type);
+      generator.writeStringField("type", type.lowercase());
       switch (type) {
-      case "not":
+      case NOT:
         writeField(generator, "field", fields.get(0));
         break;
       default:
@@ -1345,9 +1362,9 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
     private final List<String> values;
     private final ExtractionFunction extractionFunction;
 
-    private JsonInFilter(String type, String dimension, List<String> values,
+    private JsonInFilter(String dimension, List<String> values,
         ExtractionFunction extractionFunction) {
-      super(type);
+      super(Type.IN);
       this.dimension = dimension;
       this.values = values;
       this.extractionFunction = extractionFunction;
@@ -1355,7 +1372,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
 
     public void write(JsonGenerator generator) throws IOException {
       generator.writeStartObject();
-      generator.writeStringField("type", type);
+      generator.writeStringField("type", type.lowercase());
       generator.writeStringField("dimension", dimension);
       writeField(generator, "values", values);
       writeFieldIf(generator, "extractionFn", extractionFunction);

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -1329,7 +1329,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
       generator.writeStartObject();
       generator.writeStringField("type", type);
       switch (type) {
-      case "NOT":
+      case "not":
         writeField(generator, "field", fields.get(0));
         break;
       default:

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -2174,6 +2174,14 @@ public class DruidAdapterIT {
         .queryContains(druidChecker("'queryType':'timeseries'"));
   }
 
+  /** Test to make sure the "not" filter form is different than "or" & "and"
+   * */
+  @Test public void testNotFilterForm() {
+    String sql = "select count(distinct \"the_month\") from "
+            + "\"foodmart\" where \"the_month\" <> \'October\'";
+    sql(sql, FOODMART)
+            .returnsOrdered("EXPR$0=11");
+  }
 }
 
 // End DruidAdapterIT.java

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -2174,7 +2174,8 @@ public class DruidAdapterIT {
         .queryContains(druidChecker("'queryType':'timeseries'"));
   }
 
-  /** Test to make sure the "not" filter form is different than "or" & "and"
+  /**
+   * Test to make sure the "not" filter has only 1 field, rather than an array of fields.
    * */
   @Test public void testNotFilterForm() {
     String sql = "select count(distinct \"the_month\") from "

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -2179,7 +2179,11 @@ public class DruidAdapterIT {
   @Test public void testNotFilterForm() {
     String sql = "select count(distinct \"the_month\") from "
             + "\"foodmart\" where \"the_month\" <> \'October\'";
+    String druidFilter = "'filter':{'type':'not',"
+            + "'field':{'type':'selector','dimension':'the_month','value':'October'}}";
+    // Check that the filter actually worked, and that druid was responsible for the filter
     sql(sql, FOODMART)
+            .queryContains(druidChecker(druidFilter))
             .returnsOrdered("EXPR$0=11");
   }
 }


### PR DESCRIPTION
Fixed the case in the switch statement to match the JSON output, added a test case to ensure that the <> operator works correctly.