### PR TITLE
[CALCITE-2327] Avoid simplification of x AND NOT(x) to false for nullable x

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -56,7 +56,6 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -1543,7 +1542,6 @@ public class RexProgramTest extends RexProgramBuilderBase {
         "false");
   }
 
-  @Ignore
   @Test public void testSimplifyAnd3() {
     final RelDataType boolType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
     final RelDataType rowType = typeFactory.builder()
@@ -1557,7 +1555,7 @@ public class RexProgramTest extends RexProgramBuilderBase {
     checkSimplify2(
         and(aRef,
             not(aRef)),
-        "a is null and null",
+        "AND(null, IS NULL(?0.a))",
         "false");
   }
 


### PR DESCRIPTION
`x AND NOT(x) ==> FALSE AND x IS NULL`

closes #707