### PR TITLE
[CALCITE-2222] Add Quarter time unit as a valid floor unit to pushdown to Druid

### DIFF
--- a/druid/src/main/java/org/apache/calcite/adapter/druid/TimeExtractionFunction.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/TimeExtractionFunction.java
@@ -59,6 +59,7 @@ public class TimeExtractionFunction implements ExtractionFunction {
 
   private static final ImmutableSet<TimeUnitRange> VALID_TIME_FLOOR = Sets.immutableEnumSet(
       TimeUnitRange.YEAR,
+      TimeUnitRange.QUARTER,
       TimeUnitRange.MONTH,
       TimeUnitRange.DAY,
       TimeUnitRange.WEEK,


### PR DESCRIPTION
PR Goal: Enhancement of current state
Before Floor with Quarter as time unit was not pushed, After this PR it should be pushed.
PR Testing: Added more tests to DruidIT tests.
More description can be found here https://issues.apache.org/jira/browse/CALCITE-2222
