### PR TITLE
[CALCITE-2468] Fix Validator IndexOutOfBoundsException when trying to infer operand type from a struct return type

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
@@ -129,6 +129,7 @@ public class SqlAsOperator extends SqlSpecialOperator {
       SqlValidatorScope scope,
       SqlCall call) {
     // special case for AS:  never try to derive type for alias
+    // TODO:[CALCITE-2468] should expand handling for alias in InferReturnType.
     RelDataType nodeType =
         validator.deriveType(scope, call.operand(0));
     assert nodeType != null;

--- a/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
@@ -129,7 +129,6 @@ public class SqlAsOperator extends SqlSpecialOperator {
       SqlValidatorScope scope,
       SqlCall call) {
     // special case for AS:  never try to derive type for alias
-    // TODO:[CALCITE-2468] should expand handling for alias in InferReturnType.
     RelDataType nodeType =
         validator.deriveType(scope, call.operand(0));
     assert nodeType != null;

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1797,9 +1797,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       final SqlCallBinding callBinding = new SqlCallBinding(this, scope, call);
       final List<SqlNode> operands = callBinding.operands();
       int inferOperandSize;
-      // For AS operator, alias operand should not be inferred
+      // [CALCITE-2468] For AS operator, alias operand should not be inferred
       if (call.getOperator().kind == SqlKind.AS) {
-        inferOperandSize = operands.size()-1;
+        inferOperandSize = operands.size() - 1;
       } else {
         inferOperandSize = operands.size();
       }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1796,18 +1796,24 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
           call.getOperator().getOperandTypeInference();
       final SqlCallBinding callBinding = new SqlCallBinding(this, scope, call);
       final List<SqlNode> operands = callBinding.operands();
-      final RelDataType[] operandTypes = new RelDataType[operands.size()];
-      if (operandTypeInference == null) {
-        // TODO:  eventually should assert(operandTypeInference != null)
-        // instead; for now just eat it
-        Arrays.fill(operandTypes, unknownType);
+      int inferOperandSize;
+      // For AS operator, alias operand should not be inferred
+      if (call.getOperator().kind == SqlKind.AS) {
+        inferOperandSize = operands.size()-1;
       } else {
+        inferOperandSize = operands.size();
+      }
+      final RelDataType[] operandTypes = new RelDataType[inferOperandSize];
+      Arrays.fill(operandTypes, unknownType);
+      // TODO:  eventually should assert(operandTypeInference != null)
+      // instead; for now just eat it
+      if (operandTypeInference != null) {
         operandTypeInference.inferOperandTypes(
             callBinding,
             inferredType,
             operandTypes);
       }
-      for (int i = 0; i < operands.size(); ++i) {
+      for (int i = 0; i < inferOperandSize; ++i) {
         inferUnknownTypes(operandTypes[i], scope, operands.get(i));
       }
     }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -113,6 +113,16 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /** Test case for:
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2468">[CALCITE-2468]
+   * struct type alias should not cause IOOBE.</a>.
+   */
+  @Test public void testStructTypeAlias() {
+    final String sql = "select t.r AS myRow \n"
+        + "from (select row(row(1)) r from dept) t";
+    sql(sql).ok();
+  }
+
   @Test
   public void testJoinUsingDynamicTable() {
     final String sql = "select * from SALES.NATION t1\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1437,6 +1437,18 @@ LogicalProject(A=[$0], B=[$1], C=[$2], DEPTNO=[$3], NAME=[$4])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testStructTypeAlias">
+        <Resource name="sql">
+            <![CDATA[select t.r AS myRow
+from (select row(row(1)) r from dept) t]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(MYROW$$0$$0=[1])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testJoinWithUnion">
         <Resource name="sql">
             <![CDATA[select grade

--- a/server/src/test/resources/sql/type.iq
+++ b/server/src/test/resources/sql/type.iq
@@ -49,7 +49,25 @@ select * from t;
 
 !ok
 
+# Create a complex struct type
+create type mytype1 as (ii int not null);
+(0 rows modified)
+
+!update
+
+# Create a complex table
+create table v (i int not null, j mytype1 not null);
+(0 rows modified)
+
+!update
+
+select i AS myInt, j AS myStruct from v;
+MYINT INTEGER(10) NOT NULL
+MYSTRUCT STRUCT NOT NULL
+!type
+
 drop table t;
+drop table v;
 (0 rows modified)
 
 !update

--- a/server/src/test/resources/sql/type.iq
+++ b/server/src/test/resources/sql/type.iq
@@ -49,7 +49,11 @@ select * from t;
 
 !ok
 
-# Create a complex struct type
+
+# Create a table with complex structure type
+# This is to test struct type inference in
+# <a href="https://issues.apache.org/jira/browse/CALCITE-1222">[CALCITE-2468]
+
 create type mytype1 as (ii int not null);
 (0 rows modified)
 


### PR DESCRIPTION
This fixes: https://issues.apache.org/jira/browse/CALCITE-2468