### PR TITLE
[CALCITE-2271] Join of two views with window aggregates produces incorrect results or NPE

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
@@ -72,7 +72,6 @@ public class EnumerableRelImplementor extends JavaRelImplementor {
       new HashMap<>();
   private final Map<Object, ParameterExpression> stashedParameters =
       new IdentityHashMap<>();
-  int windowCount = 0;
 
   protected final Function1<String, RexToLixTranslator.InputGetter> allCorrelateVariables =
       this::getCorrelVariableGetter;

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
@@ -175,11 +175,10 @@ public class EnumerableWindow extends Window implements EnumerableRel {
 
     PhysType inputPhysType = result.physType;
 
-    final int w = implementor.windowCount++;
     ParameterExpression prevStart =
-        Expressions.parameter(int.class, builder.newName("prevStart" + w));
+        Expressions.parameter(int.class, builder.newName("prevStart"));
     ParameterExpression prevEnd =
-        Expressions.parameter(int.class, builder.newName("prevEnd" + w));
+        Expressions.parameter(int.class, builder.newName("prevEnd"));
 
     builder.add(Expressions.declare(0, prevStart, null));
     builder.add(Expressions.declare(0, prevEnd, null));

--- a/core/src/test/resources/sql/winagg.iq
+++ b/core/src/test/resources/sql/winagg.iq
@@ -420,13 +420,66 @@ limit 5;
 +--------+-----+-----+
 | deptno | AR  | BR  |
 +--------+-----+-----+
+|     10 | 110 | 100 |
 |     10 | 110 | 110 |
 |     10 | 110 | 110 |
-|     10 | 110 | 110 |
+|     10 | 110 | 150 |
 |     20 | 200 | 200 |
-|     20 | 200 |     |
 +--------+-----+-----+
 (5 rows)
+
+!ok
+
+select a."empid", a."deptno", a."commission", a.r as ar, b.r as br
+from (
+  select "empid", "deptno", "commission", first_value("empid") over w as r
+  from "hr"."emps"
+  window w as (partition by "deptno" order by "commission")) a
+join (
+  select "empid", "deptno", "commission", last_value("empid") over w as r
+  from "hr"."emps"
+  window w as (partition by "deptno" order by "commission")) b
+on a."empid" = b."empid"
+limit 5;
+
++-------+--------+------------+-----+-----+
+| empid | deptno | commission | AR  | BR  |
++-------+--------+------------+-----+-----+
+|   100 |     10 |       1000 | 110 | 100 |
+|   110 |     10 |        250 | 110 | 110 |
+|   150 |     10 |            | 110 | 150 |
+|   200 |     20 |        500 | 200 | 200 |
++-------+--------+------------+-----+-----+
+(4 rows)
+
+!ok
+
+# [CALCITE-2271] Two windows under a JOIN 2
+select
+ t1.l, t1.key as key1, t2.key as key2
+from
+ (
+  select
+   dense_rank() over (order by key) l,
+   key
+  from
+   unnest(map[1,1,2,2]) k
+ ) t1
+ join
+ (
+  select
+   dense_rank() over(order by key) l,
+   key
+  from
+   unnest(map[2,2]) k
+ ) t2 on (t1.l = t2.l and t1.key + 1 = t2.key);
+
++---+------+------+
+| L | KEY1 | KEY2 |
++---+------+------+
+| 1 |    1 |    2 |
++---+------+------+
+(1 row)
 
 !ok
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BlockBuilder.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BlockBuilder.java
@@ -121,10 +121,23 @@ public class BlockBuilder {
       }
       if (statement instanceof DeclarationStatement) {
         DeclarationStatement declaration = (DeclarationStatement) statement;
-        if (variables.contains(declaration.parameter.name)) {
-          Expression x = append(
-              newName(declaration.parameter.name, optimize),
-              declaration.initializer);
+        if (!variables.contains(declaration.parameter.name)) {
+          add(statement);
+        } else {
+          String newName = newName(declaration.parameter.name, optimize);
+          Expression x;
+          // When initializer is null, append(name, initializer) can't deduce expression type
+          if (declaration.initializer != null && isSafeForReuse(declaration)) {
+            x = append(newName, declaration.initializer);
+          } else {
+            ParameterExpression pe = Expressions.parameter(
+                declaration.parameter.type, newName);
+            DeclarationStatement newDeclaration = Expressions.declare(
+                declaration.modifiers, pe, declaration.initializer
+            );
+            x = pe;
+            add(newDeclaration);
+          }
           statement = null;
           result = x;
           if (declaration.parameter != x) {
@@ -132,8 +145,6 @@ public class BlockBuilder {
             // declaration was present in BlockBuilder
             replacements.put(declaration.parameter, x);
           }
-        } else {
-          add(statement);
         }
       } else {
         add(statement);
@@ -237,7 +248,7 @@ public class BlockBuilder {
   }
 
   protected boolean isSafeForReuse(DeclarationStatement decl) {
-    return (decl.modifiers & Modifier.FINAL) != 0;
+    return (decl.modifiers & Modifier.FINAL) != 0 && !decl.parameter.name.startsWith("_");
   }
 
   protected void addExpressionForReuse(DeclarationStatement decl) {
@@ -340,7 +351,7 @@ public class BlockBuilder {
     }
     final Map<ParameterExpression, Expression> subMap =
         new IdentityHashMap<>(useCounter.map.size());
-    final SubstituteVariableVisitor visitor = new SubstituteVariableVisitor(
+    final Shuttle visitor = new InlineVariableVisitor(
         subMap);
     final ArrayList<Statement> oldStatements = new ArrayList<>(statements);
     statements.clear();
@@ -493,7 +504,7 @@ public class BlockBuilder {
 
   /** Substitute Variable Visitor. */
   private static class SubstituteVariableVisitor extends Shuttle {
-    private final Map<ParameterExpression, Expression> map;
+    protected final Map<ParameterExpression, Expression> map;
     private final Map<ParameterExpression, Boolean> actives =
         new IdentityHashMap<>();
 
@@ -518,6 +529,14 @@ public class BlockBuilder {
         }
       }
       return super.visit(parameterExpression);
+    }
+  }
+
+  /** Inline Variable Visitor. */
+  private static class InlineVariableVisitor extends SubstituteVariableVisitor {
+    InlineVariableVisitor(
+        Map<ParameterExpression, Expression> map) {
+      super(map);
     }
 
     @Override public Expression visit(UnaryExpression unaryExpression,
@@ -550,6 +569,7 @@ public class BlockBuilder {
       return super.visit(binaryExpression, expression0, expression1);
     }
   }
+
 
   /** Use counter. */
   private static class UseCounter extends VisitorImpl<Void> {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BlockBuilder.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BlockBuilder.java
@@ -570,7 +570,6 @@ public class BlockBuilder {
     }
   }
 
-
   /** Use counter. */
   private static class UseCounter extends VisitorImpl<Void> {
     private final Map<ParameterExpression, Slot> map = new IdentityHashMap<>();

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
@@ -2940,6 +2940,9 @@ public abstract class Expressions {
    */
   public static DeclarationStatement declare(int modifiers, String name,
       Expression initializer) {
+    assert initializer != null
+        : "empty initializer for variable declaration with name '" + name + "', modifiers "
+        + modifiers + ". Please use declare(int, ParameterExpression, initializer) instead";
     return declare(modifiers, parameter(initializer.getType(), name),
         initializer);
   }

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
@@ -995,7 +995,8 @@ public class ExpressionTest {
             + "  final int _b = 1 + 2;\n"
             + "  final int _c = 1 + 3;\n"
             + "  final int _d = 1 + 4;\n"
-            + "  org.apache.calcite.linq4j.test.ExpressionTest.bar(1, _b, _c, _d, org.apache.calcite.linq4j.test.ExpressionTest.foo(_c));\n"
+            + "  final int _b0 = 1 + 3;\n"
+            + "  org.apache.calcite.linq4j.test.ExpressionTest.bar(1, _b, _c, _d, org.apache.calcite.linq4j.test.ExpressionTest.foo(_b0));\n"
             + "}\n",
         Expressions.toString(expression));
     expression.accept(new Shuttle());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-2271

Avoid NPE in BlockBuilder.append when empty variable initializer is used