### PR TITLE
Bug/calcite 2641

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
@@ -42,6 +42,7 @@ import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.util.ImmutableNullableList;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.ToTypeConvertible;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableMap;
@@ -164,6 +165,12 @@ public class SqlUserDefinedTableMacro extends SqlFunction {
   private static Object coerce(Object o, RelDataType type) {
     if (o == null) {
       return null;
+    }
+    if (o instanceof ToTypeConvertible) {
+      Object converted = ((ToTypeConvertible) o).convertTo(type);
+      if (converted != null) {
+        return coerce(converted, type);
+      }
     }
     if (!(type instanceof RelDataTypeFactoryImpl.JavaType)) {
       return null;

--- a/core/src/main/java/org/apache/calcite/util/DateString.java
+++ b/core/src/main/java/org/apache/calcite/util/DateString.java
@@ -17,9 +17,12 @@
 package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactoryImpl;
 
 import com.google.common.base.Preconditions;
 
+import java.sql.Date;
 import java.util.Calendar;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -29,7 +32,7 @@ import javax.annotation.Nonnull;
  *
  * <p>Immutable, internally represented as a string (in ISO format).
  */
-public class DateString implements Comparable<DateString> {
+public class DateString implements Comparable<DateString>, ToTypeConvertible {
   private static final Pattern PATTERN =
       Pattern.compile("[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]");
 
@@ -88,6 +91,20 @@ public class DateString implements Comparable<DateString> {
 
   @Override public int compareTo(@Nonnull DateString o) {
     return v.compareTo(o.v);
+  }
+
+  @Override public Object convertTo(RelDataType type) {
+    if (!(type instanceof RelDataTypeFactoryImpl.JavaType)) {
+      return null;
+    }
+    Class cl = ((RelDataTypeFactoryImpl.JavaType) type).getJavaClass();
+    if (cl.isAssignableFrom(Date.class)) {
+      return new Date(getMillisSinceEpoch());
+    }
+    if (cl.isAssignableFrom(java.util.Date.class)) {
+      return new java.util.Date(getMillisSinceEpoch());
+    }
+    return null;
   }
 
   /** Creates a DateString from a Calendar. */

--- a/core/src/main/java/org/apache/calcite/util/TimeString.java
+++ b/core/src/main/java/org/apache/calcite/util/TimeString.java
@@ -17,10 +17,13 @@
 package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactoryImpl;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
+import java.sql.Time;
 import java.util.Calendar;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -31,7 +34,7 @@ import javax.annotation.Nonnull;
  * <p>Immutable, internally represented as a string (in ISO format),
  * and can support unlimited precision (milliseconds, nanoseconds).
  */
-public class TimeString implements Comparable<TimeString> {
+public class TimeString implements Comparable<TimeString>, ToTypeConvertible {
   private static final Pattern PATTERN =
       Pattern.compile("[0-9][0-9]:[0-9][0-9]:[0-9][0-9](\\.[0-9]*[1-9])?");
 
@@ -133,6 +136,17 @@ public class TimeString implements Comparable<TimeString> {
     return v.compareTo(o.v);
   }
 
+  @Override public Object convertTo(RelDataType type) {
+    if (!(type instanceof RelDataTypeFactoryImpl.JavaType)) {
+      return null;
+    }
+    Class cl = ((RelDataTypeFactoryImpl.JavaType) type).getJavaClass();
+    if (!cl.isAssignableFrom(Time.class)) {
+      return null;
+    }
+    return new Time(getMillisOfDay());
+  }
+
   /** Creates a TimeString from a Calendar. */
   public static TimeString fromCalendarFields(Calendar calendar) {
     return new TimeString(
@@ -222,6 +236,7 @@ public class TimeString implements Comparable<TimeString> {
   private int precision() {
     return v.length() < 9 ? 0 : (v.length() - 9);
   }
+
 }
 
 // End TimeString.java

--- a/core/src/main/java/org/apache/calcite/util/ToTypeConvertible.java
+++ b/core/src/main/java/org/apache/calcite/util/ToTypeConvertible.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import org.apache.calcite.rel.type.RelDataType;
+
+/**
+ * Helper API to deal with conversion between internal sql type representation and java sql types
+ */
+public interface ToTypeConvertible {
+
+  /**
+   * Converts to desired type, null otherwise
+   * @param type desired type to be converted to
+   * @return value converted to class specified by type or null when conversion is not possible
+   */
+  Object convertTo(RelDataType type);
+
+}
+
+// End ToTypeConvertible.java

--- a/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
@@ -457,6 +457,27 @@ public class TableFunctionTest {
       assertThat(CalciteAssert.toString(resultSet), equalTo(expected));
     }
   }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2641">[CALCITE-2641]</a>
+   */
+  @Test public void testTimestampInParams() throws SQLException {
+    try (Connection connection = DriverManager.getConnection("jdbc:calcite:")) {
+      CalciteConnection calciteConnection =
+          connection.unwrap(CalciteConnection.class);
+      SchemaPlus rootSchema = calciteConnection.getRootSchema();
+      SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
+      final TableFunction table =
+          TableFunctionImpl.create(Smalls.DAYSBETWEEN_METHOD);
+      schema.add("DaysBetween", table);
+      final String sql = "select count(*) as CNT\n"
+          + "from table(\"s\".\"DaysBetween\"(TIMESTAMP '2018-01-01 01:01:01', TIMESTAMP '2018-01-05 01:01:01')) \n";
+      ResultSet resultSet = connection.createStatement().executeQuery(sql);
+      assertThat(CalciteAssert.toString(resultSet),
+          equalTo("CNT=3\n"));
+    }
+  }
 }
 
 // End TableFunctionTest.java

--- a/core/src/test/java/org/apache/calcite/util/Smalls.java
+++ b/core/src/test/java/org/apache/calcite/util/Smalls.java
@@ -56,6 +56,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -86,6 +87,8 @@ public class Smalls {
       Types.lookupMethod(Smalls.class, "fibonacciTable");
   public static final Method FIBONACCI2_TABLE_METHOD =
       Types.lookupMethod(Smalls.class, "fibonacciTableWithLimit", long.class);
+  public static final Method DAYSBETWEEN_METHOD =
+      Types.lookupMethod(Smalls.class, "daysBetween", Timestamp.class, Timestamp.class);
   public static final Method VIEW_METHOD =
       Types.lookupMethod(Smalls.class, "view", String.class);
   public static final Method STR_METHOD =
@@ -280,6 +283,29 @@ public class Smalls {
       public boolean rolledUpColumnValidInsideAgg(String column, SqlCall call,
           SqlNode parent, CalciteConnectionConfig config) {
         return true;
+      }
+    };
+  }
+
+  public static QueryableTable daysBetween(Timestamp from, Timestamp to) {
+    return new AbstractQueryableTable(Object[].class) {
+
+      @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        return typeFactory.builder()
+            .add("daybetween", typeFactory.createJavaType(Timestamp.class))
+            .build();
+      }
+
+      @Override public Queryable<Timestamp> asQueryable(QueryProvider queryProvider,
+                                                        SchemaPlus schema,
+                                                        String tableName) {
+        List<Timestamp> days = new ArrayList<>();
+        Long day = 24L * 60L * 60L * 1000L;
+        for (Timestamp t = new Timestamp(from.getTime() + day); t.before(to);
+             t = new Timestamp(t.getTime() + day)) {
+          days.add(t);
+        }
+        return Linq4j.asEnumerable(days).asQueryable();
       }
     };
   }


### PR DESCRIPTION
This pull fixes bug https://issues.apache.org/jira/browse/CALCITE-2641 .

It adds conversion between Time/Date/Timestamp strings - internal calcite representation for some values into appropriate java classes when user defined table macro/function  is called.