### PR TITLE
[CALCITE-2615] When simplifying NOT-AND-OR, RexSimplify incorrectly a…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -427,7 +427,7 @@ public class RexSimplify {
       final RexNode t2 = simplify.simplify(t, RexUnknownAs.UNKNOWN);
       terms.set(i, t2);
       final RexNode inverse =
-          simplify.simplify(rexBuilder.makeCall(SqlStdOperatorTable.NOT, t2),
+          simplify.simplify(rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_TRUE, t2),
               RexUnknownAs.UNKNOWN);
       final RelOptPredicateList newPredicates = simplify.predicates.union(rexBuilder,
           RelOptPredicateList.of(rexBuilder, ImmutableList.of(inverse)));
@@ -1219,6 +1219,8 @@ public class RexSimplify {
     final List<RexNode> terms = RelOptUtil.disjunctions(call);
     if (predicateElimination) {
       simplifyOrTerms(terms);
+    } else {
+      simplifyList(terms, unknownAs);
     }
     return simplifyOrs(terms, unknownAs);
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -1229,6 +1229,7 @@ public class RexSimplify {
    * Modifies the list in place.
    * The simplified expression returns UNKNOWN values as is (not as FALSE). */
   public RexNode simplifyOrs(List<RexNode> terms) {
+    simplifyList(terms, UNKNOWN);
     return simplifyOrs(terms, UNKNOWN);
   }
 
@@ -1241,7 +1242,7 @@ public class RexSimplify {
           simplifier -> simplifier.simplifyOrs(terms, unknownAs));
     }
     for (int i = 0; i < terms.size(); i++) {
-      final RexNode term = simplify(terms.get(i), unknownAs);
+      final RexNode term = terms.get(i);
       switch (term.getKind()) {
       case LITERAL:
         if (RexLiteral.isNullLiteral(term)) {

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -1219,8 +1219,6 @@ public class RexSimplify {
     final List<RexNode> terms = RelOptUtil.disjunctions(call);
     if (predicateElimination) {
       simplifyOrTerms(terms);
-    } else {
-      simplifyList(terms, unknownAs);
     }
     return simplifyOrs(terms, unknownAs);
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -413,35 +413,6 @@ public class RexSimplify {
     }
   }
 
-  private void simplifyOrTerms(List<RexNode> terms) {
-    // Suppose we are processing "e1(x) OR e2(x) OR e3(x)". When we are
-    // visiting "e3(x)" we know both "e1(x)" and "e2(x)" are not true (they
-    // may be unknown), because if either of them were true we would have
-    // stopped.
-    RexSimplify simplify = this;
-    for (int i = 0; i < terms.size(); i++) {
-      final RexNode t = terms.get(i);
-      if (Predicate.of(t) == null) {
-        continue;
-      }
-      final RexNode t2 = simplify.simplify(t, RexUnknownAs.UNKNOWN);
-      terms.set(i, t2);
-      final RexNode inverse =
-          simplify.simplify(rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_TRUE, t2),
-              RexUnknownAs.UNKNOWN);
-      final RelOptPredicateList newPredicates = simplify.predicates.union(rexBuilder,
-          RelOptPredicateList.of(rexBuilder, ImmutableList.of(inverse)));
-      simplify = simplify.withPredicates(newPredicates);
-    }
-    for (int i = 0; i < terms.size(); i++) {
-      final RexNode t = terms.get(i);
-      if (Predicate.of(t) != null) {
-        continue;
-      }
-      terms.set(i, simplify.simplify(t, RexUnknownAs.UNKNOWN));
-    }
-  }
-
   private RexNode simplifyNot(RexCall call, RexUnknownAs unknownAs) {
     final RexNode a = call.getOperands().get(0);
     switch (a.getKind()) {
@@ -1217,11 +1188,6 @@ public class RexSimplify {
   private RexNode simplifyOr(RexCall call, RexUnknownAs unknownAs) {
     assert call.getKind() == SqlKind.OR;
     final List<RexNode> terms = RelOptUtil.disjunctions(call);
-    if (predicateElimination) {
-      simplifyOrTerms(terms);
-    } else {
-      simplifyList(terms, unknownAs);
-    }
     return simplifyOrs(terms, unknownAs);
   }
 
@@ -1240,8 +1206,18 @@ public class RexSimplify {
       return verify(before, unknownAs,
           simplifier -> simplifier.simplifyOrs(terms, unknownAs));
     }
+    Set<Predicate> preds = new HashSet<>();
     for (int i = 0; i < terms.size(); i++) {
       final RexNode term = simplify(terms.get(i), unknownAs);
+      Predicate p = Predicate.of(term);
+      if (p != null) {
+        Predicate negatedP = p.negate();
+        if (preds.contains(negatedP)) {
+          return rexBuilder.makeLiteral(true);
+        }
+        preds.add(p);
+      }
+
       switch (term.getKind()) {
       case LITERAL:
         if (RexLiteral.isNullLiteral(term)) {
@@ -1690,6 +1666,8 @@ public class RexSimplify {
       }
       return IsPredicate.of(t);
     }
+
+    Predicate negate();
   }
 
   /** Comparison between a {@link RexInputRef} or {@link RexFieldAccess} and a
@@ -1733,6 +1711,32 @@ public class RexSimplify {
       }
       return null;
     }
+
+    @Override public Predicate negate() {
+      if (ref.getType().isNullable()) {
+        return null;
+      }
+      SqlKind negatedKind = kind.negateNullSafe();
+      if (kind != negatedKind && negatedKind != null) {
+        return new Comparison(ref, negatedKind, literal);
+      }
+      return null;
+    }
+
+    @Override public int hashCode() {
+      return Objects.hash(ref, kind, literal);
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == null || !(o instanceof Comparison)) {
+        return false;
+      }
+      Comparison cmp = (Comparison) o;
+      return Objects.equals(ref, cmp.ref)
+              && Objects.equals(kind, cmp.kind)
+              && Objects.equals(literal, cmp.literal);
+
+    }
   }
 
   /** Represents an IS Predicate. */
@@ -1758,6 +1762,29 @@ public class RexSimplify {
       }
       return null;
     }
+
+    @Override public Predicate negate() {
+      SqlKind negatedKind = kind.negate();
+      if (kind != negatedKind && negatedKind != null) {
+        return new IsPredicate(ref, negatedKind);
+      }
+      return null;
+    }
+
+    @Override public int hashCode() {
+      return Objects.hash(ref, kind);
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == null || !(o instanceof IsPredicate)) {
+        return false;
+      }
+      IsPredicate cmp = (IsPredicate) o;
+      return Objects.equals(ref, cmp.ref)
+              && Objects.equals(kind, cmp.kind);
+
+    }
+
   }
 
   private static boolean isUpperBound(final RexNode e) {

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -1229,7 +1229,6 @@ public class RexSimplify {
    * Modifies the list in place.
    * The simplified expression returns UNKNOWN values as is (not as FALSE). */
   public RexNode simplifyOrs(List<RexNode> terms) {
-    simplifyList(terms, UNKNOWN);
     return simplifyOrs(terms, UNKNOWN);
   }
 
@@ -1242,7 +1241,7 @@ public class RexSimplify {
           simplifier -> simplifier.simplifyOrs(terms, unknownAs));
     }
     for (int i = 0; i < terms.size(); i++) {
-      final RexNode term = terms.get(i);
+      final RexNode term = simplify(terms.get(i), unknownAs);
       switch (term.getKind()) {
       case LITERAL:
         if (RexLiteral.isNullLiteral(term)) {

--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -1548,11 +1548,11 @@ public class RexProgramTest extends RexProgramBuilderBase {
             eq(aRef, literal1)),
         "true");
 
-    // "a = 1 or a != 1" ==> "true"
+    // TODO: make this simplify to "true"
     checkSimplifyFilter(
         or(eq(aRef, literal1),
             ne(aRef, literal1)),
-        "true");
+        "OR(=(?0.a, 1), <>(?0.a, 1))");
 
     // "b != 1 or b = 1" cannot be simplified, because b might be null
     final RexNode neOrEq =
@@ -1619,8 +1619,7 @@ public class RexProgramTest extends RexProgramBuilderBase {
         "true");
   }
 
-  /** CALCITE-2615 */
-  @Test public void testSimplifyOrNoPredReuse() {
+  @Test public void testSimplifyNotAnd() {
     final RexNode e = or(
         le(
             vBool(1),

--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -1548,11 +1548,11 @@ public class RexProgramTest extends RexProgramBuilderBase {
             eq(aRef, literal1)),
         "true");
 
-    // TODO: make this simplify to "true"
+    // "a = 1 or a != 1" ==> "true"
     checkSimplifyFilter(
         or(eq(aRef, literal1),
             ne(aRef, literal1)),
-        "OR(=(?0.a, 1), <>(?0.a, 1))");
+        "true");
 
     // "b != 1 or b = 1" cannot be simplified, because b might be null
     final RexNode neOrEq =
@@ -1619,7 +1619,8 @@ public class RexProgramTest extends RexProgramBuilderBase {
         "true");
   }
 
-  @Test public void testSimplifyNotAnd() {
+  /** CALCITE-2615 */
+  @Test public void testSimplifyOrNoPredReuse() {
     final RexNode e = or(
         le(
             vBool(1),

--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -1558,7 +1558,7 @@ public class RexProgramTest extends RexProgramBuilderBase {
     final RexNode neOrEq =
         or(ne(bRef, literal1),
             eq(bRef, literal1));
-    checkSimplifyFilter(neOrEq, "OR(<>(?0.b, 1), IS NOT NULL(?0.b))");
+    checkSimplifyFilter(neOrEq, "OR(<>(?0.b, 1), =(?0.b, 1))");
 
     // Careful of the excluded middle!
     // We cannot simplify "b != 1 or b = 1" to "true" because if b is null, the
@@ -1567,7 +1567,7 @@ public class RexProgramTest extends RexProgramBuilderBase {
     final RexNode simplified =
         this.simplify.simplifyUnknownAs(neOrEq, RexUnknownAs.UNKNOWN);
     assertThat(simplified.toString(),
-        equalTo("OR(<>(?0.b, 1), IS NOT NULL(?0.b))"));
+        equalTo("OR(<>(?0.b, 1), =(?0.b, 1))"));
 
     // "a is null or a is not null" ==> "true"
     checkSimplifyFilter(
@@ -1617,6 +1617,18 @@ public class RexProgramTest extends RexProgramBuilderBase {
         "OR(null, <>(0, ?0.int0))",
         "<>(0, ?0.int0)",
         "true");
+  }
+
+  @Test public void testSimplifyNotAnd() {
+    final RexNode e = or(
+        le(
+            vBool(1),
+            literal(true)),
+        eq(
+            literal(false),
+            eq(literal(false), vBool(1))));
+    final String expected = "OR(<=(?0.bool1, true), =(false, =(false, ?0.bool1)))";
+    checkSimplify3(e, expected, expected, expected);
   }
 
   @Test public void testSimplifyUnknown() {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4831,7 +4831,7 @@ LogicalProject(EXPR$0=[1])
       LogicalProject(DEPTNO=[$7])
         LogicalFilter(condition=[>($7, 1)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalFilter(condition=[OR(>($7, 7), >($7, 1))])
+    LogicalFilter(condition=[OR(>($7, 7), >($7, 10), >($7, 1))])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4831,7 +4831,7 @@ LogicalProject(EXPR$0=[1])
       LogicalProject(DEPTNO=[$7])
         LogicalFilter(condition=[>($7, 1)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalFilter(condition=[OR(>($7, 7), >($7, 10), >($7, 1))])
+    LogicalFilter(condition=[OR(>($7, 7), >($7, 1))])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>


### PR DESCRIPTION
…pplies predicates deduced for operands to the same operands.

Simplifying (b<=true or false=(b=false)) was simplified to true; even in cases when p1 was null.