### PR TITLE
[CALCITE-2736] Update the ReduceExpressionsRule to better expose options

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -90,6 +90,7 @@ import org.apache.calcite.rel.rules.ProjectWindowTransposeRule;
 import org.apache.calcite.rel.rules.PruneEmptyRules;
 import org.apache.calcite.rel.rules.PushProjector;
 import org.apache.calcite.rel.rules.ReduceExpressionsRule;
+import org.apache.calcite.rel.rules.ReduceExpressionsRule.ProjectReduceExpressionsRule;
 import org.apache.calcite.rel.rules.SemiJoinFilterTransposeRule;
 import org.apache.calcite.rel.rules.SemiJoinJoinTransposeRule;
 import org.apache.calcite.rel.rules.SemiJoinProjectTransposeRule;
@@ -134,6 +135,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.apache.calcite.plan.RelOptRule.none;
 import static org.apache.calcite.plan.RelOptRule.operand;
@@ -284,6 +286,38 @@ public class RelOptRulesTest extends RelOptTestBase {
         + "THEN substring(ename, 1, cast(2 as int)) ELSE NULL end from emp"
         + " group by deptno, ename, case when 1=2 then substring(ename,1, cast(2 as int))  else null end";
     sql(sql).with(hepPlanner).checkUnchanged();
+  }
+
+  @Test public void testReduceDynamic() {
+    testDynamic(true).get();
+  }
+
+  @Test public void testNoReduceDynamic() {
+    testDynamic(false).get();
+  }
+
+  /**
+   * Test reduction or not of a dynamic function.
+   *
+   * @param allowReduce Whether to allow dynamic functions to be reduced.
+   * @return The supplier to be executed in the context of the original test to ensure correct
+   *         test name mapping.
+   */
+  private Supplier<Void> testDynamic(boolean allowReduce) {
+    HepProgramBuilder builder = new HepProgramBuilder();
+    RelOptRule rule = new ProjectReduceExpressionsRule(
+        LogicalProject.class,
+        ReduceExpressionsRule.DEFAULT_OPTIONS.treatDynamicCallsAsNonConstant(!allowReduce),
+        RelFactories.LOGICAL_BUILDER);
+    builder.addRuleInstance(rule);
+    HepPlanner hepPlanner = new HepPlanner(builder.build());
+    final String sql = "select USER from emp";
+
+    // return a supplier to be executed in the context of the original test method.
+    return () -> {
+      checkPlanning(tester, null, hepPlanner, sql, !allowReduce);
+      return null;
+    };
   }
 
   @Test public void testProjectToWindowRuleForMultipleWindows() {
@@ -2200,7 +2234,8 @@ public class RelOptRulesTest extends RelOptTestBase {
   @Test public void testReduceNullableToNotNull2() throws Exception {
     final ReduceExpressionsRule.ProjectReduceExpressionsRule rule =
         new ReduceExpressionsRule.ProjectReduceExpressionsRule(
-            LogicalProject.class, false,
+            LogicalProject.class,
+            ReduceExpressionsRule.DEFAULT_OPTIONS.matchNullability(false),
             RelFactories.LOGICAL_BUILDER);
     checkReduceNullableToNotNull(rule);
   }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6842,6 +6842,28 @@ LogicalAggregate(group=[{0, 1, 2}])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testReduceDynamic">
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(USER=['sa'])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(USER=[USER])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testNoReduceDynamic">
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(USER=[USER])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>             
     <TestCase name="testReduceNullableToNotNull">
         <Resource name="sql">
             <![CDATA[select


### PR DESCRIPTION
* Update the reduction rule to use an options object to control behavior.
* Update existing methods so they use options object
* Deprecate methods that accept booleans instead of options object
* Expose ability to avoid special handling for dynamic calls

Change-Id: I8c772d29a6678776ca878566edd58c581b508bd3