### PR TITLE
[CALCITE-2238] [CALCITE-2239] Fix Pig and Spark adapter failures with JDK 10

### DIFF
--- a/pig/src/test/java/org/apache/calcite/test/PigRelBuilderStyleTest.java
+++ b/pig/src/test/java/org/apache/calcite/test/PigRelBuilderStyleTest.java
@@ -39,6 +39,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.hadoop.fs.Path;
 import org.apache.pig.pigunit.Cluster;
 import org.apache.pig.pigunit.PigTest;
+import org.apache.pig.pigunit.pig.PigServer;
 import org.apache.pig.test.Util;
 
 import org.junit.After;
@@ -277,7 +278,10 @@ public class PigRelBuilderStyleTest extends AbstractPigTest {
 
   @After
   public void shutdownPigServer() {
-    PigTest.getPigServer().shutdown();
+    PigServer pigServer = PigTest.getPigServer();
+    if (pigServer != null) {
+      pigServer.shutdown();
+    }
   }
 
   @Before

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,8 @@ limitations under the License.
     <guava.version>19.0</guava.version>
     <joda.version>2.8.1</joda.version>
     <h2.version>1.4.185</h2.version>
-    <hadoop.version>2.7.0</hadoop.version>
+    <!-- Require Hadoop 2.7.4+ due to HADOOP-14586 -->
+    <hadoop.version>2.7.5</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hppc.version>0.7.1</hppc.version>
     <hsqldb.version>2.4.0</hsqldb.version>


### PR DESCRIPTION
This fixes both CALCITE-2238 and CALCITE-2239 since upgrading
Apache Hadoop to 2.7.4+ fixes Java version parsing. See HADOOP-14586
for more information about how version parsing is important.