### PR TITLE
[CALCITE-2271] Join of two views with window aggregates produces inco…

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
@@ -175,11 +175,11 @@ public class EnumerableWindow extends Window implements EnumerableRel {
 
     PhysType inputPhysType = result.physType;
 
-    final int w = implementor.windowCount++;
+    final int globalWindowIdx = implementor.windowCount++;
     ParameterExpression prevStart =
-        Expressions.parameter(int.class, builder.newName("prevStart" + w));
+        Expressions.parameter(int.class, builder.newName("prevStart_w" + globalWindowIdx));
     ParameterExpression prevEnd =
-        Expressions.parameter(int.class, builder.newName("prevEnd" + w));
+        Expressions.parameter(int.class, builder.newName("prevEnd_w" + globalWindowIdx));
 
     builder.add(Expressions.declare(0, prevStart, null));
     builder.add(Expressions.declare(0, prevEnd, null));
@@ -226,7 +226,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
 
       final Expression list_ =
           builder.append(
-              "list",
+              "list_w" + globalWindowIdx,
               Expressions.new_(
                   ArrayList.class,
                   Expressions.call(
@@ -286,7 +286,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
                 outputPhysType.getJavaFieldType(i)));
       }
 
-      declareAndResetState(typeFactory, builder, result, windowIdx, aggs,
+      declareAndResetState(typeFactory, builder, result, globalWindowIdx, windowIdx, aggs,
           outputPhysType, outputRow);
 
       // There are assumptions that minX==0. If ever change this, look for
@@ -763,7 +763,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
   }
 
   private void declareAndResetState(final JavaTypeFactory typeFactory,
-      BlockBuilder builder, final Result result, int windowIdx,
+      BlockBuilder builder, final Result result, int globalWindowIdx, int windowIdx,
       List<AggImpState> aggs, PhysType outputPhysType,
       List<Expression> outputRow) {
     for (final AggImpState agg : aggs) {
@@ -820,7 +820,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
         ParameterExpression pe =
             Expressions.parameter(type,
                 builder.newName(aggName
-                    + "s" + i + "w" + windowIdx));
+                    + "s" + i + "w" + globalWindowIdx + "n" + windowIdx));
         builder.add(Expressions.declare(0, pe, null));
         decls.add(pe);
       }
@@ -833,7 +833,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
       }
       ParameterExpression aggRes = Expressions.parameter(0,
           aggHolderType,
-          builder.newName(aggName + "w" + windowIdx));
+          builder.newName(aggName + "w" + globalWindowIdx + "n" + windowIdx));
 
       builder.add(
           Expressions.declare(0, aggRes,

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3530,24 +3530,24 @@ public class JdbcTest {
             "deptno=10; empid=150; S=18760.0; FIVE=5; M=7000.0; C=2",
             "deptno=20; empid=200; S=8200.0; FIVE=5; M=8000.0; C=1")
         .planContains(CalcitePrepareImpl.DEBUG
-            ? "_list.add(new Object[] {\n"
+            ? "_list_w0.add(new Object[] {\n"
             + "        row[0],\n" // box-unbox is optimized
             + "        row[1],\n"
             + "        row[2],\n"
             + "        row[3],\n"
-            + "        COUNTa0w0,\n"
-            + "        $SUM0a1w0,\n"
-            + "        MINa2w0,\n"
-            + "        COUNTa3w0});"
-            : "_list.add(new Object[] {\n"
+            + "        COUNTa0w0n0,\n"
+            + "        $SUM0a1w0n0,\n"
+            + "        MINa2w0n0,\n"
+            + "        COUNTa3w0n0});"
+            : "_list_w0.add(new Object[] {\n"
                 + "        row[0],\n" // box-unbox is optimized
                 + "        row[1],\n"
                 + "        row[2],\n"
                 + "        row[3],\n"
-                + "        a0w0,\n"
-                + "        a1w0,\n"
-                + "        a2w0,\n"
-                + "        a3w0});")
+                + "        a0w0n0,\n"
+                + "        a1w0n0,\n"
+                + "        a2w0n0,\n"
+                + "        a3w0n0});")
         .planContains("return new Object[] {\n"
             + "                  current[1],\n"
             + "                  current[0],\n"
@@ -3597,9 +3597,9 @@ public class JdbcTest {
    */
   @Test public void testWinAggScalarNonNullPhysType() {
     String planLine =
-        "a0s0w0 = org.apache.calcite.runtime.SqlFunctions.lesser(a0s0w0, org.apache.calcite.runtime.SqlFunctions.toFloat(_rows[j]));";
+        "a0s0w0n0 = org.apache.calcite.runtime.SqlFunctions.lesser(a0s0w0n0, org.apache.calcite.runtime.SqlFunctions.toFloat(_rows[j]));";
     if (CalcitePrepareImpl.DEBUG) {
-      planLine = planLine.replaceAll("a0s0w0", "MINa0s0w0");
+      planLine = planLine.replaceAll("a0s0w0n0", "MINa0s0w0n0");
     }
     CalciteAssert.hr()
         .query("select min(\"salary\"+1) over w as m\n"
@@ -3622,9 +3622,9 @@ public class JdbcTest {
    */
   @Test public void testWinAggScalarNonNullPhysTypePlusOne() {
     String planLine =
-        "a0s0w0 = org.apache.calcite.runtime.SqlFunctions.lesser(a0s0w0, org.apache.calcite.runtime.SqlFunctions.toFloat(_rows[j]));";
+        "a0s0w0n0 = org.apache.calcite.runtime.SqlFunctions.lesser(a0s0w0n0, org.apache.calcite.runtime.SqlFunctions.toFloat(_rows[j]));";
     if (CalcitePrepareImpl.DEBUG) {
-      planLine = planLine.replaceAll("a0s0w0", "MINa0s0w0");
+      planLine = planLine.replaceAll("a0s0w0n0", "MINa0s0w0n0");
     }
     CalciteAssert.hr()
         .query("select 1+min(\"salary\"+1) over w as m\n"

--- a/core/src/test/resources/sql/winagg.iq
+++ b/core/src/test/resources/sql/winagg.iq
@@ -414,8 +414,7 @@ join (
   select "deptno", last_value("empid") over w as r
   from "hr"."emps"
   window w as (partition by "deptno" order by "commission")) b
-on a."deptno" = b."deptno"
-limit 5;
+on a."deptno" = b."deptno" and a.r = b.r;
 
 +--------+-----+-----+
 | deptno | AR  | BR  |
@@ -424,9 +423,37 @@ limit 5;
 |     10 | 110 | 110 |
 |     10 | 110 | 110 |
 |     20 | 200 | 200 |
-|     20 | 200 |     |
 +--------+-----+-----+
-(5 rows)
+(4 rows)
+
+!ok
+
+# [CALCITE-2271] Two windows under a JOIN 2
+select
+ t1.l, t1.key as key1, t2.key as key2
+from
+ (
+  select
+   dense_rank() over (order by key) l,
+   key
+  from
+   unnest(map[1,1,2,2]) k
+ ) t1
+ join
+ (
+  select
+   dense_rank() over(order by key) l,
+   key
+  from
+   unnest(map[2,2]) k
+ ) t2 on (t1.l = t2.l and t1.key + 1 = t2.key);
+
++---+------+------+
+| L | KEY1 | KEY2 |
++---+------+------+
+| 1 |    1 |    2 |
++---+------+------+
+(1 row)
 
 !ok
 


### PR DESCRIPTION
…rrect results or NPE

Ensures that result and state variables (aXwY and aXsYwZ) and 'list' variable of window aggregates have unique names during join to avoid conflicts during blocks merge.