### PR TITLE
[CALCITE-1069] In Aggregate, deprecate indicators, and allow GROUPING…

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/AggContext.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/AggContext.java
@@ -18,6 +18,7 @@ package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.util.ImmutableBitSet;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -67,6 +68,24 @@ public interface AggContext {
    * @return Parameter types of the aggregate
    */
   List<? extends Type> parameterTypes();
+
+  /** Returns the ordinals of the input fields that make up the key. */
+  List<Integer> keyOrdinals();
+
+  /**
+   * Returns the types of the group key as
+   * {@link org.apache.calcite.rel.type.RelDataType}.
+   */
+  List<? extends RelDataType> keyRelTypes();
+
+  /**
+   * Returns the types of the group key as
+   * {@link java.lang.reflect.Type}.
+   */
+  List<? extends Type> keyTypes();
+
+  /** Returns the grouping sets we are aggregating on. */
+  List<ImmutableBitSet> groupSets();
 }
 
 // End AggContext.java

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/AggResultContext.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/AggResultContext.java
@@ -16,6 +16,9 @@
  */
 package org.apache.calcite.adapter.enumerable;
 
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.rel.core.AggregateCall;
+
 /**
  * Information for a call to
  * {@link AggImplementor#implementResult(AggContext, AggResultContext)}
@@ -25,6 +28,17 @@ package org.apache.calcite.adapter.enumerable;
  * implementation MUST NOT destroy the contents of {@link #accumulator()}.
  */
 public interface AggResultContext extends NestedBlockBuilder, AggResetContext {
+  /** Expression by which to reference the key upon which the values in the
+   * accumulator were aggregated. Most aggregate functions depend on only the
+   * accumulator, but quasi-aggregate functions such as GROUPING access at the
+   * key. */
+  Expression key();
+
+  /** Returns an expression that references the {@code i}th field of the key,
+   * cast to the appropriate type. */
+  Expression keyField(int i);
+
+  AggregateCall call();
 }
 
 // End AggResultContext.java

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
@@ -49,6 +49,7 @@ import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.runtime.SortedMultiMap;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.util.BuiltInMethod;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
@@ -787,6 +788,22 @@ public class EnumerableWindow extends Window implements EnumerableRel {
             public List<? extends RelDataType> parameterRelTypes() {
               return EnumUtils.fieldRowTypes(result.physType.getRowType(),
                   constants, agg.call.getArgList());
+            }
+
+            public List<ImmutableBitSet> groupSets() {
+              throw new UnsupportedOperationException();
+            }
+
+            public List<Integer> keyOrdinals() {
+              throw new UnsupportedOperationException();
+            }
+
+            public List<? extends RelDataType> keyRelTypes() {
+              throw new UnsupportedOperationException();
+            }
+
+            public List<? extends Type> keyTypes() {
+              throw new UnsupportedOperationException();
             }
           };
       String aggName = "a" + agg.aggIdx;

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/AggAddContextImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/AggAddContextImpl.java
@@ -29,7 +29,7 @@ import java.util.List;
 public abstract class AggAddContextImpl extends AggResultContextImpl
     implements AggAddContext {
   public AggAddContextImpl(BlockBuilder block, List<Expression> accumulator) {
-    super(block, accumulator);
+    super(block, null, accumulator, null, null);
   }
 
   public final List<Expression> arguments() {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/AggResetContextImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/AggResetContextImpl.java
@@ -20,6 +20,7 @@ import org.apache.calcite.adapter.enumerable.AggResetContext;
 import org.apache.calcite.adapter.enumerable.NestedBlockBuilderImpl;
 import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.rel.core.AggregateCall;
 
 import java.util.List;
 
@@ -27,14 +28,15 @@ import java.util.List;
  * Implementation of
  * {@link org.apache.calcite.adapter.enumerable.AggResetContext}
  */
-public class AggResetContextImpl extends NestedBlockBuilderImpl
+public abstract class AggResetContextImpl extends NestedBlockBuilderImpl
     implements AggResetContext {
   private final List<Expression> accumulator;
 
   /**
-   * Creates aggregate reset context
-   * @param block code block that will contain the added initialization
-   * @param accumulator accumulator variables that store the intermediate
+   * Creates aggregate reset context.
+   *
+   * @param block Code block that will contain the added initialization
+   * @param accumulator Accumulator variables that store the intermediate
    *                    aggregate state
    */
   public AggResetContextImpl(BlockBuilder block, List<Expression> accumulator) {
@@ -44,6 +46,10 @@ public class AggResetContextImpl extends NestedBlockBuilderImpl
 
   public List<Expression> accumulator() {
     return accumulator;
+  }
+
+  public AggregateCall call() {
+    throw new UnsupportedOperationException();
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/AggResultContextImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/AggResultContextImpl.java
@@ -17,8 +17,11 @@
 package org.apache.calcite.adapter.enumerable.impl;
 
 import org.apache.calcite.adapter.enumerable.AggResultContext;
+import org.apache.calcite.adapter.enumerable.PhysType;
 import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.ParameterExpression;
+import org.apache.calcite.rel.core.AggregateCall;
 
 import java.util.List;
 
@@ -28,15 +31,38 @@ import java.util.List;
  */
 public class AggResultContextImpl extends AggResetContextImpl
     implements AggResultContext {
+  private final AggregateCall call;
+  private final ParameterExpression key;
+  private final PhysType keyPhysType;
+
   /**
-   * Creates aggregate result context
-   * @param block code block that will contain the result calculation statements
-   * @param accumulator accumulator variables that store the intermediate
+   * Creates aggregate result context.
+   *
+   * @param block Code block that will contain the result calculation statements
+   * @param call Aggregate call
+   * @param accumulator Accumulator variables that store the intermediate
    *                    aggregate state
+   * @param key Key
    */
-  public AggResultContextImpl(BlockBuilder block,
-      List<Expression> accumulator) {
+  public AggResultContextImpl(BlockBuilder block, AggregateCall call,
+      List<Expression> accumulator, ParameterExpression key,
+      PhysType keyPhysType) {
     super(block, accumulator);
+    this.call = call;
+    this.key = key;
+    this.keyPhysType = keyPhysType;
+  }
+
+  public Expression key() {
+    return key;
+  }
+
+  public Expression keyField(int i) {
+    return keyPhysType.fieldReference(key, i);
+  }
+
+  @Override public AggregateCall call() {
+    return call;
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/WinAggResultContextImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/WinAggResultContextImpl.java
@@ -45,7 +45,7 @@ public abstract class WinAggResultContextImpl extends AggResultContextImpl
   public WinAggResultContextImpl(BlockBuilder block,
       List<Expression> accumulator,
       Function<BlockBuilder, WinAggFrameResultContext> frameContextBuilder) {
-    super(block, accumulator);
+    super(block, null, accumulator, null, null);
     this.frame = frameContextBuilder;
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -508,7 +508,7 @@ public abstract class RelOptUtil {
               extraName);
 
       ret =
-          LogicalAggregate.create(ret, false,
+          LogicalAggregate.create(ret,
               ImmutableBitSet.of(), null, ImmutableList.of(aggCall));
     }
 
@@ -557,8 +557,7 @@ public abstract class RelOptUtil {
         || logic == RelOptUtil.Logic.TRUE_FALSE_UNKNOWN;
     if (!outerJoin) {
       final LogicalAggregate aggregate =
-          LogicalAggregate.create(ret, false,
-              ImmutableBitSet.range(keyCount), null,
+          LogicalAggregate.create(ret, ImmutableBitSet.range(keyCount), null,
               ImmutableList.<AggregateCall>of());
       return new Exists(aggregate, false, false);
     }
@@ -586,9 +585,8 @@ public abstract class RelOptUtil {
             null,
             null);
 
-    ret = LogicalAggregate.create(ret, false,
-        ImmutableBitSet.range(projectedKeyCount), null,
-        ImmutableList.of(aggCall));
+    ret = LogicalAggregate.create(ret, ImmutableBitSet.range(projectedKeyCount),
+        null, ImmutableList.of(aggCall));
 
     switch (logic) {
     case TRUE_FALSE_UNKNOWN:
@@ -787,14 +785,13 @@ public abstract class RelOptUtil {
               0, rel, null, null));
     }
 
-    return LogicalAggregate.create(rel, false,
-        ImmutableBitSet.of(), null, aggCalls);
+    return LogicalAggregate.create(rel, ImmutableBitSet.of(), null, aggCalls);
   }
 
   /** @deprecated Use {@link RelBuilder#distinct()}. */
   @Deprecated // to be removed before 2.0
   public static RelNode createDistinctRel(RelNode rel) {
-    return LogicalAggregate.create(rel, false,
+    return LogicalAggregate.create(rel,
         ImmutableBitSet.range(rel.getRowType().getFieldCount()), null,
         ImmutableList.<AggregateCall>of());
   }

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1204,8 +1204,7 @@ public class SubstitutionVisitor {
         Mappings.apply2(mapping, aggregate.groupSets);
     List<AggregateCall> aggregateCalls =
         apply(mapping, aggregate.aggCalls);
-    return MutableAggregate.of(input, aggregate.indicator, groupSet, groupSets,
-        aggregateCalls);
+    return MutableAggregate.of(input, groupSet, groupSets, aggregateCalls);
   }
 
   private static List<AggregateCall> apply(final Mapping mapping,
@@ -1267,7 +1266,7 @@ public class SubstitutionVisitor {
                 ImmutableList.of(target.groupSet.cardinality() + i), -1,
                 aggregateCall.type, aggregateCall.name));
       }
-      result = MutableAggregate.of(target, false, groupSet.build(), null,
+      result = MutableAggregate.of(target, groupSet.build(), null,
           aggregateCalls);
     }
     return MutableRels.createCastRel(result, query.rowType, true);

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -206,6 +206,7 @@ public class RelFactories {
    * that returns a vanilla {@link LogicalAggregate}.
    */
   private static class AggregateFactoryImpl implements AggregateFactory {
+    @SuppressWarnings("deprecation")
     public RelNode createAggregate(RelNode input, boolean indicator,
         ImmutableBitSet groupSet, ImmutableList<ImmutableBitSet> groupSets,
         List<AggregateCall> aggCalls) {

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
@@ -86,6 +86,21 @@ public final class LogicalAggregate extends Aggregate {
 
   /** Creates a LogicalAggregate. */
   public static LogicalAggregate create(final RelNode input,
+      ImmutableBitSet groupSet, List<ImmutableBitSet> groupSets,
+      List<AggregateCall> aggCalls) {
+    return create_(input, false, groupSet, groupSets, aggCalls);
+  }
+
+  @Deprecated // to be removed before 2.0
+  public static LogicalAggregate create(final RelNode input,
+      boolean indicator,
+      ImmutableBitSet groupSet,
+      List<ImmutableBitSet> groupSets,
+      List<AggregateCall> aggCalls) {
+    return create_(input, indicator, groupSet, groupSets, aggCalls);
+  }
+
+  private static LogicalAggregate create_(final RelNode input,
       boolean indicator,
       ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets,

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableAggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableAggregate.java
@@ -28,16 +28,14 @@ import java.util.Objects;
 
 /** Mutable equivalent of {@link org.apache.calcite.rel.core.Aggregate}. */
 public class MutableAggregate extends MutableSingleRel {
-  public final boolean indicator;
   public final ImmutableBitSet groupSet;
   public final ImmutableList<ImmutableBitSet> groupSets;
   public final List<AggregateCall> aggCalls;
 
   private MutableAggregate(MutableRel input, RelDataType rowType,
-      boolean indicator, ImmutableBitSet groupSet,
+      ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
     super(MutableRelType.AGGREGATE, rowType, input);
-    this.indicator = indicator;
     this.groupSet = groupSet;
     this.groupSets = groupSets == null
         ? ImmutableList.of(groupSet)
@@ -49,20 +47,16 @@ public class MutableAggregate extends MutableSingleRel {
    * Creates a MutableAggregate.
    *
    * @param input     Input relational expression
-   * @param indicator Whether row type should include indicator fields to
-   *                  indicate which grouping set is active; must be true if
-   *                  aggregate is not simple
    * @param groupSet  Bit set of grouping fields
    * @param groupSets List of all grouping sets; null for just {@code groupSet}
    * @param aggCalls  Collection of calls to aggregate functions
    */
-  public static MutableAggregate of(MutableRel input, boolean indicator,
-      ImmutableBitSet groupSet, ImmutableList<ImmutableBitSet> groupSets,
-      List<AggregateCall> aggCalls) {
+  public static MutableAggregate of(MutableRel input, ImmutableBitSet groupSet,
+      ImmutableList<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
     RelDataType rowType =
         Aggregate.deriveRowType(input.cluster.getTypeFactory(),
-            input.rowType, indicator, groupSet, groupSets, aggCalls);
-    return new MutableAggregate(input, rowType, indicator, groupSet,
+            input.rowType, false, groupSet, groupSets, aggCalls);
+    return new MutableAggregate(input, rowType, groupSet,
         groupSets, aggCalls);
   }
 
@@ -89,8 +83,7 @@ public class MutableAggregate extends MutableSingleRel {
   }
 
   @Override public MutableRel clone() {
-    return MutableAggregate.of(input.clone(),
-        indicator, groupSet, groupSets, aggCalls);
+    return MutableAggregate.of(input.clone(), groupSet, groupSets, aggCalls);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
@@ -194,7 +194,7 @@ public abstract class MutableRels {
       final MutableAggregate aggregate = (MutableAggregate) node;
       relBuilder.push(fromMutable(aggregate.input, relBuilder));
       relBuilder.aggregate(
-          relBuilder.groupKey(aggregate.groupSet, aggregate.indicator, aggregate.groupSets),
+          relBuilder.groupKey(aggregate.groupSet, aggregate.groupSets),
           aggregate.aggCalls);
       return relBuilder.build();
     case SORT:
@@ -312,9 +312,8 @@ public abstract class MutableRels {
     if (rel instanceof Aggregate) {
       final Aggregate aggregate = (Aggregate) rel;
       final MutableRel input = toMutable(aggregate.getInput());
-      return MutableAggregate.of(input, aggregate.indicator,
-          aggregate.getGroupSet(), aggregate.getGroupSets(),
-          aggregate.getAggCallList());
+      return MutableAggregate.of(input, aggregate.getGroupSet(),
+          aggregate.getGroupSets(), aggregate.getAggCallList());
     }
     if (rel instanceof Sort) {
       final Sort sort = (Sort) rel;

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
@@ -106,7 +106,7 @@ public class AggregateFilterTransposeRule extends RelOptRule {
         RexUtil.apply(mapping, filter.getCondition());
     final Filter newFilter = filter.copy(filter.getTraitSet(),
         newAggregate, newCondition);
-    if (allColumnsInAggregate && !aggregate.indicator) {
+    if (allColumnsInAggregate && aggregate.getGroupSets().size() == 1) {
       // Everything needed by the filter is returned by the aggregate.
       assert newGroupSet.equals(aggregate.getGroupSet());
       call.transformTo(newFilter);
@@ -119,7 +119,7 @@ public class AggregateFilterTransposeRule extends RelOptRule {
         topGroupSet.set(newGroupSet.indexOf(c));
       }
       ImmutableList<ImmutableBitSet> newGroupingSets = null;
-      if (aggregate.indicator) {
+      if (aggregate.groupSets.size() > 1) {
         ImmutableList.Builder<ImmutableBitSet> newGroupingSetsBuilder =
                 ImmutableList.builder();
         for (ImmutableBitSet groupingSet : aggregate.getGroupSets()) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
@@ -88,7 +88,7 @@ public class AggregateProjectMergeRule extends RelOptRule {
 
     final ImmutableBitSet newGroupSet = aggregate.getGroupSet().permute(map);
     ImmutableList<ImmutableBitSet> newGroupingSets = null;
-    if (aggregate.indicator) {
+    if (aggregate.getGroupSets().size() > 1) {
       newGroupingSets =
           ImmutableBitSet.ORDERING.immutableSortedCopy(
               ImmutableBitSet.permute(aggregate.getGroupSets(), map));

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.java
@@ -137,7 +137,7 @@ public class FilterAggregateTransposeRule extends RelOptRule {
       return false;
     }
 
-    if (aggregate.indicator) {
+    if (aggregate.getGroupSets().size() > 1) {
       // If grouping sets are used, the filter can be pushed if
       // the columns referenced in the predicate are present in
       // all the grouping sets.

--- a/core/src/main/java/org/apache/calcite/rel/stream/StreamRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/stream/StreamRules.java
@@ -108,7 +108,7 @@ public class StreamRules {
     private DeltaAggregateTransposeRule() {
       super(
           operand(Delta.class,
-              operand(Aggregate.class, any())));
+              operand(Aggregate.class, null, Aggregate.NO_INDICATOR, any())));
     }
 
     @Override public void onMatch(RelOptRuleCall call) {
@@ -118,9 +118,8 @@ public class StreamRules {
       final LogicalDelta newDelta =
           LogicalDelta.create(aggregate.getInput());
       final LogicalAggregate newAggregate =
-          LogicalAggregate.create(newDelta, aggregate.indicator,
-              aggregate.getGroupSet(), aggregate.groupSets,
-              aggregate.getAggCallList());
+          LogicalAggregate.create(newDelta, aggregate.getGroupSet(),
+              aggregate.groupSets, aggregate.getAggCallList());
       call.transformTo(newAggregate);
     }
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -93,11 +93,14 @@ public class RexCall extends RexNode {
   }
 
   public String toString() {
-    if (digest == null) {
-      digest = computeDigest(
+    // This data race is intentional
+    String localDigest = digest;
+    if (localDigest == null) {
+      localDigest = computeDigest(
           isA(SqlKind.CAST) || isA(SqlKind.NEW_SPECIFICATION));
+      digest = localDigest;
     }
-    return digest;
+    return localDigest;
   }
 
   public <R> R accept(RexVisitor<R> visitor) {

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -320,9 +320,6 @@ public interface CalciteResource {
   @BaseMessage("Windowed aggregate expression is illegal in {0} clause")
   ExInst<SqlValidatorException> windowedAggregateIllegalInClause(String a0);
 
-  @BaseMessage("Aggregate expression is illegal in GROUP BY clause")
-  ExInst<SqlValidatorException> aggregateIllegalInGroupBy();
-
   @BaseMessage("Aggregate expressions cannot be nested")
   ExInst<SqlValidatorException> nestedAggIllegal();
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAggFunction.java
@@ -125,6 +125,12 @@ public abstract class SqlAggFunction extends SqlFunction implements Context {
   public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
     throw new UnsupportedOperationException("remove before calcite-2.0");
   }
+
+  /** Whether this aggregate function allows a {@code FILTER (WHERE ...)}
+   * clause. */
+  public boolean allowsFilter() {
+    return true;
+  }
 }
 
 // End SqlAggFunction.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlAbstractGroupFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlAbstractGroupFunction.java
@@ -16,8 +16,8 @@
  */
 package org.apache.calcite.sql.fun;
 
+import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlCall;
-import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
@@ -37,7 +37,7 @@ import org.apache.calcite.util.Static;
  * Base class for grouping functions {@code GROUP_ID}, {@code GROUPING_ID},
  * {@code GROUPING}.
  */
-public class SqlAbstractGroupFunction extends SqlFunction {
+public class SqlAbstractGroupFunction extends SqlAggFunction {
   /**
    * Creates a SqlAbstractGroupFunction.
    *
@@ -54,8 +54,8 @@ public class SqlAbstractGroupFunction extends SqlFunction {
       SqlOperandTypeInference operandTypeInference,
       SqlOperandTypeChecker operandTypeChecker,
       SqlFunctionCategory category) {
-    super(name, kind, returnTypeInference, operandTypeInference,
-        operandTypeChecker, category);
+    super(name, null, kind, returnTypeInference, operandTypeInference,
+        operandTypeChecker, category, false, false);
   }
 
   @Override public void validateCall(SqlCall call, SqlValidator validator,
@@ -87,6 +87,14 @@ public class SqlAbstractGroupFunction extends SqlFunction {
             Static.RESOURCE.groupingArgument(getName()));
       }
     }
+  }
+
+  @Override public boolean isQuantifierAllowed() {
+    return false;
+  }
+
+  @Override public boolean allowsFilter() {
+    return false;
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupIdFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupIdFunction.java
@@ -22,7 +22,10 @@ import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 
 /**
- * The {@code GROUP_ID} function.
+ * The {@code GROUP_ID()} function.
+ *
+ * <p>Accepts no arguments. If the query has {@code GROUP BY x, y, z} then
+ * {@code GROUP_ID()} is the same as {@code GROUPING(x, y, z)}.
  *
  * <p>This function is not defined in the SQL standard; our implementation is
  * consistent with Oracle.

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupingFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupingFunction.java
@@ -24,6 +24,13 @@ import org.apache.calcite.sql.type.ReturnTypes;
 /**
  * The {@code GROUPING} function.
  *
+ * <p>Accepts 1 or more arguments.
+ * Example: {@code GROUPING(deptno, gender)} returns
+ * 3 if both deptno and gender are being grouped,
+ * 2 if only deptno is being grouped,
+ * 1 if only gender is being groped,
+ * 0 if neither deptno nor gender are being grouped.
+ *
  * <p>This function is defined in the SQL standard.
  * {@code GROUPING_ID} is a non-standard synonym.
  *

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -195,26 +195,28 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlInternalOperator GROUPING_SETS =
       new SqlRollupOperator("GROUPING SETS", SqlKind.GROUPING_SETS);
 
-  /** {@code GROUPING} function. Occurs in similar places to an aggregate
+  /** {@code GROUPING(c1 [, c2, ...])} function.
+   *
+   * <p>Occurs in similar places to an aggregate
    * function ({@code SELECT}, {@code HAVING} clause, etc. of an aggregate
    * query), but not technically an aggregate function. */
   public static final SqlGroupingFunction GROUPING =
       new SqlGroupingFunction("GROUPING");
 
-  /** {@code GROUP_ID} function. */
+  /** {@code GROUP_ID()} function. (Oracle-specific.) */
   public static final SqlGroupIdFunction GROUP_ID =
       new SqlGroupIdFunction();
 
-  /** {@code GROUP_ID} function is a synonym for {@code GROUPING}.
+  /** {@code GROUPING_ID} function is a synonym for {@code GROUPING}.
    *
    * <p>Some history. The {@code GROUPING} function is in the SQL standard,
-   * and originally supported only one argument. The {@code GROUP_ID} is not
-   * standard (though supported in Oracle and SQL Server) and supports zero or
+   * and originally supported only one argument. {@code GROUPING_ID} is not
+   * standard (though supported in Oracle and SQL Server) and supports one or
    * more arguments.
    *
    * <p>The SQL standard has changed to allow {@code GROUPING} to have multiple
-   * arguments. It is now equivalent to {@code GROUP_ID}, so we made
-   * {@code GROUP_ID} a synonym for {@code GROUPING}. */
+   * arguments. It is now equivalent to {@code GROUPING_ID}, so we made
+   * {@code GROUPING_ID} a synonym for {@code GROUPING}. */
   public static final SqlGroupingFunction GROUPING_ID =
       new SqlGroupingFunction("GROUPING_ID");
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggFinder.java
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.fun.SqlAbstractGroupFunction;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.util.Util;
 
@@ -105,7 +106,9 @@ class AggFinder extends SqlBasicVisitor<Void> {
   public Void visit(SqlCall call) {
     final SqlOperator operator = call.getOperator();
     // If nested aggregates disallowed or found an aggregate at invalid level
-    if (operator.isAggregator() && !operator.requiresOver()) {
+    if (operator.isAggregator()
+        && !(operator instanceof SqlAbstractGroupFunction)
+        && !operator.requiresOver()) {
       if (delegate != null) {
         return operator.acceptCall(delegate, call);
       }

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
@@ -248,7 +248,6 @@ public class AggregatingSelectScope
     public final ImmutableList<SqlNode> groupExprList;
     public final ImmutableBitSet groupSet;
     public final ImmutableList<ImmutableBitSet> groupSets;
-    public final boolean indicator;
     public final Map<Integer, Integer> groupExprProjection;
 
     Resolved(List<SqlNode> extraExprList, List<SqlNode> groupExprList,
@@ -258,7 +257,6 @@ public class AggregatingSelectScope
       this.groupExprList = ImmutableList.copyOf(groupExprList);
       this.groupSet = ImmutableBitSet.range(groupExprList.size());
       this.groupSets = ImmutableList.copyOf(groupSets);
-      this.indicator = !this.groupSets.equals(ImmutableList.of(groupSet));
       this.groupExprProjection = ImmutableMap.copyOf(groupExprProjection);
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/DelegatingNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/DelegatingNamespace.java
@@ -101,10 +101,6 @@ public abstract class DelegatingNamespace implements SqlValidatorNamespace {
   public void makeNullable() {
   }
 
-  public String translate(String name) {
-    return namespace.translate(name);
-  }
-
   public <T> T unwrap(Class<T> clazz) {
     if (clazz.isInstance(this)) {
       return clazz.cast(this);

--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -246,10 +246,6 @@ public class IdentifierNamespace extends AbstractNamespace {
     return resolvedNamespace.resolve();
   }
 
-  @Override public String translate(String name) {
-    return resolvedNamespace.translate(name);
-  }
-
   @Override public SqlValidatorTable getTable() {
     return resolvedNamespace == null ? null : resolve().getTable();
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlQualified.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlQualified.java
@@ -19,8 +19,6 @@ package org.apache.calcite.sql.validate;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.ImmutableList;
-
 import java.util.List;
 
 /**
@@ -34,14 +32,13 @@ import java.util.List;
  * <p>It is immutable.
  */
 public class SqlQualified {
-  private final SqlValidatorScope scope;
   public final int prefixLength;
   public final SqlValidatorNamespace namespace;
   public final SqlIdentifier identifier;
 
   private SqlQualified(SqlValidatorScope scope, int prefixLength,
       SqlValidatorNamespace namespace, SqlIdentifier identifier) {
-    this.scope = scope;
+    Util.discard(scope);
     this.prefixLength = prefixLength;
     this.namespace = namespace;
     this.identifier = identifier;
@@ -56,40 +53,12 @@ public class SqlQualified {
     return new SqlQualified(scope, prefixLength, namespace, identifier);
   }
 
-  public List<String> translatedNames() {
-    if (scope == null) {
-      return identifier.names;
-    }
-    final SqlNameMatcher nameMatcher =
-        scope.getValidator().getCatalogReader().nameMatcher();
-    final ImmutableList.Builder<String> builder = ImmutableList.builder();
-    final SqlValidatorScope.ResolvedImpl resolved =
-        new SqlValidatorScope.ResolvedImpl();
-    final List<String> prefix = Util.skipLast(identifier.names);
-    scope.resolve(prefix, nameMatcher, false, resolved);
-    SqlValidatorNamespace namespace =
-        resolved.count() == 1 ? resolved.only().namespace : null;
-    builder.add(identifier.names.get(0));
-    for (String name : Util.skip(identifier.names)) {
-      if (namespace != null) {
-        name = namespace.translate(name);
-        namespace = null;
-      }
-      builder.add(name);
-    }
-    return builder.build();
-  }
-
   public final List<String> prefix() {
     return identifier.names.subList(0, prefixLength);
   }
 
   public final List<String> suffix() {
     return Util.skip(identifier.names, prefixLength);
-  }
-
-  public final List<String> suffixTranslated() {
-    return Util.skip(translatedNames(), prefixLength);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3793,7 +3793,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     if (groupList == null) {
       return;
     }
-    validateNoAggs(aggOrOverFinder, groupList, "GROUP BY");
+    final String clause = "GROUP BY";
+    validateNoAggs(aggOrOverFinder, groupList, clause);
     final SqlValidatorScope groupScope = getGroupScope(select);
     inferUnknownTypes(unknownType, groupScope, groupList);
 
@@ -3842,7 +3843,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
     SqlNode agg = aggFinder.findAgg(groupList);
     if (agg != null) {
-      throw newValidationError(agg, RESOURCE.aggregateIllegalInGroupBy());
+      throw newValidationError(agg, RESOURCE.aggregateIllegalInClause(clause));
     }
   }
 
@@ -3886,8 +3887,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   protected void validateWhereOrOn(
       SqlValidatorScope scope,
       SqlNode condition,
-      String keyword) {
-    validateNoAggs(aggOrOverOrGroupFinder, condition, keyword);
+      String clause) {
+    validateNoAggs(aggOrOverOrGroupFinder, condition, clause);
     inferUnknownTypes(
         booleanType,
         scope,
@@ -3896,7 +3897,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
     final RelDataType type = deriveType(scope, condition);
     if (!SqlTypeUtil.inBooleanFamily(type)) {
-      throw newValidationError(condition, RESOURCE.condMustBeBoolean(keyword));
+      throw newValidationError(condition, RESOURCE.condMustBeBoolean(clause));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorNamespace.java
@@ -162,11 +162,6 @@ public interface SqlValidatorNamespace {
   void makeNullable();
 
   /**
-   * Translates a field name to the name in the underlying namespace.
-   */
-  String translate(String name);
-
-  /**
    * Returns this namespace, or a wrapped namespace, cast to a particular
    * class.
    *

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -578,11 +578,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
     }
 
     relBuilder.push(
-        LogicalAggregate.create(newProject,
-            false,
-            newGroupSet,
-            null,
-            newAggCalls));
+        LogicalAggregate.create(newProject, newGroupSet, null, newAggCalls));
 
     if (!omittedConstants.isEmpty()) {
       final List<RexNode> postProjects = new ArrayList<>(relBuilder.fields());
@@ -2311,12 +2307,8 @@ public class RelDecorrelator implements ReflectiveVisitor {
       ImmutableBitSet groupSet =
           ImmutableBitSet.range(groupCount);
       LogicalAggregate newAggregate =
-          LogicalAggregate.create(joinOutputProject,
-              false,
-              groupSet,
-              null,
+          LogicalAggregate.create(joinOutputProject, groupSet, null,
               newAggCalls);
-
       List<RexNode> newAggOutputProjectList = Lists.newArrayList();
       for (int i : groupSet) {
         newAggOutputProjectList.add(

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -107,7 +107,6 @@ GroupingInWrongClause={0} operator may only occur in SELECT, HAVING or ORDER BY 
 NotSelectDistinctExpr=Expression ''{0}'' is not in the select clause
 AggregateIllegalInClause=Aggregate expression is illegal in {0} clause
 WindowedAggregateIllegalInClause=Windowed aggregate expression is illegal in {0} clause
-AggregateIllegalInGroupBy=Aggregate expression is illegal in GROUP BY clause
 NestedAggIllegal=Aggregate expressions cannot be nested
 AggregateInFilterIllegal=FILTER must not contain aggregate expression
 AggregateIllegalInOrderBy=Aggregate expression is illegal in ORDER BY clause of non-aggregating SELECT

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -138,8 +138,7 @@ public class RelWriterTest {
                 final RelDataType bigIntType =
                     cluster.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
                 LogicalAggregate aggregate =
-                    LogicalAggregate.create(filter, false,
-                        ImmutableBitSet.of(0), null,
+                    LogicalAggregate.create(filter, ImmutableBitSet.of(0), null,
                         ImmutableList.of(
                             AggregateCall.create(SqlStdOperatorTable.COUNT,
                                 true, ImmutableList.of(1), -1, bigIntType,

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -487,6 +487,64 @@ public class RelBuilderTest {
     assertThat(str(root), is(expected));
   }
 
+  @Test public void testRename() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+
+    // No rename necessary (null name is ignored)
+    RelNode root =
+        builder.scan("DEPT")
+            .rename(Arrays.asList("DEPTNO", null))
+            .build();
+    final String expected = "LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(str(root), is(expected));
+
+    // No rename necessary (prefix matches)
+    root =
+        builder.scan("DEPT")
+            .rename(ImmutableList.of("DEPTNO"))
+            .build();
+    assertThat(str(root), is(expected));
+
+    // Add project to rename fields
+    root =
+        builder.scan("DEPT")
+            .rename(Arrays.asList("NAME", null, "DEPTNO"))
+            .build();
+    final String expected2 = ""
+        + "LogicalProject(NAME=[$0], DNAME=[$1], DEPTNO=[$2])\n"
+        + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(str(root), is(expected2));
+
+    // If our requested list has non-unique names, we might get the same field
+    // names we started with. Don't add a useless project.
+    root =
+        builder.scan("DEPT")
+            .rename(Arrays.asList("DEPTNO", null, "DEPTNO"))
+            .build();
+    final String expected3 = ""
+        + "LogicalProject(DEPTNO=[$0], DNAME=[$1], DEPTNO0=[$2])\n"
+        + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(str(root), is(expected3));
+    root =
+        builder.scan("DEPT")
+            .rename(Arrays.asList("DEPTNO", null, "DEPTNO"))
+            .rename(Arrays.asList("DEPTNO", null, "DEPTNO"))
+            .build();
+    // No extra Project
+    assertThat(str(root), is(expected3));
+
+    // Name list too long
+    try {
+      root =
+          builder.scan("DEPT")
+              .rename(ImmutableList.of("NAME", "DEPTNO", "Y", "Z"))
+              .build();
+      fail("expected error, got " + root);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("More names than fields"));
+    }
+  }
+
   @Test public void testPermute() {
     final RelBuilder builder = RelBuilder.create(config().build());
     RelNode root =
@@ -587,7 +645,7 @@ public class RelBuilderTest {
     RelNode root =
         builder.scan("EMP")
             .aggregate(
-                builder.groupKey(ImmutableBitSet.of(7), true,
+                builder.groupKey(ImmutableBitSet.of(7),
                     ImmutableList.of(ImmutableBitSet.of(7),
                         ImmutableBitSet.of())),
                 builder.aggregateCall(SqlStdOperatorTable.COUNT, false,
@@ -595,7 +653,7 @@ public class RelBuilderTest {
                         builder.field("EMPNO"), builder.literal(100)), "C"))
             .build();
     final String expected = ""
-        + "LogicalAggregate(group=[{7}], groups=[[{7}, {}]], indicator=[true], C=[COUNT() FILTER $8])\n"
+        + "LogicalAggregate(group=[{7}], groups=[[{7}, {}]], C=[COUNT() FILTER $8])\n"
         + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[>($0, 100)])\n"
         + "    LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(str(root), is(expected));
@@ -663,7 +721,7 @@ public class RelBuilderTest {
       RelNode root =
           builder.scan("EMP")
               .aggregate(
-                  builder.groupKey(ImmutableBitSet.of(7), true,
+                  builder.groupKey(ImmutableBitSet.of(7),
                       ImmutableList.of(ImmutableBitSet.of(4),
                           ImmutableBitSet.of())))
               .build();
@@ -679,15 +737,59 @@ public class RelBuilderTest {
     RelNode root =
         builder.scan("EMP")
             .aggregate(
-                builder.groupKey(ImmutableBitSet.of(7, 6), true,
+                builder.groupKey(ImmutableBitSet.of(7, 6),
                     ImmutableList.of(ImmutableBitSet.of(7),
                         ImmutableBitSet.of(6),
                         ImmutableBitSet.of(7))))
             .build();
     final String expected = ""
-        + "LogicalAggregate(group=[{6, 7}], groups=[[{6}, {7}]], indicator=[true])\n"
+        + "LogicalAggregate(group=[{6, 7}], groups=[[{6}, {7}]])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(str(root), is(expected));
+  }
+
+  @Test public void testAggregateGrouping() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+            .aggregate(builder.groupKey(6, 7),
+                builder.aggregateCall(SqlStdOperatorTable.GROUPING, false, null,
+                    "g", builder.field("DEPTNO")))
+            .build();
+    final String expected = ""
+        + "LogicalAggregate(group=[{6, 7}], g=[GROUPING($7)])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(str(root), is(expected));
+  }
+
+  @Test public void testAggregateGroupingWithDistinctFails() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    try {
+      RelNode root =
+          builder.scan("EMP")
+              .aggregate(builder.groupKey(6, 7),
+                  builder.aggregateCall(SqlStdOperatorTable.GROUPING, true, null,
+                      "g", builder.field("DEPTNO")))
+              .build();
+      fail("expected error, got " + root);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("DISTINCT not allowed"));
+    }
+  }
+
+  @Test public void testAggregateGroupingWithFilterFails() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    try {
+      RelNode root =
+          builder.scan("EMP")
+              .aggregate(builder.groupKey(6, 7),
+                  builder.aggregateCall(SqlStdOperatorTable.GROUPING, false,
+                      builder.literal(true), "g", builder.field("DEPTNO")))
+              .build();
+      fail("expected error, got " + root);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("FILTER not allowed"));
+    }
   }
 
   @Test public void testDistinct() {

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1280,7 +1280,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
 
     // Aggregate
     final LogicalAggregate aggregate =
-        LogicalAggregate.create(join, false, ImmutableBitSet.of(2, 0),
+        LogicalAggregate.create(join, ImmutableBitSet.of(2, 0),
             ImmutableList.<ImmutableBitSet>of(),
             ImmutableList.of(
                 AggregateCall.create(
@@ -2162,7 +2162,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
         + "group by grouping sets ((deptno), (ename, deptno))";
     final Map<Class<? extends RelNode>, Integer> expected = new HashMap<>();
     expected.put(TableScan.class, 1);
-    expected.put(Project.class, 3);
+    expected.put(Project.class, 2);
     expected.put(Aggregate.class, 1);
     checkNodeTypeCount(sql, expected);
   }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -600,10 +600,12 @@ LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
-  LogicalAggregate(group=[{0}], EXPR$0=[COUNT($0)], EXPR$1=[MIN($1)])
-    LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
-      LogicalProject(DEPTNO=[$7], SAL=[$5])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(DEPTNO=[$0], EXPR$0=[$1], EXPR$1=[CAST($2):INTEGER NOT NULL])
+    LogicalAggregate(group=[{0}], EXPR$0=[COUNT($0) FILTER $2], EXPR$1=[MIN($1) FILTER $2])
+      LogicalProject(DEPTNO=[$0], EXPR$1=[$1], $g_0=[=($2, 0)])
+        LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], $g=[GROUPING($0)])
+          LogicalProject(DEPTNO=[$7], SAL=[$5])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -1089,9 +1091,9 @@ LogicalProject(DNAME=[$0], C=[$1])
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(DDEPTNO=[$0], DNAME=[$1], C=[$2])
-  LogicalProject(DDEPTNO=[CASE($2, null, $0)], DNAME=[CASE($3, null, $1)], C=[$4])
-    LogicalFilter(condition=[=(CASE($3, null, $1), 'Charlie')])
-      LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], C=[COUNT()])
+  LogicalProject(DDEPTNO=[$0], DNAME=[$1], C=[$2])
+    LogicalFilter(condition=[=($1, 'Charlie')])
+      LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], C=[COUNT()])
         LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
@@ -1115,21 +1117,19 @@ LogicalProject(DDEPTNO=[$0], DNAME=[$1], C=[$2])
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(DNAME=[$0], DDEPTNO=[$1], C=[$2])
-  LogicalProject(DNAME=[$0], DDEPTNO=[CASE($3, null, $1)], C=[$4])
-    LogicalFilter(condition=[=($0, 'Charlie')])
-      LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], indicator=[true], C=[COUNT()])
-        LogicalProject(DNAME=[$1], DDEPTNO=[$0])
-          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+  LogicalFilter(condition=[=($0, 'Charlie')])
+    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], C=[COUNT()])
+      LogicalProject(DNAME=[$1], DDEPTNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(DNAME=[$0], DDEPTNO=[$1], C=[$2])
-  LogicalProject(DNAME=[$0], DDEPTNO=[CASE($3, null, $1)], C=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], indicator=[true], C=[COUNT()])
-      LogicalFilter(condition=[=($0, 'Charlie')])
-        LogicalProject(DNAME=[$1], DDEPTNO=[$0])
-          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], C=[COUNT()])
+    LogicalFilter(condition=[=($0, 'Charlie')])
+      LogicalProject(DNAME=[$1], DDEPTNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
     </TestCase>
@@ -3110,28 +3110,25 @@ group by rollup(deptno,job)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], U=[$9])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[2])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[3])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], U=[$9])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[2])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], U=[2])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], U=[3])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], U=[2])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], U=[3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3144,28 +3141,25 @@ group by rollup(deptno,job)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], U=[$9])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[null])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[null])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], U=[$9])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[null])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], U=[null])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], U=[null])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], U=[null])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], U=[null])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], U=[null])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3179,28 +3173,25 @@ group by rollup(deptno, job)
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3213,28 +3204,25 @@ group by rollup(deptno, job)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[COUNT()])
-      LogicalProject(DEPTNO=[$7], JOB=[$2])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[COUNT()])
+  LogicalProject(DEPTNO=[$7], JOB=[$2])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[$SUM0($2)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
-        LogicalProject(DEPTNO=[$7], JOB=[$2])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
-        LogicalProject(DEPTNO=[$7], JOB=[$2])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[$SUM0($2)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+      LogicalProject(DEPTNO=[$7], JOB=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+      LogicalProject(DEPTNO=[$7], JOB=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3247,28 +3235,25 @@ group by rollup(deptno, job)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[COUNT($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[COUNT($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[$SUM0($2)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[$SUM0($2)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3281,28 +3266,25 @@ group by rollup(deptno, job)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[MAX($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[MAX($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[MAX($2)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[MAX($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[MAX($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[MAX($2)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[MAX($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[MAX($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], MGR=[$3])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3315,28 +3297,25 @@ LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[MIN($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[MIN($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[MIN($2)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[MIN($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[MIN($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[MIN($2)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[MIN($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[MIN($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3349,26 +3328,23 @@ group by rollup(deptno, job)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[AVG($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[AVG($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[AVG($2)])
-    LogicalUnion(all=[true])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[AVG($2)])
+  LogicalUnion(all=[true])
+    LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3381,28 +3357,25 @@ group by rollup(deptno,job)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4], EXPR$3=[$5], EXPR$4=[$6], EXPR$5=[$7])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4], EXPR$3=[$5], EXPR$4=[$6], EXPR$5=[$7])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)], EXPR$3=[COUNT()], EXPR$4=[MIN($0)], EXPR$5=[MAX($2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-        LogicalUnion(all=[true])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)], EXPR$3=[COUNT()], EXPR$4=[MIN($0)], EXPR$5=[MAX($2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+    LogicalUnion(all=[true])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4], EXPR$3=[$5], EXPR$4=[$6], EXPR$5=[$7])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[SUM($2)], EXPR$3=[$SUM0($3)], EXPR$4=[MIN($4)], EXPR$5=[MAX($5)])
-    LogicalUnion(all=[true])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()], EXPR$4=[MIN($0)], EXPR$5=[MAX($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()], EXPR$4=[MIN($0)], EXPR$5=[MAX($2)])
-        LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)], EXPR$3=[$SUM0($3)], EXPR$4=[MIN($4)], EXPR$5=[MAX($5)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()], EXPR$4=[MIN($0)], EXPR$5=[MAX($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()], EXPR$4=[MIN($0)], EXPR$5=[MAX($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -3470,21 +3443,19 @@ LogicalFilter(condition=[>($1, 5000)])
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(ENAME=[CASE($3, null, $0)], SAL=[CASE($4, null, $1)], DEPTNO=[CASE($5, null, $2)])
-  LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}, {0}, {}]], indicator=[true])
-    LogicalFilter(condition=[>($1, 5000)])
-      LogicalProject(ENAME=[$1], SAL=[$5], DEPTNO=[$7])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}, {0}, {}]])
+  LogicalFilter(condition=[>($1, 5000)])
+    LogicalProject(ENAME=[$1], SAL=[$5], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(ENAME=[CASE($3, null, $0)], SAL=[CASE($4, null, $1)], DEPTNO=[CASE($5, null, $2)])
-  LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}, {0}, {}]], indicator=[true])
-    LogicalFilter(condition=[>($1, 5000)])
-      LogicalAggregate(group=[{0, 1, 2}])
-        LogicalProject(ENAME=[$1], SAL=[$5], DEPTNO=[$7])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}, {0}, {}]])
+  LogicalFilter(condition=[>($1, 5000)])
+    LogicalAggregate(group=[{0, 1, 2}])
+      LogicalProject(ENAME=[$1], SAL=[$5], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -4911,21 +4882,19 @@ group by rollup(x, y)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(X=[$0], EXPR$1=[$4], Y=[$1])
-  LogicalProject(X=[CASE($2, null, $0)], Y=[CASE($3, null, $1)], i$X=[$2], i$Y=[$3], EXPR$1=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$1=[SUM($2)])
-      LogicalProject(X=[$0], Y=[$1], Z=[$2])
-        LogicalProject(X=[$7], Y=[$0], Z=[$5], ZZ=[*($5, 2)])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalProject(X=[$0], EXPR$1=[$2], Y=[$1])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$1=[SUM($2)])
+    LogicalProject(X=[$0], Y=[$1], Z=[$2])
+      LogicalProject(X=[$7], Y=[$0], Z=[$5], ZZ=[*($5, 2)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(X=[$0], EXPR$1=[$4], Y=[$1])
-  LogicalProject(X=[CASE($2, null, $0)], Y=[CASE($3, null, $1)], i$X=[$2], i$Y=[$3], EXPR$1=[$4])
-    LogicalProject(DEPTNO=[$1], EMPNO=[$0], i$DEPTNO=[$3], i$EMPNO=[$2], EXPR$1=[$4])
-      LogicalAggregate(group=[{0, 7}], groups=[[{0, 7}, {7}, {}]], indicator=[true], EXPR$1=[SUM($5)])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalProject(X=[$0], EXPR$1=[$2], Y=[$1])
+  LogicalProject(DEPTNO=[$1], EMPNO=[$0], EXPR$1=[$2])
+    LogicalAggregate(group=[{0, 7}], groups=[[{0, 7}, {7}, {}]], EXPR$1=[SUM($5)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -5084,10 +5053,10 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT(DISTINCT $1)], EXPR$2=[SUM($2)])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(DEPTNO=[$0], EXPR$1=[$1], EXPR$2=[CAST($2):INTEGER NOT NULL])
-  LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1) FILTER $5], EXPR$2=[MIN($4) FILTER $6])
-    LogicalProject(DEPTNO=[$0], ENAME=[$1], i$DEPTNO=[$2], i$ENAME=[$3], EXPR$2=[$4], $i0_1=[=(+(CASE($2, 0, 1), CASE($3, 0, 2)), 3)], $i0=[=(+(CASE($2, 0, 1), CASE($3, 0, 2)), 1)])
-      LogicalProject(DEPTNO=[$1], ENAME=[$0], i$DEPTNO=[$3], i$ENAME=[$2], EXPR$2=[$4])
-        LogicalAggregate(group=[{1, 7}], groups=[[{1, 7}, {7}]], indicator=[true], EXPR$2=[SUM($5)])
+  LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1) FILTER $3], EXPR$2=[MIN($2) FILTER $4])
+    LogicalProject(DEPTNO=[$0], ENAME=[$1], EXPR$2=[$2], $g_0=[=($3, 0)], $g_1=[=($3, 1)])
+      LogicalProject(DEPTNO=[$1], ENAME=[$0], EXPR$2=[$2], $g=[$3])
+        LogicalAggregate(group=[{1, 7}], groups=[[{1, 7}, {7}]], EXPR$2=[SUM($5)], $g=[GROUPING($7, $1)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -5098,18 +5067,16 @@ LogicalProject(DEPTNO=[$0], EXPR$1=[$1], EXPR$2=[CAST($2):INTEGER NOT NULL])
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[COUNT(DISTINCT $2)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[COUNT(DISTINCT $2)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4])
-  LogicalAggregate(group=[{0, 1}], indicator=[true], EXPR$2=[COUNT($2)])
-    LogicalAggregate(group=[{0, 1, 2}])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[COUNT($2) FILTER $3])
+  LogicalProject(DEPTNO=[$0], JOB=[$1], ENAME=[$2], $g_0=[=($3, 0)])
+    LogicalAggregate(group=[{0, 1, 2}], $g=[GROUPING($0, $1, $2)])
       LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -5121,19 +5088,17 @@ LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$4], EXPR$3=[$5])
-  LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], i$DEPTNO=[$2], i$JOB=[$3], EXPR$2=[$4], EXPR$3=[$5])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[COUNT(DISTINCT $2)], EXPR$3=[SUM($3)])
-      LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1], SAL=[$5])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[COUNT(DISTINCT $2)], EXPR$3=[SUM($3)])
+  LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1], SAL=[$5])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[CASE($2, null, $0)], JOB=[CASE($3, null, $1)], EXPR$2=[$4], EXPR$3=[CAST($5):INTEGER NOT NULL])
-  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[COUNT($2) FILTER $7], EXPR$3=[MIN($6) FILTER $8])
-    LogicalProject(DEPTNO=[$0], JOB=[$1], ENAME=[$2], i$DEPTNO=[$3], i$JOB=[$4], i$ENAME=[$5], EXPR$3=[$6], $i0_1_2=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 7)], $i0_1=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 3)])
-      LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}]], indicator=[true], EXPR$3=[SUM($3)])
+LogicalProject(DEPTNO=[$0], JOB=[$1], EXPR$2=[$2], EXPR$3=[CAST($3):INTEGER NOT NULL])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[COUNT($2) FILTER $4], EXPR$3=[MIN($3) FILTER $5])
+    LogicalProject(DEPTNO=[$0], JOB=[$1], ENAME=[$2], EXPR$3=[$3], $g_0=[=($4, 0)], $g_1=[=($4, 1)])
+      LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}]], EXPR$3=[SUM($3)], $g=[GROUPING($0, $1, $2)])
         LogicalProject(DEPTNO=[$7], JOB=[$2], ENAME=[$1], SAL=[$5])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -5597,19 +5562,21 @@ group by e.deptno, d.deptno]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalAggregate(group=[{7, 9}])
-  LogicalJoin(condition=[=($7, $9)], joinType=[inner])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+LogicalProject(DEPTNO=[$0], DEPTNO0=[$1])
+  LogicalAggregate(group=[{7, 9}])
+    LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(DEPTNO=[$0], DEPTNO0=[$1])
-  LogicalJoin(condition=[=($0, $1)], joinType=[inner])
-    LogicalAggregate(group=[{7}])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+  LogicalProject(DEPTNO=[$0], DEPTNO0=[$1])
+    LogicalJoin(condition=[=($0, $1)], joinType=[inner])
+      LogicalAggregate(group=[{7}])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
     </TestCase>
@@ -5819,10 +5786,10 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT(DISTINCT $1)], EXPR$2=[COUNT(DISTINC
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1) FILTER $6], EXPR$2=[COUNT($2) FILTER $7])
-  LogicalProject(DEPTNO=[$0], ENAME=[$1], JOB=[$2], i$DEPTNO=[$3], i$ENAME=[$4], i$JOB=[$5], $i0_1=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 3)], $i0_2=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 5)], $i0=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 1)])
-    LogicalProject(DEPTNO=[$2], ENAME=[$0], JOB=[$1], i$DEPTNO=[$5], i$ENAME=[$3], i$JOB=[$4])
-      LogicalAggregate(group=[{1, 2, 7}], groups=[[{1, 7}, {2, 7}, {7}]], indicator=[true])
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1) FILTER $3], EXPR$2=[COUNT($2) FILTER $4])
+  LogicalProject(DEPTNO=[$0], ENAME=[$1], JOB=[$2], $g_1=[=($3, 1)], $g_2=[=($3, 2)])
+    LogicalProject(DEPTNO=[$2], ENAME=[$0], JOB=[$1], $g=[$3])
+      LogicalAggregate(group=[{1, 2, 7}], groups=[[{1, 7}, {2, 7}]], $g=[GROUPING($7, $1, $2)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -5841,9 +5808,9 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT(DISTINCT $0)], EXPR$1=[COUNT(DISTINCT
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalAggregate(group=[{}], EXPR$0=[COUNT($0) FILTER $4], EXPR$1=[COUNT($1) FILTER $5])
-  LogicalProject(ENAME=[$0], JOB=[$1], i$ENAME=[$2], i$JOB=[$3], $i0=[=(+(CASE($2, 0, 1), CASE($3, 0, 2)), 1)], $i1=[=(+(CASE($2, 0, 1), CASE($3, 0, 2)), 2)], $=[=(+(CASE($2, 0, 1), CASE($3, 0, 2)), 0)])
-    LogicalAggregate(group=[{1, 2}], groups=[[{1}, {2}, {}]], indicator=[true])
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0) FILTER $2], EXPR$1=[COUNT($1) FILTER $3])
+  LogicalProject(ENAME=[$0], JOB=[$1], $g_1=[=($2, 1)], $g_2=[=($2, 2)])
+    LogicalAggregate(group=[{1, 2}], groups=[[{1}, {2}]], $g=[GROUPING($1, $2)])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -5863,9 +5830,9 @@ LogicalAggregate(group=[{0}], CDDJ=[COUNT(DISTINCT $0, $1)], S=[SUM($2)])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(DEPTNO=[$0], CDDJ=[$1], S=[CAST($2):INTEGER NOT NULL])
-  LogicalAggregate(group=[{0}], CDDJ=[COUNT($0, $1) FILTER $5], S=[MIN($4) FILTER $6])
-    LogicalProject(DEPTNO=[$0], JOB=[$1], i$DEPTNO=[$2], i$JOB=[$3], S=[$4], $i0_1=[=(+(CASE($2, 0, 1), CASE($3, 0, 2)), 3)], $i0=[=(+(CASE($2, 0, 1), CASE($3, 0, 2)), 1)])
-      LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], indicator=[true], S=[SUM($2)])
+  LogicalAggregate(group=[{0}], CDDJ=[COUNT($0, $1) FILTER $3], S=[MIN($2) FILTER $4])
+    LogicalProject(DEPTNO=[$0], JOB=[$1], S=[$2], $g_0=[=($3, 0)], $g_1=[=($3, 1)])
+      LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], S=[SUM($2)], $g=[GROUPING($0, $1)])
         LogicalProject(DEPTNO=[$7], JOB=[$2], SAL=[$5])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -5922,9 +5889,9 @@ LogicalAggregate(group=[{0}], CDE=[COUNT(DISTINCT $1)], CDJE=[COUNT(DISTINCT $2,
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(DEPTNO=[$0], CDE=[$1], CDJE=[$2], CDDJ=[$3], S=[CAST($4):INTEGER NOT NULL])
-  LogicalAggregate(group=[{0}], CDE=[COUNT($1) FILTER $8], CDJE=[COUNT($2, $1) FILTER $7], CDDJ=[COUNT($0, $2) FILTER $9], S=[MIN($6) FILTER $10])
-    LogicalProject(DEPTNO=[$2], ENAME=[$0], JOB=[$1], i$DEPTNO=[$5], i$ENAME=[$3], i$JOB=[$4], S=[$6], $i0_1_2=[=(+(+(CASE($5, 0, 1), CASE($3, 0, 2)), CASE($4, 0, 4)), 7)], $i0_1=[=(+(+(CASE($5, 0, 1), CASE($3, 0, 2)), CASE($4, 0, 4)), 3)], $i0_2=[=(+(+(CASE($5, 0, 1), CASE($3, 0, 2)), CASE($4, 0, 4)), 5)], $i0=[=(+(+(CASE($5, 0, 1), CASE($3, 0, 2)), CASE($4, 0, 4)), 1)])
-      LogicalAggregate(group=[{1, 2, 7}], groups=[[{1, 2, 7}, {1, 7}, {2, 7}, {7}]], indicator=[true], S=[SUM($5)])
+  LogicalAggregate(group=[{0}], CDE=[COUNT($1) FILTER $5], CDJE=[COUNT($2, $1) FILTER $4], CDDJ=[COUNT($0, $2) FILTER $6], S=[MIN($3) FILTER $7])
+    LogicalProject(DEPTNO=[$2], ENAME=[$0], JOB=[$1], S=[$3], $g_0=[=($4, 0)], $g_1=[=($4, 1)], $g_2=[=($4, 2)], $g_3=[=($4, 3)])
+      LogicalAggregate(group=[{1, 2, 7}], groups=[[{1, 2, 7}, {1, 7}, {2, 7}, {7}]], S=[SUM($5)], $g=[GROUPING($7, $1, $2)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -7488,9 +7455,9 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM(DISTINCT $1)], EXPR$2=[SUM(DISTINCT $2
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(NAME=[$0], EXPR$1=[CAST($1):BIGINT NOT NULL], EXPR$2=[CAST($2):INTEGER NOT NULL])
-  LogicalAggregate(group=[{0}], EXPR$1=[SUM($1) FILTER $6], EXPR$2=[SUM($2) FILTER $7])
-    LogicalProject(NAME=[$0], CN=[$1], SM=[$2], i$NAME=[$3], i$CN=[$4], i$SM=[$5], $i0_1=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 3)], $i0_2=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 5)], $i0=[=(+(+(CASE($3, 0, 1), CASE($4, 0, 2)), CASE($5, 0, 4)), 1)])
-      LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1}, {0, 2}, {0}]], indicator=[true])
+  LogicalAggregate(group=[{0}], EXPR$1=[SUM($1) FILTER $3], EXPR$2=[SUM($2) FILTER $4])
+    LogicalProject(NAME=[$0], CN=[$1], SM=[$2], $g_1=[=($3, 1)], $g_2=[=($3, 2)])
+      LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1}, {0, 2}]], $g=[GROUPING($0, $1, $2)])
         LogicalAggregate(group=[{0}], CN=[COUNT()], SM=[SUM($1)])
           LogicalProject(NAME=[$1], DEPTNO=[$0])
             LogicalTableScan(table=[[CATALOG, SALES, DEPT]])

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2174,11 +2174,9 @@ order by 2]]>
         <Resource name="plan">
             <![CDATA[
 LogicalSort(sort0=[$1], dir0=[ASC])
-  LogicalProject(DEPTNO=[$0], ENAME=[$1], EXPR$2=[$4])
-    LogicalProject(DEPTNO=[$0], ENAME=[CASE($3, null, $1)], i$DEPTNO=[$2], i$ENAME=[$3], EXPR$2=[$4])
-      LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], indicator=[true], EXPR$2=[SUM($2)])
-        LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], EXPR$2=[SUM($2)])
+    LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -2193,11 +2191,10 @@ group by sal,
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalProject(EXPR$0=[$6])
-  LogicalProject(SAL=[$0], DEPTNO=[CASE($4, null, $1)], ENAME=[CASE($5, null, $2)], i$SAL=[$3], i$DEPTNO=[$4], i$ENAME=[$5], EXPR$0=[$6])
-    LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}, {0, 2}]], indicator=[true], EXPR$0=[SUM($0)])
-      LogicalProject(SAL=[$5], DEPTNO=[$7], ENAME=[$1])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalProject(EXPR$0=[$3])
+  LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0, 1}, {0, 2}]], EXPR$0=[SUM($0)])
+    LogicalProject(SAL=[$5], DEPTNO=[$7], ENAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -2210,9 +2207,8 @@ group by grouping sets (a, b), grouping sets (c, d)]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalProject(EXPR$0=[CASE($4, null, $0)], EXPR$1=[CASE($5, null, $1)], EXPR$2=[CASE($6, null, $2)], EXPR$3=[CASE($7, null, $3)], i$EXPR$0=[$4], i$EXPR$1=[$5], i$EXPR$2=[$6], i$EXPR$3=[$7])
-    LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 2}, {0, 3}, {1, 2}, {1, 3}]], indicator=[true])
-      LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
+  LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 2}, {0, 3}, {1, 2}, {1, 3}]])
+    LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2225,9 +2221,8 @@ group by grouping sets (a, (a, b)), grouping sets (c), d]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalProject(EXPR$0=[$0], EXPR$1=[CASE($5, null, $1)], EXPR$2=[$2], EXPR$3=[$3], i$EXPR$0=[$4], i$EXPR$1=[$5], i$EXPR$2=[$6], i$EXPR$3=[$7])
-    LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1, 2, 3}, {0, 2, 3}]], indicator=[true])
-      LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
+  LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1, 2, 3}, {0, 2, 3}]])
+    LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2240,9 +2235,8 @@ group by rollup(a, b), rollup(c, d)]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalProject(EXPR$0=[CASE($4, null, $0)], EXPR$1=[CASE($5, null, $1)], EXPR$2=[CASE($6, null, $2)], EXPR$3=[CASE($7, null, $3)], i$EXPR$0=[$4], i$EXPR$1=[$5], i$EXPR$2=[$6], i$EXPR$3=[$7])
-    LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1, 2, 3}, {0, 1, 2}, {0, 1}, {0, 2, 3}, {0, 2}, {0}, {2, 3}, {2}, {}]], indicator=[true])
-      LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
+  LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1, 2, 3}, {0, 1, 2}, {0, 1}, {0, 2, 3}, {0, 2}, {0}, {2, 3}, {2}, {}]])
+    LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2255,10 +2249,9 @@ group by cube(a, b)]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalProject(EXPR$0=[CASE($2, null, $0)], EXPR$1=[CASE($3, null, $1)], i$EXPR$0=[$2], i$EXPR$1=[$3])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], indicator=[true])
-      LogicalProject(EXPR$0=[$0], EXPR$1=[$1])
-        LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]])
+    LogicalProject(EXPR$0=[$0], EXPR$1=[$1])
+      LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2271,10 +2264,9 @@ group by rollup(b, (a, d))]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalProject(EXPR$1=[CASE($3, null, $0)], EXPR$0=[CASE($4, null, $1)], EXPR$3=[CASE($5, null, $2)], i$EXPR$1=[$3], i$EXPR$0=[$4], i$EXPR$3=[$5])
-    LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0}, {}]], indicator=[true])
-      LogicalProject(EXPR$1=[$1], EXPR$0=[$0], EXPR$3=[$3])
-        LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
+  LogicalAggregate(group=[{0, 1, 2}], groups=[[{0, 1, 2}, {0}, {}]])
+    LogicalProject(EXPR$1=[$1], EXPR$0=[$0], EXPR$3=[$3])
+      LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2287,9 +2279,8 @@ group by rollup(a, b), rollup(c, d)]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalProject(EXPR$0=[CASE($4, null, $0)], EXPR$1=[CASE($5, null, $1)], EXPR$2=[CASE($6, null, $2)], EXPR$3=[CASE($7, null, $3)], i$EXPR$0=[$4], i$EXPR$1=[$5], i$EXPR$2=[$6], i$EXPR$3=[$7])
-    LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1, 2, 3}, {0, 1, 2}, {0, 1}, {0, 2, 3}, {0, 2}, {0}, {2, 3}, {2}, {}]], indicator=[true])
-      LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
+  LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1, 2, 3}, {0, 1, 2}, {0, 1}, {0, 2, 3}, {0, 2}, {0}, {2, 3}, {2}, {}]])
+    LogicalValues(tuples=[[{ 1, 2, 3, 4 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2301,11 +2292,9 @@ group by rollup(a, b)]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalProject(A=[$0], B=[$1], C=[$4])
-  LogicalProject(A=[CASE($2, null, $0)], B=[CASE($3, null, $1)], i$A=[$2], i$B=[$3], C=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], C=[COUNT()])
-      LogicalProject(A=[null], B=[2])
-        LogicalValues(tuples=[[{ 0 }]])
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], C=[COUNT()])
+  LogicalProject(A=[null], B=[2])
+    LogicalValues(tuples=[[{ 0 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2333,9 +2322,8 @@ group by grouping sets ((a, b), c), grouping sets ((x, y), ())]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalProject(EXPR$0=[CASE($5, null, $0)], EXPR$1=[CASE($6, null, $1)], EXPR$2=[CASE($7, null, $2)], EXPR$3=[CASE($8, null, $3)], EXPR$4=[CASE($9, null, $4)], i$EXPR$0=[$5], i$EXPR$1=[$6], i$EXPR$2=[$7], i$EXPR$3=[$8], i$EXPR$4=[$9])
-    LogicalAggregate(group=[{0, 1, 2, 3, 4}], groups=[[{0, 1, 3, 4}, {0, 1}, {2, 3, 4}, {2}]], indicator=[true])
-      LogicalValues(tuples=[[{ 0, 1, 2, 3, 4 }]])
+  LogicalAggregate(group=[{0, 1, 2, 3, 4}], groups=[[{0, 1, 3, 4}, {0, 1}, {2, 3, 4}, {2}]])
+    LogicalValues(tuples=[[{ 0, 1, 2, 3, 4 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -2350,8 +2338,8 @@ order by 2]]>
         <Resource name="plan">
             <![CDATA[
 LogicalSort(sort0=[$1], dir0=[ASC])
-  LogicalProject(DEPTNO=[$1], EXPR$1=[1], EXPR$2=[$2], EXPR$3=[1])
-    LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+  LogicalProject(DEPTNO=[$1], EXPR$1=[$2], EXPR$2=[$3], EXPR$3=[$4])
+    LogicalAggregate(group=[{0, 1}], EXPR$1=[GROUPING($1)], EXPR$2=[COUNT()], EXPR$3=[GROUPING($0)])
       LogicalProject(EMPNO=[$0], DEPTNO=[$7])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -2366,11 +2354,10 @@ group by rollup(empno, deptno)]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalProject(DEPTNO=[$1], EXPR$1=[CASE($3, 1, 0)], EXPR$2=[$4], EXPR$3=[CASE($2, 1, 0)])
-  LogicalProject(EMPNO=[CASE($2, null, $0)], DEPTNO=[CASE($3, null, $1)], i$EMPNO=[$2], i$DEPTNO=[$3], EXPR$2=[$4])
-    LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], indicator=[true], EXPR$2=[COUNT()])
-      LogicalProject(EMPNO=[$0], DEPTNO=[$7])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalProject(DEPTNO=[$1], EXPR$1=[$2], EXPR$2=[$3], EXPR$3=[$4])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$1=[GROUPING($1)], EXPR$2=[COUNT()], EXPR$3=[GROUPING($0)])
+    LogicalProject(EMPNO=[$0], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -2726,9 +2713,10 @@ GROUP BY empno, EXPR$2]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
-  LogicalProject(EMPNO=[$0], EXPR$2=[$7])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalProject(EMPNO=[$0], EXPR$2=[$1], EXPR$20=[$2])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(EMPNO=[$0], EXPR$2=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -2848,9 +2836,10 @@ group by hop(rowtime, interval '1' hour, interval '3' hour)]]>
         <Resource name="plan">
             <![CDATA[
 LogicalDelta
-  LogicalAggregate(group=[{0}], C=[COUNT()])
-    LogicalProject($f0=[HOP($0, 3600000, 10800000)])
-      LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+  LogicalProject(ROWTIME=[$0], C=[$1])
+    LogicalAggregate(group=[{0}], C=[COUNT()])
+      LogicalProject($f0=[HOP($0, 3600000, 10800000)])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
 ]]>
         </Resource>
     </TestCase>

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -483,16 +483,51 @@ group by deptno;
 +---+---+
 | C | G |
 +---+---+
-| 1 | 1 |
-| 1 | 1 |
-| 1 | 1 |
-| 2 | 1 |
-| 2 | 1 |
-| 2 | 1 |
+| 1 | 0 |
+| 1 | 0 |
+| 1 | 0 |
+| 2 | 0 |
+| 2 | 0 |
+| 2 | 0 |
 +---+---+
 (6 rows)
 
 !ok
+
+!use scott
+
+# GROUPING in SELECT clause of CUBE query
+select deptno, job, count(*) as c, grouping(deptno) as d,
+  grouping(job) j, grouping(deptno, job) as x
+from "scott".emp
+group by cube(deptno, job);
++--------+-----------+----+---+---+---+
+| DEPTNO | JOB       | C  | D | J | X |
++--------+-----------+----+---+---+---+
+|     10 | CLERK     |  1 | 0 | 0 | 0 |
+|     10 | MANAGER   |  1 | 0 | 0 | 0 |
+|     10 | PRESIDENT |  1 | 0 | 0 | 0 |
+|     10 |           |  3 | 0 | 1 | 1 |
+|     20 | ANALYST   |  2 | 0 | 0 | 0 |
+|     20 | CLERK     |  2 | 0 | 0 | 0 |
+|     20 | MANAGER   |  1 | 0 | 0 | 0 |
+|     20 |           |  5 | 0 | 1 | 1 |
+|     30 | CLERK     |  1 | 0 | 0 | 0 |
+|     30 | MANAGER   |  1 | 0 | 0 | 0 |
+|     30 | SALESMAN  |  4 | 0 | 0 | 0 |
+|     30 |           |  6 | 0 | 1 | 1 |
+|        | ANALYST   |  2 | 1 | 0 | 2 |
+|        | CLERK     |  4 | 1 | 0 | 2 |
+|        | MANAGER   |  3 | 1 | 0 | 2 |
+|        | PRESIDENT |  1 | 1 | 0 | 2 |
+|        | SALESMAN  |  4 | 1 | 0 | 2 |
+|        |           | 14 | 1 | 1 | 3 |
++--------+-----------+----+---+---+---+
+(18 rows)
+
+!ok
+
+!use post
 
 # GROUPING, GROUP_ID, GROUPING_ID in SELECT clause of GROUP BY query
 select count(*) as c,
@@ -501,22 +536,29 @@ select count(*) as c,
   grouping_id(deptno) as gd,
   grouping_id(gender) as gg,
   grouping_id(gender, deptno) as ggd,
-  grouping_id(gender, deptno) as gdg
+  grouping_id(deptno, gender) as gdg
 from emp
-group by deptno, gender;
+group by rollup(deptno, gender);
 +---+---+-----+----+----+-----+-----+
 | C | G | GID | GD | GG | GGD | GDG |
 +---+---+-----+----+----+-----+-----+
-| 1 | 1 |   3 |  1 |  1 |   3 |   3 |
-| 1 | 1 |   3 |  1 |  1 |   3 |   3 |
-| 1 | 1 |   3 |  1 |  1 |   3 |   3 |
-| 1 | 1 |   3 |  1 |  1 |   3 |   3 |
-| 1 | 1 |   3 |  1 |  1 |   3 |   3 |
-| 1 | 1 |   3 |  1 |  1 |   3 |   3 |
-| 1 | 1 |   3 |  1 |  1 |   3 |   3 |
-| 2 | 1 |   3 |  1 |  1 |   3 |   3 |
+| 1 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 1 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 1 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 1 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 1 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 1 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 1 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 2 | 0 |   0 |  0 |  0 |   0 |   0 |
+| 9 | 1 |   0 |  1 |  1 |   3 |   3 |
+| 1 | 0 |   0 |  0 |  1 |   2 |   1 |
+| 1 | 0 |   0 |  0 |  1 |   2 |   1 |
+| 1 | 0 |   0 |  0 |  1 |   2 |   1 |
+| 2 | 0 |   0 |  0 |  1 |   2 |   1 |
+| 2 | 0 |   0 |  0 |  1 |   2 |   1 |
+| 2 | 0 |   0 |  0 |  1 |   2 |   1 |
 +---+---+-----+----+----+-----+-----+
-(8 rows)
+(15 rows)
 
 !ok
 
@@ -527,40 +569,48 @@ select count(*) as c,
   grouping(deptno, gender, deptno) as gdgd,
   grouping_id(deptno, gender, deptno) as gidgd
 from emp
-group by deptno, gender
+group by rollup(deptno, gender)
 having grouping(deptno) <= grouping_id(deptno, gender, deptno);
 +---+----+-----+------+-------+
 | C | GD | GID | GDGD | GIDGD |
 +---+----+-----+------+-------+
-| 1 |  1 |   1 |    7 |     7 |
-| 1 |  1 |   1 |    7 |     7 |
-| 1 |  1 |   1 |    7 |     7 |
-| 1 |  1 |   1 |    7 |     7 |
-| 1 |  1 |   1 |    7 |     7 |
-| 1 |  1 |   1 |    7 |     7 |
-| 1 |  1 |   1 |    7 |     7 |
-| 2 |  1 |   1 |    7 |     7 |
+| 1 |  0 |   0 |    0 |     0 |
+| 1 |  0 |   0 |    0 |     0 |
+| 1 |  0 |   0 |    0 |     0 |
+| 1 |  0 |   0 |    0 |     0 |
+| 1 |  0 |   0 |    0 |     0 |
+| 1 |  0 |   0 |    0 |     0 |
+| 1 |  0 |   0 |    0 |     0 |
+| 2 |  0 |   0 |    0 |     0 |
+| 1 |  0 |   0 |    2 |     2 |
+| 1 |  0 |   0 |    2 |     2 |
+| 1 |  0 |   0 |    2 |     2 |
+| 2 |  0 |   0 |    2 |     2 |
+| 2 |  0 |   0 |    2 |     2 |
+| 2 |  0 |   0 |    2 |     2 |
+| 9 |  1 |   1 |    7 |     7 |
 +---+----+-----+------+-------+
-(8 rows)
+(15 rows)
 
 !ok
 
 # GROUPING in ORDER BY clause
 select count(*) as c
 from emp
-group by deptno
-order by grouping(deptno);
+group by rollup(deptno)
+order by grouping(deptno), c;
 +---+
 | C |
 +---+
 | 1 |
-| 2 |
+| 1 |
 | 1 |
 | 2 |
-| 1 |
 | 2 |
+| 2 |
+| 9 |
 +---+
-(6 rows)
+(7 rows)
 
 !ok
 
@@ -605,27 +655,28 @@ group by rollup(deptno);
 select deptno, gender, grouping(deptno) gd, grouping(gender) gg,
   grouping_id(deptno, gender) dg, grouping_id(gender, deptno) gd,
   group_id() gid, count(*) c
-from emp group by cube(deptno, gender);
+from emp
+group by cube(deptno, gender);
 +--------+--------+----+----+----+----+-----+---+
 | DEPTNO | GENDER | GD | GG | DG | GD | GID | C |
 +--------+--------+----+----+----+----+-----+---+
 |     10 | F      |  0 |  0 |  0 |  0 |   0 | 1 |
 |     10 | M      |  0 |  0 |  0 |  0 |   0 | 1 |
-|     10 |        |  0 |  1 |  1 |  2 |   1 | 2 |
 |     20 | M      |  0 |  0 |  0 |  0 |   0 | 1 |
-|     20 |        |  0 |  1 |  1 |  2 |   1 | 1 |
 |     30 | F      |  0 |  0 |  0 |  0 |   0 | 2 |
-|     30 |        |  0 |  1 |  1 |  2 |   1 | 2 |
 |     50 | F      |  0 |  0 |  0 |  0 |   0 | 1 |
 |     50 | M      |  0 |  0 |  0 |  0 |   0 | 1 |
-|     50 |        |  0 |  1 |  1 |  2 |   1 | 2 |
 |     60 | F      |  0 |  0 |  0 |  0 |   0 | 1 |
-|     60 |        |  0 |  1 |  1 |  2 |   1 | 1 |
 |        | F      |  0 |  0 |  0 |  0 |   0 | 1 |
-|        | F      |  1 |  0 |  2 |  1 |   2 | 6 |
-|        | M      |  1 |  0 |  2 |  1 |   2 | 3 |
-|        |        |  0 |  1 |  1 |  2 |   1 | 1 |
-|        |        |  1 |  1 |  3 |  3 |   3 | 9 |
+|        |        |  1 |  1 |  3 |  3 |   0 | 9 |
+|     10 |        |  0 |  1 |  1 |  2 |   0 | 2 |
+|     20 |        |  0 |  1 |  1 |  2 |   0 | 1 |
+|     30 |        |  0 |  1 |  1 |  2 |   0 | 2 |
+|     50 |        |  0 |  1 |  1 |  2 |   0 | 2 |
+|     60 |        |  0 |  1 |  1 |  2 |   0 | 1 |
+|        | F      |  1 |  0 |  2 |  1 |   0 | 6 |
+|        | M      |  1 |  0 |  2 |  1 |   0 | 3 |
+|        |        |  0 |  1 |  1 |  2 |   0 | 1 |
 +--------+--------+----+----+----+----+-----+---+
 (17 rows)
 
@@ -719,6 +770,142 @@ group by rollup(1);
 !ok
 
 !use scott
+
+# When
+#   [CALCITE-1824] GROUP_ID returns wrong result
+# is fixed, there will be an extra row (null, 1, 14).
+select deptno, group_id() as g, count(*) as c
+from "scott".emp
+group by grouping sets (deptno, (), ());
+
++--------+---+----+
+| DEPTNO | G | C  |
++--------+---+----+
+|     10 | 0 |  3 |
+|     20 | 0 |  5 |
+|     30 | 0 |  6 |
+|        | 0 | 14 |
++--------+---+----+
+(4 rows)
+
+!ok
+
+# From http://rwijk.blogspot.com/2008/12/groupid.html
+select deptno
+       , job
+       , empno
+       , ename
+       , sum(sal) sumsal
+       , case grouping_id(deptno,job,empno)
+           when 0 then 'grouped by deptno,job,empno,ename'
+           when 1 then 'grouped by deptno,job'
+           when 3 then 'grouped by deptno'
+           when 7 then 'grouped by ()'
+         end gr_text
+    from "scott".emp
+   group by rollup(deptno,job,(empno,ename))
+   order by deptno
+       , job
+       , empno;
+
++--------+-----------+-------+--------+----------+-----------------------------------+
+| DEPTNO | JOB       | EMPNO | ENAME  | SUMSAL   | GR_TEXT                           |
++--------+-----------+-------+--------+----------+-----------------------------------+
+|     10 | CLERK     |  7934 | MILLER |  1300.00 | grouped by deptno,job,empno,ename |
+|     10 | CLERK     |       |        |  1300.00 | grouped by deptno,job             |
+|     10 | MANAGER   |  7782 | CLARK  |  2450.00 | grouped by deptno,job,empno,ename |
+|     10 | MANAGER   |       |        |  2450.00 | grouped by deptno,job             |
+|     10 | PRESIDENT |  7839 | KING   |  5000.00 | grouped by deptno,job,empno,ename |
+|     10 | PRESIDENT |       |        |  5000.00 | grouped by deptno,job             |
+|     10 |           |       |        |  8750.00 | grouped by deptno                 |
+|     20 | ANALYST   |  7788 | SCOTT  |  3000.00 | grouped by deptno,job,empno,ename |
+|     20 | ANALYST   |  7902 | FORD   |  3000.00 | grouped by deptno,job,empno,ename |
+|     20 | ANALYST   |       |        |  6000.00 | grouped by deptno,job             |
+|     20 | CLERK     |  7369 | SMITH  |   800.00 | grouped by deptno,job,empno,ename |
+|     20 | CLERK     |  7876 | ADAMS  |  1100.00 | grouped by deptno,job,empno,ename |
+|     20 | CLERK     |       |        |  1900.00 | grouped by deptno,job             |
+|     20 | MANAGER   |  7566 | JONES  |  2975.00 | grouped by deptno,job,empno,ename |
+|     20 | MANAGER   |       |        |  2975.00 | grouped by deptno,job             |
+|     20 |           |       |        | 10875.00 | grouped by deptno                 |
+|     30 | CLERK     |  7900 | JAMES  |   950.00 | grouped by deptno,job,empno,ename |
+|     30 | CLERK     |       |        |   950.00 | grouped by deptno,job             |
+|     30 | MANAGER   |  7698 | BLAKE  |  2850.00 | grouped by deptno,job,empno,ename |
+|     30 | MANAGER   |       |        |  2850.00 | grouped by deptno,job             |
+|     30 | SALESMAN  |  7499 | ALLEN  |  1600.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |  7521 | WARD   |  1250.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |  7654 | MARTIN |  1250.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |  7844 | TURNER |  1500.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |       |        |  5600.00 | grouped by deptno,job             |
+|     30 |           |       |        |  9400.00 | grouped by deptno                 |
+|        |           |       |        | 29025.00 | grouped by ()                     |
++--------+-----------+-------+--------+----------+-----------------------------------+
+(27 rows)
+
+!ok
+
+# From http://rwijk.blogspot.com/2008/12/groupid.html
+# (replacing "to_char(...)" with "cast(... as varchar)")
+# The current results are incorrect. When
+#   [CALCITE-1824] GROUP_ID returns wrong result
+# is fixed, there will be 4 more rows.
+select deptno
+       , job
+       , empno
+       , ename
+       , sum(sal) sumsal
+       , case grouping_id(deptno,job,empno)
+           when 0 then 'grouped by deptno,job,empno,ename'
+           when 1 then 'grouped by deptno,job'
+           when 3 then 'grouped by deptno, grouping set ' || cast(3+group_id() as varchar)
+           when 7 then 'grouped by (), grouping set ' || cast(5+group_id() as varchar)
+         end gr_text
+    from "scott".emp
+   group by grouping sets
+         ( (deptno,job,empno,ename)
+         , (deptno,job)
+         , deptno
+         , deptno
+         , ()
+         , ()
+         )
+   order by deptno
+       , job
+       , empno;
+
++--------+-----------+-------+--------+----------+-----------------------------------+
+| DEPTNO | JOB       | EMPNO | ENAME  | SUMSAL   | GR_TEXT                           |
++--------+-----------+-------+--------+----------+-----------------------------------+
+|     10 | CLERK     |  7934 | MILLER |  1300.00 | grouped by deptno,job,empno,ename |
+|     10 | CLERK     |       |        |  1300.00 | grouped by deptno,job             |
+|     10 | MANAGER   |  7782 | CLARK  |  2450.00 | grouped by deptno,job,empno,ename |
+|     10 | MANAGER   |       |        |  2450.00 | grouped by deptno,job             |
+|     10 | PRESIDENT |  7839 | KING   |  5000.00 | grouped by deptno,job,empno,ename |
+|     10 | PRESIDENT |       |        |  5000.00 | grouped by deptno,job             |
+|     10 |           |       |        |  8750.00 | grouped by deptno, grouping set 3 |
+|     20 | ANALYST   |  7788 | SCOTT  |  3000.00 | grouped by deptno,job,empno,ename |
+|     20 | ANALYST   |  7902 | FORD   |  3000.00 | grouped by deptno,job,empno,ename |
+|     20 | ANALYST   |       |        |  6000.00 | grouped by deptno,job             |
+|     20 | CLERK     |  7369 | SMITH  |   800.00 | grouped by deptno,job,empno,ename |
+|     20 | CLERK     |  7876 | ADAMS  |  1100.00 | grouped by deptno,job,empno,ename |
+|     20 | CLERK     |       |        |  1900.00 | grouped by deptno,job             |
+|     20 | MANAGER   |  7566 | JONES  |  2975.00 | grouped by deptno,job,empno,ename |
+|     20 | MANAGER   |       |        |  2975.00 | grouped by deptno,job             |
+|     20 |           |       |        | 10875.00 | grouped by deptno, grouping set 3 |
+|     30 | CLERK     |  7900 | JAMES  |   950.00 | grouped by deptno,job,empno,ename |
+|     30 | CLERK     |       |        |   950.00 | grouped by deptno,job             |
+|     30 | MANAGER   |  7698 | BLAKE  |  2850.00 | grouped by deptno,job,empno,ename |
+|     30 | MANAGER   |       |        |  2850.00 | grouped by deptno,job             |
+|     30 | SALESMAN  |  7499 | ALLEN  |  1600.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |  7521 | WARD   |  1250.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |  7654 | MARTIN |  1250.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |  7844 | TURNER |  1500.00 | grouped by deptno,job,empno,ename |
+|     30 | SALESMAN  |       |        |  5600.00 | grouped by deptno,job             |
+|     30 |           |       |        |  9400.00 | grouped by deptno, grouping set 3 |
+|        |           |       |        | 29025.00 | grouped by (), grouping set 5     |
++--------+-----------+-------+--------+----------+-----------------------------------+
+(27 rows)
+
+!ok
 
 # [KYLIN-751] Max on negative double values is not working
 # [CALCITE-735] Primitive.DOUBLE.min should be large and negative


### PR DESCRIPTION
… to be used as an aggregate function

Deprecate the Aggregate.indicator field (strongly encouraging people
to set it to false) and to allow GROUPING (and its synonym, GROUP_ID)
to be used as an aggregate function. It will be handled at implement
time.

With indicator = false, even queries with more than one grouping set
will just output the join keys and the aggregate functions. A join key
will be nullable if it doesn't appear in all grouping sets.

The output row type of Aggregate will be more consistent, and this will
have benefits such as fewer bugs in rules.

Add RelBuilder.rename().

Remove SqlValidatorNamespace.translate() and
SqlQualified.suffixTranslated().