### PR TITLE
[CALCITE-2689] ElasticSearch Adapter. Grouping on date / number fields fails.

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchMapping.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchMapping.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.elasticsearch;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.collect.ImmutableMap;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Stores elastic search <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html">mapping</a>
+ * information for particular index / type. This information is extracted from
+ * {@code /$index/$type/_mapping} endpoint.
+ *
+ * <p>This class is immutable</p>
+ */
+class ElasticsearchMapping {
+
+  private final String index;
+
+  private final String type;
+
+  private final Map<String, Datatype> mapping;
+
+  ElasticsearchMapping(final String index, final String type, final Map<String, String> mapping) {
+    this.index = Objects.requireNonNull(index, "index");
+    this.type = Objects.requireNonNull(type, "type");
+    Objects.requireNonNull(mapping, "mapping");
+
+    final Map<String, Datatype> transformed = mapping.entrySet()
+        .stream().collect(Collectors.toMap(Map.Entry::getKey, e -> new Datatype(e.getValue())));
+    this.mapping = ImmutableMap.copyOf(transformed);
+  }
+
+  /**
+   * Returns ES schema for each field. Mapping is represented as field name {@code foo.bar.qux}
+   * and type ({@code keyword}, {@code boolean}, {@code long}).
+   *
+   * @return immutable mapping between field and ES type.
+   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html">Mapping Types</a>
+   */
+  Map<String, Datatype> mapping() {
+    return this.mapping;
+  }
+
+  /**
+   * Used as special aggregation key for missing values (documents which are missing a field).
+   * Buckets with that value are then converted to {@code null}s in flat tabular format.
+   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html">Missing Value</a>
+   */
+  Optional<JsonNode> missingValueFor(String fieldName) {
+    if (!mapping().containsKey(fieldName)) {
+      final String message = String.format(Locale.ROOT, "Field %s not defined for %s/%s",
+          fieldName, index, type);
+      throw new IllegalArgumentException(message);
+    }
+
+    return mapping().get(fieldName).missingValue();
+  }
+
+  String index() {
+    return this.index;
+  }
+
+  String type() {
+    return this.type;
+  }
+
+  /**
+   * Represents elastic data-type, like {@code long}, {@code keyword}, {@code date} etc.
+   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html">Mapping Types</a>
+   */
+  static class Datatype {
+
+    private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
+
+    // pre-cache missing values
+    private static final Set<JsonNode> MISSING_VALUES = Stream.of("string", // for ES2
+        "text", "keyword",
+        "date", "long", "integer", "double", "float")
+        .map(Datatype::missingValueForType)
+        .collect(Collectors.toSet());
+
+    private final String name;
+    private final JsonNode missingValue;
+
+    private Datatype(final String name) {
+      this.name = Objects.requireNonNull(name, "name");
+      this.missingValue = missingValueForType(name);
+    }
+
+    /**
+     * Mapping between ES type and json value which represents {@code missing value} during
+     * aggregations. This value can't be {@code null} and should match type or the field
+     * (for ES long type it also has to be json integer, for date it has to match date format or be
+     * integer (millis epoch) etc.
+     *
+     * <p>It is used for terms aggregations to represent SQL {@code null}.
+     *
+     * @param name name of the type ({@code long}, {@code keyword} ...)
+     * @return json which will be used in elastic search terms aggregation for missing value.
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_missing_value_13">Missing Value</a>
+     */
+    private static JsonNode missingValueForType(String name) {
+      switch (name) {
+      case "string": // for ES2
+      case "text":
+      case "keyword":
+        return FACTORY.textNode("__MISSING__");
+      case "long":
+        return FACTORY.numberNode(Long.MIN_VALUE);
+      case "integer":
+        return FACTORY.numberNode(Integer.MIN_VALUE);
+      case "short":
+        return FACTORY.numberNode(Short.MIN_VALUE);
+      case "double":
+        return FACTORY.numberNode(Double.MIN_VALUE);
+      case "float":
+        return FACTORY.numberNode(Float.MIN_VALUE);
+      case "date":
+        // sentinel for missing dates: 9999-12-31
+        final long millisEpoch = LocalDate.of(9999, 12, 31)
+            .atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
+        // by default elastic returns dates as longs
+        return FACTORY.numberNode(millisEpoch);
+      }
+
+      // this is unknown type
+      return null;
+    }
+
+    /**
+     * Name of the type: {@code text}, {@code integer}, {@code float} etc.
+     */
+    String name() {
+      return this.name;
+    }
+
+    Optional<JsonNode> missingValue() {
+      return Optional.ofNullable(missingValue);
+    }
+
+    static boolean isMissingValue(JsonNode node) {
+      return MISSING_VALUES.contains(node);
+    }
+  }
+
+}
+
+// End ElasticsearchMapping.java

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
@@ -219,7 +219,11 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
       final ObjectNode section = parent.with(aggName);
       final ObjectNode terms = section.with("terms");
       terms.put("field", name);
