### PR TITLE
[CALCITE-1581] UDTF like in hive

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -938,6 +938,8 @@ SqlSelect SqlSelect() :
     final SqlNode having;
     final SqlNodeList windowDecls;
     final Span s;
+    Pair<List<SqlNode>, SqlNode> selectListResult;
+    SqlNode udtfCall = null;
 }
 {
     <SELECT>
@@ -961,9 +963,12 @@ SqlSelect SqlSelect() :
     {
         keywordList = new SqlNodeList(keywords, s.addAll(keywords).pos());
     }
-    selectList = SelectList()
+    selectListResult = SelectList() {
+        selectList = selectListResult.left;
+        udtfCall = selectListResult.right;
+    }
     (
-        <FROM> fromClause = FromClause()
+        <FROM> fromClause = FromClause(udtfCall)
         where = WhereOpt()
         groupBy = GroupByOpt()
         having = HavingOpt()
@@ -1450,9 +1455,63 @@ SqlInsert WhenNotMatchedClause(SqlNode table) :
 }
 
 /**
- * Parses the select list of a SELECT statement.
+ * parser the hive like UDTF function call
  */
-List<SqlNode> SelectList() :
+Pair<List<SqlNode>, SqlNode> SelectHiveUDTF() :
+{
+    final Span s;
+    List<SqlNode> list = new ArrayList<SqlNode>();
+    SqlIdentifier id, id2;
+    SqlNode call;
+    final SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION;
+    SqlNode tableRef;
+    final String udtfPrefix = "UDTF$";
+    final String aliasPrefix = "s$";
+    String aliasName;
+    List<SqlNode> aliasList = new ArrayList<SqlNode>();
+    int aliasIndex = 0;
+}
+{
+    call = NamedRoutineCall(funcType, ExprContext.ACCEPT_CURSOR)
+    {
+        s = span();
+        SqlNode function = SqlStdOperatorTable.COLLECTION_TABLE.createCall(s.pos(), call);
+        tableRef = SqlStdOperatorTable.LATERAL.createCall(s.end(this), function);
+    }
+    <AS>
+    <LPAREN>
+    id = SimpleIdentifier()
+    {
+        aliasName = aliasPrefix + (aliasIndex++);
+        id2 = id.setName(0, aliasName);
+        list.add(SqlStdOperatorTable.AS.createCall(getPos(), id2, id));
+
+        aliasList.add(new SqlIdentifier(aliasName, getPos()));
+    }
+    ( <COMMA> id = SimpleIdentifier()
+        {
+            aliasName = aliasPrefix + (aliasIndex++);
+            id2 = id.setName(0, aliasName);
+            list.add(SqlStdOperatorTable.AS.createCall(getPos(), id2, id));
+            aliasList.add(new SqlIdentifier(aliasName, getPos()));
+        }
+    ) *
+    <RPAREN>
+    {
+        //create UDTF call (table function call)
+        id = new SqlIdentifier(udtfPrefix + Util.getNewUDTFAliasIndex(), getPos());
+        List<SqlNode> idList = new ArrayList<SqlNode>();
+        idList.add(tableRef);
+        idList.add(id);
+        idList.addAll(aliasList);
+        tableRef = SqlStdOperatorTable.AS.createCall(
+            Span.of(tableRef).end(this), idList);
+
+        return Pair.of(list, tableRef);
+    }
+}
+
+Pair<List<SqlNode>, SqlNode> SelectListNormal() :
 {
     final List<SqlNode> list = new ArrayList<SqlNode>();
     SqlNode item;
@@ -1467,7 +1526,30 @@ List<SqlNode> SelectList() :
         }
     )*
     {
-        return list;
+        return Pair.of(list, null);
+    }
+}
+
+/**
+ * Parses the select list of a SELECT statement.
+ */
+Pair<List<SqlNode>, SqlNode> SelectList() :
+{
+    Pair<List<SqlNode>, SqlNode> result;
+}
+{
+    (
+        LOOKAHEAD( NamedFunctionCall() <AS> <LPAREN> )
+        result = SelectHiveUDTF() {
+            if (!this.conformance.isHiveCompatible()) {
+                throw new ParseException(RESOURCE.hiveUDTFNotAllowed().str());
+            }
+        }
+        |
+        result = SelectListNormal()
+    )
+    {
+        return result;
     }
 }
 
@@ -1602,7 +1684,7 @@ SqlNode JoinTable(SqlNode e) :
  * PostgreSQL. The parser allows SELECT without FROM, but the validator fails
  * if conformance is, say, STRICT_2003.
  */
