### PR TITLE
[CALCITE-1703] Functions on TIMESTAMP column throws ClassCastException

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
@@ -636,13 +636,13 @@ public class PhysTypeImpl implements PhysType {
 
   public Expression fieldReference(
       Expression expression, int field, Type storageType) {
-    Type fieldType;
+    Class fieldType;
     if (storageType == null) {
       storageType = fieldClass(field);
       fieldType = null;
     } else {
       fieldType = fieldClass(field);
-      if (fieldType != java.sql.Date.class) {
+      if (!java.util.Date.class.isAssignableFrom(fieldType)) {
         fieldType = null;
       }
     }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -870,8 +870,18 @@ public class RexImpTable {
     if (type instanceof RelDataTypeFactoryImpl.JavaType) {
       final SqlTypeName typeName = type.getSqlTypeName();
       if (typeName != null && typeName != SqlTypeName.OTHER) {
+
+        final RelDataType sqlType;
+        if (typeName.allowsScale()) {
+          sqlType = typeFactory.createSqlType(typeName, type.getPrecision(), type.getScale());
+        } else if (typeName.allowsPrecNoScale()) {
+          sqlType = typeFactory.createSqlType(typeName, type.getPrecision());
+        } else {
+          sqlType = typeFactory.createSqlType(typeName);
+        }
+
         return typeFactory.createTypeWithNullability(
-            typeFactory.createSqlType(typeName),
+            sqlType,
             type.isNullable());
       }
     }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -1020,6 +1020,18 @@ public class RexToLixTranslator {
       } else {
         return Expressions.convert_(operand, toType);
       }
+    } else if (fromType == java.sql.Time.class) {
+      if (toBox == Primitive.INT) {
+        return Expressions.call(BuiltInMethod.TIME_TO_INT.method, operand);
+      } else {
+        return Expressions.convert_(operand, toType);
+      }
+    } else if (fromType == java.sql.Timestamp.class) {
+      if (toBox == Primitive.LONG) {
+        return Expressions.call(BuiltInMethod.TIMESTAMP_TO_LONG.method, operand);
+      } else {
+        return Expressions.convert_(operand, toType);
+      }
     } else if (toType == java.sql.Date.class) {
       // E.g. from "int" or "Integer" to "java.sql.Date",
       // generate "SqlFunctions.internalToDate".

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -535,17 +535,17 @@ public class RexToLixTranslator {
       }
       break;
     case TIMESTAMP:
-      int targetScale = targetType.getScale();
-      if (targetScale == RelDataType.SCALE_NOT_SPECIFIED) {
-        targetScale = 0;
+      int targetTimestampPrecision = targetType.getPrecision();
+      if (targetTimestampPrecision == RelDataType.PRECISION_NOT_SPECIFIED) {
+        targetTimestampPrecision = 0;
       }
-      if (targetScale < sourceType.getScale()) {
+      if (targetTimestampPrecision < sourceType.getPrecision()) {
         convert =
             Expressions.call(
                 BuiltInMethod.ROUND_LONG.method,
                 convert,
                 Expressions.constant(
-                    (long) Math.pow(10, 3 - targetScale)));
+                    (long) Math.pow(10, 3 - targetTimestampPrecision)));
       }
       break;
     case INTERVAL_YEAR:

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -651,6 +651,14 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
       }
       return typeName;
     }
+
+    @Override public int getPrecision() {
+      if (java.sql.Timestamp.class == clazz) {
+        // Timestamp class can hold fractions up to nano seconds.
+        return 9;
+      }
+      return super.getPrecision();
+    }
   }
 
   /** Key to the data type cache. */

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -655,6 +655,12 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     @Override public int getPrecision() {
       if (java.sql.Timestamp.class == clazz) {
         // Timestamp class can hold fractions up to nano seconds.
+        // Without doing this, Timestamp fraction part gets lost
+        // when the value is cast to TIMESTAMP (without precision).
+        // That affects where clause conditions with '='.
+        // E.g. where \"ts\" = TIMESTAMP '2018-12-14 18:29:34.123'
+        // does not match even if the 'ts' has the same timestamp
+        // because the fraction part 123 is dropped.
         return 9;
       }
       return super.getPrecision();

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1565,6 +1565,7 @@ public class SqlFunctions {
     return o instanceof Integer ? (Integer) o
         : o instanceof Number ? toInt((Number) o)
         : o instanceof String ? toInt((String) o)
+        : o instanceof java.sql.Time ? toInt((java.sql.Time) o)
         : o instanceof java.util.Date ? toInt((java.util.Date) o)
         : (Integer) cannotConvert(o, int.class);
   }
@@ -1610,6 +1611,7 @@ public class SqlFunctions {
     return o instanceof Long ? (Long) o
         : o instanceof Number ? toLong((Number) o)
         : o instanceof String ? toLong((String) o)
+        : o instanceof java.util.Date ? toLong((java.util.Date) o)
         : (Long) cannotConvert(o, long.class);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
@@ -184,6 +184,7 @@ import org.junit.runners.Suite;
     CalciteRemoteDriverTest.class,
     StreamTest.class,
     SortRemoveRuleTest.class,
+    ObjectArrayTableTest.class,
 
     // test cases
     TableInRootSchemaTest.class,

--- a/core/src/test/java/org/apache/calcite/test/ObjectArrayTableTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ObjectArrayTableTest.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.apache.calcite.adapter.java.AbstractQueryableTable;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.EnumerableDefaults;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for querying Java Object array table.
+ */
+public class ObjectArrayTableTest {
+
+  /**
+   * A functional interface to implement a test.
+   */
+  @FunctionalInterface private interface TestWithConnection {
+    void test(Connection connection) throws SQLException;
+  }
+
+  /**
+   * Execute a test with an in-memory table having java.sql.Date, Time, Timestamp columns.
+   * @param test the actual test code
+   */
+  private void withJavaSqlDateTypes(TestWithConnection test) throws SQLException {
+    try (
+        Connection connection = DriverManager.getConnection("jdbc:calcite:");
+        CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class)
+    ) {
+      final SchemaPlus rootSchema = calciteConnection.getRootSchema();
+
+      final JavaTypeFactoryImpl typeFactory =
+          new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+
+      final RelDataType rowType = typeFactory.createStructType(
+          Arrays.asList(
+              typeFactory.createJavaType(java.sql.Date.class),
+              typeFactory.createJavaType(java.sql.Time.class),
+              typeFactory.createJavaType(java.sql.Timestamp.class)
+          ),
+          Arrays.asList("dt", "tm", "ts")
+      );
+
+      final Enumerable<Object[]> enumerable =
+          Linq4j.asEnumerable(
+              Collections.singletonList(new Object[]{
+                  java.sql.Date.valueOf("2018-12-14"),
+                  java.sql.Time.valueOf("18:29:34"),
+                  java.sql.Timestamp.valueOf("2018-12-14 18:29:34.123")}));
+
+      final Table table = new AbstractQueryableTable(Object[].class) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        @Override public Queryable<Object[]> asQueryable(QueryProvider queryProvider,
+                                                         SchemaPlus schema, String tableName) {
+          return EnumerableDefaults.asOrderedQueryable(enumerable);
+        }
+
+        @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+          return rowType;
+        }
+      };
+
+      rootSchema.add("java_sql_date_types", table);
+
+      test.test(connection);
+    }
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-1703">[CALCITE-1703]
+   * Before the fix, functions on TIME and TIMESTAMP column can throw ClassCastException</a>. */
+  @Test public void testJavaSqlDateColumnReference() throws SQLException {
+
+    withJavaSqlDateTypes(connection -> {
+      // 'extract' function expects numeric date representation.
+      // RexToLixTranslator.convert() handles Java type to numeric storage type conversion.
+      // Storage types are defined at EnumUtils.toInternal.
+      final Statement statement = connection.createStatement();
+      String sql = "select extract(year from \"dt\"),"
+          + " extract(hour from \"tm\"),"
+          + " extract(day from \"ts\")"
+          + " from \"java_sql_date_types\"";
+
+      ResultSet resultSet = statement.executeQuery(sql);
+      assertTrue(resultSet.next());
+      assertEquals("extract(year from java.sql.Date.valueOf(\"2018-12-14\"))",
+          2018, resultSet.getInt(1));
+      assertEquals("extract(hour from java.sql.Time.valueOf(\"18:29:34\"))",
+          18, resultSet.getInt(2));
+      assertEquals("extract(day from"
+              + " java.sql.Timestamp.valueOf(\"2018-12-14 18:29:34.123\"))",
+          14, resultSet.getInt(3));
+    });
+
+  }
+
+  /**
+   * Test to confirm java.sql.Time column can be used by a filter condition.
+   */
+  @Test public void testTimeFilter() throws SQLException {
+
+    withJavaSqlDateTypes(connection -> {
+
+      String sql = "select 'result'"
+          + " from \"java_sql_date_types\"";
+
+      Statement statement = connection.createStatement();
+      ResultSet resultSet = statement.executeQuery(sql + " where \"tm\" > TIME '18:29:33'");
+      assertTrue("java.sql.Time.valueOf(\"18:29:34\") > TIME '18:29:33'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql + " where \"tm\" = TIME '18:29:34'");
+      assertTrue("java.sql.Time.valueOf(\"18:29:34\") = TIME '18:29:34'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql + " where \"tm\" > TIME '18:29:34'");
+      assertFalse("java.sql.Time.valueOf(\"18:29:34\") > TIME '18:29:34'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql
+          + " where \"tm\" between TIME '18:29:34' and TIME '18:29:35'");
+      assertTrue("java.sql.Time.valueOf(\"18:29:34\")"
+          + " between TIME '18:29:34' and  TIME '18:29:35'", resultSet.next());
+    });
+
+  }
+
+  /**
+   * Test to confirm java.sql.Date column can be used by a filter condition.
+   */
+  @Test public void testDateFilter() throws SQLException {
+
+    withJavaSqlDateTypes(connection -> {
+
+      String sql = "select 'result'"
+          + " from \"java_sql_date_types\"";
+
+      Statement statement = connection.createStatement();
+      ResultSet resultSet = statement.executeQuery(sql
+          + " where \"dt\" > DATE '2018-12-13'");
+      assertTrue("java.sql.Date.valueOf(\"2018-12-14\") > DATE '2018-12-13'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql + " where \"dt\" = DATE '2018-12-14'");
+      assertTrue("java.sql.Date.valueOf(\"2018-12-14\") = DATE '2018-12-14'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql + " where \"dt\" > DATE '2018-12-14'");
+      assertFalse("java.sql.Date.valueOf(\"2018-12-14\") > DATE '2018-12-14'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql
+          + " where \"dt\" between DATE '2018-12-14' and DATE '2018-12-15'");
+      assertTrue("java.sql.Date.valueOf(\"2018-12-14\")"
+          + " between DATE '2018-12-14' and DATE '2018-12-14'", resultSet.next());
+    });
+
+  }
+
+  /**
+   * Test to confirm java.sql.Timestamp column can be used by a filter condition.
+   */
+  @Test public void testTimestampFilter() throws SQLException {
+
+    withJavaSqlDateTypes(connection -> {
+
+      String sql = "select 'result'"
+          + " from \"java_sql_date_types\"";
+
+      Statement statement = connection.createStatement();
+      ResultSet resultSet = statement.executeQuery(sql
+          + " where \"ts\" > TIMESTAMP '2018-12-14 18:29:34.122'");
+      assertTrue("java.sql.Timestamp.valueOf(\"2018-12-14 18:29:34.123\")"
+          + " > TIMESTAMP '2018-12-14 18:29:34.122'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql
+          + " where \"ts\" = TIMESTAMP '2018-12-14 18:29:34.123'");
+      assertTrue("java.sql.Timestamp.valueOf(\"2018-12-14 18:29:34.123\")"
+          + " = TIMESTAMP '2018-12-14 18:29:34.123'", resultSet.next());
+
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql
+          + " where \"ts\" > TIMESTAMP '2018-12-14 18:29:34.123'");
+      assertFalse("java.sql.Timestamp.valueOf(\"2018-12-14 18:29:34.123\")"
+          + " > TIMESTAMP '2018-12-14 18:29:34.123'", resultSet.next());
+
+      statement = connection.createStatement();
+      resultSet = statement.executeQuery(sql
+          + " where \"ts\" between TIMESTAMP '2018-12-14 18:29:34.122'"
+          + " and TIMESTAMP '2018-12-14 18:29:34.123'");
+      assertTrue("java.sql.Timestamp.valueOf(\"2018-12-14 18:29:34.123\")"
+          + " between TIMESTAMP '2018-12-14 18:29:34.122'"
+          + " and TIMESTAMP '2018-12-14 18:29:34.123'", resultSet.next());
+    });
+
+  }
+}
+
+// End ObjectArrayTableTest.java

