### PR TITLE
[CALCITE-2290] Fix type issue while flattening

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -827,7 +827,8 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
         RelDataType targetType = removeDistinct(rexCall.getType());
         return rexBuilder.makeCast(
             targetType,
-            input);
+            input,
+            true);
       }
       if (!rexCall.isA(SqlKind.COMPARISON)) {
         return super.visitCall(rexCall);

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2839,6 +2839,20 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).with(tester).ok();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2290">[CALCITE-2290]
+   * Type mismatch during flattening</a>. */
+  @Test public void testCaseFlatten() {
+    final String sql = "SELECT (res1 = 'qwe') res2 "
+        + "FROM ("
+        + "  SELECT ("
+        + "    CASE WHEN (FALSE) "
+        + "      THEN NULL"
+        + "      ELSE 'qwe'"
+        + "    END) res1 FROM (values(1)))";
+    sql(sql).ok();
+  }
+
   /**
    * Visitor that checks that every {@link RelNode} in a tree is valid.
    *

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -5244,4 +5244,22 @@ LogicalProject(A=[$0], B=[$1])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testCaseFlatten">
+        <Resource name="sql">
+            <![CDATA[SELECT (res1 = 'qwe') res2 
+FROM (
+  SELECT (
+    CASE WHEN (FALSE)
+      THEN NULL
+      ELSE 'qwe'
+    END) res1 FROM (values(1)))]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(RES2=[=($0, 'qwe')])
+  LogicalProject(RES1=[CAST('qwe'):CHAR(3) CHARACTER SET "ISO-8859-1" COLLATE "ISO-8859-1$en_US$primary"])
+    LogicalValues(tuples=[[{ 1 }]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
Fix an issue during flattening of the rel structure where type nullability
is removed from an expression during rewrite, by instructing
RexBuilder#makeCast to preserve it.