### PR TITLE
[CALCITE-2276] Fix support for explicit ROW value constructor

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3242,7 +3242,8 @@ SqlNode Expression3(ExprContext exprContext) :
     }
     list = ParenthesizedSimpleIdentifierList() {
         if (exprContext != ExprContext.ACCEPT_ALL
-            && exprContext != ExprContext.ACCEPT_CURSOR)
+            && exprContext != ExprContext.ACCEPT_CURSOR
+            && !this.conformance.allowExplicitRowValueConstructor())
         {
             throw SqlUtil.newContextException(s.end(list),
                 RESOURCE.illegalRowExpression());

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -86,6 +86,10 @@ public abstract class SqlAbstractConformance implements SqlConformance {
   public boolean allowGeometry() {
     return SqlConformanceEnum.DEFAULT.allowGeometry();
   }
+
+  public boolean allowExplicitRowValueConstructor() {
+    return SqlConformanceEnum.DEFAULT.allowExplicitRowValueConstructor();
+  }
 }
 
 // End SqlAbstractConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -306,6 +306,20 @@ public interface SqlConformance {
    * false otherwise.
    */
   boolean allowGeometry();
+
+  /**
+   * Whether to allow SQL syntax "{@code ROW(expr1, expr2, expr3)}".
+   * <p>The equivalent syntax in standard SQL is
+   * "{@code (expr1, expr2, expr3)}".
+   *
+   * <p>PostgreSQL allow this behavior.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#DEFAULT},
+   * {@link SqlConformanceEnum#LENIENT};
+   * false otherwise.
+   */
+  boolean allowExplicitRowValueConstructor();
 }
 
 // End SqlConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -239,6 +239,16 @@ public enum SqlConformanceEnum implements SqlConformance {
       return false;
     }
   }
+
+  public boolean allowExplicitRowValueConstructor() {
+    switch (this) {
+    case DEFAULT:
+    case LENIENT:
+      return true;
+    default:
+      return false;
+    }
+  }
 }
 
 // End SqlConformanceEnum.java

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1016,6 +1016,26 @@ public class SqlParserTest {
         "SELECT `T`.`R`.`EXPR$1`.`EXPR$2`\n"
             + "FROM (SELECT (ROW((ROW(1, 2)), (ROW(3, 4, 5, 6)))) AS `R`\n"
             + "FROM `SALES`.`DEPTS`) AS `T`");
+
+    // Conformance DEFAULT and LENIENT support explicit row value constructor
+    conformance = SqlConformanceEnum.DEFAULT;
+    check("select row(t1a, t2a) from t1",
+          "SELECT (ROW(`T1A`, `T2A`))\n"
+            + "FROM `T1`");
+    conformance = SqlConformanceEnum.LENIENT;
+    check("select row(t1a, t2a) from t1",
+          "SELECT (ROW(`T1A`, `T2A`))\n"
+            + "FROM `T1`");
+
+    String pattern = "ROW expression encountered in illegal context";
+    conformance = SqlConformanceEnum.MYSQL_5;
+    sql("select ^row(t1a, t2a)^ from t1").fails(pattern);
+    conformance = SqlConformanceEnum.ORACLE_12;
+    sql("select ^row(t1a, t2a)^ from t1").fails(pattern);
+    conformance = SqlConformanceEnum.STRICT_2003;
+    sql("select ^row(t1a, t2a)^ from t1").fails(pattern);
+    conformance = SqlConformanceEnum.SQL_SERVER_2008;
+    sql("select ^row(t1a, t2a)^ from t1").fails(pattern);
   }
 
   @Test public void testPeriod() {

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -1330,8 +1330,27 @@ from "scott".emp;
 # Explicit ROW
 select deptno, row (empno, deptno) as r
 from "scott".emp;
-ROW expression encountered in illegal context
-!error
++--------+------------+
+| DEPTNO | R          |
++--------+------------+
+|     10 | {7782, 10} |
+|     10 | {7839, 10} |
+|     10 | {7934, 10} |
+|     20 | {7369, 20} |
+|     20 | {7566, 20} |
+|     20 | {7788, 20} |
+|     20 | {7876, 20} |
+|     20 | {7902, 20} |
+|     30 | {7499, 30} |
+|     30 | {7521, 30} |
+|     30 | {7654, 30} |
+|     30 | {7698, 30} |
+|     30 | {7844, 30} |
+|     30 | {7900, 30} |
++--------+------------+
+(14 rows)
+
+!ok
 
 # [CALCITE-877] Allow ROW as argument to COLLECT
 select deptno, collect(r) as empnos


### PR DESCRIPTION
Because ROW(...) and (...) is equivalent and ROW is optional in SQL STD, we should support this.

JIRA: [CALCITE-2276](https://issues.apache.org/jira/browse/CALCITE-2276).