### PR TITLE
[CALCITE-2674] SqlIdentifier same name with built-in function but with escape character should be still resolved as an identifier

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1812,7 +1812,6 @@ SqlNode TableRef2(boolean lateral) :
     SqlNode tableRef;
     SqlNode over;
     SqlNodeList extendList = null;
-    String alias;
     final SqlIdentifier id;
     final Span s, s2;
     SqlNodeList args;
@@ -1897,9 +1896,7 @@ SqlNode TableRef2(boolean lateral) :
         tableRef = ExtendedTableRef()
     )
     [
-        [ <AS> ] alias = Identifier() {
-            id = new SqlIdentifier(alias, getPos());
-        }
+        [ <AS> ] id = SimpleIdentifier()
         [ columnAliasList = ParenthesizedSimpleIdentifierList() ]
         {
             if (columnAliasList == null) {
@@ -3007,7 +3004,7 @@ void Expression2b(ExprContext exprContext, List<Object> list) :
 {
     SqlNode e;
     SqlOperator op;
-    String p;
+    SqlIdentifier p;
 }
 {
     (
@@ -3021,11 +3018,11 @@ void Expression2b(ExprContext exprContext, List<Object> list) :
     }
     (
         <DOT>
-        p = Identifier() {
+        p = SimpleIdentifier() {
             list.add(
                 new SqlParserUtil.ToTreeListItem(
                     SqlStdOperatorTable.DOT, getPos()));
-            list.add(new SqlIdentifier(p, getPos()));
+            list.add(p);
         }
     )*
 }
@@ -3052,7 +3049,7 @@ List<Object> Expression2(ExprContext exprContext) :
     SqlNodeList nodeList;
     SqlNode e;
     SqlOperator op;
-    String p;
+    SqlIdentifier p;
     final Span s = span();
 }
 {
@@ -3177,11 +3174,11 @@ List<Object> Expression2(ExprContext exprContext) :
                 }
                 (
                     <DOT>
-                    p = Identifier() {
+                    p = SimpleIdentifier() {
                         list.add(
                             new SqlParserUtil.ToTreeListItem(
                                 SqlStdOperatorTable.DOT, getPos()));
-                        list.add(new SqlIdentifier(p, getPos()));
+                        list.add(p);
                     }
                 )*
             |
@@ -4157,20 +4154,22 @@ SqlDynamicParam DynamicParam() :
     }
 }
 
-
 /**
- * Parses a simple identifier as a string.
+ * Parses a dot(maybe) split identifier segment. Each time it reads an identifier it writes one element
+ * to each list, and the quotes list records whether the identifier was quoted.
  */
-String Identifier() :
+void IdentifierSegment(List<String> names, List<SqlParserPos> positions, List<Boolean> quotes) :
 {
     String id;
     char unicodeEscapeChar = BACKSLASH;
+    boolean isEscaped = true;
 }
 {
     (
         <IDENTIFIER>
         {
             id = unquotedIdentifier();
+            isEscaped = false;
         }
     |
         <QUOTED_IDENTIFIER> {
@@ -4202,17 +4201,38 @@ String Identifier() :
         {
             SqlLiteral lit = SqlLiteral.createCharString(id, "UTF16", getPos());
             lit = lit.unescapeUnicode(unicodeEscapeChar);
-            return lit.toValue();
+            id = lit.toValue();
         }
     |
-        id = NonReservedKeyWord()
+        id = NonReservedKeyWord() {
+            isEscaped = false;
+        }
     )
     {
         if (id.length() > this.identifierMaxLength) {
             throw SqlUtil.newContextException(getPos(),
                 RESOURCE.identifierTooLong(id, this.identifierMaxLength));
         }
-        return id;
+        names.add(id);
+        if (quotes != null) {
+            quotes.add(isEscaped);
+        }
+        if (positions != null) {
+            positions.add(getPos().setQuoted(isEscaped));
+        }
+    }
+}
+
+/**
+ * Parses a simple identifier as a String.
+ */
+String Identifier() :
+{
+    List<String> names = new ArrayList<String>();
+}
+{
+    IdentifierSegment(names, null, null) {
+        return names.get(0);
     }
 }
 
@@ -4221,11 +4241,12 @@ String Identifier() :
  */
 SqlIdentifier SimpleIdentifier() :
 {
-    final String p;
+    List<String> names = new ArrayList<String>();
+    List<SqlParserPos> positions = new ArrayList<SqlParserPos>();
 }
 {
-    p = Identifier() {
-        return new SqlIdentifier(p, getPos());
+    IdentifierSegment(names, positions, null) {
+        return new SqlIdentifier(names.get(0), positions.get(0));
     }
 }
 
@@ -4270,21 +4291,14 @@ SqlIdentifier CompoundIdentifier() :
 {
     List<String> list = new ArrayList<String>();
     List<SqlParserPos> posList = new ArrayList<SqlParserPos>();
-    String p;
+    List<Boolean> quotes = new ArrayList<Boolean>();
     boolean star = false;
 }
 {
-    p = Identifier()
-    {
-        posList.add(getPos());
-        list.add(p);
-    }
+    IdentifierSegment(list, posList, quotes)
     (
         <DOT>
-        p = Identifier() {
-            list.add(p);
-            posList.add(getPos());
-        }
+        IdentifierSegment(list, posList, quotes)
     )*
     (
         <DOT>

--- a/core/src/main/java/org/apache/calcite/sql/SqlIdentifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIdentifier.java
@@ -358,6 +358,22 @@ public class SqlIdentifier extends SqlNode {
     return names.size() == 1 && !isStar();
   }
 
+  /**
+   * Returns whether this id is escaped by quoting.
+   */
+  public boolean isQuoted() {
+    if (componentPositions != null) {
+      for (SqlParserPos pos : componentPositions) {
+        // if all the component pos is quoted, we think this SqlIdentifier is quoted.
+        if (!pos.isQuoted()) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
   public SqlMonotonicity getMonotonicity(SqlValidatorScope scope) {
     // for "star" column, whether it's static or dynamic return not_monotonic directly.
     if (Util.last(names).equals("") || DynamicRecordType.isDynamicStarColName(Util.last(names))) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -663,7 +663,7 @@ public abstract class SqlUtil {
   public static SqlCall makeCall(
       SqlOperatorTable opTab,
       SqlIdentifier id) {
-    if (id.names.size() == 1) {
+    if (id.names.size() == 1 && !id.isQuoted()) {
       final List<SqlOperator> list = new ArrayList<>();
       opTab.lookupOperatorOverloads(id, null, SqlSyntax.FUNCTION, list);
       for (SqlOperator operator : list) {

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserPos.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserPos.java
@@ -51,6 +51,8 @@ public class SqlParserPos implements Serializable {
   private final int columnNumber;
   private final int endLineNumber;
   private final int endColumnNumber;
+  // Flag to indicate if this SqlParserPos is quoted, default to be false.
+  private boolean quoted = false;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -123,6 +125,17 @@ public class SqlParserPos implements Serializable {
    */
   public int getEndColumnNum() {
     return endColumnNumber;
+  }
+
+  /** Mark this SqlParserPos as quoted and return itself. **/
+  public SqlParserPos setQuoted(boolean quoted) {
+    this.quoted = quoted;
+    return this;
+  }
+
+  /** @return true if this SqlParserPos is quoted. **/
+  public boolean isQuoted() {
+    return quoted;
   }
 
   @Override public String toString() {

--- a/core/src/test/java/org/apache/calcite/sql/validate/LexEscapeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/validate/LexEscapeTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.validate;
+
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
+import org.apache.calcite.adapter.enumerable.EnumerableProject;
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParser.Config;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Planner;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+import org.apache.calcite.tools.RelConversionException;
+import org.apache.calcite.tools.ValidationException;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Testing {@link SqlValidator} and {@link Lex} quoting.
+ */
+public class LexEscapeTest {
+
+  private static Planner getPlanner(List<RelTraitDef> traitDefs,
+      Config parserConfig, Program... programs) {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    rootSchema.add("TMP", new AbstractTable() {
+      @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        return typeFactory.createStructType(
+            ImmutableList.of(typeFactory.createSqlType(SqlTypeName.VARCHAR),
+                typeFactory.createSqlType(SqlTypeName.INTEGER)),
+            ImmutableList.of("localtime", "current_timestamp"));
+      }
+    });
+    final FrameworkConfig config = Frameworks.newConfigBuilder()
+        .parserConfig(parserConfig)
+        .defaultSchema(rootSchema)
+        .traitDefs(traitDefs)
+        .programs(programs)
+        .operatorTable(SqlStdOperatorTable.instance())
+        .build();
+    return Frameworks.getPlanner(config);
+  }
+
+  private static void runProjectQueryWithLex(Lex lex, String sql)
+      throws SqlParseException, ValidationException, RelConversionException {
+    Config javaLex = SqlParser.configBuilder().setLex(lex).build();
+    Planner planner = getPlanner(null, javaLex, Programs.ofRules(Programs.RULE_SET));
+    SqlNode parse = planner.parse(sql);
+    SqlNode validate = planner.validate(parse);
+    RelNode convert = planner.rel(validate).rel;
+    RelTraitSet traitSet =
+        planner.getEmptyTraitSet().replace(EnumerableConvention.INSTANCE);
+    RelNode transform = planner.transform(0, traitSet, convert);
+    assertThat(transform, instanceOf(EnumerableProject.class));
+    List<RelDataTypeField> fields = transform.getRowType().getFieldList();
+    // Get field type from sql text and validate we parsed it after validation.
+    assert fields.size() == 4;
+    assert fields.get(0).getType().getSqlTypeName() == SqlTypeName.VARCHAR;
+    assert fields.get(1).getType().getSqlTypeName() == SqlTypeName.TIME;
+    assert fields.get(2).getType().getSqlTypeName() == SqlTypeName.INTEGER;
+    assert fields.get(3).getType().getSqlTypeName() == SqlTypeName.TIMESTAMP;
+  }
+
+  @Test public void testCalciteEscapeOracle()
+      throws SqlParseException, ValidationException, RelConversionException {
+    String sql = "select \"localtime\", localtime, "
+        + "\"current_timestamp\", current_timestamp from TMP";
+    runProjectQueryWithLex(Lex.ORACLE, sql);
+  }
+
+  @Test public void testCalciteEscapeMySql()
+      throws SqlParseException, ValidationException, RelConversionException {
+    String sql = "select `localtime`, localtime, `current_timestamp`, current_timestamp from TMP";
+    runProjectQueryWithLex(Lex.MYSQL, sql);
+  }
+
+  @Test public void testCalciteEscapeMySqlAnsi()
+      throws SqlParseException, ValidationException, RelConversionException {
+    String sql = "select \"localtime\", localtime, "
+        + "\"current_timestamp\", current_timestamp from TMP";
+    runProjectQueryWithLex(Lex.MYSQL_ANSI, sql);
+  }
+
+  @Test public void testCalciteEscapeSqlServer()
+      throws SqlParseException, ValidationException, RelConversionException {
+    String sql = "select [localtime], localtime, [current_timestamp], current_timestamp from TMP";
+    runProjectQueryWithLex(Lex.SQL_SERVER, sql);
+  }
+
+  @Test public void testCalciteEscapeJava()
+      throws SqlParseException, ValidationException, RelConversionException {
+    String sql = "select `localtime`, localtime, `current_timestamp`, current_timestamp from TMP";
+    runProjectQueryWithLex(Lex.JAVA, sql);
+  }
+}
+
+// End LexEscapeTest.java


### PR DESCRIPTION
This is the JIRA: [CALCITE-2674](https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-2674?filter=allopenissues)