### PR TITLE
[calcite-2147] Expand ROLLUP/CUBE when used within GROUPING SETS

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -775,6 +775,24 @@ public class SqlValidatorUtil {
               ((SqlCall) groupExpr).getOperandList());
       builder.add(ImmutableBitSet.union(bitSets));
       return;
+    case ROLLUP:
+    case CUBE: {
+      // GROUPING SETS ( (a), ROLLUP(c,b), CUBE(d,e) ) is EQUIVALENT to
+      // GROUPING SETS ( (a), (c,b), (b) ,(), (d,e), (d), (e) ).
+      // Expand all ROLLUP/CUBE nodes
+
+      List<ImmutableBitSet> operandBitset =
+              analyzeGroupTuple(scope, groupAnalyzer,
+                      ((SqlCall) groupExpr).getOperandList());
+      switch (groupExpr.getKind()) {
+      case ROLLUP:
+        builder.addAll(rollup(operandBitset));
+        return;
+      default:
+        builder.addAll(cube(operandBitset));
+        return;
+      }
+    }
     default:
       builder.add(
           analyzeGroupExpr(scope, groupAnalyzer, groupExpr));

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -305,6 +305,27 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
         + "group by grouping sets ((deptno), (ename, deptno))\n"
         + "order by 2").ok();
   }
+  // Equivalence Example:
+  //   GROUP BY GROUPING SETS (ROLLUP(A, B), CUBE(C,D))
+  // is equal to
+  //   GROUP BY GROUPING SETS ((A,B), (A), (), (C,D), (C), (D) )
+  @Test public void testGroupingSetsWithRollup() {
+    sql("select deptno, ename, sum(sal) from emp\n"
+            + "group by grouping sets ( rollup(deptno), (ename, deptno))\n"
+            + "order by 2").ok();
+  }
+
+  @Test public void testGroupingSetsWithCube() {
+    sql("select deptno, ename, sum(sal) from emp\n"
+            + "group by grouping sets ( (deptno), CUBE(ename, deptno))\n"
+            + "order by 2").ok();
+  }
+
+  @Test public void testGroupingSetsWithRollupCube() {
+    sql("select deptno, ename, sum(sal) from emp\n"
+            + "group by grouping sets ( CUBE(deptno), ROLLUP(ename, deptno))\n"
+            + "order by 2").ok();
+  }
 
   @Test public void testGroupingSetsProduct() {
     // Example in SQL:2011:

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2265,6 +2265,52 @@ LogicalSort(sort0=[$1], dir0=[ASC])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testGroupingSetsWithRollup">
+        <Resource name="sql">
+            <![CDATA[select deptno, ename, sum(sal) from emp
+group by grouping sets (rollup(deptno), (ename, deptno))
+order by 2]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalSort(sort0=[$1], dir0=[ASC])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {}]], EXPR$2=[SUM($2)])
+    LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testGroupingSetsWithCube">
+        <Resource name="sql">
+            <![CDATA[select deptno, ename, sum(sal) from emp
+group by grouping sets ((deptno), cube(ename, deptno))
+order by 2]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalSort(sort0=[$1], dir0=[ASC])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], EXPR$2=[SUM($2)])
+    LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testGroupingSetsWithRollupCube">
+        <Resource name="sql">
+            <![CDATA[select deptno, ename, sum(sal) from emp
+group by grouping sets (cube(deptno), rollup(ename, deptno))
+order by 2]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalSort(sort0=[$1], dir0=[ASC])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], EXPR$2=[SUM($2)])
+    LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+
     <TestCase name="testDuplicateGroupingSets">
         <Resource name="sql">
             <![CDATA[select sum(sal) from emp


### PR DESCRIPTION
When ROLLUP/CUBE are included in GROUPING SETS, the rollup/cube must be expanded and added to the grouping sets. 

core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java: convertGroupSet() is modified to expand the ROLLUP/CUBE operator when included in GROUPING SETS.

core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java:  New tests added to validate the change

core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml: static plans are added to validate the tests.

The equivalence examples are here.
https://technet.microsoft.com/en-us/library/bb510427(v=sql.105).aspx