### PR TITLE
[CALCITE-2196]Update codeGen of metadataHandler in JaninoRelMetadataProvider to include Class definition at begin of dynamic code.

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -23,8 +23,6 @@ import org.apache.calcite.adapter.enumerable.EnumerableProject;
 import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.interpreter.JaninoRexCompiler;
 import org.apache.calcite.linq4j.Ord;
-import org.apache.calcite.linq4j.tree.ClassDeclaration;
-import org.apache.calcite.linq4j.tree.MemberDeclaration;
 import org.apache.calcite.linq4j.tree.Primitive;
 import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.plan.volcano.AbstractConverter;
@@ -68,15 +66,13 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.commons.compiler.CompilerFactoryFactory;
-import org.codehaus.commons.compiler.IClassBodyEvaluator;
 import org.codehaus.commons.compiler.ICompilerFactory;
+import org.codehaus.commons.compiler.ISimpleCompiler;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -378,12 +374,10 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
         buff.append(pair.getKey());
       }
     }
-    ClassDeclaration decl = new ClassDeclaration(0, name, Object.class,
-        ImmutableList.<Type>of(), ImmutableList.<MemberDeclaration>of());
     final List<Object> argList = new ArrayList<Object>(Pair.right(providerList));
     argList.add(0, ImmutableList.copyOf(relClasses));
     try {
-      return compile(decl, buff.toString(), def, argList);
+      return compile(name, buff.toString(), def, argList);
     } catch (CompileException | IOException e) {
       throw new RuntimeException("Error compiling:\n"
           + buff, e);
@@ -435,8 +429,8 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
     return buff;
   }
 
-  static <M extends Metadata> MetadataHandler<M> compile(ClassDeclaration expr,
-      String s, MetadataDef<M> def,
+  static <M extends Metadata> MetadataHandler<M> compile(String className,
+      String classBody, MetadataDef<M> def,
       List<Object> argList) throws CompileException, IOException {
     final ICompilerFactory compilerFactory;
     try {
@@ -445,23 +439,35 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
       throw new IllegalStateException(
           "Unable to instantiate java compiler", e);
     }
-    final IClassBodyEvaluator cbe = compilerFactory.newClassBodyEvaluator();
-    cbe.setClassName(expr.name);
-    cbe.setImplementedInterfaces(new Class[]{def.handlerClass});
-    cbe.setParentClassLoader(JaninoRexCompiler.class.getClassLoader());
+
+    final ISimpleCompiler compiler = compilerFactory.newSimpleCompiler();
+    compiler.setParentClassLoader(JaninoRexCompiler.class.getClassLoader());
+
     if (CalcitePrepareImpl.DEBUG) {
       // Add line numbers to the generated janino class
-      cbe.setDebuggingInformation(true, true, true);
-      System.out.println(s);
+      compiler.setDebuggingInformation(true, true, true);
+      System.out.println(classBody);
     }
-    cbe.cook(new StringReader(s));
-    final Constructor constructor = cbe.getClazz().getDeclaredConstructors()[0];
+
+    StringBuilder buff = new StringBuilder("public final class ");
+    buff.append(className);
+    buff.append(" implements ");
+    buff.append(def.handlerClass.getCanonicalName());
+    buff.append(" { \n");
+    buff.append(classBody);
+    buff.append("\n}");
+
+    compiler.cook(buff.toString());
+    final Constructor constructor;
     final Object o;
     try {
+      constructor = compiler.getClassLoader().loadClass(className)
+              .getDeclaredConstructors()[0];
       o = constructor.newInstance(argList.toArray());
     } catch (InstantiationException
         | IllegalAccessException
-        | InvocationTargetException e) {
+        | InvocationTargetException
+        | ClassNotFoundException e) {
       throw new RuntimeException(e);
     }
     return def.handlerClass.cast(o);

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -249,6 +249,16 @@ log4j.logger.org.apache.calcite.plan.RelOptPlanner=DEBUG
 log4j.logger.org.apache.calcite.plan.hep.HepPlanner=TRACE
 {% endhighlight %}
 
+## Debug generated class in Intellij
+
+Calcite uses janino to generates Java code. The generated classes can be debugged interactively, see more details in <http://janino-compiler.github.io/janino/">the Janino tutorial</a>..
+
+To debug generated class, all that needs to be done is set two system properties when starting the JVM:
+* `-Dorg.codehaus.janino.source_debugging.enable=true`
+* `-Dorg.codehaus.janino.source_debugging.dir=C:\tmp` (This property is optional; if not set, then the temporary files will be created in the default temporary-file directory.)
+
+After code is generated, mark the folder which contains generated temporary files as generated sources root or sources root manually or directly set the value of `org.codehaus.janino.source_debugging.dir` to existed sources root when starting the JVM.
+
 ## CSV adapter
 
 See the [tutorial]({{ site.baseurl }}/docs/tutorial.html).


### PR DESCRIPTION
JaninoRelMetadataProvider uses IClassBodyEvaluator to compile generated code. The generated classes can not be debugged in interactively using Idea using the method referenced by http://janino-compiler.github.io/janino/ because generated code only contains classBody. 
If using ISimpleCompiler to compile complete compile unit instead of classBody, generated classes can be debugged interactively, even though they were created on-the-fly.