### PR TITLE
[CALCITE-2331] evaluation of predicate (A or B) and C fails for ES adapter

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/AbstractElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/AbstractElasticsearchTable.java
@@ -31,6 +31,8 @@ import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.schema.impl.AbstractTableQueryable;
 import org.apache.calcite.sql.type.SqlTypeName;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -43,16 +45,19 @@ abstract class AbstractElasticsearchTable extends AbstractQueryableTable
 
   final String indexName;
   final String typeName;
+  final ObjectMapper mapper;
 
   /**
    * Creates an ElasticsearchTable.
    * @param indexName Elastic Search index
    * @param typeName Elastic Search index type
+   * @param mapper Jackson API to parse (and created) JSON documents
    */
-  AbstractElasticsearchTable(String indexName, String typeName) {
+  AbstractElasticsearchTable(String indexName, String typeName, ObjectMapper mapper) {
     super(Object[].class);
     this.indexName = Objects.requireNonNull(indexName, "indexName");
     this.typeName = Objects.requireNonNull(typeName, "typeName");
+    this.mapper = Objects.requireNonNull(mapper, "mapper");
   }
 
   @Override public String toString() {

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchConstants.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchConstants.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * Internal constants referenced in this package.
+ */
+interface ElasticsearchConstants {
+
+  String INDEX = "_index";
+  String TYPE = "_type";
+  String FIELDS = "fields";
+  String SOURCE_PAINLESS = "params._source";
+  String SOURCE_GROOVY = "_source";
+  String SOURCE = SOURCE_GROOVY;
+  String ID = "_id";
+  String UID = "_uid";
+
+  /* Aggregation pushdown operations supported */
+  String AGG_SUM = "SUM";
+  String AGG_SUM0 = "$SUM0";
+  String AGG_COUNT = "COUNT";
+  String AGG_MIN = "MIN";
+  String AGG_MAX = "MAX";
+  String AGG_AVG = "AVG";
+
+  Set<String> META_COLUMNS = ImmutableSet.of(UID, ID, TYPE, INDEX);
+
+}
+
+// End ElasticsearchConstants.java

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
@@ -98,6 +98,10 @@ class ElasticsearchRules {
     return "\"" + s + "\"";
   }
 
+  static String stripQuotes(String s) {
+    return s.startsWith("\"") && s.endsWith("\"") ? s.substring(1, s.length() - 1) : s;
+  }
+
   /**
    * Translator from {@link RexNode} to strings in Elasticsearch's expression
    * language.
@@ -144,10 +148,6 @@ class ElasticsearchRules {
       }
       throw new IllegalArgumentException("Translation of " + call.toString()
         + "is not supported by ElasticsearchProject");
-    }
-
-    private String stripQuotes(String s) {
-      return s.startsWith("'") && s.endsWith("'") ? s.substring(1, s.length() - 1) : s;
     }
 
     List<String> visitList(List<RexNode> list) {

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchema.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchema.java
@@ -55,7 +55,7 @@ public class ElasticsearchSchema extends AbstractSchema {
    * @param mapper mapper for JSON (de)serialization
    * @param index name of ES index
    */
-  ElasticsearchSchema(RestClient client, ObjectMapper mapper, String index) {
+  public ElasticsearchSchema(RestClient client, ObjectMapper mapper, String index) {
     super();
     this.client = Objects.requireNonNull(client, "client");
     this.mapper = Objects.requireNonNull(mapper, "mapper");
@@ -66,7 +66,7 @@ public class ElasticsearchSchema extends AbstractSchema {
     final ImmutableMap.Builder<String, Table> builder = ImmutableMap.builder();
     try {
       for (String type: listTypes()) {
-        builder.put(type, new ElasticsearchTable(client, index, type));
+        builder.put(type, new ElasticsearchTable(client, mapper, index, type));
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to get types for " + index, e);
@@ -82,7 +82,7 @@ public class ElasticsearchSchema extends AbstractSchema {
    * @throws IllegalStateException if reply is not understood
    */
   private Set<String> listTypes() throws IOException  {
-    final String endpoint = index + "/_mapping";
+    final String endpoint = "/" + index + "/_mapping";
     final Response response = client.performRequest("GET", endpoint);
     try (InputStream is = response.getEntity().getContent()) {
       JsonNode root = mapper.readTree(is);

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
@@ -25,7 +25,6 @@ import org.apache.http.HttpHost;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import com.google.common.base.Preconditions;
 
 import org.elasticsearch.client.RestClient;

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
@@ -48,18 +48,18 @@ import java.util.Objects;
 public class ElasticsearchTable extends AbstractElasticsearchTable {
   private final RestClient restClient;
   private final ElasticsearchVersion version;
-  private final ObjectMapper mapper;
+
 
   /**
    * Creates an ElasticsearchTable.
    * @param client low-level ES rest client
+   * @param mapper Jackson API
    * @param indexName elastic search index
    * @param typeName elastic searh index type
    */
-  ElasticsearchTable(RestClient client, String indexName, String typeName) {
-    super(indexName, typeName);
+  ElasticsearchTable(RestClient client, ObjectMapper mapper, String indexName, String typeName) {
+    super(indexName, typeName, Objects.requireNonNull(mapper, "mapper"));
     this.restClient = Objects.requireNonNull(client, "client");
-    this.mapper = new ObjectMapper();
     try {
       this.version = detectVersion(client, mapper);
     } catch (IOException e) {
@@ -89,7 +89,9 @@ public class ElasticsearchTable extends AbstractElasticsearchTable {
 
   @Override protected String scriptedFieldPrefix() {
     // ES2 vs ES5 scripted field difference
-    return version == ElasticsearchVersion.ES2 ? "_source" : "params._source";
+    return version == ElasticsearchVersion.ES2
+        ? ElasticsearchConstants.SOURCE_GROOVY
+        : ElasticsearchConstants.SOURCE_PAINLESS;
   }
 
   @Override protected Enumerable<Object> find(String index, List<String> ops,
@@ -117,7 +119,6 @@ public class ElasticsearchTable extends AbstractElasticsearchTable {
     String uri = String.format(Locale.ROOT, "/%s/%s/_search", indexName, typeName);
     HttpEntity entity = new StringEntity(query, ContentType.APPLICATION_JSON);
     Response response = restClient.performRequest("POST", uri, Collections.emptyMap(), entity);
-
     if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
       final String error = EntityUtils.toString(response.getEntity());
       final String message = String.format(Locale.ROOT,

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverter.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverter.java
@@ -39,10 +39,9 @@ import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
 
-import com.google.common.collect.Lists;
-
 import java.util.AbstractList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Relational expression representing a scan of a table in an Elasticsearch data source.
@@ -117,7 +116,7 @@ public class ElasticsearchToEnumerableConverter extends ConverterImpl implements
    * @return list of constant expressions
    */
   private static <T> List<Expression> constantList(List<T> values) {
-    return Lists.transform(values, Expressions::constant);
+    return values.stream().map(Expressions::constant).collect(Collectors.toList());
   }
 }
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverterRule.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverterRule.java
@@ -38,7 +38,7 @@ public class ElasticsearchToEnumerableConverterRule extends ConverterRule {
    *
    * @param relBuilderFactory Builder for relational expressions
    */
-  ElasticsearchToEnumerableConverterRule(
+  private ElasticsearchToEnumerableConverterRule(
       RelBuilderFactory relBuilderFactory) {
     super(RelNode.class, (Predicate<RelNode>) r -> true,
         ElasticsearchRel.CONVENTION, EnumerableConvention.INSTANCE,

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ExpressionNotAnalyzableException.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ExpressionNotAnalyzableException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+/**
+ * Thrown when {@link org.apache.calcite.rel.RelNode} expression can't be processed
+ * (or converted into ES query)
+ */
+class ExpressionNotAnalyzableException extends Exception {
+  ExpressionNotAnalyzableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}
+
+// End ExpressionNotAnalyzableException.java

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
@@ -1,0 +1,929 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import org.apache.calcite.adapter.elasticsearch.QueryBuilders.BoolQueryBuilder;
+import org.apache.calcite.adapter.elasticsearch.QueryBuilders.QueryBuilder;
+import org.apache.calcite.adapter.elasticsearch.QueryBuilders.RangeQueryBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.boolQuery;
+import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.existsQuery;
+import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.rangeQuery;
+import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.regexpQuery;
+import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.termQuery;
+
+import static java.lang.String.format;
+
+/**
+ * Query predicate analyzer. Uses visitor pattern to traverse existing expression
+ * and convert it to {@link QueryBuilder}.
+ *
+ * <p>Major part of this class have been copied from
+ * <a href="https://www.dremio.com/">dremio</a> ES adapter
+ * (thanks to their team for improving calcite-ES integration).
+ */
+class PredicateAnalyzer {
+
+  /**
+   * Internal exception
+   */
+  @SuppressWarnings("serial")
+  private static final class PredicateAnalyzerException extends RuntimeException {
+
+    PredicateAnalyzerException(String message) {
+      super(message);
+    }
+
+    PredicateAnalyzerException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  private PredicateAnalyzer() {}
+
+  /**
+   * Walks the expression tree, attempting to convert the entire tree into
+   * an equivalent Elasticsearch query filter. If an error occurs, or if it
+   * is determined that the expression cannot be converted, an exception is
+   * thrown and an error message logged.
+   *
+   * <p>Callers should catch ExpressionNotAnalyzableException
+   * and fall back to not using push-down filters.
+   *
+   * @param expression expression to analyze
+   * @return search query which can be used to query ES cluster
+   * @throws ExpressionNotAnalyzableException when expression can't processed by this analyzer
+   */
+  static QueryBuilder analyze(RexNode expression) throws ExpressionNotAnalyzableException {
+    Objects.requireNonNull(expression, "expression");
+    try {
+      // visits expression tree
+      QueryExpression e = (QueryExpression) expression.accept(new Visitor());
+
+      if (e != null && e.isPartial()) {
+        throw new UnsupportedOperationException("Can't handle partial QueryExpression: " + e);
+      }
+      return e != null ? e.builder() : null;
+    } catch (Throwable e) {
+      Throwables.propagateIfPossible(e, UnsupportedOperationException.class);
+      throw new ExpressionNotAnalyzableException("Can't convert " + expression, e);
+    }
+  }
+
+  /**
+   * Converts expressions of the form NOT(LIKE(...)) into NOT_LIKE(...)
+   */
+  private static class NotLikeConverter extends RexShuttle {
+    final RexBuilder rexBuilder;
+
+    NotLikeConverter(RexBuilder rexBuilder) {
+      this.rexBuilder = rexBuilder;
+    }
+
+    @Override public RexNode visitCall(RexCall call) {
+      if (call.getOperator().getKind() == SqlKind.NOT) {
+        RexNode child = call.getOperands().get(0);
+        if (child.getKind() == SqlKind.LIKE) {
+          List<RexNode> operands = ((RexCall) child).getOperands()
+              .stream()
+              .map(rexNode -> rexNode.accept(NotLikeConverter.this))
+              .collect(Collectors.toList());
+          return rexBuilder.makeCall(SqlStdOperatorTable.NOT_LIKE, operands);
+        }
+      }
+      return super.visitCall(call);
+    }
+  }
+
+  /**
+   * Traverses {@link RexNode} tree and builds ES query.
+   */
+  private static class Visitor extends RexVisitorImpl<Expression> {
+
+    private Visitor() {
+      super(true);
+    }
+
+    @Override public Expression visitInputRef(RexInputRef inputRef) {
+      return new NamedFieldExpression(inputRef);
+    }
+
+    @Override public Expression visitLiteral(RexLiteral literal) {
+      return new LiteralExpression(literal);
+    }
+
+    private boolean supportedRexCall(RexCall call) {
+      final SqlSyntax syntax = call.getOperator().getSyntax();
+      switch (syntax) {
+      case BINARY:
+        switch (call.getKind()) {
+        case AND:
+        case OR:
+        case LIKE:
+        case EQUALS:
+        case NOT_EQUALS:
+        case GREATER_THAN:
+        case GREATER_THAN_OR_EQUAL:
+        case LESS_THAN:
+        case LESS_THAN_OR_EQUAL:
+          return true;
+        default:
+          return false;
+        }
+      case SPECIAL:
+        switch (call.getKind()) {
+        case CAST:
+        case LIKE:
+        case OTHER_FUNCTION:
+          return true;
+        case CASE:
+        case SIMILAR:
+        default:
+          return false;
+        }
+      case FUNCTION:
+        return true;
+      case POSTFIX:
+        switch (call.getKind()) {
+        case IS_NOT_NULL:
+        case IS_NULL:
+          return true;
+        default: // fall through
+        }
+        // fall through
+      case FUNCTION_ID:
+      case FUNCTION_STAR:
+      case PREFIX: // NOT()
+      default:
+        return false;
+      }
+    }
+
+    @Override public Expression visitCall(RexCall call) {
+
+      SqlSyntax syntax = call.getOperator().getSyntax();
+      if (!supportedRexCall(call)) {
+        String message = String.format(Locale.ROOT, "Unsupported call: [%s]", call);
+        throw new PredicateAnalyzerException(message);
+      }
+
+      switch (syntax) {
+      case BINARY:
+        return binary(call);
+      case POSTFIX:
+        return postfix(call);
+      case SPECIAL:
+        switch (call.getKind()) {
+        case CAST:
+          return toCastExpression(call);
+        case LIKE:
+          return binary(call);
+        default:
+          // manually process ITEM($0, 'foo') which in our case will be named attribute
+          if (call.getOperator().getName().equalsIgnoreCase("ITEM")) {
+            return toNamedField((RexLiteral) call.getOperands().get(1));
+          }
+          String message = String.format(Locale.ROOT, "Unsupported call: [%s]", call);
+          throw new PredicateAnalyzerException(message);
+        }
+      case FUNCTION:
+        if (call.getOperator().getName().equalsIgnoreCase("CONTAINS")) {
+          List<Expression> operands = new ArrayList<>();
+          for (RexNode node : call.getOperands()) {
+            final Expression nodeExpr = node.accept(this);
+            operands.add(nodeExpr);
+          }
+          String query = convertQueryString(operands.subList(0, operands.size() - 1),
+              operands.get(operands.size() - 1));
+          return QueryExpression.create(new NamedFieldExpression()).queryString(query);
+        }
+        // fall through
+      default:
+        String message = format(Locale.ROOT, "Unsupported syntax [%s] for call: [%s]",
+            syntax, call);
+        throw new PredicateAnalyzerException(message);
+      }
+    }
+
+    private static String convertQueryString(List<Expression> fields, Expression query) {
+      int index = 0;
+      Preconditions.checkArgument(query instanceof LiteralExpression,
+          "Query string must be a string literal");
+      String queryString = ((LiteralExpression) query).stringValue();
+      Map<String, String> fieldMap = new LinkedHashMap<>();
+      for (Expression expr : fields) {
+        if (expr instanceof NamedFieldExpression) {
+          NamedFieldExpression field = (NamedFieldExpression) expr;
+          String fieldIndexString = String.format(Locale.ROOT, "$%d", index++);
+          fieldMap.put(fieldIndexString, field.getReference());
+        }
+      }
+      try {
+        return queryString;
+      } catch (Exception e) {
+        throw new PredicateAnalyzerException(e);
+      }
+    }
+
+    private QueryExpression postfix(RexCall call) {
+      Preconditions.checkArgument(call.getKind() == SqlKind.IS_NULL
+          || call.getKind() == SqlKind.IS_NOT_NULL);
+      if (call.getOperands().size() != 1) {
+        String message = String.format(Locale.ROOT, "Unsupported operator: [%s]", call);
+        throw new PredicateAnalyzerException(message);
+      }
+      Expression a = call.getOperands().get(0).accept(this);
+      // Elasticsearch does not want is null/is not null (exists query)
+      // for _id and _index, although it supports for all other metadata column
+      isColumn(a, call, ElasticsearchConstants.ID, true);
+      isColumn(a, call, ElasticsearchConstants.INDEX, true);
+      QueryExpression operand = QueryExpression.create((TerminalExpression) a);
+      return call.getKind() == SqlKind.IS_NOT_NULL ? operand.exists() : operand.notExists();
+    }
+
+    /**
+     * Process a call which is a binary operation, transforming into an equivalent
+     * query expression. Note that the incoming call may be either a simple binary
+     * expression, such as {@code foo > 5}, or it may be several simple expressions connected
+     * by {@code AND} or {@code OR} operators, such as {@code foo > 5 AND bar = 'abc' AND 'rot' < 1}
+     *
+     * @param call existing call
+     * @return evaluated expression
+     */
+    private QueryExpression binary(RexCall call) {
+
+      // if AND/OR, do special handling
+      if (call.getKind() == SqlKind.AND || call.getKind() == SqlKind.OR) {
+        return andOr(call);
+      }
+
+      checkForIncompatibleDateTimeOperands(call);
+
+      Preconditions.checkState(call.getOperands().size() == 2);
+      final Expression a = call.getOperands().get(0).accept(this);
+      final Expression b = call.getOperands().get(1).accept(this);
+
+      final SwapResult pair = swap(a, b);
+      final boolean swapped = pair.isSwapped();
+
+      // For _id and _index columns, only equals/not_equals work!
+      if (isColumn(pair.getKey(), call, ElasticsearchConstants.ID, false)
+          || isColumn(pair.getKey(), call, ElasticsearchConstants.INDEX, false)
+          || isColumn(pair.getKey(), call, ElasticsearchConstants.UID, false)) {
+        switch (call.getKind()) {
+        case EQUALS:
+        case NOT_EQUALS:
+          break;
+        default:
+          throw new PredicateAnalyzerException(
+              "Cannot handle " + call.getKind() + " expression for _id field, " + call);
+        }
+      }
+
+      switch (call.getKind()) {
+      case LIKE:
+        throw new UnsupportedOperationException("LIKE not yet supported");
+      case EQUALS:
+        return QueryExpression.create(pair.getKey()).equals(pair.getValue());
+      case NOT_EQUALS:
+        return QueryExpression.create(pair.getKey()).notEquals(pair.getValue());
+      case GREATER_THAN:
+        if (swapped) {
+          return QueryExpression.create(pair.getKey()).lt(pair.getValue());
+        }
+        return QueryExpression.create(pair.getKey()).gt(pair.getValue());
+      case GREATER_THAN_OR_EQUAL:
+        if (swapped) {
+          return QueryExpression.create(pair.getKey()).lte(pair.getValue());
+        }
+        return QueryExpression.create(pair.getKey()).gte(pair.getValue());
+      case LESS_THAN:
+        if (swapped) {
+          return QueryExpression.create(pair.getKey()).gt(pair.getValue());
+        }
+        return QueryExpression.create(pair.getKey()).lt(pair.getValue());
+      case LESS_THAN_OR_EQUAL:
+        if (swapped) {
+          return QueryExpression.create(pair.getKey()).gte(pair.getValue());
+        }
+        return QueryExpression.create(pair.getKey()).lte(pair.getValue());
+      default:
+        break;
+      }
+      String message = String.format(Locale.ROOT, "Unable to handle call: [%s]", call);
+      throw new PredicateAnalyzerException(message);
+    }
+
+    private QueryExpression andOr(RexCall call) {
+      QueryExpression[] expressions = new QueryExpression[call.getOperands().size()];
+      PredicateAnalyzerException firstError = null;
+      boolean partial = false;
+      for (int i = 0; i < call.getOperands().size(); i++) {
+        try {
+          Expression expr = call.getOperands().get(i).accept(this);
+          if (expr instanceof NamedFieldExpression) {
+            // nop currently
+          } else {
+            expressions[i] = (QueryExpression) call.getOperands().get(i).accept(this);
+          }
+          partial |= expressions[i].isPartial();
+        } catch (PredicateAnalyzerException e) {
+          if (firstError == null) {
+            firstError = e;
+          }
+          partial = true;
+        }
+      }
+
+      switch (call.getKind()) {
+      case OR:
+        if (partial) {
+          if (firstError != null) {
+            throw firstError;
+          } else {
+            final String message = String.format(Locale.ROOT, "Unable to handle call: [%s]", call);
+            throw new PredicateAnalyzerException(message);
+          }
+        }
+        return CompoundQueryExpression.or(expressions);
+      case AND:
+        return CompoundQueryExpression.and(partial, expressions);
+      default:
+        String message = String.format(Locale.ROOT, "Unable to handle call: [%s]", call);
+        throw new PredicateAnalyzerException(message);
+      }
+    }
+
+    /**
+     * Holder class for a pair of expressions. Used to convert {@code 1 = foo} into {@code foo = 1}
+     */
+    private static class SwapResult {
+      final boolean swapped;
+      final TerminalExpression terminal;
+      final LiteralExpression literal;
+
+      SwapResult(boolean swapped, TerminalExpression terminal, LiteralExpression literal) {
+        super();
+        this.swapped = swapped;
+        this.terminal = terminal;
+        this.literal = literal;
+      }
+
+      TerminalExpression getKey() {
+        return terminal;
+      }
+
+      LiteralExpression getValue() {
+        return literal;
+      }
+
+      boolean isSwapped() {
+        return swapped;
+      }
+    }
+
+    /**
+     * Swap order of operands such that the literal expression is always on the right.
+     *
+     * <p>NOTE: Some combinations of operands are implicitly not supported and will
+     * cause an exception to be thrown. For example, we currently do not support
+     * comparing a literal to another literal as convention {@code 5 = 5}. Nor do we support
+     * comparing named fields to other named fields as convention {@code $0 = $1}.
+     * @param left left expression
+     * @param right right expression
+     */
+    private static SwapResult swap(Expression left, Expression right) {
+
+      TerminalExpression terminal;
+      LiteralExpression literal = expressAsLiteral(left);
+      boolean swapped = false;
+      if (literal != null) {
+        swapped = true;
+        terminal = (TerminalExpression) right;
+      } else {
+        literal = expressAsLiteral(right);
+        terminal = (TerminalExpression) left;
+      }
+
+      if (literal == null || terminal == null) {
+        String message = String.format(Locale.ROOT,
+            "Unexpected combination of expressions [left: %s] [right: %s]", left, right);
+        throw new PredicateAnalyzerException(message);
+      }
+
+      if (CastExpression.isCastExpression(terminal)) {
+        terminal = CastExpression.unpack(terminal);
+      }
+
+      return new SwapResult(swapped, terminal, literal);
+    }
+
+    private CastExpression toCastExpression(RexCall call) {
+      TerminalExpression argument = (TerminalExpression) call.getOperands().get(0).accept(this);
+      return new CastExpression(call.getType(), argument);
+    }
+
+    private static NamedFieldExpression toNamedField(RexLiteral literal) {
+      return new NamedFieldExpression(literal);
+    }
+
+    /**
+     * Try to convert a generic expression into a literal expression.
+     */
+    private static LiteralExpression expressAsLiteral(Expression exp) {
+
+      if (exp instanceof LiteralExpression) {
+        return (LiteralExpression) exp;
+      }
+
+      return null;
+    }
+
+    private static boolean isColumn(Expression exp, RexNode node,
+        String columnName, boolean throwException) {
+      if (!(exp instanceof NamedFieldExpression)) {
+        return false;
+      }
+
+      final NamedFieldExpression termExp = (NamedFieldExpression) exp;
+      if (columnName.equals(termExp.getRootName())) {
+        if (throwException) {
+          throw new PredicateAnalyzerException("Cannot handle _id field in " + node);
+        }
+        return true;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Empty interface; exists only to define type hierarchy
+   */
+  interface Expression {
+  }
+
+  /**
+   * Main expression operators (like {@code equals}, {@code gt}, {@code exists} etc.)
+   */
+  abstract static class QueryExpression implements Expression {
+
+    public abstract QueryBuilder builder();
+
+    public boolean isPartial() {
+      return false;
+    }
+
+    public abstract QueryExpression exists();
+
+    public abstract QueryExpression notExists();
+
+    public abstract QueryExpression like(LiteralExpression literal);
+
+    public abstract QueryExpression notLike(LiteralExpression literal);
+
+    public abstract QueryExpression equals(LiteralExpression literal);
+
+    public abstract QueryExpression notEquals(LiteralExpression literal);
+
+    public abstract QueryExpression gt(LiteralExpression literal);
+
+    public abstract QueryExpression gte(LiteralExpression literal);
+
+    public abstract QueryExpression lt(LiteralExpression literal);
+
+    public abstract QueryExpression lte(LiteralExpression literal);
+
+    public abstract QueryExpression queryString(String query);
+
+    public abstract QueryExpression isTrue();
+
+    public static QueryExpression create(TerminalExpression expression) {
+
+      if (expression instanceof NamedFieldExpression) {
+        return new SimpleQueryExpression((NamedFieldExpression) expression);
+      } else {
+        String message = String.format(Locale.ROOT, "Unsupported expression: [%s]", expression);
+        throw new PredicateAnalyzerException(message);
+      }
+    }
+  }
+
+  /**
+   * Builds conjunctions / disjunctions based on existing expressions
+   */
+  static class CompoundQueryExpression extends QueryExpression {
+
+    private final boolean partial;
+    private final BoolQueryBuilder builder = boolQuery();
+
+    public static CompoundQueryExpression or(QueryExpression... expressions) {
+      CompoundQueryExpression bqe = new CompoundQueryExpression(false);
+      for (QueryExpression expression : expressions) {
+        bqe.builder.should(expression.builder());
+      }
+      return bqe;
+    }
+
+    /**
+     * if partial expression, we will need to complete it with a full filter
+     * @param partial whether we partially converted a and for push down purposes.
+     * @param expressions list of expressions to join with {@code and} boolean
+     * @return new instance of expression
+     */
+    public static CompoundQueryExpression and(boolean partial, QueryExpression... expressions) {
+      CompoundQueryExpression bqe = new CompoundQueryExpression(partial);
+      for (QueryExpression expression : expressions) {
+        if (expression != null) { // partial expressions have nulls for missing nodes
+          bqe.builder.must(expression.builder());
+        }
+      }
+      return bqe;
+    }
+
+    private CompoundQueryExpression(boolean partial) {
+      this.partial = partial;
+    }
+
+    @Override public boolean isPartial() {
+      return partial;
+    }
+
+    @Override public QueryBuilder builder() {
+      return Objects.requireNonNull(builder);
+    }
+
+    @Override public QueryExpression exists() {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['exists'] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression notExists() {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['notExists'] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression like(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['like'] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression notLike(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['notLike'] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression equals(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['='] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression notEquals(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['not'] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression gt(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['>'] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression gte(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['>='] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression lt(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['<'] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression lte(LiteralExpression literal) {
+      throw new PredicateAnalyzerException("SqlOperatorImpl ['<='] "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression queryString(String query) {
+      throw new PredicateAnalyzerException("QueryString "
+          + "cannot be applied to a compound expression");
+    }
+
+    @Override public QueryExpression isTrue() {
+      throw new PredicateAnalyzerException("isTrue cannot be applied to a compound expression");
+    }
+  }
+
+  /**
+   * Usually basic expression of type {@code a = 'val'} or {@code b > 42}.
+   */
+  static class SimpleQueryExpression extends QueryExpression {
+
+    private final NamedFieldExpression rel;
+    private QueryBuilder builder;
+
+    private String getFieldReference() {
+      return rel.getReference();
+    }
+
+    private SimpleQueryExpression(NamedFieldExpression rel) {
+      this.rel = rel;
+    }
+
+    @Override public QueryBuilder builder() {
+      return Objects.requireNonNull(builder);
+    }
+
+    @Override public QueryExpression exists() {
+      builder = existsQuery(getFieldReference());
+      return this;
+    }
+
+    @Override public QueryExpression notExists() {
+      // Even though Lucene doesn't allow a stand alone mustNot boolean query,
+      // Elasticsearch handles this problem transparently on its end
+      builder = boolQuery().mustNot(existsQuery(getFieldReference()));
+      return this;
+    }
+
+    @Override public QueryExpression like(LiteralExpression literal) {
+      builder = regexpQuery(getFieldReference(), literal.stringValue());
+      return this;
+    }
+
+    @Override public QueryExpression notLike(LiteralExpression literal) {
+      builder = boolQuery()
+              // NOT LIKE should return false when field is NULL
+              .must(existsQuery(getFieldReference()))
+              .mustNot(regexpQuery(getFieldReference(), literal.stringValue()));
+      return this;
+    }
+
+    @Override public QueryExpression equals(LiteralExpression literal) {
+      Object value = literal.value();
+      if (value instanceof GregorianCalendar) {
+        builder = boolQuery()
+                .must(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gte(value)))
+                .must(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lte(value)));
+      } else {
+        builder = termQuery(getFieldReference(), value);
+      }
+      return this;
+    }
+
+    @Override public QueryExpression notEquals(LiteralExpression literal) {
+      Object value = literal.value();
+      if (value instanceof GregorianCalendar) {
+        builder = boolQuery()
+                .should(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gt(value)))
+                .should(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lt(value)));
+      } else {
+        builder = boolQuery()
+                // NOT LIKE should return false when field is NULL
+                .must(existsQuery(getFieldReference()))
+                .mustNot(termQuery(getFieldReference(), value));
+      }
+      return this;
+    }
+
+    @Override public QueryExpression gt(LiteralExpression literal) {
+      Object value = literal.value();
+      builder = addFormatIfNecessary(literal,
+          rangeQuery(getFieldReference()).gt(value));
+      return this;
+    }
+
+    @Override public QueryExpression gte(LiteralExpression literal) {
+      Object value = literal.value();
+      builder = addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gte(value));
+      return this;
+    }
+
+    @Override public QueryExpression lt(LiteralExpression literal) {
+      Object value = literal.value();
+      builder = addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lt(value));
+      return this;
+    }
+
+    @Override public QueryExpression lte(LiteralExpression literal) {
+      Object value = literal.value();
+      builder = addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lte(value));
+      return this;
+    }
+
+    @Override public QueryExpression queryString(String query) {
+      throw new UnsupportedOperationException("QueryExpression not yet supported: " + query);
+    }
+
+    @Override public QueryExpression isTrue() {
+      builder = termQuery(getFieldReference(), true);
+      return this;
+    }
+  }
+
+
+  /**
+   * By default, range queries on date/time need use the format of the source to parse the literal.
+   * So we need to specify that the literal has "date_time" format
+   * @param literal literal value
+   * @param rangeQueryBuilder query builder to optionally add {@code format} expression
+   * @return existing builder with possible {@code format} attribute
+   */
+  private static RangeQueryBuilder addFormatIfNecessary(LiteralExpression literal,
+      RangeQueryBuilder rangeQueryBuilder) {
+    if (literal.value() instanceof GregorianCalendar) {
+      rangeQueryBuilder.format("date_time");
+    }
+    return rangeQueryBuilder;
+  }
+
+  /**
+   * Empty interface; exists only to define type hierarchy
+   */
+  interface TerminalExpression extends Expression {
+  }
+
+  /**
+   * SQL cast: {@code cast(col as INTEGER)}
+   */
+  static final class CastExpression implements TerminalExpression {
+    private final RelDataType type;
+    private final TerminalExpression argument;
+
+    private CastExpression(RelDataType type, TerminalExpression argument) {
+      this.type = type;
+      this.argument = argument;
+    }
+
+    public boolean isCastFromLiteral() {
+      return argument instanceof LiteralExpression;
+    }
+
+    static TerminalExpression unpack(TerminalExpression exp) {
+      if (!(exp instanceof CastExpression)) {
+        return exp;
+      }
+      return ((CastExpression) exp).argument;
+    }
+
+    static boolean isCastExpression(Expression exp) {
+      return exp instanceof CastExpression;
+    }
+
+  }
+
+  /**
+   * Used for bind variables
+   */
+  static final class NamedFieldExpression implements TerminalExpression {
+
+    private final String name;
+
+    private NamedFieldExpression() {
+      this.name = null;
+    }
+
+    private NamedFieldExpression(RexInputRef schemaField) {
+      this.name = schemaField == null ? null : schemaField.getName();
+    }
+
+    private NamedFieldExpression(RexLiteral literal) {
+      this.name = literal == null ? null : RexLiteral.stringValue(literal);
+    }
+
+    String getRootName() {
+      return name;
+    }
+
+    boolean isMetaField() {
+      return ElasticsearchConstants.META_COLUMNS.contains(getRootName());
+    }
+
+    String getReference() {
+      return getRootName();
+    }
+  }
+
+  /**
+   * Literal like {@code 'foo' or 42 or true} etc.
+   */
+  static final class LiteralExpression implements TerminalExpression {
+
+    final RexLiteral literal;
+
+    LiteralExpression(RexLiteral literal) {
+      this.literal = literal;
+    }
+
+    Object value() {
+
+      if (isIntegral()) {
+        return longValue();
+      } else if (isFloatingPoint()) {
+        return doubleValue();
+      } else if (isBoolean()) {
+        return booleanValue();
+      } else if (isString()) {
+        return RexLiteral.stringValue(literal);
+      } else {
+        return rawValue();
+      }
+    }
+
+    boolean isIntegral() {
+      return SqlTypeName.INT_TYPES.contains(literal.getType().getSqlTypeName());
+    }
+
+    boolean isFloatingPoint() {
+      return SqlTypeName.APPROX_TYPES.contains(literal.getType().getSqlTypeName());
+    }
+
+    boolean isBoolean() {
+      return SqlTypeName.BOOLEAN_TYPES.contains(literal.getType().getSqlTypeName());
+    }
+
+    public boolean isString() {
+      return SqlTypeName.CHAR_TYPES.contains(literal.getType().getSqlTypeName());
+    }
+
+    long longValue() {
+      return ((Number) literal.getValue()).longValue();
+    }
+
+    double doubleValue() {
+      return ((Number) literal.getValue()).doubleValue();
+    }
+
+    boolean booleanValue() {
+      return RexLiteral.booleanValue(literal);
+    }
+
+    String stringValue() {
+      return RexLiteral.stringValue(literal);
+    }
+
+    Object rawValue() {
+      return literal.getValue();
+    }
+  }
+
+  /**
+   * If one operand in a binary operator is a DateTime type, but the other isn't,
+   * we should not push down the predicate
+   * @param call current node being evaluated
+   */
+  private static void checkForIncompatibleDateTimeOperands(RexCall call) {
+    RelDataType op1 = call.getOperands().get(0).getType();
+    RelDataType op2 = call.getOperands().get(1).getType();
+    if ((SqlTypeFamily.DATETIME.contains(op1) && !SqlTypeFamily.DATETIME.contains(op2))
+           || (SqlTypeFamily.DATETIME.contains(op2) && !SqlTypeFamily.DATETIME.contains(op1))
+           || (SqlTypeFamily.DATE.contains(op1) && !SqlTypeFamily.DATE.contains(op2))
+           || (SqlTypeFamily.DATE.contains(op2) && !SqlTypeFamily.DATE.contains(op1))
+           || (SqlTypeFamily.TIMESTAMP.contains(op1) && !SqlTypeFamily.TIMESTAMP.contains(op2))
+           || (SqlTypeFamily.TIMESTAMP.contains(op2) && !SqlTypeFamily.TIMESTAMP.contains(op1))
+           || (SqlTypeFamily.TIME.contains(op1) && !SqlTypeFamily.TIME.contains(op2))
+           || (SqlTypeFamily.TIME.contains(op2) && !SqlTypeFamily.TIME.contains(op1))) {
+      throw new PredicateAnalyzerException("Cannot handle " + call.getKind()
+          + " expression for _id field, " + call);
+    }
+  }
+}
+
+// End PredicateAnalyzer.java

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/QueryBuilders.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/QueryBuilders.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Utility class to generate elastic search queries. Most query builders have
+ * been copied from ES distribution. The reason we have separate definition is
+ * high-level client dependency on core modules (like lucene, netty, XContent etc.) which
+ * is not compatible between different major versions.
+ *
+ * <p>Jackson API is used to generate ES query as JSON document.
+ */
+class QueryBuilders {
+
+  private QueryBuilders() {}
+
+  /**
+   * A Query that matches documents containing a term.
+   *
+   * @param name  The name of the field
+   * @param value The value of the term
+   */
+  static TermQueryBuilder termQuery(String name, String value) {
+    return new TermQueryBuilder(name, value);
+  }
+
+  /**
+   * A Query that matches documents containing a term.
+   *
+   * @param name  The name of the field
+   * @param value The value of the term
+   */
+  static TermQueryBuilder termQuery(String name, int value) {
+    return new TermQueryBuilder(name, value);
+  }
+
+  /**
+   * A Query that matches documents containing a term.
+   *
+   * @param name  The name of the field
+   * @param value The value of the term
+   */
+  static TermQueryBuilder termQuery(String name, long value) {
+    return new TermQueryBuilder(name, value);
+  }
+
+  /**
+   * A Query that matches documents containing a term.
+   *
+   * @param name  The name of the field
+   * @param value The value of the term
+   */
+  static TermQueryBuilder termQuery(String name, float value) {
+    return new TermQueryBuilder(name, value);
+  }
+
+  /**
+   * A Query that matches documents containing a term.
+   *
+   * @param name  The name of the field
+   * @param value The value of the term
+   */
+  static TermQueryBuilder termQuery(String name, double value) {
+    return new TermQueryBuilder(name, value);
+  }
+
+  /**
+   * A Query that matches documents containing a term.
+   *
+   * @param name  The name of the field
+   * @param value The value of the term
+   */
+  static TermQueryBuilder termQuery(String name, boolean value) {
+    return new TermQueryBuilder(name, value);
+  }
+
+  /**
+   * A Query that matches documents containing a term.
+   *
+   * @param name  The name of the field
+   * @param value The value of the term
+   */
+  static TermQueryBuilder termQuery(String name, Object value) {
+    return new TermQueryBuilder(name, value);
+  }
+
+  /**
+   * A Query that matches documents within an range of terms.
+   *
+   * @param name The field name
+   */
+  static RangeQueryBuilder rangeQuery(String name) {
+    return new RangeQueryBuilder(name);
+  }
+
+  /**
+   * A Query that matches documents containing terms with a specified regular expression.
+   *
+   * @param name   The name of the field
+   * @param regexp The regular expression
+   */
+  static RegexpQueryBuilder regexpQuery(String name, String regexp) {
+    return new RegexpQueryBuilder(name, regexp);
+  }
+
+
+  /**
+   * A Query that matches documents matching boolean combinations of other queries.
+   */
+  static BoolQueryBuilder boolQuery() {
+    return new BoolQueryBuilder();
+  }
+
+  /**
+   * A query that wraps another query and simply returns a constant score equal to the
+   * query boost for every document in the query.
+   *
+   * @param queryBuilder The query to wrap in a constant score query
+   */
+  static ConstantScoreQueryBuilder constantScoreQuery(QueryBuilder queryBuilder) {
+    return new ConstantScoreQueryBuilder(queryBuilder);
+  }
+
+  /**
+   * A filter to filter only documents where a field exists in them.
+   *
+   * @param name The name of the field
+   */
+  static ExistsQueryBuilder existsQuery(String name) {
+    return new ExistsQueryBuilder(name);
+  }
+
+  /**
+   * Base class to build ES queries
+   */
+  abstract static class QueryBuilder {
+
+    /**
+     * Convert existing query to JSON format using jackson API.
+     * @param generator used to generate JSON elements
+     * @throws IOException if IO error occurred
+     */
+    abstract void writeJson(JsonGenerator generator) throws IOException;
+  }
+
+  /**
+   * Query for boolean logic
+   */
+  static class BoolQueryBuilder extends QueryBuilder {
+    private final List<QueryBuilder> mustClauses = new ArrayList<>();
+    private final List<QueryBuilder> mustNotClauses = new ArrayList<>();
+    private final List<QueryBuilder> filterClauses = new ArrayList<>();
+    private final List<QueryBuilder> shouldClauses = new ArrayList<>();
+
+    BoolQueryBuilder must(QueryBuilder queryBuilder) {
+      Objects.requireNonNull(queryBuilder, "queryBuilder");
+      mustClauses.add(queryBuilder);
+      return this;
+    }
+
+    BoolQueryBuilder filter(QueryBuilder queryBuilder) {
+      Objects.requireNonNull(queryBuilder, "queryBuilder");
+      filterClauses.add(queryBuilder);
+      return this;
+    }
+
+    BoolQueryBuilder mustNot(QueryBuilder queryBuilder) {
+      Objects.requireNonNull(queryBuilder, "queryBuilder");
+      mustNotClauses.add(queryBuilder);
+      return this;
+    }
+
+    BoolQueryBuilder should(QueryBuilder queryBuilder) {
+      Objects.requireNonNull(queryBuilder, "queryBuilder");
+      shouldClauses.add(queryBuilder);
+      return this;
+    }
+
+    @Override protected void writeJson(JsonGenerator gen) throws IOException {
+      gen.writeStartObject();
+      gen.writeFieldName("bool");
+      gen.writeStartObject();
+      writeJsonArray("must", mustClauses, gen);
+      writeJsonArray("filter", filterClauses, gen);
+      writeJsonArray("must_not", mustNotClauses, gen);
+      writeJsonArray("should", shouldClauses, gen);
+      gen.writeEndObject();
+      gen.writeEndObject();
+    }
+
+    private void writeJsonArray(String field, List<QueryBuilder> clauses, JsonGenerator gen)
+        throws IOException {
+      if (clauses.isEmpty()) {
+        return;
+      }
+
+      if (clauses.size() == 1) {
+        gen.writeFieldName(field);
+        clauses.get(0).writeJson(gen);
+      } else {
+        gen.writeArrayFieldStart(field);
+        for (QueryBuilder clause: clauses) {
+          clause.writeJson(gen);
+        }
+        gen.writeEndArray();
+      }
+    }
+  }
+
+  /**
+   * A Query that matches documents containing a term.
+   */
+  static class TermQueryBuilder extends QueryBuilder {
+    private final String fieldName;
+    private final Object value;
+
+    private TermQueryBuilder(final String fieldName, final Object value) {
+      this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
+      this.value = Objects.requireNonNull(value, "value");
+    }
+
+    @Override void writeJson(final JsonGenerator generator) throws IOException {
+      generator.writeStartObject();
+      generator.writeFieldName("term");
+      generator.writeStartObject();
+      generator.writeFieldName(fieldName);
+      writeScalar(generator, value);
+      generator.writeEndObject();
+      generator.writeEndObject();
+    }
+  }
+
+  /**
+   * Write single simple (scalar) value (string, number, boolean or null) to json output.
+   *
+   * @param generator api to generate JSON document
+   * @param value JSON value to write
+   * @throws IOException if can't write to output
+   */
+  private static void writeScalar(JsonGenerator generator, Object value) throws IOException {
+    if (value == null) {
+      generator.writeNull();
+    } else if (value instanceof CharSequence) {
+      generator.writeString(Objects.toString(value));
+    } else if (value instanceof Number) {
+      // write numbers as string
+      generator.writeNumber(value.toString());
+    } else if (value instanceof Boolean) {
+      generator.writeBoolean((Boolean) value);
+    } else {
+      final String message = String.format(Locale.ROOT, "Unsupported type %s : %s",
+          value.getClass(), value);
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  /**
+   * A Query that matches documents within an range of terms.
+   */
+  static class RangeQueryBuilder extends QueryBuilder {
+    private final String fieldName;
+
+    private Object lt;
+    private boolean lte;
+    private Object gt;
+    private boolean gte;
+
+    private String format;
+
+    private RangeQueryBuilder(final String fieldName) {
+      this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
+    }
+
+    private RangeQueryBuilder to(Object value, boolean lte) {
+      this.lt = Objects.requireNonNull(value, "value");
+      this.lte = lte;
+      return this;
+    }
+
+    private RangeQueryBuilder from(Object value, boolean gte) {
+      this.gt = Objects.requireNonNull(value, "value");
+      this.gte = gte;
+      return this;
+    }
+
+    RangeQueryBuilder lt(Object value) {
+      return to(value, false);
+    }
+
+    RangeQueryBuilder lte(Object value) {
+      return to(value, true);
+    }
+
+    RangeQueryBuilder gt(Object value) {
+      return from(value, false);
+    }
+
+    RangeQueryBuilder gte(Object value) {
+      return from(value, true);
+    }
+
+    RangeQueryBuilder format(String format) {
+      this.format = format;
+      return this;
+    }
+
+    @Override void writeJson(final JsonGenerator generator) throws IOException {
+      if (lt == null && gt == null) {
+        throw new IllegalStateException("Either lower or upper bound should be provided");
+      }
+
+      generator.writeStartObject();
+      generator.writeFieldName("range");
+      generator.writeStartObject();
+      generator.writeFieldName(fieldName);
+      generator.writeStartObject();
+
+      if (gt != null) {
+        final String op = gte ? "gte" : "gt";
+        generator.writeFieldName(op);
+        writeScalar(generator, gt);
+      }
+
+      if (lt != null) {
+        final String op = lte ? "lte" : "lt";
+        generator.writeFieldName(op);
+        writeScalar(generator, lt);
+      }
+
+      if (format != null) {
+        generator.writeStringField("format", format);
+      }
+
+      generator.writeEndObject();
+      generator.writeEndObject();
+      generator.writeEndObject();
+    }
+  }
+
+  /**
+   * A Query that does fuzzy matching for a specific value.
+   */
+  static class RegexpQueryBuilder extends QueryBuilder {
+    private final String fieldName;
+    private final String value;
+
+    RegexpQueryBuilder(final String fieldName, final String value) {
+      this.fieldName = fieldName;
+      this.value = value;
+    }
+
+    @Override void writeJson(final JsonGenerator generator) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Constructs a query that only match on documents that the field has a value in them.
+   */
+  static class ExistsQueryBuilder extends QueryBuilder {
+    private final String fieldName;
+
+    ExistsQueryBuilder(final String fieldName) {
+      this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
+    }
+
+    @Override void writeJson(final JsonGenerator generator) throws IOException {
+      generator.writeStartObject();
+      generator.writeFieldName("exists");
+      generator.writeStartObject();
+      generator.writeStringField("field", fieldName);
+      generator.writeEndObject();
+      generator.writeEndObject();
+    }
+  }
+
+  /**
+   * A query that wraps a filter and simply returns a constant score equal to the
+   * query boost for every document in the filter.
+   */
+  static class ConstantScoreQueryBuilder extends QueryBuilder {
+
+    private final QueryBuilder builder;
+
+    private ConstantScoreQueryBuilder(final QueryBuilder builder) {
+      this.builder = Objects.requireNonNull(builder, "builder");
+    }
+
+    @Override void writeJson(final JsonGenerator generator) throws IOException {
+      generator.writeStartObject();
+      generator.writeFieldName("constant_score");
+      generator.writeStartObject();
+      generator.writeFieldName("filter");
+      builder.writeJson(generator);
+      generator.writeEndObject();
+      generator.writeEndObject();
+    }
+  }
+}
+
+// End QueryBuilders.java

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.ViewTable;
+import org.apache.calcite.schema.impl.ViewTableMacro;
+import org.apache.calcite.test.CalciteAssert;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Test of different boolean expressions (some more complex than others).
+ */
+public class BooleanLogicTest {
+
+  @ClassRule
+  public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
+
+  private static final String NAME = "docs";
+
+  /**
+   * Used to create {@code zips} index and insert some data
+   * @throws Exception when ES node setup failed
+   */
+  @BeforeClass
+  public static void setupInstance() throws Exception {
+
+    final Map<String, String> mapping = ImmutableMap.of("A", "keyword", "b", "keyword",
+        "c", "keyword", "int", "long");
+
+    NODE.createIndex(NAME, mapping);
+
+    String doc = "{'a': 'a', 'b':'b', 'c':'c', 'int': 42}".replace('\'', '"');
+    NODE.insertDocument(NAME, (ObjectNode) NODE.mapper().readTree(doc));
+  }
+
+  private CalciteAssert.ConnectionFactory newConnectionFactory() {
+    return new CalciteAssert.ConnectionFactory() {
+      @Override public Connection createConnection() throws SQLException {
+        final Connection connection = DriverManager.getConnection("jdbc:calcite:");
+        final SchemaPlus root = connection.unwrap(CalciteConnection.class).getRootSchema();
+
+        root.add("elastic", new ElasticsearchSchema(NODE.restClient(), NODE.mapper(), NAME));
+
+        // add calcite view programmatically
+        final String viewSql = String.format(Locale.ROOT,
+            "select cast(_MAP['a'] AS varchar(2)) AS a, "
+                + " cast(_MAP['b'] AS varchar(2)) AS b, "
+                +  " cast(_MAP['c'] AS varchar(2)) AS c, "
+                +  " cast(_MAP['int'] AS integer) AS num"
+                +  " from \"elastic\".\"%s\"", NAME);
+
+        ViewTableMacro macro = ViewTable.viewMacro(root, viewSql,
+                Collections.singletonList("elastic"), Arrays.asList("elastic", "view"), false);
+        root.add("VIEW", macro);
+
+        return connection;
+      }
+    };
+  }
+
+  @Test
+  public void expressions() {
+    assertSingle("select * from view");
+    assertSingle("select * from view where a = 'a'");
+    assertEmpty("select * from view where a <> 'a'");
+    assertSingle("select * from view where  'a' = a");
+    assertEmpty("select * from view where a = 'b'");
+    assertEmpty("select * from view where 'b' = a");
+    assertSingle("select * from view where a in ('a', 'b')");
+    assertSingle("select * from view where a in ('a', 'c') and b = 'b'");
+    assertSingle("select * from view where (a = 'ZZ' or a = 'a')  and b = 'b'");
+    assertSingle("select * from view where b = 'b' and a in ('a', 'c')");
+    assertSingle("select * from view where num = 42 and a in ('a', 'c')");
+    assertEmpty("select * from view where a in ('a', 'c') and b = 'c'");
+    assertSingle("select * from view where a in ('a', 'c') and b = 'b' and num = 42");
+    assertSingle("select * from view where a in ('a', 'c') and b = 'b' and num >= 42");
+    assertEmpty("select * from view where a in ('a', 'c') and b = 'b' and num <> 42");
+    assertEmpty("select * from view where a in ('a', 'c') and b = 'b' and num > 42");
+    assertSingle("select * from view where num = 42");
+    assertSingle("select * from view where 42 = num");
+    assertEmpty("select * from view where num > 42");
+    assertEmpty("select * from view where 42 > num");
+    assertEmpty("select * from view where num > 42 and num > 42");
+    assertEmpty("select * from view where num > 42 and num < 42");
+    assertEmpty("select * from view where num > 42 and num < 42 and num <> 42");
+    assertEmpty("select * from view where num > 42 and num < 42 and num = 42");
+    assertEmpty("select * from view where num > 42 or num < 42 and num = 42");
+    assertSingle("select * from view where num > 42 and num < 42 or num = 42");
+    assertSingle("select * from view where num > 42 or num < 42 or num = 42");
+    assertSingle("select * from view where num >= 42 and num <= 42 and num = 42");
+    assertEmpty("select * from view where num >= 42 and num <= 42 and num <> 42");
+    assertEmpty("select * from view where num < 42");
+    assertEmpty("select * from view where num <> 42");
+    assertSingle("select * from view where num >= 42");
+    assertSingle("select * from view where num <= 42");
+    assertSingle("select * from view where num < 43");
+    assertSingle("select * from view where num < 50");
+    assertSingle("select * from view where num > 41");
+    assertSingle("select * from view where num > 0");
+    assertSingle("select * from view where (a = 'a' and b = 'b') or (num = 42 and c = 'c')");
+    assertSingle("select * from view where (a = 'a' or b = 'b') or (num = 42 and c = 'c')");
+    assertSingle("select * from view where a = 'a' and (b = '0' or (b = 'b' and "
+            +  "(c = '0' or (c = 'c' and num = 42))))");
+  }
+
+  private void assertSingle(String query) {
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query(query)
+            .returns("A=a; B=b; C=c; NUM=42\n");
+  }
+
+  private void assertEmpty(String query) {
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query(query)
+            .returns("");
+  }
+
+}
+
+// End BooleanLogicTest.java

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchVersionTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchVersionTest.java
@@ -36,6 +36,7 @@ public class ElasticsearchVersionTest {
     assertEquals(ElasticsearchVersion.fromString("6.0.1"), ElasticsearchVersion.ES6);
     assertEquals(ElasticsearchVersion.fromString("7.0.1"), ElasticsearchVersion.ES7);
     assertEquals(ElasticsearchVersion.fromString("111.0.1"), ElasticsearchVersion.UNKNOWN);
+    assertEquals(ElasticsearchVersion.fromString("2020.12.12"), ElasticsearchVersion.UNKNOWN);
 
     assertFails("");
     assertFails(".");

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchNode.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchNode.java
@@ -56,7 +56,7 @@ class EmbeddedElasticsearchNode implements AutoCloseable {
    * @return instance which needs to be explicitly started (using {@link #start()})
    */
   private static EmbeddedElasticsearchNode create(Settings settings) {
-    // ensure GroovyPlugin is installed or otherwise scripted fields would not work
+    // ensure PainlessPlugin is installed or otherwise scripted fields would not work
     Node node = new LocalNode(settings, Arrays.asList(Netty4Plugin.class, PainlessPlugin.class));
     return new EmbeddedElasticsearchNode(node);
   }
@@ -64,9 +64,10 @@ class EmbeddedElasticsearchNode implements AutoCloseable {
   /**
    * Creates elastic node as single member of a cluster. Node will not be started
    * unless {@link #start()} is explicitly called.
+   * <p>Need {@code synchronized} because of static caches inside ES (which are not thread safe).
    * @return instance which needs to be explicitly started (using {@link #start()})
    */
-  public static EmbeddedElasticsearchNode create() {
+  public static synchronized EmbeddedElasticsearchNode create() {
     File data = Files.createTempDir();
     data.deleteOnExit();
     File home = Files.createTempDir();
@@ -77,6 +78,9 @@ class EmbeddedElasticsearchNode implements AutoCloseable {
         .put("path.home", home.getAbsolutePath())
         .put("path.data", data.getAbsolutePath())
         .put("http.type", "netty4")
+        // allow multiple instances to run in parallel
+        .put("transport.tcp.port", 0)
+        .put("http.port", 0)
         .put("network.host", "localhost")
         .build();
 

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ProjectionTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ProjectionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.ViewTable;
+import org.apache.calcite.schema.impl.ViewTableMacro;
+import org.apache.calcite.test.CalciteAssert;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Checks renaming of fields (also upper, lower cases) during projections
+ */
+public class ProjectionTest {
+
+  @ClassRule
+  public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
+
+  private static final String NAME = "docs";
+
+  @BeforeClass
+  public static void setupInstance() throws Exception {
+
+    final Map<String, String> mappings = ImmutableMap.of("A", "keyword",
+        "b", "keyword", "cCC", "keyword", "DDd", "keyword");
+
+    NODE.createIndex(NAME, mappings);
+
+    String doc = "{'A': 'aa', 'b': 'bb', 'cCC': 'cc', 'DDd': 'dd'}".replace('\'', '"');
+    NODE.insertDocument(NAME, (ObjectNode) NODE.mapper().readTree(doc));
+  }
+
+  private CalciteAssert.ConnectionFactory newConnectionFactory() {
+    return new CalciteAssert.ConnectionFactory() {
+      @Override public Connection createConnection() throws SQLException {
+        final Connection connection = DriverManager.getConnection("jdbc:calcite:");
+        final SchemaPlus root = connection.unwrap(CalciteConnection.class).getRootSchema();
+
+        root.add("elastic", new ElasticsearchSchema(NODE.restClient(), NODE.mapper(), NAME));
+
+        // add calcite view programmatically
+        final String viewSql = String.format(Locale.ROOT,
+            "select cast(_MAP['A'] AS varchar(2)) AS \"a\", "
+                + " cast(_MAP['b'] AS varchar(2)) AS \"b\", "
+                +  " cast(_MAP['cCC'] AS varchar(2)) AS \"c\", "
+                +  " cast(_MAP['DDd'] AS varchar(2)) AS \"d\" "
+                +  " from \"elastic\".\"%s\"", NAME);
+
+        ViewTableMacro macro = ViewTable.viewMacro(root, viewSql,
+                Collections.singletonList("elastic"), Arrays.asList("elastic", "view"), false);
+        root.add("VIEW", macro);
+
+        return connection;
+      }
+    };
+  }
+
+  @Test
+  public void projection() {
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select * from view")
+            .returns("a=aa; b=bb; c=cc; d=dd\n");
+  }
+}
+
+// End ProjectionTest.java

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/QueryBuildersTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/QueryBuildersTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Check that internal queries are correctly converted to ES search query (as JSON)
+ */
+public class QueryBuildersTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void term() throws Exception {
+    assertEquals("{\"term\":{\"foo\":\"bar\"}}",
+        toJson(QueryBuilders.termQuery("foo", "bar")));
+    assertEquals("{\"term\":{\"foo\":true}}",
+        toJson(QueryBuilders.termQuery("foo", true)));
+    assertEquals("{\"term\":{\"foo\":false}}",
+        toJson(QueryBuilders.termQuery("foo", false)));
+    assertEquals("{\"term\":{\"foo\":123}}",
+        toJson(QueryBuilders.termQuery("foo", (long) 123)));
+    assertEquals("{\"term\":{\"foo\":41}}",
+        toJson(QueryBuilders.termQuery("foo", (short) 41)));
+    assertEquals("{\"term\":{\"foo\":42.42}}",
+        toJson(QueryBuilders.termQuery("foo", 42.42D)));
+    assertEquals("{\"term\":{\"foo\":1.1}}",
+        toJson(QueryBuilders.termQuery("foo", 1.1F)));
+  }
+
+  @Test
+  public void boolQuery() throws Exception {
+    QueryBuilders.QueryBuilder q1 = QueryBuilders.boolQuery()
+        .must(QueryBuilders.termQuery("foo", "bar"));
+
+    assertEquals("{\"bool\":{\"must\":{\"term\":{\"foo\":\"bar\"}}}}",
+        toJson(q1));
+
+    QueryBuilders.QueryBuilder q2 = QueryBuilders.boolQuery()
+        .must(QueryBuilders.termQuery("f1", "v1")).must(QueryBuilders.termQuery("f2", "v2"));
+
+    assertEquals("{\"bool\":{\"must\":[{\"term\":{\"f1\":\"v1\"}},{\"term\":{\"f2\":\"v2\"}}]}}",
+        toJson(q2)
+    );
+
+    QueryBuilders.QueryBuilder q3 = QueryBuilders.boolQuery()
+        .mustNot(QueryBuilders.termQuery("f1", "v1"));
+
+    assertEquals("{\"bool\":{\"must_not\":{\"term\":{\"f1\":\"v1\"}}}}",
+        toJson(q3)
+    );
+
+  }
+
+  @Test
+  public void exists() throws Exception {
+    assertEquals("{\"exists\":{\"field\":\"foo\"}}",
+        toJson(QueryBuilders.existsQuery("foo")));
+  }
+
+  @Test
+  public void range() throws Exception {
+    assertEquals("{\"range\":{\"f\":{\"lt\":0}}}",
+        toJson(QueryBuilders.rangeQuery("f").lt(0)));
+    assertEquals("{\"range\":{\"f\":{\"gt\":0}}}",
+        toJson(QueryBuilders.rangeQuery("f").gt(0)));
+    assertEquals("{\"range\":{\"f\":{\"gte\":0}}}",
+        toJson(QueryBuilders.rangeQuery("f").gte(0)));
+    assertEquals("{\"range\":{\"f\":{\"lte\":0}}}",
+        toJson(QueryBuilders.rangeQuery("f").lte(0)));
+    assertEquals("{\"range\":{\"f\":{\"gt\":1,\"lt\":2}}}",
+        toJson(QueryBuilders.rangeQuery("f").gt(1).lt(2)));
+    assertEquals("{\"range\":{\"f\":{\"gt\":11,\"lt\":0}}}",
+        toJson(QueryBuilders.rangeQuery("f").lt(0).gt(11)));
+    assertEquals("{\"range\":{\"f\":{\"gt\":1,\"lte\":2}}}",
+        toJson(QueryBuilders.rangeQuery("f").gt(1).lte(2)));
+    assertEquals("{\"range\":{\"f\":{\"gte\":1,\"lte\":\"zz\"}}}",
+        toJson(QueryBuilders.rangeQuery("f").gte(1).lte("zz")));
+    assertEquals("{\"range\":{\"f\":{\"gte\":1}}}",
+        toJson(QueryBuilders.rangeQuery("f").gte(1)));
+    assertEquals("{\"range\":{\"f\":{\"gte\":\"zz\"}}}",
+        toJson(QueryBuilders.rangeQuery("f").gte("zz")));
+    assertEquals("{\"range\":{\"f\":{\"gt\":\"a\",\"lt\":\"z\"}}}",
+        toJson(QueryBuilders.rangeQuery("f").gt("a").lt("z")));
+    assertEquals("{\"range\":{\"f\":{\"gte\":3}}}",
+        toJson(QueryBuilders.rangeQuery("f").gt(1).gt(2).gte(3)));
+    assertEquals("{\"range\":{\"f\":{\"lte\":3}}}",
+        toJson(QueryBuilders.rangeQuery("f").lt(1).lt(2).lte(3)));
+  }
+
+  private String toJson(QueryBuilders.QueryBuilder builder) throws IOException {
+    StringWriter writer = new StringWriter();
+    JsonGenerator gen = mapper.getFactory().createGenerator(writer);
+    builder.writeJson(gen);
+    gen.flush();
+    gen.close();
+    return writer.toString();
+  }
+}
+
+// End QueryBuildersTest.java

--- a/elasticsearch/src/test/java/org/apache/calcite/test/ElasticsearchChecker.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/test/ElasticsearchChecker.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.test;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -26,17 +27,19 @@ public class ElasticsearchChecker {
 
   private ElasticsearchChecker() {}
 
+
   /** Returns a function that checks that a particular Elasticsearch pipeline is
    * generated to implement a query.
    * @param strings expected expressions
    * @return validation function
    */
   public static Consumer<List> elasticsearchChecker(final String... strings) {
+    Objects.requireNonNull(strings, "strings");
     return actual -> {
       Object[] actualArray = actual == null || actual.isEmpty() ? null
-          : ((List) actual.get(0)).toArray();
+            : ((List) actual.get(0)).toArray();
       CalciteAssert.assertArrayEqual("expected Elasticsearch query not found", strings,
-          actualArray);
+            actualArray);
     };
   }
 }


### PR DESCRIPTION
Please note this patch fixes only ES adapter (not mongo, which is also affected).

Add new PredicateAnalyzer which uses visitor pattern to construct correct expression. The original version was copied from [Dremio project](https://github.com/dremio/dremio-oss/blob/master/plugins/elasticsearch/src/main/java/com/dremio/plugins/elastic/planning/rules/ProjectAnalyzer.java) (thanks to their team for improving calcite-ES integration)

Create internal QueryBuilders which mimics functionality of original ES API (TermQuery, BoolQuery, RangeQuery etc.)

### Introduced Regression
There is one regression in the test `testFilterRedundant`. When expressions on the same column not being optimized:
```sql
--- original
where state > 'CA' and state < 'AZ' and state = 'OK'
-- Multiple constraints on the same column. 
-- If there is an '=', it supersedes all other operators.
where state = 'OK'
```
This test is currently excluded from suite
