### PR TITLE
[CALCITE-2207] Enforce minimum JDK 8 via maven-enforcer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@ limitations under the License.
     <junit.version>4.12</junit.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <!-- Apache 18 has 3.0.1, but need 3.0.2 for [MSOURCES-94]. -->
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <!-- Apache 18 has 2.10.3, but need 2.10.4 for [MJAVADOC-442]. -->
@@ -671,6 +672,10 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <!-- This is the configuration used by "mvn javadoc:javadoc". It is
              configured strict, so that it shows errors such as broken links in
              javadoc on private methods. The configuration for "mvn site" is
@@ -782,6 +787,26 @@ limitations under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven-checkstyle-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>enforce-java</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireJavaVersion>
+                    <version>[1.8,)</version>
+                  </requireJavaVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Tested with JDK 7:
```
mvn --version
Apache Maven 3.5.3 (3383c37e1f9e9b3bc3df5050c29c8aff9f295297; 2018-02-24T13:49:05-06:00)
Maven home: /usr/local/Cellar/maven/3.5.3/libexec
Java version: 1.7.0_80, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"

mvn clean package -DskipTests
...
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (enforce-java) @ calcite ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.7.0-80 is not in the allowed range [1.8,).
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1:enforce (enforce-java) on project calcite: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
...
```

Checked with JDK 8, 9, and 10-ea and build works as designed.