--- a/core/src/test/java/org/apache/calcite/test/ObjectArrayTableTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ObjectArrayTableTest.java
@@ -39,10 +39,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import static java.lang.String.format;
 
 /**
  * Test for querying Java Object array table.
@@ -241,6 +244,35 @@ public class ObjectArrayTableTest {
     });
 
   }
+
+  /**
+   * Test to confirm java.sql.Timestamp can be casted to Timestamp with different precision.
+   * The cast should be done the same as with TIMESTAMP literal.
+   */
+  @Test public void testCastTimestampToTimestamp() throws SQLException {
+
+    withJavaSqlDateTypes(connection -> {
+
+      Statement statement = connection.createStatement();
+      final String sql = "select %s as EXPECTED, %s as ACTUAL from \"java_sql_date_types\"";
+
+      for (int i = 3; i >= 0; i--) {
+        final String castTo = format(Locale.ROOT, "TIMESTAMP(%d)", i);
+
+        final String expected = format(Locale.ROOT,
+            "cast(TIMESTAMP '2018-12-14 18:29:34.123' as %s)", castTo);
+        final String actual = format(Locale.ROOT, "cast(\"ts\" as %s)", castTo);
+        final ResultSet resultSet = statement.executeQuery(
+            format(Locale.ROOT, sql, expected, actual));
+        resultSet.next();
+        assertEquals(format(Locale.ROOT, "cast(java.sql.Timestamp as %s)", castTo),
+            resultSet.getTimestamp(1), resultSet.getTimestamp(2));
+      }
+
+    });
+
+  }
+
 }
 
 // End ObjectArrayTableTest.java


