### PR TITLE
[CALCITE-2755] Expose document _id field when querying ElasticSearch

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchConstants.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchConstants.java
@@ -30,6 +30,11 @@ interface ElasticsearchConstants {
   String FIELDS = "fields";
   String SOURCE_PAINLESS = "params._source";
   String SOURCE_GROOVY = "_source";
+
+  /**
+   * Attribute which uniquely identifies a document (ID)
+   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html">ID Field</a>
+   */
   String ID = "_id";
   String UID = "_uid";
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
@@ -276,12 +276,16 @@ final class ElasticsearchJson {
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
   static class SearchHit {
+
+    /**
+     * ID of the document (not available in aggregations)
+     */
     private final String id;
     private final Map<String, Object> source;
     private final Map<String, Object> fields;
 
     @JsonCreator
-    SearchHit(@JsonProperty("_id") final String id,
+    SearchHit(@JsonProperty(ElasticsearchConstants.ID) final String id,
                       @JsonProperty("_source") final Map<String, Object> source,
                       @JsonProperty("fields") final Map<String, Object> fields) {
       this.id = Objects.requireNonNull(id, "id");

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchMethod.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchMethod.java
@@ -35,6 +35,7 @@ enum ElasticsearchMethod {
       List.class, // sort
       List.class, // groupBy
       List.class, // aggregations
+      List.class, // expression mapping
       Long.class, // offset
       Long.class); // fetch
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
@@ -68,6 +68,10 @@ public class ElasticsearchProject extends Project implements ElasticsearchRel {
       final String name = pair.right;
       final String expr = pair.left.accept(translator);
 
+      if (ElasticsearchRules.isItem(pair.left)) {
+        implementor.addExpressionItemMapping(name, ElasticsearchRules.stripQuotes(expr));
+      }
+
       if (expr.equals("\"" + name + "\"")) {
         fields.add(name);
       } else if (expr.matches("\"literal\":.+")) {

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRel.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRel.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.Pair;
 
 import java.util.ArrayList;
@@ -65,6 +66,15 @@ public interface ElasticsearchRel extends RelNode {
     final List<String> groupBy = new ArrayList<>();
 
     /**
+     * Keeps mapping between calcite expression identifier (like {@code EXPR$0}) and
+     * original item call like {@code _MAP['foo.bar']} ({@code foo.bar} really).
+     * This information otherwise might be lost during query translation.
+     *
+     * @see SqlStdOperatorTable#ITEM
+     */
+    final List<Map.Entry<String, String>> expressionItemMap = new ArrayList<>();
+
+    /**
      * Starting index (default {@code 0}). Equivalent to {@code start} in ES query.
      * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html">From/Size</a>
      */
@@ -97,6 +107,12 @@ public interface ElasticsearchRel extends RelNode {
       Objects.requireNonNull(field, "field");
       Objects.requireNonNull(expression, "expression");
       aggregations.add(new Pair<>(field, expression));
+    }
+
+    void addExpressionItemMapping(String expressionId, String item) {
+      Objects.requireNonNull(expressionId, "expressionId");
+      Objects.requireNonNull(item, "item");
+      expressionItemMap.add(new Pair<>(expressionId, item));
     }
 
     void offset(long offset) {

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
@@ -82,6 +82,15 @@ class ElasticsearchRules {
     return null;
   }
 
+  static boolean isItem(RexNode node) {
+    final Boolean result = node.accept(new RexVisitorImpl<Boolean>(false) {
+      @Override public Boolean visitCall(final RexCall call) {
+        return isItem(call) != null;
+      }
+    });
+    return Boolean.TRUE.equals(result);
+  }
+
   static List<String> elasticsearchFieldNames(final RelDataType rowType) {
     return SqlValidatorUtil.uniquify(
         new AbstractList<String>() {
@@ -102,7 +111,8 @@ class ElasticsearchRules {
   }
 
   static String stripQuotes(String s) {
-    return s.startsWith("\"") && s.endsWith("\"") ? s.substring(1, s.length() - 1) : s;
+    return s.length() > 1 && s.startsWith("\"") && s.endsWith("\"")
+        ? s.substring(1, s.length() - 1) : s;
   }
 
   /**

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverter.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverter.java
@@ -89,12 +89,15 @@ public class ElasticsearchToEnumerableConverter extends ConverterImpl implements
     final Expression aggregations = block.append("aggregations",
         constantArrayList(implementor.aggregations, Pair.class));
 
+    final Expression mappings = block.append("mappings",
+        constantArrayList(implementor.expressionItemMap, Pair.class));
+
     final Expression offset = block.append("offset", Expressions.constant(implementor.offset));
     final Expression fetch = block.append("fetch", Expressions.constant(implementor.fetch));
 
     Expression enumerable = block.append("enumerable",
         Expressions.call(table, ElasticsearchMethod.ELASTICSEARCH_QUERYABLE_FIND.method, ops,
-            fields, sort, groupBy, aggregations, offset, fetch));
+            fields, sort, groupBy, aggregations, mappings, offset, fetch));
     block.add(Expressions.return_(null, enumerable));
     return relImplementor.result(physType, block.toBlock());
   }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
@@ -31,11 +31,17 @@ import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.regex.PatternSyntaxException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Checks renaming of fields (also upper, lower cases) during projections
@@ -72,7 +78,8 @@ public class Projection2Test {
             "select _MAP['a'] AS \"a\", "
                 + " _MAP['b.a']  AS \"b.a\", "
                 +  " _MAP['b.b'] AS \"b.b\", "
-                +  " _MAP['b.c.a'] AS \"b.c.a\" "
+                +  " _MAP['b.c.a'] AS \"b.c.a\", "
+                +  " _MAP['_id'] AS \"id\" " // _id field is implicit
                 +  " from \"elastic\".\"%s\"", NAME);
 
         ViewTableMacro macro = ViewTable.viewMacro(root, viewSql,
@@ -102,6 +109,135 @@ public class Projection2Test {
             .returns("EXPR$0=1; EXPR$1=2; EXPR$2=3; EXPR$3=foo; EXPR$4=null; EXPR$5=null\n");
   }
 
+  /**
+   * Test that {@code _id} field is available when queried explicitly.
+   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html">ID Field</a>
+   */
+  @Test
+  public void projectionWithIdField() {
+
+    final CalciteAssert.AssertThat factory = CalciteAssert.that().with(newConnectionFactory());
+
+    factory
+        .query("select \"id\" from view")
+        .returns(regexMatch("id=\\p{Graph}+"));
+
+    factory
+        .query("select \"id\", \"id\" from view")
+        .returns(regexMatch("id=\\p{Graph}+; id=\\p{Graph}+"));
+
+    factory
+        .query("select \"id\", \"a\" from view")
+        .returns(regexMatch("id=\\p{Graph}+; a=1"));
+
+    factory
+        .query("select \"a\", \"id\" from view")
+        .returns(regexMatch("a=1; id=\\p{Graph}+"));
+
+    // single _id column
+    final String sql1 = String.format(Locale.ROOT, "select _MAP['_id'] "
+        + " from \"elastic\".\"%s\"", NAME);
+    factory
+        .query(sql1)
+        .returns(regexMatch("EXPR$0=\\p{Graph}+"));
+
+    // multiple columns: _id and a
+    final String sql2 = String.format(Locale.ROOT, "select _MAP['_id'], _MAP['a'] "
+        + " from \"elastic\".\"%s\"", NAME);
+    factory
+        .query(sql2)
+        .returns(regexMatch("EXPR$0=\\p{Graph}+; EXPR$1=1"));
+
+    // multiple _id columns
+    final String sql3 = String.format(Locale.ROOT, "select _MAP['_id'], _MAP['_id'] "
+        + " from \"elastic\".\"%s\"", NAME);
+    factory
+        .query(sql3)
+        .returns(regexMatch("EXPR$0=\\p{Graph}+; EXPR$1=\\p{Graph}+"));
+
+    // _id column with same alias
+    final String sql4 = String.format(Locale.ROOT, "select _MAP['_id'] as \"_id\" "
+        + " from \"elastic\".\"%s\"", NAME);
+    factory
+        .query(sql4)
+        .returns(regexMatch("_id=\\p{Graph}+"));
+
+    // _id field not available implicitly
+    final String sql5 = String.format(Locale.ROOT, "select * from \"elastic\".\"%s\"", NAME);
+    factory
+        .query(sql5)
+        .returns(regexMatch("_MAP={a=1, b={a=2, b=3, c={a=foo}}}"));
+  }
+
+  /**
+   * Allows values to contain regular expressions instead of exact values.
+   * <pre>
+   *   {@code
+   *      key1=foo1; key2=\\w+; key4=\\d{3,4}
+   *   }
+   * </pre>
+   * @param lines lines with regexp
+   * @return consumer to be used in {@link org.apache.calcite.test.CalciteAssert.AssertQuery}
+   */
+  private static Consumer<ResultSet> regexMatch(String...lines) {
+    return rset -> {
+      try {
+        final int columnCount = rset.getMetaData().getColumnCount();
+        final StringBuilder actual = new StringBuilder();
+        int processedRows = 0;
+        boolean fail = false;
+        while (rset.next()) {
+          if (processedRows >= lines.length) {
+            fail = true;
+          }
+
+          for (int i = 1; i <= columnCount; i++) {
+            final String name = rset.getMetaData().getColumnName(i);
+            final String value = rset.getString(i);
+            actual.append(name).append('=').append(value);
+            if (i < columnCount) {
+              actual.append("; ");
+            }
+
+            // don't re-check if already failed
+            if (!fail) {
+              // splitting string of type: key1=val1; key2=val2
+              final String keyValue = lines[processedRows].split("; ")[i - 1];
+              final String[] parts = keyValue.split("=", 2);
+              final String expectedName = parts[0];
+              final String expectedValue = parts[1];
+
+              boolean valueMatches = expectedValue.equals(value);
+
+              if (!valueMatches) {
+                // try regex
+                try {
+                  valueMatches = value != null && value.matches(expectedValue);
+                } catch (PatternSyntaxException ignore) {
+                  // probably not a regular expression
+                }
+              }
+
+              fail = !(name.equals(expectedName) && valueMatches);
+            }
+
+          }
+
+          processedRows++;
+        }
+
+        // also check that processed same number of rows
+        fail &= processedRows == lines.length;
+
+        if (fail) {
+          assertEquals(String.join("\n", Arrays.asList(lines)), actual.toString());
+          fail("Should have failed on previous line, but for some reason didn't");
+        }
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
 }
 
 // End Projection2Test.java


### PR DESCRIPTION
[CALCITE-2755](https://issues.apache.org/jira/browse/CALCITE-2755)

Allow user to query (project) [_id](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html) field explicitly.

Note that (by default) meta fields are not available for `select *` type of queries and have to be explicitly listed in projection like `select _MAP['_id'], _MAP['a'] from elastic`.

Add additional mapping between calcite expression `EXPR$n` and item name `foo.bar` (as part of `_MAP['foo.bar']`). This information is otherwise lost during query translation.

Pls check that [saving mapping](https://github.com/apache/calcite/pull/982/files#diff-f24822f58a8062386da5287cd57cae65R75) between expression and item RexCalls is the right (recommended?)  approach.