### PR TITLE
[CALCITE-2113] Push Column pruning to Druid when aggregate cannot be pushed

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/ExtractProjectFromAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ExtractProjectFromAggregateRule.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.MappingType;
+import org.apache.calcite.util.mapping.Mappings;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Rule to extract a {@link org.apache.calcite.rel.core.Project} from
+ * {@link org.apache.calcite.rel.core.Aggregate} based on the fields used in the aggregate.
+ */
+public class ExtractProjectFromAggregateRule extends RelOptRule {
+
+  /**
+   * Creates a ExtractProjectFromAggregateRule.
+   *
+   * @param relBuilderFactory Builder for relational expressions
+   */
+  public ExtractProjectFromAggregateRule(
+      Class<? extends Aggregate> aggregateClass,
+      Class<? extends RelNode> inputClass,
+      RelBuilderFactory relBuilderFactory) {
+    this(operand(aggregateClass, operand(inputClass, any())),
+        relBuilderFactory);
+  }
+
+  protected ExtractProjectFromAggregateRule(RelOptRuleOperand operand,
+      RelBuilderFactory builderFactory) {
+    super(operand, builderFactory, null);
+  }
+
+  public void onMatch(RelOptRuleCall call) {
+    final Aggregate aggregate = call.rel(0);
+    final RelNode input = call.rel(1);
+    // Compute which input fields are used.
+    // 1. group fields are always used
+    final ImmutableBitSet.Builder inputFieldsUsed =
+        aggregate.getGroupSet().rebuild();
+    // 2. agg functions
+    for (AggregateCall aggCall : aggregate.getAggCallList()) {
+      for (int i : aggCall.getArgList()) {
+        inputFieldsUsed.set(i);
+      }
+      if (aggCall.filterArg >= 0) {
+        inputFieldsUsed.set(aggCall.filterArg);
+      }
+    }
+    RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
+    RelBuilder relBuilder = call.builder();
+
+    List<RexNode> projects = Lists.newArrayList();
+    final Mapping mapping =
+        Mappings.create(
+            MappingType.INVERSE_SURJECTION,
+            aggregate.getInput().getRowType().getFieldCount(),
+            inputFieldsUsed.cardinality());
+    final Map<Integer, Integer> newKeys = new HashMap<>();
+    int j = 0;
+    for (int i : inputFieldsUsed.build()) {
+      projects.add(rexBuilder.makeInputRef(aggregate.getInput(), i));
+      mapping.set(i, j++);
+    }
+
+    relBuilder = relBuilder.push(input).project(projects);
+
+    final ImmutableBitSet newGroupSet =
+        Mappings.apply(mapping, aggregate.getGroupSet());
+
+    final ImmutableList<ImmutableBitSet> newGroupSets =
+        ImmutableList.copyOf(
+            Iterables.transform(aggregate.getGroupSets(),
+                new Function<ImmutableBitSet, ImmutableBitSet>() {
+                  public ImmutableBitSet apply(ImmutableBitSet input) {
+                    return Mappings.apply(mapping, input);
+                  }
+                }));
+    final List<RelBuilder.AggCall> newAggCallList = new ArrayList<>();
+    for (AggregateCall aggCall : aggregate.getAggCallList()) {
+      final ImmutableList<RexNode> args =
+          relBuilder.fields(
+              Mappings.apply2(mapping, aggCall.getArgList()));
+      final RexNode filterArg = aggCall.filterArg < 0 ? null
+          : relBuilder.field(Mappings.apply(mapping, aggCall.filterArg));
+      RelBuilder.AggCall newAggCall =
+          relBuilder.aggregateCall(aggCall.getAggregation(),
+              aggCall.isDistinct(), aggCall.isApproximate(),
+              filterArg, aggCall.name, args);
+      newAggCallList.add(newAggCall);
+    }
+
+    final RelBuilder.GroupKey groupKey =
+        relBuilder.groupKey(newGroupSet, newGroupSets);
+    RelNode rel = relBuilder.aggregate(groupKey, newAggCallList).build();
+    call.transformTo(rel);
+  }
+}
+
+// End ExtractProjectFromAggregateRule.java

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8024,4 +8024,23 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testExtractProjectFromAggregateRule">
+        <Resource name="sql">
+            <![CDATA[select count(ename)
+from sales.emp_b as e]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
+  LogicalProject(SAL=[$5])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($5)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8024,10 +8024,16 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
         </Resource>
     </TestCase>
-    <TestCase name="testExtractProjectFromAggregateRule">
+    <TestCase name="testAggregateExtractProjectRule">
         <Resource name="sql">
             <![CDATA[select count(ename)
 from sales.emp_b as e]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($5)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
@@ -8036,10 +8042,62 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
+    </TestCase>
+    <TestCase name="testAggregateExtractProjectRuleWithGroupingSets">
+        <Resource name="sql">
+            <![CDATA[select count(ename)
+from sales.emp_b as e]]>
+        </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalAggregate(group=[{}], EXPR$0=[SUM($5)])
+LogicalAggregate(group=[{0, 7}], groups=[[{0, 7}, {0}, {7}]], EXPR$2=[SUM($5)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{0, 2}], groups=[[{0, 2}, {0}, {2}]], EXPR$2=[SUM($1)])
+  LogicalProject(EMPNO=[$0], SAL=[$5], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testAggregateExtractProjectRuleWithGroupingSets2">
+        <Resource name="sql">
+            <![CDATA[select count(ename)
+from sales.emp_b as e]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0, 7}], groups=[[{0, 7}, {0}, {7}]], EXPR$2=[SUM($0)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}]], EXPR$2=[SUM($0)])
+  LogicalProject(EMPNO=[$0], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testAggregateExtractProjectRuleWithFilter">
+        <Resource name="sql">
+            <![CDATA[select count(ename)
+from sales.emp_b as e]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0) FILTER $1])
+  LogicalProject(SAL=[$5], $f1=[=($0, 40)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0) FILTER $1])
+  LogicalProject(SAL=[$5], $f1=[=($0, 40)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
@@ -32,6 +32,7 @@ import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.rules.AggregateFilterTransposeRule;
+import org.apache.calcite.rel.rules.ExtractProjectFromAggregateRule;
 import org.apache.calcite.rel.rules.FilterAggregateTransposeRule;
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
 import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
@@ -110,6 +111,8 @@ public class DruidRules {
       new DruidFilterAggregateTransposeRule(RelFactories.LOGICAL_BUILDER);
   public static final DruidPostAggregationProjectRule POST_AGGREGATION_PROJECT =
       new DruidPostAggregationProjectRule(RelFactories.LOGICAL_BUILDER);
+  public static final DruidExtractProjectFromAggregateRule PROJECT_EXTRACT_RULE =
+      new DruidExtractProjectFromAggregateRule(RelFactories.LOGICAL_BUILDER);
 
   public static final List<RelOptRule> RULES =
       ImmutableList.of(FILTER,
@@ -119,6 +122,7 @@ public class DruidRules {
           //   causes very fine-grained aggregations to be pushed to Druid
           // AGGREGATE_FILTER_TRANSPOSE,
           AGGREGATE_PROJECT,
+          PROJECT_EXTRACT_RULE,
           PROJECT,
           POST_AGGREGATION_PROJECT,
           AGGREGATE,
@@ -1273,6 +1277,29 @@ public class DruidRules {
           relBuilderFactory);
     }
   }
+
+  /**
+   * Rule to extract a {@link org.apache.calcite.rel.core.Project} from
+   * {@link org.apache.calcite.rel.core.Aggregate} on top of
+   * {@link org.apache.calcite.adapter.druid.DruidQuery} based on the fields
+   * used in the aggregate.
+   */
+  public static class DruidExtractProjectFromAggregateRule extends ExtractProjectFromAggregateRule {
+
+    /**
+     * Creates a DruidExtractProjectFromAggregateRule.
+     *
+     * @param relBuilderFactory Builder for relational expressions
+     */
+    public DruidExtractProjectFromAggregateRule(
+        RelBuilderFactory relBuilderFactory) {
+      super(
+          operand(Aggregate.class,
+              operand(DruidQuery.class, none())),
+          relBuilderFactory);
+    }
+  }
+
 }
 
 // End DruidRules.java

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
@@ -32,7 +32,7 @@ import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.rules.AggregateFilterTransposeRule;
-import org.apache.calcite.rel.rules.ExtractProjectFromAggregateRule;
+import org.apache.calcite.rel.rules.AggregateExtractProjectRule;
 import org.apache.calcite.rel.rules.FilterAggregateTransposeRule;
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
 import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
@@ -111,8 +111,8 @@ public class DruidRules {
       new DruidFilterAggregateTransposeRule(RelFactories.LOGICAL_BUILDER);
   public static final DruidPostAggregationProjectRule POST_AGGREGATION_PROJECT =
       new DruidPostAggregationProjectRule(RelFactories.LOGICAL_BUILDER);
-  public static final DruidExtractProjectFromAggregateRule PROJECT_EXTRACT_RULE =
-      new DruidExtractProjectFromAggregateRule(RelFactories.LOGICAL_BUILDER);
+  public static final DruidAggregateExtractProjectRule PROJECT_EXTRACT_RULE =
+      new DruidAggregateExtractProjectRule(RelFactories.LOGICAL_BUILDER);
 
   public static final List<RelOptRule> RULES =
       ImmutableList.of(FILTER,
@@ -1284,14 +1284,14 @@ public class DruidRules {
    * {@link org.apache.calcite.adapter.druid.DruidQuery} based on the fields
    * used in the aggregate.
    */
-  public static class DruidExtractProjectFromAggregateRule extends ExtractProjectFromAggregateRule {
+  public static class DruidAggregateExtractProjectRule extends AggregateExtractProjectRule {
 
     /**
-     * Creates a DruidExtractProjectFromAggregateRule.
+     * Creates a DruidAggregateExtractProjectRule.
      *
      * @param relBuilderFactory Builder for relational expressions
      */
-    public DruidExtractProjectFromAggregateRule(
+    public DruidAggregateExtractProjectRule(
         RelBuilderFactory relBuilderFactory) {
       super(
           operand(Aggregate.class,

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -3086,8 +3086,8 @@ public class DruidAdapterIT {
         + "group by \"B\"";
     String expectedSubExplain = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
-        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], projects=[[$63, "
-        + "$89]], groups=[{0}], aggs=[[COUNT($1)]]";
+        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], projects=[[$89, "
+        + "$63]], groups=[{1}], aggs=[[COUNT($0)]]";
 
     testCountWithApproxDistinct(true, sql, expectedSubExplain);
     testCountWithApproxDistinct(false, sql, expectedSubExplain);


### PR DESCRIPTION
This PR introduces a DruidExtractProjectFromAggregateRule which
transforms Aggregate -> DruidQuery to Aggregate -> Project -> DruidQuery.  
The project can then be pushed to Druid using DruidProjectRule. 
Note: this can only be reproduced in DruidAdapterIT by using HepPlanner, so added a test to RelOptRulesTest