### PR TITLE
[CALCITE-2463] Silence ERROR logs from CalciteException, SqlValidatorException

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/CalciteException.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.runtime;
 
+import org.apache.calcite.prepare.CalcitePrepareImpl;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +60,9 @@ public class CalciteException extends RuntimeException {
     // TODO: Force the caller to pass in a Logger as a trace argument for
     // better context.  Need to extend ResGen for this.
     LOGGER.trace("CalciteException", this);
-    LOGGER.error(toString());
+    if (CalcitePrepareImpl.DEBUG) {
+      LOGGER.error(toString());
+    }
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorException.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorException.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql.validate;
 
+import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.util.CalciteValidatorException;
 
 import org.slf4j.Logger;
@@ -56,7 +57,9 @@ public class SqlValidatorException extends Exception
 
     // TODO: see note in CalciteException constructor
     LOGGER.trace("SqlValidatorException", this);
-    LOGGER.error(toString());
+    if (CalcitePrepareImpl.DEBUG) {
+      LOGGER.error(toString());
+    }
   }
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-2463

Output exception messages to logger only in `calcite.debug=true` mode