### PR TITLE
[CALCITE-2769] Handles empty and malformed csv lines, allows space before or after comma

### DIFF
--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
@@ -177,7 +177,7 @@ class CsvEnumerator<E> implements Enumerator<E> {
         if (cancelFlag.get()) {
           return false;
         }
-        final String[] strings = reader.readNext(); 
+        final String[] strings = reader.readNext();
         if (strings == null) {
           if (reader instanceof CsvStreamReader) {
             try {
@@ -201,7 +201,11 @@ class CsvEnumerator<E> implements Enumerator<E> {
             }
           }
         }
-        try { current = rowConverter.convertRow(strings); } catch(Exception e) { continue;}
+        try {
+          current = rowConverter.convertRow(strings);
+        } catch(Exception e) {
+          continue;
+        }
         return true;
       }
     } catch (IOException e) {
@@ -333,7 +337,7 @@ class CsvEnumerator<E> implements Enumerator<E> {
       this.stream = stream;
     }
 
-    public Object[] convertRow(String[] strings) {  
+    public Object[] convertRow(String[] strings) {
       if (stream) {
         return convertStreamRow(strings);
       } else {

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
@@ -177,7 +177,7 @@ class CsvEnumerator<E> implements Enumerator<E> {
         if (cancelFlag.get()) {
           return false;
         }
-        final String[] strings = reader.readNext();
+        final String[] strings = reader.readNext(); 
         if (strings == null) {
           if (reader instanceof CsvStreamReader) {
             try {
@@ -201,7 +201,7 @@ class CsvEnumerator<E> implements Enumerator<E> {
             }
           }
         }
-        current = rowConverter.convertRow(strings);
+        try { current = rowConverter.convertRow(strings); } catch(Exception e) { continue;}
         return true;
       }
     } catch (IOException e) {
@@ -237,6 +237,7 @@ class CsvEnumerator<E> implements Enumerator<E> {
     abstract E convertRow(String[] rows);
 
     protected Object convert(CsvFieldType fieldType, String string) {
+      string = string.trim();
       if (fieldType == null) {
         return string;
       }
@@ -332,7 +333,7 @@ class CsvEnumerator<E> implements Enumerator<E> {
       this.stream = stream;
     }
 
-    public Object[] convertRow(String[] strings) {
+    public Object[] convertRow(String[] strings) {  
       if (stream) {
         return convertStreamRow(strings);
       } else {

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
@@ -203,7 +203,7 @@ class CsvEnumerator<E> implements Enumerator<E> {
         }
         try {
           current = rowConverter.convertRow(strings);
-        } catch(Exception e) {
+        } catch (Exception e) {
           continue;
         }
         return true;


### PR DESCRIPTION
"Name", s-p-a-c-e 89 - was not handled well, now it works.

CSV files can have empty lines now.