### PR TITLE
[CALCITE-2701] Make instances of generated Baz classes immutable (Stamatis Zampetakis)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
@@ -124,13 +124,6 @@ public class EnumerableRelImplementor extends JavaRelImplementor {
     final List<MemberDeclaration> memberDeclarations = new ArrayList<>();
     new TypeRegistrar(memberDeclarations).go(result);
 
-    // The following is a workaround to
-    // http://jira.codehaus.org/browse/JANINO-169. Otherwise we'd remove the
-    // member variable, rename the "root0" parameter as "root", and reference it
-    // directly from inner classes.
-    final ParameterExpression root0_ =
-        Expressions.parameter(Modifier.FINAL, DataContext.class, "root0");
-
     // This creates the following code
     // final Integer v1stashed = (Integer) root.get("v1stashed")
     // It is convenient for passing non-literal "compile-time" constants
@@ -145,20 +138,14 @@ public class EnumerableRelImplementor extends JavaRelImplementor {
 
     final BlockStatement block = Expressions.block(
         Iterables.concat(
-            ImmutableList.of(
-                Expressions.statement(
-                    Expressions.assign(DataContext.ROOT, root0_))),
             stashed,
             result.block.statements));
-    memberDeclarations.add(
-        Expressions.fieldDecl(0, DataContext.ROOT, null));
-
     memberDeclarations.add(
         Expressions.methodDecl(
             Modifier.PUBLIC,
             Enumerable.class,
             BuiltInMethod.BINDABLE_BIND.method.getName(),
-            Expressions.list(root0_),
+            Expressions.list(DataContext.ROOT),
             block));
     memberDeclarations.add(
         Expressions.methodDecl(Modifier.PUBLIC, Class.class,

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -1381,8 +1381,9 @@ public class JdbcTest {
 
   /** Janino bug
    * <a href="https://jira.codehaus.org/browse/JANINO-169">[JANINO-169]</a>
-   * running queries against the JDBC adapter. As of janino-2.7.3 bug is
-   * open but we have a workaround in EnumerableRelImplementor. */
+   * running queries against the JDBC adapter. The bug is not present with
+   * janino-3.0.9 so the workaround in EnumerableRelImplementor was removed.
+   */
   @Test public void testJanino169() {
     CalciteAssert.that()
         .with(CalciteAssert.Config.JDBC_FOODMART)


### PR DESCRIPTION
Revert the workaround introduced in EnumerableRelImplementor due to JANINO-169.