### PR TITLE
[CALCITE-2652] SqlNode to SQL conversion fails if the join condition …

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -186,6 +186,10 @@ public abstract class SqlImplementor {
     if (node.isAlwaysFalse()) {
       return SqlLiteral.createBoolean(false, POS);
     }
+    if (node instanceof RexInputRef) {
+      Context joinContext = leftContext.implementor().joinContext(leftContext, rightContext);
+      return joinContext.toSql(null, node);
+    }
     if (!(node instanceof RexCall)) {
       throw new AssertionError(node);
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -990,6 +990,12 @@ public class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  /** CALCITE-2652: expectation is to not get an exception */
+  @Test public void testBooleanColInOn() {
+    final String sql = "SELECT 1 from emps join emp on (emp.deptno = emps.empno and manager)";
+    sql(sql).schema(CalciteAssert.SchemaSpec.POST).exec();
+  }
+
   @Test public void testCartesianProductWithInnerJoinSyntax() {
     String query = "select * from \"department\"\n"
         + "INNER JOIN \"employee\" ON TRUE";


### PR DESCRIPTION
…contains a boolean column reference

Previously when a join ON condition have contained an exact reference it ended up with an exception.