### PR TITLE
[CALCITE-2571] Trim all characters from string

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -1724,6 +1724,7 @@ public class RexImpTable {
   private static class TrimImplementor implements NotNullImplementor {
     public Expression implement(RexToLixTranslator translator, RexCall call,
         List<Expression> translatedOperands) {
+      final boolean strict = !translator.typeFactory.getTypeSystem().allowExtendedTrim();
       final Object value =
           ((ConstantExpression) translatedOperands.get(0)).value;
       SqlTrimFunction.Flag flag = (SqlTrimFunction.Flag) value;
@@ -1736,7 +1737,8 @@ public class RexImpTable {
               flag == SqlTrimFunction.Flag.BOTH
               || flag == SqlTrimFunction.Flag.TRAILING),
           translatedOperands.get(1),
-          translatedOperands.get(2));
+          translatedOperands.get(2),
+          Expressions.constant(strict));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -131,7 +131,15 @@ abstract class CalciteConnectionImpl
                 return true;
               }
             };
-        cfg.typeSystem(RelDataTypeSystem.class, RelDataTypeSystem.DEFAULT);
+      }
+      if (cfg.conformance().allowExtendedTrim()) {
+        typeSystem =
+            new DelegatingTypeSystem(typeSystem) {
+              @Override public boolean
+              allowExtendedTrim() {
+                return true;
+              }
+            };
       }
       this.typeFactory = new JavaTypeFactoryImpl(typeSystem);
     }

--- a/core/src/main/java/org/apache/calcite/rel/type/DelegatingTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/DelegatingTypeSystem.java
@@ -94,6 +94,10 @@ public class DelegatingTypeSystem implements RelDataTypeSystem {
   public boolean shouldConvertRaggedUnionTypesToVarying() {
     return typeSystem.shouldConvertRaggedUnionTypesToVarying();
   }
+
+  public boolean allowExtendedTrim() {
+    return typeSystem.allowExtendedTrim();
+  }
 }
 
 // End DelegatingTypeSystem.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -100,6 +100,9 @@ public interface RelDataTypeSystem {
   /** Whether the least restrictive type of a number of CHAR types of different
    * lengths should be a VARCHAR type. And similarly BINARY to VARBINARY. */
   boolean shouldConvertRaggedUnionTypesToVarying();
+
+  /** Whether TRIM will accept trim character with a length other than 1. */
+  boolean allowExtendedTrim();
 }
 
 // End RelDataTypeSystem.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
@@ -248,6 +248,10 @@ public abstract class RelDataTypeSystemImpl implements RelDataTypeSystem {
     return false;
   }
 
