### PR TITLE
[CALCITE-2342] Fix improper use of assert

### DIFF
--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -538,7 +538,7 @@ public final class Schemas {
       return PathImpl.EMPTY;
     }
     if (!rootSchema.name.isEmpty()) {
-      assert rootSchema.name.equals(iterator.next());
+      Preconditions.checkState(rootSchema.name.equals(iterator.next()));
     }
     for (;;) {
       final String name = iterator.next();


### PR DESCRIPTION
Fix an improper use of assert in Schemas#path(CalciteSchema,
Iterable<String>) causing iterator not to move to the next
element if assertions are not turned on.