### PR TITLE
[CALCITE-2507] Aliasing a star in select list should throw a parsing e…

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1559,6 +1559,11 @@ SqlNode SelectItem() :
     SqlIdentifier id;
 }
 {
+    LOOKAHEAD(7)
+    e = StarIdentifier() {
+        return e;
+    }
+    |
     e = SelectExpression()
     [
         [ <AS> ]
@@ -1579,10 +1584,6 @@ SqlNode SelectExpression() :
     SqlNode e;
 }
 {
-    <STAR> {
-        return SqlIdentifier.star(getPos());
-    }
-|
     e = Expression(ExprContext.ACCEPT_SUB_QUERY) {
         return e;
     }
@@ -4244,6 +4245,46 @@ SqlNodeList ParenthesizedSimpleIdentifierList() :
     SimpleIdentifierCommaList(list)
     <RPAREN> {
         return new SqlNodeList(list, s.end(this));
+    }
+}
+
+/**
+ * Parses a star identifier.
+ */
+SqlIdentifier StarIdentifier() :
+{
+    List<String> list = new ArrayList<String>();
+    List<SqlParserPos> posList = new ArrayList<SqlParserPos>();
+    String p;
+}
+{
+    [
+        p = Identifier()
+        {
+            list.add(p);
+            posList.add(getPos());
+        }
+        <DOT>
+        [
+            p = Identifier() {
+                list.add(p);
+                posList.add(getPos());
+            }
+            <DOT>
+            [
+                p = Identifier() {
+                    list.add(p);
+                    posList.add(getPos());
+                }
+                <DOT>
+            ]
+        ]
+    ]
+    <STAR> {
+        list.add("");
+        posList.add(getPos());
+        SqlParserPos pos = SqlParserPos.sum(posList);
+        return SqlIdentifier.star(list, pos, posList);
     }
 }
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -695,11 +695,14 @@ public class SqlParserTest {
         "Lexical error at line 1, column 10\\.  Encountered: \"#\" \\(35\\), after : \"\"");
   }
 
-  // TODO: should fail in parser
   @Test public void testStarAsFails() {
-    sql("select * as x from emp")
-        .ok("SELECT * AS `X`\n"
-            + "FROM `EMP`");
+    checkFails("select * ^as^ x from emp",
+        "(?s).*Encountered \"as\" at line 1, column 10.*");
+  }
+
+  @Test public void testCatalogSchemaTableAsFails() {
+    checkFails("select cat.schem.emp.* ^as^ x from cat.schem.emp",
+        "(?s).*Encountered \"as\" at line 1, column 24.*");
   }
 
   @Test public void testDerivedColumnList() {
@@ -2420,10 +2423,7 @@ public class SqlParserTest {
   }
 
   @Test public void testAliasedStar() {
-    // OK in parser; validator will give error
-    sql("select emp.* as foo from emp")
-        .ok("SELECT `EMP`.* AS `FOO`\n"
-                + "FROM `EMP`");
+    checkFails("select emp.* ^as^ foo from emp", "(?s).*Encountered \"as\" at line 1, column 14.*");
   }
 
   @Test public void testTableStarColumnFails() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -4788,8 +4788,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test public void testStarAliasFails() {
-    sql("select emp.^*^ AS x from emp")
-        .fails("Unknown field '\\*'");
+    checkFails("select emp.^*^ AS x from emp", "(?s).*Encountered \"AS\" at line 1, column 14.*");
   }
 
   @Test public void testNonLocalStar() {


### PR DESCRIPTION
…rror.

Aliasing a Star was not generating a parser error. SqlValidator was catching this error and reporting to the user. This fix is to handle it in parser.