### PR TITLE
[CALCITE-2572] Handle substring start position of less than 1

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -108,23 +108,49 @@ public class SqlFunctions {
   }
 
   /** SQL SUBSTRING(string FROM ... FOR ...) function. */
-  public static String substring(String s, int from, int for_) {
-    return s.substring(from - 1, Math.min(from - 1 + for_, s.length()));
+  public static String substring(String c, int s, int l) {
+    int lc = c.length();
+    if (s < 0) {
+      s += lc + 1;
+    }
+    int e = s + l;
+    if (e < s) {
+      throw new IllegalArgumentException("substring error: negative substring length not allowed");
+    }
+    if (s > lc || e < 1) {
+      return "";
+    }
+    int s1 = Math.max(s, 1);
+    int e1 = Math.min(e, lc + 1);
+    return c.substring(s1 - 1, e1 - 1);
   }
 
   /** SQL SUBSTRING(string FROM ...) function. */
-  public static String substring(String s, int from) {
-    return s.substring(from - 1);
+  public static String substring(String c, int s) {
+    return substring(c, s, c.length() + 1);
   }
 
   /** SQL SUBSTRING(binary FROM ... FOR ...) function. */
-  public static ByteString substring(ByteString b, int from, int for_) {
-    return b.substring(from - 1, Math.min(from - 1 + for_, b.length()));
+  public static ByteString substring(ByteString c, int s, int l) {
+    int lc = c.length();
+    if (s < 0) {
+      s += lc + 1;
+    }
+    int e = s + l;
+    if (e < s) {
+      throw new IllegalArgumentException("substring error: negative substring length not allowed");
+    }
+    if (s > lc || e < 1) {
+      return ByteString.EMPTY;
+    }
+    int s1 = Math.max(s, 1);
+    int e1 = Math.min(e, lc + 1);
+    return c.substring(s1 - 1, e1 - 1);
   }
 
   /** SQL SUBSTRING(binary FROM ...) function. */
-  public static ByteString substring(ByteString b, int from) {
-    return b.substring(from - 1);
+  public static ByteString substring(ByteString c, int s) {
+    return substring(c, s, c.length() + 1);
   }
 
   /** SQL UPPER(string) function. */

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5209,14 +5209,66 @@ public abstract class SqlOperatorBaseTest {
         "ab",
         "VARCHAR(3) NOT NULL");
     tester.checkString(
+        "substring('abc' from 2 for 8)",
+        "bc",
+        "VARCHAR(3) NOT NULL");
+    tester.checkString(
+        "substring('abc' from 0 for 2)",
+        "a",
+        "VARCHAR(3) NOT NULL");
+    tester.checkString(
+        "substring('abc' from 0 for 0)",
+        "",
+        "VARCHAR(3) NOT NULL");
+    tester.checkString(
+        "substring('abc' from 8 for 2)",
+        "",
+        "VARCHAR(3) NOT NULL");
+    tester.checkFails(
+        "substring('abc' from 1 for -1)",
+        "substring error: negative substring length not allowed",
+        true);
+    tester.checkString(
         "substring('abc' from 2)", "bc", "VARCHAR(3) NOT NULL");
+    tester.checkString(
+        "substring('abc' from 0)", "abc", "VARCHAR(3) NOT NULL");
+    tester.checkString(
+        "substring('abc' from 8)", "", "VARCHAR(3) NOT NULL");
+    tester.checkString(
+        "substring('abc' from -2)", "bc", "VARCHAR(3) NOT NULL");
 
     tester.checkString(
         "substring(x'aabbcc' from 1 for 2)",
         "aabb",
         "VARBINARY(3) NOT NULL");
     tester.checkString(
+        "substring(x'aabbcc' from 2 for 8)",
+        "bbcc",
+        "VARBINARY(3) NOT NULL");
+    tester.checkString(
+        "substring(x'aabbcc' from 0 for 2)",
+        "aa",
+        "VARBINARY(3) NOT NULL");
+    tester.checkString(
+        "substring(x'aabbcc' from 0 for 0)",
+        "",
+        "VARBINARY(3) NOT NULL");
+    tester.checkString(
+        "substring(x'aabbcc' from 8 for 2)",
+        "",
+        "VARBINARY(3) NOT NULL");
+    tester.checkFails(
+        "substring(x'aabbcc' from 1 for -1)",
+        "substring error: negative substring length not allowed",
+        true);
+    tester.checkString(
         "substring(x'aabbcc' from 2)", "bbcc", "VARBINARY(3) NOT NULL");
+    tester.checkString(
+        "substring(x'aabbcc' from 0)", "aabbcc", "VARBINARY(3) NOT NULL");
+    tester.checkString(
+        "substring(x'aabbcc' from 8)", "", "VARBINARY(3) NOT NULL");
+    tester.checkString(
+        "substring(x'aabbcc' from -2)", "bbcc", "VARBINARY(3) NOT NULL");
 
     if (Bug.FRG296_FIXED) {
       // substring regexp not supported yet


### PR DESCRIPTION
Calcite substring throws a IndexOutOfBoundsException with a position less than 1. Per the SQL standard, the position should be treated as the larger of the provided value and 1, however many implementations treat negative values as starting from the end of the string.

Extended standard:
https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions162.htm
https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_substring
https://spark.apache.org/docs/2.3.0/api/sql/index.html#substring
https://www.sqlite.org/lang_corefunc.html#substr

Follow the standard:
https://docs.microsoft.com/en-us/sql/t-sql/functions/substring-transact-sql?view=sql-server-2017
https://www.postgresql.org/docs/9.1/static/functions-string.html