### PR TITLE
CALCITE-2081 fix join two window function NPE

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
@@ -73,6 +73,8 @@ public class EnumerableRelImplementor extends JavaRelImplementor {
    * details. */
   private static final int MAX_CONSTRUCTOR_ARG_COUNT = 10;
 
+  private int windowCount = 0;
+
   public final Map<String, Object> map;
   private final Map<String, RexToLixTranslator.InputGetter> corrVars =
       Maps.newHashMap();
@@ -552,6 +554,14 @@ public class EnumerableRelImplementor extends JavaRelImplementor {
         register(type);
       }
     }
+  }
+
+  public void setWindowCount(int windowCount) {
+    this.windowCount = windowCount;
+  }
+
+  public int getWindowCount() {
+    return windowCount;
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
@@ -175,10 +175,14 @@ public class EnumerableWindow extends Window implements EnumerableRel {
 
     PhysType inputPhysType = result.physType;
 
+    int windowCount = implementor.getWindowCount();
+
     ParameterExpression prevStart =
-        Expressions.parameter(int.class, builder.newName("prevStart"));
+        Expressions.parameter(int.class, builder.newName("prevStart" + windowCount));
     ParameterExpression prevEnd =
-        Expressions.parameter(int.class, builder.newName("prevEnd"));
+        Expressions.parameter(int.class, builder.newName("prevEnd" + windowCount));
+
+    implementor.setWindowCount(windowCount + 1);
 
     builder.add(Expressions.declare(0, prevStart, null));
     builder.add(Expressions.declare(0, prevEnd, null));

--- a/core/src/test/resources/sql/winagg.iq
+++ b/core/src/test/resources/sql/winagg.iq
@@ -404,4 +404,24 @@ order by gender, r;
 
 !ok
 
+#window function under join operation
+select a."deptno", a.r as ar, b.r as br from
+    (select "deptno", first_value("empid") over (partition by "deptno" order by "commission") as r from "hr"."emps") a
+    join
+    (select "deptno", last_value("empid")  over (partition by "deptno" order by "commission") as r from "hr"."emps") b
+    on a."deptno" = b."deptno" limit 5;
+
++--------+-----+-----+
+| deptno | AR  | BR  |
++--------+-----+-----+
+|     10 | 110 | 110 |
+|     10 | 110 | 110 |
+|     10 | 110 | 110 |
+|     20 | 200 | 200 |
+|     20 | 200 |     |
++--------+-----+-----+
+(5 rows)
+
+!ok
+
 # End winagg.iq


### PR DESCRIPTION
as Luis pointed out, the issue is because of the name collision between two window functions. 
so adding a context to record the window function count to avoid collision is one possible fix.