### PR TITLE
[CALCITE-2442] Cassandra intermittent test failures 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@ limitations under the License.
     <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
     <hydromatic-tpcds.version>0.4</hydromatic-tpcds.version>
     <jackson.version>2.9.4</jackson.version>
+    <jamm.version>0.3.2</jamm.version>
     <janino.version>2.7.6</janino.version>
     <java-diff.version>1.1.1</java-diff.version>
     <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
@@ -441,6 +442,15 @@ limitations under the License.
         <groupId>org.codehaus.janino</groupId>
         <artifactId>janino</artifactId>
         <version>${janino.version}</version>
+      </dependency>
+      <!--
+        Only required to specify updated version,
+        should be removed when cassandra-all is updated
+      -->
+      <dependency>
+        <groupId>com.github.jbellis</groupId>
+        <artifactId>jamm</artifactId>
+        <version>${jamm.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.janino</groupId>


### PR DESCRIPTION

1. Wrong parsing of new [JDK version scheme](http://openjdk.java.net/jeps/223) (by calcite and cassandra dependencies like jamm). `10-ea` vs `10.0.2`
2. Cassandra startup timeout on Linux Jenkins CI server. Contrary to github travis CI (the one which validates PRs), it takes about 20s for embedded cassandra to start (still under investigation).
3. Windows OS. [CassandraUnit](https://github.com/jsevellec/cassandra-unit) leaves `.toDelete` folder in maven module folder (`cassandra/`) rather than `target/` where all build and temporary files should be located. Not a failure but annoyance.
4. Explicitly shutdown cassandra cluster (not done by CassandraUnit by default)