### PR TITLE
[CALCITE-2542] Fix SqlNode AtomicRowExpression + DOT operation does not parse correctly

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3000,6 +3000,7 @@ void Expression2b(ExprContext exprContext, List<Object> list) :
 {
     SqlNode e;
     SqlOperator op;
+    String p;
 }
 {
     (
@@ -3011,6 +3012,15 @@ void Expression2b(ExprContext exprContext, List<Object> list) :
     e = Expression3(exprContext) {
         list.add(e);
     }
+    (
+        <DOT>
+        p = Identifier() {
+            list.add(
+                new SqlParserUtil.ToTreeListItem(
+                    SqlStdOperatorTable.DOT, getPos()));
+            list.add(new SqlIdentifier(p, getPos()));
+        }
+    )*
 }
 
 /**

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlDotOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlDotOperator.java
@@ -95,6 +95,9 @@ public class SqlDotOperator extends SqlSpecialOperator {
       SqlValidatorScope scope, SqlCall call) {
     RelDataType nodeType = validator.deriveType(scope, call.getOperandList().get(0));
     assert nodeType != null;
+    if (!nodeType.isStruct()) {
+      throw SqlUtil.newContextException(SqlParserPos.ZERO, Static.RESOURCE.incompatibleTypes());
+    }
 
     final String fieldName = call.getOperandList().get(1).toString();
     RelDataTypeField field =
@@ -129,6 +132,8 @@ public class SqlDotOperator extends SqlSpecialOperator {
     final RelDataType type =
         callBinding.getValidator().deriveType(callBinding.getScope(), left);
     if (type.getSqlTypeName() != SqlTypeName.ROW) {
+      return false;
+    } else if (type.getSqlIdentifier().isStar()) {
       return false;
     }
     final RelDataType operandType = callBinding.getOperandType(0);

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1072,6 +1072,11 @@ public class SqlParserTest {
     return false;
   }
 
+  @Test public void testRowWitDot() {
+    check("select (1,2).a from c.t", "SELECT ((ROW(1, 2)).`A`)\nFROM `C`.`T`");
+    check("select row(1,2).a from c.t", "SELECT ((ROW(1, 2)).`A`)\nFROM `C`.`T`");
+  }
+
   @Test public void testPeriod() {
     // We don't have a PERIOD constructor currently;
     // ROW constructor is sufficient for now.
@@ -1490,6 +1495,10 @@ public class SqlParserTest {
     check("select count(1), count(distinct 2) from emp",
         "SELECT COUNT(1), COUNT(DISTINCT 2)\n"
             + "FROM `EMP`");
+  }
+
+  @Test public void testFunctionCallWithDot() {
+    checkExp("foo(a,b).c", "(`FOO`(`A`, `B`).`C`)");
   }
 
   @Test public void testFunctionInFunction() {
@@ -2448,11 +2457,6 @@ public class SqlParserTest {
     sql("select emp.* as foo from emp")
         .ok("SELECT `EMP`.* AS `FOO`\n"
                 + "FROM `EMP`");
-  }
-
-  @Test public void testTableStarColumnFails() {
-    sql("select emp.*^.^xx from emp")
-        .fails("(?s).*Encountered \".\" .*");
   }
 
   @Test public void testNotExists() {
@@ -6598,6 +6602,7 @@ public class SqlParserTest {
         "(?s)Encountered \"to year\" at line 1, column 19.\n"
             + "Was expecting one of:\n"
             + "    <EOF> \n"
+            + "    \"\\.\" \\.\\.\\.\n"
             + "    \"NOT\" \\.\\.\\..*");
     checkExpFails("interval '1-2' year ^to^ day", ANY);
     checkExpFails("interval '1-2' year ^to^ hour", ANY);

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -78,6 +78,16 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).convertsTo(plan);
   }
 
+  @Test public void testNestRowDotLiteral() {
+    final String sql = "select ((1,2),(3,4,5)).\"EXPR$1\".\"EXPR$2\" from emp";
+    sql(sql).ok();
+  }
+
+  @Test public void testRowDotLiteral() {
+    final String sql = "select row(1,2).\"EXPR$1\" from emp";
+    sql(sql).ok();
+  }
+
   @Test public void testIntegerLiteral() {
     final String sql = "select 1 from emp";
     sql(sql).ok();

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1259,6 +1259,24 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "INTEGER NOT NULL");
   }
 
+  @Test public void testRowWitValidDot() {
+    checkColumnType("select ((1,2),(3,4,5)).\"EXPR$1\".\"EXPR$2\"\n from dept",
+        "INTEGER NOT NULL");
+    checkColumnType("select row(1,2).\"EXPR$1\" from dept",
+        "INTEGER NOT NULL");
+    checkColumnType("select t.a.\"EXPR$1\" from (select row(1,2) as a from (values (1))) as t",
+        "INTEGER NOT NULL");
+  }
+
+  @Test public void testRowWitInvalidDotOperation() {
+    checkExpFails("select t.^s.\"EXPR$1\"^ from (select 1 AS s from (values (1))) as t",
+        "(?s).*Column 'S\\.EXPR\\$1' not found in table 'T'.*");
+    checkExpFails("select array[1, 2, 3].\"EXPR$1\" from dept",
+        "(?s).*Incompatible types.*");
+    checkExpFails("select 'mystr'.\"EXPR$1\" from dept",
+        "(?s).*Incompatible types.*");
+  }
+
   @Test public void testMultiset() {
     checkExpType("multiset[1]", "INTEGER NOT NULL MULTISET NOT NULL");
     checkExpType(
@@ -4818,8 +4836,10 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
   @Test public void testStarDotIdFails() {
     // Fails in parser
+    sql("select emp.^*^.\"EXPR$1\" from emp")
+        .fails("(?s).*Unknown field '\\*'");
     sql("select emp.^*^.foo from emp")
-        .fails("(?s).*Encountered \".\" at .*");
+        .fails("(?s).*Unknown field '\\*'");
     // Parser does not allow star dot identifier.
     sql("select ^*^.foo from emp")
         .fails("(?s).*Encountered \".\" at .*");

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -778,6 +778,28 @@ from emp
 window w1 as (partition by job order by hiredate rows 2 preceding)]]>
         </Resource>
     </TestCase>
+    <TestCase name="testNestRowDotLiteral">
+        <Resource name="sql">
+            <![CDATA[select 1 from emp]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[ROW(ROW(1, 2), ROW(3, 4, 5)).EXPR$1.EXPR$2])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testRowDotLiteral">
+        <Resource name="sql">
+            <![CDATA[select 1 from emp]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[ROW(1, 2).EXPR$1])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testIntegerLiteral">
         <Resource name="sql">
             <![CDATA[select 1 from emp]]>


### PR DESCRIPTION
Fixes for: https://issues.apache.org/jira/browse/CALCITE-2542

Couldn't find a way to uniformly throw parser exception if preceeding node is `*`. So moved the parser exception to a more complex check on validator. Please comment on this approach.