### PR TITLE
Fix an incorrectly implemented data race in RexCall.toString

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -93,11 +93,14 @@ public class RexCall extends RexNode {
   }
 
   public String toString() {
-    if (digest == null) {
-      digest = computeDigest(
+    // This data race is intentional
+    String localDigest = digest;
+    if (localDigest == null) {
+      localDigest = computeDigest(
           isA(SqlKind.CAST) || isA(SqlKind.NEW_SPECIFICATION));
+      digest = localDigest;
     }
-    return digest;
+    return localDigest;
   }
 
   public <R> R accept(RexVisitor<R> visitor) {


### PR DESCRIPTION
Anyone cares to discuss this? I think this is a data race that, in multithreaded environments can lead to errors.