### PR TITLE
[CALCITE-2324] Extract seconds, minutes from date works not correct in some cases

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -2023,6 +2023,14 @@ public class RexImpTable {
           throw new AssertionError("unexpected " + sqlTypeName);
         }
         break;
+      case HOUR:
+      case MINUTE:
+      case SECOND:
+        switch (sqlTypeName) {
+        case DATE:
+          return Expressions.multiply(operand, Expressions.constant(0L));
+        }
+        break;
       }
 
       operand = mod(operand, getFactor(unit));

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5515,14 +5515,20 @@ public abstract class SqlOperatorBaseTest {
                       // '1970-01-01 00:00:00' for given date
         "BIGINT NOT NULL");
 
-    if (TODO) {
-      // Looks like there is a bug in current execution code which returns 13
-      // instead of 0
-      tester.checkScalar(
-          "extract(second from date '2008-2-23')",
-          "0",
-          "BIGINT NOT NULL");
-    }
+    tester.checkScalar(
+        "extract(second from date '2008-2-23')",
+        "0",
+        "BIGINT NOT NULL");
+
+    tester.checkScalar(
+        "extract(minute from date '9999-2-23')",
+        "0",
+        "BIGINT NOT NULL");
+
+    tester.checkScalar(
+        "extract(minute from date '0001-1-1')",
+        "0",
+        "BIGINT NOT NULL");
 
     tester.checkScalar(
         "extract(minute from date '2008-2-23')",


### PR DESCRIPTION
1) Fix extraction minutes, seconds, hours in case of extract from date
2) updated tests