### PR TITLE
Make findbugs:jsr305 dependency optional

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -71,6 +71,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,7 @@ limitations under the License.
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>${findbugs.version}</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
It is not required at runtime, so the dependency should not be transitive