### PR TITLE
[CALCITE-2301] JDBC adapter: use query timeout from the top-level statement

### DIFF
--- a/core/src/main/java/org/apache/calcite/DataContext.java
+++ b/core/src/main/java/org/apache/calcite/DataContext.java
@@ -85,6 +85,10 @@ public interface DataContext {
      * frequently and cease execution (e.g. by returning end of data). */
     CANCEL_FLAG("cancelFlag", AtomicBoolean.class),
 
+    /** Query timeout in milliseconds.
+     * When no timeout is set, the value is 0 or not present. */
+    TIMEOUT("timeout", Long.class),
+
     /** Advisor that suggests completion hints for SQL statements. */
     SQL_ADVISOR("sqlAdvisor", SqlAdvisor.class),
 

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverter.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverter.java
@@ -190,7 +190,11 @@ public class JdbcToEnumerableConverter
               sql_,
               rowBuilderFactory_));
     }
-
+    builder0.add(
+        Expressions.statement(
+            Expressions.call(enumerable,
+                BuiltInMethod.RESULT_SET_ENUMERABLE_SET_TIMEOUT.method,
+                DataContext.ROOT)));
     builder0.add(
         Expressions.return_(null, enumerable));
     return implementor.result(physType, builder0.toBlock());

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -305,6 +305,11 @@ abstract class CalciteConnectionImpl
       throw new RuntimeException(e);
     }
     map.put(DataContext.Variable.CANCEL_FLAG.camelName, cancelFlag);
+    int queryTimeout = statement.getQueryTimeout();
+    // Avoid overflow
+    if (queryTimeout > 0 && queryTimeout < Integer.MAX_VALUE / 1000) {
+      map.put(DataContext.Variable.TIMEOUT.camelName, queryTimeout * 1000L);
+    }
     final DataContext dataContext = createDataContext(map, signature.rootSchema);
     return signature.enumerable(dataContext);
   }

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -847,6 +847,9 @@ public interface CalciteResource {
   @BaseMessage("Null key of JSON object is not allowed")
   ExInst<CalciteException> nullKeyOfJsonObjectNotAllowed();
 
+  @BaseMessage("Timeout of ''{0}'' ms for query execution is reached. Query execution started at ''{1}''")
+  ExInst<CalciteException> queryExecutionTimeoutReached(String timeout, String queryStart);
+
   @BaseMessage("While executing SQL [{0}] on JDBC sub-schema")
   ExInst<RuntimeException> exceptionWhilePerformingQueryOnJdbcSubSchema(String sql);
 }

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -146,6 +146,8 @@ public enum BuiltInMethod {
   JDBC_SCHEMA_DATA_SOURCE(JdbcSchema.class, "getDataSource"),
   ROW_VALUE(Row.class, "getObject", int.class),
   ROW_AS_COPY(Row.class, "asCopy", Object[].class),
+  RESULT_SET_ENUMERABLE_SET_TIMEOUT(ResultSetEnumerable.class, "setTimeout",
+      DataContext.class),
   RESULT_SET_ENUMERABLE_OF(ResultSetEnumerable.class, "of", DataSource.class,
       String.class, Function1.class),
   RESULT_SET_ENUMERABLE_OF_PREPARED(ResultSetEnumerable.class, "of",

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -275,5 +275,6 @@ IllegalEmptyBehaviorInJsonQueryFunc=Illegal empty behavior ''{0}'' specified in 
 ArrayOrObjectValueRequiredInStrictModeOfJsonQueryFunc=Strict jsonpath mode requires array or object value, and the actual value is: ''{0}''
 IllegalErrorBehaviorInJsonQueryFunc=Illegal error behavior ''{0}'' specified in JSON_VALUE function
 NullKeyOfJsonObjectNotAllowed=Null key of JSON object is not allowed
+QueryExecutionTimeoutReached=Timeout of ''{0}'' ms for query execution is reached. Query execution started at ''{1}''
 ExceptionWhilePerformingQueryOnJdbcSubSchema = While executing SQL [{0}] on JDBC sub-schema
 # End CalciteResource.properties


### PR DESCRIPTION
This PR exposes "deadline timestamp" to Enumerable via DataContext, so JDBC adapter can leverage it instead of default 10 seconds.