### PR TITLE
[CALCITE-2265] Strange cast created for ROW comparison

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeFamily;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlCollation;
@@ -38,12 +39,14 @@ import org.apache.calcite.util.Util;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import java.nio.charset.Charset;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.calcite.util.Static.RESOURCE;
 
@@ -1309,6 +1312,59 @@ public abstract class SqlTypeUtil {
     return family;
   }
 
+  /**
+   * Checks if all types in a list have the same family, as determined by
+   * {@link #isSameFamily(RelDataType, RelDataType)}.
+   *
+   * @param types list of types to check
+   * @return true if all types are of the same family
+   */
+  public static boolean isSameFamily(List<RelDataType> types) {
+    final Set<RelDataTypeFamily> families = Sets.newHashSet(RexUtil.families(types));
+    if (families.size() < 2) {
+      return true;
+    } else {
+      for (Pair<RelDataType, RelDataType> adjacent : Pair.adjacents(types)) {
+        if (!isSameFamily(adjacent.left, adjacent.right)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Returns whether two types are scalar types of the same family, or struct types whose fields
+   * are pairwise of the same family.
+   *
+   * @param type1 First type
+   * @param type2 Second type
+   * @return Whether types have the same family
+   */
+  private static boolean isSameFamily(RelDataType type1, RelDataType type2) {
+    if (type1.isStruct() != type2.isStruct()) {
+      return false;
+    }
+
+    if (type1.isStruct()) {
+      int n = type1.getFieldCount();
+      if (n != type2.getFieldCount()) {
+        return false;
+      }
+      for (Pair<RelDataTypeField, RelDataTypeField> pair
+          : Pair.zip(type1.getFieldList(), type2.getFieldList())) {
+        if (!isSameFamily(pair.left.getType(), pair.right.getType())) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    final RelDataTypeFamily family1 = family(type1);
+    final RelDataTypeFamily family2 = family(type2);
+    return family1 == family2;
+  }
+
   /** Returns whether a character data type can be implicitly converted to a
    * given family in a compare operation. */
   private static boolean canConvertStringInCompare(RelDataTypeFamily family) {
@@ -1371,6 +1427,8 @@ public abstract class SqlTypeUtil {
   public static boolean isArray(RelDataType type) {
     return type.getSqlTypeName() == SqlTypeName.ARRAY;
   }
+
+
 }
 
 // End SqlTypeUtil.java

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -73,13 +73,11 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Standard implementation of {@link SqlRexConvertletTable}.
@@ -877,9 +875,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       SqlOperandTypeChecker.Consistency consistency, List<RelDataType> types) {
     switch (consistency) {
     case COMPARE:
-      final Set<RelDataTypeFamily> families =
-          Sets.newHashSet(RexUtil.families(types));
-      if (families.size() < 2) {
+      if (SqlTypeUtil.isSameFamily(types)) {
         // All arguments are of same family. No need for explicit casts.
         return null;
       }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.sql.type;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeSystem;
 
 import com.google.common.collect.Lists;
 
@@ -34,21 +33,21 @@ import static org.junit.Assert.fail;
 public class SqlTypeFactoryTest {
 
   @Test public void testLeastRestrictiveWithAny() {
-    Fixture f = new Fixture();
+    SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(Lists.newArrayList(f.sqlBigInt, f.sqlAny));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.ANY));
   }
 
   @Test public void testLeastRestrictiveWithNumbers() {
-    Fixture f = new Fixture();
+    SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(Lists.newArrayList(f.sqlBigInt, f.sqlInt));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.BIGINT));
   }
 
   @Test public void testLeastRestrictiveWithNullability() {
-    Fixture f = new Fixture();
+    SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(Lists.newArrayList(f.sqlVarcharNullable, f.sqlAny));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.ANY));
@@ -56,7 +55,7 @@ public class SqlTypeFactoryTest {
   }
 
   @Test public void testLeastRestrictiveWithNull() {
-    Fixture f = new Fixture();
+    SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(Lists.newArrayList(f.sqlNull, f.sqlNull));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.NULL));
@@ -77,7 +76,7 @@ public class SqlTypeFactoryTest {
 
   /** Unit test for {@link ArraySqlType#getPrecedenceList()}. */
   @Test public void testArrayPrecedenceList() {
-    Fixture f = new Fixture();
+    SqlTypeFixture f = new SqlTypeFixture();
     assertThat(checkPrecendenceList(f.arrayBigInt, f.arrayBigInt, f.arrayFloat),
         is(3));
     assertThat(
@@ -112,39 +111,6 @@ public class SqlTypeFactoryTest {
     assertThat(SqlTypeUtil.comparePrecision(p0, p1), is(expectedComparison));
     assertThat(SqlTypeUtil.comparePrecision(p0, p0), is(0));
     assertThat(SqlTypeUtil.comparePrecision(p1, p1), is(0));
-  }
-
-  /** Sets up data needed by a test. */
-  private static class Fixture {
-    SqlTypeFactoryImpl typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
-    final RelDataType sqlBigInt = typeFactory.createTypeWithNullability(
-        typeFactory.createSqlType(SqlTypeName.BIGINT), false);
-    final RelDataType sqlBigIntNullable = typeFactory.createTypeWithNullability(
-        typeFactory.createSqlType(SqlTypeName.BIGINT), true);
-    final RelDataType sqlInt = typeFactory.createTypeWithNullability(
-        typeFactory.createSqlType(SqlTypeName.INTEGER), false);
-    final RelDataType sqlVarcharNullable = typeFactory.createTypeWithNullability(
-        typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
-    final RelDataType sqlNull = typeFactory.createTypeWithNullability(
-        typeFactory.createSqlType(SqlTypeName.NULL), false);
-    final RelDataType sqlAny = typeFactory.createTypeWithNullability(
-        typeFactory.createSqlType(SqlTypeName.ANY), false);
-    final RelDataType sqlFloat = typeFactory.createTypeWithNullability(
-        typeFactory.createSqlType(SqlTypeName.FLOAT), false);
-    final RelDataType arrayFloat = typeFactory.createTypeWithNullability(
-        typeFactory.createArrayType(sqlFloat, -1), false);
-    final RelDataType arrayBigInt = typeFactory.createTypeWithNullability(
-        typeFactory.createArrayType(sqlBigIntNullable, -1), false);
-    final RelDataType multisetFloat = typeFactory.createTypeWithNullability(
-        typeFactory.createMultisetType(sqlFloat, -1), false);
-    final RelDataType multisetBigInt = typeFactory.createTypeWithNullability(
-        typeFactory.createMultisetType(sqlBigIntNullable, -1), false);
-    final RelDataType arrayBigIntNullable = typeFactory.createTypeWithNullability(
-        typeFactory.createArrayType(sqlBigIntNullable, -1), true);
-    final RelDataType arrayOfArrayBigInt = typeFactory.createTypeWithNullability(
-        typeFactory.createArrayType(arrayBigInt, -1), false);
-    final RelDataType arrayOfArrayFloat = typeFactory.createTypeWithNullability(
-        typeFactory.createArrayType(arrayFloat, -1), false);
   }
 
 }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+
+/**
+ * Reusable {@link RelDataType} fixtures for tests.
+ */
+class SqlTypeFixture {
+  SqlTypeFactoryImpl typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+  final RelDataType sqlBoolean = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.BOOLEAN), false);
+  final RelDataType sqlBigInt = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.BIGINT), false);
+  final RelDataType sqlBigIntNullable = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+  final RelDataType sqlInt = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.INTEGER), false);
+  final RelDataType sqlDate = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.DATE), false);
+  final RelDataType sqlVarchar = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.VARCHAR), false);
+  final RelDataType sqlChar = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.CHAR), false);
+  final RelDataType sqlVarcharNullable = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+  final RelDataType sqlNull = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.NULL), false);
+  final RelDataType sqlAny = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.ANY), false);
+  final RelDataType sqlFloat = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.FLOAT), false);
+  final RelDataType arrayFloat = typeFactory.createTypeWithNullability(
+      typeFactory.createArrayType(sqlFloat, -1), false);
+  final RelDataType arrayBigInt = typeFactory.createTypeWithNullability(
+      typeFactory.createArrayType(sqlBigIntNullable, -1), false);
+  final RelDataType multisetFloat = typeFactory.createTypeWithNullability(
+      typeFactory.createMultisetType(sqlFloat, -1), false);
+  final RelDataType multisetBigInt = typeFactory.createTypeWithNullability(
+      typeFactory.createMultisetType(sqlBigIntNullable, -1), false);
+  final RelDataType arrayBigIntNullable = typeFactory.createTypeWithNullability(
+      typeFactory.createArrayType(sqlBigIntNullable, -1), true);
+  final RelDataType arrayOfArrayBigInt = typeFactory.createTypeWithNullability(
+      typeFactory.createArrayType(arrayBigInt, -1), false);
+  final RelDataType arrayOfArrayFloat = typeFactory.createTypeWithNullability(
+      typeFactory.createArrayType(arrayFloat, -1), false);
+}
+
+// End SqlTypeFixture.java

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.util.Pair;
+
+import static org.apache.calcite.sql.type.SqlTypeUtil.isSameFamily;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test of {@link org.apache.calcite.sql.type.SqlTypeUtil}.
+ */
+public class SqlTypeUtilTest {
+
+  private final SqlTypeFixture f = new SqlTypeFixture();
+
+  @Test
+  public void testTypesIsSameFamilyWithNumberTypes() {
+    assertThat(isSameFamily(ImmutableList.of(f.sqlBigInt, f.sqlBigInt)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(f.sqlInt, f.sqlBigInt)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(f.sqlFloat, f.sqlBigInt)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(f.sqlInt, f.sqlBigIntNullable)),
+        is(true));
+  }
+
+  @Test
+  public void testTypesIsSameFamilyWithCharTypes() {
+    assertThat(isSameFamily(ImmutableList.of(f.sqlVarchar, f.sqlVarchar)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(f.sqlVarchar, f.sqlChar)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(f.sqlVarchar, f.sqlVarcharNullable)),
+        is(true));
+  }
+
+  @Test
+  public void testTypesIsSameFamilyWithInconvertibleTypes() {
+    assertThat(isSameFamily(ImmutableList.of(f.sqlBoolean, f.sqlBigInt)), is(false));
+    assertThat(isSameFamily(ImmutableList.of(f.sqlFloat, f.sqlBoolean)), is(false));
+    assertThat(isSameFamily(ImmutableList.of(f.sqlInt, f.sqlDate)), is(false));
+  }
+
+  @Test
+  public void testTypesIsSameFamilyWithNumberStructTypes() {
+    final RelDataType bigIntAndFloat = struct(f.sqlBigInt, f.sqlFloat);
+    final RelDataType floatAndBigInt = struct(f.sqlFloat, f.sqlBigInt);
+
+    assertThat(isSameFamily(ImmutableList.of(bigIntAndFloat, floatAndBigInt)),
+        is(true));
+    assertThat(isSameFamily(ImmutableList.of(bigIntAndFloat, bigIntAndFloat)),
+        is(true));
+    assertThat(isSameFamily(ImmutableList.of(bigIntAndFloat, bigIntAndFloat)),
+        is(true));
+    assertThat(isSameFamily(ImmutableList.of(floatAndBigInt, floatAndBigInt)),
+        is(true));
+  }
+
+  @Test
+  public void testTypesIsSameFamilyWithCharStructTypes() {
+    final RelDataType varCharStruct = struct(f.sqlVarchar);
+    final RelDataType charStruct = struct(f.sqlChar);
+
+    assertThat(isSameFamily(ImmutableList.of(varCharStruct, charStruct)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(charStruct, varCharStruct)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(varCharStruct, varCharStruct)), is(true));
+    assertThat(isSameFamily(ImmutableList.of(charStruct, charStruct)), is(true));
+  }
+
+  @Test
+  public void testTypesIsSameFamilyWithInconvertibleStructTypes() {
+    final RelDataType dateStruct = struct(f.sqlDate);
+    final RelDataType boolStruct = struct(f.sqlBoolean);
+    assertThat(isSameFamily(ImmutableList.of(dateStruct, boolStruct)), is(false));
+
+    final RelDataType charIntStruct = struct(f.sqlChar, f.sqlInt);
+    final RelDataType charDateStruct = struct(f.sqlChar, f.sqlDate);
+    assertThat(isSameFamily(ImmutableList.of(charIntStruct, charDateStruct)),
+        is(false));
+
+    final RelDataType boolDateStruct = struct(f.sqlBoolean, f.sqlDate);
+    final RelDataType floatIntStruct = struct(f.sqlInt, f.sqlFloat);
+    assertThat(isSameFamily(ImmutableList.of(boolDateStruct, floatIntStruct)),
+        is(false));
+  }
+
+  private RelDataType struct(RelDataType...relDataTypes) {
+    final ImmutableList.Builder<Pair<String, RelDataType>> builder = ImmutableList.builder();
+    for (int i = 0; i < relDataTypes.length; i++) {
+      builder.add(Pair.of("field" + i, relDataTypes[i]));
+    }
+    return f.typeFactory.createStructType(builder.build());
+  }
+}
+
+// End SqlTypeUtilTest.java

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -5890,6 +5890,13 @@ public class JdbcTest {
             });
   }
 
+  @Test public void testRowComparison() {
+    CalciteAssert.that()
+        .with(CalciteAssert.Config.JDBC_SCOTT)
+        .query("SELECT empno FROM JDBC_SCOTT.emp WHERE (ename, job) < ('Blake', 'Manager')")
+        .returnsUnordered("EMPNO=7876", "EMPNO=7499", "EMPNO=7698");
+  }
+
   @Test public void testUnicode() throws Exception {
     CalciteAssert.AssertThat with =
         CalciteAssert.that().with(CalciteAssert.Config.FOODMART_CLONE);


### PR DESCRIPTION
Fix for Calcite-2265: https://issues.apache.org/jira/browse/CALCITE-2265

StandardConvertletTable.consistentType now checks if structs' members 
are pair-wise of the same family.

Added isSameFamily methods to SqlTypeUtil to determine if two types, or
a list of types, are of the same family. Added unit test to verify this
new functionality.

Added new case to JdbcTest to verify row comparison are executed in
HSQLDB.

Refactored common code from SqlTypeUtil.isComparable for determining
the family of a RelDataType.

Extracted SqlTypeFixture from SqlTypeFactoryTest.