### PR TITLE
[CALCITE-2494] RexFieldAccess should implement equals/hashCode

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
@@ -91,6 +91,25 @@ public class RexFieldAccess extends RexNode {
   public RexNode getReferenceExpr() {
     return expr;
   }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RexFieldAccess that = (RexFieldAccess) o;
+
+    return field.equals(that.field) && expr.equals(that.expr);
+  }
+
+  @Override public int hashCode() {
+    int result = expr.hashCode();
+    result = 31 * result + field.hashCode();
+    return result;
+  }
 }
 
 // End RexFieldAccess.java

--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -70,6 +70,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -1557,6 +1559,17 @@ public class RexProgramTest extends RexProgramBuilderBase {
             not(aRef)),
         "AND(null, IS NULL(?0.a))",
         "false");
+  }
+
+  @Test public void fieldAccessEqualsHashCode() {
+    assertEquals("vBool() instances should be equal", vBool(), vBool());
+    assertEquals("vBool().hashCode()", vBool().hashCode(), vBool().hashCode());
+    assertNotSame("vBool() is expected to produce new RexFieldAccess", vBool(), vBool());
+    assertNotEquals("vBool(0) != vBool(1)", vBool(0), vBool(1));
+  }
+
+  @Test public void testSimplifyDynamicParam() {
+    checkSimplify2(or(vBool(), vBool()), "?0.bool0", "?0.bool0");
   }
 
   /** Unit test for


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-2494