### PR TITLE
[CALCITE-2358] use null literal instead of empty string

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfig.java
@@ -32,6 +32,8 @@ public interface CalciteConnectionConfig extends ConnectionConfig {
   boolean approximateTopN();
   /** @see CalciteConnectionProperty#APPROXIMATE_DECIMAL */
   boolean approximateDecimal();
+  /** @see CalciteConnectionProperty#NULL_IS_EMPTY */
+  boolean nullIsEmpty();
   /** @see CalciteConnectionProperty#AUTO_TEMP */
   boolean autoTemp();
   /** @see CalciteConnectionProperty#MATERIALIZATIONS_ENABLED */

--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
@@ -63,6 +63,10 @@ public class CalciteConnectionConfigImpl extends ConnectionConfigImpl
         .getBoolean();
   }
 
+  @Override public boolean nullIsEmpty() {
+    return CalciteConnectionProperty.NULL_IS_EMPTY.wrap(properties).getBoolean();
+  }
+
   public boolean autoTemp() {
     return CalciteConnectionProperty.AUTO_TEMP.wrap(properties).getBoolean();
   }

--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionProperty.java
@@ -48,6 +48,11 @@ public enum CalciteConnectionProperty implements ConnectionProperty {
    * DECIMAL types are acceptable. */
   APPROXIMATE_DECIMAL("approximateDecimal", Type.BOOLEAN, false, false),
 
+  /**
+   * Whether to treat empty strings as null for Druid Adapter.
+   */
+  NULL_IS_EMPTY("nullIsEmpty", Type.BOOLEAN, true, false),
+
   /** Whether to store query results in temporary tables. */
   AUTO_TEMP("autoTemp", Type.BOOLEAN, false, false),
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidSqlCastConverter.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidSqlCastConverter.java
@@ -56,8 +56,8 @@ public class DruidSqlCastConverter implements DruidSqlOperatorConverter {
 
     if (SqlTypeName.CHAR_TYPES.contains(fromType) && SqlTypeName.DATETIME_TYPES.contains(toType)) {
       //case chars to dates
-      return castCharToDateTime(timeZone, operandExpression,
-          toType);
+      return castCharToDateTime(timeZone, operandExpression, toType,
+          druidQuery.getConnectionConfig().nullIsEmpty() ? "" : null);
     } else if (SqlTypeName.DATETIME_TYPES.contains(fromType) && SqlTypeName.CHAR_TYPES.contains
         (toType)) {
       //case dates to chars
@@ -99,13 +99,13 @@ public class DruidSqlCastConverter implements DruidSqlOperatorConverter {
   private static String castCharToDateTime(
       TimeZone timeZone,
       String operand,
-      final SqlTypeName toType) {
+      final SqlTypeName toType, String format) {
     // Cast strings to date times by parsing them from SQL format.
     final String timestampExpression = DruidExpressions.functionCall(
         "timestamp_parse",
         ImmutableList.of(
             operand,
-            DruidExpressions.stringLiteral(""),
+            DruidExpressions.stringLiteral(format),
             DruidExpressions.stringLiteral(timeZone.getID())));
 
     if (toType == SqlTypeName.DATE) {


### PR DESCRIPTION
Use null literal instead of empty string with timestamp_parse druid expression.
Added a configuration parameter to allow smooth transition between older Druid version (non Sql compatible) and newer Druid versions (Sql Compatible 0.13.0 and above)