### PR TITLE
Fix sqlline by excluding redundant slf4j dependency (log4j-over-slf4j) from cassandra-all

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -78,6 +78,15 @@ limitations under the License.
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- log4j is already present in the classpath.
+           sqlline can't initialize due to NoClassDefFoundError. See CALCITE-2734
+        -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
SLF4J initialization was failing due to `NoClassDefFoundError`.

For more info see [CALCITE-2734](https://issues.apache.org/jira/browse/CALCITE-2734)