### PR TITLE
[CALCITE-2558] Improve re-compilation times by skipping parser.java update on each build

### DIFF
--- a/babel/pom.xml
+++ b/babel/pom.xml
@@ -102,6 +102,24 @@ limitations under the License.
       <!-- Sorted by groupId, artifactId. Put versions in
            pluginManagement in the root POM, not here. -->
       <plugin>
+        <groupId>org.apache.drill.tools</groupId>
+        <artifactId>drill-fmpp-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <configuration>
+              <config>src/main/codegen/config.fmpp</config>
+              <output>${project.build.directory}/generated-sources/fmpp</output>
+              <templates>${top.dir}/core/src/main/codegen/templates</templates>
+            </configuration>
+            <id>generate-fmpp-sources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${maven-dependency-plugin.version}</version>
         <executions>
@@ -201,41 +219,4 @@ limitations under the License.
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <!-- CALCITE-538: workaround for https://github.com/freemarker/fmpp/issues/11
-        FMPP always overwrites destination file, however we do not want
-        recompile the whole module every time.
-      -->
-      <id>generate-parser</id>
-      <activation>
-        <property>
-          <name>!skipGenerate</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.googlecode.fmpp-maven-plugin</groupId>
-            <artifactId>fmpp-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <configuration>
-                  <cfgFile>src/main/codegen/config.fmpp</cfgFile>
-                  <outputDirectory>${project.build.directory}/generated-sources/fmpp</outputDirectory>
-                  <templateDirectory>${top.dir}/core/src/main/codegen/templates</templateDirectory>
-                </configuration>
-                <id>generate-fmpp-sources</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -181,6 +181,36 @@ limitations under the License.
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.drill.tools</groupId>
+        <artifactId>drill-fmpp-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <configuration>
+              <config>src/main/codegen/config.fmpp</config>
+              <templates>src/main/codegen/templates</templates>
+            </configuration>
+            <id>generate-fmpp-sources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+          <execution>
+            <configuration>
+              <config>src/test/codegen/config.fmpp</config>
+              <templates>src/main/codegen/templates</templates>
+              <output>${project.build.directory}/generated-test-sources/fmpp</output>
+              <scope>test</scope>
+            </configuration>
+            <id>generate-fmpp-test-sources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
@@ -466,51 +496,6 @@ limitations under the License.
             <filtering>true</filtering>
           </resource>
         </resources>
-      </build>
-    </profile>
-    <profile>
-      <!-- CALCITE-538: workaround for https://github.com/freemarker/fmpp/issues/11
-        FMPP always overwrites destination file, however we do not want
-        recompile the whole module every time.
-      -->
-      <id>generate-parser</id>
-      <activation>
-        <property>
-          <name>!skipGenerate</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.googlecode.fmpp-maven-plugin</groupId>
-            <artifactId>fmpp-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <configuration>
-                  <cfgFile>src/main/codegen/config.fmpp</cfgFile>
-                  <templateDirectory>src/main/codegen/templates</templateDirectory>
-                </configuration>
-                <id>generate-fmpp-sources</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-              <execution>
-                <configuration>
-                  <cfgFile>src/test/codegen/config.fmpp</cfgFile>
-                  <templateDirectory>src/main/codegen/templates</templateDirectory>
-                  <outputDirectory>${project.build.directory}/generated-test-sources/fmpp</outputDirectory>
-                </configuration>
-                <id>generate-fmpp-test-sources</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
       </build>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ limitations under the License.
     <elasticsearch.version>6.2.4</elasticsearch.version>
     <esri-geometry-api.version>2.2.0</esri-geometry-api.version>
     <findbugs.version>3.0.1</findbugs.version>
-    <fmpp-maven-plugin.version>1.0</fmpp-maven-plugin.version>
+    <drill-fmpp-maven-plugin.version>1.14.0</drill-fmpp-maven-plugin.version>
     <foodmart-data-hsqldb.version>0.3</foodmart-data-hsqldb.version>
     <foodmart-queries.version>0.4.1</foodmart-queries.version>
     <forbiddenapis.version>2.5</forbiddenapis.version>
@@ -132,7 +132,7 @@ limitations under the License.
     <xalan.version>2.7.1</xalan.version>
     <xerces.version>2.9.1</xerces.version>
     <sketches.version>0.9.0</sketches.version>
-    <fmpp.version>0.9.14</fmpp.version>
+    <fmpp.version>0.9.16</fmpp.version>
 
     <!-- Other properties (not version numbers) -->
     <maven-javadoc-plugin.excludePackageNames>
@@ -813,9 +813,9 @@ limitations under the License.
       <plugins>
         <!-- Sorted by groupId, artifactId. -->
         <plugin>
-          <groupId>com.googlecode.fmpp-maven-plugin</groupId>
-          <artifactId>fmpp-maven-plugin</artifactId>
-          <version>${fmpp-maven-plugin.version}</version>
+          <groupId>org.apache.drill.tools</groupId>
+          <artifactId>drill-fmpp-maven-plugin</artifactId>
+          <version>${drill-fmpp-maven-plugin.version}</version>
           <dependencies>
             <dependency>
               <groupId>org.freemarker</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -106,6 +106,24 @@ limitations under the License.
       <!-- Sorted by groupId, artifactId. Put versions in
            pluginManagement in the root POM, not here. -->
       <plugin>
+        <groupId>org.apache.drill.tools</groupId>
+        <artifactId>drill-fmpp-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <configuration>
+              <config>src/main/codegen/config.fmpp</config>
+              <output>${project.build.directory}/generated-sources/fmpp</output>
+              <templates>${top.dir}/core/src/main/codegen/templates</templates>
+            </configuration>
+            <id>generate-fmpp-sources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${maven-dependency-plugin.version}</version>
         <executions>
@@ -205,41 +223,4 @@ limitations under the License.
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <!-- CALCITE-538: workaround for https://github.com/freemarker/fmpp/issues/11
-        FMPP always overwrites destination file, however we do not want
-        recompile the whole module every time.
-      -->
-      <id>generate-parser</id>
-      <activation>
-        <property>
-          <name>!skipGenerate</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.googlecode.fmpp-maven-plugin</groupId>
-            <artifactId>fmpp-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <configuration>
-                  <cfgFile>src/main/codegen/config.fmpp</cfgFile>
-                  <outputDirectory>${project.build.directory}/generated-sources/fmpp</outputDirectory>
-                  <templateDirectory>${top.dir}/core/src/main/codegen/templates</templateDirectory>
-                </configuration>
-                <id>generate-fmpp-sources</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-2558

fmpp-maven-plugin updated SqlParserImpl.java on each build even in case
the file was not modified. It causes maven-compiler-plugin to re-compile everything

New behavior is update SqlParserImpl.java only in case it is modified,
and it significantly improves repeated compilations.