### PR TITLE
CALCITE-2099 fix incorrect code generated by union

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnion.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnion.java
@@ -62,10 +62,6 @@ public class EnumerableUnion extends Union implements EnumerableRel {
                 Expressions.list(childExp)
                     .appendIfNotNull(result.physType.comparer()));
       }
-
-      // Once the first input has chosen its format, ask for the same for
-      // other inputs.
-      pref = pref.of(result.format);
     }
 
     builder.add(unionExp);

--- a/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
+++ b/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
@@ -132,6 +132,12 @@ public class CsvTest {
     connection.close();
   }
 
+  @Test
+  public void testUnionGroupByWithoutGroupKey() throws SQLException {
+    sql("model", "select count(*) as c1 from EMPS group by NAME union "
+        + "select count(*) as c1  from EMPS group by NAME").ok();
+  }
+
   /**
    * Tests the vanity driver with properties in the URL.
    */


### PR DESCRIPTION

-      // Once the first input has chosen its format, ask for the same for
-      // other inputs.
-      pref = pref.of(result.format);

the first input didn't actually use the 3rd line for its format, it is derived from the caller.  

the problem of the test case is actually caused by this line, while the second `group by` try to derive its result selector, this line will incorrectly changing its pref from `array` to `custom`. 

Test run pass locally 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Calcite ............................................ SUCCESS [  3.773 s]
[INFO] Calcite Linq4j ..................................... SUCCESS [ 11.440 s]
[INFO] Calcite Core ....................................... SUCCESS [04:43 min]
[INFO] Calcite Cassandra .................................. SUCCESS [  3.135 s]
[INFO] Calcite Druid ...................................... SUCCESS [  3.749 s]
[INFO] Calcite Elasticsearch .............................. SUCCESS [  2.782 s]
[INFO] Calcite Elasticsearch5 ............................. SUCCESS [  2.194 s]
[INFO] Calcite Examples ................................... SUCCESS [  0.226 s]
[INFO] Calcite Example CSV ................................ SUCCESS [ 10.016 s]
[INFO] Calcite Example Function ........................... SUCCESS [  2.747 s]
[INFO] Calcite File ....................................... SUCCESS [  6.298 s]
[INFO] Calcite MongoDB .................................... SUCCESS [  1.621 s]
[INFO] Calcite Pig ........................................ SUCCESS [03:26 min]
[INFO] Calcite Piglet ..................................... SUCCESS [  3.922 s]
[INFO] Calcite Plus ....................................... SUCCESS [  4.193 s]
[INFO] Calcite Server ..................................... SUCCESS [  6.023 s]
[INFO] Calcite Spark ...................................... SUCCESS [ 15.920 s]
[INFO] Calcite Splunk ..................................... SUCCESS [  2.096 s]
[INFO] Calcite Ubenchmark ................................. SUCCESS [  4.722 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 09:35 min
[INFO] Finished at: 2018-02-12T18:47:56+08:00
[INFO] Final Memory: 178M/1355M