### PR TITLE
Suggestion: Improvement of Autoboxing and Unboxing

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/GeoFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/GeoFunctions.java
@@ -449,7 +449,7 @@ public class GeoFunctions {
       String value = style.substring(equals + 1, space);
       switch (name) {
       case "quad_segs":
-        quadSegCount = Integer.valueOf(value);
+        quadSegCount = Integer.parseInt(value);
         break;
       case "endcap":
         endCapStyle = CapStyle.of(value);


### PR DESCRIPTION
Hi,
I have found some usage of “int a = Integer.valueOf(String)” in this project.
In fact the return type of “Integer.valueOf()” is “Integer” which is wrapper class.  Wrapper class stores in the heap rather than stack. It take more time to loopup. The other potential problem is that Java implement autoboxing and unboxing since JDK 1.5. If run this in low version JDK, it may get trouble.
Furthermore, in the above case, it need to cast Integer to int.
I recommend use “Integer.parseInt(String)” which return type is int to improve its performance.

PS:
This case also applies to “double-Doubel”, “float-Float”, “long-Long” and so on.

Detail websites and lines are listed below

51 | https://github.com/apache/calcite/blob/master/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSchemaFactory.java
-- | --
452 | https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/runtime/GeoFunctions.java
1369-1380 | https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/util/Util.java
143-148 163 165 168 | https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/util/TimestampString.java
322 | https://github.com/apache/calcite/blob/master/piglet/src/main/java/org/apache/calcite/piglet/Handler.java
164-166 179 181 184 | https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/util/TimeString.java
45 | https://github.com/apache/calcite/blob/master/geode/src/main/java/org/apache/calcite/adapter/geode/simple/GeodeSimpleSchemaFactory.java

Sorry for my lack of IDE， i can only create the PR which fix only one file from the website.

Best regards
