### PR TITLE
[CALCITE-2333] Stop releasing zips

### DIFF
--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -34,7 +34,7 @@ adapters.
 Prerequisites are maven (3.5.2 or later)
 and Java (JDK 8, 9 or 10) on your path.
 
-Unpack the source distribution `.tar.gz` or `.zip` file,
+Unpack the source distribution `.tar.gz` file,
 `cd` to the root directory of the unpacked source,
 then build using maven:
 
@@ -591,11 +591,8 @@ The version will be automatically changed when performing the release for real.
   * apache-calcite-X.Y.Z-src.tar.gz
   * apache-calcite-X.Y.Z-src.tar.gz.asc
   * apache-calcite-X.Y.Z-src.tar.gz.sha256
-  * apache-calcite-X.Y.Z-src.zip
-  * apache-calcite-X.Y.Z-src.zip.asc
-  * apache-calcite-X.Y.Z-src.zip.sha256
 * Note that the file names start `apache-calcite-`.
-* In the two source distros `.tar.gz` and `.zip` (currently there is
+* In the source distro `.tar.gz` (currently there is
   no binary distro), check that all files belong to a directory called
   `apache-calcite-X.Y.Z-src`.
 * That directory must contain files `NOTICE`, `LICENSE`,
@@ -688,7 +685,7 @@ curl -O https://dist.apache.org/repos/dist/release/calcite/KEYS
 # (Assumes your O/S has a 'shasum' command.)
 function checkHash() {
   cd "$1"
-  for i in *.{zip,pom,gz}; do
+  for i in *.{pom,gz}; do
     if [ ! -f $i ]; then
       continue
     fi
@@ -733,7 +730,6 @@ https://dist.apache.org/repos/dist/dev/calcite/apache-calcite-X.Y.Z-rcN/
 
 The hashes of the artifacts are as follows:
 src.tar.gz.sha256 XXXX
-src.zip.sha256 XXXX
 
 A staged Maven repository is available for review at:
 https://repository.apache.org/content/repositories/orgapachecalcite-NNNN

--- a/site/downloads/index.md
+++ b/site/downloads/index.md
@@ -49,6 +49,7 @@ Release          | Date       | Commit   | Download
 {% endcomment %}{% endif %}{% comment %}
 {% endcomment %}{% capture d1 %}{{ post.date | date: "%F"}}{% endcapture %}{% comment %}
 {% endcomment %}{% capture d2 %}2017-08-31{% endcapture %}{% comment %}
+{% endcomment %}{% capture d3 %}2018-06-01{% endcapture %}{% comment %}
 {% endcomment %}{% if d1 > d2 %}{% comment %}
 {% endcomment %}{% assign digest = "sha256" %}{% comment %}
 {% endcomment %}{% else %}{% comment %}
@@ -60,10 +61,12 @@ Release          | Date       | Commit   | Download
 {% endcomment %} | <a href="{{ p }}/{{ v }}-src.tar.gz{{ q }}">tar</a>{% comment %}
 {% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.{{ digest }}">digest</a>{% comment %}
 {% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.asc">pgp</a>){% comment %}
+{% endcomment %}{% if d1 < d3 %}{% comment %}
 {% endcomment %} {% raw %}<br>{% endraw %}{% comment %}
 {% endcomment %} <a href="{{ p }}/{{ v }}-src.zip{{ q }}">zip</a>{% comment %}
 {% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.{{ digest }}">digest</a>{% comment %}
 {% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.asc">pgp</a>){% comment %}
+{% endcomment %}{% endif %}{% comment %}
 {% endcomment %}
 {% endfor %}
 

--- a/src/main/config/assemblies/source-assembly.xml
+++ b/src/main/config/assemblies/source-assembly.xml
@@ -18,7 +18,6 @@ limitations under the License.
 <assembly>
   <id>source-release</id>
   <formats>
-    <format>zip</format>
     <format>tar.gz</format>
   </formats>
   <fileSets>


### PR DESCRIPTION
This updates the website and maven configs to stop releasing zips for future releases.

The site was tested locally and works fine.

Can someone verify that I have updated the pom.xml files correctly?