### PR TITLE
[CALCITE-2447] Add power, atan2 methods with arguments "(BigDecimal b…

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -830,6 +830,10 @@ public class SqlFunctions {
     return Math.pow(b0, b1.doubleValue());
   }
 
+  public static double power(BigDecimal b0, long b1) {
+    return Math.pow(b0.doubleValue(), b1);
+  }
+
   // LN
 
   /** SQL {@code LN(number)} function applied to double values. */
@@ -1113,6 +1117,11 @@ public class SqlFunctions {
   /** SQL <code>ATAN2</code> operator applied to long/BigDecimal values. */
   public static double atan2(long b0, BigDecimal b1) {
     return Math.atan2(b0, b1.doubleValue());
+  }
+
+  /** SQL <code>ATAN2</code> operator applied to BigDecimal/long values. */
+  public static double atan2(BigDecimal b0, long b1) {
+    return Math.atan2(b0.doubleValue(), b1);
   }
 
   /** SQL <code>ATAN2</code> operator applied to BigDecimal values. */

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -2158,6 +2158,28 @@ where false;
 
 !ok
 
+# [CALCITE-2447] Power sqlfunction fails with NoSuchMethodException
+values power(0.5, 2);
++--------+
+| EXPR$0 |
++--------+
+|   0.25 |
++--------+
+(1 row)
+
+!ok
+
+# [CALCITE-2447] Atan2 sqlfunction fails with NoSuchMethodException
+values atan2(0.5, 2);
++---------------------+
+| EXPR$0              |
++---------------------+
+| 0.24497866312686414 |
++---------------------+
+(1 row)
+
+!ok
+
 !set outputformat csv
 
 # [CALCITE-1167] OVERLAPS should match even if operands are in (high, low) order


### PR DESCRIPTION
The PR adds methods `org.apache.calcite.runtime.SqlFunctions#power(java.math.BigDecimal, long)` and `org.apache.calcite.runtime.SqlFunctions#atan2(double, double)` to make possible running queries like `values power(0.5, 2);` and `values atan2(0.5, 2);`