### PR TITLE
[CALCITE-2721] Support parsing of DOT + MEMBER_FUNCTION

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3060,7 +3060,7 @@ void Expression2b(ExprContext exprContext, List<Object> list) :
 {
     SqlNode e;
     SqlOperator op;
-    SqlIdentifier p;
+    SqlNode ext;
 }
 {
     (
@@ -3075,11 +3075,11 @@ void Expression2b(ExprContext exprContext, List<Object> list) :
     }
     (
         LOOKAHEAD(2) <DOT>
-        p = SimpleIdentifier() {
+        ext = RowExpressionExtension() {
             list.add(
                 new SqlParserUtil.ToTreeListItem(
                     SqlStdOperatorTable.DOT, getPos()));
-            list.add(p);
+            list.add(ext);
         }
     )*
 }
@@ -3434,6 +3434,54 @@ SqlNode UnsignedNumericLiteralOrParam() :
         e = DynamicParam()
     )
     { return e; }
+}
+
+/**
+ * Parses a row expression extension, it can be either an identifier,
+ * or a call to a named function.
+ */
+SqlNode RowExpressionExtension() :
+{
+    final SqlFunctionCategory funcType;
+    final SqlIdentifier p;
+    final Span s;
+    final List<SqlNode> args;
+    SqlCall call;
+    SqlNode e;
+    SqlLiteral quantifier = null;
+}
+{
+    p = SimpleIdentifier() {
+        e = p;
+    }
+    (
+        LOOKAHEAD( <LPAREN> ) { s = span(); }
+        {
+            funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+        }
+        (
+            LOOKAHEAD(2) <LPAREN> <STAR> {
+                args = startList(SqlIdentifier.star(getPos()));
+            }
+            <RPAREN>
+        |
+            LOOKAHEAD(2) <LPAREN> <RPAREN> {
+                args = Collections.emptyList();
+            }
+        |
+            args = FunctionParameterList(ExprContext.ACCEPT_SUB_QUERY) {
+                quantifier = (SqlLiteral) args.get(0);
+                args.remove(0);
+            }
+        )
+        {
+            call = createCall(p, s.end(this), funcType, quantifier, args);
+            e = call;
+        }
+    )?
+    {
+        return e;
+    }
 }
 
 /**

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1128,9 +1128,11 @@ public class SqlParserTest {
     return false;
   }
 
-  @Test public void testRowWitDot() {
+  @Test public void testRowWithDot() {
     check("select (1,2).a from c.t", "SELECT ((ROW(1, 2)).`A`)\nFROM `C`.`T`");
     check("select row(1,2).a from c.t", "SELECT ((ROW(1, 2)).`A`)\nFROM `C`.`T`");
+    check("select tbl.foo(0).col.bar from tbl",
+        "SELECT ((`TBL`.`FOO`(0).`COL`).`BAR`)\nFROM `TBL`");
   }
 
   @Test public void testPeriod() {
@@ -7524,6 +7526,24 @@ public class SqlParserTest {
     checkExpFails(
         "\"SUBSTRING\"('a' ^from^ 1)",
         "(?s).*Encountered \"from\" at .*");
+  }
+
+  /**
+   * Tests that applying member function of a specific type as a suffix function
+   */
+  @Test public void testMemberFunction() {
+    check("SELECT myColumn.func(a, b) FROM tbl",
+        "SELECT `MYCOLUMN`.`FUNC`(`A`, `B`)\n"
+            + "FROM `TBL`");
+    check("SELECT myColumn.mySubField.func() FROM tbl",
+        "SELECT `MYCOLUMN`.`MYSUBFIELD`.`FUNC`()\n"
+            + "FROM `TBL`");
+    check("SELECT tbl.myColumn.mySubField.func() FROM tbl",
+        "SELECT `TBL`.`MYCOLUMN`.`MYSUBFIELD`.`FUNC`()\n"
+            + "FROM `TBL`");
+    check("SELECT tbl.foo(0).col.bar(2, 3) FROM tbl",
+        "SELECT ((`TBL`.`FOO`(0).`COL`).`BAR`(2, 3))\n"
+            + "FROM `TBL`");
   }
 
   @Test public void testUnicodeLiteral() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1240,6 +1240,16 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     }
   }
 
+  /**
+   * Not able to parse member function yet.
+   */
+  @Test public void testInvalidMemberFunction() {
+    checkExpFails("myCol.^func()^",
+        "(?s).*No match found for function signature FUNC().*");
+    checkExpFails("myCol.mySubschema.^memberFunc()^",
+        "(?s).*No match found for function signature MEMBERFUNC().*");
+  }
+
   @Test public void testRowtype() {
     check("values (1),(2),(1)");
     checkResultType(
@@ -1267,7 +1277,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "INTEGER NOT NULL");
   }
 
-  @Test public void testRowWitValidDot() {
+  @Test public void testRowWithValidDot() {
     checkColumnType("select ((1,2),(3,4,5)).\"EXPR$1\".\"EXPR$2\"\n from dept",
         "INTEGER NOT NULL");
     checkColumnType("select row(1,2).\"EXPR$1\" from dept",


### PR DESCRIPTION
This fixes: https://issues.apache.org/jira/browse/CALCITE-2721