### PR TITLE
[CALCITE-2529] All numbers are in the same type family

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -832,10 +832,6 @@ public class SqlFunctions {
     return Math.exp(b0.doubleValue());
   }
 
-  public static double exp(long b0) {
-    return Math.exp(b0);
-  }
-
   // POWER
 
   /** SQL <code>POWER</code> operator applied to double values. */
@@ -847,20 +843,12 @@ public class SqlFunctions {
     return Math.pow(b0, b1.doubleValue());
   }
 
-  public static double power(long b0, long b1) {
-    return Math.pow(b0, b1);
+  public static double power(BigDecimal b0, double b1) {
+    return Math.pow(b0.doubleValue(), b1);
   }
 
   public static double power(BigDecimal b0, BigDecimal b1) {
     return Math.pow(b0.doubleValue(), b1.doubleValue());
-  }
-
-  public static double power(long b0, BigDecimal b1) {
-    return Math.pow(b0, b1.doubleValue());
-  }
-
-  public static double power(BigDecimal b0, long b1) {
-    return Math.pow(b0.doubleValue(), b1);
   }
 
   // LN
@@ -868,11 +856,6 @@ public class SqlFunctions {
   /** SQL {@code LN(number)} function applied to double values. */
   public static double ln(double d) {
     return Math.log(d);
-  }
-
-  /** SQL {@code LN(number)} function applied to long values. */
-  public static double ln(long b0) {
-    return Math.log(b0);
   }
 
   /** SQL {@code LN(number)} function applied to BigDecimal values. */
@@ -884,11 +867,6 @@ public class SqlFunctions {
 
   /** SQL <code>LOG10(numeric)</code> operator applied to double values. */
   public static double log10(double b0) {
-    return Math.log10(b0);
-  }
-
-  /** SQL {@code LOG10(number)} function applied to long values. */
-  public static double log10(long b0) {
     return Math.log10(b0);
   }
 
@@ -1090,11 +1068,6 @@ public class SqlFunctions {
   }
 
   // ACOS
-  /** SQL <code>ACOS</code> operator applied to long values. */
-  public static double acos(long b0) {
-    return Math.acos(b0);
-  }
-
   /** SQL <code>ACOS</code> operator applied to BigDecimal values. */
   public static double acos(BigDecimal b0) {
     return Math.acos(b0.doubleValue());
@@ -1106,11 +1079,6 @@ public class SqlFunctions {
   }
 
   // ASIN
-  /** SQL <code>ASIN</code> operator applied to long values. */
-  public static double asin(long b0) {
-    return Math.asin(b0);
-  }
-
   /** SQL <code>ASIN</code> operator applied to BigDecimal values. */
   public static double asin(BigDecimal b0) {
     return Math.asin(b0.doubleValue());
@@ -1122,11 +1090,6 @@ public class SqlFunctions {
   }
 
   // ATAN
-  /** SQL <code>ATAN</code> operator applied to long values. */
-  public static double atan(long b0) {
-    return Math.atan(b0);
-  }
-
   /** SQL <code>ATAN</code> operator applied to BigDecimal values. */
   public static double atan(BigDecimal b0) {
     return Math.atan(b0.doubleValue());
@@ -1138,18 +1101,13 @@ public class SqlFunctions {
   }
 
   // ATAN2
-  /** SQL <code>ATAN2</code> operator applied to long values. */
-  public static double atan2(long b0, long b1) {
-    return Math.atan2(b0, b1);
-  }
-
-  /** SQL <code>ATAN2</code> operator applied to long/BigDecimal values. */
-  public static double atan2(long b0, BigDecimal b1) {
+  /** SQL <code>ATAN2</code> operator applied to double/BigDecimal values. */
+  public static double atan2(double b0, BigDecimal b1) {
     return Math.atan2(b0, b1.doubleValue());
   }
 
-  /** SQL <code>ATAN2</code> operator applied to BigDecimal/long values. */
-  public static double atan2(BigDecimal b0, long b1) {
+  /** SQL <code>ATAN2</code> operator applied to BigDecimal/double values. */
+  public static double atan2(BigDecimal b0, double b1) {
     return Math.atan2(b0.doubleValue(), b1);
   }
 
@@ -1164,11 +1122,6 @@ public class SqlFunctions {
   }
 
   // COS
-  /** SQL <code>COS</code> operator applied to long values. */
-  public static double cos(long b0) {
-    return Math.cos(b0);
-  }
-
   /** SQL <code>COS</code> operator applied to BigDecimal values. */
   public static double cos(BigDecimal b0) {
     return Math.cos(b0.doubleValue());
@@ -1180,11 +1133,6 @@ public class SqlFunctions {
   }
 
   // COT
-  /** SQL <code>COT</code> operator applied to long values. */
-  public static double cot(long b0) {
-    return 1.0d / Math.tan(b0);
-  }
-
   /** SQL <code>COT</code> operator applied to BigDecimal values. */
   public static double cot(BigDecimal b0) {
     return 1.0d / Math.tan(b0.doubleValue());
@@ -1196,11 +1144,6 @@ public class SqlFunctions {
   }
 
   // DEGREES
-  /** SQL <code>DEGREES</code> operator applied to long values. */
-  public static double degrees(long b0) {
-    return Math.toDegrees(b0);
-  }
-
   /** SQL <code>DEGREES</code> operator applied to BigDecimal values. */
   public static double degrees(BigDecimal b0) {
     return Math.toDegrees(b0.doubleValue());
@@ -1212,11 +1155,6 @@ public class SqlFunctions {
   }
 
   // RADIANS
-  /** SQL <code>RADIANS</code> operator applied to long values. */
-  public static double radians(long b0) {
-    return Math.toRadians(b0);
-  }
-
   /** SQL <code>RADIANS</code> operator applied to BigDecimal values. */
   public static double radians(BigDecimal b0) {
     return Math.toRadians(b0.doubleValue());
@@ -1329,11 +1267,6 @@ public class SqlFunctions {
   }
 
   // SIN
-  /** SQL <code>SIN</code> operator applied to long values. */
-  public static double sin(long b0) {
-    return Math.sin(b0);
-  }
-
   /** SQL <code>SIN</code> operator applied to BigDecimal values. */
   public static double sin(BigDecimal b0) {
     return Math.sin(b0.doubleValue());
@@ -1345,11 +1278,6 @@ public class SqlFunctions {
   }
 
   // TAN
-  /** SQL <code>TAN</code> operator applied to long values. */
-  public static double tan(long b0) {
-    return Math.tan(b0);
-  }
-
   /** SQL <code>TAN</code> operator applied to BigDecimal values. */
   public static double tan(BigDecimal b0) {
     return Math.tan(b0.doubleValue());

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4600,7 +4600,11 @@ public abstract class SqlOperatorBaseTest {
     tester.setFor(
         SqlStdOperatorTable.ATAN2);
     tester.checkType("atan2(2, -2)", "DOUBLE NOT NULL");
-    tester.checkType("atan2(cast(1 as float), -1)", "DOUBLE NOT NULL");
+    tester.checkScalarApprox(
+        "atan2(cast(1 as float), -1)",
+        "DOUBLE NOT NULL",
+        2.3562d,
+        0.0001d);
     tester.checkType(
         "atan2(case when false then 0.5 else null end, -1)", "DOUBLE");
     tester.checkFails(

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
@@ -47,12 +47,12 @@ public enum Primitive {
       Integer.MAX_VALUE, Integer.SIZE),
   LONG(Long.TYPE, Long.class, 2, 0L, Long.MIN_VALUE, null, null,
       Long.MAX_VALUE, Long.SIZE),
-  FLOAT(Float.TYPE, Float.class, 3, 0F, -Float.MAX_VALUE, -Float.MIN_VALUE,
+  FLOAT(Float.TYPE, Float.class, 2, 0F, -Float.MAX_VALUE, -Float.MIN_VALUE,
       Float.MIN_VALUE, Float.MAX_VALUE, Float.SIZE),
-  DOUBLE(Double.TYPE, Double.class, 3, 0D, -Double.MAX_VALUE, -Double.MIN_VALUE,
+  DOUBLE(Double.TYPE, Double.class, 2, 0D, -Double.MAX_VALUE, -Double.MIN_VALUE,
       Double.MIN_VALUE, Double.MAX_VALUE, Double.SIZE),
-  VOID(Void.TYPE, Void.class, 4, null, null, null, null, null, -1),
-  OTHER(null, null, 5, null, null, null, null, null, -1);
+  VOID(Void.TYPE, Void.class, 3, null, null, null, null, null, -1),
+  OTHER(null, null, 4, null, null, null, null, null, -1);
 
   public final Class primitiveClass;
   public final Class boxClass;

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/PrimitiveTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/PrimitiveTest.java
@@ -42,12 +42,16 @@ public class PrimitiveTest {
     assertTrue(Primitive.INT.assignableFrom(Primitive.INT));
     assertTrue(Primitive.INT.assignableFrom(Primitive.SHORT));
     assertFalse(Primitive.INT.assignableFrom(Primitive.LONG));
+    assertFalse(Primitive.INT.assignableFrom(Primitive.FLOAT));
+    assertFalse(Primitive.INT.assignableFrom(Primitive.DOUBLE));
 
     assertTrue(Primitive.LONG.assignableFrom(Primitive.BYTE));
     assertTrue(Primitive.LONG.assignableFrom(Primitive.SHORT));
     assertTrue(Primitive.LONG.assignableFrom(Primitive.CHAR));
     assertTrue(Primitive.LONG.assignableFrom(Primitive.INT));
     assertTrue(Primitive.LONG.assignableFrom(Primitive.LONG));
+    assertFalse(Primitive.LONG.assignableFrom(Primitive.FLOAT));
+    assertFalse(Primitive.LONG.assignableFrom(Primitive.DOUBLE));
 
     // SHORT and CHAR cannot be assigned to each other
 
@@ -56,12 +60,24 @@ public class PrimitiveTest {
     assertFalse(Primitive.SHORT.assignableFrom(Primitive.CHAR));
     assertFalse(Primitive.SHORT.assignableFrom(Primitive.INT));
     assertFalse(Primitive.SHORT.assignableFrom(Primitive.LONG));
+    assertFalse(Primitive.SHORT.assignableFrom(Primitive.FLOAT));
+    assertFalse(Primitive.SHORT.assignableFrom(Primitive.DOUBLE));
 
     assertFalse(Primitive.CHAR.assignableFrom(Primitive.BYTE));
     assertFalse(Primitive.CHAR.assignableFrom(Primitive.SHORT));
     assertTrue(Primitive.CHAR.assignableFrom(Primitive.CHAR));
     assertFalse(Primitive.CHAR.assignableFrom(Primitive.INT));
     assertFalse(Primitive.CHAR.assignableFrom(Primitive.LONG));
+    assertFalse(Primitive.CHAR.assignableFrom(Primitive.FLOAT));
+    assertFalse(Primitive.CHAR.assignableFrom(Primitive.DOUBLE));
+
+    assertTrue(Primitive.DOUBLE.assignableFrom(Primitive.BYTE));
+    assertTrue(Primitive.DOUBLE.assignableFrom(Primitive.SHORT));
+    assertTrue(Primitive.DOUBLE.assignableFrom(Primitive.CHAR));
+    assertTrue(Primitive.DOUBLE.assignableFrom(Primitive.INT));
+    assertTrue(Primitive.DOUBLE.assignableFrom(Primitive.LONG));
+    assertTrue(Primitive.DOUBLE.assignableFrom(Primitive.FLOAT));
+    assertTrue(Primitive.DOUBLE.assignableFrom(Primitive.DOUBLE));
 
     // cross-family assignments
 


### PR DESCRIPTION
For example, I get `RuntimeException: while resolving method 'atan2[double, int]'` when trying to execute a query with `ATAN2(c_double, 2)` (where c_double is a column containing the double type). atan2[double, double] should resolve as a valid implementation in this case.