### PR TITLE
[CALCITE-2518] Add failOnWarnings to maven-javadoc-plugin configuration

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -372,7 +372,7 @@ class RuleQueue {
    * <p>where W<sub>n, p</sub>, the weight of n within its parent p, is
    *
    * <blockquote>W<sub>n, p</sub> = Cost<sub>n</sub> / (SelfCost<sub>p</sub> +
-   * Cost<sub>n<sub>0</sub></sub> + ... + Cost<sub>n<sub>k</sub></sub>)
+   * Cost<sub>n0</sub> + ... + Cost<sub>nk</sub>)
    * </blockquote>
    */
   double computeImportance(RelSubset subset) {

--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -40,13 +40,6 @@ package org.apache.calcite.util;
  * the fix is integrated into other branches, the constant will be removed from
  * those branches.</p>
  *
- * <p><b>To do</b></p>
- *
- * <p>The following is a list of tasks to be completed before committing to
- * master branch.</p>
- *
- * <ul>
- * </ul>
  */
 public abstract class Bug {
   //~ Static fields/initializers ---------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -745,10 +745,14 @@ limitations under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <additionalparam>-html5</additionalparam>
+          <doclint>all,-missing</doclint>
+          <failOnWarnings>true</failOnWarnings>
           <links>
             <link>${maven-javadoc-plugin.link}</link>
           </links>
+          <notimestamp>true</notimestamp>
           <excludePackageNames>${maven-javadoc-plugin.excludePackageNames}</excludePackageNames>
+          <quiet>true</quiet>
           <show>private</show>
         </configuration>
       </plugin>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-2518

Missing tags like @param, @return are excluded from warnings list.