### PR TITLE
[CALCITE-2699]The bug of timestampadd handles time

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -2621,7 +2621,13 @@ public class RexImpTable {
             operand0.getType().getSqlTypeName() == SqlTypeName.TIMESTAMP
                 ? BuiltInMethod.ADD_MONTHS
                 : BuiltInMethod.ADD_MONTHS_INT;
-        return Expressions.call(method.method, trop0, trop1);
+        if (typeName == SqlTypeName.TIME) {
+          return Expressions.convert_(
+                  trop0,
+                  (Class) long.class);
+        } else {
+          return Expressions.call(method.method, trop0, trop1);
+        }
 
       case INTERVAL_DAY:
       case INTERVAL_DAY_HOUR:

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
@@ -29,13 +29,13 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 /**
  * The <code>TIMESTAMPADD</code> function, which adds an interval to a
- * timestamp.
+ * timestamp or time or date.
  *
  * <p>The SQL syntax is
  *
  * <blockquote>
  * <code>TIMESTAMPADD(<i>timestamp interval</i>, <i>quantity</i>,
- * <i>timestamp</i>)</code>
+ * <i>timestamp or time or date</i>)</code>
  * </blockquote>
  *
  * <p>The interval time unit can one of the following literals:<ul>
@@ -51,7 +51,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
  * <li>YEAR (and synonym  SQL_TSI_YEAR)
  * </ul>
  *
- * <p>Returns modified timestamp.
+ * <p>Returns modified timestamp or time or date.
  */
 public class SqlTimestampAddFunction extends SqlFunction {
 
@@ -85,7 +85,11 @@ public class SqlTimestampAddFunction extends SqlFunction {
             MICROSECOND_PRECISION);
         break;
       default:
-        type = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+        if (operandType2.getSqlTypeName() == SqlTypeName.TIME) {
+          type = typeFactory.createSqlType(SqlTypeName.TIME);
+        } else {
+          type = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+        }
       }
       break;
     default:

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -6957,6 +6957,43 @@ public abstract class SqlOperatorBaseTest {
         "2016-06-30", "DATE NOT NULL");
     tester.checkScalar("timestampadd(MONTH, -1, date '2016-03-31')",
         "2016-02-29", "DATE NOT NULL");
+
+    // TIMESTAMPADD with time; returns a time value.The interval is positive.
+    tester.checkScalar("timestampadd(SECOND, 1, time '23:59:59')",
+            "00:00:00", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(MINUTE, 1, time '00:00:00')",
+            "00:01:00", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(MINUTE, 1, time '23:59:59')",
+            "00:00:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(HOUR, 1, time '23:59:59')",
+            "00:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(DAY, 15, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(WEEK, 3, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(MONTH, 6, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(QUARTER, 1, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(YEAR, 10, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    // TIMESTAMPADD with time; returns a time value .The interval is negative.
+    tester.checkScalar("timestampadd(SECOND, -1, time '00:00:00')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(MINUTE, -1, time '00:00:00')",
+            "23:59:00", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(HOUR, -1, time '00:00:00')",
+            "23:00:00", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(DAY, -1, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(WEEK, -1, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(MONTH, -1, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(QUARTER, -1, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
+    tester.checkScalar("timestampadd(YEAR, -1, time '23:59:59')",
+            "23:59:59", "TIME(0) NOT NULL");
   }
 
   @Test public void testTimestampAddFractionalSeconds() {

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1230,7 +1230,7 @@ Not implemented:
 | HOUR(date)                | Equivalent to `EXTRACT(HOUR FROM date)`. Returns an integer between 0 and 23.
 | MINUTE(date)              | Equivalent to `EXTRACT(MINUTE FROM date)`. Returns an integer between 0 and 59.
 | SECOND(date)              | Equivalent to `EXTRACT(SECOND FROM date)`. Returns an integer between 0 and 59.
-| TIMESTAMPADD(timeUnit, integer, datetime) | Returns *datetime* with an interval of (signed) *integer* *timeUnit*s added. Equivalent to `datetime + INTERVAL 'integer' timeUnit`
+| TIMESTAMPADD(timeUnit, integer, datetime) | Returns *datetime or date or time* with an interval of (signed) *integer* *timeUnit*s added. Equivalent to `datetime or date or time + INTERVAL 'integer' timeUnit`
 | TIMESTAMPDIFF(timeUnit, datetime, datetime2) | Returns the (signed) number of *timeUnit* intervals between *datetime* and *datetime2*. Equivalent to `(datetime2 - datetime) timeUnit`
 
 Calls to niladic functions such as `CURRENT_DATE` do not accept parentheses in
@@ -1474,6 +1474,8 @@ Not implemented:
 | {fn MINUTE(date)} | Equivalent to `EXTRACT(MINUTE FROM date)`. Returns an integer between 0 and 59.
 | {fn SECOND(date)} | Equivalent to `EXTRACT(SECOND FROM date)`. Returns an integer between 0 and 59.
 | {fn TIMESTAMPADD(timeUnit, count, timestamp)} | Adds an interval of *count* *timeUnit*s to a timestamp
+| {fn TIMESTAMPADD(timeUnit, count, time)} | Adds an interval of *count* *timeUnit*s to a time
+| {fn TIMESTAMPADD(timeUnit, count, date)} | Adds an interval of *count* *timeUnit*s to a date
 | {fn TIMESTAMPDIFF(timeUnit, timestamp1, timestamp2)} | Subtracts *timestamp1* from *timestamp2* and returns the result in *timeUnit*s
 
 Not implemented:


### PR DESCRIPTION
## What is the purpose of the change

*Fix the bug of `timestampadd` handles time*
https://issues.apache.org/jira/browse/CALCITE-2699

## Brief change log

- *`DeduceType` method of `SqlTimestampAddFunction` will add the logic of time processing:*

  ```java
                          if (operandType2.getSqlTypeName().equals(SqlTypeName.TIME)) {
                              type = typeFactory.createSqlType(SqlTypeName.TIME);
                          } else {
                              type = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
                          }
  ```

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *Add time tests to `TIMESTAMPADD`*

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)