### PR TITLE
[CALCITE-2720] Presence of an empty aggregation should not lead to Ex…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -412,6 +412,9 @@ public class RelMetadataQuery {
     // Determine the simple origin of the first column in the
     // RelNode.  If it's simple, then that means that the underlying
     // table is also simple, even if the column itself is derived.
+    if (rel.getRowType().getFieldCount() == 0) {
+      return null;
+    }
     final Set<RelColumnOrigin> colOrigins = getColumnOrigins(rel, 0);
     if (colOrigins == null || colOrigins.size() == 0) {
       return null;

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -87,6 +87,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilder.AggCall;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
@@ -123,7 +124,6 @@ import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.apache.calcite.test.Matchers.within;
-
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -2384,6 +2384,17 @@ public class RelMetadataTest extends SqlToRelTestBase {
       return false;
     }
   };
+
+  @Test public void testEmptyAggregateNotCausesException() throws Exception {
+    final FrameworkConfig config = RelBuilderTest.config().build();
+    final RelBuilder builder = RelBuilder.create(config);
+
+    RelMetadataQuery mq = RelMetadataQuery.instance();
+    RelNode agg = builder
+        .scan("EMP")
+        .aggregate(builder.groupKey(), Collections.<AggCall> emptyList()).build();
+    mq.getTableOrigin(agg);
+  }
 
   @Test public void testGetPredicatesForJoin() throws Exception {
     final FrameworkConfig config = RelBuilderTest.config().build();


### PR DESCRIPTION
…ceptions.

In case an empty aggregation IndexOutofBoundsException-s might have happened - only in case LoptOptimizeJoinRule was used.