### PR TITLE
[CALCITE-2143] fix bug where SqlImplementor generated sql that refere…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -946,7 +946,7 @@ public abstract class SqlImplementor {
                 && neededAlias != null
                 && (aliases.size() != 1 || !aliases.containsKey(neededAlias))) {
           newContext =
-              aliasContext(ImmutableMap.of(neededAlias, rel.getRowType()),
+              aliasContext(ImmutableMap.of(neededAlias, rel.getInput(0).getRowType()),
                   qualified);
         } else {
           newContext = aliasContext(aliases, qualified);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2288,6 +2288,25 @@ public class RelToSqlConverterTest {
     sql(sql).ok(expected);
   }
 
+  @Test
+  public void testFieldNamesWithAggregateSubQuery() {
+    final String query = "select mytable.\"city\", sum(mytable.\"store_sales\") as \"my-alias\" \n"
+        + "from (select c.\"city\", s.\"store_sales\" \n"
+        + "from \"sales_fact_1997\" as s \n"
+        + "  join \"customer\" as c using (\"customer_id\") \n"
+        + "group by c.\"city\", s.\"store_sales\") AS mytable\n"
+        + "group by mytable.\"city\"";
+
+    final String expected = "SELECT \"t0\".\"city\", SUM(\"t0\".\"store_sales\") AS \"my-alias\"\n"
+        + "FROM (SELECT \"customer\".\"city\", \"sales_fact_1997\".\"store_sales\"\n"
+        + "FROM \"foodmart\".\"sales_fact_1997\"\n"
+        + "INNER JOIN \"foodmart\".\"customer\" "
+        + "ON \"sales_fact_1997\".\"customer_id\" = \"customer\".\"customer_id\"\n"
+        + "GROUP BY \"customer\".\"city\", \"sales_fact_1997\".\"store_sales\") AS \"t0\"\n"
+        + "GROUP BY \"t0\".\"city\"";
+    sql(query).ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   private static class Sql {
     private CalciteAssert.SchemaSpec schemaSpec;


### PR DESCRIPTION
…nced aliases defined in same statement

I doubt this is the best way to fix this... I'm still wrapping my head around this code. But the point is that field names are being generated that respect aliases defined in the same node. Field names need to be looked up based on input RowType instead. 