### PR TITLE
[CALCITE-2483] Fix integer overflow in Druid segment metadata query

### DIFF
--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidConnectionImpl.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidConnectionImpl.java
@@ -719,8 +719,8 @@ class DruidConnectionImpl implements DruidConnection {
     public String id;
     public List<String> intervals;
     public Map<String, JsonColumn> columns;
-    public int size;
-    public int numRows;
+    public long size;
+    public long numRows;
     public Map<String, JsonAggregator> aggregators;
   }
 


### PR DESCRIPTION
As description at [CALCITE-2483](https://issues.apache.org/jira/browse/CALCITE-2483). Both the `numRows` and `size` have `long` type in Druid source code, Calcite should match that.