### PR TITLE
[CALCITE-2632] Add hashCode and equals implementations to RexNode.

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Window.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Window.java
@@ -363,7 +363,7 @@ public abstract class Window extends SingleRel {
     }
 
     @Override public boolean equals(Object obj) {
-      return (this == obj);
+      return this == obj;
     }
 
     @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/rel/core/Window.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Window.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.AbstractList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A relational expression representing a set of window aggregates.
@@ -359,6 +360,14 @@ public abstract class Window extends SingleRel {
       super(type, aggFun, operands);
       this.ordinal = ordinal;
       this.distinct = distinct;
+    }
+
+    @Override public boolean equals(Object obj) {
+      return (this == obj);
+    }
+
+    @Override public int hashCode() {
+      return Objects.hash(digest, ordinal, distinct);
     }
 
     @Override public RexCall clone(RelDataType type, List<RexNode> operands) {

--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -173,6 +173,17 @@ public class RexCall extends RexNode {
   public RexCall clone(RelDataType type, List<RexNode> operands) {
     return new RexCall(type, op, operands);
   }
+
+  @Override public boolean equals(Object obj) {
+    if (!(obj instanceof RexCall)) {
+      return false;
+    }
+    return obj == this || Objects.equals(toString(), obj.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
 }
 
 // End RexCall.java

--- a/core/src/main/java/org/apache/calcite/rex/RexCorrelVariable.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCorrelVariable.java
@@ -54,6 +54,20 @@ public class RexCorrelVariable extends RexVariable {
   @Override public SqlKind getKind() {
     return SqlKind.CORREL_VARIABLE;
   }
+
+  @Override public boolean equals(Object obj) {
+    if (obj == null || obj.getClass() != this.getClass()) {
+      return false;
+    }
+    RexCorrelVariable o = (RexCorrelVariable) obj;
+    return o == this || Objects.equals(digest, o.digest) &&
+        Objects.equals(type, o.type) &&
+        Objects.equals(id, o.id);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(digest, type, id);
+  }
 }
 
 // End RexCorrelVariable.java

--- a/core/src/main/java/org/apache/calcite/rex/RexCorrelVariable.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCorrelVariable.java
@@ -60,9 +60,9 @@ public class RexCorrelVariable extends RexVariable {
       return false;
     }
     RexCorrelVariable o = (RexCorrelVariable) obj;
-    return o == this || Objects.equals(digest, o.digest) &&
-        Objects.equals(type, o.type) &&
-        Objects.equals(id, o.id);
+    return o == this || Objects.equals(digest, o.digest)
+        && Objects.equals(type, o.type)
+        && Objects.equals(id, o.id);
   }
 
   @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/rex/RexDynamicParam.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexDynamicParam.java
@@ -16,10 +16,11 @@
  */
 package org.apache.calcite.rex;
 
-import java.util.Objects;
-
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
+
+import java.util.Objects;
+
 
 /**
  * Dynamic parameter reference in a row-expression.
@@ -67,9 +68,9 @@ public class RexDynamicParam extends RexVariable {
       return false;
     }
     RexDynamicParam o = (RexDynamicParam) obj;
-    return o == this || Objects.equals(digest, o.digest) &&
-        Objects.equals(type, o.type) &&
-        Objects.equals(index, o.index);
+    return o == this || Objects.equals(digest, o.digest)
+        && Objects.equals(type, o.type)
+        && Objects.equals(index, o.index);
   }
 
   @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/rex/RexDynamicParam.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexDynamicParam.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.rex;
 
+import java.util.Objects;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
 
@@ -59,6 +61,19 @@ public class RexDynamicParam extends RexVariable {
   public <R, P> R accept(RexBiVisitor<R, P> visitor, P arg) {
     return visitor.visitDynamicParam(this, arg);
   }
-}
 
+  @Override public boolean equals(Object obj) {
+    if (obj == null || obj.getClass() != this.getClass()) {
+      return false;
+    }
+    RexDynamicParam o = (RexDynamicParam) obj;
+    return o == this || Objects.equals(digest, o.digest) &&
+        Objects.equals(type, o.type) &&
+        Objects.equals(index, o.index);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(digest, type, index);
+  }
+}
 // End RexDynamicParam.java

--- a/core/src/main/java/org/apache/calcite/rex/RexNode.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexNode.java
@@ -20,6 +20,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
 
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Row expression.
@@ -81,6 +82,10 @@ public abstract class RexNode {
   public String toString() {
     return digest;
   }
+
+  @Override public abstract boolean equals(Object obj);
+
+  @Override public abstract int hashCode();
 
   /**
    * Accepts a visitor, dispatching to the right overloaded

--- a/core/src/main/java/org/apache/calcite/rex/RexNode.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexNode.java
@@ -20,7 +20,6 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
 
 import java.util.Collection;
-import java.util.Objects;
 
 /**
  * Row expression.
@@ -83,10 +82,6 @@ public abstract class RexNode {
     return digest;
   }
 
-  @Override public abstract boolean equals(Object obj);
-
-  @Override public abstract int hashCode();
-
   /**
    * Accepts a visitor, dispatching to the right overloaded
    * {@link RexVisitor#visitInputRef visitXxx} method.
@@ -101,6 +96,16 @@ public abstract class RexNode {
    * {@link RexBiVisitor#visitInputRef(RexInputRef, Object)} visitXxx} method.
    */
   public abstract <R, P> R accept(RexBiVisitor<R, P> visitor, P arg);
+
+  /**
+   * Every Node must implement {@link Object#equals(Object)}.
+   */
+  @Override public abstract boolean equals(Object obj);
+
+  /**
+   * Every Node must implement {@link Object#equals(Object)}.
+   */
+  @Override public abstract int hashCode();
 }
 
 // End RexNode.java

--- a/core/src/main/java/org/apache/calcite/rex/RexRangeRef.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexRangeRef.java
@@ -16,9 +16,9 @@
  */
 package org.apache.calcite.rex;
 
-import java.util.Objects;
-
 import org.apache.calcite.rel.type.RelDataType;
+
+import java.util.Objects;
 
 /**
  * Reference to a range of columns.
@@ -82,8 +82,8 @@ public class RexRangeRef extends RexNode {
       return false;
     }
     RexRangeRef o = (RexRangeRef) obj;
-    return o == this || Objects.equals(type, o.type) &&
-        Objects.equals(offset, o.offset);
+    return o == this || Objects.equals(type, o.type)
+        && Objects.equals(offset, o.offset);
   }
 
   @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/rex/RexRangeRef.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexRangeRef.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.rex;
 
+import java.util.Objects;
+
 import org.apache.calcite.rel.type.RelDataType;
 
 /**
@@ -73,6 +75,19 @@ public class RexRangeRef extends RexNode {
 
   public <R, P> R accept(RexBiVisitor<R, P> visitor, P arg) {
     return visitor.visitRangeRef(this, arg);
+  }
+
+  @Override public boolean equals(Object obj) {
+    if (obj == null || obj.getClass() != this.getClass()) {
+      return false;
+    }
+    RexRangeRef o = (RexRangeRef) obj;
+    return o == this || Objects.equals(type, o.type) &&
+        Objects.equals(offset, o.offset);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(type, offset);
   }
 }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5245,9 +5245,9 @@ LogicalAggregate(group=[{0}], EXPR$1=[STDDEV_POP($1)], EXPR$2=[AVG($1)], EXPR$3=
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5)):INTEGER NOT NULL], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[CAST(POWER(/(-($4, /(*($2, $2), $3)), CASE(=($3, 1), null, -($3, 1))), 0.5)):INTEGER NOT NULL], EXPR$4=[CAST(/(-($5, /(*($2, $2), $3)), $3)):INTEGER NOT NULL], EXPR$5=[CAST(/(-($6, /(*($2, $2), $3)), CASE(=($3, 1), null, -($3, 1)))):INTEGER NOT NULL])
-  LogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], agg#1=[$SUM0($1)], agg#2=[COUNT()], agg#3=[$SUM0($3)], agg#4=[$SUM0($4)], agg#5=[$SUM0($5)])
-    LogicalProject(NAME=[$0], DEPTNO=[$1], $f2=[*($1, $1)], $f3=[*($1, $1)], $f4=[*($1, $1)], $f5=[*($1, $1)])
+LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5)):INTEGER NOT NULL], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[CAST(POWER(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null, -($3, 1))), 0.5)):INTEGER NOT NULL], EXPR$4=[CAST(/(-($1, /(*($2, $2), $3)), $3)):INTEGER NOT NULL], EXPR$5=[CAST(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null, -($3, 1)))):INTEGER NOT NULL])
+  LogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], agg#1=[$SUM0($1)], agg#2=[COUNT()])
+    LogicalProject(NAME=[$0], DEPTNO=[$1], $f2=[*($1, $1)])
       LogicalProject(NAME=[$1], DEPTNO=[$0])
         LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
@@ -5775,8 +5775,7 @@ LogicalProject(DEPTNO=[$0], ENAME=[$1])
   LogicalProject(DEPTNO=[$9], ENAME=[$1])
     LogicalJoin(condition=[=($7, $9)], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalFilter(condition=[=($0, 10)])
-        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
     </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1846,29 +1846,22 @@ from (select 2+deptno d2, 3+deptno d3 from emp) e
         <Resource name="plan">
             <![CDATA[
 LogicalProject(D2=[$0], D3=[$1])
-  LogicalProject(D2=[$0], D3=[$1], D1=[CAST($2):INTEGER], D30=[$3], $f2=[CAST($4):BOOLEAN])
+  LogicalProject(D2=[$0], D3=[$1], D1=[CAST($2):INTEGER], D6=[$3], $f2=[CAST($4):BOOLEAN])
     LogicalJoin(condition=[AND(=($0, $2), =($1, $3))], joinType=[inner])
       LogicalProject(D2=[+(2, $7)], D3=[+(3, $7)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalAggregate(group=[{0, 1}], agg#0=[MIN($2)])
-        LogicalProject(D1=[$0], D3=[$2], $f0=[true])
+        LogicalProject(D1=[$0], D6=[$2], $f0=[true])
           LogicalFilter(condition=[IS NOT NULL($1)])
-            LogicalProject(D1=[$0], $f0=[$3], D3=[$2])
+            LogicalProject(D1=[$0], $f0=[$3], D6=[$2])
               LogicalJoin(condition=[=($0, $1)], joinType=[left])
                 LogicalProject(D1=[+($0, 1)])
                   LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
                 LogicalAggregate(group=[{0, 1}], agg#0=[MIN($2)])
-                  LogicalProject(D1=[$3], D3=[$4], $f0=[true])
-                    LogicalJoin(condition=[AND(=($0, $3), =($1, $3), =($2, $4))], joinType=[inner])
+                  LogicalProject(D4=[$0], D6=[$2], $f0=[true])
+                    LogicalFilter(condition=[=($1, $0)])
                       LogicalProject(D4=[+($0, 4)], D5=[+($0, 5)], D6=[+($0, 6)])
                         LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-                      LogicalJoin(condition=[true], joinType=[inner])
-                        LogicalAggregate(group=[{0}])
-                          LogicalProject(D1=[+($0, 1)])
-                            LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-                        LogicalAggregate(group=[{0}])
-                          LogicalProject(D3=[+(3, $7)])
-                            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -4778,29 +4771,22 @@ from (select 2+deptno d2, 3+deptno d3 from emp) e
         <Resource name="plan">
             <![CDATA[
 LogicalProject(D2=[$0], D3=[$1])
-  LogicalProject(D2=[$0], D3=[$1], D1=[CAST($2):INTEGER], D30=[$3], $f2=[CAST($4):BOOLEAN])
+  LogicalProject(D2=[$0], D3=[$1], D1=[CAST($2):INTEGER], D6=[$3], $f2=[CAST($4):BOOLEAN])
     LogicalJoin(condition=[AND(=($0, $2), =($1, $3))], joinType=[inner])
       LogicalProject(D2=[+(2, $7)], D3=[+(3, $7)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalAggregate(group=[{0, 1}], agg#0=[MIN($2)])
-        LogicalProject(D1=[$0], D3=[$2], $f0=[true])
+        LogicalProject(D1=[$0], D6=[$2], $f0=[true])
           LogicalFilter(condition=[IS NOT NULL($1)])
-            LogicalProject(D1=[$0], $f0=[$3], D3=[$2])
+            LogicalProject(D1=[$0], $f0=[$3], D6=[$2])
               LogicalJoin(condition=[=($0, $1)], joinType=[left])
                 LogicalProject(D1=[+($0, 1)])
                   LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
                 LogicalAggregate(group=[{0, 1}], agg#0=[MIN($2)])
-                  LogicalProject(D1=[$3], D3=[$4], $f0=[true])
-                    LogicalJoin(condition=[AND(=($0, $3), =($1, $3), =($2, $4))], joinType=[inner])
+                  LogicalProject(D4=[$0], D6=[$2], $f0=[true])
+                    LogicalFilter(condition=[=($1, $0)])
                       LogicalProject(D4=[+($0, 4)], D5=[+($0, 5)], D6=[+($0, 6)])
                         LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-                      LogicalJoin(condition=[true], joinType=[inner])
-                        LogicalAggregate(group=[{0}])
-                          LogicalProject(D1=[+($0, 1)])
-                            LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-                        LogicalAggregate(group=[{0}])
-                          LogicalProject(D3=[+(3, $7)])
-                            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -5298,7 +5284,10 @@ LogicalProject(ANYEMPNO=[$1])
     </TestCase>
     <TestCase name="testWithinGroup1">
         <Resource name="sql">
-            <![CDATA[select deptno, collect(empno) within group (order by deptno, hiredate desc) from emp group by deptno]]>
+            <![CDATA[select deptno,
+ collect(empno) within group (order by deptno, hiredate desc)
+from emp
+group by deptno]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
@@ -5310,7 +5299,14 @@ LogicalAggregate(group=[{0}], EXPR$1=[COLLECT($1) WITHIN GROUP ([1, 2 DESC])])
     </TestCase>
     <TestCase name="testWithinGroup2">
         <Resource name="sql">
-            <![CDATA[select dept.deptno, collect(sal) within group (order by sal desc) as s, collect(sal) within group (order by 1)as s1, collect(sal) within group (order by sal) filter (where sal > 2000) as s2 from emp join dept using (deptno) group by dept.deptn]]>
+            <![CDATA[select dept.deptno,
+ collect(sal) within group (order by sal desc) as s,
+ collect(sal) within group (order by 1)as s1,
+ collect(sal) within group (order by sal)
+  filter (where sal > 2000) as s2
+from emp
+join dept using (deptno)
+group by dept.deptno]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
@@ -5324,7 +5320,10 @@ LogicalAggregate(group=[{0}], S=[COLLECT($1) WITHIN GROUP ([1 DESC])], S1=[COLLE
     </TestCase>
     <TestCase name="testWithinGroup3">
         <Resource name="sql">
-            <![CDATA[select deptno, collect(empno) filter (where empno not in (1, 2)), count(*) from emp group by deptno]]>
+            <![CDATA[select deptno,
+ collect(empno) within group (order by empno not in (1, 2)), count(*)
+from emp
+group by deptno]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[


### PR DESCRIPTION
Previously there was no default hashCode/equals implementations.
To ensure that they are working properly is cruical while working with basic collections like sets/maps.