### PR TITLE
Fix JSON syntax error

### DIFF
--- a/site/_docs/file_adapter.md
+++ b/site/_docs/file_adapter.md
@@ -72,13 +72,13 @@ as follows.
     "type": "custom",
     "factory": "org.apache.calcite.adapter.file.FileSchemaFactory",
     "operand": {
-      "tables": {
+      "tables": [ {
         "name": "EMPS",
         "url": "file:file/src/test/resources/sales/EMPS.html"
       }, {
         "name": "DEPTS"
         "url": "file:file/src/test/resources/sales/DEPTS.html"
-      }
+      } ]
     }
   ]
 }


### PR DESCRIPTION
The "tables" operand should take an array, but the JSON example doesn't wrap the two tables in brackets.