### PR TITLE
[CALCITE-1962] Changes SqlOrderBy unparse method to use the SqlPrettyWriter.fetchOffset

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlOrderBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOrderBy.java
@@ -95,26 +95,7 @@ public class SqlOrderBy extends SqlCall {
         unparseListClause(writer, orderBy.orderList);
         writer.endList(listFrame);
       }
-      if (orderBy.offset != null) {
-        final SqlWriter.Frame frame2 =
-            writer.startList(SqlWriter.FrameTypeEnum.OFFSET);
-        writer.newlineAndIndent();
-        writer.keyword("OFFSET");
-        orderBy.offset.unparse(writer, -1, -1);
-        writer.keyword("ROWS");
-        writer.endList(frame2);
-      }
-      if (orderBy.fetch != null) {
-        final SqlWriter.Frame frame3 =
-            writer.startList(SqlWriter.FrameTypeEnum.FETCH);
-        writer.newlineAndIndent();
-        writer.keyword("FETCH");
-        writer.keyword("NEXT");
-        orderBy.fetch.unparse(writer, -1, -1);
-        writer.keyword("ROWS");
-        writer.keyword("ONLY");
-        writer.endList(frame3);
-      }
+      writer.fetchOffset(orderBy.fetch, orderBy.offset);
       writer.endList(frame);
     }
   }


### PR DESCRIPTION
Changes SqlOrderBy's unparse method to use the SqlPrettyWriter.fetchOffset which writes dialect specific fetch/offset/limit statements.