### PR TITLE
CALCITE-1862  fix stackoverflow when planning

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterMergeRule.java
@@ -81,6 +81,8 @@ public class FilterMergeRule extends RelOptRule {
         .filter(newCondition);
 
     call.transformTo(relBuilder.build());
+    // New plan is absolutely better than old plan.
+    call.getPlanner().setImportance(topFilter, 0.0);
   }
 
   /**

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -365,8 +365,8 @@ window w as (partition by productId)]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalProject(EXPR$0=[DOT(ITEM(DOT(DOT(ITEM($2, 1), 'DETAIL'), 'SKILLS'), +(2, 3)), 'DESC')])
-  LogicalProject(DEPTNO=[$0], NAME=[$1], TYPE=[$2.TYPE], DESC=[$2.DESC], EMPLOYEES=[$3])
+LogicalProject(EXPR$0=[DOT(ITEM(DOT(DOT(ITEM($6, 1), 'DETAIL'), 'SKILLS'), +(2, 3)), 'DESC')])
+  LogicalProject(DEPTNO=[$0], NAME=[$1], TYPE=[$2.TYPE], DESC=[$2.DESC], A=[$2.OTHERS.A], B=[$2.OTHERS.B], EMPLOYEES=[$3])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
 ]]>
         </Resource>

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -2139,4 +2139,36 @@ where false;
 
 !ok
 
+!use scott
+
+select *
+from (
+  select *
+  from (
+    select cast(null as integer) as d
+    from "scott".emp)
+  where d is null and d is null)
+where d is null;
++---+
+| D |
++---+
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
+|   |
++---+
+(14 rows)
+
+!ok
+
 # End misc.iq


### PR DESCRIPTION
overflow happen because FilterMerge is repeatedly applied on the root algebra. 

tests run pass.