### PR TITLE
[CALCITE-2535] Runtime failure check not working in SqlTesterImpl.java

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -180,6 +180,11 @@ public abstract class Bug {
    */
   public static final boolean CALCITE_2401_FIXED = false;
 
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2539">[CALCITE-2539]
+   * Several test case not passed in CalciteSqlOperatorTest.java</a> is fixed. */
+  public static final boolean CALCITE_2539_FIXED = false;
+
   /**
    * Use this to flag temporary code.
    */

--- a/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
@@ -70,13 +70,15 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
- * Implementation of {@link org.apache.calcite.test.SqlValidatorTestCase.Tester}
+ * Abstract implementation of {@link org.apache.calcite.test.SqlValidatorTestCase.Tester}
  * that talks to a mock catalog.
+ *
+ * This is to implement the default behavior: testing is only against {@link SqlValidator}.
  */
-public class SqlTesterImpl implements SqlTester, AutoCloseable {
+public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
   protected final SqlTestFactory factory;
 
-  public SqlTesterImpl(SqlTestFactory factory) {
+  public AbstractSqlTester(SqlTestFactory factory) {
     this.factory = factory;
   }
 
@@ -110,19 +112,9 @@ public class SqlTesterImpl implements SqlTester, AutoCloseable {
     try {
       sqlNode = parseQuery(sap.sql);
       validator = getValidator();
-    } catch (SqlParseException e) {
-      String errMessage = e.getMessage();
-      if (expectedMsgPattern == null) {
-        throw new RuntimeException("Error while parsing query:" + sap.sql, e);
-      } else if (errMessage == null
-          || !errMessage.matches(expectedMsgPattern)) {
-        throw new RuntimeException("Error did not match expected ["
-            + expectedMsgPattern + "] while parsing query ["
-            + sap.sql + "]", e);
-      }
-      return;
     } catch (Throwable e) {
-      throw new RuntimeException("Error while parsing query: " + sap.sql, e);
+      checkParseEx(e, expectedMsgPattern, sap.sql);
+      return;
     }
 
     Throwable thrown = null;
@@ -133,6 +125,24 @@ public class SqlTesterImpl implements SqlTester, AutoCloseable {
     }
 
     SqlValidatorTestCase.checkEx(thrown, expectedMsgPattern, sap);
+  }
+
+  protected void checkParseEx(Throwable e, String expectedMsgPattern, String sql) {
+    try {
+      throw e;
+    } catch (SqlParseException spe) {
+      String errMessage = spe.getMessage();
+      if (expectedMsgPattern == null) {
+        throw new RuntimeException("Error while parsing query:" + sql, spe);
+      } else if (errMessage == null
+          || !errMessage.matches(expectedMsgPattern)) {
+        throw new RuntimeException("Error did not match expected ["
+            + expectedMsgPattern + "] while parsing query ["
+            + sql + "]", spe);
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException("Error while parsing query: " + sql, t);
+    }
   }
 
   public RelDataType getColumnType(String sql) {
@@ -265,7 +275,7 @@ public class SqlTesterImpl implements SqlTester, AutoCloseable {
     }
   }
 
-  public SqlTesterImpl withQuoting(Quoting quoting) {
+  public SqlTester withQuoting(Quoting quoting) {
     return with("quoting", quoting);
   }
 
@@ -288,11 +298,11 @@ public class SqlTesterImpl implements SqlTester, AutoCloseable {
         .withUnquotedCasing(lex.unquotedCasing);
   }
 
-  public SqlTesterImpl withConformance(SqlConformance conformance) {
+  public SqlTester withConformance(SqlConformance conformance) {
     if (conformance == null) {
       conformance = SqlConformanceEnum.DEFAULT;
     }
-    final SqlTesterImpl tester = with("conformance", conformance);
+    final SqlTester tester = with("conformance", conformance);
     if (conformance instanceof SqlConformanceEnum) {
       return tester
           .withConnectionFactory(
@@ -307,14 +317,16 @@ public class SqlTesterImpl implements SqlTester, AutoCloseable {
     return with("operatorTable", operatorTable);
   }
 
-  public SqlTesterImpl withConnectionFactory(
+  public SqlTester withConnectionFactory(
       CalciteAssert.ConnectionFactory connectionFactory) {
     return with("connectionFactory", connectionFactory);
   }
 
-  protected SqlTesterImpl with(final String name, final Object value) {
-    return new SqlTesterImpl(factory.with(name, value));
+  protected final SqlTester with(final String name, final Object value) {
+    return with(factory.with(name, value));
   }
+
+  protected abstract SqlTester with(SqlTestFactory factory);
 
   // SqlTester methods
 
@@ -536,7 +548,7 @@ public class SqlTesterImpl implements SqlTester, AutoCloseable {
    * @param expression Scalar expression
    * @return Query that evaluates a scalar expression
    */
-  private String buildQuery2(String expression) {
+  protected String buildQuery2(String expression) {
     // "values (1 < 5)"
     // becomes
     // "select p0 < p1 from (values (1, 5)) as t(p0, p1)"
@@ -665,4 +677,4 @@ public class SqlTesterImpl implements SqlTester, AutoCloseable {
 
 }
 
-// End SqlTesterImpl.java
+// End AbstractSqlTester.java

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -576,7 +576,7 @@ public class SqlAdvisorTest extends SqlValidatorTestCase {
   }
 
   @Override public SqlTester getTester() {
-    return new SqlTesterImpl(ADVISOR_TEST_FACTORY);
+    return new SqlValidatorTester(ADVISOR_TEST_FACTORY);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -531,9 +531,11 @@ public abstract class SqlOperatorBaseTest {
         "cast(.48 as varchar(10))",
         ".48",
         "VARCHAR(10) NOT NULL");
-    tester.checkFails(
-        "cast(2.523 as char(2))", STRING_TRUNC_MESSAGE,
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "cast(2.523 as char(2))", STRING_TRUNC_MESSAGE,
+          true);
+    }
 
     tester.checkString(
         "cast(-0.29 as varchar(10))",
@@ -563,13 +565,14 @@ public abstract class SqlOperatorBaseTest {
     if (TODO) {
       checkCastToString("cast(-0.1 as real)", "CHAR(5)", "-1E-1");
     }
-
-    tester.checkFails(
-        "cast(1.3243232e0 as varchar(4))", STRING_TRUNC_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast(1.9e5 as char(4))", STRING_TRUNC_MESSAGE,
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "cast(1.3243232e0 as varchar(4))", STRING_TRUNC_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast(1.9e5 as char(4))", STRING_TRUNC_MESSAGE,
+          true);
+    }
 
     // string
     checkCastToString("'abc'", "CHAR(1)", "a");
@@ -634,18 +637,21 @@ public abstract class SqlOperatorBaseTest {
     checkCastToString("True", "CHAR(6)", "TRUE  ");
     checkCastToString("True", "VARCHAR(6)", "TRUE");
     checkCastToString("False", "CHAR(5)", "FALSE");
-    tester.checkFails(
-        "cast(true as char(3))", INVALID_CHAR_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast(false as char(4))", INVALID_CHAR_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast(true as varchar(3))", INVALID_CHAR_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast(false as varchar(4))", INVALID_CHAR_MESSAGE,
-        true);
+
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "cast(true as char(3))", INVALID_CHAR_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast(false as char(4))", INVALID_CHAR_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast(true as varchar(3))", INVALID_CHAR_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast(false as varchar(4))", INVALID_CHAR_MESSAGE,
+          true);
+    }
   }
 
   @Test public void testCastExactNumericLimits() {
@@ -678,14 +684,16 @@ public abstract class SqlOperatorBaseTest {
             type, LITERAL_OUT_OF_RANGE_MESSAGE,
             false);
       } else {
-        checkCastFails(
-            MAX_OVERFLOW_NUMERIC_STRINGS[i],
-            type, OUT_OF_RANGE_MESSAGE,
-            true);
-        checkCastFails(
-            MIN_OVERFLOW_NUMERIC_STRINGS[i],
-            type, OUT_OF_RANGE_MESSAGE,
-            true);
+        if (Bug.CALCITE_2539_FIXED) {
+          checkCastFails(
+              MAX_OVERFLOW_NUMERIC_STRINGS[i],
+              type, OUT_OF_RANGE_MESSAGE,
+              true);
+          checkCastFails(
+              MIN_OVERFLOW_NUMERIC_STRINGS[i],
+              type, OUT_OF_RANGE_MESSAGE,
+              true);
+        }
       }
 
       // Convert from string to type
@@ -698,15 +706,17 @@ public abstract class SqlOperatorBaseTest {
           type,
           MIN_NUMERIC_STRINGS[i]);
 
-      checkCastFails(
-          "'" + MAX_OVERFLOW_NUMERIC_STRINGS[i] + "'",
-          type, OUT_OF_RANGE_MESSAGE,
-          true);
-      checkCastFails(
-          "'" + MIN_OVERFLOW_NUMERIC_STRINGS[i] + "'",
-          type,
-          OUT_OF_RANGE_MESSAGE,
-          true);
+      if (Bug.CALCITE_2539_FIXED) {
+        checkCastFails(
+            "'" + MAX_OVERFLOW_NUMERIC_STRINGS[i] + "'",
+            type, OUT_OF_RANGE_MESSAGE,
+            true);
+        checkCastFails(
+            "'" + MIN_OVERFLOW_NUMERIC_STRINGS[i] + "'",
+            type,
+            OUT_OF_RANGE_MESSAGE,
+            true);
+      }
 
       // Convert from type to string
       checkCastToString(MAX_NUMERIC_STRINGS[i], null, null);
@@ -715,7 +725,9 @@ public abstract class SqlOperatorBaseTest {
       checkCastToString(MIN_NUMERIC_STRINGS[i], null, null);
       checkCastToString(MIN_NUMERIC_STRINGS[i], type, null);
 
-      checkCastFails("'notnumeric'", type, INVALID_CHAR_MESSAGE, true);
+      if (Bug.CALCITE_2539_FIXED) {
+        checkCastFails("'notnumeric'", type, INVALID_CHAR_MESSAGE, true);
+      }
     }
   }
 
@@ -1215,14 +1227,16 @@ public abstract class SqlOperatorBaseTest {
     // generate Java constants that throw when the class is loaded, thus
     // ExceptionInInitializerError.
     tester.checkScalarExact("cast('15' as integer)", "INTEGER NOT NULL", "15");
-    tester.checkFails("cast('15.4' as integer)", "xxx", true);
-    tester.checkFails("cast('15.6' as integer)", "xxx", true);
-    tester.checkFails("cast('ue' as boolean)", "xxx", true);
-    tester.checkFails("cast('' as boolean)", "xxx", true);
-    tester.checkFails("cast('' as integer)", "xxx", true);
-    tester.checkFails("cast('' as real)", "xxx", true);
-    tester.checkFails("cast('' as double)", "xxx", true);
-    tester.checkFails("cast('' as smallint)", "xxx", true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails("cast('15.4' as integer)", "xxx", true);
+      tester.checkFails("cast('15.6' as integer)", "xxx", true);
+      tester.checkFails("cast('ue' as boolean)", "xxx", true);
+      tester.checkFails("cast('' as boolean)", "xxx", true);
+      tester.checkFails("cast('' as integer)", "xxx", true);
+      tester.checkFails("cast('' as real)", "xxx", true);
+      tester.checkFails("cast('' as double)", "xxx", true);
+      tester.checkFails("cast('' as smallint)", "xxx", true);
+    }
   }
 
   @Test public void testCastDateTime() {
@@ -1342,21 +1356,23 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails(
         "cast('nottime' as TIME)", BAD_DATETIME_MESSAGE,
         true);
-    tester.checkFails(
-        "cast('1241241' as TIME)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('12:54:78' as TIME)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('12:34:5' as TIME)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('12:3:45' as TIME)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('1:23:45' as TIME)", BAD_DATETIME_MESSAGE,
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "cast('1241241' as TIME)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('12:54:78' as TIME)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('12:34:5' as TIME)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('12:3:45' as TIME)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('1:23:45' as TIME)", BAD_DATETIME_MESSAGE,
+          true);
+    }
 
     // timestamp <-> string
     checkCastToString(
@@ -1406,18 +1422,21 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails(
         "cast('nottime' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
         true);
-    tester.checkFails(
-        "cast('1241241' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('1945-20-24 12:42:25.34' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('1945-01-24 25:42:25.34' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('1945-1-24 12:23:34.454' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
-        true);
+
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "cast('1241241' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('1945-20-24 12:42:25.34' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('1945-01-24 25:42:25.34' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('1945-1-24 12:23:34.454' as TIMESTAMP)", BAD_DATETIME_MESSAGE,
+          true);
+    }
 
     // date <-> string
     checkCastToString("DATE '1945-02-24'", null, "1945-02-24");
@@ -1438,12 +1457,15 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails(
         "cast('notdate' as DATE)", BAD_DATETIME_MESSAGE,
         true);
-    tester.checkFails(
-        "cast('52534253' as DATE)", BAD_DATETIME_MESSAGE,
-        true);
-    tester.checkFails(
-        "cast('1945-30-24' as DATE)", BAD_DATETIME_MESSAGE,
-        true);
+
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "cast('52534253' as DATE)", BAD_DATETIME_MESSAGE,
+          true);
+      tester.checkFails(
+          "cast('1945-30-24' as DATE)", BAD_DATETIME_MESSAGE,
+          true);
+    }
 
     // cast null
     tester.checkNull("cast(null as date)");
@@ -1896,12 +1918,14 @@ public abstract class SqlOperatorBaseTest {
     }
     tester.checkScalar("{fn DAYOFMONTH(DATE '2014-12-10')}", 10,
         "BIGINT NOT NULL");
-    tester.checkFails("{fn DAYOFWEEK(DATE '2014-12-10')}",
-        "cannot translate call EXTRACT.*",
-        true);
-    tester.checkFails("{fn DAYOFYEAR(DATE '2014-12-10')}",
-        "cannot translate call EXTRACT.*",
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails("{fn DAYOFWEEK(DATE '2014-12-10')}",
+          "cannot translate call EXTRACT.*",
+          true);
+      tester.checkFails("{fn DAYOFYEAR(DATE '2014-12-10')}",
+          "cannot translate call EXTRACT.*",
+          true);
+    }
     tester.checkScalar("{fn HOUR(TIMESTAMP '2014-12-10 12:34:56')}", 12,
         "BIGINT NOT NULL");
     tester.checkScalar("{fn MINUTE(TIMESTAMP '2014-12-10 12:34:56')}", 34,
@@ -1921,9 +1945,12 @@ public abstract class SqlOperatorBaseTest {
     tester.checkScalar("{fn TIMESTAMPDIFF(HOUR,"
         + " TIMESTAMP '2014-03-29 12:34:56',"
         + " TIMESTAMP '2014-03-29 12:34:56')}", "0", "INTEGER NOT NULL");
-    tester.checkFails("{fn WEEK(DATE '2014-12-10')}",
-        "cannot translate call EXTRACT.*",
-        true);
+
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails("{fn WEEK(DATE '2014-12-10')}",
+          "cannot translate call EXTRACT.*",
+          true);
+    }
     tester.checkScalar("{fn YEAR(DATE '2014-12-10')}", 2014, "BIGINT NOT NULL");
 
     // System Functions
@@ -2192,9 +2219,11 @@ public abstract class SqlOperatorBaseTest {
     }
     tester.checkNull("1e1 / cast(null as float)");
 
-    tester.checkFails(
-        "100.1 / 0.00000000000000001", OUT_OF_RANGE_MESSAGE,
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "100.1 / 0.00000000000000001", OUT_OF_RANGE_MESSAGE,
+          true);
+    }
   }
 
   @Test public void testDivideOperatorIntervals() {
@@ -3963,15 +3992,17 @@ public abstract class SqlOperatorBaseTest {
             + "                    \\^",
         true);
 
-    tester.checkFails(
-        "'cd' similar to '[(a-e)]d' ",
-        "Invalid regular expression: \\[\\(a-e\\)\\]d at 1",
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails(
+          "'cd' similar to '[(a-e)]d' ",
+          "Invalid regular expression: \\[\\(a-e\\)\\]d at 1",
+          true);
 
-    tester.checkFails(
-        "'yd' similar to '[(a-e)]d' ",
-        "Invalid regular expression: \\[\\(a-e\\)\\]d at 1",
-        true);
+      tester.checkFails(
+          "'yd' similar to '[(a-e)]d' ",
+          "Invalid regular expression: \\[\\(a-e\\)\\]d at 1",
+          true);
+    }
 
     // all the following tests wrong results due to missing functionality
     // or defect (FRG-375, 377).
@@ -5643,15 +5674,17 @@ public abstract class SqlOperatorBaseTest {
         SqlStdOperatorTable.WEEK,
         VM_FENNEL,
         VM_JAVA);
-    // TODO: Not implemented in operator test execution code
-    tester.checkFails(
-        "week(date '2008-1-23')",
-        "cannot translate call EXTRACT.*",
-        true);
-    tester.checkFails(
-        "week(cast(null as date))",
-        "cannot translate call EXTRACT.*",
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      // TODO: Not implemented in operator test execution code
+      tester.checkFails(
+          "week(date '2008-1-23')",
+          "cannot translate call EXTRACT.*",
+          true);
+      tester.checkFails(
+          "week(cast(null as date))",
+          "cannot translate call EXTRACT.*",
+          true);
+    }
   }
 
   @Test public void testDayOfYear() {
@@ -5659,15 +5692,17 @@ public abstract class SqlOperatorBaseTest {
         SqlStdOperatorTable.DAYOFYEAR,
         VM_FENNEL,
         VM_JAVA);
-    // TODO: Not implemented in operator test execution code
-    tester.checkFails(
-        "dayofyear(date '2008-1-23')",
-        "cannot translate call EXTRACT.*",
-        true);
-    tester.checkFails(
-        "dayofyear(cast(null as date))",
-        "cannot translate call EXTRACT.*",
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      // TODO: Not implemented in operator test execution code
+      tester.checkFails(
+          "dayofyear(date '2008-1-23')",
+          "cannot translate call EXTRACT.*",
+          true);
+      tester.checkFails(
+          "dayofyear(cast(null as date))",
+          "cannot translate call EXTRACT.*",
+          true);
+    }
   }
 
   @Test public void testDayOfMonth() {
@@ -5687,14 +5722,16 @@ public abstract class SqlOperatorBaseTest {
         SqlStdOperatorTable.DAYOFWEEK,
         VM_FENNEL,
         VM_JAVA);
-    // TODO: Not implemented in operator test execution code
-    tester.checkFails(
-        "dayofweek(date '2008-1-23')",
-        "cannot translate call EXTRACT.*",
-        true);
-    tester.checkFails("dayofweek(cast(null as date))",
-        "cannot translate call EXTRACT.*",
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      // TODO: Not implemented in operator test execution code
+      tester.checkFails(
+          "dayofweek(date '2008-1-23')",
+          "cannot translate call EXTRACT.*",
+          true);
+      tester.checkFails("dayofweek(cast(null as date))",
+          "cannot translate call EXTRACT.*",
+          true);
+    }
   }
 
   @Test public void testHour() {
@@ -5874,14 +5911,16 @@ public abstract class SqlOperatorBaseTest {
 
     // Postgres doesn't support DOW, ISODOW, DOY and WEEK on INTERVAL DAY TIME type.
     // SQL standard doesn't have extract units for DOW, ISODOW, DOY and WEEK.
-    tester.checkFails("extract(doy from interval '2 3:4:5.678' day to second)",
-        INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
-    tester.checkFails("extract(dow from interval '2 3:4:5.678' day to second)",
-        INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
-    tester.checkFails("extract(week from interval '2 3:4:5.678' day to second)",
-        INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
-    tester.checkFails("extract(isodow from interval '2 3:4:5.678' day to second)",
-        INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
+    if (Bug.CALCITE_2539_FIXED) {
+      tester.checkFails("extract(doy from interval '2 3:4:5.678' day to second)",
+          INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
+      tester.checkFails("extract(dow from interval '2 3:4:5.678' day to second)",
+          INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
+      tester.checkFails("extract(week from interval '2 3:4:5.678' day to second)",
+          INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
+      tester.checkFails("extract(isodow from interval '2 3:4:5.678' day to second)",
+          INVALID_EXTRACT_UNIT_CONVERTLET_ERROR, true);
+    }
 
     tester.checkFails(
         "^extract(month from interval '2 3:4:5.678' day to second)^",
@@ -6109,23 +6148,25 @@ public abstract class SqlOperatorBaseTest {
         "2008",
         "BIGINT NOT NULL");
 
-    // TODO: Not implemented in operator test execution code
-    tester.checkFails(
-        "extract(doy from timestamp '2008-2-23 12:34:56')",
-        "cannot translate call EXTRACT.*",
-        true);
+    if (Bug.CALCITE_2539_FIXED) {
+      // TODO: Not implemented in operator test execution code
+      tester.checkFails(
+          "extract(doy from timestamp '2008-2-23 12:34:56')",
+          "cannot translate call EXTRACT.*",
+          true);
 
-    // TODO: Not implemented in operator test execution code
-    tester.checkFails(
-        "extract(dow from timestamp '2008-2-23 12:34:56')",
-        "cannot translate call EXTRACT.*",
-        true);
+      // TODO: Not implemented in operator test execution code
+      tester.checkFails(
+          "extract(dow from timestamp '2008-2-23 12:34:56')",
+          "cannot translate call EXTRACT.*",
+          true);
 
-    // TODO: Not implemented in operator test execution code
-    tester.checkFails(
-        "extract(week from timestamp '2008-2-23 12:34:56')",
-        "cannot translate call EXTRACT.*",
-        true);
+      // TODO: Not implemented in operator test execution code
+      tester.checkFails(
+          "extract(week from timestamp '2008-2-23 12:34:56')",
+          "cannot translate call EXTRACT.*",
+          true);
+    }
 
     tester.checkScalar(
         "extract(decade from timestamp '2008-2-23 12:34:56')",
@@ -6817,7 +6858,7 @@ public abstract class SqlOperatorBaseTest {
    * {@code SELECT sum(1) FROM emp GROUP BY deptno} has type "INTEGER NOT NULL",
    */
   protected void checkAggType(SqlTester tester, String expr, String type) {
-    tester.checkColumnType(SqlTesterImpl.buildQueryAgg(expr), type);
+    tester.checkColumnType(AbstractSqlTester.buildQueryAgg(expr), type);
   }
 
   @Test public void testAvgFunc() {
@@ -7322,6 +7363,7 @@ public abstract class SqlOperatorBaseTest {
         "0",
         0d);
   }
+
   /**
    * Tests that CAST fails when given a value just outside the valid range for
    * that type. For example,
@@ -7414,15 +7456,17 @@ public abstract class SqlOperatorBaseTest {
           // Casting overlarge string/binary values do not fail -
           // they are truncated. See testCastTruncates().
         } else {
-          // Value outside legal bound should fail at runtime (not
-          // validate time).
-          //
-          // NOTE: Because Java and Fennel calcs give
-          // different errors, the pattern hedges its bets.
-          tester.checkFails(
-              "CAST(" + literalString + " AS " + type + ")",
-              "(?s).*(Overflow during calculation or cast\\.|Code=22003).*",
-              true);
+          if (Bug.CALCITE_2539_FIXED) {
+            // Value outside legal bound should fail at runtime (not
+            // validate time).
+            //
+            // NOTE: Because Java and Fennel calcs give
+            // different errors, the pattern hedges its bets.
+            tester.checkFails(
+                "CAST(" + literalString + " AS " + type + ")",
+                "(?s).*(Overflow during calculation or cast\\.|Code=22003).*",
+                true);
+          }
         }
       }
     }
@@ -7533,7 +7577,7 @@ public abstract class SqlOperatorBaseTest {
                   query = "SELECT " + s + " FROM (VALUES (1))";
                 }
               } else {
-                query = SqlTesterImpl.buildQuery(s);
+                query = AbstractSqlTester.buildQuery(s);
               }
               tester.check(query, SqlTests.ANY_TYPE_CHECKER,
                   SqlTests.ANY_PARAMETER_CHECKER, result -> { });
@@ -7648,7 +7692,7 @@ public abstract class SqlOperatorBaseTest {
    * Implementation of {@link org.apache.calcite.sql.test.SqlTester} based on a
    * JDBC connection.
    */
-  protected static class TesterImpl extends SqlTesterImpl {
+  protected static class TesterImpl extends SqlRuntimeTester {
     public TesterImpl(SqlTestFactory testFactory) {
       super(testFactory);
     }
@@ -7672,8 +7716,8 @@ public abstract class SqlOperatorBaseTest {
       }
     }
 
-    @Override protected TesterImpl with(final String name, final Object value) {
-      return new TesterImpl(factory.with(name, value));
+    @Override protected SqlTester with(SqlTestFactory factory) {
+      return new TesterImpl(factory);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlRuntimeTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlRuntimeTester.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.test;
+
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserUtil;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.util.CheckUtil;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tester of {@link SqlValidator} and runtime execution of the input SQL.
+ */
+public class SqlRuntimeTester extends AbstractSqlTester {
+  public SqlRuntimeTester(SqlTestFactory factory) {
+    super(factory);
+  }
+
+  @Override protected SqlTester with(SqlTestFactory factory) {
+    return new SqlRuntimeTester(factory);
+  }
+
+  @Override public void checkFails(String expression, String expectedError, boolean runtime) {
+    assertExceptionIsThrown(
+        runtime ? buildQuery2(expression) : buildQuery(expression),
+        expectedError,
+        runtime
+    );
+  }
+
+  public void assertExceptionIsThrown(
+      String sql,
+      String expectedMsgPattern) {
+    assertExceptionIsThrown(sql, expectedMsgPattern, false);
+  }
+
+  public void assertExceptionIsThrown(
+      String sql,
+      String expectedMsgPattern,
+      boolean runtime) {
+    SqlValidator validator;
+    SqlNode sqlNode;
+    SqlParserUtil.StringAndPos sap = SqlParserUtil.findPos(sql);
+    try {
+      sqlNode = parseQuery(sap.sql);
+    } catch (Throwable e) {
+      checkParseEx(e, expectedMsgPattern, sap.sql);
+      return;
+    }
+
+    Throwable thrown = null;
+    CheckUtil.Stage stage;
+    validator = getValidator();
+    if (runtime) {
+      stage = CheckUtil.Stage.RUNTIME;
+      SqlNode validated = validator.validate(sqlNode);
+      assertNotNull(validated);
+      try {
+        check(sap.sql, SqlTests.ANY_TYPE_CHECKER, SqlTests.ANY_PARAMETER_CHECKER,
+            SqlTests.ANY_RESULT_CHECKER);
+      } catch (Throwable ex) {
+        // get the real exception in runtime check
+        thrown = ex;
+      }
+    } else {
+      stage = CheckUtil.Stage.VALIDATE;
+      try {
+        validator.validate(sqlNode);
+      } catch (Throwable ex) {
+        thrown = ex;
+      }
+    }
+
+    CheckUtil.checkEx(thrown, expectedMsgPattern, sap, stage);
+  }
+}
+
+// End SqlRuntimeTester.java

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
@@ -62,6 +62,17 @@ public abstract class SqlTests {
   };
 
   /**
+   * Checker that allows any result.
+   */
+  public static final ResultChecker ANY_RESULT_CHECKER = result -> {
+    while (true) {
+      if (!result.next()) {
+        break;
+      }
+    }
+  };
+
+  /**
    * Helper function to get the string representation of a RelDataType
    * (include precision/scale but no charset or collation)
    *

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlValidatorTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlValidatorTester.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.test;
+
+import org.apache.calcite.sql.validate.SqlValidator;
+
+/**
+ * Tester of {@link SqlValidator}.
+ */
+public class SqlValidatorTester extends AbstractSqlTester {
+
+  public SqlValidatorTester(SqlTestFactory factory) {
+    super(factory);
+  }
+
+  @Override protected SqlTester with(SqlTestFactory factory) {
+    return new SqlValidatorTester(factory);
+  }
+}
+
+// End SqlValidatorTester.java

--- a/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/validate/SqlValidatorUtilTest.java
@@ -21,7 +21,8 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.test.SqlTestFactory;
-import org.apache.calcite.sql.test.SqlTesterImpl;
+import org.apache.calcite.sql.test.SqlTester;
+import org.apache.calcite.sql.test.SqlValidatorTester;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -124,8 +125,8 @@ public class SqlValidatorUtilTest {
     final List<SqlNode> newList = new ArrayList<>(2);
     newList.add(new SqlIdentifier(Arrays.asList("f0", "c0"), SqlParserPos.ZERO));
     newList.add(new SqlIdentifier(Arrays.asList("f0", "c0"), SqlParserPos.ZERO));
-    final SqlTesterImpl tester =
-        new SqlTesterImpl(SqlTestFactory.INSTANCE);
+    final SqlTester tester =
+        new SqlValidatorTester(SqlTestFactory.INSTANCE);
     final SqlValidatorImpl validator =
         (SqlValidatorImpl) tester.getValidator();
     try {

--- a/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
@@ -19,7 +19,7 @@ package org.apache.calcite.test;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.test.SqlTester;
-import org.apache.calcite.sql.test.SqlTesterImpl;
+import org.apache.calcite.sql.test.SqlValidatorTester;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.BarfingInvocationHandler;
 import org.apache.calcite.util.Util;
@@ -102,7 +102,7 @@ public class SqlTestGen {
     }
 
     public SqlTester getTester() {
-      return new SqlTesterImpl(SPOOLER_VALIDATOR) {
+      return new SqlValidatorTester(SPOOLER_VALIDATOR) {
         public void assertExceptionIsThrown(
             String sql,
             String expectedMsgPattern) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorDynamicTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorDynamicTest.java
@@ -18,7 +18,7 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.test.SqlTester;
-import org.apache.calcite.sql.test.SqlTesterImpl;
+import org.apache.calcite.sql.test.SqlValidatorTester;
 import org.apache.calcite.test.catalog.MockCatalogReaderDynamic;
 
 import org.junit.BeforeClass;
@@ -96,7 +96,7 @@ public class SqlValidatorDynamicTest extends SqlValidatorTestCase {
   @Override public SqlTester getTester() {
     // Dymamic schema should not be reused since it is mutable, so
     // we create new SqlTestFactory for each test
-    return new SqlTesterImpl(SqlTestFactory.INSTANCE
+    return new SqlValidatorTester(SqlTestFactory.INSTANCE
         .withCatalogReader(MockCatalogReaderDynamic::new));
   }
 //~ Methods ----------------------------------------------------------------

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorFeatureTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorFeatureTest.java
@@ -24,7 +24,7 @@ import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.test.SqlTester;
-import org.apache.calcite.sql.test.SqlTesterImpl;
+import org.apache.calcite.sql.test.SqlValidatorTester;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
@@ -55,7 +55,7 @@ public class SqlValidatorFeatureTest extends SqlValidatorTestCase {
   //~ Methods ----------------------------------------------------------------
 
   @Override public SqlTester getTester() {
-    return new SqlTesterImpl(SqlTestFactory.INSTANCE.withValidator(FeatureValidator::new));
+    return new SqlValidatorTester(SqlTestFactory.INSTANCE.withValidator(FeatureValidator::new));
   }
 
   @Test public void testDistinct() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
@@ -17,33 +17,29 @@
 package org.apache.calcite.test;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParserUtil;
+import org.apache.calcite.sql.test.AbstractSqlTester;
 import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.test.SqlTester;
-import org.apache.calcite.sql.test.SqlTesterImpl;
+import org.apache.calcite.sql.test.SqlValidatorTester;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.test.catalog.MockCatalogReaderExtended;
-import org.apache.calcite.util.TestUtil;
-import org.apache.calcite.util.Util;
+import org.apache.calcite.util.CheckUtil;
 
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
 import java.nio.charset.Charset;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * An abstract base class for implementing tests against {@link SqlValidator}.
@@ -59,25 +55,18 @@ import static org.junit.Assert.fail;
 public class SqlValidatorTestCase {
   //~ Static fields/initializers ---------------------------------------------
 
-  private static final Pattern LINE_COL_PATTERN =
-      Pattern.compile("At line ([0-9]+), column ([0-9]+)");
-
-  private static final Pattern LINE_COL_TWICE_PATTERN =
-      Pattern.compile(
-          "(?s)From line ([0-9]+), column ([0-9]+) to line ([0-9]+), column ([0-9]+): (.*)");
-
   private static final SqlTestFactory EXTENDED_TEST_FACTORY =
       SqlTestFactory.INSTANCE.withCatalogReader(MockCatalogReaderExtended::new);
 
-  static final SqlTesterImpl EXTENDED_CATALOG_TESTER =
-      new SqlTesterImpl(EXTENDED_TEST_FACTORY);
+  static final SqlTester EXTENDED_CATALOG_TESTER =
+      new SqlValidatorTester(EXTENDED_TEST_FACTORY);
 
-  static final SqlTesterImpl EXTENDED_CATALOG_TESTER_2003 =
-      new SqlTesterImpl(EXTENDED_TEST_FACTORY)
+  static final SqlTester EXTENDED_CATALOG_TESTER_2003 =
+      new SqlValidatorTester(EXTENDED_TEST_FACTORY)
           .withConformance(SqlConformanceEnum.PRAGMATIC_2003);
 
-  static final SqlTesterImpl EXTENDED_CATALOG_TESTER_LENIENT =
-      new SqlTesterImpl(EXTENDED_TEST_FACTORY)
+  static final SqlTester EXTENDED_CATALOG_TESTER_LENIENT =
+      new SqlValidatorTester(EXTENDED_TEST_FACTORY)
           .withConformance(SqlConformanceEnum.LENIENT);
 
   public static final MethodRule TESTER_CONFIGURATION_RULE = new TesterConfigurationRule();
@@ -102,7 +91,7 @@ public class SqlValidatorTestCase {
    * same set of tests in a different testing environment.
    */
   public SqlTester getTester() {
-    return new SqlTesterImpl(SqlTestFactory.INSTANCE);
+    return new SqlValidatorTester(SqlTestFactory.INSTANCE);
   }
 
   public final Sql sql(String sql) {
@@ -135,7 +124,7 @@ public class SqlValidatorTestCase {
 
   public void checkExp(String sql) {
     tester.assertExceptionIsThrown(
-        SqlTesterImpl.buildQuery(sql),
+        AbstractSqlTester.buildQuery(sql),
         null);
   }
 
@@ -156,7 +145,7 @@ public class SqlValidatorTestCase {
       String sql,
       String expected) {
     tester.assertExceptionIsThrown(
-        SqlTesterImpl.buildQuery(sql),
+        AbstractSqlTester.buildQuery(sql),
         expected);
   }
 
@@ -175,7 +164,7 @@ public class SqlValidatorTestCase {
       String sql,
       String expected) {
     checkColumnType(
-        SqlTesterImpl.buildQuery(sql),
+        AbstractSqlTester.buildQuery(sql),
         expected);
   }
 
@@ -224,7 +213,7 @@ public class SqlValidatorTestCase {
       String sql,
       String expected) {
     tester.checkIntervalConv(
-        SqlTesterImpl.buildQuery(sql),
+        AbstractSqlTester.buildQuery(sql),
         expected);
   }
 
@@ -260,174 +249,7 @@ public class SqlValidatorTestCase {
       Throwable ex,
       String expectedMsgPattern,
       SqlParserUtil.StringAndPos sap) {
-    if (null == ex) {
-      if (expectedMsgPattern == null) {
-        // No error expected, and no error happened.
-        return;
-      } else {
-        throw new AssertionError("Expected query to throw exception, "
-            + "but it did not; query [" + sap.sql
-            + "]; expected [" + expectedMsgPattern + "]");
-      }
-    }
-    Throwable actualException = ex;
-    String actualMessage = actualException.getMessage();
-    int actualLine = -1;
-    int actualColumn = -1;
-    int actualEndLine = 100;
-    int actualEndColumn = 99;
-
-    // Search for an CalciteContextException somewhere in the stack.
-    CalciteContextException ece = null;
-    for (Throwable x = ex; x != null; x = x.getCause()) {
-      if (x instanceof CalciteContextException) {
-        ece = (CalciteContextException) x;
-        break;
-      }
-      if (x.getCause() == x) {
-        break;
-      }
-    }
-
-    // Search for a SqlParseException -- with its position set -- somewhere
-    // in the stack.
-    SqlParseException spe = null;
-    for (Throwable x = ex; x != null; x = x.getCause()) {
-      if ((x instanceof SqlParseException)
-          && (((SqlParseException) x).getPos() != null)) {
-        spe = (SqlParseException) x;
-        break;
-      }
-      if (x.getCause() == x) {
-        break;
-      }
-    }
-
-    if (ece != null) {
-      actualLine = ece.getPosLine();
-      actualColumn = ece.getPosColumn();
-      actualEndLine = ece.getEndPosLine();
-      actualEndColumn = ece.getEndPosColumn();
-      if (ece.getCause() != null) {
-        actualException = ece.getCause();
-        actualMessage = actualException.getMessage();
-      }
-    } else if (spe != null) {
-      actualLine = spe.getPos().getLineNum();
-      actualColumn = spe.getPos().getColumnNum();
-      actualEndLine = spe.getPos().getEndLineNum();
-      actualEndColumn = spe.getPos().getEndColumnNum();
-      if (spe.getCause() != null) {
-        actualException = spe.getCause();
-        actualMessage = actualException.getMessage();
-      }
-    } else {
-      final String message = ex.getMessage();
-      if (message != null) {
-        Matcher matcher = LINE_COL_TWICE_PATTERN.matcher(message);
-        if (matcher.matches()) {
-          actualLine = Integer.parseInt(matcher.group(1));
-          actualColumn = Integer.parseInt(matcher.group(2));
-          actualEndLine = Integer.parseInt(matcher.group(3));
-          actualEndColumn = Integer.parseInt(matcher.group(4));
-          actualMessage = matcher.group(5);
-        } else {
-          matcher = LINE_COL_PATTERN.matcher(message);
-          if (matcher.matches()) {
-            actualLine = Integer.parseInt(matcher.group(1));
-            actualColumn = Integer.parseInt(matcher.group(2));
-          } else {
-            if (expectedMsgPattern != null
-                && actualMessage.matches(expectedMsgPattern)) {
-              return;
-            }
-          }
-        }
-      }
-    }
-
-    if (null == expectedMsgPattern) {
-      actualException.printStackTrace();
-      fail("Validator threw unexpected exception"
-          + "; query [" + sap.sql
-          + "]; exception [" + actualMessage
-          + "]; class [" + actualException.getClass()
-          + "]; pos [line " + actualLine
-          + " col " + actualColumn
-          + " thru line " + actualLine
-          + " col " + actualColumn + "]");
-    }
-
-    String sqlWithCarets;
-    if (actualColumn <= 0
-        || actualLine <= 0
-        || actualEndColumn <= 0
-        || actualEndLine <= 0) {
-      if (sap.pos != null) {
-        AssertionError e =
-            new AssertionError("Expected error to have position,"
-                + " but actual error did not: "
-                + " actual pos [line " + actualLine
-                + " col " + actualColumn
-                + " thru line " + actualEndLine + " col "
-                + actualEndColumn + "]");
-        e.initCause(actualException);
-        throw e;
-      }
-      sqlWithCarets = sap.sql;
-    } else {
-      sqlWithCarets =
-          SqlParserUtil.addCarets(
-              sap.sql,
-              actualLine,
-              actualColumn,
-              actualEndLine,
-              actualEndColumn + 1);
-      if (sap.pos == null) {
-        throw new AssertionError("Actual error had a position, but expected "
-            + "error did not. Add error position carets to sql:\n"
-            + sqlWithCarets);
-      }
-    }
-
-    if (actualMessage != null) {
-      actualMessage = Util.toLinux(actualMessage);
-    }
-
-    if (actualMessage == null
-        || !actualMessage.matches(expectedMsgPattern)) {
-      actualException.printStackTrace();
-      final String actualJavaRegexp =
-          (actualMessage == null)
-              ? "null"
-              : TestUtil.quoteForJava(
-                  TestUtil.quotePattern(actualMessage));
-      fail("Validator threw different "
-          + "exception than expected; query [" + sap.sql
-          + "];\n"
-          + " expected pattern [" + expectedMsgPattern
-          + "];\n"
-          + " actual [" + actualMessage
-          + "];\n"
-          + " actual as java regexp [" + actualJavaRegexp
-          + "]; pos [" + actualLine
-          + " col " + actualColumn
-          + " thru line " + actualEndLine
-          + " col " + actualEndColumn
-          + "]; sql [" + sqlWithCarets + "]");
-    } else if (sap.pos != null
-        && (actualLine != sap.pos.getLineNum()
-            || actualColumn != sap.pos.getColumnNum()
-            || actualEndLine != sap.pos.getEndLineNum()
-            || actualEndColumn != sap.pos.getEndColumnNum())) {
-      fail("Validator threw expected "
-          + "exception [" + actualMessage
-          + "];\nbut at pos [line " + actualLine
-          + " col " + actualColumn
-          + " thru line " + actualEndLine
-          + " col " + actualEndColumn
-          + "];\nsql [" + sqlWithCarets + "]");
-    }
+    CheckUtil.checkEx(ex, expectedMsgPattern, sap, CheckUtil.Stage.VALIDATE);
   }
 
   //~ Inner Interfaces -------------------------------------------------------
@@ -570,7 +392,7 @@ public class SqlValidatorTestCase {
      */
     Sql(SqlTester tester, String sql, boolean query) {
       this.tester = tester;
-      this.sql = query ? sql : SqlTesterImpl.buildQuery(sql);
+      this.sql = query ? sql : AbstractSqlTester.buildQuery(sql);
     }
 
     Sql tester(SqlTester tester) {

--- a/core/src/test/java/org/apache/calcite/util/CheckUtil.java
+++ b/core/src/test/java/org/apache/calcite/util/CheckUtil.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import org.apache.calcite.runtime.CalciteContextException;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParserUtil;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Static utilities for checking SQL.
+ */
+public abstract class CheckUtil {
+  private static final Pattern LINE_COL_PATTERN =
+      Pattern.compile("At line ([0-9]+), column ([0-9]+)");
+
+  private static final Pattern LINE_COL_TWICE_PATTERN =
+      Pattern.compile(
+          "(?s)From line ([0-9]+), column ([0-9]+) to line ([0-9]+), column ([0-9]+): (.*)");
+
+  /**
+   * Checks whether an exception matches the expected pattern. If <code>
+   * sap</code> contains an error location, checks this too.
+   *
+   * @param ex                 Exception thrown
+   * @param expectedMsgPattern Expected pattern
+   * @param sap                Query and (optional) position in query
+   * @param stage              Query processing stage
+   */
+  public static void checkEx(
+      Throwable ex,
+      String expectedMsgPattern,
+      SqlParserUtil.StringAndPos sap,
+      Stage stage) {
+    if (null == ex) {
+      if (expectedMsgPattern == null) {
+        // No error expected, and no error happened.
+        return;
+      } else {
+        throw new AssertionError("Expected query to throw exception, "
+            + "but it did not; query [" + sap.sql
+            + "]; expected [" + expectedMsgPattern + "]");
+      }
+    }
+    Throwable actualException = ex;
+    String actualMessage = actualException.getMessage();
+    int actualLine = -1;
+    int actualColumn = -1;
+    int actualEndLine = 100;
+    int actualEndColumn = 99;
+
+    // Search for an CalciteContextException somewhere in the stack.
+    CalciteContextException ece = null;
+    for (Throwable x = ex; x != null; x = x.getCause()) {
+      if (x instanceof CalciteContextException) {
+        ece = (CalciteContextException) x;
+        break;
+      }
+      if (x.getCause() == x) {
+        break;
+      }
+    }
+
+    // Search for a SqlParseException -- with its position set -- somewhere
+    // in the stack.
+    SqlParseException spe = null;
+    for (Throwable x = ex; x != null; x = x.getCause()) {
+      if ((x instanceof SqlParseException)
+          && (((SqlParseException) x).getPos() != null)) {
+        spe = (SqlParseException) x;
+        break;
+      }
+      if (x.getCause() == x) {
+        break;
+      }
+    }
+
+    if (ece != null) {
+      actualLine = ece.getPosLine();
+      actualColumn = ece.getPosColumn();
+      actualEndLine = ece.getEndPosLine();
+      actualEndColumn = ece.getEndPosColumn();
+      if (ece.getCause() != null) {
+        actualException = ece.getCause();
+        actualMessage = actualException.getMessage();
+      }
+    } else if (spe != null) {
+      actualLine = spe.getPos().getLineNum();
+      actualColumn = spe.getPos().getColumnNum();
+      actualEndLine = spe.getPos().getEndLineNum();
+      actualEndColumn = spe.getPos().getEndColumnNum();
+      if (spe.getCause() != null) {
+        actualException = spe.getCause();
+        actualMessage = actualException.getMessage();
+      }
+    } else {
+      final String message = ex.getMessage();
+      if (message != null) {
+        Matcher matcher = LINE_COL_TWICE_PATTERN.matcher(message);
+        if (matcher.matches()) {
+          actualLine = Integer.parseInt(matcher.group(1));
+          actualColumn = Integer.parseInt(matcher.group(2));
+          actualEndLine = Integer.parseInt(matcher.group(3));
+          actualEndColumn = Integer.parseInt(matcher.group(4));
+          actualMessage = matcher.group(5);
+        } else {
+          matcher = LINE_COL_PATTERN.matcher(message);
+          if (matcher.matches()) {
+            actualLine = Integer.parseInt(matcher.group(1));
+            actualColumn = Integer.parseInt(matcher.group(2));
+          } else {
+            if (expectedMsgPattern != null
+                && actualMessage.matches(expectedMsgPattern)) {
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    if (null == expectedMsgPattern) {
+      actualException.printStackTrace();
+      fail(stage.getComponentName() + " threw unexpected exception"
+          + "; query [" + sap.sql
+          + "]; exception [" + actualMessage
+          + "]; class [" + actualException.getClass()
+          + "]; pos [line " + actualLine
+          + " col " + actualColumn
+          + " thru line " + actualLine
+          + " col " + actualColumn + "]");
+    }
+
+    String sqlWithCarets;
+    if (actualColumn <= 0
+        || actualLine <= 0
+        || actualEndColumn <= 0
+        || actualEndLine <= 0) {
+      if (sap.pos != null) {
+        AssertionError e =
+            new AssertionError("Expected error to have position,"
+                + " but actual error did not: "
+                + " actual pos [line " + actualLine
+                + " col " + actualColumn
+                + " thru line " + actualEndLine + " col "
+                + actualEndColumn + "]");
+        e.initCause(actualException);
+        throw e;
+      }
+      sqlWithCarets = sap.sql;
+    } else {
+      sqlWithCarets =
+          SqlParserUtil.addCarets(
+              sap.sql,
+              actualLine,
+              actualColumn,
+              actualEndLine,
+              actualEndColumn + 1);
+      if (sap.pos == null) {
+        throw new AssertionError("Actual error had a position, but expected "
+            + "error did not. Add error position carets to sql:\n"
+            + sqlWithCarets);
+      }
+    }
+
+    if (actualMessage != null) {
+      actualMessage = Util.toLinux(actualMessage);
+    }
+
+    if (actualMessage == null
+        || !actualMessage.matches(expectedMsgPattern)) {
+      actualException.printStackTrace();
+      final String actualJavaRegexp =
+          (actualMessage == null)
+              ? "null"
+              : TestUtil.quoteForJava(
+              TestUtil.quotePattern(actualMessage));
+      fail(stage.getComponentName() + " threw different "
+          + "exception than expected; query [" + sap.sql
+          + "];\n"
+          + " expected pattern [" + expectedMsgPattern
+          + "];\n"
+          + " actual [" + actualMessage
+          + "];\n"
+          + " actual as java regexp [" + actualJavaRegexp
+          + "]; pos [" + actualLine
+          + " col " + actualColumn
+          + " thru line " + actualEndLine
+          + " col " + actualEndColumn
+          + "]; sql [" + sqlWithCarets + "]");
+    } else if (sap.pos != null
+        && (actualLine != sap.pos.getLineNum()
+        || actualColumn != sap.pos.getColumnNum()
+        || actualEndLine != sap.pos.getEndLineNum()
+        || actualEndColumn != sap.pos.getEndColumnNum())) {
+      fail(stage.getComponentName() + " threw expected "
+          + "exception [" + actualMessage
+          + "];\nbut at pos [line " + actualLine
+          + " col " + actualColumn
+          + " thru line " + actualEndLine
+          + " col " + actualEndColumn
+          + "];\nsql [" + sqlWithCarets + "]");
+    }
+  }
+
+  /** Stage of query processing */
+  public enum Stage {
+    PARSE("Parser"),
+    VALIDATE("Validator"),
+    RUNTIME("Executor");
+
+    private final String componentName;
+
+    Stage(String componentName) {
+      this.componentName = componentName;
+    }
+
+    public String getComponentName() {
+      return componentName;
+    }
+  }
+}
+
+// End CheckUtil.java

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -1762,6 +1762,8 @@ EnumerableCalc(expr#0=[{inputs}], expr#1=['TR'], expr#2=['UE'], expr#3=[||($t1, 
   EnumerableValues(tuples=[[{ 0 }]])
 !plan
 
+!if (fixed.calcite2539) {
+
 # In the following, that we get an error at run time,
 # and that the plan shows that the expression has not been reduced.
 values cast('null' as boolean);
@@ -1824,6 +1826,7 @@ Caused by: java.lang.NumberFormatException: For input string: "4567891234"
 values cast('12345678901234567890' as bigint);
 Caused by: java.lang.NumberFormatException: For input string: "12345678901234567890"
 !error
+!}
 
 # Out of REAL range
 # (Should give an error, not infinity.)

--- a/core/src/test/resources/sql/spatial.iq
+++ b/core/src/test/resources/sql/spatial.iq
@@ -802,6 +802,7 @@ EXPR$0
 {"rings":[[[11,11],[11,19],[19,19],[19,11],[11,11]]]}
 !ok
 
+!if (fixed.calcite2539) {
 # ST_BUFFER(geom, bufferSize, style) variant - not implemented
 SELECT ST_Buffer(
  ST_GeomFromText('POINT(100 90)'),
@@ -816,6 +817,7 @@ SELECT ST_Buffer(
  50, 2);
 at org.apache.calcite.runtime.GeoFunctions.todo
 !error GeoFunctions
+!}
 
 # ST_ConvexHull(geom) Computes the smallest convex polygon that contains all the points in the Geometry
 # Not implemented


### PR DESCRIPTION
This is an alternative for #821.

This is the [JIRA](https://issues.apache.org/jira/browse/CALCITE-2535).

1. Make run time failure check work as expected;
2. Add AbstractFailureOptimizedEnumerable.java to yield exception thrown from function execution.