### PR TITLE
[CALCITE-1886] Support LIMIT [offset,] row_count

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -575,6 +575,12 @@ JAVACODE boolean matchesPrefix(int[] seq, int[][] prefixes)
  *    [ OFFSET start ]</pre>
  * </blockquote>
  *
+ * <p>MySQL syntax for limit:
+ *
+ * <blockquote><pre>
+ *    [ LIMIT { count | start, count } ]</pre>
+ * </blockquote>
+ *
  * <p>SQL:2008 syntax for limit:
  *
  * <blockquote><pre>
@@ -601,6 +607,18 @@ SqlNode OrderedQueryOrExpr(ExprContext exprContext) :
     [
         // Postgres-style syntax. "LIMIT ... OFFSET ..."
         <LIMIT> ( count = UnsignedNumericLiteral() | <ALL> )
+        [
+            // MySQL-style syntax. "LIMIT start, count"
+            <COMMA> start = UnsignedNumericLiteral()
+            {
+                if (!this.conformance.isLimitStartCountAllowed()) {
+                    throw new ParseException(RESOURCE.limitStartCountNotAllowed().str());
+                }
+                SqlNode temp = count;
+                count = start;
+                start = temp;
+            }
+        ]
     ]
     [
         // ROW or ROWS is required in SQL:2008 but we make it optional

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -606,23 +606,25 @@ SqlNode OrderedQueryOrExpr(ExprContext exprContext) :
     ]
     [
         // Postgres-style syntax. "LIMIT ... OFFSET ..."
-        <LIMIT> ( count = UnsignedNumericLiteral() | <ALL> )
-        [
+        <LIMIT>
+        (
             // MySQL-style syntax. "LIMIT start, count"
-            <COMMA> start = UnsignedNumericLiteral()
+            start = UnsignedNumericLiteral() <COMMA> count = UnsignedNumericLiteral()
             {
                 if (!this.conformance.isLimitStartCountAllowed()) {
                     throw new ParseException(RESOURCE.limitStartCountNotAllowed().str());
                 }
-                SqlNode temp = count;
-                count = start;
-                start = temp;
             }
-        ]
+        |
+            count = UnsignedNumericLiteral()
+        |
+            <ALL>
+        )
     ]
     [
         // ROW or ROWS is required in SQL:2008 but we make it optional
         // because it is not present in Postgres-style syntax.
+        // If you specify both LIMIT start and OFFSET, OFFSET wins.
         <OFFSET> start = UnsignedNumericLiteral() [ <ROW> | <ROWS> ]
     ]
     [

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -34,6 +34,9 @@ public interface CalciteResource {
   @BaseMessage("Bang equal ''!='' is not allowed under the current SQL conformance level")
   ExInst<CalciteException> bangEqualNotAllowed();
 
+  @BaseMessage("''LIMIT start, count'' is not allowed under the current SQL conformance level")
+  ExInst<CalciteException> limitStartCountNotAllowed();
+
   @BaseMessage("APPLY operator is not allowed under the current SQL conformance level")
   ExInst<CalciteException> applyNotAllowed();
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -74,6 +74,10 @@ public abstract class SqlAbstractConformance implements SqlConformance {
   public boolean allowExtend() {
     return SqlConformanceEnum.DEFAULT.allowExtend();
   }
+
+  public boolean isLimitStartCountAllowed() {
+    return SqlConformanceEnum.DEFAULT.isLimitStartCountAllowed();
+  }
 }
 
 // End SqlAbstractConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -259,6 +259,19 @@ public interface SqlConformance {
    */
   boolean allowExtend();
 
+  /**
+   * Whether to allow 'LIMIT start, count'.
+   *
+   * <p>In standard SQL it is 'LIMIT count OFFSET start'.
+   *
+   * <p>MySQL and CUBRID allow this behavior.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#LENIENT};
+   * false otherwise.
+   */
+
+  boolean isLimitStartCountAllowed();
 }
 
 // End SqlConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -197,6 +197,15 @@ public enum SqlConformanceEnum implements SqlConformance {
       return false;
     }
   }
+
+  public boolean isLimitStartCountAllowed() {
+    switch (this) {
+    case LENIENT:
+      return true;
+    default:
+      return false;
+    }
+  }
 }
 
 // End SqlConformanceEnum.java

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -18,6 +18,7 @@
 #
 ParserContext=line {0,number,#}, column {1,number,#}
 BangEqualNotAllowed=Bang equal ''!='' is not allowed under the current SQL conformance level
+LimitStartCountNotAllowed=''LIMIT start, count'' is not allowed under the current SQL conformance level
 ApplyNotAllowed=APPLY operator is not allowed under the current SQL conformance level
 IllegalLiteral=Illegal {0} literal {1}: {2}
 IdentifierTooLong=Length of identifier ''{0}'' must be less than or equal to {1,number,#} characters

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2537,12 +2537,21 @@ public class SqlParserTest {
             .fails("'LIMIT start, count' is not allowed under the current SQL conformance level");
 
     conformance = SqlConformanceEnum.LENIENT;
-    final String expected = "SELECT `A`\n"
-            + "FROM `FOO`\n"
-            + "OFFSET 1 ROWS\n"
-            + "FETCH NEXT 2 ROWS ONLY";
-    sql("select a from foo limit 1,2")
-            .ok(expected);
+    sql("select a from foo limit 2,3")
+            .ok("SELECT `A`\n"
+                    + "FROM `FOO`\n"
+                    + "OFFSET 2 ROWS\n"
+                    + "FETCH NEXT 3 ROWS ONLY");
+    sql("select a from foo limit 2,3 offset 4")
+            .ok("SELECT `A`\n"
+                    + "FROM `FOO`\n"
+                    + "OFFSET 4 ROWS\n"
+                    + "FETCH NEXT 3 ROWS ONLY");
+    sql("select a from foo limit 2,3 fetch next 4 rows only")
+            .ok("SELECT `A`\n"
+                    + "FROM `FOO`\n"
+                    + "OFFSET 2 ROWS\n"
+                    + "FETCH NEXT 4 ROWS ONLY");
   }
 
   @Test public void testSqlInlineComment() {

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2531,6 +2531,20 @@ public class SqlParserTest {
         .ok(expected);
   }
 
+  @Test public void testLimitStartCount() {
+    conformance = SqlConformanceEnum.DEFAULT;
+    sql("select a from foo limit 1,2")
+            .fails("'LIMIT start, count' is not allowed under the current SQL conformance level");
+
+    conformance = SqlConformanceEnum.LENIENT;
+    final String expected = "SELECT `A`\n"
+            + "FROM `FOO`\n"
+            + "OFFSET 1 ROWS\n"
+            + "FETCH NEXT 2 ROWS ONLY";
+    sql("select a from foo limit 1,2")
+            .ok(expected);
+  }
+
   @Test public void testSqlInlineComment() {
     check(
         "select 1 from t --this is a comment\n",


### PR DESCRIPTION
Add MySQL LIMIT extension syntax support, enabled with SqlConformanceEnum.LENIENT