### PR TITLE
[CALCITE-2111]HepPlanner apply more and more rules

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/hep/HepMatchOrder.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepMatchOrder.java
@@ -37,7 +37,14 @@ public enum HepMatchOrder {
    * Match from root down. A match attempt at an ancestor always precedes all
    * match attempts at its descendants.
    */
-  TOP_DOWN
+  TOP_DOWN,
+
+  /**
+   * Match in depth first order. It avoid the rule apply for
+   * the previous relNode repeatedly after new vertex is generated
+   * in one rule apply
+   */
+  DEPTH_FIRST
 }
 
 // End HepMatchOrder.java

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -887,14 +887,14 @@ public class HepPlanner extends AbstractRelOptPlanner {
       mapDigestToVertex.remove(oldDigest);
     }
     String newDigest = rel.recomputeDigest();
-    if (mapDigestToVertex.get(newDigest) == null) {
-      mapDigestToVertex.put(newDigest, vertex);
-    } else {
-      // REVIEW jvs 5-Apr-2006:  Could this lead us to
-      // miss common subexpressions?  When called from
-      // addRelToGraph, we'll check after this method returns,
-      // but what about the other callers?
-    }
+    // When a transformation happened in one rule apply, support
+    // vertex2 replace vertex1, but the current relNode of
+    // vertex1 and vertex2 is same,
+    // then the digest is also same. but we can't remove vertex2,
+    // otherwise the digest will be removed wrongly in the mapDigestToVertex
+    //  when collectGC
+    // so it must update the digest that map to vertex
+    mapDigestToVertex.put(newDigest, vertex);
     if (rel != vertex.getCurrentRel()) {
       vertex.replaceRel(rel);
     }

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -399,7 +399,8 @@ public class HepPlanner extends AbstractRelOptPlanner {
     LOGGER.trace("Applying rule set {}", rules);
 
     boolean fullRestartAfterTransformation =
-        currentProgram.matchOrder != HepMatchOrder.ARBITRARY;
+        currentProgram.matchOrder != HepMatchOrder.ARBITRARY
+        && currentProgram.matchOrder != HepMatchOrder.DEPTH_FIRST;
 
     int nMatches = 0;
 
@@ -418,19 +419,19 @@ public class HepPlanner extends AbstractRelOptPlanner {
               return;
             }
             if (fullRestartAfterTransformation) {
-              if (currentProgram.matchOrder == HepMatchOrder.DEPTH_FIRST) {
-                nMatches =
-                    depthFirstApply(getGraphIterator(newVertex), rules,
-                        forceConversions, nMatches);
-              } else {
-                iter = getGraphIterator(root);
-              }
+              iter = getGraphIterator(root);
             } else {
               // To the extent possible, pick up where we left
               // off; have to create a new iterator because old
               // one was invalidated by transformation.
               iter = getGraphIterator(newVertex);
-
+              if (currentProgram.matchOrder == HepMatchOrder.DEPTH_FIRST) {
+                nMatches =
+                    depthFirstApply(iter, rules, forceConversions, nMatches);
+                if (nMatches >= currentProgram.matchLimit) {
+                  return;
+                }
+              }
               // Remember to go around again since we're
               // skipping some stuff.
               fixpoint = false;

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepProgram.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepProgram.java
@@ -66,7 +66,7 @@ public class HepProgram {
 
   void initialize(boolean clearCache) {
     matchLimit = MATCH_UNTIL_FIXPOINT;
-    matchOrder = HepMatchOrder.ARBITRARY;
+    matchOrder = HepMatchOrder.DEPTH_FIRST;
     group = null;
 
     for (HepInstruction instruction : instructions) {

--- a/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.plan.RelOptListener;
 import org.apache.calcite.plan.hep.HepMatchOrder;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
@@ -28,9 +29,13 @@ import org.apache.calcite.rel.rules.CoerceInputsRule;
 import org.apache.calcite.rel.rules.FilterToCalcRule;
 import org.apache.calcite.rel.rules.ProjectRemoveRule;
 import org.apache.calcite.rel.rules.ProjectToCalcRule;
+import org.apache.calcite.rel.rules.ReduceExpressionsRule;
 import org.apache.calcite.rel.rules.UnionToDistinctRule;
 
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * HepPlannerTest is a unit test for {@link HepPlanner}. See
@@ -45,6 +50,110 @@ public class HepPlannerTest extends RelOptTestBase {
   private static final String UNION_TREE =
       "(select name from dept union select ename from emp)"
       + " union (select ename from bonus)";
+
+  private static final String COMPLEX_UNION_TREE =
+      "select * from (\n"
+          + "\tselect ENAME, 50011895 as cat_id, '1' as cat_name, 1 as require_free_postage, 0 as  require_15return, 0 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50011895 union all\n"
+          + "\tselect ENAME, 50013023 as cat_id, '2' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013023 union all\n"
+          + "\tselect ENAME, 50013032 as cat_id, '3' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013032 union all\n"
+          + "\tselect ENAME, 50013024 as cat_id, '4' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013024 union all\n"
+          + "\tselect ENAME, 50004204 as cat_id, '5' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50004204 union all\n"
+          + "\tselect ENAME, 50013043 as cat_id, '6' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013043 union all\n"
+          + "\tselect ENAME, 290903 as cat_id, '7' as cat_name, 1 as require_free_postage, 0 as  require_15return, 0 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 290903 union all\n"
+          + "\tselect ENAME, 50008261 as cat_id, '8' as cat_name, 1 as require_free_postage, 0 as  require_15return, 0 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50008261 union all\n"
+          + "\tselect ENAME, 124478013 as cat_id, '9' as cat_name, 0 as require_free_postage, 0 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 124478013 union all\n"
+          + "\tselect ENAME, 124472005 as cat_id, '10' as cat_name, 0 as require_free_postage, 0 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 124472005 union all\n"
+          + "\tselect ENAME, 50013475 as cat_id, '11' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013475 union all\n"
+          + "\tselect ENAME, 50018263 as cat_id, '12' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50018263 union all\n"
+          + "\tselect ENAME, 50013498 as cat_id, '13' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013498 union all\n"
+          + "\tselect ENAME, 350511 as cat_id, '14' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 350511 union all\n"
+          + "\tselect ENAME, 50019790 as cat_id, '15' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019790 union all\n"
+          + "\tselect ENAME, 50015382 as cat_id, '16' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50015382 union all\n"
+          + "\tselect ENAME, 350503 as cat_id, '17' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 350503 union all\n"
+          + "\tselect ENAME, 350401 as cat_id, '18' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 350401 union all\n"
+          + "\tselect ENAME, 50015560 as cat_id, '19' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50015560 union all\n"
+          + "\tselect ENAME, 122658003 as cat_id, '20' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 122658003 union all\n"
+          + "\tselect ENAME, 122716008 as cat_id, '21' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 122716008 union all\n"
+          + "\tselect ENAME, 50018406 as cat_id, '22' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50018406 union all\n"
+          + "\tselect ENAME, 50018407 as cat_id, '23' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50018407 union all\n"
+          + "\tselect ENAME, 50024678 as cat_id, '24' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024678 union all\n"
+          + "\tselect ENAME, 50022290 as cat_id, '25' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022290 union all\n"
+          + "\tselect ENAME, 50020072 as cat_id, '26' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020072 union all\n"
+          + "\tselect ENAME, 50024679 as cat_id, '27' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024679 union all\n"
+          + "\tselect ENAME, 50013326 as cat_id, '28' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013326 union all\n"
+          + "\tselect ENAME, 50020032 as cat_id, '19' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020032 union all\n"
+          + "\tselect ENAME, 50022273 as cat_id, '30' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022273 union all\n"
+          + "\tselect ENAME, 50013511 as cat_id, '31' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013511 union all\n"
+          + "\tselect ENAME, 122694006 as cat_id, '32' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 122694006 union all\n"
+          + "\tselect ENAME, 50019940 as cat_id, '33' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019940 union all\n"
+          + "\tselect ENAME, 50022288 as cat_id, '34' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022288 union all\n"
+          + "\tselect ENAME, 50020069 as cat_id, '35' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020069 union all\n"
+          + "\tselect ENAME, 50021800 as cat_id, '36' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50021800 union all\n"
+          + "\tselect ENAME, 50024684 as cat_id, '37' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024684 union all\n"
+          + "\tselect ENAME, 50024676 as cat_id, '38' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024676 union all\n"
+          + "\tselect ENAME, 50020070 as cat_id, '39' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020070 union all\n"
+          + "\tselect ENAME, 50020058 as cat_id, '40' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020058 union all\n"
+          + "\tselect ENAME, 50019938 as cat_id, '41' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019938 union all\n"
+          + "\tselect ENAME, 122686009 as cat_id, '42' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 122686009 union all\n"
+          + "\tselect ENAME, 50022286 as cat_id, '43' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022286 union all\n"
+          + "\tselect ENAME, 122692007 as cat_id, '44' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 122692007 union all\n"
+          + "\tselect ENAME, 50020059 as cat_id, '45' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020059 union all\n"
+          + "\tselect ENAME, 50006050 as cat_id, '45' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50006050 union all\n"
+          + "\tselect ENAME, 122718006 as cat_id, '47' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 122718006 union all\n"
+          + "\tselect ENAME, 50022652 as cat_id, '48' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022652 union all\n"
+          + "\tselect ENAME, 50024685 as cat_id, '49' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024685 union all\n"
+          + "\tselect ENAME, 50020104 as cat_id, '50' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020104 union all\n"
+          + "\tselect ENAME, 50013500 as cat_id, '51' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013500 union all\n"
+          + "\tselect ENAME, 50003558 as cat_id, '52' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50003558 union all\n"
+          + "\tselect ENAME, 50020061 as cat_id, '53' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020061 union all\n"
+          + "\tselect ENAME, 122656012 as cat_id, '54' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 122656012 union all\n"
+          + "\tselect ENAME, 50024812 as cat_id, '55' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024812 union all\n"
+          + "\tselect ENAME, 50022287 as cat_id, '56' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022287 union all\n"
+          + "\tselect ENAME, 50020107 as cat_id, '57' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020107 union all\n"
+          + "\tselect ENAME, 50019842 as cat_id, '58' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019842 union all\n"
+          + "\tselect ENAME, 50020106 as cat_id, '59' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020106 union all\n"
+          + "\tselect ENAME, 50020071 as cat_id, '60' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020071 union all\n"
+          + "\tselect ENAME, 50019939 as cat_id, '61' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019939 union all\n"
+          + "\tselect ENAME, 50020034 as cat_id, '62' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020034 union all\n"
+          + "\tselect ENAME, 50020025 as cat_id, '63' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020025 union all\n"
+          + "\tselect ENAME, 50022293 as cat_id, '64' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022293 union all\n"
+          + "\tselect ENAME, 50022279 as cat_id, '65' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022279 union all\n"
+          + "\tselect ENAME, 50013818 as cat_id, '66' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013818 union all\n"
+          + "\tselect ENAME, 50020060 as cat_id, '67' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020060 union all\n"
+          + "\tselect ENAME, 50020062 as cat_id, '68' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020062 union all\n"
+          + "\tselect ENAME, 50022276 as cat_id, '69' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022276 union all\n"
+          + "\tselect ENAME, 50022280 as cat_id, '70' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022280 union all\n"
+          + "\tselect ENAME, 50020619 as cat_id, '71' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020619 union all\n"
+          + "\tselect ENAME, 50013347 as cat_id, '72' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013347 union all\n"
+          + "\tselect ENAME, 50008698 as cat_id, '73' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50008698 union all\n"
+          + "\tselect ENAME, 50013334 as cat_id, '74' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013334 union all\n"
+          + "\tselect ENAME, 50024810 as cat_id, '75' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024810 union all\n"
+          + "\tselect ENAME, 50019936 as cat_id, '76' as cat_name, 1 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019936 union all\n"
+          + "\tselect ENAME, 50024813 as cat_id, '77' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024813 union all\n"
+          + "\tselect ENAME, 50020959 as cat_id, '78' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020959 union all\n"
+          + "\tselect ENAME, 124474002 as cat_id, '79' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 124474002 union all\n"
+          + "\tselect ENAME, 50019853 as cat_id, '80' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019853 union all\n"
+          + "\tselect ENAME, 50019837 as cat_id, '81' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50019837 union all\n"
+          + "\tselect ENAME, 50022289 as cat_id, '82' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022289 union all\n"
+          + "\tselect ENAME, 50022278 as cat_id, '83' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022278 union all\n"
+          + "\tselect ENAME, 50024690 as cat_id, '84' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50024690 union all\n"
+          + "\tselect ENAME, 50592002 as cat_id, '85' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50592002 union all\n"
+          + "\tselect ENAME, 50013342 as cat_id, '86' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50013342 union all\n"
+          + "\tselect ENAME, 50022296 as cat_id, '87' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022296 union all\n"
+          + "\tselect ENAME, 123456001 as cat_id, '88' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 123456001 union all\n"
+          + "\tselect ENAME, 50022298 as cat_id, '89' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022298 union all\n"
+          + "\tselect ENAME, 50022274 as cat_id, '90' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022274 union all\n"
+          + "\tselect ENAME, 50006046 as cat_id, '91' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50006046 union all\n"
+          + "\tselect ENAME, 50020676 as cat_id, '92' as cat_name, 1 as require_free_postage, 0 as  require_15return, 0 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020676 union all\n"
+          + "\tselect ENAME, 50020678 as cat_id, '93' as cat_name, 1 as require_free_postage, 0 as  require_15return, 0 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020678 union all\n"
+          + "\tselect ENAME, 121398012 as cat_id, '94' as cat_name, 1 as require_free_postage, 0 as  require_15return, 0 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 121398012 union all\n"
+          + "\tselect ENAME, 50020720 as cat_id, '95' as cat_name, 1 as require_free_postage, 0 as  require_15return, 0 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50020720 union all\n"
+          + "\tselect ENAME, 50001714 as cat_id, '96' as cat_name, 0 as require_free_postage, 1 as  require_15return, 1 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50001714 union all\n"
+          + "\tselect ENAME, 50008905 as cat_id, '97' as cat_name, 1 as require_free_postage, 0 as  require_15return, 1 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50008905 union all\n"
+          + "\tselect ENAME, 50008904 as cat_id, '98' as cat_name, 1 as require_free_postage, 0 as  require_15return, 1 as require_48hour,1 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50008904 union all\n"
+          + "\tselect ENAME, 50022358 as cat_id, '99' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022358 union all\n"
+          + "\tselect ENAME, 50022371 as cat_id, '100' as cat_name, 0 as require_free_postage, 0 as  require_15return, 0 as require_48hour,0 as  require_insurance from emp where EMPNO = 20171216 and MGR = 0 and ENAME = 'Y' and SAL = 50022371\n"
+          + ") a";
 
   //~ Methods ----------------------------------------------------------------
 
@@ -183,13 +292,83 @@ public class HepPlannerTest extends RelOptTestBase {
     programBuilder.addRuleInstance(FilterToCalcRule.INSTANCE);
 
     HepPlanner planner = new HepPlanner(programBuilder.build());
-    planner.setRoot(
-        tester.convertSqlToRel("select upper(name) from dept where deptno=20").rel);
+    planner.setRoot(tester
+        .convertSqlToRel("select upper(name) from dept where deptno=20").rel);
     planner.findBestExp();
     // Reuse of HepPlanner (should trigger GC).
-    planner.setRoot(
-        tester.convertSqlToRel("select upper(name) from dept where deptno=20").rel);
+    planner.setRoot(tester
+        .convertSqlToRel("select upper(name) from dept where deptno=20").rel);
     planner.findBestExp();
+  }
+
+  @Test public void testRuleApply() throws Exception {
+    //Test HepMatchOrder.ARBITRARY
+    HepProgramBuilder programBuilder1 = HepProgram.builder();
+    programBuilder1.addMatchOrder(HepMatchOrder.ARBITRARY);
+    programBuilder1.addRuleInstance(ReduceExpressionsRule.FILTER_INSTANCE);
+    programBuilder1.addRuleInstance(ReduceExpressionsRule.PROJECT_INSTANCE);
+
+    HepTestListener listener1 = new HepTestListener(0);
+    HepPlanner planner1 = new HepPlanner(programBuilder1.build());
+    planner1.addListener(listener1);
+    planner1.setRoot(tester.convertSqlToRel(COMPLEX_UNION_TREE).rel);
+    planner1.findBestExp();
+    Long applyTimes1 = listener1.getApplyTimes();
+    assertThat(applyTimes1, is(5451L));
+
+    //Test HepMatchOrder.ARBITRARY
+    HepProgramBuilder programBuilder2 = HepProgram.builder();
+    programBuilder2.addMatchOrder(HepMatchOrder.DEPTH_FIRST);
+    programBuilder2.addRuleInstance(ReduceExpressionsRule.FILTER_INSTANCE);
+    programBuilder2.addRuleInstance(ReduceExpressionsRule.PROJECT_INSTANCE);
+
+    HepTestListener listener2 = new HepTestListener(0);
+    HepPlanner planner2 = new HepPlanner(programBuilder2.build());
+    planner2.addListener(listener2);
+    planner2.setRoot(tester.convertSqlToRel(COMPLEX_UNION_TREE).rel);
+    planner2.findBestExp();
+    Long applyTimes2 = listener2.getApplyTimes();
+    assertThat(applyTimes2, is(302L));
+
+    //The count of Rule Apply is more than 10 times
+    assertThat(applyTimes1 > applyTimes2 * 10, is(true));
+  }
+
+  /**
+   * Listener for Hep Test
+   */
+  private class HepTestListener implements RelOptListener {
+    private long applyTimes;
+
+    HepTestListener(long applyTimes) {
+      this.applyTimes = applyTimes;
+    }
+
+    public long getApplyTimes() {
+      return applyTimes;
+    }
+
+    @Override public void relEquivalenceFound(RelEquivalenceEvent event) {
+
+    }
+
+    @Override public void ruleAttempted(RuleAttemptedEvent event) {
+      if (event.isBefore()) {
+        ++applyTimes;
+      }
+    }
+
+    @Override public void ruleProductionSucceeded(RuleProductionEvent event) {
+
+    }
+
+    @Override public void relDiscarded(RelDiscardedEvent event) {
+
+    }
+
+    @Override public void relChosen(RelChosenEvent event) {
+
+    }
   }
 }
 

--- a/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
@@ -328,7 +328,7 @@ public class HepPlannerTest extends RelOptTestBase {
     planner2.setRoot(tester.convertSqlToRel(COMPLEX_UNION_TREE).rel);
     planner2.findBestExp();
     Long applyTimes2 = listener2.getApplyTimes();
-    assertThat(applyTimes2, is(302L));
+    assertThat(applyTimes2, is(403L));
 
     //The count of Rule Apply is more than 10 times
     assertThat(applyTimes1 > applyTimes2 * 10, is(true));


### PR DESCRIPTION
HepPlanner apply more and more rules, it spend more time on rule apply.
When it happen transformation in one rule apply, then the previous relNodes are all applied again.
and so when it happen transformation, then rule apply the left relNodes like depth first search, and when all rule for left relNodes are applied, then restart from the root of plan tree, it decrease the count of rule applied.