### PR TITLE
[Calcite-2108] Fix AggregateJoinTransposeRule failure when process aggregateCall above SqlSumEmptyIsZeroAggFunction without groupKeys.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
@@ -212,9 +212,8 @@ public interface SqlSplittableAggFunction {
     }
   }
 
-  /** Splitting strategy for {@code SUM}. */
-  class SumSplitter implements SqlSplittableAggFunction {
-    public static final SumSplitter INSTANCE = new SumSplitter();
+  /** Common Splitting strategy for {@coide SUM} and {@coide SUM0}. */
+  abstract class AbstractSumSplitter implements SqlSplittableAggFunction {
 
     public RexNode singleton(RexBuilder rexBuilder,
         RelDataType inputRowType, AggregateCall aggregateCall) {
@@ -260,9 +259,33 @@ public interface SqlSplittableAggFunction {
         throw new AssertionError("unexpected count " + merges);
       }
       int ordinal = extra.register(node);
-      return AggregateCall.create(SqlStdOperatorTable.SUM, false, false,
+      return AggregateCall.create(getMergeAggFunctionOfTopSplit(), false, false,
           ImmutableList.of(ordinal), -1, aggregateCall.type,
           aggregateCall.name);
+    }
+
+    protected abstract SqlAggFunction getMergeAggFunctionOfTopSplit();
+
+  }
+
+  /** Splitting strategy for {@coide SUM}. */
+  class SumSplitter extends AbstractSumSplitter {
+
+    public static final SumSplitter INSTANCE = new SumSplitter();
+
+    @Override public SqlAggFunction getMergeAggFunctionOfTopSplit() {
+      return SqlStdOperatorTable.SUM;
+    }
+
+  }
+
+  /** Splitting strategy for {@code SUM0}. */
+  class Sum0Splitter extends AbstractSumSplitter {
+
+    public static final Sum0Splitter INSTANCE = new Sum0Splitter();
+
+    @Override public SqlAggFunction getMergeAggFunctionOfTopSplit() {
+      return SqlStdOperatorTable.SUM0;
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlSumEmptyIsZeroAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlSumEmptyIsZeroAggFunction.java
@@ -68,7 +68,7 @@ public class SqlSumEmptyIsZeroAggFunction extends SqlAggFunction {
 
   @Override public <T> T unwrap(Class<T> clazz) {
     if (clazz == SqlSplittableAggFunction.class) {
-      return clazz.cast(SqlSplittableAggFunction.SumSplitter.INSTANCE);
+      return clazz.cast(SqlSplittableAggFunction.Sum0Splitter.INSTANCE);
     }
     return super.unwrap(clazz);
   }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2897,6 +2897,20 @@ public class RelOptRulesTest extends RelOptTestBase {
     checkPlanning(tester, preProgram, new HepPlanner(program), sql);
   }
 
+  @Test public void testPushAggregateSumThroughJoinAfterAggregateReduce() throws Exception {
+    final HepProgram preProgram = new HepProgramBuilder()
+            .addRuleInstance(AggregateProjectMergeRule.INSTANCE)
+            .build();
+    final HepProgram program = new HepProgramBuilder()
+            .addRuleInstance(AggregateReduceFunctionsRule.INSTANCE)
+            .addRuleInstance(AggregateJoinTransposeRule.EXTENDED)
+            .build();
+    final String sql = "select sum(sal)\n"
+            + "from (select * from sales.emp where empno = 10) as e\n"
+            + "join sales.dept as d on e.job = d.name";
+    checkPlanning(tester, preProgram, new HepPlanner(program), sql);
+  }
+
   /** Push a variety of aggregate functions. */
   @Test public void testPushAggregateFunctionsThroughJoin() throws Exception {
     final HepProgram preProgram = new HepProgramBuilder()

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5723,6 +5723,38 @@ LogicalProject(JOB=[$0], EXPR$1=[$2])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testPushAggregateSumThroughJoinAfterAggregateReduce">
+        <Resource name="sql">
+            <![CDATA[select e.job,sum(sal)
+from (select * from sales.emp where empno = 10) as e
+join sales.dept as d on e.job = d.name
+group by e.job,d.name]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($5)])
+  LogicalJoin(condition=[=($2, $10)], joinType=[inner])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+      LogicalFilter(condition=[=($0, 10)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EXPR$0=[CASE(=($1, 0), null, $0)])
+  LogicalAggregate(group=[{}], EXPR$0=[$SUM0($5)], agg#1=[$SUM0($6)])
+    LogicalProject(JOB=[$0], EXPR$0=[$1], $f2=[$2], NAME=[$3], $f1=[$4], $f5=[CAST(*($1, $4)):INTEGER NOT NULL], $f6=[*($2, $4)])
+      LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+        LogicalAggregate(group=[{2}], EXPR$0=[$SUM0($5)], agg#1=[COUNT()])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+            LogicalFilter(condition=[=($0, 10)])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalAggregate(group=[{1}], agg#0=[COUNT()])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testReduceConstantsIsNotNull">
         <Resource name="sql">
             <![CDATA[select empno from emp


### PR DESCRIPTION
Fix AggregateJoinTransposeRule failure when process aggregateCall above SqlSumEmptyIsZeroAggFunction without groupKeys. Please go to https://issues.apache.org/jira/browse/CALCITE-2108 to get detailed messages.