### PR TITLE
[CALCITE-2409] Use StringWriter to get source rather than file creation

### DIFF
--- a/spark/src/main/java/org/apache/calcite/adapter/spark/SparkHandlerImpl.java
+++ b/spark/src/main/java/org/apache/calcite/adapter/spark/SparkHandlerImpl.java
@@ -31,6 +31,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -49,7 +50,6 @@ public class SparkHandlerImpl implements CalcitePrepare.SparkHandler {
       new JavaSparkContext("local[1]", "calcite");
 
   private static SparkHandlerImpl instance;
-  private static final File SRC_DIR = new File("/tmp");
   private static final File CLASS_DIR = new File("target/classes");
 
   /** Creates a SparkHandlerImpl. */
@@ -106,8 +106,8 @@ public class SparkHandlerImpl implements CalcitePrepare.SparkHandler {
 
   public ArrayBindable compile(ClassDeclaration expr, String s) {
     final String className = "CalciteProgram" + classId.getAndIncrement();
-    final File file = new File(SRC_DIR, className + ".java");
-    try (Writer w = Util.printWriter(file)) {
+    final String classFileName = className + ".java";
+    try (Writer w = new StringWriter()) {
       String source = "public class " + className + "\n"
           + "    implements " + ArrayBindable.class.getName()
           + ", " + Serializable.class.getName()
@@ -120,10 +120,9 @@ public class SparkHandlerImpl implements CalcitePrepare.SparkHandler {
       System.out.println("======================");
 
       w.write(source);
-      w.close();
       JaninoCompiler compiler = new JaninoCompiler();
       compiler.getArgs().setDestdir(CLASS_DIR.getAbsolutePath());
-      compiler.getArgs().setSource(source, file.getAbsolutePath());
+      compiler.getArgs().setSource(w.toString(), classFileName);
       compiler.getArgs().setFullClassName(className);
       compiler.compile();
       @SuppressWarnings("unchecked")


### PR DESCRIPTION
`SparkHandlerImpl` from Calcite's Spark module expects that `/tmp` folder exists (`X:\tmp` in case of Windows where X is a disk where it runs). In case of folder absence it fails like describe in [CALCITE-2409](https://issues.apache.org/jira/browse/CALCITE-2409)
The PR provides a way of usage System.getProperty("java.io.tmpdir") as tmp folder (mostly actual for Windows)