### PR TITLE
[CALCITE-2611] Linq4j code generation failure if one side of an OR co…

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -923,6 +923,16 @@ public class ReflectiveSchemaTest {
             new java.sql.Date(100 * DateTimeUtils.MILLIS_PER_DAY)) // 1970-04-11
     };
   }
+
+  /** CALCITE-2611 unknown on one side of an or may lead to uncompilable code */
+  @Test
+  public void testUnknownInOr() {
+    CalciteAssert.that()
+        .withSchema("s", CATCHALL)
+        .query("select (\"value\" = 3 and unknown) or ( \"value\"  = 3 ) "
+            + "from \"s\".\"primesCustomBoxed\"")
+        .returnsUnordered("EXPR$0=false\nEXPR$0=false\nEXPR$0=true");
+  }
 }
 
 // End ReflectiveSchemaTest.java

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/OptimizeShuttle.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/OptimizeShuttle.java
@@ -241,7 +241,7 @@ public class OptimizeShuttle extends Shuttle {
       break;
     case Equal:
       if (isConstantNull(expression1)
-          && Primitive.is(expression0.getType())) {
+          && isKnownNotNull(expression0)) {
         return FALSE_EXPR;
       }
       // a == true  -> a
@@ -253,7 +253,7 @@ public class OptimizeShuttle extends Shuttle {
       break;
     case NotEqual:
       if (isConstantNull(expression1)
-          && Primitive.is(expression0.getType())) {
+          && isKnownNotNull(expression0)) {
         return TRUE_EXPR;
       }
       // a != true  -> !a

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/BlockBuilderTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/BlockBuilderTest.java
@@ -147,6 +147,22 @@ public class BlockBuilderTest {
 
   }
 
+  /** CALCITE-2611: unknown on one side of an or may lead to uncompilable code */
+  @Test
+  public void testOptimizeBoxedFalseEqNull() {
+    BlockBuilder outer = new BlockBuilder();
+    outer.append(
+        Expressions.equal(
+            OptimizeShuttle.BOXED_FALSE_EXPR,
+            Expressions.constant(null)));
+
+    assertEquals("Expected to optimize Boolean.FALSE = null to false",
+        "{\n"
+            + "  return false;\n"
+            + "}\n",
+        Expressions.toString(outer.toBlock()));
+  }
+
   /**
    * Class with generics to validate if {@link Expressions#call(Method, Expression...)} works.
    * @param <I> result type


### PR DESCRIPTION
…ntains unknown

The code generation have failed because of compilation exception in case the expression
was simplified in a way that Linq4j had to interpret `Boolean.FALSE = null` after some
optimization steps.