### PR TITLE
[CALCITE-1954] SqlValidator should maintain nullability across joins …

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2003,7 +2003,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
             usingScope,
             alias,
             new AliasNamespace(this, call, enclosingNode),
-            false);
+            forceNullable);
       }
       return node;
     case MATCH_RECOGNIZE:

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -4127,6 +4127,17 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             "RANK or DENSE_RANK functions require ORDER BY clause in window specification");
   }
 
+  @Test public void testLeftOuterJoinWithAlias() {
+    final String query =
+        "select * from "
+            + "(select row_number() over (order by sal) from emp) as emp1(r1) "
+            + "left outer join "
+            + "(select  dense_rank() over(order by sal) from emp) as emp2(r2) "
+            + "on (emp1.r1 = emp2.r2)";
+    // In this case, R2 is nullable in the join since we have a left outer join.
+    sql(query).type("RecordType(BIGINT NOT NULL R1, BIGINT R2) NOT NULL");
+  }
+
   @Test public void testInvalidWindowFunctionWithGroupBy() {
     sql("select max(^empno^) over () from emp\n"
         + "group by deptno")


### PR DESCRIPTION
…and renaming

Change-Id: I0e24bdec01510d7f525df0ef98364ad661924cd4