### PR TITLE
[CALCITE-2799] Allow alias in having clause for aggregate functions for MYSQL_5, LENIENT, BABEL conformance levels

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5865,9 +5865,6 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
           throw validator.newValidationError(id,
               RESOURCE.columnAmbiguous(name));
         }
-        if (havingExpr && validator.isAggregate(root)) {
-          return super.visit(id);
-        }
         expr = stripAs(expr);
         if (expr instanceof SqlIdentifier) {
           SqlIdentifier sid = (SqlIdentifier) expr;

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -301,6 +301,19 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
         .conformance(SqlConformanceEnum.LENIENT).ok();
   }
 
+  @Test public void testHavingAggregateByAliasEqualToColumnName() {
+    sql("select x+10 as x\n"
+      + "from (values(1),(2)) as t(x)\n"
+      + "group by x\n"
+      + "having max(x)>1")
+      .conformance(SqlConformanceEnum.LENIENT).ok();
+  }
+
+  @Test public void testAliasInHavingAggregate() {
+    sql("select empno as e from emp group by e having count(e) > 1")
+      .conformance(SqlConformanceEnum.LENIENT).ok();
+  }
+
   @Test public void testGroupJustOneAgg() {
     // just one agg
     final String sql =

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -6566,7 +6566,6 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         tester.withConformance(SqlConformanceEnum.LENIENT);
     final SqlTester strict =
         tester.withConformance(SqlConformanceEnum.STRICT_2003);
-
     sql("select count(empno) as e from emp having ^e^ > 10")
         .tester(strict).fails("Column 'E' not found in any table")
         .tester(lenient).sansCarets().ok();
@@ -6585,10 +6584,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select count(empno) as deptno from emp having ^deptno^ > 10")
         .tester(strict).fails("Expression 'DEPTNO' is not being grouped")
         .tester(lenient).sansCarets().ok();
-    // Alias in aggregate is not allowed.
-    sql("select empno as e from emp having max(^e^) > 10")
+    sql("select empno as e from emp group by empno having max(^e^) > 10")
         .tester(strict).fails("Column 'E' not found in any table")
-        .tester(lenient).fails("Column 'E' not found in any table");
+        .tester(lenient).sansCarets().ok();
     sql("select count(empno) as e from emp having ^e^ > 10")
         .tester(strict).fails("Column 'E' not found in any table")
         .tester(lenient).sansCarets().ok();

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -117,6 +117,34 @@ LogicalFilter(condition=[>($0, 1)])
             <![CDATA[select count(empno) as e from emp having e > 1]]>
         </Resource>
     </TestCase>
+    <TestCase name="testAliasInHavingAggregate">
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(E=[$0])
+  LogicalFilter(condition=[>($1, 1)])
+    LogicalAggregate(group=[{0}], agg#0=[COUNT()])
+      LogicalProject(E=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="sql">
+            <![CDATA[select empno as e from emp group by e having count(e) > 1]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testHavingAggregateByAliasEqualToColumnName">
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(X=[$0])
+  LogicalFilter(condition=[>($1, 1)])
+    LogicalAggregate(group=[{0}], agg#0=[MAX($0)])
+      LogicalProject(X=[+($0, 10)])
+        LogicalValues(tuples=[[{ 1 }, { 2 }]])
+]]>
+        </Resource>
+        <Resource name="sql">
+            <![CDATA[select x+10 as x from (values(1),(2)) as t(x) group by x having max(x)>1]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testAllValueList">
         <Resource name="sql">
             <![CDATA[select empno from emp where deptno > all (10, 20)]]>


### PR DESCRIPTION
Details in [CALCITE-2799](https://issues.apache.org/jira/browse/CALCITE-2799).