### PR TITLE
[CALCITE-2116]Fix bug that the digests are not same for the common su…

### DIFF
--- a/core/src/main/java/org/apache/calcite/interpreter/Interpreter.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Interpreter.java
@@ -48,6 +48,7 @@ import com.google.common.collect.Maps;
 
 import java.math.BigDecimal;
 import java.util.ArrayDeque;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -386,6 +387,7 @@ public class Interpreter extends AbstractEnumerable<Object[]>
   /** Implementation of {@link Source} using a {@link java.util.ArrayDeque}. */
   private static class ListSource implements Source {
     private final ArrayDeque<Row> list;
+    private Iterator<Row> iterator = null;
 
     ListSource(ListSink sink) {
       this.list = sink.list;
@@ -393,8 +395,12 @@ public class Interpreter extends AbstractEnumerable<Object[]>
 
     public Row receive() {
       try {
-        return list.remove();
+        if (iterator == null) {
+          iterator = list.iterator();
+        }
+        return iterator.next();
       } catch (NoSuchElementException e) {
+        iterator = null;
         return null;
       }
     }

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -811,6 +811,9 @@ public class HepPlanner extends AbstractRelOptPlanner {
       rel = rel.copy(rel.getTraitSet(), newInputs);
       onCopy(oldRel, rel);
     }
+    //ComputeDigest when add to DAG firstly
+    // or can't get equivVertex for common subexpression
+    rel.recomputeDigest();
 
     // try to find equivalent rel only if DAG is allowed
     if (!noDAG) {
@@ -886,7 +889,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
     if (mapDigestToVertex.get(oldDigest) == vertex) {
       mapDigestToVertex.remove(oldDigest);
     }
-    String newDigest = rel.recomputeDigest();
+    String newDigest = rel.getDigest();
     // When a transformation happened in one rule apply, support
     // vertex2 replace vertex1, but the current relNode of
     // vertex1 and vertex2 is same,


### PR DESCRIPTION
For the same subquery, we think they have same relNode, but when adding relNode to graph, the digest are not the same,
like testReplaceCommonSubexpression, for subquery "select * from dept", it's expected that the trees of relNode are same, but not.
The reason is that when finding the digest of one relNode by mapDigestToVertex, the digest is from constructor instead of recompute, so the digest can't contain the input of digest and it's not match for the same subquery.
and if the problem is fixed, the union has same inputs for the same subquery. and while executing the result, the source of union are the same, and get one row and remove it for ListSource, but it need be got twice, then the another source is removed at the same time because of the inputs are the same, so the code of ListSource would be modified that the row can't be removed