### PR TITLE
[CALCITE-2662] Planner: allow parsing directly a stream instead of a java.lang.String

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -55,6 +55,8 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Properties;
 
@@ -170,6 +172,20 @@ public class PlannerImpl implements Planner, ViewExpander {
     }
     ensure(State.STATE_2_READY);
     SqlParser parser = SqlParser.create(sql, parserConfig);
+    SqlNode sqlNode = parser.parseStmt();
+    state = State.STATE_3_PARSED;
+    return sqlNode;
+  }
+
+  public SqlNode parse(final InputStream inputStream, final Charset charset)
+          throws SqlParseException {
+    switch (state) {
+    case STATE_0_CLOSED:
+    case STATE_1_RESET:
+      ready();
+    }
+    ensure(State.STATE_2_READY);
+    SqlParser parser = SqlParser.create(inputStream, charset, parserConfig);
     SqlNode sqlNode = parser.parseStmt();
     state = State.STATE_3_PARSED;
     return sqlNode;

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -55,8 +55,7 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 
-import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.io.Reader;
 import java.util.List;
 import java.util.Properties;
 
@@ -177,7 +176,7 @@ public class PlannerImpl implements Planner, ViewExpander {
     return sqlNode;
   }
 
-  public SqlNode parse(final InputStream inputStream, final Charset charset)
+  public SqlNode parse(final Reader source)
           throws SqlParseException {
     switch (state) {
     case STATE_0_CLOSED:
@@ -185,7 +184,7 @@ public class PlannerImpl implements Planner, ViewExpander {
       ready();
     }
     ensure(State.STATE_2_READY);
-    SqlParser parser = SqlParser.create(inputStream, charset, parserConfig);
+    SqlParser parser = SqlParser.create(source, parserConfig);
     SqlNode sqlNode = parser.parseStmt();
     state = State.STATE_3_PARSED;
     return sqlNode;

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
@@ -27,10 +27,8 @@ import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlDelegatingConformance;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.StringReader;
-import java.nio.charset.Charset;
 import java.util.Objects;
 
 /**
@@ -103,9 +101,21 @@ public class SqlParser {
     return new SqlParser(sql, parser, config);
   }
 
-  public static SqlParser create(InputStream sql, Charset encoding, Config config) {
+  /**
+   * Creates a <code>SqlParser</code> to parse the given string using the
+   * parser implementation created from given {@link SqlParserImplFactory}
+   * with given quoting syntax and casing policies for identifiers.
+   * <p>Differently from
+   * {@link #create(java.lang.String, org.apache.calcite.sql.parser.SqlParser.Config) )}
+   * the parser won't be able to return the 'originalInput' query
+   *
+   * @param reader Teh source for the SQL statement or expression to parse.
+   * @param config The parser configuration (identifier max length, etc.)
+   * @return A parser
+   */
+  public static SqlParser create(Reader reader, Config config) {
     SqlAbstractParserImpl parser =
-        config.parserFactory().getParser(new InputStreamReader(sql, encoding));
+        config.parserFactory().getParser(reader);
 
     return new SqlParser(null, parser, config);
   }

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql.parser;
 
+
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.avatica.util.Quoting;
 import org.apache.calcite.config.Lex;
@@ -26,7 +27,10 @@ import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlDelegatingConformance;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.util.Objects;
 
 /**
@@ -97,6 +101,13 @@ public class SqlParser {
         config.parserFactory().getParser(new StringReader(sql));
 
     return new SqlParser(sql, parser, config);
+  }
+
+  public static SqlParser create(InputStream sql, Charset encoding, Config config) {
+    SqlAbstractParserImpl parser =
+        config.parserFactory().getParser(new InputStreamReader(sql, encoding));
+
+    return new SqlParser(null, parser, config);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
@@ -117,7 +117,7 @@ public class SqlParser {
     SqlAbstractParserImpl parser =
         config.parserFactory().getParser(reader);
 
-    return new SqlParser(null, parser, config);
+    return new SqlParser("?", parser, config);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
@@ -107,9 +107,9 @@ public class SqlParser {
    * with given quoting syntax and casing policies for identifiers.
    * <p>Differently from
    * {@link #create(java.lang.String, org.apache.calcite.sql.parser.SqlParser.Config) )}
-   * the parser won't be able to return the 'originalInput' query
+   * the parser is not able to return the 'originalInput' query but it will return "?"
    *
-   * @param reader Teh source for the SQL statement or expression to parse.
+   * @param reader The source for the SQL statement or expression to parse.
    * @param config The parser configuration (identifier max length, etc.)
    * @return A parser
    */

--- a/core/src/main/java/org/apache/calcite/tools/Planner.java
+++ b/core/src/main/java/org/apache/calcite/tools/Planner.java
@@ -25,6 +25,9 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.util.Pair;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
 /**
  * A fa&ccedil;ade that covers Calcite's query planning process: parse SQL,
  * validate the parse tree, convert the parse tree to a relational expression,
@@ -44,6 +47,17 @@ public interface Planner extends AutoCloseable {
    * @throws org.apache.calcite.sql.parser.SqlParseException on parse error
    */
   SqlNode parse(String sql) throws SqlParseException;
+
+  /**
+   * Parses and validates a SQL statement.
+   *
+   * @param input An inputstream which contains the SQL statement to parse.
+   * @param encoding The encoding of the stream
+   *
+   * @return The root node of the SQL parse tree.
+   * @throws org.apache.calcite.sql.parser.SqlParseException on parse error
+   */
+  SqlNode parse(InputStream input, Charset encoding) throws SqlParseException;
 
   /**
    * Validates a SQL statement.

--- a/core/src/main/java/org/apache/calcite/tools/Planner.java
+++ b/core/src/main/java/org/apache/calcite/tools/Planner.java
@@ -25,8 +25,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.util.Pair;
 
-import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.io.Reader;
 
 /**
  * A fa&ccedil;ade that covers Calcite's query planning process: parse SQL,
@@ -51,13 +50,12 @@ public interface Planner extends AutoCloseable {
   /**
    * Parses and validates a SQL statement.
    *
-   * @param input An inputstream which contains the SQL statement to parse.
-   * @param encoding The encoding of the stream
+   * @param source A reader which will provide the SQL statement to parse.
    *
    * @return The root node of the SQL parse tree.
    * @throws org.apache.calcite.sql.parser.SqlParseException on parse error
    */
-  SqlNode parse(InputStream input, Charset encoding) throws SqlParseException;
+  SqlNode parse(Reader source) throws SqlParseException;
 
   /**
    * Validates a SQL statement.

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -49,6 +49,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -596,6 +598,17 @@ public class SqlParserTest {
 
   protected SqlParser getSqlParser(String sql) {
     return SqlParser.create(sql,
+        SqlParser.configBuilder()
+            .setParserFactory(parserImplFactory())
+            .setQuoting(quoting)
+            .setUnquotedCasing(unquotedCasing)
+            .setQuotedCasing(quotedCasing)
+            .setConformance(conformance)
+            .build());
+  }
+
+  protected SqlParser getSqlParser(Reader source) {
+    return SqlParser.create(source,
         SqlParser.configBuilder()
             .setParserFactory(parserImplFactory())
             .setQuoting(quoting)
@@ -8402,6 +8415,15 @@ public class SqlParserTest {
         "('[]' IS NOT JSON ARRAY)");
     checkExp("'100' is not json scalar",
         "('100' IS NOT JSON SCALAR)");
+  }
+
+  @Test public void testParseWithReader() throws Exception {
+    String query = "select * from dual";
+    SqlParser sqlParserReader = getSqlParser(new StringReader(query));
+    SqlNode node1 = sqlParserReader.parseQuery();
+    SqlParser sqlParserString = getSqlParser(query);
+    SqlNode node2 = sqlParserString.parseQuery();
+    assertEquals(node2.toString(), node1.toString());
   }
 
   //~ Inner Interfaces -------------------------------------------------------

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
@@ -42,6 +42,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 
+import java.io.StringReader;
 import java.util.Map;
 import java.util.Objects;
 
@@ -112,7 +113,9 @@ public class SqlTestFactory {
   }
 
   public SqlParser createParser(String sql) {
-    return SqlParser.create(sql, parserConfig.get());
+    return SqlParser.create(
+            new StringReader(sql), // using a Reader is enough
+            parserConfig.get());
   }
 
   public static SqlParser.Config createParserConfig(ImmutableMap<String, Object> options) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10779,7 +10779,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
       fail("expecting an error");
       return;
     } catch (CalciteContextException error) {
-      // we want the exception
+      // we want the exception to report column and line
       assertEquals("At line 1, column 15: Object 'B' not found", error.getMessage());
       messagePassingSqlString = error.getMessage();
       // the error does not contain the original query (even using a String)
@@ -10794,6 +10794,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
       validator.validate(node);
       fail("expecting an error");
     } catch (CalciteContextException error) {
+      // we want exactly the same error as with java.lang.String input
       assertEquals(error.getMessage(), messagePassingSqlString);
       // the error does not contain the original query (using a Reader)
       assertNull(error.getOriginalStatement());


### PR DESCRIPTION
This change allows to parse a query having just an InputStream source.
This will enable to save a few memory copies, for instance in the case of a query which is coming from a Netty ByteBuf