### PR TITLE
[CALCITE-2237] Upgrade Maven Surefire plugin to 2.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,8 @@ limitations under the License.
     <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
     <maven-scm-provider.version>1.9.4</maven-scm-provider.version>
     <maven-shade-plugin.version>2.1</maven-shade-plugin.version>
+    <!-- Apache 19 has 2.20.1, but need 2.21.0+ for [MPOM-184] -->
+    <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
     <mockito.version>2.5.5</mockito.version>
     <mongo-java-driver.version>3.5.0</mongo-java-driver.version>
     <mysql-driver.version>5.1.20</mysql-driver.version>
@@ -855,6 +857,7 @@ limitations under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+	  <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <threadCount>1</threadCount>
             <perCoreThreadCount>true</perCoreThreadCount>


### PR DESCRIPTION
Fixes NPE when using Maven Surefire plugin 2.20.1 on JDK 10.
See SUREFIRE-1439 and MPOM-184 for details.