### PR TITLE
[CALCITE-2727] MV rewriting looping broken out falsely when view table reference set is empty

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AbstractMaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AbstractMaterializedViewRule.java
@@ -301,8 +301,8 @@ public abstract class AbstractMaterializedViewRule extends RelOptRule {
           // Extract view table references
           final Set<RelTableRef> viewTableRefs = mq.getTableReferences(viewNode);
           if (viewTableRefs == null) {
-            // Bail out
-            return;
+            // Skip it
+            continue;
           }
 
           // Extract view tables


### PR DESCRIPTION
When we iterate through all applicable materializations trying to rewrite the given query, the looping is broken out falsely when view table reference set is empty.

How to test?
Existing UTs