### PR TITLE
Add option to use docker to build the website

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,2 +1,3 @@
 .sass-cache
 Gemfile.lock
+.jekyll-metadata

--- a/site/README.md
+++ b/site/README.md
@@ -22,30 +22,59 @@ limitations under the License.
 This directory contains the code for the Apache Calcite web site,
 [calcite.apache.org](https://calcite.apache.org/).
 
-## Setup
+You can build the site manually using your environment or use the docker compose file.
 
-Site generation currently works best with ruby-2.4.1.
+## Manually
+
+### Setup your environment
+
+Site generation currently works best with ruby-2.5.1.
 
 1. `cd site`
 2. `svn co https://svn.apache.org/repos/asf/calcite/site target`
-3. `sudo apt-get install rubygems ruby2.1-dev zlib1g-dev` (linux)
-4. `sudo gem install bundler github-pages jekyll jekyll-oembed`
+3. `sudo apt-get install rubygems ruby2.5-dev zlib1g-dev` (linux)
+4. `sudo gem install bundler`
 5. `bundle install`
 
-## Add javadoc
+### Add javadoc
 
 1. `cd ..`
 2. `mvn -DskipTests site`
 3. `rm -rf site/target/apidocs site/target/testapidocs`
 4. `mv target/site/apidocs target/site/testapidocs site/target`
 
-## Running locally
+### Running locally
 
 Before opening a pull request, you can preview your contributions by
 running from within the directory:
 
 1. `bundle exec jekyll serve`
 2. Open [http://localhost:4000](http://localhost:4000)
+
+## Using docker
+
+### Setup your environment
+
+1. Install [docker](https://docs.docker.com/install/)
+2. Install [docker-compose](https://docs.docker.com/compose/install/)
+
+### Build site
+1. `cd site`
+2. `docker-compose run build-site`
+
+### Generate javadoc
+1. `cd site`
+2. `docker-compose run generate-javadoc`
+
+### Running development mode locally
+You can preview your work while working on the site.
+
+1. `cd site`
+2. `docker-compose run --service-ports dev`
+
+The web server will be started on [http://localhost:4000](http://localhost:4000)
+
+As you make changes to the site, the site will automatically rebuild.
 
 ## Pushing to site
 

--- a/site/docker-compose.yml
+++ b/site/docker-compose.yml
@@ -12,14 +12,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-source 'https://rubygems.org'
-gem 'github-pages', '182'
-gem 'rouge'
-gem 'jekyll-redirect-from'
 
-group :jekyll_plugins do
-  gem 'jekyll_oembed'
-end
-
-# End Gemfile
+version: '3'
+services:
+  dev:
+    image: jekyll/jekyll:3
+    command: jekyll serve --watch --force_polling
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/srv/jekyll
+  build-site:
+    image: jekyll/jekyll:3
+    command: jekyll build
+    volumes:
+      - .:/srv/jekyll
+  generate-javadoc:
+    image: maven:alpine
+    working_dir: /usr/src/calcite
+    command: sh -c "mvn -DskipTests site; rm -rf site/target/apidocs site/target/testapidocs; mkdir -p site/target; mv target/site/apidocs target/site/testapidocs site/target"
+    volumes:
+      - ../:/usr/src/calcite
+      - maven-repo:/root/.m2
+volumes:
+  maven-repo:


### PR DESCRIPTION
I am currently looking into publishing the website for calcite-avatica-go 3.0.0 once its released.

I use Windows as my main environment and didn't want to install ruby and a bunch of dependencies in my Linux VMs.

I added a docker-compose file to automate most of the site authoring steps and to make it easier for contributors to update the site.

I also made the following changes:
- bumped the ruby version.
- bumped the `github-pages` gem to version `182`.
- `jerkyll_oembed` was failing, because it was quite old, so I followed the new instructions from https://github.com/18F/jekyll-oembed
- For the manual (old instructions), I remove the `gem install` command because I think `bundle install` will install the gems from the gemfile. I am not too familiar with ruby, so please let me know if this is wrong.

- I did not use jekyll's `--incremental` for watching changes as it didn't work very well (some pages would not be updated and in some cases, the rebuilt files were broken).

I did not automate the push to site step yet, as it's been a very long time since I've used svn. I think we need to explicitly inform svn when we delete or add files (unlike git where we just delete it from the filesystem), so I wasn't sure how that step could be automated down to 1 command using `docker-compose`. If someone could work out how to do this, I think it would be a very nice addition for a future PR.

pinging @julianhyde  and @michaelmior for review (as you guys seem to work on the site a fair bit)