### PR TITLE
CALCITE-1889 SqlValidatorUtil#checkIdentifierListForDuplicates should accept compound identifiers as well(Rajeshbabu)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -269,7 +269,7 @@ public class SqlValidatorUtil {
     final List<String> names = Lists.transform(columnList,
         new Function<SqlNode, String>() {
           public String apply(SqlNode o) {
-            return ((SqlIdentifier) o).getSimple();
+            return ((SqlIdentifier) o).toString();
           }
         });
     final int i = Util.firstDuplicate(names);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -266,16 +266,16 @@ public class SqlValidatorUtil {
    */
   static void checkIdentifierListForDuplicates(List<SqlNode> columnList,
       SqlValidatorImpl.ValidationErrorFunction validationErrorFunction) {
-    final List<String> names = Lists.transform(columnList,
-        new Function<SqlNode, String>() {
-          public String apply(SqlNode o) {
-            return ((SqlIdentifier) o).toString();
+    final List<List<String>> names = Lists.transform(columnList,
+        new Function<SqlNode, List<String>>() {
+          public List<String> apply(SqlNode o) {
+            return ((SqlIdentifier) o).names;
           }
         });
     final int i = Util.firstDuplicate(names);
     if (i >= 0) {
       throw validationErrorFunction.apply(columnList.get(i),
-          RESOURCE.duplicateNameInColumnList(names.get(i)));
+          RESOURCE.duplicateNameInColumnList(Util.last(names.get(i))));
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
@@ -16,11 +16,16 @@
  */
 package org.apache.calcite.sql.validate;
 
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
 import com.google.common.collect.Lists;
 
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -29,6 +34,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link SqlValidatorUtil}.
@@ -109,6 +115,16 @@ public class SqlValidatorUtilTest {
     checkChangedFieldList(nameList, resultList, false);
   }
 
+  @Test public void testCheckingDuplicatesWithCompoundIdentifiers() {
+    List<SqlNode> newList = new ArrayList<SqlNode>(2);
+    newList.add(new SqlIdentifier(Arrays.asList("f0", "c0"), SqlParserPos.ZERO));
+    newList.add(new SqlIdentifier(Arrays.asList("f1", "c1"), SqlParserPos.ZERO));
+    try {
+      SqlValidatorUtil.checkIdentifierListForDuplicates(newList, null);
+    } catch (AssertionError e) {
+      fail("Should not fail with AssertionError");
+    }
+  }
 }
 
 // End SqlValidatorUtilTest.java

--- a/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.calcite.sql.validate;
 
+import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.test.DefaultSqlTestFactory;
+import org.apache.calcite.sql.test.SqlTesterImpl;
 
 import com.google.common.collect.Lists;
 
@@ -30,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
@@ -115,14 +119,24 @@ public class SqlValidatorUtilTest {
     checkChangedFieldList(nameList, resultList, false);
   }
 
+  @SuppressWarnings("resource")
   @Test public void testCheckingDuplicatesWithCompoundIdentifiers() {
     List<SqlNode> newList = new ArrayList<SqlNode>(2);
     newList.add(new SqlIdentifier(Arrays.asList("f0", "c0"), SqlParserPos.ZERO));
-    newList.add(new SqlIdentifier(Arrays.asList("f1", "c1"), SqlParserPos.ZERO));
+    newList.add(new SqlIdentifier(Arrays.asList("f0", "c0"), SqlParserPos.ZERO));
+    final SqlTesterImpl sqlTesterImpl = new SqlTesterImpl(DefaultSqlTestFactory.INSTANCE);
+    try {
+      SqlValidatorUtil.checkIdentifierListForDuplicates(newList,
+          ((SqlValidatorImpl) sqlTesterImpl.getValidator()).getValidationErrorFunction());
+      fail("Should fail with CalciteContextException");
+    } catch (Exception e) {
+      assertThat(e, is(instanceOf(CalciteContextException.class)));
+    }
+    newList.set(1, new SqlIdentifier(Arrays.asList("f0", "c1"), SqlParserPos.ZERO));
     try {
       SqlValidatorUtil.checkIdentifierListForDuplicates(newList, null);
-    } catch (AssertionError e) {
-      fail("Should not fail with AssertionError");
+    } catch (Exception e) {
+      fail("should not through any exception");
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
+++ b/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
@@ -488,8 +488,6 @@ public class MockCatalogReader extends CalciteCatalogReader {
     }
     registerTable(structNullableTypeTable);
 
-    registerExtendTable(f, structTypeSchema);
-
     // Register "STRUCT.T_10" view.
     // Same columns as "STRUCT.T",
     // but "F0.C0" is set to 10 by default,
@@ -522,26 +520,6 @@ public class MockCatalogReader extends CalciteCatalogReader {
     registerTable(struct10View);
 
     return this;
-  }
-
-  private void registerExtendTable(final Fixture f, MockSchema structTypeSchema) {
-    final List<CompoundNameColumn> columnsExtended = Arrays.asList(
-        new CompoundNameColumn("", "K0", f.varchar20TypeNull),
-        new CompoundNameColumn("", "C1", f.varchar20TypeNull),
-        new CompoundNameColumn("F0", "C0", f.intType),
-        new CompoundNameColumn("F1", "C1", f.intTypeNull));
-    final List<CompoundNameColumn> extendedColumns =
-        new ArrayList<CompoundNameColumn>(columnsExtended);
-    extendedColumns.add(new CompoundNameColumn("F2", "C2", f.varchar20Type));
-    final CompoundNameColumnResolver structExtendedTableResolver =
-        new CompoundNameColumnResolver(extendedColumns, "F0");
-    final MockTable structExtendedTypeTable =
-        MockTable.create(this, structTypeSchema, "T_EXTEND", false, 100,
-            structExtendedTableResolver);
-    for (CompoundNameColumn column : columnsExtended) {
-      structExtendedTypeTable.addColumn(column.getName(), column.type);
-    }
-    registerTable(structExtendedTypeTable);
   }
 
   /** Adds some extra tables to the mock catalog. These increase the time and
@@ -593,6 +571,27 @@ public class MockCatalogReader extends CalciteCatalogReader {
         empModifiableViewNames3.get(0), empModifiableViewNames3.get(1),
         empModifiableViewNames3.get(2), false, 20, null);
     registerTable(mockEmpViewTable3);
+
+    MockSchema structTypeSchema = new MockSchema("STRUCT");
+    registerSchema(structTypeSchema);
+    final Fixture f = new Fixture();
+    final List<CompoundNameColumn> columnsExtended = Arrays.asList(
+        new CompoundNameColumn("", "K0", f.varchar20TypeNull),
+        new CompoundNameColumn("", "C1", f.varchar20TypeNull),
+        new CompoundNameColumn("F0", "C0", f.intType),
+        new CompoundNameColumn("F1", "C1", f.intTypeNull));
+    final List<CompoundNameColumn> extendedColumns =
+        new ArrayList<CompoundNameColumn>(columnsExtended);
+    extendedColumns.add(new CompoundNameColumn("F2", "C2", f.varchar20Type));
+    final CompoundNameColumnResolver structExtendedTableResolver =
+        new CompoundNameColumnResolver(extendedColumns, "F0");
+    final MockTable structExtendedTypeTable =
+        MockTable.create(this, structTypeSchema, "T_EXTEND", false, 100,
+            structExtendedTableResolver);
+    for (CompoundNameColumn column : columnsExtended) {
+      structExtendedTypeTable.addColumn(column.getName(), column.type);
+    }
+    registerTable(structExtendedTypeTable);
 
     return this;
   }

--- a/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
+++ b/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
@@ -488,6 +488,8 @@ public class MockCatalogReader extends CalciteCatalogReader {
     }
     registerTable(structNullableTypeTable);
 
+    registerExtendTable(f, structTypeSchema);
+
     // Register "STRUCT.T_10" view.
     // Same columns as "STRUCT.T",
     // but "F0.C0" is set to 10 by default,
@@ -522,12 +524,31 @@ public class MockCatalogReader extends CalciteCatalogReader {
     return this;
   }
 
+  private void registerExtendTable(final Fixture f, MockSchema structTypeSchema) {
+    final List<CompoundNameColumn> columnsExtended = Arrays.asList(
+        new CompoundNameColumn("", "K0", f.varchar20TypeNull),
+        new CompoundNameColumn("", "C1", f.varchar20TypeNull),
+        new CompoundNameColumn("F0", "C0", f.intType),
+        new CompoundNameColumn("F1", "C1", f.intTypeNull));
+    final List<CompoundNameColumn> extendedColumns =
+        new ArrayList<CompoundNameColumn>(columnsExtended);
+    extendedColumns.add(new CompoundNameColumn("F2", "C2", f.varchar20Type));
+    final CompoundNameColumnResolver structExtendedTableResolver =
+        new CompoundNameColumnResolver(extendedColumns, "F0");
+    final MockTable structExtendedTypeTable =
+        MockTable.create(this, structTypeSchema, "T_EXTEND", false, 100,
+            structExtendedTableResolver);
+    for (CompoundNameColumn column : columnsExtended) {
+      structExtendedTypeTable.addColumn(column.getName(), column.type);
+    }
+    registerTable(structExtendedTypeTable);
+  }
+
   /** Adds some extra tables to the mock catalog. These increase the time and
    * complexity of initializing the catalog (because they contain views whose
    * SQL needs to be parsed) and so are not used for all tests. */
   public MockCatalogReader init2() {
     MockSchema salesSchema = new MockSchema("SALES");
-
     // Same as "EMP_20" except it uses ModifiableViewTable which populates
     // constrained columns with default values on INSERT and has a single constraint on DEPTNO.
     List<String> empModifiableViewNames = ImmutableList.of(

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8707,28 +8707,24 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
 
   @Test public void testInsertWithExtendedColumns() {
-    final SqlTester lenient =
-        tester.withConformance(SqlConformanceEnum.LENIENT);
-    final SqlTester strict =
-        tester.withConformance(SqlConformanceEnum.STRICT_2003);
-
-    String sql0 = "insert into empnullables (empno, ename, \"f.dc\" varchar(10))\n"
+    final Sql s = sql("?").withExtendedCatalogLenient();
+    final String sql0 = "insert into empnullables (empno, ename, \"f.dc\" varchar(10))\n"
             + "values (?, ?, ?)";
-    sql(sql0).tester(lenient).ok()
+    s.sql(sql0).ok()
             .bindType("RecordType(INTEGER ?0, VARCHAR(20) ?1, VARCHAR(10) ?2)")
-            .tester(strict).fails("Extended columns not allowed under "
+            .tester(EXTENDED_CATALOG_TESTER_2003).fails("Extended columns not allowed under "
                 + "the current SQL conformance level");
-    sql0 = "insert into empnullables (empno, ename, dynamic_column double not null)\n"
-        + "values (?, ?, ?)";
-    sql(sql0).tester(lenient).ok()
+    final String sql1 = "insert into empnullables (empno, ename, "
+        + "dynamic_column double not null) values (?, ?, ?)";
+    s.sql(sql1).ok()
         .bindType("RecordType(INTEGER ?0, VARCHAR(20) ?1, DOUBLE ?2)")
-        .tester(strict).fails("Extended columns not allowed under "
+        .tester(EXTENDED_CATALOG_TESTER_2003).fails("Extended columns not allowed under "
             + "the current SQL conformance level");
-    sql0 = "insert into struct.t_extend (f0.c0, f1.c1, "
+    final String sql2 = "insert into struct.t_extend (f0.c0, f1.c1, "
             + "\"F2\".\"C2\" varchar(20) not null) values (?, ?, ?)";
-    sql(sql0).tester(lenient).ok()
+    s.sql(sql2).ok()
             .bindType("RecordType(INTEGER ?0, INTEGER ?1, VARCHAR(20) ?2)")
-            .tester(strict).fails("Extended columns not allowed under "
+            .tester(EXTENDED_CATALOG_TESTER_2003).fails("Extended columns not allowed under "
                  + "the current SQL conformance level");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8724,6 +8724,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .bindType("RecordType(INTEGER ?0, VARCHAR(20) ?1, DOUBLE ?2)")
         .tester(strict).fails("Extended columns not allowed under "
             + "the current SQL conformance level");
+    sql0 = "insert into struct.t_extend (f0.c0, f1.c1, "
+            + "\"F2\".\"C2\" varchar(20) not null) values (?, ?, ?)";
+    sql(sql0).tester(lenient).ok()
+            .bindType("RecordType(INTEGER ?0, INTEGER ?1, VARCHAR(20) ?2)")
+            .tester(strict).fails("Extended columns not allowed under "
+                 + "the current SQL conformance level");
   }
 
   @Test public void testInsertBindSubset() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
@@ -65,23 +65,22 @@ public class SqlValidatorTestCase {
       Pattern.compile(
           "(?s)From line ([0-9]+), column ([0-9]+) to line ([0-9]+), column ([0-9]+): (.*)");
 
+  static final SqlTestFactory SQL_TEST_FACTORY =
+      new DelegatingSqlTestFactory(DefaultSqlTestFactory.INSTANCE) {
+        @Override public MockCatalogReader createCatalogReader(
+            SqlTestFactory factory, JavaTypeFactory typeFactory) {
+          return super.createCatalogReader(this, typeFactory).init2();
+        }
+      };
+
   static final SqlTesterImpl EXTENDED_CATALOG_TESTER =
-      new SqlTesterImpl(
-        new DelegatingSqlTestFactory(DefaultSqlTestFactory.INSTANCE) {
-          @Override public MockCatalogReader createCatalogReader(
-              SqlTestFactory factory, JavaTypeFactory typeFactory) {
-            return super.createCatalogReader(this, typeFactory).init2();
-          }
-        });
+      new SqlTesterImpl(SQL_TEST_FACTORY);
 
   static final SqlTesterImpl EXTENDED_CATALOG_TESTER_2003 =
-      new SqlTesterImpl(
-        new DelegatingSqlTestFactory(DefaultSqlTestFactory.INSTANCE) {
-          @Override public MockCatalogReader createCatalogReader(
-              SqlTestFactory factory, JavaTypeFactory typeFactory) {
-            return super.createCatalogReader(this, typeFactory).init2();
-          }
-        }).withConformance(SqlConformanceEnum.PRAGMATIC_2003);
+      new SqlTesterImpl(SQL_TEST_FACTORY).withConformance(SqlConformanceEnum.PRAGMATIC_2003);
+
+  static final SqlTesterImpl EXTENDED_CATALOG_TESTER_LENIANT =
+      new SqlTesterImpl(SQL_TEST_FACTORY).withConformance(SqlConformanceEnum.LENIENT);
 
   //~ Instance fields --------------------------------------------------------
 
@@ -573,6 +572,10 @@ public class SqlValidatorTestCase {
 
     Sql withExtendedCatalog2003() {
       return tester(EXTENDED_CATALOG_TESTER_2003);
+    }
+
+    Sql withExtendedCatalogLenient() {
+      return tester(EXTENDED_CATALOG_TESTER_LENIANT);
     }
 
     Sql ok() {


### PR DESCRIPTION
SqlValidatorUtil#checkIdentifierListForDuplicates always matching only simple identifiers so passing compound identifiers fails with assertion error. This pr fixes it and added added a test case with proper compound identifiers in extended columns.