### PR TITLE
[CALCITE-2635] getMonotonocity is slow on wide tables

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -332,14 +332,13 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
   }
 
   public SqlMonotonicity getMonotonicity(String columnName) {
-    final int i = rowType.getFieldNames().indexOf(columnName);
-    if (i >= 0) {
-      for (RelCollation collation : table.getStatistic().getCollations()) {
-        final RelFieldCollation fieldCollation =
-            collation.getFieldCollations().get(0);
-        if (fieldCollation.getFieldIndex() == i) {
-          return fieldCollation.direction.monotonicity();
-        }
+    for (RelCollation collation : table.getStatistic().getCollations()) {
+      final RelFieldCollation fieldCollation =
+          collation.getFieldCollations().get(0);
+      final int fieldIndex = fieldCollation.getFieldIndex();
+      if (rowType.getFieldCount() > fieldIndex
+          && rowType.getFieldNames().get(fieldIndex).equals(columnName)) {
+        return fieldCollation.direction.monotonicity();
       }
     }
     return SqlMonotonicity.NOT_MONOTONIC;


### PR DESCRIPTION
Instead of getting the index of the column from rowType and then comparing
it to the collation field index, gets the collation field index and checks
if the corresponding rowType index matches.