### PR TITLE
[CALCITE-2345] added tests using fongo for Mongo Adapter

### DIFF
--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -51,7 +51,6 @@ limitations under the License.
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-linq4j</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -64,6 +63,11 @@ limitations under the License.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.fakemongo</groupId>
+      <artifactId>fongo</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSchema.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSchema.java
@@ -19,13 +19,14 @@ package org.apache.calcite.adapter.mongodb;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
-
 import com.mongodb.client.MongoDatabase;
 
 import java.util.List;
@@ -54,6 +55,17 @@ public class MongoSchema extends AbstractSchema {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Allows tests to inject their instance of the database.
+   *
+   * @param mongoDb existing mongo database instance
+   */
+  @VisibleForTesting
+  MongoSchema(MongoDatabase mongoDb) {
+    super();
+    this.mongoDb = Preconditions.checkNotNull(mongoDb, "mongoDb");
   }
 
   @Override protected Map<String, Table> getTableMap() {

--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.mongodb;
+
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.test.CalciteAssert;
+
+import com.github.fakemongo.junit.FongoRule;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+import org.bson.BsonDocument;
+import org.bson.Document;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Tests current adapter using in-memory (fake) implementation of Mongo API:
+ * <a href="https://github.com/fakemongo/fongo">Fongo</a>.
+ *
+ */
+public class MongoAdapterTest {
+
+  @Rule
+  public final FongoRule rule = new FongoRule();
+
+  private MongoDatabase mongoDb;
+  private MongoCollection<Document> zips;
+
+  @Before
+  public void setUp() throws Exception {
+    mongoDb = rule.getDatabase(getClass().getSimpleName());
+    zips = mongoDb.getCollection("zips");
+  }
+
+  /**
+   * Handcrafted connection where we manually added {@link MongoSchema}
+   */
+  private CalciteAssert.ConnectionFactory newConnectionFactory() {
+    return new CalciteAssert.ConnectionFactory() {
+      @Override public Connection createConnection() throws SQLException {
+        Connection connection = DriverManager.getConnection("jdbc:calcite:");
+        final SchemaPlus root = connection.unwrap(CalciteConnection.class).getRootSchema();
+        root.add("mongo", new MongoSchema(mongoDb));
+        return connection;
+      }
+    };
+  }
+
+  @Test
+  public void single() {
+    zips.insertOne(new Document());
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select * from \"mongo\".\"zips\"")
+            .runs()
+            .returnsCount(1);
+  }
+
+  @Test
+  public void empty() {
+    // for some reason fongo doesn't list collection if it was unused
+    zips.insertOne(new Document());
+    zips.deleteMany(new BsonDocument());
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select * from \"mongo\".\"zips\"")
+            .runs()
+            .returnsCount(0);
+  }
+
+  @Test
+  public void filter() {
+    zips.insertOne(new Document("CITY", "New York").append("STATE", "NY"));
+    zips.insertOne(new Document("CITY", "Washington").append("STATE", "DC"));
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select cast(_MAP['CITY'] as varchar(20)) as \"city\" from \"mongo\".\"zips\" "
+                    + " where _MAP['STATE'] = 'NY'")
+            .returns("city=New York\n");
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select cast(_MAP['CITY'] as varchar(20)) as \"city\" from \"mongo\".\"zips\" "
+                   + " where _MAP['STATE'] = 'DC'")
+            .returns("city=Washington\n");
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select cast(_MAP['CITY'] as varchar(20)) as \"city\" from \"mongo\".\"zips\" "
+                    + " where _MAP['STATE'] in ('DC', 'NY')")
+            .returns("city=New York\ncity=Washington\n");
+  }
+
+  @Test
+  public void limit() {
+    zips.insertOne(new Document("CITY", "New York").append("STATE", "NY"));
+    zips.insertOne(new Document("CITY", "Washington").append("STATE", "DC"));
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select * from \"mongo\".\"zips\" limit 1")
+            .returnsCount(1);
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select * from \"mongo\".\"zips\" limit 2")
+            .returnsCount(2);
+
+  }
+
+  /**
+   * Following queries are not supported in Mongo adapter :
+   * <pre>
+   * {@code A and (B or C)}
+   * {@code (A or B) and C}
+   * </pre>
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/CALCITE-2331">[CALCITE-2331]</a>
+   */
+  @Ignore("broken; [CALCITE-2331] is logged to fix it")
+  @Test
+  public void validateCALCITE2331() {
+    zips.insertOne(new Document("CITY", "New York").append("STATE", "NY"));
+    zips.insertOne(new Document("CITY", "Washington").append("STATE", "DC"));
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select cast(_MAP['CITY'] as varchar(20)) as \"city\" from \"mongo\".\"zips\" "
+                    + " where _MAP['STATE'] in ('DC', 'NY') and _MAP['CITY'] = 'New York'")
+            .returns("city=New York\n");
+  }
+}
+
+// End MongoAdapterTest.java

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@ limitations under the License.
     <freemarker.version>2.3.25-incubating</freemarker.version>
     <git-commit-id-plugin.version>2.1.9</git-commit-id-plugin.version>
     <geode.version>1.3.0</geode.version>
+    <fongo.version>2.1.1</fongo.version>
 
     <!-- We support (and test against) Guava versions between
          19.0 and 23.0. Default is 19.0 due to Cassandra adapter. -->
@@ -457,6 +458,11 @@ limitations under the License.
         <groupId>org.mongodb</groupId>
         <artifactId>mongo-java-driver</artifactId>
         <version>${mongo-java-driver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.fakemongo</groupId>
+        <artifactId>fongo</artifactId>
+        <version>${fongo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
Better test coverage for Mongo Adapter using in-memory implementation of Mongo API:  [Fongo](https://github.com/fakemongo/fongo)