### PR TITLE
[CALCITE-2331] added ignored unit tests for predicate (A or B) and C which is failing for some adapters

### DIFF
--- a/mongodb/src/test/java/org/apache/calcite/test/MongoAdapterIT.java
+++ b/mongodb/src/test/java/org/apache/calcite/test/MongoAdapterIT.java
@@ -414,6 +414,25 @@ public class MongoAdapterIT {
         .returnsCount(29353);
   }
 
+  /**
+   * In some cases filtering fails when subtree has {@code OR} operator.
+   * Seems like filter evaluation is not properly working for filters of type
+   *
+   * <pre>
+   * {@code A and (B or C)}
+   * {@code (A or B) and C}
+   * </pre>
+   * @see <a href="https://issues.apache.org/jira/browse/CALCITE-2331">[CALCITE-2331]</a>
+   */
+  @Ignore("broken; [CALCITE-2331] is logged to fix it")
+  @Test public void testOrFilter() {
+    CalciteAssert.that()
+        .enable(enabled())
+        .with(ZIPS)
+        .query("select state, city from zips where state in ('NY', 'WI') and city = 'NEW YORK'")
+        .returnsCount(40);
+  }
+
   @Test public void testCountGroupByEmpty() {
     CalciteAssert.that()
         .enable(enabled())


### PR DESCRIPTION
For more information see [CALCITE-2331](https://issues.apache.org/jira/browse/CALCITE-2331).

### "Invalid" queries
```sql
select count(*) from "elastic" where _MAP['foo'] in ('1', '2') and true;
select count(*) from "elastic" where true and _MAP['foo'] in ('1', '2');
select count(*) from "elastic" where (_MAP['foo'] ='1' or _MAP['foo'] = '2') and true;
```
Any expression of type `A and (B or C) `  `(A or B) and C`