### PR TITLE
[CALCITE-2320] Filtering UDF when converting Filter to JDBCFilter

### DIFF
--- a/plus/src/main/java/org/apache/calcite/chinook/ChosenCustomerEmail.java
+++ b/plus/src/main/java/org/apache/calcite/chinook/ChosenCustomerEmail.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.chinook;
+
+/**
+ * Example UDF for where clause to check pushing to JDBC
+ */
+public class ChosenCustomerEmail {
+
+  public String eval() {
+    return "ftremblay@gmail.com";
+  }
+
+}
+
+// End ChosenCustomerEmail.java

--- a/plus/src/main/resources/chinook/chinook.json
+++ b/plus/src/main/resources/chinook/chinook.json
@@ -65,6 +65,10 @@
         {
           "name": "ASCONCATOFPARAMS",
           "className": "org.apache.calcite.chinook.StringConcatFunction"
+        },
+        {
+          "name": "CHOSENCUSTOMEREMAIL",
+          "className": "org.apache.calcite.chinook.ChosenCustomerEmail"
         }
       ]
     }

--- a/plus/src/test/resources/sql/functions.iq
+++ b/plus/src/test/resources/sql/functions.iq
@@ -28,3 +28,14 @@ SELECT email, ASCONCATOFPARAMS(firstname, lastname) AS joined FROM SIMPLE_CUSTOM
 (3 rows)
 
 !ok
+
+# Checks whether CHOOSENCUSTOMFUNCTION function is properly computed and not passed to subschema, like jdbc
+SELECT * FROM SIMPLE_CUSTOMER WHERE email = CHOSENCUSTOMEREMAIL();
++-----------+----------+---------------------+
+| FIRSTNAME | LASTNAME | EMAIL               |
++-----------+----------+---------------------+
+| François  | Tremblay | ftremblay@gmail.com |
++-----------+----------+---------------------+
+(1 row)
+
+!ok


### PR DESCRIPTION
UDFs in WHERE clause can be pushed down to jdbc schema which is an incorrect behavior.  Thus, this change adds the check against such cases.