### PR TITLE
[CALCITE-2359] Fix inconsistent results casting single-field intervals to integers

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -592,6 +592,8 @@ public class RexToLixTranslator {
         convert = RexImpTable.multiplyDivide(convert, multiplier, divider);
       }
     }
+
+    convert = scaleIntervalToNumber(sourceType, targetType, convert);
     return convert;
   }
 
@@ -1255,6 +1257,35 @@ public class RexToLixTranslator {
 
   public Expression getRoot() {
     return root;
+  }
+
+  private static Expression scaleIntervalToNumber(
+      RelDataType sourceType,
+      RelDataType targetType,
+      Expression operand) {
+    switch (targetType.getSqlTypeName().getFamily()) {
+    case NUMERIC:
+      switch (sourceType.getSqlTypeName()) {
+      case INTERVAL_YEAR:
+      case INTERVAL_YEAR_MONTH:
+      case INTERVAL_MONTH:
+      case INTERVAL_DAY:
+      case INTERVAL_DAY_HOUR:
+      case INTERVAL_DAY_MINUTE:
+      case INTERVAL_DAY_SECOND:
+      case INTERVAL_HOUR:
+      case INTERVAL_HOUR_MINUTE:
+      case INTERVAL_HOUR_SECOND:
+      case INTERVAL_MINUTE:
+      case INTERVAL_MINUTE_SECOND:
+      case INTERVAL_SECOND:
+        // Scale to the given field.
+        final BigDecimal multiplier = BigDecimal.ONE;
+        final BigDecimal divider = sourceType.getSqlTypeName().getEndUnit().multiplier;
+        operand = RexImpTable.multiplyDivide(operand, multiplier, divider);
+      }
+    }
+    return operand;
   }
 
   /** Translates a field of an input to an expression. */

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -503,6 +503,9 @@ public class RexBuilder {
       SqlTypeName typeName = literal.getTypeName();
       if (canRemoveCastFromLiteral(type, value, typeName)) {
         switch (typeName) {
+        case INTERVAL_YEAR:
+        case INTERVAL_YEAR_MONTH:
+        case INTERVAL_MONTH:
         case INTERVAL_DAY:
         case INTERVAL_DAY_HOUR:
         case INTERVAL_DAY_MINUTE:

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -843,6 +843,56 @@ public abstract class SqlOperatorBaseTest {
         "cast(INTERVAL '5' day as integer)",
         "INTEGER NOT NULL",
         "5");
+
+    // Interval to integer
+    tester.checkScalarExact(
+            "cast(INTERVAL '1' year as integer)",
+            "INTEGER NOT NULL",
+            "1");
+    tester.checkScalarExact(
+            "cast((INTERVAL '1' year - INTERVAL '2' year) as integer)",
+            "INTEGER NOT NULL",
+            "-1");
+    tester.checkScalarExact(
+            "cast(INTERVAL '1' month as integer)",
+            "INTEGER NOT NULL",
+            "1");
+    tester.checkScalarExact(
+            "cast((INTERVAL '1' month - INTERVAL '2' month) as integer)",
+            "INTEGER NOT NULL",
+            "-1");
+    tester.checkScalarExact(
+            "cast(INTERVAL '1' day as integer)",
+            "INTEGER NOT NULL",
+            "1");
+    tester.checkScalarExact(
+            "cast((INTERVAL '1' day - INTERVAL '2' day) as integer)",
+            "INTEGER NOT NULL",
+            "-1");
+    tester.checkScalarExact(
+            "cast(INTERVAL '1' hour as integer)",
+            "INTEGER NOT NULL",
+            "1");
+    tester.checkScalarExact(
+            "cast((INTERVAL '1' hour - INTERVAL '2' hour) as integer)",
+            "INTEGER NOT NULL",
+            "-1");
+    tester.checkScalarExact(
+            "cast(INTERVAL '1' hour as integer)",
+            "INTEGER NOT NULL",
+            "1");
+    tester.checkScalarExact(
+            "cast((INTERVAL '1' minute - INTERVAL '2' minute) as integer)",
+            "INTEGER NOT NULL",
+            "-1");
+    tester.checkScalarExact(
+            "cast(INTERVAL '1' minute as integer)",
+            "INTEGER NOT NULL",
+            "1");
+    tester.checkScalarExact(
+            "cast((INTERVAL '1' second - INTERVAL '2' second) as integer)",
+            "INTEGER NOT NULL",
+            "-1");
   }
 
   @Test public void testCastToInterval() {

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ limitations under the License.
     <servlet.version>3.0.1</servlet.version>
     <slf4j.version>1.7.13</slf4j.version>
     <spark.version>2.2.0</spark.version>
-    <sqlline.version>1.3.0</sqlline.version>
+    <sqlline.version>1.4.0</sqlline.version>
     <xalan.version>2.7.1</xalan.version>
     <xerces.version>2.9.1</xerces.version>
     <sketches.version>0.9.0</sketches.version>


### PR DESCRIPTION
Ensure casting single-field intervals to integers always returns the result in terms
of the trailing unit.

Previously we had the following behavior:
- Casting a standalone day interval literal returned results in terms of unit.
- Casting a standalone year interval literal returned results in terms of months.
- Casting a day interval expression returned results in terms of milliseconds.
- Casting a year interval expression returned results in terms of months.