### PR TITLE
[CALCITE-1842] Wrong order of inputs for makeCost() call in Sort.computeSelfCost()

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Sort.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Sort.java
@@ -136,7 +136,7 @@ public abstract class Sort extends SingleRel {
     double rowCount = mq.getRowCount(this);
     double bytesPerRow = getRowType().getFieldCount() * 4;
     return planner.getCostFactory().makeCost(
-        Util.nLogN(rowCount) * bytesPerRow, rowCount, 0);
+            rowCount, Util.nLogN(rowCount) * bytesPerRow, 0);
   }
 
   @Override public List<RexNode> getChildExps() {


### PR DESCRIPTION
[Jira ticket 1842](https://issues.apache.org/jira/browse/CALCITE-1842) addressed the problem already:

The mistake in the input computation of `Sort` will make the LIMIT does not get pushed into the Druid Query. The difference in performance can be huge.
Right now this problem was reported only in Druid Adapter but this change is generic for all adapters, so specific Druid test cases were not created.

I did not find any test cases to check the cost of `RelNode` and do not know where to put the test cases if we want to test it out. If test cases are still necessary please let me know where to add.