### PR TITLE
[CALCITE-2609]  Bugfix - adding additional requirement for JdbcFilter…

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -951,7 +951,7 @@ public class JdbcRules {
       SqlOperator operator = call.getOperator();
       if (operator instanceof SqlFunction
           && ((SqlFunction) operator).getFunctionType().isUserDefined()) {
-        containsUsedDefinedFunction |= true;
+        containsUsedDefinedFunction = true;
       }
       return super.visitCall(call);
     }
@@ -973,7 +973,7 @@ public class JdbcRules {
     }
 
     @Override public Void visitDynamicParam(RexDynamicParam dynamicParam) {
-      containsDynamicParam |= true;
+      containsDynamicParam = true;
       return super.visitDynamicParam(dynamicParam);
     }
   }

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -943,7 +943,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
   }
 
   private static String getClassName(RelDataType type) {
-    return null;
+    return Object.class.getName();
   }
 
   private static int getScale(RelDataType type) {

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -943,6 +943,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
   }
 
   private static String getClassName(RelDataType type) {
+    // AvaticaParameter requires className field to be not null, see CALCITE-2613
     return Object.class.getName();
   }
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -56,6 +56,14 @@ limitations under the License.
       <artifactId>avatica-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.calcite.avatica</groupId>
+      <artifactId>avatica-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
+++ b/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
@@ -32,13 +32,13 @@ import java.util.Properties;
  */
 public class CalciteConnectionProvider {
 
-  private static final String DRIVER_URL = "jdbc:calcite:";
+  public static final String DRIVER_URL = "jdbc:calcite:";
 
   public Connection connection() throws IOException, SQLException {
     return DriverManager.getConnection(DRIVER_URL, provideConnectionInfo());
   }
 
-  private Properties provideConnectionInfo() throws IOException {
+  public Properties provideConnectionInfo() throws IOException {
     Properties info = new Properties();
     info.setProperty("lex", "MYSQL");
     info.setProperty("model", "inline:" + provideSchema());

--- a/plus/src/main/java/org/apache/calcite/chinook/ChinookAvaticaServer.java
+++ b/plus/src/main/java/org/apache/calcite/chinook/ChinookAvaticaServer.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.chinook;
+
+import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.jdbc.JdbcMeta;
+import org.apache.calcite.avatica.remote.Driver;
+import org.apache.calcite.avatica.remote.Service;
+import org.apache.calcite.avatica.server.AvaticaProtobufHandler;
+import org.apache.calcite.avatica.server.HttpServer;
+import org.apache.calcite.avatica.server.Main;
+
+import net.hydromatic.chinook.data.hsqldb.ChinookHsqldb;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Wrapping Calcite engine with Avatica tansport for testing JDBC capabilities between
+ * Avatica JDBC transport and Calcite
+ */
+public class ChinookAvaticaServer {
+
+  private HttpServer server;
+
+  public void startWithCalcite() throws Exception {
+    this.server = Main.start(new String[]{CalciteChinookMetaFactory.class.getName()}, 0,
+        new Main.HandlerFactory() {
+          @Override public AvaticaProtobufHandler createHandler(Service service) {
+            return new AvaticaProtobufHandler(service);
+          }
+        });
+  }
+
+  public void startWithRaw() throws Exception {
+    this.server = Main.start(new String[]{RawChinookMetaFactory.class.getName()}, 0,
+        new Main.HandlerFactory() {
+          @Override public AvaticaProtobufHandler createHandler(Service service) {
+            return new AvaticaProtobufHandler(service);
+          }
+        });
+  }
+
+  public String getURL() {
+    return "jdbc:avatica:remote:url=http://localhost:" + server.getPort() + ";serialization="
+        + Driver.Serialization.PROTOBUF.name();
+  }
+
+  public void stop() {
+    server.stop();
+  }
+
+  /**
+   * Factory for chinnok calcite database wrapped in meta for avatica
+   */
+  public static class CalciteChinookMetaFactory implements Meta.Factory {
+
+    private static CalciteConnectionProvider provider = new CalciteConnectionProvider();
+
+    private static JdbcMeta instance = null;
+
+    private static JdbcMeta getInstance() {
+      if (instance == null) {
+        try {
+          instance = new JdbcMeta(provider.DRIVER_URL, provider.provideConnectionInfo());
+        } catch (SQLException | IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return instance;
+    }
+
+    @Override public Meta create(List<String> args) {
+      return getInstance();
+    }
+  }
+
+  /**
+   * Factory for chinnok calcite database wrapped in meta for avatica
+   */
+  public static class RawChinookMetaFactory implements Meta.Factory {
+
+    private static CalciteConnectionProvider provider = new CalciteConnectionProvider();
+
+    private static JdbcMeta instance = null;
+
+    private static JdbcMeta getInstance() {
+      if (instance == null) {
+        try {
+          instance = new JdbcMeta(ChinookHsqldb.URI,
+              ChinookHsqldb.USER, ChinookHsqldb.PASSWORD);
+        } catch (SQLException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return instance;
+    }
+
+    @Override public Meta create(List<String> args) {
+      return getInstance();
+    }
+  }
+}
+
+// End ChinookAvaticaServer.java

--- a/plus/src/main/java/org/apache/calcite/chinook/ConnectionFactory.java
+++ b/plus/src/main/java/org/apache/calcite/chinook/ConnectionFactory.java
@@ -36,7 +36,7 @@ public class ConnectionFactory implements Quidem.ConnectionFactory {
   /**
    * Wrapping with Fairy environmental decoration
    */
-  private enum DBWrapper {
+  public enum DBWrapper {
     CALCITE_AS_ADMIN {
       @Override public Connection connection() throws Exception {
         EnvironmentFairy.login(EnvironmentFairy.User.ADMIN);

--- a/plus/src/test/java/org/apache/calcite/chinook/RemotePreparedStatementParametersTest.java
+++ b/plus/src/test/java/org/apache/calcite/chinook/RemotePreparedStatementParametersTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.chinook;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * Tests against parameters in prepared statement when using underlying jdbc subschema
+ */
+public class RemotePreparedStatementParametersTest {
+
+  @Test public void testSimpleStringParameterShouldWorkWithCalcite() throws Exception {
+    // given
+    ChinookAvaticaServer server = new ChinookAvaticaServer();
+    server.startWithCalcite();
+    Connection connection = DriverManager.getConnection(server.getURL());
+    // when
+    PreparedStatement pS =
+        connection.prepareStatement("select * from chinook.artist where name = ?");
+    pS.setString(1, "AC/DC");
+    // then
+    ResultSet resultSet = pS.executeQuery();
+  }
+
+  @Test public void testSeveralParametersShouldWorkWithCalcite() throws Exception {
+    // given
+    ChinookAvaticaServer server = new ChinookAvaticaServer();
+    server.startWithCalcite();
+    Connection connection = DriverManager.getConnection(server.getURL());
+    // when
+    PreparedStatement pS =
+        connection.prepareStatement(
+            "select * from chinook.track where name = ? or milliseconds > ?");
+    pS.setString(1, "AC/DC");
+    pS.setInt(2, 10);
+    // then
+    ResultSet resultSet = pS.executeQuery();
+  }
+
+  @Test public void testParametersShouldWorkWithRaw() throws Exception {
+    // given
+    ChinookAvaticaServer server = new ChinookAvaticaServer();
+    server.startWithRaw();
+    Connection connection = DriverManager.getConnection(server.getURL());
+    // when
+    PreparedStatement pS =
+        connection.prepareStatement("select * from artist where name = ?");
+    pS.setString(1, "AC/DC");
+    // then
+    ResultSet resultSet = pS.executeQuery();
+  }
+}
+
+// End RemotePreparedStatementParametersTest.java

--- a/plus/src/test/java/org/apache/calcite/test/PlusSuite.java
+++ b/plus/src/test/java/org/apache/calcite/test/PlusSuite.java
@@ -20,6 +20,7 @@ import org.apache.calcite.adapter.os.OsAdapterTest;
 import org.apache.calcite.adapter.tpcds.TpcdsTest;
 import org.apache.calcite.adapter.tpch.TpchTest;
 import org.apache.calcite.chinook.EndToEndTest;
+import org.apache.calcite.chinook.RemotePreparedStatementParametersTest;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -32,7 +33,8 @@ import org.junit.runners.Suite;
     OsAdapterTest.class,
     TpcdsTest.class,
     TpchTest.class,
-    EndToEndTest.class
+    EndToEndTest.class,
+    RemotePreparedStatementParametersTest.class
     })
 public class PlusSuite {
 }


### PR DESCRIPTION
…Rule

Jdbc rules converts part of a query to a jdbc statement to external schema, but
when dynamic params are used it should either create prepared statement
with passed dynamic params or don't filter such cases. Simplier is to filter it.

After a bugfix one test in JdbcTest was obsolete because it relies on passing
the query to jdbc schema during planning. Test was trimmed a little bit. Part of it
was moved to another test.

This fixes also [CALCITE-2613] by adding simplest support for AvaticaParameter.getClassname().
This is done by implementing CalcitePrepareImpl.getClassName - simply by returning an Object
classname.

Fixing one of JdbcConverterRule constructors - it throws class cast exception. There was an
invalid casting from Guava Predicate (which is not a functional interface) to java buitin
Predicate (which is a functional interface), by choosing apply method as a functional interface
candidate.