### PR TITLE
[CALCITE-2288] Assertion type issue when reducing expression

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -113,9 +113,6 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.RelBuilder;
 
-import static org.apache.calcite.plan.RelOptRule.none;
-import static org.apache.calcite.plan.RelOptRule.operand;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -128,6 +125,9 @@ import java.util.List;
 import java.util.Properties;
 
 import javax.annotation.Nullable;
+
+import static org.apache.calcite.plan.RelOptRule.none;
+import static org.apache.calcite.plan.RelOptRule.operand;
 
 import static org.junit.Assert.assertTrue;
 
@@ -3921,6 +3921,15 @@ public class RelOptRulesTest extends RelOptTestBase {
     final RelNode relAfter = hepPlanner.findBestExp();
     final String planAfter = NL + RelOptUtil.toString(relAfter);
     diffRepos.assertEquals("planAfter", "${planAfter}", planAfter);
+  }
+
+  @Test public void testPartialExpressionReduction() {
+    final String sql = "select "
+        + "EXTRACT(SECOND FROM CAST(CASE WHEN TRUE THEN {ts '2018-01-01 01:23:45'} ELSE NULL END AS TIMESTAMP)) = "
+        + "EXTRACT(SECOND FROM d) "
+        + "FROM (VALUES({ts '2018-01-01 01:23:45'})) tbl(d)";
+
+    checkPlanning(ReduceExpressionsRule.PROJECT_INSTANCE, sql);
   }
 }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8397,6 +8397,26 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testPartialExpressionReduction">
+        <Resource name="sql">
+            <![CDATA[select
+    EXTRACT(SECOND FROM CAST({ts '2018-01-01 01:23:45'} AS TIMESTAMP)) =
+    EXTRACT(SECOND FROM d) 
+    FROM (VALUES({ts '2018-01-01 01:23:45'})) tbl(d)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EXPR$0=[=(EXTRACT(FLAG(SECOND), CAST(CASE(true, 2018-01-01 01:23:45, null)):TIMESTAMP(0)), EXTRACT(FLAG(SECOND), $0))])
+  LogicalValues(tuples=[[{ 2018-01-01 01:23:45 }]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EXPR$0=[CAST(=(45, EXTRACT(FLAG(SECOND), $0))):BOOLEAN])
+  LogicalValues(tuples=[[{ 2018-01-01 01:23:45 }]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testWhereNotInCorrelated2">
         <Resource name="sql">
             <![CDATA[select * from emp e1


### PR DESCRIPTION
When partially reducing an expression which has a nullable type,
the reducer might drop the nullability bit, causing assertion to fail
while adding the new expression has the type is now different.

Use the newly introduced ExprSimplifier to manage nullability in
RexReplacer so that nullability is preserved.