+  public boolean allowExtendedTrim() {
+    return false;
+  }
+
 }
 
 // End RelDataTypeSystemImpl.java

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -217,29 +217,32 @@ public class SqlFunctions {
 
   /** SQL {@code RTRIM} function applied to string. */
   public static String rtrim(String s) {
-    return trim_(s, false, true, ' ');
+    return trim(false, true, " ", s);
   }
 
   /** SQL {@code LTRIM} function. */
   public static String ltrim(String s) {
-    return trim_(s, true, false, ' ');
+    return trim(true, false, " ", s);
   }
 
   /** SQL {@code TRIM(... seek FROM s)} function. */
-  public static String trim(boolean leading, boolean trailing, String seek,
+  public static String trim(boolean left, boolean right, String seek,
       String s) {
-    return trim_(s, leading, trailing, seek.charAt(0));
+    return trim(left, right, seek, s, true);
   }
 
-  /** SQL {@code TRIM} function. */
-  private static String trim_(String s, boolean left, boolean right, char c) {
+  public static String trim(boolean left, boolean right, String seek,
+      String s, boolean strict) {
+    if (strict && seek.length() != 1) {
+      throw new IllegalArgumentException("trim error: trim character must be exactly 1 character");
+    }
     int j = s.length();
     if (right) {
       for (;;) {
         if (j == 0) {
           return "";
         }
-        if (s.charAt(j - 1) != c) {
+        if (seek.indexOf(s.charAt(j - 1)) < 0) {
           break;
         }
         --j;
@@ -251,7 +254,7 @@ public class SqlFunctions {
         if (i == j) {
           return "";
         }
-        if (s.charAt(i) != c) {
+        if (seek.indexOf(s.charAt(i)) < 0) {
           break;
         }
         ++i;
@@ -1497,7 +1500,7 @@ public class SqlFunctions {
 
   /** CAST(VARCHAR AS BOOLEAN). */
   public static boolean toBoolean(String s) {
-    s = trim_(s, true, true, ' ');
+    s = trim(true, true, " ", s);
     if (s.equalsIgnoreCase("TRUE")) {
       return true;
     } else if (s.equalsIgnoreCase("FALSE")) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -98,6 +98,10 @@ public abstract class SqlAbstractConformance implements SqlConformance {
   public boolean shouldConvertRaggedUnionTypesToVarying() {
     return SqlConformanceEnum.DEFAULT.shouldConvertRaggedUnionTypesToVarying();
   }
+
+  public boolean allowExtendedTrim() {
+    return SqlConformanceEnum.DEFAULT.allowExtendedTrim();
+  }
 }
 
 // End SqlAbstractConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -372,6 +372,27 @@ public interface SqlConformance {
    * false otherwise.
    */
   boolean shouldConvertRaggedUnionTypesToVarying();
+
+  /**
+   * Whether TRIM should support more than one trim character.
+   *
+   * <p>For example, consider the query
+   *
+   * <blockquote><pre>SELECT TRIM('eh' FROM 'hehe__hehe')</pre></blockquote>
+   *
+   * <p>Under strict behavior, if the length of trim character is not 1,
+   * an exception should be thrown. This query will result in an exception.
+   * However many implimentations trim all the characters resulting in
+   * a return value of '__'.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#BABEL},
+   * {@link SqlConformanceEnum#LENIENT},
+   * {@link SqlConformanceEnum#MYSQL_5},
+   * {@link SqlConformanceEnum#SQL_SERVER_2008};
+   * false otherwise.
+   */
+  boolean allowExtendedTrim();
 }
 
 // End SqlConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -291,6 +291,19 @@ public enum SqlConformanceEnum implements SqlConformance {
       return false;
     }
   }
+
+  public boolean allowExtendedTrim() {
+    switch (this) {
+    case BABEL:
+    case LENIENT:
+    case MYSQL_5:
+    case SQL_SERVER_2008:
+      return true;
+    default:
+      return false;
+    }
+  }
+
 }
 
 // End SqlConformanceEnum.java

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -275,7 +275,7 @@ public enum BuiltInMethod {
   TRUNCATE(SqlFunctions.class, "truncate", String.class, int.class),
   TRUNCATE_OR_PAD(SqlFunctions.class, "truncateOrPad", String.class, int.class),
   TRIM(SqlFunctions.class, "trim", boolean.class, boolean.class, String.class,
-      String.class),
+      String.class, boolean.class),
   REPLACE(SqlFunctions.class, "replace", String.class, String.class,
       String.class),
   TRANSLATE3(SqlFunctions.class, "translate3", String.class, String.class, String.class),

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5301,29 +5301,29 @@ public abstract class SqlOperatorBaseTest {
     tester.checkNull("trim(cast(null as varchar(1)) from 'a')");
     tester.checkNull("trim('a' from cast(null as varchar(1)))");
 
-    if (Bug.FNL3_FIXED) {
-      // SQL:2003 6.29.9: trim string must have length=1. Failure occurs
-      // at runtime.
-      //
-      // TODO: Change message to "Invalid argument\(s\) for
-      // 'TRIM' function".
-      // The message should come from a resource file, and should still
-      // have the SQL error code 22027.
-      tester.checkFails(
-          "trim('xy' from 'abcde')",
-          "could not calculate results for the following row:\n"
-              + "\\[ 0 \\]\n"
-              + "Messages:\n"
-              + "\\[0\\]:PC=0 Code=22027 ",
-          true);
-      tester.checkFails(
-          "trim('' from 'abcde')",
-          "could not calculate results for the following row:\n"
-              + "\\[ 0 \\]\n"
-              + "Messages:\n"
-              + "\\[0\\]:PC=0 Code=22027 ",
-          true);
-    }
+    // SQL:2003 6.29.9: trim string must have length=1. Failure occurs
+    // at runtime.
+    //
+    // TODO: Change message to "Invalid argument\(s\) for
+    // 'TRIM' function".
+    // The message should come from a resource file, and should still
+    // have the SQL error code 22027.
+    tester.checkFails(
+        "trim('xy' from 'abcde')",
+        "trim error: trim character must be exactly 1 character",
+        true);
+    tester.checkFails(
+        "trim('' from 'abcde')",
+        "trim error: trim character must be exactly 1 character",
+        true);
+
+    final SqlTester tester1 = tester.withConformance(SqlConformanceEnum.MYSQL_5);
+    tester1.checkString(
+        "trim(leading 'eh' from 'hehe__hehe')", "__hehe", "VARCHAR(10) NOT NULL");
+    tester1.checkString(
+        "trim(trailing 'eh' from 'hehe__hehe')", "hehe__", "VARCHAR(10) NOT NULL");
+    tester1.checkString(
+        "trim('eh' from 'hehe__hehe')", "__", "VARCHAR(10) NOT NULL");
   }
 
   @Test public void testRtrimFunc() {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
@@ -178,6 +178,13 @@ public class SqlTestFactory {
         }
       };
     }
+    if (conformance.allowExtendedTrim()) {
+      typeSystem = new DelegatingTypeSystem(typeSystem) {
+        public boolean allowExtendedTrim() {
+          return true;
+        }
+      };
+    }
     return new JavaTypeFactoryImpl(typeSystem);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -2428,7 +2428,7 @@ public class JdbcTest {
             + ": org.apache.calcite.runtime.SqlFunctions.substring("
             + "org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", "
             + "org.apache.calcite.runtime.SqlFunctions.substring(inp2_, "
-            + "inp1_ * 0 + 1)), (v5 ? 4 : 5) - 2);")
+            + "inp1_ * 0 + 1), true), (v5 ? 4 : 5) - 2);")
         .returns("T=ill\n"
             + "T=ric\n"
             + "T=ebastian\n"
@@ -2465,7 +2465,7 @@ public class JdbcTest {
             + ": org.apache.calcite.runtime.SqlFunctions.substring("
             + "org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", "
             + "org.apache.calcite.runtime.SqlFunctions.substring(inp2_, "
-            + "inp1_ * 0 + 1)), $L4J$C$5_2);")
+            + "inp1_ * 0 + 1), true), $L4J$C$5_2);")
         .returns("T=ll\n"
             + "T=ic\n"
             + "T=bastian\n"


### PR DESCRIPTION
Most SQL implementations trim all characters if more then one is provided to the trim function. Calcite's SqlFunctions implementation silently drops the extra characters, resulting in data corruption.

Here is a sampling of implementations that trim all characters:
MySQL - https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_trim
Sql Server - https://docs.microsoft.com/en-us/sql/t-sql/functions/trim-transact-sql?view=sql-server-2017
Flink - https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/sql.html
Spark - https://spark.apache.org/docs/2.3.0/api/sql/index.html#trim
Postgres - https://www.postgresql.org/docs/9.1/static/functions-string.html
SqLite - https://www.sqlite.org/lang_corefunc.html#trim