### PR TITLE
[CALCITE-2801] Check input type in AggregateUnionAggregateRule when remove the bottom Aggregate

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionAggregateRule.java
@@ -18,6 +18,7 @@ package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.RelFactories;
@@ -96,6 +97,22 @@ public class AggregateUnionAggregateRule extends RelOptRule {
 
   //~ Methods ----------------------------------------------------------------
 
+  /**
+   * Returns an input with the same row type with the input Aggregate.
+   */
+  private RelNode getInputWithSameRowType(Aggregate bottomAggRel) {
+    if (RelOptUtil.areRowTypesEqual(
+            bottomAggRel.getRowType(),
+            bottomAggRel.getInput(0).getRowType(),
+            false)) {
+      return bottomAggRel.getInput(0);
+    } else {
+      return RelOptUtil.createProject(
+          bottomAggRel.getInput(),
+          bottomAggRel.getGroupSet().asList());
+    }
+  }
+
   public void onMatch(RelOptRuleCall call) {
     final Aggregate topAggRel = call.rel(0);
     final Union union = call.rel(1);
@@ -111,11 +128,11 @@ public class AggregateUnionAggregateRule extends RelOptRule {
       // Aggregate is the second input
       bottomAggRel = call.rel(3);
       relBuilder.push(call.rel(2))
-          .push(call.rel(3).getInput(0));
+          .push(getInputWithSameRowType(bottomAggRel));
     } else if (call.rel(2) instanceof Aggregate) {
       // Aggregate is the first input
       bottomAggRel = call.rel(2);
-      relBuilder.push(call.rel(2).getInput(0))
+      relBuilder.push(getInputWithSameRowType(bottomAggRel))
           .push(call.rel(3));
     } else {
       return;

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2955,17 +2955,16 @@ public class RelOptRulesTest extends RelOptTestBase {
 
   @Test public void testPullAggregateThroughUnion() {
     HepProgram program = new HepProgramBuilder()
-        .addRuleInstance(AggregateProjectMergeRule.INSTANCE)
         .addRuleInstance(AggregateUnionAggregateRule.INSTANCE)
         .build();
 
-    final String sql = "select job, deptno from"
-        + " (select job, deptno from emp as e1"
-        + " group by job, deptno"
+    final String sql = "select deptno, job from"
+        + " (select deptno, job from emp as e1"
+        + " group by deptno,job"
         + "  union all"
-        + " select job, deptno from emp as e2"
-        + " group by job, deptno)"
-        + " group by job, deptno";
+        + " select deptno, job from emp as e2"
+        + " group by deptno,job)"
+        + " group by deptno,job";
     sql(sql).with(program).check();
   }
 
@@ -2982,6 +2981,24 @@ public class RelOptRulesTest extends RelOptTestBase {
         + " select deptno, job from emp as e2"
         + " group by deptno,job)"
         + " group by deptno,job";
+    sql(sql).with(program).check();
+  }
+
+  @Test public void testPullAggregateThroughUnionAndAddProjects() {
+    // Once the bottom aggregate pulled through union, we need to add a Project
+    // if the new input contains a different type from the union.
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(AggregateProjectMergeRule.INSTANCE)
+        .addRuleInstance(AggregateUnionAggregateRule.INSTANCE)
+        .build();
+
+    final String sql = "select job, deptno from"
+        + " (select job, deptno from emp as e1"
+        + " group by job, deptno"
+        + "  union all"
+        + " select job, deptno from emp as e2"
+        + " group by job, deptno)"
+        + " group by job, deptno";
     sql(sql).with(program).check();
   }
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2955,16 +2955,17 @@ public class RelOptRulesTest extends RelOptTestBase {
 
   @Test public void testPullAggregateThroughUnion() {
     HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(AggregateProjectMergeRule.INSTANCE)
         .addRuleInstance(AggregateUnionAggregateRule.INSTANCE)
         .build();
 
-    final String sql = "select deptno, job from"
-        + " (select deptno, job from emp as e1"
-        + " group by deptno,job"
+    final String sql = "select job, deptno from"
+        + " (select job, deptno from emp as e1"
+        + " group by job, deptno"
         + "  union all"
-        + " select deptno, job from emp as e2"
-        + " group by deptno,job)"
-        + " group by deptno,job";
+        + " select job, deptno from emp as e2"
+        + " group by job, deptno)"
+        + " group by job, deptno";
     sql(sql).with(program).check();
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5401,10 +5401,10 @@ LogicalProject(X=[$0], EXPR$1=[$2], Y=[$1])
 LogicalAggregate(group=[{0, 1}])
   LogicalUnion(all=[true])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalProject(JOB=[$2], DEPTNO=[$7])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalProject(JOB=[$2], DEPTNO=[$7])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -5412,9 +5412,9 @@ LogicalAggregate(group=[{0, 1}])
             <![CDATA[
 LogicalAggregate(group=[{0, 1}])
   LogicalUnion(all=[true])
-    LogicalProject(DEPTNO=[$7], JOB=[$2])
+    LogicalProject(JOB=[$2], DEPTNO=[$7])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalProject(DEPTNO=[$7], JOB=[$2])
+    LogicalProject(JOB=[$2], DEPTNO=[$7])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5401,10 +5401,10 @@ LogicalProject(X=[$0], EXPR$1=[$2], Y=[$1])
 LogicalAggregate(group=[{0, 1}])
   LogicalUnion(all=[true])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject(JOB=[$2], DEPTNO=[$7])
+      LogicalProject(DEPTNO=[$7], JOB=[$2])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject(JOB=[$2], DEPTNO=[$7])
+      LogicalProject(DEPTNO=[$7], JOB=[$2])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -5412,9 +5412,9 @@ LogicalAggregate(group=[{0, 1}])
             <![CDATA[
 LogicalAggregate(group=[{0, 1}])
   LogicalUnion(all=[true])
-    LogicalProject(JOB=[$2], DEPTNO=[$7])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalProject(JOB=[$2], DEPTNO=[$7])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -5442,6 +5442,33 @@ LogicalAggregate(group=[{0, 1}])
     LogicalProject(DEPTNO=[$7], JOB=[$2])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testPullAggregateThroughUnionAndAddProjects">
+        <Resource name="sql">
+            <![CDATA[select job, deptno from (select job, deptno from emp as e1 group by job, deptno  union all select job, deptno from emp as e2 group by job, deptno) group by job, deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0, 1}])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0, 1}])
+      LogicalProject(JOB=[$2], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}])
+      LogicalProject(JOB=[$2], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{0, 1}])
+  LogicalUnion(all=[true])
+    LogicalProject(JOB=[$2], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(JOB=[$2], DEPTNO=[$7])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>


### PR DESCRIPTION
In `AggregateUnionAggregateRule`, we may remove the bottom Aggregate and use it's input as the new input of Union directly. However, the bottom Aggregate and it's input may not share the same row type. As Union requires all inputs with the same row type, once we remove the bottom Aggregate, an exception will be thrown.

This pull request checks the input types in `AggregateUnionAggregateRule` and adds a `Project` when the removed bottom aggregate contains a different row type with its input.