### PR TITLE
[CALCITE-2016] support chaining ITEM and DOT operators for complex type access

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3099,22 +3099,12 @@ List<Object> Expression2(ExprContext exprContext) :
                 }
                 (
                     <DOT>
-                    (
-                    <QUOTED_STRING> {
-                        list.add(
-                            new SqlParserUtil.ToTreeListItem(
-                                SqlStdOperatorTable.DOT, getPos()));
-                        p = SqlParserUtil.trim(token.image, "'"); // no embedded quotes
-                        list.add(SqlLiteral.createCharString(p, getPos()));
-                    }
-                    |
                     p = Identifier() {
                         list.add(
                             new SqlParserUtil.ToTreeListItem(
                                 SqlStdOperatorTable.DOT, getPos()));
-                        list.add(SqlLiteral.createCharString(p, getPos()));
+                        list.add(new SqlIdentifier(p, getPos()));
                     }
-                    )
                 )*
             |
                 {

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2975,6 +2975,7 @@ List<Object> Expression2(ExprContext exprContext) :
     SqlNodeList nodeList;
     SqlNode e;
     SqlOperator op;
+    String p;
     final Span s = span();
 }
 {
@@ -3096,6 +3097,25 @@ List<Object> Expression2(ExprContext exprContext) :
                             SqlStdOperatorTable.ITEM, getPos()));
                     list.add(e);
                 }
+                (
+                    <DOT>
+                    (
+                    <QUOTED_STRING> {
+                        list.add(
+                            new SqlParserUtil.ToTreeListItem(
+                                SqlStdOperatorTable.DOT, getPos()));
+                        p = SqlParserUtil.trim(token.image, "'"); // no embedded quotes
+                        list.add(SqlLiteral.createCharString(p, getPos()));
+                    }
+                    |
+                    p = Identifier() {
+                        list.add(
+                            new SqlParserUtil.ToTreeListItem(
+                                SqlStdOperatorTable.DOT, getPos()));
+                        list.add(SqlLiteral.createCharString(p, getPos()));
+                    }
+                    )
+                )*
             |
                 {
                     checkNonQueryExpression(exprContext);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlDotOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlDotOperator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexCallBinding;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.Arrays;
+
+/**
+ * The dot operator {@code .}, used to access a field of a
+ * record. For example, {@code a.b}.
+ */
+public class SqlDotOperator extends SqlSpecialOperator {
+  public SqlDotOperator() {
+    super("DOT",
+        SqlKind.DOT,
+        100,
+        true,
+        null,
+        null,
+        null);
+  }
+
+  @Override public ReduceResult reduceExpr(int ordinal, TokenSequence list) {
+    SqlNode left = list.node(ordinal - 1);
+    SqlNode right = list.node(ordinal + 1);
+    return new ReduceResult(ordinal - 1,
+        ordinal + 2,
+        createCall(
+            SqlParserPos.sum(
+                Arrays.asList(left.getParserPosition(),
+                    right.getParserPosition(),
+                    list.pos(ordinal))),
+            left,
+            right));
+  }
+
+  @Override public void unparse(
+      SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    final SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.IDENTIFIER);
+    call.operand(0).unparse(writer, leftPrec, 0);
+    writer.sep(".");
+    call.operand(1).unparse(writer, 0, 0);
+    writer.endList(frame);
+  }
+
+  @Override public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.of(2);
+  }
+
+  @Override public boolean checkOperandTypes(
+      SqlCallBinding callBinding,
+      boolean throwOnFailure) {
+    final SqlNode left = callBinding.operand(0);
+    final SqlNode right = callBinding.operand(1);
+    RelDataType type =
+        callBinding.getValidator().deriveType(
+            callBinding.getScope(),
+            left);
+    if (SqlTypeName.ROW != type.getSqlTypeName()) {
+      return false;
+    }
+    final RelDataType operandType = callBinding.getOperandType(0);
+    final SqlSingleOperandTypeChecker checker = getChecker(operandType);
+    return checker.checkSingleOperandType(callBinding, right, 0,
+        throwOnFailure);
+  }
+
+  private SqlSingleOperandTypeChecker getChecker(RelDataType operandType) {
+    switch (operandType.getSqlTypeName()) {
+    case ROW:
+      return OperandTypes.family(SqlTypeFamily.STRING);
+    default:
+      throw new AssertionError(operandType.getSqlTypeName());
+    }
+  }
+
+  @Override public String getAllowedSignatures(String name) {
+    return "<A>.<B>";
+  }
+
+  @Override public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+    final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    final RelDataType operandType = opBinding.getOperandType(0);
+    switch (operandType.getSqlTypeName()) {
+    case ROW:
+      if (opBinding instanceof SqlCallBinding) {
+        return typeFactory.createTypeWithNullability(
+            opBinding.getOperandType(0).getField(
+                ((SqlCallBinding) opBinding).operand(1).toString().replaceAll("^'|'$", ""),
+                false, false)
+            .getType(), true);
+      } else if (opBinding instanceof RexCallBinding) {
+        return typeFactory.createTypeWithNullability(
+            opBinding.getOperandType(0).getField(
+                ((RexCallBinding) opBinding).getStringLiteralOperand(1).toString(), false, false)
+            .getType(), true);
+      } else {
+        throw new AssertionError();
+      }
+    default:
+      throw new AssertionError();
+    }
+  }
+}
+
+// End SqlDotOperator.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -295,15 +295,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   /**
    * Dot operator, '<code>.</code>', used for referencing fields of records.
    */
