### PR TITLE
[CALCITE-2456] fix VolcanoRuleCall#match for unordered child operand

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
@@ -165,6 +165,8 @@ public abstract class RelOptRuleCall {
    * children, and hence where the matched children are not retrievable by any
    * other means.
    *
+   * <p>Warning: it produces wrong result for {@code unordered(...)} case.
+   *
    * @param rel Relational expression
    * @return Children of relational expression
    */

--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -19,6 +19,8 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.core.Aggregate;
@@ -37,7 +39,6 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -79,31 +80,23 @@ public abstract class PruneEmptyRules {
           "Union") {
         public void onMatch(RelOptRuleCall call) {
           final LogicalUnion union = call.rel(0);
-          final List<RelNode> inputs = call.getChildRels(union);
+          final List<RelNode> inputs = union.getInputs();
           assert inputs != null;
-          final List<RelNode> newInputs = new ArrayList<>();
+          final RelBuilder builder = call.builder();
+          int nonEmptyInputs = 0;
           for (RelNode input : inputs) {
             if (!isEmpty(input)) {
-              newInputs.add(input);
+              builder.push(input);
+              nonEmptyInputs++;
             }
           }
-          assert newInputs.size() < inputs.size()
-              : "planner promised us at least one Empty child";
-          final RelBuilder builder = call.builder();
-          switch (newInputs.size()) {
-          case 0:
+          assert nonEmptyInputs < inputs.size()
+              : "planner promised us at least one Empty child: " + RelOptUtil.toString(union);
+          if (nonEmptyInputs == 0) {
             builder.push(union).empty();
-            break;
-          case 1:
-            builder.push(
-                RelOptUtil.createCastRel(
-                    newInputs.get(0),
-                    union.getRowType(),
-                    true));
-            break;
-          default:
-            builder.push(LogicalUnion.create(newInputs, union.all));
-            break;
+          } else {
+            builder.union(union.all, nonEmptyInputs);
+            builder.convert(union.getRowType(), true);
           }
           call.transformTo(builder.build());
         }
@@ -128,35 +121,27 @@ public abstract class PruneEmptyRules {
           "Minus") {
         public void onMatch(RelOptRuleCall call) {
           final LogicalMinus minus = call.rel(0);
-          final List<RelNode> inputs = call.getChildRels(minus);
+          final List<RelNode> inputs = minus.getInputs();
           assert inputs != null;
-          final List<RelNode> newInputs = new ArrayList<>();
+          int nonEmptyInputs = 0;
+          final RelBuilder builder = call.builder();
           for (RelNode input : inputs) {
             if (!isEmpty(input)) {
-              newInputs.add(input);
-            } else if (newInputs.isEmpty()) {
+              builder.push(input);
+              nonEmptyInputs++;
+            } else if (nonEmptyInputs == 0) {
               // If the first input of Minus is empty, the whole thing is
               // empty.
               break;
             }
           }
-          assert newInputs.size() < inputs.size()
-              : "planner promised us at least one Empty child";
-          final RelBuilder builder = call.builder();
-          switch (newInputs.size()) {
-          case 0:
+          assert nonEmptyInputs < inputs.size()
+              : "planner promised us at least one Empty child: " + RelOptUtil.toString(minus);
+          if (nonEmptyInputs == 0) {
             builder.push(minus).empty();
-            break;
-          case 1:
-            builder.push(
-                RelOptUtil.createCastRel(
-                    newInputs.get(0),
-                    minus.getRowType(),
-                    true));
-            break;
-          default:
-            builder.push(LogicalMinus.create(newInputs, minus.all));
-            break;
+          } else {
+            builder.minus(minus.all, nonEmptyInputs);
+            builder.convert(minus.getRowType(), true);
           }
           call.transformTo(builder.build());
         }
@@ -189,8 +174,24 @@ public abstract class PruneEmptyRules {
       };
 
   private static boolean isEmpty(RelNode node) {
-    return node instanceof Values
-        && ((Values) node).getTuples().isEmpty();
+    if (node instanceof Values) {
+      return ((Values) node).getTuples().isEmpty();
+    }
+    if (node instanceof HepRelVertex) {
+      return isEmpty(((HepRelVertex) node).getCurrentRel());
+    }
+    // Note: relation input might be a RelSubset, so we just iterate over the relations
+    // in order to check if the subset is equivalent to an empty relation.
+    if (!(node instanceof RelSubset)) {
+      return false;
+    }
+    RelSubset subset = (RelSubset) node;
+    for (RelNode rel : subset.getRels()) {
+      if (isEmpty(rel)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
@@ -155,7 +155,6 @@ public class VolcanoPlannerTest {
         equalTo(
             sort(
                 "NoneSingleRel:Subset#0.NONE",
-                "PhysSingleRel:Subset#0.NONE",
                 "PhysSingleRel:Subset#0.PHYS")));
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rules/SortRemoveRuleTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rules/SortRemoveRuleTest.java
@@ -73,8 +73,7 @@ public final class SortRemoveRuleTest {
     RelRoot planRoot = planner.rel(validate);
     RelNode planBefore = planRoot.rel;
     RelTraitSet desiredTraits = planBefore.getTraitSet()
-        .replace(EnumerableConvention.INSTANCE)
-        .replace(planRoot.collation).simplify();
+        .replace(EnumerableConvention.INSTANCE);
     RelNode planAfter = planner.transform(0, desiredTraits, planBefore);
     return planner.transform(1, desiredTraits, planAfter);
   }


### PR DESCRIPTION
This PR fixes the bug described in https://issues.apache.org/jira/browse/CALCITE-2456, where the `unordered` child operand type is not handled properly in VolcanoRuleCall. 