### PR TITLE
[CALCITE-2783] Fix null related issues during RexToLix translation

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -599,7 +599,6 @@ public class RexImpTable {
             + String.valueOf(call.getOperator());
         final RexCall call2 = call2(false, translator, call);
         switch (nullAs) {
-        case NOT_POSSIBLE: // Just foldAnd
         case TRUE:
           // AND call should return false iff has FALSEs,
           // thus if we convert nulls to true then no harm is made
@@ -609,6 +608,8 @@ public class RexImpTable {
           final List<Expression> expressions =
               translator.translateList(call2.getOperands(), nullAs);
           return Expressions.foldAnd(expressions);
+        case NOT_POSSIBLE:
+          // This doesn't mean that none of the arguments might be null, ex: (s and s is not null)
         case NULL:
         case IS_NULL:
         case IS_NOT_NULL:
@@ -641,7 +642,6 @@ public class RexImpTable {
             + String.valueOf(call.getOperator());
         final RexCall call2 = call2(harmonize, translator, call);
         switch (nullAs) {
-        case NOT_POSSIBLE: // Just foldOr
         case TRUE:
           // This should return false iff all arguments are FALSE,
           // thus we convert nulls to TRUE and foldOr
@@ -651,6 +651,8 @@ public class RexImpTable {
           final List<Expression> expressions =
               translator.translateList(call2.getOperands(), nullAs);
           return Expressions.foldOr(expressions);
+        case NOT_POSSIBLE:
+          // This doesn't mean that none of the arguments might be null, ex: (s or s is null)
         case NULL:
         case IS_NULL:
         case IS_NOT_NULL:
@@ -689,6 +691,10 @@ public class RexImpTable {
 
         private NullAs negate(NullAs nullAs) {
           switch (nullAs) {
+          case IS_NOT_NULL:
+            return NullAs.IS_NULL;
+          case IS_NULL:
+            return NullAs.IS_NOT_NULL;
           case FALSE:
             return NullAs.TRUE;
           case TRUE:
@@ -2535,6 +2541,11 @@ public class RexImpTable {
         RexToLixTranslator translator, RexCall call, NullAs nullAs) {
       List<RexNode> operands = call.getOperands();
       assert operands.size() == 1;
+      switch (nullAs) {
+      case IS_NOT_NULL:
+      case IS_NULL:
+        return BOXED_FALSE_EXPR;
+      }
       if (seek == null) {
         return translator.translate(operands.get(0),
             negate ? NullAs.IS_NOT_NULL : NullAs.IS_NULL);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -599,6 +599,10 @@ public class RexImpTable {
             + String.valueOf(call.getOperator());
         final RexCall call2 = call2(false, translator, call);
         switch (nullAs) {
+        case NOT_POSSIBLE:
+          // This doesn't mean that none of the arguments might be null, ex: (s and s is not null)
+          nullAs = NullAs.TRUE;
+          // fallthru
         case TRUE:
           // AND call should return false iff has FALSEs,
           // thus if we convert nulls to true then no harm is made
@@ -608,8 +612,6 @@ public class RexImpTable {
           final List<Expression> expressions =
               translator.translateList(call2.getOperands(), nullAs);
           return Expressions.foldAnd(expressions);
-        case NOT_POSSIBLE:
-          // This doesn't mean that none of the arguments might be null, ex: (s and s is not null)
         case NULL:
         case IS_NULL:
         case IS_NOT_NULL:
@@ -642,6 +644,10 @@ public class RexImpTable {
             + String.valueOf(call.getOperator());
         final RexCall call2 = call2(harmonize, translator, call);
         switch (nullAs) {
+        case NOT_POSSIBLE:
+          // This doesn't mean that none of the arguments might be null, ex: (s or s is null)
+          nullAs = NullAs.FALSE;
+          // fallthru
         case TRUE:
           // This should return false iff all arguments are FALSE,
           // thus we convert nulls to TRUE and foldOr
@@ -651,8 +657,6 @@ public class RexImpTable {
           final List<Expression> expressions =
               translator.translateList(call2.getOperands(), nullAs);
           return Expressions.foldOr(expressions);
-        case NOT_POSSIBLE:
-          // This doesn't mean that none of the arguments might be null, ex: (s or s is null)
         case NULL:
         case IS_NULL:
         case IS_NOT_NULL:

--- a/core/src/test/resources/sql/conditions.iq
+++ b/core/src/test/resources/sql/conditions.iq
@@ -283,4 +283,21 @@ select case when s=0 then false else 100/s > 0 end from ax;
 (2 rows)
 
 !ok
+
+# Test case for CALCITE-2783
+with ax(s) as (values (true),(false),(cast(null as boolean)))
+select s, (s or s is null), (s and s is not null) from ax;
+
++-------+--------+--------+
+| S     | EXPR$1 | EXPR$2 |
++-------+--------+--------+
+| false | false  | false  |
+| true  | true   | true   |
+|       | true   | false  |
++-------+--------+--------+
+(3 rows)
+
+!ok
+
+
 # End conditions.iq


### PR DESCRIPTION
Earlier, expressions like ( s or s is null ) = true have resulted in an exception.
Some other fixes to handle null translations to true/false in IS NULL/IS NOT NULL cases.