-  public static final SqlBinaryOperator DOT =
-      new SqlBinaryOperator(
-          ".",
-          SqlKind.DOT,
-          80,
-          true,
-          null,
-          null,
-          OperandTypes.ANY_ANY);
+  public static final SqlOperator DOT = new SqlDotOperator();
 
   /**
    * Logical equals operator, '<code>=</code>'.

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -248,6 +248,16 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
           }
         });
 
+    // "DOT"
+    registerOp(
+        SqlStdOperatorTable.DOT,
+        new SqlRexConvertlet() {
+          public RexNode convertCall(SqlRexContext cx, SqlCall call) {
+            return cx.getRexBuilder().makeCall(SqlStdOperatorTable.DOT,
+                cx.convertExpression(call.operand(0)),
+                cx.getRexBuilder().makeLiteral(call.operand(1).toString()));
+          }
+        });
     // "AS" has no effect, so expand "x AS id" into "x".
     registerOp(
         SqlStdOperatorTable.AS,

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4251,7 +4251,7 @@ public class SqlParserTest {
   }
 
   @Test public void testArrayElementWithDot() {
-    checkExp("a[1].b.c[2].d", "(((`A`[1].'B').'C')[2].'D')");
+    checkExp("a[1+2].b.c[2].d", "(((`A`[(1 + 2)].'B').'C')[2].'D')");
     checkExp("a[b[1]].c.f0[d[1]]", "((`A`[`B`[1]].'C').'F0')[`D`[1]]");
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4251,8 +4251,8 @@ public class SqlParserTest {
   }
 
   @Test public void testArrayElementWithDot() {
-    checkExp("a[1+2].b.c[2].d", "(((`A`[(1 + 2)].'B').'C')[2].'D')");
-    checkExp("a[b[1]].c.f0[d[1]]", "((`A`[`B`[1]].'C').'F0')[`D`[1]]");
+    checkExp("a[1+2].b.c[2].d", "(((`A`[(1 + 2)].`B`).`C`)[2].`D`)");
+    checkExp("a[b[1]].c.f0[d[1]]", "((`A`[`B`[1]].`C`).`F0`)[`D`[1]]");
   }
 
   @Test public void testArrayValueConstructor() {

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4250,6 +4250,11 @@ public class SqlParserTest {
     checkExp("a[b[1 + 2] + 3]", "`A`[(`B`[(1 + 2)] + 3)]");
   }
 
+  @Test public void testArrayElementWithDot() {
+    checkExp("a[1].b.c[2].d", "(((`A`[1].'B').'C')[2].'D')");
+    checkExp("a[b[1]].c.f0[d[1]]", "((`A`[`B`[1]].'C').'F0')[`D`[1]]");
+  }
+
   @Test public void testArrayValueConstructor() {
     checkExp("array[1, 2]", "(ARRAY[1, 2])");
     checkExp("array [1, 2]", "(ARRAY[1, 2])"); // with space

--- a/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
+++ b/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
@@ -1615,10 +1615,16 @@ public class MockCatalogReader extends CalciteCatalogReader {
                     .build())
             .kind(StructKind.PEEK_FIELDS_NO_EXPAND)
             .build();
+    final RelDataType skillRecordType =
+        typeFactory.builder()
+            .add("TYPE", varchar10Type)
+            .add("DESC", varchar20Type)
+            .build();
     final RelDataType empRecordType =
         typeFactory.builder()
             .add("EMPNO", intType)
-            .add("ENAME", varchar10Type).build();
+            .add("ENAME", varchar10Type)
+            .add("SKILLS", typeFactory.createArrayType(skillRecordType, -1)).build();
     final RelDataType empListType =
         typeFactory.createArrayType(empRecordType, -1);
 

--- a/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
+++ b/core/src/test/java/org/apache/calcite/test/MockCatalogReader.java
@@ -1624,7 +1624,8 @@ public class MockCatalogReader extends CalciteCatalogReader {
         typeFactory.builder()
             .add("EMPNO", intType)
             .add("ENAME", varchar10Type)
-            .add("SKILLS", typeFactory.createArrayType(skillRecordType, -1)).build();
+            .add("SKILLS", typeFactory.createArrayType(skillRecordType, -1))
+            .build();
     final RelDataType empListType =
         typeFactory.createArrayType(empRecordType, -1);
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1033,6 +1033,10 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test public void testArrayOfRecord() {
+    sql("select employees[1].skills[2].desc from dept_nested").ok();
+  }
+
   @Test public void testUnnestArray() {
     sql("select*from unnest(array(select*from dept))").ok();
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1034,7 +1034,7 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   @Test public void testArrayOfRecord() {
-    sql("select employees[1].skills[2].desc from dept_nested").ok();
+    sql("select employees[1].skills[2+3].desc from dept_nested").ok();
   }
 
   @Test public void testUnnestArray() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7780,6 +7780,8 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test public void testArrayOfRecordType() {
+    sql("SELECT name, dept_nested.employees[1].ne as ne from dept_nested")
+        .fails("Unknown field 'NE'");
     sql("SELECT name, dept_nested.employees[1].ename as ename from dept_nested")
         .type("RecordType(VARCHAR(10) NOT NULL NAME, VARCHAR(10) ENAME) NOT NULL");
     sql("SELECT dept_nested.employees[1].skills[1].desc as DESCRIPTION from dept_nested")

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7400,7 +7400,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + " UNNEST(d.employees) as e";
     final String type = "RecordType(INTEGER NOT NULL DEPTNO,"
         + " INTEGER NOT NULL EMPNO,"
-        + " VARCHAR(10) NOT NULL ENAME) NOT NULL";
+        + " VARCHAR(10) NOT NULL ENAME,"
+        + " RecordType(VARCHAR(10) NOT NULL TYPE, VARCHAR(20) NOT NULL DESC)"
+        + " NOT NULL ARRAY NOT NULL SKILLS) NOT NULL";
     sql(sql).type(type);
 
     // equivalent query using CROSS JOIN
@@ -7775,6 +7777,13 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     checkResultType(
         "SELECT customer.contact.coord.x, customer.contact.email, contact.coord.y FROM customer.contact",
         "RecordType(INTEGER NOT NULL X, VARCHAR(20) NOT NULL EMAIL, INTEGER NOT NULL Y) NOT NULL");
+  }
+
+  @Test public void testArrayOfRecordType() {
+    sql("SELECT name, dept_nested.employees[1].ename as ename from dept_nested")
+        .type("RecordType(VARCHAR(10) NOT NULL NAME, VARCHAR(10) ENAME) NOT NULL");
+    sql("SELECT dept_nested.employees[1].skills[1].desc as DESCRIPTION from dept_nested")
+        .type("RecordType(VARCHAR(20) DESCRIPTION) NOT NULL");
   }
 
   /** Test case for
@@ -8465,6 +8474,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "\n"
         + "CURRENT_VALUE -\n"
         + "DEFAULT -\n"
+        + "DOT -\n"
         + "ITEM -\n"
         + "NEXT_VALUE -\n"
         + "PATTERN_EXCLUDE -\n"
@@ -8476,7 +8486,6 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "$LiteralChain -\n"
         + "+ pre\n"
         + "- pre\n"
-        + ". left\n"
         + "FINAL pre\n"
         + "RUNNING pre\n"
         + "\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -365,7 +365,7 @@ window w as (partition by productId)]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalProject(EXPR$0=[DOT(ITEM(DOT(ITEM($2, 1), 'SKILLS'), 2), 'DESC')])
+LogicalProject(EXPR$0=[DOT(ITEM(DOT(ITEM($2, 1), 'SKILLS'), +(2, 3)), 'DESC')])
   LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
 ]]>
         </Resource>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -359,6 +359,17 @@ from orders
 window w as (partition by productId)]]>
         </Resource>
     </TestCase>
+    <TestCase name="testArrayOfRecord">
+        <Resource name="sql">
+            <![CDATA[select*from unnest(array(select*from dept))]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[DOT(ITEM(DOT(ITEM($2, 1), 'SKILLS'), 2), 'DESC')])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testUnnestArray">
         <Resource name="sql">
             <![CDATA[select*from unnest(array(select*from dept))]]>


### PR DESCRIPTION
This change adds parser implementation and SqlDotOperator implementation to handle chaining ITEM and DOT operators when accessing complex type.