### PR TITLE
[CALCITE-1932]  Project.getPermutation() should return null if not a …

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Project.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Project.java
@@ -45,7 +45,9 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Relational expression that computes a set of
@@ -331,9 +333,15 @@ public abstract class Project extends SingleRel {
       return null;
     }
     Permutation permutation = new Permutation(fieldCount);
+    Set<Integer> alreadyProjected = new HashSet<>(fieldCount);
     for (int i = 0; i < fieldCount; ++i) {
       final RexNode exp = projects.get(i);
       if (exp instanceof RexInputRef) {
+        if (alreadyProjected.contains(((RexInputRef) exp).getIndex())) {
+          return null;
+        } else {
+          alreadyProjected.add(((RexInputRef) exp).getIndex());
+        }
         permutation.set(i, ((RexInputRef) exp).getIndex());
       } else {
         return null;

--- a/core/src/test/java/org/apache/calcite/util/PermutationTestCase.java
+++ b/core/src/test/java/org/apache/calcite/util/PermutationTestCase.java
@@ -17,6 +17,14 @@
 package org.apache.calcite.util;
 
 
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import com.google.common.collect.ImmutableList;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -151,6 +159,29 @@ public class PermutationTestCase {
     } catch (ArrayIndexOutOfBoundsException e) {
       // success
     }
+  }
+
+  @Test public void testProjectPermutation() {
+    final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    final RexBuilder builder = new RexBuilder(typeFactory);
+    // A project with [1, 1] is not a permutation, so should return null
+    final Permutation perm = Project.getPermutation(2,
+        ImmutableList.of(builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 1),
+            builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 1)));
+    assertEquals(perm, null);
+
+    // A project with [0, 1, 0] is not a permutation, so should return null
+    final Permutation perm1 = Project.getPermutation(2,
+        ImmutableList.of(builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 0),
+            builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 1),
+            builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 0)));
+    assertEquals(perm1, null);
+
+    // A project of [1, 0] is a valid permutation!
+    final Permutation perm2 = Project.getPermutation(2,
+        ImmutableList.of(builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 1),
+            builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 0)));
+    assertEquals(perm2, new Permutation(new int[]{1, 0}));
   }
 }
 


### PR DESCRIPTION
…permutation (e.g. repeated InputRef)

Change-Id: I791feeaf67f7bdddd41ef52a3677eed501674798