### PR DESCRIPTION
Currently, TIMESTAMP or TIME column is used at any function, ClassCastException is thrown. For example, if a TIMESTAMP column `date_added` is used like this, `select name, EXTRACT(YEAR FROM date_added) as year_added from FLOWFILE`, Calcite generates the following code. And a ClassCastException is thrown at `(Long) current[1]`:

```Java
            public Object current() {
              final Object[] current = (Object[]) inputEnumerator.current();
              return new Object[] {
                  current[0],
                  (java.sql.Timestamp) current[1] == null ? (Long) null : Long.valueOf(org.apache.calcite.avatica.util.DateTimeUtils.unixDateExtract(org.apache.calcite.avatica.util.TimeUnitRange.YEAR, (Long) current[1] / 86400000L))};
            }
```

That happens because of the wrong if condition at `PhysTypeImple.fieldReference` method where it ignores the fieldType that is used as a fromType to convert the value to Long. Since fromType is null, the generated code casts `current[1]` to Long blindly.

The condition should accept not only `java.sql.Date` but also `java.sql.Time` and `java.sql.Timestamp`. Since these classes are all sub-class of `java.util.Date`, using `isAssignableFrom` method will address the issue.

Current if statement only supports `java.sql.Date`:
![image](https://user-images.githubusercontent.com/1107620/49925417-363d4980-fefc-11e8-8675-78c68b540da7.png)

DISCLAIMER: This is my first PR to Apache Calcite project. Kindly give me some advice on unit testing.

I wanted to add an unit test to reproduce the issue and prove this fix it. But I couldn't figure out where is the right place for such test.

There is an existing case [testExtractYearFromTimestamp ](https://github.com/apache/calcite/blob/master/core/src/test/java/org/apache/calcite/test/JdbcTest.java#L1474) but this test doesn't call `PhysTypeImple.fieldReference`. Some other test cases in the same JdbcTest such as `testSumOverUnboundedPreceding` does call `PhysTypeImple.fieldReference`. I don't know where this difference comes from..