### PR TITLE
[CALCITE-1873] SqlValidatorImpl: Strip AS when visiting group-by-ordinal.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5415,7 +5415,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
             // SQL ordinals are 1-based, but Sort's are 0-based
             int ordinal = intValue - 1;
-            return select.getSelectList().get(ordinal);
+            return SqlUtil.stripAs(select.getSelectList().get(ordinal));
           }
           break;
         }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -6304,6 +6304,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + " group by 1,2")
         .tester(strict).fails("Expression 'DEPTNO' is not being grouped")
         .tester(lenient).sansCarets().ok();
+    sql("select ^empno^, count(*) from emp group by 1 order by 1")
+        .tester(strict).fails("Expression 'EMPNO' is not being grouped")
+        .tester(lenient).sansCarets().ok();
+    sql("select ^empno^ eno, count(*) from emp group by 1 order by 1")
+        .tester(strict).fails("Expression 'EMPNO' is not being grouped")
+        .tester(lenient).sansCarets().ok();
     sql("select count(*) from (select 1 from emp"
         + " group by substring(ename from 2 for 3))")
         .tester(strict).ok()


### PR DESCRIPTION
Otherwise, you could get an error like "Expression 'EMP.EMPNO' is not being grouped"
in the attached test cases.