### PR TITLE
[CALCITE-2104] [core] Add separate rules for "AggregateUnionAggregate…

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2529,6 +2529,22 @@ public class RelOptRulesTest extends RelOptTestBase {
             + " group by deptno,job");
   }
 
+  @Test public void testPullAggregateThroughUnion2() throws Exception {
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(AggregateUnionAggregateRule.AGG_ON_SECOND_INPUT)
+        .addRuleInstance(AggregateUnionAggregateRule.AGG_ON_FIRST_INPUT)
+        .build();
+
+    checkPlanning(program,
+        "select deptno, job from"
+            + " (select deptno, job from emp as e1"
+            + " group by deptno,job"
+            + "  union all"
+            + " select deptno, job from emp as e2"
+            + " group by deptno,job)"
+            + " group by deptno,job");
+  }
+
   private void transitiveInference(RelOptRule... extraRules) throws Exception {
     final DiffRepository diffRepos = getDiffRepos();
     final String sql = diffRepos.expand(null, "${sql}");

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5035,6 +5035,33 @@ LogicalAggregate(group=[{0, 1}])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testPullAggregateThroughUnion2">
+        <Resource name="sql">
+            <![CDATA[select deptno, job from (select deptno, job from emp as e1 group by deptno,job  union all select deptno, job from emp as e2 group by deptno,job) group by deptno,job]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0, 1}])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}])
+      LogicalProject(DEPTNO=[$7], JOB=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}])
+      LogicalProject(DEPTNO=[$7], JOB=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{0, 1}])
+  LogicalUnion(all=[true])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testProjectWindowTransposeRule">
         <Resource name="sql">
             <![CDATA[select count(empno) over(), deptno from emp]]>


### PR DESCRIPTION
…Rule" to reduce potential matching cost in VolcanoPlanner

Problem: 
     when optimize some sql (has Union + Aggregate pattern) based on VolcanoPlanner may take a long time(tens of seconds or a few minutes).
     After adding the time cost statistics for each rule during the optimization phase, I found that "AggregateUnionAggregateRule" has a large value, but the query pattern will not be matched finally.
     So I try to make a minor change for AggregateUnionAggregateRule and the statistics shows a improvement for the same query be tested. 