### PR TITLE
[CALCITE-2090] Extend Druid Range Rules to extract interval from Floor and more fixes

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
@@ -86,8 +86,7 @@ import java.util.Set;
  */
 public abstract class DateRangeRules {
 
-  private DateRangeRules() {
-  }
+  private DateRangeRules() {}
 
   private static final Predicate<Filter> FILTER_PREDICATE =
       new PredicateImpl<Filter>() {

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -868,6 +868,9 @@ public class RexLiteral extends RexNode {
       if (clazz == Long.class) {
         // Milliseconds since 1970-01-01 00:00:00
         return clazz.cast(((TimestampString) value).getMillisSinceEpoch());
+      } else if (clazz == Calendar.class) {
+        // Note: Nanos are ignored
+        return clazz.cast(((TimestampString) value).toCalendar());
       }
       break;
     case INTERVAL_YEAR:

--- a/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
@@ -517,6 +517,114 @@ public class DateRangeRulesTest {
 
   }
 
+  @Test public void testCeilEqRewrite() {
+    final Calendar c = Util.calendar();
+    c.clear();
+    c.set(2010, Calendar.FEBRUARY, 10, 11, 12, 05);
+    final Fixture2 f = new Fixture2();
+    // Always False
+    checkDateRange(f, f.eq(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("false"));
+    checkDateRange(f, f.eq(f.timestampLiteral(TimestampString.fromCalendarFields(c)), f.ceilYear),
+        is("false"));
+
+    c.clear();
+    c.set(2010, Calendar.JANUARY, 1, 0, 0, 0);
+    checkDateRange(f, f.eq(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2009-01-01 00:00:00), <=($9, 2010-01-01 00:00:00))"));
+
+    c.set(2010, Calendar.FEBRUARY, 1, 0, 0, 0);
+    checkDateRange(f, f.eq(f.ceilMonth, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-01-01 00:00:00), <=($9, 2010-02-01 00:00:00))"));
+
+    c.set(2010, Calendar.DECEMBER, 1, 0, 0, 0);
+    checkDateRange(f, f.eq(f.ceilMonth, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-11-01 00:00:00), <=($9, 2010-12-01 00:00:00))"));
+
+    c.set(2010, Calendar.FEBRUARY, 4, 0, 0, 0);
+    checkDateRange(f, f.eq(f.ceilDay, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-02-03 00:00:00), <=($9, 2010-02-04 00:00:00))"));
+
+    c.set(2010, Calendar.DECEMBER, 31, 0, 0, 0);
+    checkDateRange(f, f.eq(f.ceilDay, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-12-30 00:00:00), <=($9, 2010-12-31 00:00:00))"));
+
+    c.set(2010, Calendar.FEBRUARY, 4, 4, 0, 0);
+    checkDateRange(f, f.eq(f.ceilHour, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-02-04 03:00:00), <=($9, 2010-02-04 04:00:00))"));
+
+    c.set(2010, Calendar.DECEMBER, 31, 23, 0, 0);
+    checkDateRange(f, f.eq(f.ceilHour, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-12-31 22:00:00), <=($9, 2010-12-31 23:00:00))"));
+
+    c.set(2010, Calendar.FEBRUARY, 4, 2, 32, 0);
+    checkDateRange(f,
+        f.eq(f.ceilMinute, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-02-04 02:31:00), <=($9, 2010-02-04 02:32:00))"));
+
+    c.set(2010, Calendar.FEBRUARY, 4, 2, 59, 0);
+    checkDateRange(f,
+        f.eq(f.ceilMinute, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("AND(>($9, 2010-02-04 02:58:00), <=($9, 2010-02-04 02:59:00))"));
+  }
+
+  @Test public void testCeilLtRewrite() {
+    final Calendar c = Util.calendar();
+
+    c.clear();
+    c.set(2010, Calendar.FEBRUARY, 10, 11, 12, 05);
+    final Fixture2 f = new Fixture2();
+    checkDateRange(f, f.lt(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("<=($9, 2010-01-01 00:00:00)"));
+
+    c.clear();
+    c.set(2010, Calendar.JANUARY, 1, 0, 0, 0);
+    checkDateRange(f, f.lt(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("<=($9, 2009-01-01 00:00:00)"));
+  }
+
+  @Test public void testCeilLeRewrite() {
+    final Calendar c = Util.calendar();
+    c.clear();
+    c.set(2010, Calendar.FEBRUARY, 10, 11, 12, 05);
+    final Fixture2 f = new Fixture2();
+    checkDateRange(f, f.le(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("<=($9, 2010-01-01 00:00:00)"));
+
+    c.clear();
+    c.set(2010, Calendar.JANUARY, 1, 0, 0, 0);
+    checkDateRange(f, f.le(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is("<=($9, 2010-01-01 00:00:00)"));
+  }
+
+  @Test public void testCeilGtRewrite() {
+    final Calendar c = Util.calendar();
+    c.clear();
+    c.set(2010, Calendar.FEBRUARY, 10, 11, 12, 05);
+    final Fixture2 f = new Fixture2();
+    checkDateRange(f, f.gt(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is(">($9, 2010-01-01 00:00:00)"));
+
+    c.clear();
+    c.set(2010, Calendar.JANUARY, 1, 0, 0, 0);
+    checkDateRange(f, f.gt(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is(">($9, 2010-01-01 00:00:00)"));
+  }
+
+  @Test public void testCeilGeRewrite() {
+    final Calendar c = Util.calendar();
+    c.clear();
+    c.set(2010, Calendar.FEBRUARY, 10, 11, 12, 05);
+    final Fixture2 f = new Fixture2();
+    checkDateRange(f, f.ge(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is(">($9, 2010-01-01 00:00:00)"));
+
+    c.clear();
+    c.set(2010, Calendar.JANUARY, 1, 0, 0, 0);
+    checkDateRange(f, f.ge(f.ceilYear, f.timestampLiteral(TimestampString.fromCalendarFields(c))),
+        is(">($9, 2009-01-01 00:00:00)"));
+  }
+
   private static Set<TimeUnitRange> set(TimeUnitRange... es) {
     return ImmutableSet.copyOf(es);
   }
@@ -548,6 +656,12 @@ public class DateRangeRulesTest {
     private final RexNode floorHour;
     private final RexNode floorMinute;
 
+    private final RexNode ceilYear;
+    private final RexNode ceilMonth;
+    private final RexNode ceilDay;
+    private final RexNode ceilHour;
+    private final RexNode ceilMinute;
+
     Fixture2() {
       exYearTs = rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
           ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.YEAR), ts));
@@ -575,6 +689,17 @@ public class DateRangeRulesTest {
       floorHour = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
           ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.HOUR)));
       floorMinute = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.MINUTE)));
+
+      ceilYear = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.CEIL,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.YEAR)));
+      ceilMonth = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.CEIL,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.MONTH)));
+      ceilDay = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.CEIL,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.DAY)));
+      ceilHour = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.CEIL,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.HOUR)));
+      ceilMinute = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.CEIL,
           ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.MINUTE)));
     }
   }