-SqlNode FromClause() :
+SqlNode FromClause(SqlNode udtfCall) :
 {
     SqlNode e, e2, condition;
     SqlLiteral natural, joinType, joinConditionType;
@@ -1702,6 +1784,16 @@ SqlNode FromClause() :
         }
     )*
     {
+        if (udtfCall != null) {
+            joinType = JoinType.CROSS.symbol(getPos());
+            e = new SqlJoin(joinType.getParserPosition(),
+                e,
+                SqlLiteral.createBoolean(false, joinType.getParserPosition()),
+                joinType,
+                udtfCall,
+                JoinConditionType.NONE.symbol(SqlParserPos.ZERO),
+                null);
+        }
         return e;
     }
 }

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -37,6 +37,9 @@ public interface CalciteResource {
   @BaseMessage("APPLY operator is not allowed under the current SQL conformance level")
   ExInst<CalciteException> applyNotAllowed();
 
+  @BaseMessage("Hive compatible is not enable yet")
+  ExInst<CalciteException> hiveUDTFNotAllowed();
+
   @BaseMessage("Illegal {0} literal {1}: {2}")
   ExInst<CalciteException> illegalLiteral(String a0, String a1, String a2);
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -74,6 +74,14 @@ public abstract class SqlAbstractConformance implements SqlConformance {
   public boolean allowExtend() {
     return SqlConformanceEnum.DEFAULT.allowExtend();
   }
+
+  public void setHiveCompatible(boolean flag) {
+    SqlConformanceEnum.DEFAULT.setHiveCompatible(flag);
+  }
+
+  public boolean isHiveCompatible() {
+    return SqlConformanceEnum.DEFAULT.isHiveCompatible();
+  }
 }
 
 // End SqlAbstractConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -259,6 +259,17 @@ public interface SqlConformance {
    */
   boolean allowExtend();
 
+  /**
+   * Check whether the parser is hive compatible
+   * true supported, false otherwise.
+   */
+  boolean isHiveCompatible();
+
+  /**
+   * Config whether the parser should be hive compatible
+   * @param flag true means supported, false  otherwise
+   */
+  void setHiveCompatible(boolean flag);
 }
 
 // End SqlConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -197,6 +197,17 @@ public enum SqlConformanceEnum implements SqlConformance {
       return false;
     }
   }
+
+  /** Field to indicate whether the parser should be hive compatible. */
+  private static boolean isHiveCompatible = false;
+
+  public boolean isHiveCompatible() {
+    return isHiveCompatible;
+  }
+
+  public void setHiveCompatible(boolean flag) {
+    isHiveCompatible = flag;
+  }
 }
 
 // End SqlConformanceEnum.java

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -141,6 +141,11 @@ public class Util {
       Charset.forName(SaffronProperties.INSTANCE.defaultCharset().get());
 
   /**
+   * Field to record the udtf's alias index
+   */
+  private static long udtfAliasIndex = 0;
+
+  /**
    * Maps classes to the map of their enum values. Uses a weak map so that
    * classes are not prevented from being unloaded.
    */
@@ -2310,6 +2315,12 @@ public class Util {
     calendar.setTimeInMillis(millis);
     return calendar;
   }
+
+  /**
+   * return a new udtf alias index for udtf call
+   * @return
+   */
+  public static long getNewUDTFAliasIndex() { return udtfAliasIndex++; }
 
   //~ Inner Classes ----------------------------------------------------------
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -7964,6 +7964,26 @@ public class SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testHiveLikeUDTF() {
+    String sql = "select UDTF(empid) as (a1, a2) from emps";
+    final String failedMsg = "Hive compatible is not enable yet";
+    checkFails(sql, failedMsg);
+
+    conformance.setHiveCompatible(true);
+    sql = "select UDTF(empid) as (a1, a2) from emps";
+    String expected = "SELECT `s$0` AS `A1`, `s$1` AS `A2`\n"
+            + "FROM `EMPS`\n"
+            + "CROSS JOIN LATERAL TABLE(`UDTF`(`EMPID`)) AS `UDTF$1` (`s$0`, `s$1`)";
+    sql(sql).ok(expected);
+
+    sql = "select t.a1 from (select UDTF(empid) as (a1, a2) from emps) t";
+    expected = "SELECT `T`.`A1`\n"
+            + "FROM (SELECT `s$0` AS `A1`, `s$1` AS `A2`\n"
+            + "FROM `EMPS`\n"
+            + "CROSS JOIN LATERAL TABLE(`UDTF`(`EMPID`)) AS `UDTF$2` (`s$0`, `s$1`)) AS `T`";
+    sql(sql).ok(expected);
+  }
+
   //~ Inner Interfaces -------------------------------------------------------
 
   /**


### PR DESCRIPTION
Hi, @julianhyde i have solved the issue [UDTF like in hive CALCITE-1581](https://issues.apache.org/jira/browse/CALCITE-1581) with some tests.
 My solution is fairly straightforward, just translate the Hive `UDTF` grammar to the `CROSS JOIN LATERAL TABLE`, eg:
`
select udtf(empid) as (a1, a2) from emp;
equal to
SELECT t.a1, t.a2 from emps CROSS JOIN LATERAL TABLE(udf(empid)) as  t(s0, s1)
`

So, i modify the Parser.jj to implement above translation. And add `setHiveCompatible` to enable or  disable this feature. Tests case is under `SqlParserTest.java`, test function is `testHiveLikeUDTF`.
If you have time to review the my code, I will be very grateful.
Thanks, Sihua zhou.