### PR TITLE
CALCITE-2655 - Enable Travis to test against JDK 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,13 @@ language: java
 matrix:
   fast_finish: true
   include:
+    - env: IMAGE=maven:3-jdk-12
     - env: IMAGE=maven:3-jdk-11 JDOC=Y RAT=Y
     - env: IMAGE=maven:3-jdk-10
     - env: IMAGE=maven:3-jdk-9
     - env: IMAGE=maven:3-jdk-8 JDOC=Y
+  allow_failures:
+    - env: IMAGE=maven:3-jdk-12
 branches:
   only:
     - master

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
@@ -46,8 +46,9 @@ import static org.junit.Assume.assumeTrue;
  * <p>Will start embedded cassandra cluster and populate it from local {@code twissandra.cql} file.
  * All configuration files are located in test classpath.
  *
- * <p>Note that tests will be skipped if running on JDK11 (which is not yet supported by cassandra)
- * see <a href="https://issues.apache.org/jira/browse/CASSANDRA-9608">CASSANDRA-9608</a>.
+ * <p>Note that tests will be skipped if running on JDK11 and JDK12
+ * (which is not yet supported by cassandra) see
+ * <a href="https://issues.apache.org/jira/browse/CASSANDRA-9608">CASSANDRA-9608</a>.
  *
  */
 // force tests to run sequentially (maven surefire and failsafe are running them in parallel)
@@ -73,7 +74,8 @@ public class CassandraAdapterTest {
    * version (see below).
    *
    * <p>As of this wiring Cassandra 4.x is not yet released and we're using 3.x
-   * (which fails on JDK11). All cassandra tests will be skipped if running on JDK11.
+   * (which fails on JDK11 and JDK12). All cassandra tests will be skipped if
+   * running on JDK11 and JDK12.
    *
    * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-9608">CASSANDRA-9608</a>
    * @return {@code true} if test is compatible with current environment,
@@ -83,7 +85,8 @@ public class CassandraAdapterTest {
     final boolean enabled =
         Util.getBooleanProperty("calcite.test.cassandra", true);
     Bug.upgrade("remove JDK version check once current adapter supports Cassandra 4.x");
-    final boolean compatibleJdk = TestUtil.getJavaMajorVersion() != 11;
+    final boolean compatibleJdk = TestUtil.getJavaMajorVersion() != 11
+                                      && TestUtil.getJavaMajorVersion() != 12;
     return enabled && compatibleJdk;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -915,7 +915,8 @@ limitations under the License.
               <configuration>
                 <threadCount>6</threadCount>
                 <parallel>both</parallel>
-                <argLine>-Xmx1024m</argLine>
+                <!-- work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 -->
+                <argLine>-Xmx1024m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
                 <systemPropertyVariables>
                   <calcite.integrationTest>true</calcite.integrationTest>
                 </systemPropertyVariables>
@@ -987,8 +988,8 @@ limitations under the License.
                 <value>tr</value>
               </systemProperty>
             </systemProperties>
-            <!--<argLine>-Xmx1536m -Duser.timezone=${user.timezone} -Duser.country=${user.country} -Duser.language=${user.language}</argLine>-->
-            <argLine>-Xmx1536m</argLine>
+            <!-- work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 -->
+            <argLine>-Xmx1536m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -73,13 +73,6 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>


### PR DESCRIPTION
* Made ubenchmark use the same JDK source/target as the parent pom to avoid 1.6 and JDK 12 issues.
* Cassandra Adapter test fails with JDK12.
    * Added JDK12 to version check like JDK11.