### PR TITLE
[CALCITE-2063] Add JDK 10 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@
 # limitations under the License.
 #
 language: java
+matrix:
+  fast_finish: true
+  include:
+    - env: IMAGE=maven:3-jdk-10
+    - env: IMAGE=maven:3-jdk-9
+    - env: IMAGE=maven:3-jdk-8
 branches:
   only:
     - master
@@ -24,20 +30,24 @@ branches:
     - javadoc
     - /^branch-.*$/
     - /^[0-9]+-.*$/
+env:
+  global:
+  - DOCKERRUN="docker run -it --rm -v $PWD:/src -v $HOME/.m2:/root/.m2 -w /src"
+services:
+  - docker
+before_install:
+  - docker pull $IMAGE
 install:
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  # Print the Maven version, skip tests and javadoc
+  - $DOCKERRUN $IMAGE mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Djavax.net.ssl.trustStorePassword=changeit -B -V
 script:
+  # Print surefire output to the console instead of files
   - unset _JAVA_OPTIONS
-  - mvn -Dsurefire.useFile=false -Dsurefire.parallel= test
+  - $DOCKERRUN $IMAGE mvn -Dsurefire.useFile=false -Dsurefire.parallel= -Djavax.net.ssl.trustStorePassword=changeit test
 git:
   depth: 10000
-sudo: false
+sudo: required
 cache:
   directories:
     - $HOME/.m2
-matrix:
-  fast_finish: true
-  include:
-    - jdk: oraclejdk8
-    - jdk: oraclejdk9
 # End .travis.yml


### PR DESCRIPTION
Use Docker on Travis CI to get support for JDK 10 and ibmjava.