-      terms.set("missing", ElasticsearchJson.MISSING_VALUE); // expose missing terms
+
+      transport.mapping.missingValueFor(name).ifPresent(m -> {
+        // expose missing terms. each type has a different missing value
+        terms.set("missing", m);
+      });
 
       if (fetch != null) {
         terms.put("size", fetch);

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
@@ -23,6 +23,8 @@ import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.ElasticsearchChecker;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
@@ -53,20 +55,29 @@ public class AggregationTest {
   @BeforeClass
   public static void setupInstance() throws Exception {
 
-    final Map<String, String> mappings = ImmutableMap.of("cat1", "keyword",
-        "cat2", "keyword", "cat3", "keyword",
-        "val1", "long", "val2", "long");
+    final Map<String, String> mappings = ImmutableMap.<String, String>builder()
+        .put("cat1", "keyword")
+        .put("cat2", "keyword")
+        .put("cat3", "keyword")
+        .put("cat4", "date")
+        .put("cat5", "integer")
+        .put("val1", "long")
+        .put("val2", "long")
+        .build();
 
     NODE.createIndex(NAME, mappings);
 
-    String doc1 = "{'cat1': 'a', 'cat2': 'g', 'val1': 1 }".replace('\'', '"');
-    String doc2 = "{'cat2': 'g', 'cat3': 'y', 'val2': 5 }".replace('\'', '"');
-    String doc3 = "{'cat1': 'b', 'cat2':'h', 'cat3': 'z', 'val1': 7, 'val2': '42'}"
-        .replace('\'', '"');
+    String doc1 = "{cat1:'a', cat2:'g', val1:1, cat4:'2018-01-01', cat5:1}";
+    String doc2 = "{cat2:'g', cat3:'y', val2:5, cat4:'2019-12-12'}";
+    String doc3 = "{cat1:'b', cat2:'h', cat3:'z', cat5:2, val1:7, val2:42}";
 
-    List<ObjectNode> docs = new ArrayList<>();
+    final ObjectMapper mapper = new ObjectMapper()
+        .enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES) // user-friendly settings to
+        .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES); // avoid too much quoting
+
+    final List<ObjectNode> docs = new ArrayList<>();
     for (String text: Arrays.asList(doc1, doc2, doc3)) {
-      docs.add((ObjectNode) NODE.mapper().readTree(text));
+      docs.add((ObjectNode) mapper.readTree(text));
     }
 
     NODE.insertBulk(NAME, docs);
@@ -85,6 +96,8 @@ public class AggregationTest {
             "select _MAP['cat1'] AS \"cat1\", "
                 + " _MAP['cat2']  AS \"cat2\", "
                 +  " _MAP['cat3'] AS \"cat3\", "
+                +  " _MAP['cat4'] AS \"cat4\", "
+                +  " _MAP['cat5'] AS \"cat5\", "
                 +  " _MAP['val1'] AS \"val1\", "
                 +  " _MAP['val2'] AS \"val2\" "
                 +  " from \"elastic\".\"%s\"", NAME);
@@ -255,6 +268,34 @@ public class AggregationTest {
             .returnsUnordered("cat1=a; cat2=g; cat3=null; EXPR$3=1; EXPR$4=1.0; EXPR$5=0.0",
                     "cat1=b; cat2=h; cat3=z; EXPR$3=1; EXPR$4=7.0; EXPR$5=42.0",
                     "cat1=null; cat2=g; cat3=y; EXPR$3=1; EXPR$4=0.0; EXPR$5=5.0");
+  }
+
+  /**
+   * Group by <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html">date</a>
+   * data type.
+   */
+  @Test
+  public void dateCat() {
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select cat4, sum(val1) from view group by cat4")
+        .returnsUnordered("cat4=1514764800000; EXPR$1=1.0",
+                          "cat4=1576108800000; EXPR$1=0.0",
+                          "cat4=null; EXPR$1=7.0");
+  }
+
+  /**
+   * Group by <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html">number</a>
+   * data type.
+   */
+  @Test
+  public void integerCat() {
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select cat5, sum(val1) from view group by cat5")
+        .returnsUnordered("cat5=1; EXPR$1=1.0",
+            "cat5=null; EXPR$1=0.0",
+            "cat5=2; EXPR$1=7.0");
   }
 }
 

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
@@ -54,7 +54,7 @@ public class BooleanLogicTest {
   @BeforeClass
   public static void setupInstance() throws Exception {
 
-    final Map<String, String> mapping = ImmutableMap.of("A", "keyword", "b", "keyword",
+    final Map<String, String> mapping = ImmutableMap.of("a", "keyword", "b", "keyword",
         "c", "keyword", "int", "long");
 
     NODE.createIndex(NAME, mapping);


### PR DESCRIPTION
[CALCITE-2689](https://issues.apache.org/jira/browse/CALCITE-2689)

For [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) missing value has to have same type as group key.

Currently single (text) key is used `__MISSING__` which fails when grouping on non-string fields (eg. dates, numbers or booleans).

```sql
select max(amount), date from orders group by date -- date column is of type date (in ES)
```

When using `missing` (value) query converter should consider field type.

This logic should be reviewed once we migrate to [composite aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html) (available since [6.1](https://www.elastic.co/guide/en/elasticsearch/reference/6.1/release-notes-6.1.0.html) see [PR-26800](https://github.com/elastic/elasticsearch/pull/26800)

