### PR TITLE
[CALCITE-2684] AssertionError on RexBuilder when creating BigDecimal RexLiteral (Ruben Quesada Lopez)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -926,12 +926,11 @@ public class RexBuilder {
   public RexLiteral makeExactLiteral(BigDecimal bd) {
     RelDataType relType;
     int scale = bd.scale();
-    long l = bd.unscaledValue().longValue();
     assert scale >= 0;
     assert scale <= typeFactory.getTypeSystem().getMaxNumericScale() : scale;
-    assert BigDecimal.valueOf(l, scale).equals(bd);
     if (scale == 0) {
-      if ((l >= Integer.MIN_VALUE) && (l <= Integer.MAX_VALUE)) {
+      if ((bd.compareTo(BigDecimal.valueOf(Integer.MIN_VALUE)) >= 0)
+              && (bd.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) <= 0)) {
         relType = typeFactory.createSqlType(SqlTypeName.INTEGER);
       } else {
         relType = typeFactory.createSqlType(SqlTypeName.BIGINT);

--- a/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
@@ -29,6 +29,7 @@ import org.apache.calcite.util.Util;
 
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -487,6 +488,28 @@ public class RexBuilderTest {
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage(), containsString("Second out of range: [60]"));
     }
+  }
+
+  /** Tests {@link RexBuilder#makeExactLiteral(java.math.BigDecimal)}. */
+  @Test public void testBigDecimalLiteral() {
+    final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    final RexBuilder builder = new RexBuilder(typeFactory);
+    assertBigDecimalLiteral(builder, "25");
+    assertBigDecimalLiteral(builder, "9.9");
+    assertBigDecimalLiteral(builder, "0");
+    assertBigDecimalLiteral(builder, "-75.5");
+    assertBigDecimalLiteral(builder, "10000000");
+    assertBigDecimalLiteral(builder, "100000.111111111111111111");
+    assertBigDecimalLiteral(builder, "-100000.111111111111111111");
+    assertBigDecimalLiteral(builder, "73786976294838206464"); // 2^66
+    assertBigDecimalLiteral(builder, "-73786976294838206464");
+  }
+
+  private void assertBigDecimalLiteral(RexBuilder builder, String val) {
+    final RexNode literal = builder.makeExactLiteral(new BigDecimal(val));
+    assertThat("builder.makeExactLiteral(new BigDecimal(" + val
+                    + ")).getValueAs(BigDecimal.class).toString()",
+            ((RexLiteral) literal).getValueAs(BigDecimal.class).toString(), is(val));
   }
 
 }


### PR DESCRIPTION
The method RexBuilder#makeExactLiteral(java.math.BigDecimal) throws an AssertionError if the BigDecimal parameter has an unscaled value that overflows long.
Moreover, with the current implementation, it can be possible to have this AssertionError, even in the cases when the variable l would not be used at all (decimal number).
Provided unit tests (the last one will fail with the current implementation).