### PR TITLE
[CALCITE-2301] Remove the 10-second-timeout restriction in ResultSetEnumerable

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/ResultSetEnumerable.java
+++ b/core/src/main/java/org/apache/calcite/runtime/ResultSetEnumerable.java
@@ -135,11 +135,6 @@ public class ResultSetEnumerable<T> extends AbstractEnumerable<T> {
     try {
       connection = dataSource.getConnection();
       statement = connection.createStatement();
-      try {
-        statement.setQueryTimeout(10);
-      } catch (SQLFeatureNotSupportedException e) {
-        LOGGER.debug("Failed to set query timeout.");
-      }
       if (statement.execute(sql)) {
         final ResultSet resultSet = statement.getResultSet();
         statement = null;

--- a/core/src/main/java/org/apache/calcite/runtime/ResultSetEnumerable.java
+++ b/core/src/main/java/org/apache/calcite/runtime/ResultSetEnumerable.java
@@ -31,7 +31,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;


### PR DESCRIPTION
It's not a good idea to have the magic number here. Also, databases may not get back within 10 second for various reasons (e.g., in the case of JDBC schema).