### PR TITLE
[CALCITE-2343] Fix infinite loop caused by PushProjector

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1051,6 +1051,12 @@ public class RelOptRulesTest extends RelOptTestBase {
             + "on e.ename = b.ename and e.deptno = 10");
   }
 
+  @Test public void testPushProjectWithOverPastJoin() {
+    checkPlanning(ProjectJoinTransposeRule.INSTANCE,
+        "select e.sal + b.comm, count(e.empno) over() from emp e inner join bonus b "
+            + "on e.ename = b.ename and e.deptno = 10");
+  }
+
   private static final String NOT_STRONG_EXPR =
       "case when e.sal < 11 then 11 else -1 * e.sal end";
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1370,6 +1370,29 @@ LogicalProject(EXPR$0=[+($1, $4)])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testPushProjectWithOverPastJoin">
+        <Resource name="sql">
+            <![CDATA[select e.sal + b.comm, count(e.empno) over() from emp e inner join bonus b on e.ename = b.ename and e.deptno = 10]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EXPR$0=[+($5, $12)], EXPR$1=[COUNT($0) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)])
+  LogicalJoin(condition=[AND(=($1, $9), =($7, 10))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EXPR$0=[+($1, $5)], EXPR$1=[$2])
+  LogicalJoin(condition=[AND(=($0, $4), $3)], joinType=[inner])
+    LogicalProject(ENAME=[$1], SAL=[$5], COUNT=[COUNT($0) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)], ==[=($7, 10)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(ENAME=[$0], COMM=[$3])
+      LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testPushProjectPastInnerJoinStrong">
         <Resource name="sql">
             <![CDATA[select count(*), case when e.sal < 11 then -1 * e.sal else e.sal end


### PR DESCRIPTION
Although PushProject preserves OVER() expression and pushes it
into children projects, it doesn't replace the expression by a
reference in the original top project, causing Hep planner to go
into a loop until a StackOverflowError is thrown.

Fix the issue by changing RefAndExprConverter visitor to check
if the RexOver call is in the list of expressions to preserve, like
any other RexCall node.