### PR TITLE
[CALCITE-2379] CVSS dependency-check-maven fails for calcite-spark and calcite-ubenchmark modules

### DIFF
--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -507,7 +507,8 @@ Before you start:
   (i.e. gives no errors; warnings are OK)
 * Generate a report of vulnerabilities that occur among dependencies,
   using `-Ppedantic`; if you like, run again with `-DfailBuildOnCVSS=8` to see
-  whether serious vulnerabilities exist.
+  whether serious vulnerabilities exist. Report to [private@calcite.apache.org](mailto:private@calcite.apache.org)
+  if new critical vulnerabilities are found among dependencies.
 * Make sure that `mvn apache-rat:check` succeeds. (It will be run as part of
   the release, but it's better to trouble-shoot early.)
 * Decide the supported configurations of JDK, operating system and

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -62,6 +62,14 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.10</artifactId>
+      <exclusions>
+        <!-- Excludes py4j lib, since it has vulnerabilities
+          with level >= 8. -->
+        <exclusion>
+          <groupId>net.sf.py4j</groupId>
+          <artifactId>py4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -138,6 +138,15 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
- Exclude py4j lib from spark-core
- Disable dependency-check-maven for calcite-ubenchmark module