### PR TITLE
[CALCITE-2648] Make Project with OVER and LogicalWindow have empty collation

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.type.RelDataType;
@@ -92,7 +93,10 @@ public final class LogicalWindow extends Window {
    */
   public static LogicalWindow create(RelTraitSet traitSet, RelNode input,
       List<RexLiteral> constants, RelDataType rowType, List<Group> groups) {
-    return new LogicalWindow(input.getCluster(), traitSet, input, constants,
+    // See CALCITE-2648: we assume LogicalWindow keeps no collation since
+    // there might be multiple conflicting order by groups.
+    return new LogicalWindow(input.getCluster(),
+        traitSet.replace(RelCollations.EMPTY), input, constants,
         rowType, groups);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.logical.LogicalCalc;
@@ -111,7 +112,10 @@ public abstract class CalcRelSplitter {
     }
     this.program = calc.getProgram();
     this.cluster = calc.getCluster();
-    this.traits = calc.getTraitSet();
+    // Note: current implementation assumes each LogicalWindow would partition and sort rows
+    // accordingly, so we ignore input collations for now
+    // See CALCITE-2648
+    this.traits = calc.getTraitSet().replace(RelCollations.EMPTY);
     this.typeFactory = calc.getCluster().getTypeFactory();
     this.child = calc.getInput();
     this.relTypes = relTypes;

--- a/core/src/main/java/org/apache/calcite/rex/RexOver.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexOver.java
@@ -149,7 +149,7 @@ public class RexOver extends RexCall {
   /**
    * Returns whether an expression list contains an OVER clause.
    */
-  public static boolean containsOver(List<RexNode> exprs, RexNode condition) {
+  public static boolean containsOver(List<? extends RexNode> exprs, RexNode condition) {
     try {
       RexUtil.apply(FINDER, exprs, condition);
       return false;

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -79,7 +79,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import org.hamcrest.Matcher;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -439,9 +438,6 @@ public class PlannerTest {
 
   /** Tests that outer order by is not removed since window function
    * might reorder the rows in-between */
-  @Ignore("Node [rel#22:Subset#3.ENUMERABLE.[2]] could not be implemented; planner state:\n"
-      + "\n"
-      + "Root: rel#22:Subset#3.ENUMERABLE.[2]")
   @Test public void testDuplicateSortPlanWithOver() throws Exception {
     runDuplicateSortCheck("select emp_cnt, empid+deptno from ( "
         + "select empid, deptno, count(*) over (partition by deptno) emp_cnt from ( "
@@ -450,14 +446,12 @@ public class PlannerTest {
         + "   order by emps.deptno) "
         + ")"
         + "order by deptno",
-        "EnumerableProject(EXPR$0=[$0])\n"
-        + "  EnumerableSort(sort0=[$1], dir0=[ASC])\n"
-        + "    EnumerableProject(EXPR$0=[+($0, $1)], deptno=[$1])\n"
-        + "      EnumerableProject(empid=[$0], deptno=[$1], $2=[$2])\n"
-        + "        EnumerableWindow(window#0=[window(partition {1} order by [] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [COUNT()])])\n"
-        + "          EnumerableSort(sort0=[$1], dir0=[ASC])\n"
-        + "            EnumerableProject(empid=[$0], deptno=[$1])\n"
-        + "              EnumerableTableScan(table=[[hr, emps]])\n");
+        "EnumerableSort(sort0=[$2], dir0=[ASC])\n"
+        + "  EnumerableProject(emp_cnt=[$2], EXPR$1=[+($0, $1)], deptno=[$1])\n"
+        + "    EnumerableWindow(window#0=[window(partition {1} order by [] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [COUNT()])])\n"
+        + "      EnumerableSort(sort0=[$1], dir0=[ASC])\n"
+        + "        EnumerableProject(empid=[$0], deptno=[$1])\n"
+        + "          EnumerableTableScan(table=[[hr, emps]])\n");
   }
 
   @Test public void testDuplicateSortPlanWithRemovedOver() throws Exception {


### PR DESCRIPTION
This is more like a smoke test for https://issues.apache.org/jira/browse/CALCITE-2648

This commit just sets collation for LogicalWindow and ProjectWithOver to be empty as a conservative option.