### PR TITLE
[CALCITE-2421] Improve RexSimplify when unknownAsFalse is true

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -312,7 +312,7 @@ public class RexSimplify {
   }
 
   private void simplifyAndTerms(List<RexNode> terms) {
-    RexSimplify simplify = withUnknownAsFalse(false);
+    RexSimplify simplify = this;
     for (int i = 0; i < terms.size(); i++) {
       RexNode t = terms.get(i);
       if (Predicate.of(t) == null) {

--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -1113,6 +1113,7 @@ public class RexProgramTest {
         .add("i", intNullableType)
         .add("j", intType)
         .add("k", intType)
+        .add("l", intNullableType)
         .build();
 
     final RexDynamicParam range = rexBuilder.makeDynamicParam(rowType, 0);
@@ -1125,6 +1126,7 @@ public class RexProgramTest {
     final RexNode iRef = rexBuilder.makeFieldAccess(range, 8);
     final RexNode jRef = rexBuilder.makeFieldAccess(range, 9);
     final RexNode kRef = rexBuilder.makeFieldAccess(range, 10);
+    final RexNode lRef = rexBuilder.makeFieldAccess(range, 11);
     final RexLiteral literal1 = rexBuilder.makeExactLiteral(BigDecimal.ONE);
 
     // and: remove duplicates
@@ -1157,6 +1159,21 @@ public class RexProgramTest {
 
     checkSimplify(and(aRef, bRef, not(or(not(cRef), dRef, not(eRef)))),
         "AND(?0.a, ?0.b, ?0.c, ?0.e, NOT(?0.d))");
+
+    // comparisons as terms for a AND conjunction can be simplified when unknownAsFalse
+    // set to true.
+    // e.g expression like fieldA = fieldA AND fieldB = fieldB can be simplified into
+    // fieldA IS NOT NULL AND fieldB IS NOT NULL
+    // see CALCITE-2421 for more details
+    checkSimplify2(and(eq(iRef, iRef), eq(lRef, lRef)),
+        "AND(=(?0.i, ?0.i), =(?0.l, ?0.l))",
+        "AND(IS NOT NULL(?0.i), IS NOT NULL(?0.l))");
+    checkSimplify2(and(ge(iRef, iRef), le(lRef, lRef)),
+        "AND(>=(?0.i, ?0.i), <=(?0.l, ?0.l))",
+        "AND(IS NOT NULL(?0.i), IS NOT NULL(?0.l))");
+    checkSimplify2(and(lt(iRef, iRef), gt(lRef, lRef)),
+        "AND(<(?0.i, ?0.i), >(?0.l, ?0.l))",
+        "false");
 
     // or: remove duplicates
     checkSimplify(or(aRef, bRef, aRef), "OR(?0.a, ?0.b)");


### PR DESCRIPTION
Improve simplification of expression by RexSimplify when unknownAsFalse
is true by not setting back unknownAsFalse to false while processing
terms.

Allow for expressions like A = A AND B = B to be simplified as
A IS NOT NULL AND B IS NOT NULL