### PR TITLE
[CALCITE-2369] OsAdapterTest fails on windows

### DIFF
--- a/plus/src/test/java/org/apache/calcite/adapter/os/OsAdapterTest.java
+++ b/plus/src/test/java/org/apache/calcite/adapter/os/OsAdapterTest.java
@@ -90,6 +90,8 @@ public class OsAdapterTest {
   }
 
   @Test public void testDu() {
+    Assume.assumeFalse("Skip: the 'du' table does not work on Windows",
+        isWindows());
     sql("select * from du")
         .returns(
             new Function<ResultSet, Void>() {
@@ -108,6 +110,8 @@ public class OsAdapterTest {
   }
 
   @Test public void testDuFilterSortLimit() {
+    Assume.assumeFalse("Skip: the 'du' table does not work on Windows",
+        isWindows());
     sql("select * from du where path like '%/src/test/java/%'\n"
         + "order by 1 limit 2")
         .returns(


### PR DESCRIPTION
put OsAdapterTest#testDu and OsAdapterTest#testDuFilterSortLimit to ignore in case of Windows to fix [CALCITE-2369]