### PR TITLE
[CALCITE-2484] Fix dynamic table tests giving wrong results when running tests concurrently.

### DIFF
--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -44,9 +44,6 @@ import static org.junit.Assert.fail;
  * for SqlAdvisor.
  */
 public class SqlAdvisorTest extends SqlValidatorTestCase {
-  public static final SqlTestFactory ADVISOR_TEST_FACTORY = SqlTestFactory.INSTANCE.withValidator(
-      SqlAdvisorValidator::new);
-
   //~ Static fields/initializers ---------------------------------------------
 
   private static final List<String> STAR_KEYWORD =
@@ -517,7 +514,8 @@ public class SqlAdvisorTest extends SqlValidatorTestCase {
   }
 
   @Override public SqlTester getTester() {
-    return new SqlTesterImpl(ADVISOR_TEST_FACTORY);
+    return new SqlTesterImpl(
+        new SqlTestFactory().withValidator(SqlAdvisorValidator::new));
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -7641,7 +7641,7 @@ public abstract class SqlOperatorBaseTest {
   }
 
   public static SqlTester tester() {
-    return new TesterImpl(SqlTestFactory.INSTANCE);
+    return new TesterImpl(new SqlTestFactory());
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
@@ -68,9 +68,6 @@ public class SqlTestFactory {
                           CalciteAssert.SchemaSpec.HR)))
           .build();
 
-  public static final SqlTestFactory INSTANCE =
-      new SqlTestFactory();
-
   private final ImmutableMap<String, Object> options;
   private final MockCatalogReaderFactory catalogReaderFactory;
   private final ValidatorFactory validatorFactory;
@@ -80,7 +77,7 @@ public class SqlTestFactory {
   private final Supplier<SqlValidatorCatalogReader> catalogReader;
   private final Supplier<SqlParser.Config> parserConfig;
 
-  protected SqlTestFactory() {
+  public SqlTestFactory() {
     this(DEFAULT_OPTIONS, MockCatalogReaderSimple::new, SqlValidatorUtil::newValidator);
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
@@ -125,7 +125,7 @@ public class SqlValidatorUtilTest {
     newList.add(new SqlIdentifier(Arrays.asList("f0", "c0"), SqlParserPos.ZERO));
     newList.add(new SqlIdentifier(Arrays.asList("f0", "c0"), SqlParserPos.ZERO));
     final SqlTesterImpl tester =
-        new SqlTesterImpl(SqlTestFactory.INSTANCE);
+        new SqlTesterImpl(new SqlTestFactory());
     final SqlValidatorImpl validator =
         (SqlValidatorImpl) tester.getValidator();
     try {

--- a/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
@@ -88,12 +88,14 @@ public class SqlTestGen {
    * tests.
    */
   private static class SqlValidatorSpooler extends SqlValidatorTest {
-    private static final SqlTestFactory SPOOLER_VALIDATOR = SqlTestFactory.INSTANCE.withValidator(
-        (opTab, catalogReader, typeFactory, conformance) ->
-            (SqlValidator) Proxy.newProxyInstance(
-                SqlValidatorSpooler.class.getClassLoader(),
-                new Class[]{SqlValidator.class},
-                new MyInvocationHandler()));
+    private static SqlTestFactory createSpoolerValidator() {
+      return new SqlTestFactory().withValidator(
+          (opTab, catalogReader, typeFactory, conformance) ->
+              (SqlValidator) Proxy.newProxyInstance(
+                  SqlValidatorSpooler.class.getClassLoader(),
+                  new Class[]{SqlValidator.class},
+                  new MyInvocationHandler()));
+    }
 
     private final PrintWriter pw;
 
@@ -102,7 +104,7 @@ public class SqlTestGen {
     }
 
     public SqlTester getTester() {
-      return new SqlTesterImpl(SPOOLER_VALIDATOR) {
+      return new SqlTesterImpl(createSpoolerValidator()) {
         public void assertExceptionIsThrown(
             String sql,
             String expectedMsgPattern) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorFeatureTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorFeatureTest.java
@@ -55,7 +55,7 @@ public class SqlValidatorFeatureTest extends SqlValidatorTestCase {
   //~ Methods ----------------------------------------------------------------
 
   @Override public SqlTester getTester() {
-    return new SqlTesterImpl(SqlTestFactory.INSTANCE.withValidator(FeatureValidator::new));
+    return new SqlTesterImpl(new SqlTestFactory().withValidator(FeatureValidator::new));
   }
 
   @Test public void testDistinct() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
@@ -62,19 +62,20 @@ public class SqlValidatorTestCase {
       Pattern.compile(
           "(?s)From line ([0-9]+), column ([0-9]+) to line ([0-9]+), column ([0-9]+): (.*)");
 
-  private static final SqlTestFactory EXTENDED_TEST_FACTORY =
-      SqlTestFactory.INSTANCE.withCatalogReader(MockCatalogReaderExtended::new);
-
   static final SqlTesterImpl EXTENDED_CATALOG_TESTER =
-      new SqlTesterImpl(EXTENDED_TEST_FACTORY);
+      new SqlTesterImpl(createExtendedTestFactory());
 
   static final SqlTesterImpl EXTENDED_CATALOG_TESTER_2003 =
-      new SqlTesterImpl(EXTENDED_TEST_FACTORY)
+      new SqlTesterImpl(createExtendedTestFactory())
           .withConformance(SqlConformanceEnum.PRAGMATIC_2003);
 
   static final SqlTesterImpl EXTENDED_CATALOG_TESTER_LENIENT =
-      new SqlTesterImpl(EXTENDED_TEST_FACTORY)
+      new SqlTesterImpl(createExtendedTestFactory())
           .withConformance(SqlConformanceEnum.LENIENT);
+
+  private static SqlTestFactory createExtendedTestFactory() {
+    return new SqlTestFactory().withCatalogReader(MockCatalogReaderExtended::new);
+  }
 
   //~ Instance fields --------------------------------------------------------
 
@@ -96,7 +97,7 @@ public class SqlValidatorTestCase {
    * same set of tests in a different testing environment.
    */
   public SqlTester getTester() {
-    return new SqlTesterImpl(SqlTestFactory.INSTANCE);
+    return new SqlTesterImpl(new SqlTestFactory());
   }
 
   public final Sql sql(String sql) {


### PR DESCRIPTION
This pull request fixes the bug in [CALCITE-2484](https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-2484).

### What's happening
When two dynamic table tests referencing to the same table name run concurrently, the results of the tests will be incorrect, causing the tests to fail.

### How to reproduce this bug
As the condition to trigger this bug is strict (two dynamic table tests must reference the same table name, and they must run concurrently), it's hard to reproduce this bug in the current test set.

I construct two mock test classes to reproduce this bug stably. The two test classes are the same except for their names. One of the test class is listed as follows:

```java
public class MockSqlValidatorTest1 extends SqlValidatorTestCase {
  // Member definition omitted.

  @Test
  public void testDynamicStar1() {
    final String sql = "select newid from (\n"
        + "  select *, NATION.N_NATION + 100 as newid\n"
        + "  from \"DYNAMIC\".NATION, \"DYNAMIC\".CUSTOMER)";
    sql(sql).type("RecordType(ANY NEWID) NOT NULL");
  }

  @Test
  public void testDynamicStar2() {
    final String sql = "select newid from (\n"
        + "  select *, NATION.N_NATION + 100 as newid\n"
        + "  from \"DYNAMIC\".NATION, \"DYNAMIC\".CUSTOMER)";
    sql(sql).type("RecordType(ANY NEWID) NOT NULL");
  }

  // 296 more test cases

  @Test
  public void testDynamicStar299() {
    final String sql = "select newid from (\n"
        + "  select *, NATION.N_NATION + 100 as newid\n"
        + "  from \"DYNAMIC\".NATION, \"DYNAMIC\".CUSTOMER)";
    sql(sql).type("RecordType(ANY NEWID) NOT NULL");
  }

  @Test
  public void testDynamicStar300() {
    final String sql = "select newid from (\n"
        + "  select *, NATION.N_NATION + 100 as newid\n"
        + "  from \"DYNAMIC\".NATION, \"DYNAMIC\".CUSTOMER)";
    sql(sql).type("RecordType(ANY NEWID) NOT NULL");
  }
```

You can check these two test classes [here](https://paste.ubuntu.com/p/rcWYjMzMjf/) and [here](https://paste.ubuntu.com/p/Tb2VTz74Xv/) so you can try them out.

To reproduce this bug, run
```
mvn -T 4 -Dtest=MockSqlValidatorTest* test -pl core
```
to run these two test classes concurrently, the bug will occur.

### Why is this happening
1. In the current implementation, when a test class wants to use a `SqlTestFactory`, it will use `SqlTestFactory.INSTANCE`, so every class using this factory actually shares the same factory instance.
2. `catalogReader` is a member of `SqlTestFactory`, so every class actually shares the same `catalogReader`.
3. As root schema is stored in catalog reader, table is stored in root schema, and row type is stored in table, every class actually has access to the same row type instance.
4. As dynamic table will modify row type if a column name it wants to use doesn't exist, two test cases running concurrently and using the same table name may read and modify the same row type instance, causing the result of the test to be incorrect, thus causing the failure of the test.

### How to fix this bug
What I've done in this commit is to remove SqlTestFactory.INSTANCE, and let every test class use a new instance of the factory, so that we can solve the concurrent modification problem.