### PR TITLE
[CALCITE-2736] Update the ReduceExpressionsRule to better expose options

### DIFF
--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6842,6 +6842,28 @@ LogicalAggregate(group=[{0, 1, 2}])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testReduceDynamic">
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(USER=['sa'])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(USER=[USER])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testNoReduceDynamic">
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(USER=[USER])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>             
     <TestCase name="testReduceNullableToNotNull">
         <Resource name="sql">
             <![CDATA[select


### PR DESCRIPTION
- Update the reduction rule to use an options object to control behavior.
- Update existing methods so they use options object
- Deprecate methods that accept booleans instead of options object
- Expose ability to avoid special handling for dynamic calls