### PR TITLE
CALCITE-2802 Druid adapter: Usage of range conditions like "2010-01-0…

### DIFF
--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
@@ -62,8 +62,7 @@ public class DruidDateTimeUtils {
    */
   @Nullable
   public static List<Interval> createInterval(RexNode e) {
-    final List<Range<Long>> ranges =
-        extractRanges(e, false);
+    final List<Range<Long>> ranges = extractRanges(e, false);
     if (ranges == null) {
       // We did not succeed, bail out
       return null;
@@ -72,11 +71,8 @@ public class DruidDateTimeUtils {
     for (Range r : ranges) {
       condensedRanges.add(r);
     }
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Inferred ranges on interval : " + condensedRanges);
-    }
-    return toInterval(
-        ImmutableList.<Range>copyOf(condensedRanges.asRanges()));
+    LOGGER.debug("Inferred ranges on interval : {}", condensedRanges);
+    return toInterval(ImmutableList.<Range<Long>>copyOf(condensedRanges.asRanges()));
   }
 
   protected static List<Interval> toInterval(
@@ -177,16 +173,18 @@ public class DruidDateTimeUtils {
     case GREATER_THAN_OR_EQUAL:
     {
       final Long value;
+      SqlKind kind = call.getKind();
       if (call.getOperands().get(0) instanceof RexInputRef
           && literalValue(call.getOperands().get(1)) != null) {
         value = literalValue(call.getOperands().get(1));
       } else if (call.getOperands().get(1) instanceof RexInputRef
           && literalValue(call.getOperands().get(0)) != null) {
         value = literalValue(call.getOperands().get(0));
+        kind = kind.reverse();
       } else {
         return null;
       }
-      switch (call.getKind()) {
+      switch (kind) {
       case LESS_THAN:
         return ImmutableList.of(withNot ? Range.atLeast(value) : Range.lessThan(value));
       case LESS_THAN_OR_EQUAL:

--- a/druid/src/test/java/org/apache/calcite/test/DruidDateRangeRulesTest.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidDateRangeRulesTest.java
@@ -49,6 +49,15 @@ public class DruidDateRangeRulesTest {
         is("[2014-06-01T00:00:00.000Z/2014-07-01T00:00:00.000Z]"));
   }
 
+  @Test public void testRangeCalc() {
+    final Fixture2 f = new Fixture2();
+    checkDateRange(f,
+        f.and(
+            f.le(f.timestampLiteral(2011, Calendar.JANUARY, 1), f.t),
+            f.le(f.t, f.timestampLiteral(2012, Calendar.FEBRUARY, 2))),
+        is("[2011-01-01T00:00:00.000Z/2012-02-02T00:00:00.001Z]"));
+  }
+
   @Test public void testExtractYearAndDayFromDateColumn() {
     final Fixture2 f = new Fixture2();
     // AND(AND(>=($8, 2010-01-01), <($8, 2011-01-01)),
@@ -174,6 +183,14 @@ public class DruidDateRangeRulesTest {
       exDay = rexBuilder.makeCall(intRelDataType,
           SqlStdOperatorTable.EXTRACT,
           ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.DAY), ts));
+    }
+
+    public RexNode timestampLiteral(int year, int month, int day) {
+      final Calendar c = Util.calendar();
+      c.clear();
+      c.set(year, month, day);
+      final TimestampString ts = TimestampString.fromCalendarFields(c);
+      return timestampLiteral(ts);
     }
   }
 }


### PR DESCRIPTION
…1 < timestamp" leads to incorrect results