### PR TITLE
[CALCITE-1990]Make RelDistribution to extends RelMultipleTrait

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/RelDistribution.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistribution.java
@@ -16,7 +16,7 @@
  */
 package org.apache.calcite.rel;
 
-import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.plan.RelMultipleTrait;
 import org.apache.calcite.util.mapping.Mappings;
 
 import java.util.List;
@@ -35,7 +35,7 @@ import javax.annotation.Nonnull;
  *       registered with the planner that are not trait-defs.
  * </ul>
  */
-public interface RelDistribution extends RelTrait {
+public interface RelDistribution extends RelMultipleTrait {
   /** Returns the type of distribution. */
   @Nonnull Type getType();
 

--- a/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel;
+
+import org.apache.calcite.plan.RelTraitSet;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link RelDistribution}.
+ */
+public class RelDistributionTest {
+
+  @Test public void testRelDistributionSatisfy() {
+    RelDistribution distribution1 = RelDistributions.hash(ImmutableList.of(0));
+    RelDistribution distribution2 = RelDistributions.hash(ImmutableList.of(1));
+
+    RelTraitSet traitSet = RelTraitSet.createEmpty();
+    RelTraitSet simpleTrait1 = traitSet.plus(distribution1);
+    RelTraitSet simpleTrait2 = traitSet.plus(distribution2);
+    RelTraitSet compositeTrait = traitSet.replace(RelDistributionTraitDef.INSTANCE,
+        ImmutableList.of(distribution1, distribution2));
+
+    assertThat(compositeTrait.satisfies(simpleTrait1), is(true));
+    assertThat(compositeTrait.satisfies(simpleTrait2), is(true));
+  }
+}
+
+// End RelDistributionTest.java


### PR DESCRIPTION
Make RelDistribution extends RelMultipleTrait. It will be used for satisfying between traits.
` select T1.c1,count(*) from T1 join T2 on T1.c1=T2.d1 group by T1.c1;`
`select T2.d1,count(*) from T1 join T2 on T1.c1=T2.d1 group by T1.d1;`

Supposed Plan:

     SortedAggregate(group by T1.c1 or group by T2.d1)
        SortedMergeJoin
             SortExchange(c1)
                T1(c1)
            SortExchange(d1)
                T2(d1)

For two query, if the Distribution trait of SortedMergeJoin is RelCompositeTrait with distribution hash(c1) and distribution hash(d1), then the distribution of SortedMergeJoin satisfy SortedAggregate. there is no SortExchange between SortedAggregate and SortedMergeJoin.

