### PR TITLE
[CALCITE-2593][CALCITE-2764] Planning with non-trivial composite traits (e.g. collations) might fail

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelCompositeTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelCompositeTrait.java
@@ -89,6 +89,21 @@ class RelCompositeTrait<T extends RelMultipleTrait> implements RelTrait {
   }
 
   public boolean satisfies(RelTrait trait) {
+    if (trait instanceof RelCompositeTrait) {
+      if (equals(trait)) {
+        return true;
+      }
+      //noinspection unchecked
+      RelCompositeTrait<T> other = (RelCompositeTrait<T>) trait;
+      // This trait should be the same or stricter, so this trait should satisfy each component
+      for (T t : other.traits) {
+        if (!satisfies(t)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    // This trait might be stricter, so at least one component should satisfy given trait
     for (T t : traits) {
       if (t.satisfies(trait)) {
         return true;

--- a/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
@@ -513,6 +513,10 @@ public final class RelTraitSet extends AbstractList<RelTrait> {
 
   /** Returns whether there are any composite traits in this set. */
   public boolean allSimple() {
+    if (true) {
+      // See {@link #simplify}
+      return true;
+    }
     for (RelTrait trait : traits) {
       if (trait instanceof RelCompositeTrait) {
         return false;
@@ -524,6 +528,10 @@ public final class RelTraitSet extends AbstractList<RelTrait> {
   /** Returns a trait set similar to this one but with all composite traits
    * flattened. */
   public RelTraitSet simplify() {
+    if (true) {
+      // See CALCITE-2593. Simplification of [[0, 1], [1]] to [] loses information
+      return this;
+    }
     RelTraitSet x = this;
     for (int i = 0; i < traits.length; i++) {
       final RelTrait trait = traits[i];

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -481,6 +481,22 @@ public class JdbcTest {
         .returns(expected3);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2593">[CALCITE-2593]
+   * Sometimes fails to plan when a RelNode transform multiple collations to single collation</a>.
+   */
+  @Test public void testMultipleCollationsToSingle() {
+    CalciteAssert.that()
+        .query("select y from (values (1, false), (2, true)) as t(x, y) order by y")
+        .returns("Y=false\n"
+            + "Y=true\n");
+
+    CalciteAssert.that()
+        .query("select sum(x + 1) filter (where y) as s "
+            + "from (values (1, false), (2, true)) as t(x, y)")
+        .returns("S=3\n");
+  }
+
   /** Tests a JDBC connection that provides a model that contains a table
    *  macro. */
   @Test public void testTableMacroInModel() throws Exception {


### PR DESCRIPTION
This PR validates an idea to remove `RelTraitSet#simplify`

See https://issues.apache.org/jira/browse/CALCITE-2593?focusedCommentId=16733251&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16733251