### PR TITLE
[CALCITE-1959] Reduce the amount of metadata and tableName calls in Druid

### DIFF
--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTable.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTable.java
@@ -101,23 +101,44 @@ public class DruidTable extends AbstractTable implements TranslatableTable {
    * @param metricNameSet Mutable set of metric names;
    *        may be partially populated already
    * @param timestampColumnName Name of timestamp column, or null
-   * @param connection If not null, use this connection to find column
-   *                   definitions
+   * @param connection connection used to find column definitions. Must be non-null.
+   *
    * @return A table
    */
   static Table create(DruidSchema druidSchema, String dataSourceName,
       List<LocalInterval> intervals, Map<String, SqlTypeName> fieldMap,
       Set<String> metricNameSet, String timestampColumnName,
       DruidConnectionImpl connection, Map<String, List<ComplexMetric>> complexMetrics) {
-    if (connection != null) {
-      connection.metadata(dataSourceName, timestampColumnName, intervals,
-                          fieldMap, metricNameSet, complexMetrics);
-    }
+    assert connection != null;
+
+    connection.metadata(dataSourceName, timestampColumnName, intervals,
+            fieldMap, metricNameSet, complexMetrics);
+
+    return DruidTable.create(druidSchema, dataSourceName, intervals, fieldMap,
+            metricNameSet, timestampColumnName, complexMetrics);
+  }
+
+  /** Creates a {@link DruidTable}
+   *
+   * @param druidSchema Druid schema
+   * @param dataSourceName Data source name in Druid, also table name
+   * @param intervals Intervals, or null to use default
+   * @param fieldMap Mutable map of fields (dimensions plus metrics);
+   *        may be partially populated already
+   * @param metricNameSet Mutable set of metric names;
+   *        may be partially populated already
+   * @param timestampColumnName Name of timestamp column, or null
+   * @return A table
+   */
+  static Table create(DruidSchema druidSchema, String dataSourceName,
+                      List<LocalInterval> intervals, Map<String, SqlTypeName> fieldMap,
+                      Set<String> metricNameSet, String timestampColumnName,
+                      Map<String, List<ComplexMetric>> complexMetrics) {
     final ImmutableMap<String, SqlTypeName> fields =
-        ImmutableMap.copyOf(fieldMap);
+            ImmutableMap.copyOf(fieldMap);
     return new DruidTable(druidSchema, dataSourceName,
-        new MapRelProtoDataType(fields), ImmutableSet.copyOf(metricNameSet),
-        timestampColumnName, intervals, complexMetrics, fieldMap);
+            new MapRelProtoDataType(fields), ImmutableSet.copyOf(metricNameSet),
+            timestampColumnName, intervals, complexMetrics, fieldMap);
   }
 
   /**

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTableFactory.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTableFactory.java
@@ -120,13 +120,6 @@ public class DruidTableFactory implements TableFactory {
         }
       }
     }
-    final String dataSourceName = Util.first(dataSource, name);
-    DruidConnectionImpl c;
-    if (dimensionsRaw == null || metricsRaw == null) {
-      c = new DruidConnectionImpl(druidSchema.url, druidSchema.url.replace(":8082", ":8081"));
-    } else {
-      c = null;
-    }
     final Object interval = operand.get("interval");
     final List<LocalInterval> intervals;
     if (interval instanceof String) {
@@ -134,10 +127,19 @@ public class DruidTableFactory implements TableFactory {
     } else {
       intervals = null;
     }
-    return DruidTable.create(druidSchema, dataSourceName, intervals,
-        fieldBuilder, metricNameBuilder, timestampColumnName, c, complexMetrics);
-  }
 
+    final String dataSourceName = Util.first(dataSource, name);
+
+    if (dimensionsRaw == null || metricsRaw == null) {
+      DruidConnectionImpl connection = new DruidConnectionImpl(druidSchema.url,
+              druidSchema.url.replace(":8082", ":8081"));
+      return DruidTable.create(druidSchema, dataSourceName, intervals, fieldBuilder,
+              metricNameBuilder, timestampColumnName, connection, complexMetrics);
+    } else {
+      return DruidTable.create(druidSchema, dataSourceName, intervals, fieldBuilder,
+              metricNameBuilder, timestampColumnName, complexMetrics);
+    }
+  }
 }
 
 // End DruidTableFactory.java

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -17,11 +17,13 @@
 package org.apache.calcite.test;
 
 import org.apache.calcite.adapter.druid.DruidQuery;
+import org.apache.calcite.adapter.druid.DruidSchema;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilder;
@@ -3183,6 +3185,14 @@ public class DruidAdapterIT {
               + ":true},'context':{'druid.query.fetch':true}}"));
   }
 
+  /**
+   * Test to make sure that the mapping from a Table name to a Table returned from
+   * {@link org.apache.calcite.adapter.druid.DruidSchema} is always the same Java object.
+   * */
+  @Test public void testTableMapReused() {
+    AbstractSchema schema = new DruidSchema("http://localhost:8082", "http://localhost:8081", true);
+    assert schema.getTable("wikiticker") == schema.getTable("wikiticker");
+  }
 }
 
 // End DruidAdapterIT.java


### PR DESCRIPTION
* In some cases, `DruidTable#create` would call `metadata` again when it wasn't necessary. This has been fixed.
* Instead of returning a new `Map<String, Table>` each time `DruidSchema#getTableMap` is called , the map is only created once.
* Test case was also added to check that the same `Table` reference is returned.