### PR TITLE
[CALCITE-2353] Allow user to override SqlSetOption

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3528,13 +3528,13 @@ SqlAlter SqlAlter() :
     <ALTER> { s = span(); }
     scope = Scope()
     (
-        alterNode = SqlSetOption(s, scope)
-
 <#-- additional literal parser methods are included here -->
 <#list parser.alterStatementParserMethods as method>
-    |
         alterNode = ${method}(s, scope)
+    |
 </#list>
+
+        alterNode = SqlSetOption(s, scope)
     )
     {
         return alterNode;


### PR DESCRIPTION
If alterStatementParserMethods are added before SqlSetOption then the user can replace SqlSetOption. This change matches how statementParserMethods are added at the top level.