### PR TITLE
[CALCITE-2578] Support ANY_VALUE Aggregate Function in ElasticSearch Adapter

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchFilter.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchFilter.java
@@ -99,7 +99,7 @@ public class ElasticsearchFilter extends Filter implements ElasticsearchRel {
       QueryBuilders.constantScoreQuery(PredicateAnalyzer.analyze(condition)).writeJson(generator);
       generator.flush();
       generator.close();
-      return "\"query\" : " + writer.toString();
+      return "{\"query\" : " + writer.toString() + "}";
     }
   }
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
@@ -102,7 +102,7 @@ public class ElasticsearchProject extends Project implements ElasticsearchRel {
     }
 
     implementor.list.removeIf(l -> l.startsWith("\"_source\""));
-    implementor.add(query.toString());
+    implementor.add("{" + query.toString() + "}");
   }
 }
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
@@ -34,7 +34,6 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.schema.impl.AbstractTableQueryable;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.util.Util;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
@@ -168,11 +167,10 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
     }
 
     final ObjectNode query = mapper.createObjectNode();
-
     // manually parse from previously concatenated string
-    query.setAll(
-        (ObjectNode) mapper.readTree("{"
-            + Util.toString(ops, "", ", ", "") + "}"));
+    for (String op: ops) {
+      query.setAll((ObjectNode) mapper.readTree(op));
+    }
 
     if (!sort.isEmpty()) {
       ArrayNode sortNode = query.withArray("sort");
@@ -219,9 +217,10 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
     }
 
     final ObjectNode query = mapper.createObjectNode();
-
     // manually parse into JSON from previously concatenated strings
-    query.setAll((ObjectNode) mapper.readTree("{" + Util.toString(ops, "", ", ", "") + "}"));
+    for (String op: ops) {
+      query.setAll((ObjectNode) mapper.readTree(op));
+    }
 
     // remove / override attributes which are not applicable to aggregations
     query.put("_source", false);
@@ -270,7 +269,7 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
     // simple version for queries like "select count(*), max(col1) from table" (no GROUP BY cols)
     if (!groupBy.isEmpty() || !aggregations.stream().allMatch(isCountStar)) {
       for (Map.Entry<String, String> aggregation : aggregations) {
-        JsonNode value = mapper.readTree("{" + aggregation.getValue()  + "}");
+        JsonNode value = mapper.readTree(aggregation.getValue());
         parent.set(aggregation.getKey(), value);
       }
     }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
@@ -220,6 +220,32 @@ public class AggregationTest {
             "cat1=b; cat3=z; EXPR$2=7.0; EXPR$3=42.0");
   }
 
+  /**
+   * Testing {@link org.apache.calcite.sql.SqlKind#ANY_VALUE} aggregate function
+   */
+  @Test
+  public void anyValue() throws Exception {
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select cat1, any_value(cat2) from view group by cat1")
+        .returnsUnordered("cat1=a; EXPR$1=g",
+            "cat1=null; EXPR$1=g",
+            "cat1=b; EXPR$1=h");
+
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select cat2, any_value(cat1) from view group by cat2")
+        .returnsUnordered("cat2=g; EXPR$1=a", // EXPR$1=null is also valid
+            "cat2=h; EXPR$1=b");
+
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select cat2, any_value(cat3) from view group by cat2")
+        .returnsUnordered("cat2=g; EXPR$1=y", // EXPR$1=null is also valid
+            "cat2=h; EXPR$1=z");
+
+  }
+
   @Test
   public void cat1Cat2Cat3() throws Exception {
     CalciteAssert.that()


### PR DESCRIPTION
Allow queries of type `SELECT foo, ANY_VALUE(bar) FROM elastic GROUP BY foo` in Elastic. They're
implemented as Terms aggregations with size 1.

Internal changes: Intermediate JSON operations in stored in implementor are now valid JSONs. Before they were missing leading and trailing curly brackets (`{` and `}`) and manually concatenated in ElasticsearchTable.