### PR TITLE
[CALCITE-1874] Frameworks: Configurable SqlToRelConverterConfig.

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -68,6 +68,7 @@ public class PlannerImpl implements Planner {
   private final ImmutableList<RelTraitDef> traitDefs;
 
   private final SqlParser.Config parserConfig;
+  private final SqlToRelConverter.Config sqlToRelConverterConfig;
   private final SqlRexConvertletTable convertletTable;
 
   private State state;
@@ -96,6 +97,7 @@ public class PlannerImpl implements Planner {
     this.operatorTable = config.getOperatorTable();
     this.programs = config.getPrograms();
     this.parserConfig = config.getParserConfig();
+    this.sqlToRelConverterConfig = config.getSqlToRelConverterConfig();
     this.state = State.STATE_0_CLOSED;
     this.traitDefs = config.getTraitDefs();
     this.convertletTable = config.getConvertletTable();
@@ -224,7 +226,10 @@ public class PlannerImpl implements Planner {
     final RexBuilder rexBuilder = createRexBuilder();
     final RelOptCluster cluster = RelOptCluster.create(planner, rexBuilder);
     final SqlToRelConverter.Config config = SqlToRelConverter.configBuilder()
-        .withTrimUnusedFields(false).withConvertTableAccess(false).build();
+        .withConfig(sqlToRelConverterConfig)
+        .withTrimUnusedFields(false)
+        .withConvertTableAccess(false)
+        .build();
     final SqlToRelConverter sqlToRelConverter =
         new SqlToRelConverter(new ViewExpanderImpl(), validator,
             createCatalogReader(), cluster, convertletTable, config);
@@ -260,8 +265,12 @@ public class PlannerImpl implements Planner {
 
       final RexBuilder rexBuilder = createRexBuilder();
       final RelOptCluster cluster = RelOptCluster.create(planner, rexBuilder);
-      final SqlToRelConverter.Config config = SqlToRelConverter.configBuilder()
-          .withTrimUnusedFields(false).withConvertTableAccess(false).build();
+      final SqlToRelConverter.Config config = SqlToRelConverter
+          .configBuilder()
+          .withConfig(sqlToRelConverterConfig)
+          .withTrimUnusedFields(false)
+          .withConvertTableAccess(false)
+          .build();
       final SqlToRelConverter sqlToRelConverter =
           new SqlToRelConverter(new ViewExpanderImpl(), validator,
               catalogReader, cluster, convertletTable, config);

--- a/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
+++ b/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
@@ -25,6 +25,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
 
 import com.google.common.collect.ImmutableList;
 
@@ -39,6 +40,11 @@ public interface FrameworkConfig {
    * The configuration of SQL parser.
    */
   SqlParser.Config getParserConfig();
+
+  /**
+   * The configuration of SqlToRelConverter.
+   */
+  SqlToRelConverter.Config getSqlToRelConverterConfig();
 
   /**
    * Returns the default schema that should be checked before looking at the

--- a/core/src/main/java/org/apache/calcite/tools/Frameworks.java
+++ b/core/src/main/java/org/apache/calcite/tools/Frameworks.java
@@ -33,6 +33,7 @@ import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.util.Util;
 
@@ -179,6 +180,8 @@ public class Frameworks {
     private ImmutableList<RelTraitDef> traitDefs;
     private SqlParser.Config parserConfig =
         SqlParser.Config.DEFAULT;
+    private SqlToRelConverter.Config sqlToRelConverterConfig =
+        SqlToRelConverter.Config.DEFAULT;
     private SchemaPlus defaultSchema;
     private RexExecutor executor;
     private RelOptCostFactory costFactory;
@@ -188,8 +191,8 @@ public class Frameworks {
 
     public FrameworkConfig build() {
       return new StdFrameworkConfig(context, convertletTable, operatorTable,
-          programs, traitDefs, parserConfig, defaultSchema, costFactory,
-          typeSystem, executor);
+          programs, traitDefs, parserConfig, sqlToRelConverterConfig,
+          defaultSchema, costFactory, typeSystem, executor);
     }
 
     public ConfigBuilder context(Context c) {
@@ -230,6 +233,11 @@ public class Frameworks {
 
     public ConfigBuilder parserConfig(SqlParser.Config parserConfig) {
       this.parserConfig = Preconditions.checkNotNull(parserConfig);
+      return this;
+    }
+
+    public ConfigBuilder sqlToRelConverterConfig(SqlToRelConverter.Config sqlToRelConverterConfig) {
+      this.sqlToRelConverterConfig = Preconditions.checkNotNull(sqlToRelConverterConfig);
       return this;
     }
 
@@ -278,6 +286,7 @@ public class Frameworks {
     private final ImmutableList<Program> programs;
     private final ImmutableList<RelTraitDef> traitDefs;
     private final SqlParser.Config parserConfig;
+    private final SqlToRelConverter.Config sqlToRelConverterConfig;
     private final SchemaPlus defaultSchema;
     private final RelOptCostFactory costFactory;
     private final RelDataTypeSystem typeSystem;
@@ -289,6 +298,7 @@ public class Frameworks {
         ImmutableList<Program> programs,
         ImmutableList<RelTraitDef> traitDefs,
         SqlParser.Config parserConfig,
+        SqlToRelConverter.Config sqlToRelConverterConfig,
         SchemaPlus defaultSchema,
         RelOptCostFactory costFactory,
         RelDataTypeSystem typeSystem,
@@ -299,49 +309,54 @@ public class Frameworks {
       this.programs = programs;
       this.traitDefs = traitDefs;
       this.parserConfig = parserConfig;
+      this.sqlToRelConverterConfig = sqlToRelConverterConfig;
       this.defaultSchema = defaultSchema;
       this.costFactory = costFactory;
       this.typeSystem = typeSystem;
       this.executor = executor;
     }
 
-    public SqlParser.Config getParserConfig() {
+    @Override public SqlParser.Config getParserConfig() {
       return parserConfig;
     }
 
-    public SchemaPlus getDefaultSchema() {
+    @Override public SqlToRelConverter.Config getSqlToRelConverterConfig() {
+      return sqlToRelConverterConfig;
+    }
+
+    @Override public SchemaPlus getDefaultSchema() {
       return defaultSchema;
     }
 
-    public RexExecutor getExecutor() {
+    @Override public RexExecutor getExecutor() {
       return executor;
     }
 
-    public ImmutableList<Program> getPrograms() {
+    @Override public ImmutableList<Program> getPrograms() {
       return programs;
     }
 
-    public RelOptCostFactory getCostFactory() {
+    @Override public RelOptCostFactory getCostFactory() {
       return costFactory;
     }
 
-    public ImmutableList<RelTraitDef> getTraitDefs() {
+    @Override public ImmutableList<RelTraitDef> getTraitDefs() {
       return traitDefs;
     }
 
-    public SqlRexConvertletTable getConvertletTable() {
+    @Override public SqlRexConvertletTable getConvertletTable() {
       return convertletTable;
     }
 
-    public Context getContext() {
+    @Override public Context getContext() {
       return context;
     }
 
-    public SqlOperatorTable getOperatorTable() {
+    @Override public SqlOperatorTable getOperatorTable() {
       return operatorTable;
     }
 
-    public RelDataTypeSystem getTypeSystem() {
+    @Override public RelDataTypeSystem getTypeSystem() {
       return typeSystem;
     }
   }


### PR DESCRIPTION
Allows SqlToRelConverter to be configured for a Planner. This patch is for https://issues.apache.org/jira/browse/CALCITE-1874.