### PR TITLE
CALCITE-2275: Using logical NOT operator in Join condition leads to m…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -3358,6 +3358,7 @@ public abstract class RelOptUtil {
     case OR:
     case INPUT_REF:
     case LITERAL:
+    case NOT:
       return node;
     default:
       final ImmutableBitSet bits = RelOptUtil.InputFinder.bits(node);

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8298,4 +8298,24 @@ LogicalFilter(condition=[CASE(IS NULL($7), IS NULL(20), =(CAST($7):TINYINT NOT N
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testInferringPredicatesWithNotOperatorInJoinCondition">
+      <Resource name="planBefore">
+        <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
+  LogicalJoin(condition=[AND(=($16, $7), NOT(OR(=($7, 4), =($7, 6))))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+      </Resource>
+      <Resource name="planAfter">
+        <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
+  LogicalJoin(condition=[=($16, $7)], joinType=[inner])
+    LogicalFilter(condition=[AND(<>($7, 4), <>($7, 6))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalFilter(condition=[AND(<>($7, 4), <>($7, 6))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+      </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
…istakenly push down this condition

- Adding case with NOT operator for RelOptUtil#pushDownEqualJoinConditions() method;
- Refactoring of two for-each loops into one;
- Test case of successful inferring predicate with NULL in JOIN condition.