### PR TITLE
[CALCITE-2289] Enable html5 for Javadoc on JDK 9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 script:
   # Print surefire output to the console instead of files
   - unset _JAVA_OPTIONS
-  - $DOCKERRUN $IMAGE mvn -Dsurefire.useFile=false -Dsurefire.parallel= -Djavax.net.ssl.trustStorePassword=changeit test
+  - $DOCKERRUN $IMAGE mvn -Dsurefire.useFile=false -Dsurefire.parallel= -Djavax.net.ssl.trustStorePassword=changeit test javadoc:javadoc javadoc:test-javadoc
 git:
   depth: 10000
 sudo: required

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ limitations under the License.
     <checksum-maven-plugin.version>1.2</checksum-maven-plugin.version>
     <chinook-data-hsqldb.version>0.1</chinook-data-hsqldb.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
-    <commons-lang3.version>3.2</commons-lang3.version>
+    <commons-lang3.version>3.7</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <elasticsearch-java-driver.version>2.3.2</elasticsearch-java-driver.version>
     <elasticsearch5-java-driver.version>5.5.2</elasticsearch5-java-driver.version>
@@ -81,6 +81,9 @@ limitations under the License.
     <!-- We support (and test against) Guava versions between
          19.0 and 23.0. Default is 19.0 due to Cassandra adapter. -->
     <guava.version>19.0</guava.version>
+    <!-- Default to html4 for JDK 8 but html5 on jdk9+ -->
+    <javadoc-additionalOptions></javadoc-additionalOptions>
+    <javadoc-link>https://docs.oracle.com/javase/8/docs/api/</javadoc-link>
     <joda.version>2.8.1</joda.version>
     <h2.version>1.4.185</h2.version>
     <!-- Require Hadoop 2.7.4+ due to HADOOP-14586 -->
@@ -682,13 +685,20 @@ limitations under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <additionalparam>-html5</additionalparam>
+          <additionalOptions>${javadoc-additionalOptions}</additionalOptions>
           <links>
-            <link>https://docs.oracle.com/javase/9/docs/api/</link>
+            <link>${javadoc-link}</link>
           </links>
           <excludePackageNames>org.apache.calcite.benchmarks.generated,org.apache.calcite.sql.parser.ddl,org.apache.calcite.sql.parser.impl,org.apache.calcite.sql.parser.parserextensiontesting,org.apache.calcite.piglet.parser,org.openjdk.jmh</excludePackageNames>
           <show>private</show>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <!-- Override apache parent POM's definition of release
@@ -1120,6 +1130,16 @@ limitations under the License.
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>java9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <javadoc-additionalOptions>-html5</javadoc-additionalOptions>
+        <javadoc-link>https://docs.oracle.com/javase/9/docs/api/</javadoc-link>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
* Add JDK9+ profile to enable -html5 for javadoc
* Add javadoc verification to .travis.yml to match Jenkins build