### PR TITLE
[CALCITE-2357] Freemarker dependency override issue in fmpp maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@ limitations under the License.
     <xalan.version>2.7.1</xalan.version>
     <xerces.version>2.9.1</xerces.version>
     <sketches.version>0.9.0</sketches.version>
+    <fmpp.version>0.9.14</fmpp.version>
   </properties>
 
   <issueManagement>
@@ -771,6 +772,17 @@ limitations under the License.
               <groupId>org.freemarker</groupId>
               <artifactId>freemarker</artifactId>
               <version>${freemarker.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>net.sourceforge.fmpp</groupId>
+              <artifactId>fmpp</artifactId>
+              <version>${fmpp.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>org.freemarker</groupId>
+                  <artifactId>freemarker</artifactId>
+                </exclusion>
+              </exclusions>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
This PR fixed fmpp maven plugin  indirectly depend on freemarker which override the explicit dependency.