### PR TITLE
Improvement of String.equals("xxx")

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -64,7 +64,7 @@ public class VisitorDataContext implements DataContext {
   }
 
   public Object get(String name) {
-    if (name.equals("inputRecord")) {
+    if ("inputRecord".equals(name)) {
       return values;
     } else {
       return null;


### PR DESCRIPTION
Hi,
I have found some usage of “String.equals("xxx")” in this project.
For excmple terms[t].equals(";") ，it will get nullpointexception if terms[t] ==null.
The problem can be fixed by repalced with ";".equals(terms[t]) or Objects.equals(terms[t],";").

Detail websites and lines are listed below
67	https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
264	https://github.com/apache/calcite/blob/master/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraFilter.java
93	https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/sql/SqlPrefixOperator.java
79/83	https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/util/DateTimeStringUtils.java
75	https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/util/Sources.java
Sorry for my lack of IDE, I can only create the PR which fix only one file from the website.

Best regards