### PR TITLE
[CALCITE-2428] Cassandra unit test fails to parse JDK version string

### DIFF
--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.util.Bug;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -69,7 +71,6 @@ public class CassandraAdapterTest {
    *
    * <p>As of this wiring Cassandra 4.x is not yet released and we're using 3.x
    * (which fails on JDK11). All cassandra tests will be skipped if running on JDK11.
-   * TODO: remove JDK check once current adapter supports Cassandra 4.x
    *
    * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-9608">CASSANDRA-9608</a>
    * @return {@code true} if test is compatible with current environment,
@@ -78,9 +79,8 @@ public class CassandraAdapterTest {
   private static boolean enabled() {
     final boolean enabled =
         Util.getBooleanProperty("calcite.test.cassandra", true);
-    final int major = Integer.parseInt(System.getProperty("java.version").split("\\.")[0]);
-    final boolean compatibleJdk = major != 11;
-
+    Bug.upgrade("remove JDK version check once current adapter supports Cassandra 4.x");
+    final boolean compatibleJdk = TestUtil.getJavaMajorVersion() != 11;
     return enabled && compatibleJdk;
   }
 

--- a/core/src/test/java/org/apache/calcite/util/TestUtil.java
+++ b/core/src/test/java/org/apache/calcite/util/TestUtil.java
@@ -16,8 +16,12 @@
  */
 package org.apache.calcite.util;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.junit.ComparisonFailure;
 
+import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -194,19 +198,40 @@ public abstract class TestUtil {
         .replaceAll("\\]", "\\\\]");
   }
 
-  /** Returns the Java major version: 7 for JDK 1.7, 8 for JDK 8, 10 for
-   * JDK 10, etc. */
+  /**
+   * Returns the Java major version: 7 for JDK 1.7, 8 for JDK 8, 10 for
+   * JDK 10, etc. depending on current system property {@code java.version}.
+   */
   public static int getJavaMajorVersion() {
-    if (JAVA_VERSION.startsWith("1.7")) {
-      return 7;
-    } else if (JAVA_VERSION.startsWith("1.8")) {
-      return 8;
-    } else if (JAVA_VERSION.startsWith("1.9")) {
-      return 9;
+    return majorVersionFromString(JAVA_VERSION);
+  }
+
+  /**
+   * Detects java major version given long format of full JDK version.
+   * See <a href="http://openjdk.java.net/jeps/223">JEP 223: New Version-String Scheme</a>.
+   *
+   * @param version current version as string usually from {@code java.version} property.
+   * @return major java version ({@code 8, 9, 10, 11} etc.)
+   */
+  @VisibleForTesting
+  static int majorVersionFromString(String version) {
+    Objects.requireNonNull(version, "version");
+
+    if (version.startsWith("1.")) {
+      // running on version <= 8 (expecting string of type: x.y.z*)
+      final String[] versions = version.split("\\.");
+      return Integer.parseInt(versions[1]);
     } else {
-      return 10;
+      // probably running on > 8 (just get first integer which is major version)
+      Matcher matcher = Pattern.compile("^\\d+").matcher(version);
+      if (!matcher.lookingAt()) {
+        throw new IllegalArgumentException("Can't parse (detect) JDK version from " + version);
+      }
+
+      return Integer.parseInt(matcher.group());
     }
   }
+
 }
 
 // End TestUtil.java

--- a/core/src/test/java/org/apache/calcite/util/TestUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/TestUtilTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for TestUtil
+ */
+public class TestUtilTest {
+
+  @Test
+  public void current() {
+    // shouldn't throw any exceptions (for current JDK)
+    assertTrue(TestUtil.getJavaMajorVersion() > 6);
+  }
+
+  @Test
+  public void majorVersionFromString() {
+    assertEquals(4, TestUtil.majorVersionFromString("1.4.2_03"));
+    assertEquals(5, TestUtil.majorVersionFromString("1.5.0_16"));
+    assertEquals(6, TestUtil.majorVersionFromString("1.6.0_22"));
+    assertEquals(7, TestUtil.majorVersionFromString("1.7.0_65-b20"));
+    assertEquals(8, TestUtil.majorVersionFromString("1.8.0_72-internal"));
+    assertEquals(8, TestUtil.majorVersionFromString("1.8.0_151"));
+    assertEquals(8, TestUtil.majorVersionFromString("1.8.0_141"));
+    assertEquals(9, TestUtil.majorVersionFromString("1.9.0_20-b62"));
+    assertEquals(9, TestUtil.majorVersionFromString("1.9.0-ea-b19"));
+    assertEquals(9, TestUtil.majorVersionFromString("9"));
+    assertEquals(9, TestUtil.majorVersionFromString("9.0"));
+    assertEquals(9, TestUtil.majorVersionFromString("9.0.1"));
+    assertEquals(9, TestUtil.majorVersionFromString("9-ea"));
+    assertEquals(9, TestUtil.majorVersionFromString("9.0.1"));
+    assertEquals(9, TestUtil.majorVersionFromString("9.1-ea"));
+    assertEquals(9, TestUtil.majorVersionFromString("9.1.1-ea"));
+    assertEquals(9, TestUtil.majorVersionFromString("9.1.1-ea+123"));
+    assertEquals(10, TestUtil.majorVersionFromString("10"));
+    assertEquals(10, TestUtil.majorVersionFromString("10+456"));
+    assertEquals(10, TestUtil.majorVersionFromString("10-ea"));
+    assertEquals(10, TestUtil.majorVersionFromString("10-ea42"));
+    assertEquals(10, TestUtil.majorVersionFromString("10-ea+555"));
+    assertEquals(10, TestUtil.majorVersionFromString("10-ea42+555"));
+    assertEquals(10, TestUtil.majorVersionFromString("10.0"));
+    assertEquals(10, TestUtil.majorVersionFromString("10.0.0"));
+    assertEquals(10, TestUtil.majorVersionFromString("10.0.0.0.0"));
+    assertEquals(10, TestUtil.majorVersionFromString("10.1.2.3.4.5.6.7.8"));
+    assertEquals(10, TestUtil.majorVersionFromString("10.0.1"));
+    assertEquals(10, TestUtil.majorVersionFromString("10.1.1-foo"));
+    assertEquals(11, TestUtil.majorVersionFromString("11"));
+    assertEquals(11, TestUtil.majorVersionFromString("11+111"));
+    assertEquals(11, TestUtil.majorVersionFromString("11-ea"));
+    assertEquals(11, TestUtil.majorVersionFromString("11.0"));
+    assertEquals(12, TestUtil.majorVersionFromString("12.0"));
+    assertEquals(20, TestUtil.majorVersionFromString("20.0"));
+    assertEquals(42, TestUtil.majorVersionFromString("42"));
+    assertEquals(100, TestUtil.majorVersionFromString("100"));
+    assertEquals(100, TestUtil.majorVersionFromString("100.0"));
+    assertEquals(1000, TestUtil.majorVersionFromString("1000"));
+    assertEquals(2000, TestUtil.majorVersionFromString("2000"));
+    assertEquals(205, TestUtil.majorVersionFromString("205.0"));
+    assertEquals(2017, TestUtil.majorVersionFromString("2017"));
+    assertEquals(2017, TestUtil.majorVersionFromString("2017.0"));
+    assertEquals(2017, TestUtil.majorVersionFromString("2017.12"));
+    assertEquals(2017, TestUtil.majorVersionFromString("2017.12-pre"));
+    assertEquals(2017, TestUtil.majorVersionFromString("2017.12.31"));
+  }
+
+}
+
+// End TestUtilTest.java


### PR DESCRIPTION
Previous version failed to parse correctly versions like: 9, 10-ea, 11-pre etc.
Created separate class which uses regex to detect major JDK version given
a string (usually java.version property)