--- a/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
@@ -353,6 +353,28 @@ public class DateRangeRulesTest {
             + " <($9, 2010-06-01 00:00:00)))"));
   }
 
+  // Test reWrite with multiple operands
+  @Test public void testExtractRewriteMultipleOperands() {
+    final Fixture2 f = new Fixture2();
+    checkDateRange(f,
+        f.and(f.eq(f.exYearTs, f.literal(2010)),
+            f.eq(f.exMonthTs, f.literal(10)),
+            f.eq(f.exMonthD, f.literal(5))),
+        is("AND(AND(>=($9, 2010-01-01 00:00:00), <($9, 2011-01-01 00:00:00)),"
+            + " AND(>=($9, 2010-10-01 00:00:00), <($9, 2010-11-01 00:00:00)),"
+            + " =(EXTRACT(FLAG(MONTH), $8), 5))"));
+
+    checkDateRange(f,
+        f.and(f.eq(f.exYearTs, f.literal(2010)),
+            f.eq(f.exMonthTs, f.literal(10)),
+            f.eq(f.exYearD, f.literal(2011)),
+            f.eq(f.exMonthD, f.literal(5))),
+        is("AND(AND(>=($9, 2010-01-01 00:00:00), <($9, 2011-01-01 00:00:00)),"
+            + " AND(>=($9, 2010-10-01 00:00:00), <($9, 2010-11-01 00:00:00)),"
+            + " AND(>=($8, 2011-01-01), <($8, 2012-01-01)), AND(>=($8, 2011-05-01),"
+            + " <($8, 2011-06-01)))"));
+  }
+
   @Test public void testFloorEqRewrite() {
     final Calendar c = Util.calendar();
     c.clear();

--- a/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
@@ -301,6 +301,10 @@ public class DateRangeRulesTest {
             + " AND(>=($8, 2001-01-01), <($8, 2001-02-01)))))"));
   }
 
+  @Test public void testFloorRewrite(){
+
+  }
+
   private static Set<TimeUnitRange> set(TimeUnitRange... es) {
     return ImmutableSet.copyOf(es);
   }
@@ -316,7 +320,7 @@ public class DateRangeRulesTest {
         DateRangeRules.extractTimeUnits(e);
     for (TimeUnitRange timeUnit : timeUnits) {
       e = e.accept(
-          new DateRangeRules.ExtractShuttle(f.rexBuilder, timeUnit,
+          new DateRangeRules.ExtractAndFloorShuttle(f.rexBuilder, timeUnit,
               operandRanges, timeUnits));
     }
     assertThat(e.toString(), matcher);
@@ -332,6 +336,13 @@ public class DateRangeRulesTest {
     private final RexNode exYearD; // EXTRACT YEAR from DATE field
     private final RexNode exMonthD; // EXTRACT MONTH from DATE field
     private final RexNode exDayD; // EXTRACT DAY from DATE field
+
+    private final RexNode floorYear;
+    private final RexNode floorMonth;
+    private final RexNode floorDay;
+    private final RexNode floorHour;
+    private final RexNode floorMinute;
+    private final RexNode floorSecond;
 
     Fixture2() {
       exYearTs = rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
@@ -350,6 +361,19 @@ public class DateRangeRulesTest {
       exDayD = rexBuilder.makeCall(intRelDataType,
           SqlStdOperatorTable.EXTRACT,
           ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.DAY), d));
+
+      floorYear = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.YEAR)));
+      floorMonth = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.MONTH)));
+      floorDay = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.DAY)));
+      floorHour = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.HOUR)));
+      floorMinute = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.MINUTE)));
+      floorSecond = rexBuilder.makeCall(intRelDataType, SqlStdOperatorTable.FLOOR,
+          ImmutableList.<RexNode>of(ts, rexBuilder.makeFlag(TimeUnitRange.SECOND)));
     }
   }
 }


### PR DESCRIPTION
Extend Druid Range Rules to extract interval from Floor. 

Also fixed couple of more issues found during testing - 
1) DateRangeRules getting into infinite loop when comparing against invalid month/day. e.g extract(month from ts) = 15
2) Month/Day was replaced incorrectly when extract on YEAR resulted in unbounded timerange. e.g extract(YEAR from ts) > 2010 AND extract(Month from ts) = 5, in this case since the year is not bounded, we cannot replace the extract on month. 
3) Fixed issues with rewriting when we have multiple time operands in filter. 

Also, Add tests for all above fixes. 