### PR TITLE
[CALCITE-2559] Update Checkstyle to 7.8.12

### DIFF
--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
@@ -29,7 +29,6 @@ import net.jcip.annotations.NotThreadSafe;
 
 import org.cassandraunit.CassandraCQLUnit;
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/core/src/main/java/org/apache/calcite/jdbc/CalcitePrepare.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalcitePrepare.java
@@ -47,7 +47,6 @@ import org.apache.calcite.tools.RelRunner;
 import org.apache.calcite.util.ImmutableIntList;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 

--- a/core/src/main/java/org/apache/calcite/model/ModelHandler.java
+++ b/core/src/main/java/org/apache/calcite/model/ModelHandler.java
@@ -47,7 +47,6 @@ import org.apache.calcite.util.Util;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
@@ -78,6 +78,13 @@ public class RelOptCostImpl implements RelOptCost {
     return getRows() == other.getRows();
   }
 
+  @Override public boolean equals(Object obj) {
+    if (obj instanceof RelOptCostImpl) {
+      return equals((RelOptCost) obj);
+    }
+    return false;
+  }
+
   // implement RelOptCost
   public boolean isEqWithEpsilon(RelOptCost other) {
     return Math.abs(getRows() - other.getRows()) < RelOptUtil.EPSILON;

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
@@ -131,6 +131,13 @@ class VolcanoCost implements RelOptCost {
         && (this.io == ((VolcanoCost) other).io);
   }
 
+  @Override public boolean equals(Object obj) {
+    if (obj instanceof VolcanoCost) {
+      return equals((VolcanoCost) obj);
+    }
+    return false;
+  }
+
   public boolean isEqWithEpsilon(RelOptCost other) {
     if (!(other instanceof VolcanoCost)) {
       return false;

--- a/core/src/main/java/org/apache/calcite/rel/core/Calc.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Calc.java
@@ -31,7 +31,6 @@ import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexShuttle;
-
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 

--- a/core/src/main/java/org/apache/calcite/runtime/HttpUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/HttpUtils.java
@@ -71,7 +71,7 @@ public class HttpUtils {
   }
 
   public static void appendURLEncodedArgs(
-      StringBuilder out, CharSequence ... args) {
+      StringBuilder out, CharSequence... args) {
     if (args.length % 2 != 0) {
       throw new IllegalArgumentException(
           "args should contain an even number of items");

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialectFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialectFactoryImpl.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.config.NullCollation;
-
 import org.apache.calcite.sql.dialect.AccessSqlDialect;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -107,7 +107,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
-
 import javax.sql.DataSource;
 
 /**

--- a/core/src/main/java/org/apache/calcite/util/Static.java
+++ b/core/src/main/java/org/apache/calcite/util/Static.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.util;
 
 import org.apache.calcite.runtime.CalciteResource;
-
 import org.apache.calcite.runtime.ConsList;
 import org.apache.calcite.runtime.Resources;
 

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
@@ -51,7 +51,6 @@ import static org.apache.calcite.plan.volcano.PlannerTests.TestSingleRel;
 import static org.apache.calcite.plan.volcano.PlannerTests.newCluster;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;

--- a/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
@@ -509,7 +509,7 @@ public class CalciteAssert {
     final String message =
         "With materializationsEnabled=" + materializationsEnabled
             + ", limit=" + limit;
-    try (final Closer closer = new Closer()) {
+    try (Closer closer = new Closer()) {
       if (connection.isWrapperFor(CalciteConnection.class)) {
         final CalciteConnection calciteConnection =
             connection.unwrap(CalciteConnection.class);
@@ -1340,7 +1340,7 @@ public class CalciteAssert {
     }
 
     public final AssertQuery updates(int count) {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, materializationsEnabled,
             hooks, null, checkUpdateCount(count), null);
         return this;
@@ -1358,7 +1358,7 @@ public class CalciteAssert {
     }
 
     protected AssertQuery returns(String sql, Consumer<ResultSet> checker) {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, materializationsEnabled,
             hooks, checker, null, null);
         return this;
@@ -1381,7 +1381,7 @@ public class CalciteAssert {
     }
 
     public AssertQuery throws_(String message) {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, materializationsEnabled,
             hooks, null, null, checkException(message));
         return this;
@@ -1398,7 +1398,7 @@ public class CalciteAssert {
      * @param optionalMessage An optional message to check for in the output stacktrace
      * */
     public AssertQuery failsAtValidation(String optionalMessage) {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, materializationsEnabled,
             hooks, null, null, checkValidationException(optionalMessage));
         return this;
@@ -1417,7 +1417,7 @@ public class CalciteAssert {
     }
 
     public AssertQuery runs() {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, materializationsEnabled,
             hooks, null, null, null);
         return this;
@@ -1428,7 +1428,7 @@ public class CalciteAssert {
     }
 
     public AssertQuery typeIs(String expected) {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, false,
             hooks, checkResultType(expected), null, null);
         return this;
@@ -1446,7 +1446,7 @@ public class CalciteAssert {
     }
 
     public AssertQuery convertMatches(final Function<RelNode, Void> checker) {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertPrepare(connection, sql, this.materializationsEnabled,
             checker, null);
         return this;
@@ -1458,7 +1458,7 @@ public class CalciteAssert {
 
     public AssertQuery substitutionMatches(
         final Function<RelNode, Void> checker) {
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertPrepare(connection, sql, materializationsEnabled, null, checker);
         return this;
       } catch (Exception e) {
@@ -1515,7 +1515,7 @@ public class CalciteAssert {
         return;
       }
       addHook(Hook.JAVA_PLAN, (Consumer<String>) a0 -> plan = a0);
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, materializationsEnabled,
             hooks, null, checkUpdate, null);
         assertNotNull(plan);
@@ -1532,7 +1532,7 @@ public class CalciteAssert {
     public AssertQuery queryContains(Consumer<List> predicate1) {
       final List<Object> list = new ArrayList<>();
       addHook(Hook.QUERY_PLAN, list::add);
-      try (final Connection connection = createConnection()) {
+      try (Connection connection = createConnection()) {
         assertQuery(connection, sql, limit, materializationsEnabled,
             hooks, null, null, null);
         predicate1.accept(list);
@@ -1624,7 +1624,7 @@ public class CalciteAssert {
     }
 
     public final AssertMetaData returns(Consumer<ResultSet> checker) {
-      try (final Connection c = connectionFactory.createConnection()) {
+      try (Connection c = connectionFactory.createConnection()) {
         final ResultSet resultSet = function.apply(c);
         checker.accept(resultSet);
         resultSet.close();

--- a/core/src/test/java/org/apache/calcite/test/CoreQuidemTest.java
+++ b/core/src/test/java/org/apache/calcite/test/CoreQuidemTest.java
@@ -63,14 +63,14 @@ public class CoreQuidemTest extends QuidemTest {
       // Oracle as the JDBC data source.
       return;
     }
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
       checkRun(path);
     }
   }
 
   /** Override settings for "sql/scalar.iq". */
   public void testSqlScalar() throws Exception {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
       checkRun(path);
     }
   }
@@ -80,7 +80,7 @@ public class CoreQuidemTest extends QuidemTest {
 
   // Do not disable this test; just remember not to commit changes to dummy.iq
   public void testSqlDummy() throws Exception {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
       checkRun(path);
     }
   }

--- a/core/src/test/java/org/apache/calcite/test/DiffTestCase.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffTestCase.java
@@ -473,7 +473,7 @@ public abstract class DiffTestCase {
    */
   protected static String fileContents(File file) {
     byte[] buf = new byte[2048];
-    try (final FileInputStream reader = new FileInputStream(file)) {
+    try (FileInputStream reader = new FileInputStream(file)) {
       int readCount;
       final ByteArrayOutputStream writer = new ByteArrayOutputStream();
       while ((readCount = reader.read(buf)) >= 0) {

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -21,7 +21,6 @@ import org.apache.calcite.test.CalciteAssert.AssertThat;
 import org.apache.calcite.test.CalciteAssert.DatabaseInstance;
 
 import org.hsqldb.jdbcDriver;
-
 import org.junit.Test;
 
 import java.sql.Connection;

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -99,7 +99,6 @@ import com.google.common.collect.Multimap;
 
 import org.hamcrest.Matcher;
 import org.hsqldb.jdbcDriver;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -247,7 +246,7 @@ public class JdbcTest {
   @Test public void testModelWithModifiableView() throws Exception {
     final List<Employee> employees = new ArrayList<>();
     employees.add(new Employee(135, 10, "Simon", 56.7f, null));
-    try (final TryThreadLocal.Memo ignore =
+    try (TryThreadLocal.Memo ignore =
              EmpDeptTableFactory.THREAD_COLLECTION.push(employees)) {
       final CalciteAssert.AssertThat with = modelWithView(
           "select \"name\", \"empid\" as e, \"salary\" "
@@ -319,7 +318,7 @@ public class JdbcTest {
   @Test public void testModelWithInvalidModifiableView() throws Exception {
     final List<Employee> employees = new ArrayList<>();
     employees.add(new Employee(135, 10, "Simon", 56.7f, null));
-    try (final TryThreadLocal.Memo ignore =
+    try (TryThreadLocal.Memo ignore =
              EmpDeptTableFactory.THREAD_COLLECTION.push(employees)) {
       Util.discard(RESOURCE.noValueSuppliedForViewColumn(null, null));
       modelWithView("select \"name\", \"empid\" as e, \"salary\" "
@@ -569,7 +568,7 @@ public class JdbcTest {
         throw new RuntimeException();
       }
     };
-    try (final TryThreadLocal.Memo ignore =
+    try (TryThreadLocal.Memo ignore =
              HandlerDriver.HANDLERS.push(h)) {
       final HandlerDriver driver = new HandlerDriver();
       CalciteConnection connection = (CalciteConnection)
@@ -3283,7 +3282,7 @@ public class JdbcTest {
 
   /** Query that reads no columns from either underlying table. */
   @Test public void testCountStar() {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       CalciteAssert.hr()
           .query("select count(*) c from \"hr\".\"emps\", \"hr\".\"depts\"")
           .convertContains("LogicalAggregate(group=[{}], C=[COUNT()])\n"
@@ -4177,7 +4176,7 @@ public class JdbcTest {
 
   /** Tests that field-trimming creates a project near the table scan. */
   @Test public void testTrimFields() throws Exception {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       CalciteAssert.hr()
           .query("select \"name\", count(\"commission\") + 1\n"
               + "from \"hr\".\"emps\"\n"
@@ -4192,7 +4191,7 @@ public class JdbcTest {
   /** Tests that field-trimming creates a project near the table scan, in a
    * query with windowed-aggregation. */
   @Test public void testTrimFieldsOver() throws Exception {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       // The correct plan has a project on a filter on a project on a scan.
       CalciteAssert.hr()
           .query("select \"name\",\n"
@@ -4586,7 +4585,7 @@ public class JdbcTest {
    * <p>Note that there should be an extra row "empid=200; deptno=20;
    * DNAME=null" but left join doesn't work.</p> */
   @Test public void testScalarSubQuery() {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
       CalciteAssert.hr()
           .query("select \"empid\", \"deptno\",\n"
               + " (select \"name\" from \"hr\".\"depts\"\n"
@@ -4748,7 +4747,7 @@ public class JdbcTest {
   }
 
   @Test public void testScalarSubQueryInCase() {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
       CalciteAssert.hr()
           .query("select e.\"name\",\n"
               + " (CASE e.\"deptno\"\n"
@@ -4907,7 +4906,7 @@ public class JdbcTest {
           final String sql = "select \"name\"\n"
               + "from \"hr\".\"emps\"\n"
               + "order by \"empid\" offset ? fetch next ? rows only";
-          try (final PreparedStatement p =
+          try (PreparedStatement p =
                    connection.prepareStatement(sql)) {
             final ParameterMetaData pmd = p.getParameterMetaData();
             assertThat(pmd.getParameterCount(), is(2));
@@ -4915,7 +4914,7 @@ public class JdbcTest {
             assertThat(pmd.getParameterType(2), is(Types.INTEGER));
             p.setInt(1, offset);
             p.setInt(2, fetch);
-            try (final ResultSet r = p.executeQuery()) {
+            try (ResultSet r = p.executeQuery()) {
               assertThat(r, matcher);
             }
           } catch (SQLException e) {
@@ -5096,7 +5095,7 @@ public class JdbcTest {
   private void checkCustomSchemaInFileInPwd(String fileName)
       throws SQLException {
     final File file = new File(fileName);
-    try (final PrintWriter pw = Util.printWriter(file)) {
+    try (PrintWriter pw = Util.printWriter(file)) {
       file.deleteOnExit();
       pw.println("{\n"
           + "  version: '1.0',\n"

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -165,7 +165,7 @@ public class MaterializationTest {
   }
 
   @Test public void testFilterQueryOnProjectView() {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.that()
           .withMaterializations(
@@ -213,7 +213,7 @@ public class MaterializationTest {
   private CalciteAssert.AssertQuery checkThatMaterialize(String materialize,
       String query, String name, boolean existing, String model,
       Consumer<ResultSet> explainChecker, final RuleSet rules) {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.AssertQuery that = CalciteAssert.that()
           .withMaterializations(model, existing, name, materialize)
@@ -237,7 +237,7 @@ public class MaterializationTest {
    * definition. */
   private void checkNoMaterialize(String materialize, String query,
       String model) {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.that()
           .withMaterializations(model, "m0", materialize)
@@ -323,7 +323,7 @@ public class MaterializationTest {
    * FilterToProjectUnifyRule.invert(MutableRel, MutableRel, MutableProject)
    * works incorrectly</a>. */
   @Test public void testFilterQueryOnProjectView8() {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       final String m = "select \"salary\", \"commission\",\n"
           + "\"deptno\", \"empid\", \"name\" from \"emps\"";
@@ -1975,7 +1975,7 @@ public class MaterializationTest {
         + "from \"emps\" where \"deptno\" = 10";
 
     final List<List<List<String>>> substitutedNames = new ArrayList<>();
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.that()
           .withMaterializations(HR_FKUK_MODEL,
@@ -1996,7 +1996,7 @@ public class MaterializationTest {
    * Pre-populated materializations</a>. */
   @Test public void testPrePopulated() {
     String q = "select \"deptno\" from \"emps\"";
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.that()
           .withMaterializations(
@@ -2017,7 +2017,7 @@ public class MaterializationTest {
   }
 
   @Test public void testViewSchemaPath() {
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       final String m = "select empno, deptno from emp";
       final String q = "select deptno from scott.emp";
@@ -2070,7 +2070,7 @@ public class MaterializationTest {
     String q = "select *\n"
         + "from (select * from \"emps\" where \"empid\" < 300)\n"
         + "join (select \"deptno\", count(*) as c from \"emps\" group by \"deptno\") using (\"deptno\")";
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.that()
           .withMaterializations(HR_FKUK_MODEL,
@@ -2088,7 +2088,7 @@ public class MaterializationTest {
     final String q = "select *\n"
         + "from \"emps\"\n"
         + "join \"depts\" using (\"deptno\") where \"empid\" < 300 ";
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.that()
           .withMaterializations(HR_FKUK_MODEL,
@@ -2106,7 +2106,7 @@ public class MaterializationTest {
         + "from \"emps\"\n"
         + "join \"depts\" using (\"deptno\") where \"empid\" < 300 "
         + "and \"depts\".\"deptno\" > 200";
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       CalciteAssert.that()
           .withMaterializations(HR_FKUK_MODEL,
@@ -2209,7 +2209,7 @@ public class MaterializationTest {
         {{"hr", "m1"}, {"hr", "m0"}},
         {{"hr", "m1"}, {"hr", "m1"}}};
 
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       final List<List<List<String>>> substitutedNames = new ArrayList<>();
       CalciteAssert.that()
@@ -2248,7 +2248,7 @@ public class MaterializationTest {
         {{"hr", "m2"}, {"hr", "m1"}},
         {{"hr", "m2"}, {"hr", "m2"}}};
 
-    try (final TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
+    try (TryThreadLocal.Memo ignored = Prepare.THREAD_TRIM.push(true)) {
       MaterializationService.setThreadLocal();
       final List<List<List<String>>> substitutedNames = new ArrayList<>();
       CalciteAssert.that()

--- a/core/src/test/java/org/apache/calcite/test/QuidemTest.java
+++ b/core/src/test/java/org/apache/calcite/test/QuidemTest.java
@@ -135,9 +135,9 @@ public abstract class QuidemTest {
       outFile = new File(inFile.getAbsoluteFile().getParent(), u2n("surefire/") + path);
     }
     Util.discard(outFile.getParentFile().mkdirs());
-    try (final Reader reader = Util.reader(inFile);
-         final Writer writer = Util.printWriter(outFile);
-         final Closer closer = new Closer()) {
+    try (Reader reader = Util.reader(inFile);
+         Writer writer = Util.printWriter(outFile);
+         Closer closer = new Closer()) {
       final Quidem.Config config = Quidem.configBuilder()
           .withReader(reader)
           .withWriter(writer)

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -1982,7 +1982,7 @@ public class RelBuilderTest {
     RelNode root =
         builder.values(new String[]{"a", "b"}, true, 1, false, -50)
             .build();
-    try (final PreparedStatement preparedStatement = RelRunners.run(root)) {
+    try (PreparedStatement preparedStatement = RelRunners.run(root)) {
       String s = CalciteAssert.toString(preparedStatement.executeQuery());
       final String result = "a=true; b=1\n"
           + "a=false; b=-50\n";
@@ -2004,7 +2004,7 @@ public class RelBuilderTest {
 
     // Note that because the table has been resolved in the RelNode tree
     // we do not need to supply a "schema" as context to the runner.
-    try (final PreparedStatement preparedStatement = RelRunners.run(root)) {
+    try (PreparedStatement preparedStatement = RelRunners.run(root)) {
       String s = CalciteAssert.toString(preparedStatement.executeQuery());
       final String result = ""
           + "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00; COMM=null; DEPTNO=20\n"

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1526,7 +1526,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
         + "  and a.deptno=b.deptno and a.job=b.job and a.ename=b.ename\n"
         + "  and a.mgr=b.deptno and a.slacker=b.slacker";
     // Lock to ensure that only one test is using this method at a time.
-    try (final JdbcAdapterTest.LockWrapper ignore =
+    try (JdbcAdapterTest.LockWrapper ignore =
              JdbcAdapterTest.LockWrapper.lock(LOCK)) {
       final RelNode rel = convertSql(sql);
       final RelMetadataQuery mq = RelMetadataQuery.instance();

--- a/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
@@ -323,7 +323,7 @@ abstract class RelOptTestBase extends SqlToRelTestBase {
 
     @SuppressWarnings("unchecked")
     private void check(boolean unchanged) {
-      try (final Closer closer = new Closer()) {
+      try (Closer closer = new Closer()) {
         for (Map.Entry<Hook, Consumer> entry : hooks.entrySet()) {
           closer.add(entry.getKey().addThread(entry.getValue()));
         }

--- a/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
@@ -348,7 +348,7 @@ public class ScannableTableTest {
   @Test public void testPrepared2() throws SQLException {
     final Properties properties = new Properties();
     properties.setProperty("caseSensitive", "true");
-    try (final Connection connection =
+    try (Connection connection =
              DriverManager.getConnection("jdbc:calcite:", properties)) {
       final CalciteConnection calciteConnection = connection.unwrap(
           CalciteConnection.class);

--- a/core/src/test/java/org/apache/calcite/test/SqlLineTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlLineTest.java
@@ -21,7 +21,6 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
 import org.hamcrest.Matcher;
-
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;

--- a/core/src/test/java/org/apache/calcite/test/concurrent/ConcurrentTestCommandScript.java
+++ b/core/src/test/java/org/apache/calcite/test/concurrent/ConcurrentTestCommandScript.java
@@ -2074,7 +2074,7 @@ public class ConcurrentTestCommandScript
 
     // returns 0 on success, 1 on error, 2 on bad invocation.
     public int run(String[] args) {
-      try (final PrintWriter w = Util.printWriter(System.out)) {
+      try (PrintWriter w = Util.printWriter(System.out)) {
         if (!parseCommand(args)) {
           usage();
           return 2;

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -88,7 +88,6 @@ import static org.apache.calcite.plan.RelOptRule.operand;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -225,7 +225,7 @@ public class UtilTest {
     assertEquals(
         "ID$0$_3__c_6_17__21__17__2d__15__7f__6cd9__fffd_",
         Util.toJavaId(
-            new String(bytes1, "EUC-JP"),
+            new String(bytes1, "EUC-JP"), // CHECKSTYLE: IGNORE 0
             0));
     byte[] bytes2 = {
         64, 32, 43, -45, -23, 0, 43, 54, 119, -32, -56, -34
@@ -233,7 +233,7 @@ public class UtilTest {
     assertEquals(
         "ID$0$_30c__3617__2117__2d15__7fde__a48f_",
         Util.toJavaId(
-            new String(bytes1, "UTF-16"),
+            new String(bytes1, "UTF-16"), // CHECKSTYLE: IGNORE 0
             0));
   }
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/CeilOperatorConversion.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/CeilOperatorConversion.java
@@ -27,7 +27,6 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.TimeZone;
-
 import javax.annotation.Nullable;
 
 /**

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidConnectionImpl.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidConnectionImpl.java
@@ -126,7 +126,7 @@ class DruidConnectionImpl implements DruidConnection {
       try {
         final byte[] bytes = AvaticaUtils.readFullyToBytes(in);
         System.out.println("Response: "
-            + new String(bytes, StandardCharsets.UTF_8));
+            + new String(bytes, StandardCharsets.UTF_8)); // CHECKSTYLE: IGNORE 0
         in = new ByteArrayInputStream(bytes);
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -145,7 +145,7 @@ class DruidConnectionImpl implements DruidConnection {
       }
     }
 
-    try (final JsonParser parser = factory.createParser(in)) {
+    try (JsonParser parser = factory.createParser(in)) {
       switch (queryType) {
       case TIMESERIES:
         if (parser.nextToken() == JsonToken.START_ARRAY) {
@@ -646,7 +646,7 @@ class DruidConnectionImpl implements DruidConnection {
         final byte[] bytes = AvaticaUtils.readFullyToBytes(in);
         in.close();
         System.out.println("Response: "
-            + new String(bytes, StandardCharsets.UTF_8));
+            + new String(bytes, StandardCharsets.UTF_8)); // CHECKSTYLE: IGNORE 0
         in = new ByteArrayInputStream(bytes);
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.annotation.Nullable;
 
 /**

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -87,7 +87,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
@@ -657,7 +657,7 @@ public class DruidRules {
      * the given {@link Filter}, and any extra nodes.
      */
     private static List<RelNode> constructNewNodes(List<RelNode> oldNodes,
-        boolean addFilter, int startIndex, RelNode filter, RelNode ... trailingNodes) {
+        boolean addFilter, int startIndex, RelNode filter, RelNode... trailingNodes) {
       List<RelNode> newNodes = new ArrayList<>();
 
       // The first item should always be the Table scan, so any filter would go after that

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/ExtractionDimensionSpec.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/ExtractionDimensionSpec.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 
 import java.io.IOException;
 import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 import static org.apache.calcite.adapter.druid.DruidQuery.writeField;

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/FloorOperatorConversion.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/FloorOperatorConversion.java
@@ -25,7 +25,6 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.TimeZone;
-
 import javax.annotation.Nullable;
 
 /**

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/NaryOperatorConverter.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/NaryOperatorConverter.java
@@ -23,7 +23,6 @@ import org.apache.calcite.sql.SqlOperator;
 
 import java.util.List;
 import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 /**

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/TimeExtractionFunction.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/TimeExtractionFunction.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -32,7 +31,6 @@ import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.TimeZone;
-
 import javax.annotation.Nullable;
 
 import static org.apache.calcite.adapter.druid.DruidQuery.writeFieldIf;

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -24,7 +24,6 @@ import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.ElasticsearchChecker;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;

--- a/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
+++ b/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
@@ -661,7 +661,7 @@ public class CsvTest {
   @Test public void testPrepared() throws SQLException {
     final Properties properties = new Properties();
     properties.setProperty("caseSensitive", "true");
-    try (final Connection connection =
+    try (Connection connection =
         DriverManager.getConnection("jdbc:calcite:", properties)) {
       final CalciteConnection calciteConnection = connection.unwrap(
           CalciteConnection.class);
@@ -879,10 +879,10 @@ public class CsvTest {
         "30,\"Engineering\""
     };
 
-    try (final Connection connection =
+    try (Connection connection =
              DriverManager.getConnection("jdbc:calcite:model=inline:" + model);
-         final PrintWriter pw = Util.printWriter(file);
-         final Worker<Void> worker = new Worker<>()) {
+         PrintWriter pw = Util.printWriter(file);
+         Worker<Void> worker = new Worker<>()) {
       final Thread thread = new Thread(worker);
       thread.start();
 

--- a/file/src/test/java/org/apache/calcite/adapter/file/FileReaderTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/FileReaderTest.java
@@ -21,7 +21,6 @@ import org.apache.calcite.util.Sources;
 import org.apache.calcite.util.TestUtil;
 
 import org.jsoup.select.Elements;
-
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/file/src/test/java/org/apache/calcite/adapter/file/FileSuite.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/FileSuite.java
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import java.io.IOException;
-
 import java.net.Socket;
 
 /**

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/util/GeodeUtils.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/util/GeodeUtils.java
@@ -23,7 +23,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.util.Util;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
@@ -213,10 +213,9 @@ class ExpressionWriter {
       }
       char[] chars = new char[2 * targetSize];
       Arrays.fill(chars, ' ');
-      String bigString = new String(chars);
       clear();
       for (int i = 0; i < targetSize; i++) {
-        add(bigString.substring(0, i * 2));
+        add(String.valueOf(chars, 0, i * 2));
       }
     }
   }

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -39,7 +39,6 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
 
 import com.example.Linq4jExample;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/PrimitiveTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/PrimitiveTest.java
@@ -242,7 +242,7 @@ public class PrimitiveTest {
     int[] sources = {1, 2, 3, 4, 5, 6, 0};
     final Object permute = Primitive.CHAR.permute(chars, sources);
     assertTrue(permute instanceof char[]);
-    assertEquals("bcdefga", new String((char[]) permute));
+    assertEquals("bcdefga", String.valueOf((char[]) permute));
   }
 
   /** Test for {@link Primitive#arrayToString(Object)}. */

--- a/piglet/src/test/java/org/apache/calcite/test/CalciteHandler.java
+++ b/piglet/src/test/java/org/apache/calcite/test/CalciteHandler.java
@@ -42,7 +42,7 @@ class CalciteHandler extends Handler {
   }
 
   @Override protected void dump(RelNode rel) {
-    try (final PreparedStatement preparedStatement = RelRunners.run(rel)) {
+    try (PreparedStatement preparedStatement = RelRunners.run(rel)) {
       final ResultSet resultSet = preparedStatement.executeQuery();
       dump(resultSet, true);
     } catch (SQLException e) {

--- a/plus/src/main/java/org/apache/calcite/adapter/os/SqlShell.java
+++ b/plus/src/main/java/org/apache/calcite/adapter/os/SqlShell.java
@@ -100,7 +100,7 @@ public class SqlShell {
                  new OutputStreamWriter(System.err, StandardCharsets.UTF_8));
          InputStreamReader in =
              new InputStreamReader(System.in, StandardCharsets.UTF_8);
-         final PrintWriter out =
+         PrintWriter out =
              new PrintWriter(
                  new OutputStreamWriter(System.out, StandardCharsets.UTF_8))) {
       new SqlShell(in, out, err, args).run();

--- a/plus/src/main/java/org/apache/calcite/adapter/tpcds/TpcdsSchema.java
+++ b/plus/src/main/java/org/apache/calcite/adapter/tpcds/TpcdsSchema.java
@@ -38,7 +38,6 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import com.teradata.tpcds.Results;
 import com.teradata.tpcds.Session;
 import com.teradata.tpcds.column.Column;

--- a/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
+++ b/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
@@ -22,11 +22,9 @@ import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-
 import java.util.Properties;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@ limitations under the License.
     <jmh.version>1.12</jmh.version>
     <jsoup.version>1.11.3</jsoup.version>
     <junit.version>4.12</junit.version>
+    <checkstyle.version>7.8.2</checkstyle.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
@@ -698,6 +699,11 @@ limitations under the License.
           </execution>
         </executions>
         <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+          </dependency>
           <dependency>
             <groupId>net.hydromatic</groupId>
             <artifactId>toolbox</artifactId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-2559

It catches violations better and it caches validation results, so repeated validations are faster

```
mvn clean validate for various:
 6.x  7.8.2 <-- checkstyle version
19.7   18.3 <-- build time in seconds for all Calcite modules
20.1   17.8
20.0   17.6

mvn org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check@validate:
 6.x  7.8.2 <-- checkstyle version
8.91   4.19 <-- build time in seconds for all Calcite modules
8.66   4.52
8.38   3.49
8.53   3.90
8.32   3.80
```