### PR TITLE
Ensure RelOptRule always has at least one trait. Pick implicit ones from the first operand, then from rule.relBuilderFactory

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Apache Calcite release 1.17.0
+Apache Calcite release 1.18.0
 
 This is a source or binary distribution of Apache Calcite.
 

--- a/babel/pom.xml
+++ b/babel/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-babel</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Babel</name>
   <description>Calcite Babel</description>
 

--- a/babel/pom.xml
+++ b/babel/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-babel</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Babel</name>
   <description>Calcite Babel</description>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-cassandra</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Cassandra</name>
   <description>Cassandra adapter for Calcite</description>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-cassandra</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Cassandra</name>
   <description>Cassandra adapter for Calcite</description>
 

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.adapter.cassandra;
 
 import org.apache.calcite.adapter.enumerable.EnumerableLimit;
+import org.apache.calcite.adapter.enumerable.EnumerableSort;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptRule;
@@ -272,7 +273,7 @@ public class CassandraRules {
 
     private CassandraSortRule() {
       super(
-          operandJ(Sort.class, null,
+          operandJ(EnumerableSort.class, null,
               // Limits are handled by CassandraLimit
               sort -> sort.offset == null && sort.fetch == null, CASSANDRA_OP),
           "CassandraSortRule");

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
@@ -143,7 +143,7 @@ public class EnumerableCalc extends Calc implements EnumerableRel {
             inputJavaType);
 
     final RexBuilder rexBuilder = getCluster().getRexBuilder();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = getCluster().getMetadataQuery();
     final RelOptPredicateList predicates = mq.getPulledUpPredicates(child);
     final RexSimplify simplify =
         new RexSimplify(rexBuilder, predicates, RexUtil.EXECUTOR);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRel.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRel.java
@@ -17,16 +17,28 @@
 package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.linq4j.tree.BlockStatement;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ImplicitTrait;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.RelFactories;
+
+import java.util.function.Supplier;
 
 /**
  * A relational expression of one of the
  * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention} calling
  * conventions.
  */
+@ImplicitTrait(EnumerableRel.ConventionFactory.class)
 public interface EnumerableRel
     extends RelNode {
+  /** Returns EnumerableConvention.INSTANCE. © Captain Obvious */
+  class ConventionFactory implements Supplier<Convention> {
+    @Override public Convention get() {
+      return EnumerableConvention.INSTANCE;
+    }
+  }
+
   RelFactories.FilterFactory FILTER_FACTORY = EnumerableFilter::create;
 
   RelFactories.ProjectFactory PROJECT_FACTORY = EnumerableProject::create;

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRules.java
@@ -17,7 +17,10 @@
 package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.trace.CalciteTrace;
 
 import org.slf4j.Logger;
@@ -31,6 +34,13 @@ public class EnumerableRules {
 
   public static final boolean BRIDGE_METHODS = true;
 
+  public static final RelBuilderFactory REL_BUILDER_FACTORY =
+      RelBuilder.proto(
+          RelTraitSet.createEmpty().plus(EnumerableConvention.INSTANCE),
+          (RelFactories.FilterFactory) EnumerableFilter::create,
+          (RelFactories.ProjectFactory) EnumerableProject::create
+      );
+
   public static final RelOptRule ENUMERABLE_JOIN_RULE =
       new EnumerableJoinRule();
 
@@ -41,7 +51,7 @@ public class EnumerableRules {
       new EnumerableSemiJoinRule();
 
   public static final RelOptRule ENUMERABLE_CORRELATE_RULE =
-      new EnumerableCorrelateRule(RelFactories.LOGICAL_BUILDER);
+      new EnumerableCorrelateRule(REL_BUILDER_FACTORY);
 
   private EnumerableRules() {
   }
@@ -74,10 +84,10 @@ public class EnumerableRules {
       new EnumerableMinusRule();
 
   public static final EnumerableTableModifyRule ENUMERABLE_TABLE_MODIFICATION_RULE =
-      new EnumerableTableModifyRule(RelFactories.LOGICAL_BUILDER);
+      new EnumerableTableModifyRule(REL_BUILDER_FACTORY);
 
   public static final EnumerableValuesRule ENUMERABLE_VALUES_RULE =
-      new EnumerableValuesRule(RelFactories.LOGICAL_BUILDER);
+      new EnumerableValuesRule(REL_BUILDER_FACTORY);
 
   public static final EnumerableWindowRule ENUMERABLE_WINDOW_RULE =
       new EnumerableWindowRule();
@@ -89,16 +99,16 @@ public class EnumerableRules {
       new EnumerableUncollectRule();
 
   public static final EnumerableFilterToCalcRule ENUMERABLE_FILTER_TO_CALC_RULE =
-      new EnumerableFilterToCalcRule(RelFactories.LOGICAL_BUILDER);
+      new EnumerableFilterToCalcRule(REL_BUILDER_FACTORY);
 
   public static final EnumerableProjectToCalcRule ENUMERABLE_PROJECT_TO_CALC_RULE =
-      new EnumerableProjectToCalcRule(RelFactories.LOGICAL_BUILDER);
+      new EnumerableProjectToCalcRule(REL_BUILDER_FACTORY);
 
   public static final EnumerableTableScanRule ENUMERABLE_TABLE_SCAN_RULE =
-      new EnumerableTableScanRule(RelFactories.LOGICAL_BUILDER);
+      new EnumerableTableScanRule(REL_BUILDER_FACTORY);
 
   public static final EnumerableTableFunctionScanRule ENUMERABLE_TABLE_FUNCTION_SCAN_RULE =
-      new EnumerableTableFunctionScanRule(RelFactories.LOGICAL_BUILDER);
+      new EnumerableTableFunctionScanRule(REL_BUILDER_FACTORY);
 }
 
 // End EnumerableRules.java

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -63,6 +63,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.FilterableTable;
 import org.apache.calcite.schema.ProjectableFilterableTable;
 import org.apache.calcite.schema.ScannableTable;
@@ -147,7 +148,9 @@ public class Bindables {
      * @param relBuilderFactory Builder for relational expressions
      */
     public BindableTableScanRule(RelBuilderFactory relBuilderFactory) {
-      super(operand(LogicalTableScan.class, none()), relBuilderFactory, null);
+      super(
+          operandJ(LogicalTableScan.class, null,
+              x -> Hook.ENABLE_BINDABLE.get(false), none()), relBuilderFactory, null);
     }
 
     @Override public void onMatch(RelOptRuleCall call) {

--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -248,7 +248,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
 
   @SuppressWarnings("deprecation")
   public RelOptCost getCost(RelNode rel) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     return getCost(rel, mq);
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/ImplicitTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/ImplicitTrait.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.Supplier;
+
+/**
+ * Enables to declare that annotated {@link org.apache.calcite.rel.RelNode} (or its interface)
+ * would always have given trait.
+ * For instance, {@link org.apache.calcite.adapter.enumerable.EnumerableRel} specifies
+ * {@code EnumerableConvention.INSTANCE}, which means each class that implements
+ * {@link org.apache.calcite.adapter.enumerable.EnumerableRel} should have {@code ENUMERABLE}
+ * convention.
+ */
+@Repeatable(value = ImplicitTraits.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ImplicitTrait {
+  Class<? extends Supplier<? extends RelTrait>> value();
+}
+
+// End ImplicitTrait.java

--- a/core/src/main/java/org/apache/calcite/plan/ImplicitTraits.java
+++ b/core/src/main/java/org/apache/calcite/plan/ImplicitTraits.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Enables to have multiple {@link ImplicitTrait} annotations for a single type.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ImplicitTraits {
+  ImplicitTrait[] value();
+}
+
+// End ImplicitTraits.java

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.metadata.CachingRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexExecutor;
+import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.CancelFlag;
 import org.apache.calcite.util.trace.CalciteTrace;
 
@@ -317,6 +318,13 @@ public interface RelOptPlanner {
    * @param node Relational expression
    */
   void registerClass(RelNode node);
+
+  /**
+   * Returns implicit traits for the rule. Implicit traits come from matching class
+   * (or its superclass or its interfaces) via {@link ImplicitTrait} annotation, then
+   * from {@link RelBuilderFactory#getImplicitTraits()}.
+   */
+  RelTraitSet getImplicitTraits(RelOptRule rule);
 
   /**
    * Creates an empty trait set. It contains all registered traits, and the

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -65,6 +65,8 @@ public abstract class RelOptRule {
    */
   public final List<RelOptRuleOperand> operands;
 
+  private boolean hasImplicitTraits;
+
   //~ Constructors -----------------------------------------------------------
 
   /**
@@ -106,7 +108,18 @@ public abstract class RelOptRule {
     }
     this.description = description;
     this.operands = flattenOperands(operand);
+    // When root operand have explicit trait, we assume it is good enough
+    // Otherwise the rule will try to deduce implicit traits from matching class and relbuilder
+    this.hasImplicitTraits = operand.getMatchedTrait() == null;
     assignSolveOrder();
+  }
+
+  public void matchAnyTraitSet() {
+    hasImplicitTraits = false;
+  }
+
+  public boolean hasImplicitTraits() {
+    return hasImplicitTraits;
   }
 
   //~ Methods for creating operands ------------------------------------------

--- a/core/src/main/java/org/apache/calcite/plan/RelOptTable.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptTable.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Wrapper;
 import org.apache.calcite.util.ImmutableBitSet;
 
@@ -125,7 +126,7 @@ public interface RelOptTable extends Wrapper {
   List<ColumnStrategy> getColumnStrategies();
 
   /** Can expand a view into relational expressions. */
-  interface ViewExpander {
+  @FunctionalInterface interface ViewExpander {
     /**
      * Returns a relational expression that is to be substituted for an access
      * to a SQL view.
@@ -138,6 +139,21 @@ public interface RelOptTable extends Wrapper {
      */
     RelRoot expandView(RelDataType rowType, String queryString,
         List<String> schemaPath, List<String> viewPath);
+
+    /**
+     * Returns a relational expression which is to be substituted for an access
+     * to a SQL view.
+     *
+     * @param rowType Row type of the view
+     * @param queryString Body of the view
+     * @param rootSchema Root schema of the schema tree
+     * @param schemaPath List of schema names wherein to find referenced tables
+     * @return Relational expression
+     */
+    default RelRoot expandView(RelDataType rowType, String queryString,
+        SchemaPlus rootSchema, List<String> schemaPath) {
+      throw new UnsupportedOperationException("cannot expand view");
+    }
   }
 
   /** Contains the context needed to convert a a table into a relational

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -201,7 +201,7 @@ public abstract class RelOptUtil {
    */
   public static List<RelOptTable> findAllTables(RelNode rel) {
     final Multimap<Class<? extends RelNode>, RelNode> nodes =
-        RelMetadataQuery.instance().getNodeTypes(rel);
+        rel.getCluster().getMetadataQuery().getNodeTypes(rel);
     final List<RelOptTable> usedTables = new ArrayList<>();
     for (Entry<Class<? extends RelNode>, Collection<RelNode>> e : nodes.asMap().entrySet()) {
       if (TableScan.class.isAssignableFrom(e.getKey())) {

--- a/core/src/main/java/org/apache/calcite/plan/ViewExpanders.java
+++ b/core/src/main/java/org/apache/calcite/plan/ViewExpanders.java
@@ -18,6 +18,7 @@ package org.apache.calcite.plan;
 
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.schema.SchemaPlus;
 
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -45,6 +46,12 @@ public abstract class ViewExpanders {
           List<String> schemaPath, List<String> viewPath) {
         return viewExpander.expandView(rowType, queryString, schemaPath,
             viewPath);
+      }
+
+      public RelRoot expandView(RelDataType rowType, String queryString,
+                                SchemaPlus rootSchema, List<String> schemaPath) {
+        return viewExpander.expandView(rowType, queryString,
+            rootSchema, schemaPath);
       }
     };
   }

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -143,6 +143,20 @@ public class HepPlanner extends AbstractRelOptPlanner {
       RelOptCostFactory costFactory) {
     super(costFactory, context);
     this.mainProgram = program;
+    for (HepInstruction instruction : program.instructions) {
+      if (instruction instanceof HepInstruction.RuleInstance) {
+        HepInstruction.RuleInstance ruleInstance = (HepInstruction.RuleInstance) instruction;
+        RelOptRule rule = ruleInstance.rule;
+        // null is possible for #addRuleByDescription
+        if (rule != null) {
+          verifyRule(rule);
+        }
+      } else if (instruction instanceof HepInstruction.RuleCollection) {
+        for (RelOptRule rule : ((HepInstruction.RuleCollection) instruction).rules) {
+          verifyRule(rule);
+        }
+      }
+    }
     this.onCopyHook = Util.first(onCopyHook, Functions.ignore2());
     this.noDag = noDag;
   }

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -61,6 +61,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.calcite.rel.metadata.RelMdUtil.clearCache;
+
 /**
  * HepPlanner is a heuristic implementation of the {@link RelOptPlanner}
  * interface.
@@ -866,6 +868,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
         }
         parentRel.replaceInput(i, preservedVertex);
       }
+      clearCache(parentRel);
       graph.removeEdge(parent, discardedVertex);
       graph.addEdge(parent, preservedVertex);
       updateVertex(parent, parentRel);
@@ -927,8 +930,9 @@ public class HepPlanner extends AbstractRelOptPlanner {
       }
       child = buildFinalPlan((HepRelVertex) child);
       rel.replaceInput(i, child);
-      rel.recomputeDigest();
     }
+    clearCache(rel);
+    rel.recomputeDigest();
 
     return rel;
   }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/AbstractConverter.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/AbstractConverter.java
@@ -111,6 +111,7 @@ public class AbstractConverter extends ConverterImpl {
      */
     public ExpandConversionRule(RelBuilderFactory relBuilderFactory) {
       super(operand(AbstractConverter.class, any()), relBuilderFactory, null);
+      matchAnyTraitSet();
     }
 
     public void onMatch(RelOptRuleCall call) {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -92,6 +92,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.calcite.rel.metadata.RelMdUtil.clearCache;
+
 /**
  * VolcanoPlanner optimizes queries by transforming expressions selectively
  * according to a dynamic programming algorithm.
@@ -1363,6 +1365,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
         }
       }
     }
+    clearCache(rel);
     return changeCount > 0;
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -209,7 +209,12 @@ public class VolcanoRuleCall extends RelOptRuleCall {
         this.generatedRelList = new ArrayList<>();
       }
 
-      getRule().onMatch(this);
+      volcanoPlanner.ruleCallStack.push(this);
+      try {
+        getRule().onMatch(this);
+      } finally {
+        volcanoPlanner.ruleCallStack.pop();
+      }
 
       if (LOGGER.isDebugEnabled()) {
         if (generatedRelList.isEmpty()) {

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteMaterializer.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteMaterializer.java
@@ -20,8 +20,8 @@ import org.apache.calcite.adapter.enumerable.EnumerableRel;
 import org.apache.calcite.interpreter.BindableConvention;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptMaterialization;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
@@ -61,10 +61,10 @@ class CalciteMaterializer extends CalcitePrepareImpl.CalcitePreparingStmt {
   CalciteMaterializer(CalcitePrepareImpl prepare,
       CalcitePrepare.Context context,
       CatalogReader catalogReader, CalciteSchema schema,
-      RelOptPlanner planner, SqlRexConvertletTable convertletTable) {
+      SqlRexConvertletTable convertletTable, RelOptCluster cluster) {
     super(prepare, context, catalogReader, catalogReader.getTypeFactory(),
-        schema, EnumerableRel.Prefer.ANY, planner, BindableConvention.INSTANCE,
-        convertletTable);
+        schema, EnumerableRel.Prefer.ANY, BindableConvention.INSTANCE,
+        convertletTable, cluster);
   }
 
   /** Populates a materialization record, converting a table path

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -314,8 +314,8 @@ public class CalcitePrepareImpl implements CalcitePrepare {
 
     final CalcitePreparingStmt preparingStmt =
         new CalcitePreparingStmt(this, context, catalogReader, typeFactory,
-            context.getRootSchema(), null, planner, resultConvention,
-            createConvertletTable());
+            context.getRootSchema(), null, resultConvention, createConvertletTable(),
+            createCluster(planner, new RexBuilder(typeFactory)));
     final SqlToRelConverter converter =
         preparingStmt.getSqlToRelConverter(validator, catalogReader,
             configBuilder.build());
@@ -722,8 +722,8 @@ public class CalcitePrepareImpl implements CalcitePrepare {
             : EnumerableConvention.INSTANCE;
     final CalcitePreparingStmt preparingStmt =
         new CalcitePreparingStmt(this, context, catalogReader, typeFactory,
-            context.getRootSchema(), prefer, planner, resultConvention,
-            createConvertletTable());
+            context.getRootSchema(), prefer, resultConvention, createConvertletTable(),
+            createCluster(planner, new RexBuilder(typeFactory)));
 
     final RelDataType x;
     final Prepare.PreparedResult preparedResult;
@@ -989,7 +989,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
   }
 
   protected void populateMaterializations(Context context,
-      RelOptPlanner planner, Prepare.Materialization materialization) {
+      Prepare.Materialization materialization, RelOptCluster cluster) {
     // REVIEW: initialize queryRel and tableRel inside MaterializationService,
     // not here?
     try {
@@ -1001,8 +1001,8 @@ public class CalcitePrepareImpl implements CalcitePrepare {
               context.getTypeFactory(),
               context.config());
       final CalciteMaterializer materializer =
-          new CalciteMaterializer(this, context, catalogReader, schema, planner,
-              createConvertletTable());
+          new CalciteMaterializer(this, context, catalogReader, schema,
+              createConvertletTable(), cluster);
       materializer.populate(materialization);
     } catch (Exception e) {
       throw new RuntimeException("While populating materialization "
@@ -1054,6 +1054,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     protected final RelDataTypeFactory typeFactory;
     protected final SqlRexConvertletTable convertletTable;
     private final EnumerableRel.Prefer prefer;
+    private final RelOptCluster cluster;
     private final Map<String, Object> internalParameters =
         new LinkedHashMap<>();
     private int expansionDepth;
@@ -1065,17 +1066,18 @@ public class CalcitePrepareImpl implements CalcitePrepare {
         RelDataTypeFactory typeFactory,
         CalciteSchema schema,
         EnumerableRel.Prefer prefer,
-        RelOptPlanner planner,
         Convention resultConvention,
-        SqlRexConvertletTable convertletTable) {
+        SqlRexConvertletTable convertletTable,
+        RelOptCluster cluster) {
       super(context, catalogReader, resultConvention);
       this.prepare = prepare;
       this.schema = schema;
       this.prefer = prefer;
-      this.planner = planner;
+      this.cluster = cluster;
+      this.planner = cluster.getPlanner();
+      this.rexBuilder = cluster.getRexBuilder();
       this.typeFactory = typeFactory;
       this.convertletTable = convertletTable;
-      this.rexBuilder = new RexBuilder(typeFactory);
     }
 
     @Override protected void init(Class runtimeContextClass) {
@@ -1144,7 +1146,6 @@ public class CalcitePrepareImpl implements CalcitePrepare {
         SqlValidator validator,
         CatalogReader catalogReader,
         SqlToRelConverter.Config config) {
-      final RelOptCluster cluster = prepare.createCluster(planner, rexBuilder);
       return new SqlToRelConverter(this, validator, catalogReader, cluster,
           convertletTable, config);
     }
@@ -1280,7 +1281,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
               ? MaterializationService.instance().query(schema)
               : ImmutableList.of();
       for (Prepare.Materialization materialization : materializations) {
-        prepare.populateMaterializations(context, planner, materialization);
+        prepare.populateMaterializations(context, materialization, cluster);
       }
       return materializations;
     }

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -47,7 +47,6 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
 import org.apache.calcite.tools.Program;
-import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.calcite.util.Pair;
@@ -235,10 +234,8 @@ public class PlannerImpl implements Planner, ViewExpander {
     root =
         sqlToRelConverter.convertQuery(validatedSqlNode, false, true);
     root = root.withRel(sqlToRelConverter.flattenTypes(root.rel, true));
-    final RelBuilder relBuilder =
-        config.getRelBuilderFactory().create(cluster, null);
     root = root.withRel(
-        RelDecorrelator.decorrelateQuery(root.rel, relBuilder));
+        RelDecorrelator.decorrelateQuery(root.rel, config.getRelBuilderFactory()));
     state = State.STATE_5_CONVERTED;
     return root;
   }
@@ -310,10 +307,8 @@ public class PlannerImpl implements Planner, ViewExpander {
         sqlToRelConverter.convertQuery(sqlNode, true, false);
     final RelRoot root2 =
         root.withRel(sqlToRelConverter.flattenTypes(root.rel, true));
-    final RelBuilder relBuilder =
-        config.getRelBuilderFactory().create(cluster, null);
     return root2.withRel(
-        RelDecorrelator.decorrelateQuery(root.rel, relBuilder));
+        RelDecorrelator.decorrelateQuery(root.rel, config.getRelBuilderFactory()));
   }
 
   // CalciteCatalogReader is stateless; no need to store one

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -58,6 +58,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.Reader;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 /** Implementation of {@link org.apache.calcite.tools.Planner}. */
 public class PlannerImpl implements Planner, ViewExpander {
@@ -179,7 +180,7 @@ public class PlannerImpl implements Planner, ViewExpander {
   public SqlNode validate(SqlNode sqlNode) throws ValidationException {
     ensure(State.STATE_3_PARSED);
     final SqlConformance conformance = conformance();
-    final CalciteCatalogReader catalogReader = createCatalogReader();
+    final CalciteCatalogReader catalogReader = createCatalogReader(rootSchema(defaultSchema));
     this.validator =
         new CalciteSqlValidator(operatorTable, catalogReader, typeFactory,
             conformance);
@@ -230,7 +231,7 @@ public class PlannerImpl implements Planner, ViewExpander {
         .build();
     final SqlToRelConverter sqlToRelConverter =
         new SqlToRelConverter(this, validator,
-            createCatalogReader(), cluster, convertletTable, config);
+            createCatalogReader(rootSchema(defaultSchema)), cluster, convertletTable, config);
     root =
         sqlToRelConverter.convertQuery(validatedSqlNode, false, true);
     root = root.withRel(sqlToRelConverter.flattenTypes(root.rel, true));
@@ -254,10 +255,27 @@ public class PlannerImpl implements Planner, ViewExpander {
       return PlannerImpl.this.expandView(rowType, queryString, schemaPath,
           viewPath);
     }
+
+    public RelRoot expandView(RelDataType rowType, String queryString,
+                              SchemaPlus rootSchema, List<String> schemaPath) {
+      return PlannerImpl.this.expandView(rowType, queryString, rootSchema, schemaPath);
+    }
   }
 
   @Override public RelRoot expandView(RelDataType rowType, String queryString,
-      List<String> schemaPath, List<String> viewPath) {
+                                      List<String> schemaPath, List<String> viewPath) {
+    return expandView(queryString,
+        () -> createCatalogReader(rootSchema(defaultSchema)).withSchemaPath(schemaPath));
+  }
+
+  @Override public RelRoot expandView(RelDataType rowType, String queryString,
+                                      SchemaPlus rootSchema, List<String> schemaPath) {
+    return expandView(queryString,
+        () -> createCatalogReader(rootSchema).withSchemaPath(schemaPath));
+  }
+
+  private RelRoot expandView(String queryString,
+                             Supplier<CalciteCatalogReader> catalogReaderFactory) {
     if (planner == null) {
       ready();
     }
@@ -270,8 +288,7 @@ public class PlannerImpl implements Planner, ViewExpander {
     }
 
     final SqlConformance conformance = conformance();
-    final CalciteCatalogReader catalogReader =
-        createCatalogReader().withSchemaPath(schemaPath);
+    final CalciteCatalogReader catalogReader = catalogReaderFactory.get();
     final SqlValidator validator =
         new CalciteSqlValidator(operatorTable, catalogReader, typeFactory,
             conformance);
@@ -300,8 +317,7 @@ public class PlannerImpl implements Planner, ViewExpander {
   }
 
   // CalciteCatalogReader is stateless; no need to store one
-  private CalciteCatalogReader createCatalogReader() {
-    final SchemaPlus rootSchema = rootSchema(defaultSchema);
+  private CalciteCatalogReader createCatalogReader(SchemaPlus rootSchema) {
     final Context context = config.getContext();
     final CalciteConnectionConfig connectionConfig;
 

--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.prepare;
 
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.materialize.Lattice;
@@ -35,7 +34,6 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.rel.type.RelRecordType;
-import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.schema.FilterableTable;
 import org.apache.calcite.schema.ModifiableTable;
@@ -268,22 +266,7 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
       return ((TranslatableTable) table).toRel(context, this);
     }
     final RelOptCluster cluster = context.getCluster();
-    if (Hook.ENABLE_BINDABLE.get(false)) {
-      return LogicalTableScan.create(cluster, this);
-    }
-    if (CalcitePrepareImpl.ENABLE_ENUMERABLE
-        && table instanceof QueryableTable) {
-      return EnumerableTableScan.create(cluster, this);
-    }
-    if (table instanceof ScannableTable
-        || table instanceof FilterableTable
-        || table instanceof ProjectableFilterableTable) {
-      return LogicalTableScan.create(cluster, this);
-    }
-    if (CalcitePrepareImpl.ENABLE_ENUMERABLE) {
-      return EnumerableTableScan.create(cluster, this);
-    }
-    throw new AssertionError();
+    return LogicalTableScan.create(cluster, this);
   }
 
   public List<RelCollation> getCollationList() {

--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -161,13 +161,13 @@ public abstract class AbstractRelNode implements RelNode {
 
   @SuppressWarnings("deprecation")
   public boolean isDistinct() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getMetadataQuery();
     return Boolean.TRUE.equals(mq.areRowsUnique(this));
   }
 
   @SuppressWarnings("deprecation")
   public boolean isKey(ImmutableBitSet columns) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = cluster.getMetadataQuery();
     return Boolean.TRUE.equals(mq.areColumnsUnique(this, columns));
   }
 
@@ -241,7 +241,7 @@ public abstract class AbstractRelNode implements RelNode {
 
   @SuppressWarnings("deprecation")
   public final double getRows() {
-    return estimateRowCount(RelMetadataQuery.instance());
+    return estimateRowCount(cluster.getMetadataQuery());
   }
 
   public double estimateRowCount(RelMetadataQuery mq) {
@@ -283,7 +283,7 @@ public abstract class AbstractRelNode implements RelNode {
 
   @SuppressWarnings("deprecation")
   public final RelOptCost computeSelfCost(RelOptPlanner planner) {
-    return computeSelfCost(planner, RelMetadataQuery.instance());
+    return computeSelfCost(planner, cluster.getMetadataQuery());
   }
 
   public RelOptCost computeSelfCost(RelOptPlanner planner,

--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -25,6 +25,7 @@ import org.apache.calcite.plan.RelOptQuery;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.externalize.RelWriterImpl;
@@ -178,6 +179,20 @@ public abstract class AbstractRelNode implements RelNode {
   public RelNode getInput(int i) {
     List<RelNode> inputs = getInputs();
     return inputs.get(i);
+  }
+
+  public boolean inputsSatisfy(RelTrait trait, Litmus litmus) {
+    RelTraitDef traitDef = trait.getTraitDef();
+    List<RelNode> inputs = getInputs();
+    for (int i = 0; i < inputs.size(); i++) {
+      RelNode input = inputs.get(i);
+      RelTrait inputTrait = input.getTraitSet().getTrait(traitDef);
+      if (inputTrait != null && !inputTrait.satisfies(trait)) {
+        litmus.fail("Input #{} {} of {} does not satisfy required trait {}", i, input, this, trait);
+        return false;
+      }
+    }
+    return true;
   }
 
   @SuppressWarnings("deprecation")

--- a/core/src/main/java/org/apache/calcite/rel/RelCollations.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollations.java
@@ -65,7 +65,8 @@ public class RelCollations {
 
   public static RelCollation of(List<RelFieldCollation> fieldCollations) {
     if (Util.isDistinct(ordinals(fieldCollations))) {
-      return new RelCollationImpl(ImmutableList.copyOf(fieldCollations));
+      return RelCollationTraitDef.INSTANCE.canonize(
+          new RelCollationImpl(ImmutableList.copyOf(fieldCollations)));
     }
     // Remove field collations whose field has already been seen
     final ImmutableList.Builder<RelFieldCollation> builder =
@@ -76,7 +77,8 @@ public class RelCollations {
         builder.add(fieldCollation);
       }
     }
-    return new RelCollationImpl(builder.build());
+    return RelCollationTraitDef.INSTANCE.canonize(
+        new RelCollationImpl(builder.build()));
   }
 
   /**
@@ -186,7 +188,7 @@ public class RelCollations {
     for (RelFieldCollation fc : collation.getFieldCollations()) {
       fieldCollations.add(fc.shift(offset));
     }
-    return new RelCollationImpl(fieldCollations.build());
+    return RelCollationTraitDef.INSTANCE.canonize(new RelCollationImpl(fieldCollations.build()));
   }
 
   /** Creates a copy of this collation that changes the ordinals of input

--- a/core/src/main/java/org/apache/calcite/rel/core/Filter.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Filter.java
@@ -138,13 +138,13 @@ public abstract class Filter extends SingleRel {
 
   @Deprecated // to be removed before 2.0
   public static double estimateFilteredRows(RelNode child, RexProgram program) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = child.getCluster().getMetadataQuery();
     return RelMdUtil.estimateFilteredRows(child, program, mq);
   }
 
   @Deprecated // to be removed before 2.0
   public static double estimateFilteredRows(RelNode child, RexNode condition) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = child.getCluster().getMetadataQuery();
     return RelMdUtil.estimateFilteredRows(child, condition, mq);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -189,7 +189,7 @@ public abstract class Join extends BiRel {
   public static double estimateJoinedRows(
       Join joinRel,
       RexNode condition) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = joinRel.getCluster().getMetadataQuery();
     return Util.first(RelMdUtil.getJoinRowCount(mq, joinRel, condition), 1D);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.core;
 
 import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
@@ -103,7 +104,9 @@ public class RelFactories {
    * create logical relational expressions for everything. */
   public static final RelBuilderFactory LOGICAL_BUILDER =
       RelBuilder.proto(
-          Contexts.of(DEFAULT_PROJECT_FACTORY,
+          Contexts.of(
+              RelTraitSet.createEmpty().plus(Convention.NONE),
+              DEFAULT_PROJECT_FACTORY,
               DEFAULT_FILTER_FACTORY,
               DEFAULT_JOIN_FACTORY,
               DEFAULT_SEMI_JOIN_FACTORY,

--- a/core/src/main/java/org/apache/calcite/rel/core/Union.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Union.java
@@ -62,7 +62,7 @@ public abstract class Union extends SetOp {
 
   @Deprecated // to be removed before 2.0
   public static double estimateRowCount(RelNode rel) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     return RelMdUtil.getUnionAllRowCount(mq, (Union) rel);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
@@ -40,7 +40,7 @@ import java.util.List;
  * <li>{@link org.apache.calcite.rel.rules.AggregateReduceFunctionsRule}.
  * </ul>
  */
-public final class LogicalAggregate extends Aggregate {
+public final class LogicalAggregate extends Aggregate implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Litmus;
 
 import java.util.List;
 
@@ -63,6 +64,7 @@ public final class LogicalAggregate extends Aggregate implements LogicalRel {
       List<ImmutableBitSet> groupSets,
       List<AggregateCall> aggCalls) {
     super(cluster, traitSet, child, indicator, groupSet, groupSets, aggCalls);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
@@ -60,7 +60,7 @@ import java.util.Set;
  *     merges two {@code LogicalCalc}s
  * </ul>
  */
-public final class LogicalCalc extends Calc {
+public final class LogicalCalc extends Calc implements LogicalRel {
   //~ Static fields/initializers ---------------------------------------------
 
   //~ Constructors -----------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rel.rules.FilterToCalcRule;
 import org.apache.calcite.rel.rules.ProjectToCalcRule;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 
 import java.util.List;
@@ -72,6 +73,7 @@ public final class LogicalCalc extends Calc implements LogicalRel {
       RelNode child,
       RexProgram program) {
     super(cluster, traitSet, child, program);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
@@ -41,7 +41,7 @@ import org.apache.calcite.util.Litmus;
  *
  * @see org.apache.calcite.rel.core.CorrelationId
  */
-public final class LogicalCorrelate extends Correlate {
+public final class LogicalCorrelate extends Correlate implements LogicalRel {
   //~ Instance fields --------------------------------------------------------
 
   //~ Constructors -----------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
@@ -72,6 +72,7 @@ public final class LogicalCorrelate extends Correlate implements LogicalRel {
         requiredColumns,
         joinType);
     assert !CalcitePrepareImpl.DEBUG || isValid(Litmus.THROW, null);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalExchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalExchange.java
@@ -30,7 +30,7 @@ import org.apache.calcite.rel.core.Exchange;
  * Sub-class of {@link Exchange} not
  * targeted at any particular engine or calling convention.
  */
-public final class LogicalExchange extends Exchange {
+public final class LogicalExchange extends Exchange implements LogicalRel {
   private LogicalExchange(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelDistribution distribution) {
     super(cluster, traitSet, input, distribution);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalExchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalExchange.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.util.Litmus;
 
 /**
  * Sub-class of {@link Exchange} not
@@ -35,6 +36,7 @@ public final class LogicalExchange extends Exchange implements LogicalRel {
       RelNode input, RelDistribution distribution) {
     super(cluster, traitSet, input, distribution);
     assert traitSet.containsIfApplicable(Convention.NONE);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -68,6 +68,7 @@ public final class LogicalFilter extends Filter implements LogicalRel {
     super(cluster, traitSet, child, condition);
     this.variablesSet = Objects.requireNonNull(variablesSet);
     assert isValid(Litmus.THROW, null);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -42,7 +42,7 @@ import java.util.Set;
  * Sub-class of {@link org.apache.calcite.rel.core.Filter}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalFilter extends Filter {
+public final class LogicalFilter extends Filter implements LogicalRel {
   private final ImmutableSet<CorrelationId> variablesSet;
 
   //~ Constructors -----------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalIntersect.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalIntersect.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Intersect}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalIntersect extends Intersect {
+public final class LogicalIntersect extends Intersect implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalIntersect.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalIntersect.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Intersect;
+import org.apache.calcite.util.Litmus;
 
 import java.util.List;
 
@@ -44,6 +45,7 @@ public final class LogicalIntersect extends Intersect implements LogicalRel {
       List<RelNode> inputs,
       boolean all) {
     super(cluster, traitSet, inputs, all);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -52,7 +52,7 @@ import java.util.Set;
  *
  * </ul>
  */
-public final class LogicalJoin extends Join {
+public final class LogicalJoin extends Join implements LogicalRel {
   //~ Instance fields --------------------------------------------------------
 
   // NOTE jvs 14-Mar-2006:  Normally we don't use state like this

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -28,6 +28,7 @@ import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Litmus;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -98,6 +99,7 @@ public final class LogicalJoin extends Join implements LogicalRel {
     super(cluster, traitSet, left, right, condition, variablesSet, joinType);
     this.semiJoinDone = semiJoinDone;
     this.systemFieldList = Objects.requireNonNull(systemFieldList);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalMatch.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalMatch.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Match;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Litmus;
 
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,7 @@ public class LogicalMatch extends Match implements LogicalRel {
     super(cluster, traitSet, input, rowType, pattern, strictStart, strictEnd,
         patternDefinitions, measures, after, subsets, allRows, partitionKeys,
         orderKeys, interval);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalMatch.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalMatch.java
@@ -34,7 +34,7 @@ import java.util.SortedSet;
  * Sub-class of {@link Match}
  * not targeted at any particular engine or calling convention.
  */
-public class LogicalMatch extends Match {
+public class LogicalMatch extends Match implements LogicalRel {
 
   /**
    * Creates a LogicalMatch.

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalMinus.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalMinus.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Minus}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalMinus extends Minus {
+public final class LogicalMinus extends Minus implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalMinus.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalMinus.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Minus;
+import org.apache.calcite.util.Litmus;
 
 import java.util.List;
 
@@ -41,6 +42,7 @@ public final class LogicalMinus extends Minus implements LogicalRel {
   public LogicalMinus(RelOptCluster cluster, RelTraitSet traitSet,
       List<RelNode> inputs, boolean all) {
     super(cluster, traitSet, inputs, all);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalMultiJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalMultiJoin.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.logical;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.rules.MultiJoin;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Litmus;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+
+/**
+ * A MultiJoin represents a join of N inputs, whereas regular Joins
+ * represent strictly binary joins.
+ */
+public class LogicalMultiJoin extends MultiJoin implements LogicalRel {
+
+  /**
+   * Constructs a LogicalMultiJoin.
+   *
+   * @param cluster               cluster that join belongs to
+   * @param traitSet              Trait set
+   * @param inputs                inputs into this multi-join
+   * @param joinFilter            join filter applicable to this join node
+   * @param rowType               row type of the join result of this node
+   * @param isFullOuterJoin       true if the join is a full outer join
+   * @param outerJoinConditions   outer join condition associated with each join
+   *                              input, if the input is null-generating in a
+   *                              left or right outer join; null otherwise
+   * @param joinTypes             the join type corresponding to each input; if
+   *                              an input is null-generating in a left or right
+   *                              outer join, the entry indicates the type of
+   *                              outer join; otherwise, the entry is set to
+   *                              INNER
+   * @param projFields            fields that will be projected from each input;
+   *                              if null, projection information is not
+   *                              available yet so it's assumed that all fields
+   *                              from the input are projected
+   * @param joinFieldRefCountsMap counters of the number of times each field
+   *                              is referenced in join conditions, indexed by
+   *                              the input #
+   * @param postJoinFilter        filter to be applied after the joins are
+   */
+  public LogicalMultiJoin(RelOptCluster cluster,
+      RelTraitSet traitSet,
+      List<RelNode> inputs,
+      RexNode joinFilter, RelDataType rowType,
+      boolean isFullOuterJoin, List<RexNode> outerJoinConditions,
+      List<JoinRelType> joinTypes,
+      List<ImmutableBitSet> projFields,
+      ImmutableMap<Integer, ImmutableIntList> joinFieldRefCountsMap,
+      RexNode postJoinFilter) {
+    super(cluster, traitSet, inputs, joinFilter, rowType, isFullOuterJoin, outerJoinConditions,
+        joinTypes, projFields, joinFieldRefCountsMap, postJoinFilter);
+    assert traitSet.containsIfApplicable(Convention.NONE);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
+  }
+
+  @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    return new LogicalMultiJoin(
+        getCluster(),
+        traitSet,
+        inputs,
+        joinFilter,
+        rowType,
+        isFullOuterJoin,
+        outerJoinConditions,
+        joinTypes,
+        projFields,
+        joinFieldRefCountsMap,
+        postJoinFilter);
+  }
+
+  public RelNode accept(RexShuttle shuttle) {
+    RexNode joinFilter = shuttle.apply(this.joinFilter);
+    List<RexNode> outerJoinConditions = shuttle.apply(this.outerJoinConditions);
+    RexNode postJoinFilter = shuttle.apply(this.postJoinFilter);
+
+    if (joinFilter == this.joinFilter
+        && outerJoinConditions == this.outerJoinConditions
+        && postJoinFilter == this.postJoinFilter) {
+      return this;
+    }
+
+    return new LogicalMultiJoin(
+        getCluster(),
+        traitSet,
+        inputs,
+        joinFilter,
+        rowType,
+        isFullOuterJoin,
+        outerJoinConditions,
+        joinTypes,
+        projFields,
+        joinFieldRefCountsMap,
+        postJoinFilter);
+  }
+
+  /** Creates a LogicalMultiJoin. */
+  public static LogicalMultiJoin create(List<RelNode> inputs,
+      RexNode joinFilter, RelDataType rowType,
+      boolean isFullOuterJoin, List<RexNode> outerJoinConditions,
+      List<JoinRelType> joinTypes,
+      List<ImmutableBitSet> projFields,
+      ImmutableMap<Integer, ImmutableIntList> joinFieldRefCountsMap,
+      RexNode postJoinFilter) {
+    assert inputs.size() > 1 : "MultiJoin should have at least two inputs. Inputs are: " + inputs;
+    final RelOptCluster cluster = inputs.get(0).getCluster();
+    final RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
+    return new LogicalMultiJoin(cluster, traitSet, inputs, joinFilter, rowType, isFullOuterJoin,
+        outerJoinConditions, joinTypes, projFields, joinFieldRefCountsMap, postJoinFilter);
+  }
+
+}
+
+// End LogicalMultiJoin.java

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 
 import java.util.List;
@@ -61,6 +62,7 @@ public final class LogicalProject extends Project implements LogicalRel {
       RelDataType rowType) {
     super(cluster, traitSet, input, projects, rowType);
     assert traitSet.containsIfApplicable(Convention.NONE);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -39,7 +39,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Project} not
  * targeted at any particular engine or calling convention.
  */
-public final class LogicalProject extends Project {
+public final class LogicalProject extends Project implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalRel.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalRel.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.logical;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ImplicitTrait;
+
+import java.util.function.Supplier;
+
+/**
+ * Marker interface for Logical relations.
+ * {@code @ImplicitTrait} helps planner to know rels that implement {@link LogicalRel} have
+ * Logical convention so it knows the class is specific enough.
+ */
+@ImplicitTrait(LogicalRel.ConventionFactory.class)
+public interface LogicalRel {
+  /** Returns Convention.NONE. © Captain Obvious */
+  class ConventionFactory implements Supplier<Convention> {
+    @Override public Convention get() {
+      return Convention.NONE;
+    }
+  }
+}
+
+// End LogicalRel.java

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
@@ -26,7 +26,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.util.Litmus;
 
 /**
  * Sub-class of {@link org.apache.calcite.rel.core.Sort} not
@@ -37,7 +36,8 @@ public final class LogicalSort extends Sort implements LogicalRel {
       RelNode input, RelCollation collation, RexNode offset, RexNode fetch) {
     super(cluster, traitSet, input, collation, offset, fetch);
     assert traitSet.containsIfApplicable(Convention.NONE);
-//    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
+    // RelCollationTrait creates LogicalSort and it causes below assert to fail
+    // assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Litmus;
 
 /**
  * Sub-class of {@link org.apache.calcite.rel.core.Sort} not
@@ -36,6 +37,7 @@ public final class LogicalSort extends Sort {
       RelNode input, RelCollation collation, RexNode offset, RexNode fetch) {
     super(cluster, traitSet, input, collation, offset, fetch);
     assert traitSet.containsIfApplicable(Convention.NONE);
+//    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
@@ -32,7 +32,7 @@ import org.apache.calcite.util.Litmus;
  * Sub-class of {@link org.apache.calcite.rel.core.Sort} not
  * targeted at any particular engine or calling convention.
  */
-public final class LogicalSort extends Sort {
+public final class LogicalSort extends Sort implements LogicalRel {
   private LogicalSort(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelCollation collation, RexNode offset, RexNode fetch) {
     super(cluster, traitSet, input, collation, offset, fetch);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Litmus;
 
 /**
  * Sub-class of {@link org.apache.calcite.rel.core.Sort} not
@@ -37,7 +38,7 @@ public final class LogicalSort extends Sort implements LogicalRel {
     super(cluster, traitSet, input, collation, offset, fetch);
     assert traitSet.containsIfApplicable(Convention.NONE);
     // RelCollationTrait creates LogicalSort and it causes below assert to fail
-    // assert inputsSatisfy(Convention.NONE, Litmus.THROW);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSortExchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSortExchange.java
@@ -30,7 +30,7 @@ import org.apache.calcite.rel.core.SortExchange;
  * Sub-class of {@link org.apache.calcite.rel.core.SortExchange} not
  * targeted at any particular engine or calling convention.
  */
-public class LogicalSortExchange extends SortExchange {
+public class LogicalSortExchange extends SortExchange implements LogicalRel {
   private LogicalSortExchange(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelDistribution distribution, RelCollation collation) {
     super(cluster, traitSet, input, distribution, collation);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSortExchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSortExchange.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.SortExchange;
+import org.apache.calcite.util.Litmus;
 
 /**
  * Sub-class of {@link org.apache.calcite.rel.core.SortExchange} not
@@ -34,6 +35,7 @@ public class LogicalSortExchange extends SortExchange implements LogicalRel {
   private LogicalSortExchange(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelDistribution distribution, RelCollation collation) {
     super(cluster, traitSet, input, distribution, collation);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableFunctionScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableFunctionScan.java
@@ -28,6 +28,7 @@ import org.apache.calcite.rel.metadata.RelColumnMapping;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Litmus;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -60,6 +61,7 @@ public class LogicalTableFunctionScan extends TableFunctionScan implements Logic
       Set<RelColumnMapping> columnMappings) {
     super(cluster, traitSet, inputs, rexCall, elementType, rowType,
         columnMappings);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableFunctionScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableFunctionScan.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * Sub-class of {@link org.apache.calcite.rel.core.TableFunctionScan}
  * not targeted at any particular engine or calling convention.
  */
-public class LogicalTableFunctionScan extends TableFunctionScan {
+public class LogicalTableFunctionScan extends TableFunctionScan implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
@@ -31,7 +31,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.TableModify}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalTableModify extends TableModify {
+public final class LogicalTableModify extends TableModify implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
@@ -24,6 +24,7 @@ import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Litmus;
 
 import java.util.List;
 
@@ -45,6 +46,7 @@ public final class LogicalTableModify extends TableModify implements LogicalRel 
       List<RexNode> sourceExpressionList, boolean flattened) {
     super(cluster, traitSet, table, schema, input, operation, updateColumnList,
         sourceExpressionList, flattened);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.schema.Table;
+import org.apache.calcite.util.Litmus;
 
 import com.google.common.collect.ImmutableList;
 
@@ -67,6 +68,7 @@ public final class LogicalTableScan extends TableScan implements LogicalRel {
   public LogicalTableScan(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table) {
     super(cluster, traitSet, table);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
@@ -56,7 +56,7 @@ import java.util.List;
  * <p>can. It is the optimizer's responsibility to find these ways, by applying
  * transformation rules.</p>
  */
-public final class LogicalTableScan extends TableScan {
+public final class LogicalTableScan extends TableScan implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalUnion.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalUnion.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.util.Litmus;
 
 import java.util.List;
 
@@ -43,6 +44,7 @@ public final class LogicalUnion extends Union implements LogicalRel {
       List<RelNode> inputs,
       boolean all) {
     super(cluster, traitSet, inputs, all);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalUnion.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalUnion.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Union}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalUnion extends Union {
+public final class LogicalUnion extends Union implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Litmus;
 
 import com.google.common.collect.ImmutableList;
 
@@ -59,6 +60,7 @@ public class LogicalValues extends Values implements LogicalRel {
       RelDataType rowType,
       ImmutableList<ImmutableList<RexLiteral>> tuples) {
     super(cluster, rowType, tuples, traitSet);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
@@ -39,7 +39,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Values}
  * not targeted at any particular engine or calling convention.
  */
-public class LogicalValues extends Values {
+public class LogicalValues extends Values implements LogicalRel {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
@@ -56,7 +56,7 @@ import java.util.Objects;
  * Sub-class of {@link org.apache.calcite.rel.core.Window}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalWindow extends Window {
+public final class LogicalWindow extends Window implements LogicalRel {
   /**
    * Creates a LogicalWindow.
    *

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.logical;
 
 import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
@@ -73,6 +74,7 @@ public final class LogicalWindow extends Window implements LogicalRel {
       RelNode input, List<RexLiteral> constants, RelDataType rowType,
       List<Group> groups) {
     super(cluster, traitSet, input, constants, rowType, groups);
+    assert inputsSatisfy(Convention.NONE, Litmus.THROW);
   }
 
   @Override public LogicalWindow copy(RelTraitSet traitSet,

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -266,10 +266,9 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
             .append(method.i)
             .append(")");
       }
-      buff.append(", r");
       safeArgList(buff, method.e)
           .append(");\n")
-          .append("    final Object v = mq.map.get(key);\n")
+          .append("    final Object v = mq.map.get(r, key);\n")
           .append("    if (v != null) {\n")
           .append("      if (v == ")
           .append(NullSentinel.class.getName())
@@ -287,7 +286,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
           .append(method.e.getReturnType().getName())
           .append(") v;\n")
           .append("    }\n")
-          .append("    mq.map.put(key,")
+          .append("    mq.map.put(r, key,")
           .append(NullSentinel.class.getName())
           .append(".ACTIVE);\n")
           .append("    try {\n")
@@ -298,14 +297,14 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
           .append("_(r, mq");
       argList(buff, method.e)
           .append(");\n")
-          .append("      mq.map.put(key, ")
+          .append("      mq.map.put(r, key, ")
           .append(NullSentinel.class.getName())
           .append(".mask(x));\n")
           .append("      return x;\n")
           .append("    } catch (")
           .append(Exception.class.getName())
           .append(" e) {\n")
-          .append("      mq.map.remove(key);\n")
+          .append("      mq.map.row(r).clear();\n")
           .append("      throw e;\n")
           .append("    }\n")
           .append("  }\n")

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -178,7 +178,7 @@ public class ReflectiveRelMetadataProvider
                   }
                   key1 = FlatLists.copyOf(args2);
                 }
-                if (mq.map.put(key1, NullSentinel.INSTANCE) != null) {
+                if (mq.map.put(rel, key1, NullSentinel.INSTANCE) != null) {
                   throw CyclicMetadataException.INSTANCE;
                 }
                 try {
@@ -188,7 +188,7 @@ public class ReflectiveRelMetadataProvider
                   Util.throwIfUnchecked(e.getCause());
                   throw new RuntimeException(e.getCause());
                 } finally {
-                  mq.map.remove(key1);
+                  mq.map.remove(rel, key1);
                 }
               });
       methodsMap.put(key, function);

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
@@ -817,6 +817,15 @@ public class RelMdUtil {
     }
     return alreadySorted && alreadySmaller;
   }
+
+  /**
+   * Removes cached metadata values for specified RelNode.
+   *
+   * @param rel RelNode whose cached metadata should be removed
+   */
+  public static void clearCache(RelNode rel) {
+    rel.getCluster().getMetadataQuery().clearCache(rel);
+  }
 }
 
 // End RelMdUtil.java

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -27,15 +27,15 @@ import org.apache.calcite.rex.RexTableInputRef.RelTableRef;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
 
 import java.lang.reflect.Proxy;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -76,7 +76,7 @@ import java.util.Set;
  */
 public class RelMetadataQuery {
   /** Set of active metadata queries, and cache of previous results. */
-  public final Map<List, Object> map = new HashMap<>();
+  public final Table<RelNode, List, Object> map = HashBasedTable.create();
 
   public final JaninoRelMetadataProvider metadataProvider;
 
@@ -839,6 +839,15 @@ public class RelMetadataQuery {
             revise(e.relClass, BuiltInMetadata.ExplainVisibility.DEF);
       }
     }
+  }
+
+  /**
+   * Removes cached metadata values for specified RelNode.
+   *
+   * @param rel RelNode whose cached metadata should be removed
+   */
+  public void clearCache(RelNode rel) {
+    map.row(rel).clear();
   }
 
   private static Double validatePercentage(Double result) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AbstractMaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AbstractMaterializedViewRule.java
@@ -203,7 +203,7 @@ public abstract class AbstractMaterializedViewRule extends RelOptRule {
    */
   protected void perform(RelOptRuleCall call, Project topProject, RelNode node) {
     final RexBuilder rexBuilder = node.getCluster().getRexBuilder();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final RelOptPlanner planner = call.getPlanner();
     final RexExecutor executor =
         Util.first(planner.getExecutor(), RexUtil.EXECUTOR);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExtractProjectRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExtractProjectRule.java
@@ -62,6 +62,7 @@ public class AggregateExtractProjectRule extends RelOptRule {
     // Predicate prevents matching against an Aggregate whose input
     // is already a Project. Prevents this rule firing repeatedly.
     this(
+        // TODO: consider if inputClass customization is required
         operand(aggregateClass,
             operandJ(inputClass, null, r -> !(r instanceof Project), any())),
         relBuilderFactory);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
@@ -60,10 +60,14 @@ public class AggregateFilterTransposeRule extends RelOptRule {
       new AggregateFilterTransposeRule();
 
   private AggregateFilterTransposeRule() {
+    this(RelFactories.LOGICAL_BUILDER);
+  }
+
+  private AggregateFilterTransposeRule(RelBuilderFactory relBuilderFactory) {
     this(
         operand(Aggregate.class,
             operand(Filter.class, any())),
-        RelFactories.LOGICAL_BUILDER);
+        relBuilderFactory);
   }
 
   /** Creates an AggregateFilterTransposeRule. */

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
@@ -26,8 +26,6 @@ import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.logical.LogicalAggregate;
-import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
@@ -63,17 +61,19 @@ import java.util.TreeMap;
  */
 public class AggregateJoinTransposeRule extends RelOptRule {
   public static final AggregateJoinTransposeRule INSTANCE =
-      new AggregateJoinTransposeRule(LogicalAggregate.class, LogicalJoin.class,
-          RelFactories.LOGICAL_BUILDER, false);
+      new AggregateJoinTransposeRule(RelFactories.LOGICAL_BUILDER, false);
 
   /** Extended instance of the rule that can push down aggregate functions. */
   public static final AggregateJoinTransposeRule EXTENDED =
-      new AggregateJoinTransposeRule(LogicalAggregate.class, LogicalJoin.class,
-          RelFactories.LOGICAL_BUILDER, true);
+      new AggregateJoinTransposeRule(RelFactories.LOGICAL_BUILDER, true);
 
   private final boolean allowFunctions;
 
   /** Creates an AggregateJoinTransposeRule. */
+  public AggregateJoinTransposeRule(RelBuilderFactory relBuilderFactory, boolean allowFunctions) {
+    this(Aggregate.class, Join.class, relBuilderFactory, allowFunctions);
+  }
+
   public AggregateJoinTransposeRule(Class<? extends Aggregate> aggregateClass,
       Class<? extends Join> joinClass, RelBuilderFactory relBuilderFactory,
       boolean allowFunctions) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
@@ -55,7 +55,11 @@ import java.util.TreeSet;
  */
 public class AggregateProjectMergeRule extends RelOptRule {
   public static final AggregateProjectMergeRule INSTANCE =
-      new AggregateProjectMergeRule(Aggregate.class, Project.class, RelFactories.LOGICAL_BUILDER);
+      new AggregateProjectMergeRule(RelFactories.LOGICAL_BUILDER);
+
+  public AggregateProjectMergeRule(RelBuilderFactory relBuilderFactory) {
+    this(Aggregate.class, Project.class, relBuilderFactory);
+  }
 
   public AggregateProjectMergeRule(
       Class<? extends Aggregate> aggregateClass,

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
@@ -22,9 +22,8 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.logical.LogicalAggregate;
-import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -62,23 +61,28 @@ public class AggregateProjectPullUpConstantsRule extends RelOptRule {
 
   /** The singleton. */
   public static final AggregateProjectPullUpConstantsRule INSTANCE =
-      new AggregateProjectPullUpConstantsRule(LogicalAggregate.class,
-          LogicalProject.class, RelFactories.LOGICAL_BUILDER,
+      new AggregateProjectPullUpConstantsRule(
+          Project.class, RelFactories.LOGICAL_BUILDER,
           "AggregateProjectPullUpConstantsRule");
 
   /** More general instance that matches any relational expression. */
   public static final AggregateProjectPullUpConstantsRule INSTANCE2 =
-      new AggregateProjectPullUpConstantsRule(LogicalAggregate.class,
+      new AggregateProjectPullUpConstantsRule(
           RelNode.class, RelFactories.LOGICAL_BUILDER,
           "AggregatePullUpConstantsRule");
 
   //~ Constructors -----------------------------------------------------------
 
+  public AggregateProjectPullUpConstantsRule(Class<? extends RelNode> inputClass,
+      RelBuilderFactory relBuilderFactory, String description) {
+    this(Aggregate.class, inputClass, relBuilderFactory, description);
+  }
+
   /**
    * Creates an AggregateProjectPullUpConstantsRule.
    *
    * @param aggregateClass Aggregate class
-   * @param inputClass Input class, such as {@link LogicalProject}
+   * @param inputClass Input class, such as {@link Project}
    * @param relBuilderFactory Builder for relational expressions
    * @param description Description, or null to guess description
    */

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
@@ -24,7 +24,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -94,10 +93,13 @@ public class AggregateReduceFunctionsRule extends RelOptRule {
 
   /** The singleton. */
   public static final AggregateReduceFunctionsRule INSTANCE =
-      new AggregateReduceFunctionsRule(operand(LogicalAggregate.class, any()),
-          RelFactories.LOGICAL_BUILDER);
+      new AggregateReduceFunctionsRule(RelFactories.LOGICAL_BUILDER);
 
   //~ Constructors -----------------------------------------------------------
+
+  public AggregateReduceFunctionsRule(RelBuilderFactory relBuilderFactory) {
+    super(operand(Aggregate.class, any()), relBuilderFactory, null);
+  }
 
   /** Creates an AggregateReduceFunctionsRule. */
   public AggregateReduceFunctionsRule(RelOptRuleOperand operand,

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
@@ -63,6 +63,13 @@ public class AggregateRemoveRule extends RelOptRule {
         relBuilderFactory, null);
   }
 
+  /**
+   * Creates an AggregateRemoveRule.
+   */
+  public AggregateRemoveRule(RelBuilderFactory relBuilderFactory) {
+    this(Aggregate.class, relBuilderFactory);
+  }
+
   //~ Methods ----------------------------------------------------------------
 
   public void onMatch(RelOptRuleCall call) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
@@ -54,6 +54,7 @@ public class CalcMergeRule extends RelOptRule {
             Calc.class,
             operand(Calc.class, any())),
         relBuilderFactory, null);
+    matchAnyTraitSet();
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterMultiJoinMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterMultiJoinMergeRule.java
@@ -61,7 +61,9 @@ public class FilterMultiJoinMergeRule extends RelOptRule {
             filter.getCluster().getRexBuilder());
     programBuilder.addIdentity();
     programBuilder.addCondition(filter.getCondition());
-    programBuilder.addCondition(multiJoin.getPostJoinFilter());
+    if (multiJoin.getPostJoinFilter() != null) {
+      programBuilder.addCondition(multiJoin.getPostJoinFilter());
+    }
     RexProgram mergedProgram = programBuilder.getProgram();
 
     RelBuilder builder = call.builder();

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
@@ -124,6 +124,9 @@ public class FilterProjectTransposeRule extends RelOptRule {
       boolean copyProject,
       RelBuilderFactory relBuilderFactory) {
     super(operand, relBuilderFactory, null);
+    if (copyFilter && copyProject) {
+      matchAnyTraitSet();
+    }
     this.copyFilter = copyFilter;
     this.copyProject = copyProject;
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterTableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterTableScanRule.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.adapter.enumerable.EnumerableInterpreter;
+import org.apache.calcite.adapter.enumerable.EnumerableRules;
 import org.apache.calcite.interpreter.Bindables;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -77,7 +78,7 @@ public abstract class FilterTableScanRule extends RelOptRule {
               operand(EnumerableInterpreter.class,
                   operandJ(TableScan.class, null, FilterTableScanRule::test,
                       none()))),
-          RelFactories.LOGICAL_BUILDER,
+          EnumerableRules.REL_BUILDER_FACTORY,
           "FilterTableScanRule:interpreter") {
         public void onMatch(RelOptRuleCall call) {
           final Filter filter = call.rel(0);

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinExtractFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinExtractFilterRule.java
@@ -18,7 +18,6 @@ package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 /**
@@ -40,8 +39,7 @@ public final class JoinExtractFilterRule extends AbstractJoinExtractFilterRule {
 
   /** The singleton. */
   public static final JoinExtractFilterRule INSTANCE =
-      new JoinExtractFilterRule(LogicalJoin.class,
-          RelFactories.LOGICAL_BUILDER);
+      new JoinExtractFilterRule(RelFactories.LOGICAL_BUILDER);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -51,6 +49,13 @@ public final class JoinExtractFilterRule extends AbstractJoinExtractFilterRule {
   public JoinExtractFilterRule(Class<? extends Join> clazz,
       RelBuilderFactory relBuilderFactory) {
     super(operand(clazz, any()), relBuilderFactory, null);
+  }
+
+  /**
+   * Creates a JoinExtractFilterRule.
+   */
+  public JoinExtractFilterRule(RelBuilderFactory relBuilderFactory) {
+    this(Join.class, relBuilderFactory);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinProjectTransposeRule.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -107,17 +108,17 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
   //~ Methods ----------------------------------------------------------------
 
   // override JoinProjectTransposeRule
-  protected boolean hasLeftChild(RelOptRuleCall call) {
+  @Override protected boolean hasLeftChild(RelOptRuleCall call) {
     return call.rels.length != 4;
   }
 
   // override JoinProjectTransposeRule
-  protected boolean hasRightChild(RelOptRuleCall call) {
+  @Override protected boolean hasRightChild(RelOptRuleCall call) {
     return call.rels.length > 3;
   }
 
   // override JoinProjectTransposeRule
-  protected LogicalProject getRightChild(RelOptRuleCall call) {
+  @Override protected LogicalProject getRightChild(RelOptRuleCall call) {
     if (call.rels.length == 4) {
       return call.rel(2);
     } else {
@@ -126,9 +127,9 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
   }
 
   // override JoinProjectTransposeRule
-  protected RelNode getProjectChild(
+  @Override protected RelNode getProjectChild(
       RelOptRuleCall call,
-      LogicalProject project,
+      Project project,
       boolean leftChild) {
     // locate the appropriate MultiJoin based on which rule was fired
     // and which projection we're dealing with
@@ -143,7 +144,7 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
 
     // create a new MultiJoin that reflects the columns in the projection
     // above the MultiJoin
-    return RelOptUtil.projectMultiJoin(multiJoin, project);
+    return RelOptUtil.projectMultiJoin(call.builder(), multiJoin, project);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectMultiJoinMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectMultiJoinMergeRule.java
@@ -41,6 +41,8 @@ public class ProjectMultiJoinMergeRule extends RelOptRule {
   /** Creates a ProjectMultiJoinMergeRule. */
   public ProjectMultiJoinMergeRule(RelBuilderFactory relBuilderFactory) {
     super(
+        // org.apache.calcite.plan.RelOptUtil.projectMultiJoin requires LogicalProject
+        // for some reason
         operand(LogicalProject.class,
             operand(MultiJoin.class, any())), relBuilderFactory, null);
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectMultiJoinMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectMultiJoinMergeRule.java
@@ -19,8 +19,9 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
@@ -41,16 +42,14 @@ public class ProjectMultiJoinMergeRule extends RelOptRule {
   /** Creates a ProjectMultiJoinMergeRule. */
   public ProjectMultiJoinMergeRule(RelBuilderFactory relBuilderFactory) {
     super(
-        // org.apache.calcite.plan.RelOptUtil.projectMultiJoin requires LogicalProject
-        // for some reason
-        operand(LogicalProject.class,
+        operand(Project.class,
             operand(MultiJoin.class, any())), relBuilderFactory, null);
   }
 
   //~ Methods ----------------------------------------------------------------
 
   public void onMatch(RelOptRuleCall call) {
-    LogicalProject project = call.rel(0);
+    Project project = call.rel(0);
     MultiJoin multiJoin = call.rel(1);
 
     // if all inputs have their projFields set, then projection information
@@ -69,8 +68,8 @@ public class ProjectMultiJoinMergeRule extends RelOptRule {
     // create a new MultiJoin that reflects the columns in the projection
     // above the MultiJoin
     final RelBuilder relBuilder = call.builder();
-    MultiJoin newMultiJoin =
-        RelOptUtil.projectMultiJoin(multiJoin, project);
+    RelNode newMultiJoin =
+        RelOptUtil.projectMultiJoin(call.builder(), multiJoin, project);
     relBuilder.push(newMultiJoin)
         .project(project.getProjects(), project.getRowType().getFieldNames());
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectSetOpTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectSetOpTransposeRule.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.core.SetOp;
-import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.tools.RelBuilderFactory;
 
@@ -63,7 +62,7 @@ public class ProjectSetOpTransposeRule extends RelOptRule {
       RelBuilderFactory relBuilderFactory) {
     super(
         operand(
-            LogicalProject.class,
+            Project.class,
             operand(SetOp.class, any())),
         relBuilderFactory, null);
     this.preserveExprCondition = preserveExprCondition;
@@ -73,7 +72,7 @@ public class ProjectSetOpTransposeRule extends RelOptRule {
 
   // implement RelOptRule
   public void onMatch(RelOptRuleCall call) {
-    LogicalProject origProj = call.rel(0);
+    Project origProj = call.rel(0);
     SetOp setOp = call.rel(1);
 
     // cannot push project past a distinct

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectTableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectTableScanRule.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.adapter.enumerable.EnumerableInterpreter;
+import org.apache.calcite.adapter.enumerable.EnumerableRules;
 import org.apache.calcite.interpreter.Bindables;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -75,7 +76,7 @@ public abstract class ProjectTableScanRule extends RelOptRule {
               operand(EnumerableInterpreter.class,
                   operandJ(TableScan.class, null, ProjectTableScanRule::test,
                       none()))),
-          RelFactories.LOGICAL_BUILDER,
+          EnumerableRules.REL_BUILDER_FACTORY,
           "ProjectScanRule:interpreter") {
         @Override public void onMatch(RelOptRuleCall call) {
           final Project project = call.rel(0);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToCalcRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToCalcRule.java
@@ -19,9 +19,9 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalCalc;
-import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.tools.RelBuilderFactory;
 
@@ -53,13 +53,13 @@ public class ProjectToCalcRule extends RelOptRule {
    * @param relBuilderFactory Builder for relational expressions
    */
   public ProjectToCalcRule(RelBuilderFactory relBuilderFactory) {
-    super(operand(LogicalProject.class, any()), relBuilderFactory, null);
+    super(operand(Project.class, any()), relBuilderFactory, null);
   }
 
   //~ Methods ----------------------------------------------------------------
 
   public void onMatch(RelOptRuleCall call) {
-    final LogicalProject project = call.rel(0);
+    final Project project = call.rel(0);
     final RelNode input = project.getInput();
     final RexProgram program =
         RexProgram.create(
@@ -68,6 +68,7 @@ public class ProjectToCalcRule extends RelOptRule {
             null,
             project.getRowType(),
             project.getCluster().getRexBuilder());
+    // There's no support for Calc in relBuilder yet :(
     final LogicalCalc calc = LogicalCalc.create(input, program);
     call.transformTo(calc);
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCallBinding;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
@@ -96,6 +97,12 @@ public class SortProjectTransposeRule extends RelOptRule {
   }
 
   //~ Methods ----------------------------------------------------------------
+
+
+  @Override public boolean matches(RelOptRuleCall call) {
+    return super.matches(call)
+        && !RexOver.containsOver(((Project) call.rel(1)).getProjects(), null);
+  }
 
   public void onMatch(RelOptRuleCall call) {
     final Sort sort = call.rel(0);

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteException.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.runtime;
 
+import org.apache.calcite.prepare.CalcitePrepareImpl;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +60,9 @@ public class CalciteException extends RuntimeException {
     // TODO: Force the caller to pass in a Logger as a trace argument for
     // better context.  Need to extend ResGen for this.
     LOGGER.trace("CalciteException", this);
-    LOGGER.error(toString());
+    if (CalcitePrepareImpl.DEBUG) {
+      LOGGER.error(toString());
+    }
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorException.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorException.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql.validate;
 
+import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.util.CalciteValidatorException;
 
 import org.slf4j.Logger;
@@ -56,7 +57,9 @@ public class SqlValidatorException extends Exception
 
     // TODO: see note in CalciteException constructor
     LOGGER.trace("SqlValidatorException", this);
-    LOGGER.error(toString());
+    if (CalcitePrepareImpl.DEBUG) {
+      LOGGER.error(toString());
+    }
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3034,7 +3034,7 @@ public class SqlToRelConverter {
   }
 
   protected RelNode decorrelateQuery(RelNode rootRel) {
-    return RelDecorrelator.decorrelateQuery(rootRel, relBuilder);
+    return RelDecorrelator.decorrelateQuery(rootRel, config.getRelBuilderFactory());
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -105,6 +105,7 @@ public class Programs {
 
   public static final ImmutableSet<RelOptRule> RULE_SET =
       ImmutableSet.of(
+          EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
           EnumerableRules.ENUMERABLE_JOIN_RULE,
           EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE,
           EnumerableRules.ENUMERABLE_SEMI_JOIN_RULE,

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -377,9 +377,7 @@ public class Programs {
       final CalciteConnectionConfig config =
           planner.getContext().unwrap(CalciteConnectionConfig.class);
       if (config != null && config.forceDecorrelate()) {
-        final RelBuilder relBuilder =
-            RelFactories.LOGICAL_BUILDER.create(rel.getCluster(), null);
-        return RelDecorrelator.decorrelateQuery(rel, relBuilder);
+        return RelDecorrelator.decorrelateQuery(rel, RelFactories.LOGICAL_BUILDER);
       }
       return rel;
     }

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -20,11 +20,13 @@ import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelDistribution;
@@ -239,11 +241,22 @@ public class RelBuilder {
   /** Creates a {@link RelBuilderFactory}, a partially-created RelBuilder.
    * Just add a {@link RelOptCluster} and a {@link RelOptSchema} */
   public static RelBuilderFactory proto(final Context context) {
-    return (cluster, schema) -> new RelBuilder(context, cluster, schema);
+    return new RelBuilderFactory() {
+      @Override public RelBuilder create(RelOptCluster cluster, RelOptSchema schema) {
+        return new RelBuilder(context, cluster, schema);
+      }
+
+      @Override public RelTraitSet getImplicitTraits() {
+        return context.unwrap(RelTraitSet.class);
+      }
+    };
   }
 
   /** Creates a {@link RelBuilderFactory} that uses a given set of factories. */
   public static RelBuilderFactory proto(Object... factories) {
+    if (factories.length == 0) {
+      return proto(Contexts.of(RelTraitSet.createEmpty().plus(Convention.NONE)));
+    }
     return proto(Contexts.of(factories));
   }
 

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilderFactory.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilderFactory.java
@@ -19,6 +19,7 @@ package org.apache.calcite.tools;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.core.RelFactories;
 
 /** A partially-created RelBuilder.
@@ -36,6 +37,10 @@ import org.apache.calcite.rel.core.RelFactories;
 public interface RelBuilderFactory {
   /** Creates a RelBuilder. */
   RelBuilder create(RelOptCluster cluster, RelOptSchema schema);
+
+  default RelTraitSet getImplicitTraits() {
+    return null;
+  }
 }
 
 // End RelBuilderFactory.java

--- a/core/src/main/java/org/apache/calcite/util/AbstractDateTime.java
+++ b/core/src/main/java/org/apache/calcite/util/AbstractDateTime.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+/**
+ * General class for Date/Time/Timestamp literals (TimestampString, DateString, TimeString)
+ * to make them comparable to each other
+ */
+public abstract class AbstractDateTime implements Comparable {
+  protected final String v;
+
+  public AbstractDateTime(String v) {
+    this.v = v;
+  }
+
+  @Override public int compareTo(Object o) {
+    if (o instanceof NlsString) {
+      return v.compareTo(((NlsString) o).getValue());
+    }
+    return v.compareTo(((AbstractDateTime) o).v);
+  }
+}
+
+// End AbstractDateTime.java

--- a/core/src/main/java/org/apache/calcite/util/DateString.java
+++ b/core/src/main/java/org/apache/calcite/util/DateString.java
@@ -22,22 +22,19 @@ import com.google.common.base.Preconditions;
 
 import java.util.Calendar;
 import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
 
 /**
  * Date literal.
  *
  * <p>Immutable, internally represented as a string (in ISO format).
  */
-public class DateString implements Comparable<DateString> {
+public class DateString extends AbstractDateTime {
   private static final Pattern PATTERN =
       Pattern.compile("[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]");
 
-  final String v;
-
   /** Internal constructor, no validation. */
   private DateString(String v, @SuppressWarnings("unused") boolean ignore) {
-    this.v = v;
+    super(v);
   }
 
   /** Creates a DateString. */
@@ -84,10 +81,6 @@ public class DateString implements Comparable<DateString> {
 
   @Override public int hashCode() {
     return v.hashCode();
-  }
-
-  @Override public int compareTo(@Nonnull DateString o) {
-    return v.compareTo(o.v);
   }
 
   /** Creates a DateString from a Calendar. */

--- a/core/src/main/java/org/apache/calcite/util/NlsString.java
+++ b/core/src/main/java/org/apache/calcite/util/NlsString.java
@@ -42,7 +42,7 @@ import static org.apache.calcite.util.Static.RESOURCE;
  * A string, optionally with {@link Charset character set} and
  * {@link SqlCollation}. It is immutable.
  */
-public class NlsString implements Comparable<NlsString>, Cloneable {
+public class NlsString implements Comparable, Cloneable {
   //~ Instance fields --------------------------------------------------------
 
   private static final LoadingCache<Pair<ByteString, Charset>, String>
@@ -168,10 +168,13 @@ public class NlsString implements Comparable<NlsString>, Cloneable {
         && Objects.equals(collation, ((NlsString) obj).collation);
   }
 
-  @Override public int compareTo(NlsString other) {
+  // implement Comparable
+  public int compareTo(Object other) {
     // TODO jvs 18-Jan-2006:  Actual collation support.  This just uses
     // the default collation.
-    return getValue().compareTo(other.getValue());
+    return other instanceof AbstractDateTime
+        ? getValue().compareTo(((AbstractDateTime) other).v)
+        : getValue().compareTo(((NlsString) other).getValue());
   }
 
   public String getCharsetName() {

--- a/core/src/main/java/org/apache/calcite/util/TimeString.java
+++ b/core/src/main/java/org/apache/calcite/util/TimeString.java
@@ -23,7 +23,6 @@ import com.google.common.base.Strings;
 
 import java.util.Calendar;
 import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
 
 /**
  * Time literal.
@@ -31,15 +30,13 @@ import javax.annotation.Nonnull;
  * <p>Immutable, internally represented as a string (in ISO format),
  * and can support unlimited precision (milliseconds, nanoseconds).
  */
-public class TimeString implements Comparable<TimeString> {
+public class TimeString extends AbstractDateTime {
   private static final Pattern PATTERN =
       Pattern.compile("[0-9][0-9]:[0-9][0-9]:[0-9][0-9](\\.[0-9]*[1-9])?");
 
-  final String v;
-
   /** Internal constructor, no validation. */
   private TimeString(String v, @SuppressWarnings("unused") boolean ignore) {
-    this.v = v;
+    super(v);
   }
 
   /** Creates a TimeString. */
@@ -127,10 +124,6 @@ public class TimeString implements Comparable<TimeString> {
 
   @Override public int hashCode() {
     return v.hashCode();
-  }
-
-  @Override public int compareTo(@Nonnull TimeString o) {
-    return v.compareTo(o.v);
   }
 
   /** Creates a TimeString from a Calendar. */

--- a/core/src/main/java/org/apache/calcite/util/TimestampString.java
+++ b/core/src/main/java/org/apache/calcite/util/TimestampString.java
@@ -30,24 +30,22 @@ import java.util.regex.Pattern;
  * <p>Immutable, internally represented as a string (in ISO format),
  * and can support unlimited precision (milliseconds, nanoseconds).
  */
-public class TimestampString implements Comparable<TimestampString> {
+public class TimestampString extends AbstractDateTime {
   private static final Pattern PATTERN =
       Pattern.compile("[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
           + " "
           + "[0-9][0-9]:[0-9][0-9]:[0-9][0-9](\\.[0-9]*[1-9])?");
 
-  final String v;
-
   /** Creates a TimeString. */
   public TimestampString(String v) {
-    this.v = v;
+    super(v);
     Preconditions.checkArgument(PATTERN.matcher(v).matches(), v);
   }
 
   /** Creates a TimestampString for year, month, day, hour, minute, second,
    *  millisecond values. */
   public TimestampString(int year, int month, int day, int h, int m, int s) {
-    this(DateTimeStringUtils.ymdhms(new StringBuilder(), year, month, day, h, m, s).toString());
+    super(DateTimeStringUtils.ymdhms(new StringBuilder(), year, month, day, h, m, s).toString());
   }
 
   /** Sets the fraction field of a {@code TimestampString} to a given number
@@ -107,10 +105,6 @@ public class TimestampString implements Comparable<TimestampString> {
 
   @Override public int hashCode() {
     return v.hashCode();
-  }
-
-  @Override public int compareTo(TimestampString o) {
-    return v.compareTo(o.v);
   }
 
   /** Creates a TimestampString from a Calendar. */

--- a/core/src/test/java/org/apache/calcite/plan/volcano/PlannerTests.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/PlannerTests.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.plan.volcano;
 
 import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ImplicitTrait;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -34,6 +35,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Common classes and utility methods for Volcano planner tests.
@@ -56,6 +58,13 @@ class PlannerTests {
           return true;
         }
       };
+
+  /** Returns Convention.NONE. © Captain Obvious */
+  public static class PhysConventionFactory implements Supplier<Convention> {
+    @Override public Convention get() {
+      return PHYS_CALLING_CONVENTION;
+    }
+  }
 
   static RelOptCluster newCluster(VolcanoPlanner planner) {
     final RelDataTypeFactory typeFactory =
@@ -131,6 +140,7 @@ class PlannerTests {
   }
 
   /** Relational expression with zero inputs and convention PHYS. */
+  @ImplicitTrait(PhysConventionFactory.class)
   static class PhysLeafRel extends TestLeafRel {
     PhysLeafRel(RelOptCluster cluster, String label) {
       super(cluster, cluster.traitSetOf(PHYS_CALLING_CONVENTION), label);
@@ -149,6 +159,7 @@ class PlannerTests {
   }
 
   /** Relational expression with one input and convention PHYS. */
+  @ImplicitTrait(PhysConventionFactory.class)
   static class PhysSingleRel extends TestSingleRel {
     PhysSingleRel(RelOptCluster cluster, RelNode input) {
       super(cluster, cluster.traitSetOf(PHYS_CALLING_CONVENTION), input);

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
@@ -525,6 +525,7 @@ public class VolcanoPlannerTest {
 
     SubsetRule(List<String> buf) {
       super(operand(TestSingleRel.class, operand(RelSubset.class, any())));
+      matchAnyTraitSet();
       this.buf = buf;
     }
 

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
@@ -520,7 +520,8 @@ public class VolcanoPlannerTraitTest {
     }
 
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-      assert traitSet.comprises(EnumerableConvention.INSTANCE);
+      assert traitSet.comprises(EnumerableConvention.INSTANCE)
+          : traitSet.toString() + " should be just ENUMERABLE";
       return new IterSingleRel(
           getCluster(),
           sole(inputs));
@@ -718,7 +719,8 @@ public class VolcanoPlannerTraitTest {
     IterSinglePhysMergeRule() {
       super(
           operand(IterSingleRel.class,
-              operand(PhysToIteratorConverter.class, any())));
+              EnumerableConvention.INSTANCE,
+              some(operand(PhysToIteratorConverter.class, any()))));
     }
 
     @Override public void onMatch(RelOptRuleCall call) {

--- a/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
@@ -680,7 +680,8 @@ public class CalciteAssert {
       statement.close();
       connection.close();
     } catch (Throwable e) {
-      throw new RuntimeException(message, e);
+      e.addSuppressed(new RuntimeException(message));
+      throw e;
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3288,9 +3288,9 @@ public class JdbcTest {
               + "  LogicalProject(DUMMY=[0])\n"
               + "    LogicalJoin(condition=[true], joinType=[inner])\n"
               + "      LogicalProject(DUMMY=[0])\n"
-              + "        EnumerableTableScan(table=[[hr, emps]])\n"
+              + "        LogicalTableScan(table=[[hr, emps]])\n"
               + "      LogicalProject(DUMMY=[0])\n"
-              + "        EnumerableTableScan(table=[[hr, depts]])");
+              + "        LogicalTableScan(table=[[hr, depts]])");
     }
   }
 
@@ -4183,7 +4183,7 @@ public class JdbcTest {
           .convertContains("LogicalProject(name=[$1], EXPR$1=[+($2, 1)])\n"
               + "  LogicalAggregate(group=[{0, 1}], agg#0=[COUNT($2)])\n"
               + "    LogicalProject(deptno=[$1], name=[$2], commission=[$4])\n"
-              + "      EnumerableTableScan(table=[[hr, emps]])\n");
+              + "      LogicalTableScan(table=[[hr, emps]])\n");
     }
   }
 
@@ -4201,7 +4201,7 @@ public class JdbcTest {
               + "LogicalProject(name=[$2], EXPR$1=[+(COUNT($3) OVER (PARTITION BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 1)])\n"
               + "  LogicalFilter(condition=[>($0, 10)])\n"
               + "    LogicalProject(empid=[$0], deptno=[$1], name=[$2], commission=[$4])\n"
-              + "      EnumerableTableScan(table=[[hr, emps]])\n");
+              + "      LogicalTableScan(table=[[hr, emps]])\n");
     }
   }
 
@@ -4508,9 +4508,9 @@ public class JdbcTest {
         + "LogicalProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
         + "  LogicalFilter(condition=[EXISTS({\n"
         + "LogicalFilter(condition=[=($cor0.deptno, $0)])\n"
-        + "  EnumerableTableScan(table=[[hr, depts]])\n"
+        + "  LogicalTableScan(table=[[hr, depts]])\n"
         + "})], variablesSet=[[$cor0]])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n";
+        + "    LogicalTableScan(table=[[hr, emps]])\n";
     CalciteAssert.hr().query(sql).convertContains(plan)
         .returnsUnordered(
             "empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000",

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -1151,7 +1151,7 @@ public class MaterializationTest {
         HR_FKUK_MODEL,
         CalciteAssert.checkResultContains(
             "EnumerableCalc(expr#0..1=[{inputs}], expr#2=[1], expr#3=[+($t1, $t2)],"
-                + " deptno=[$t0], $f1=[$t3])\n"
+                + " deptno=[$t0], S=[$t3])\n"
                 + "  EnumerableAggregate(group=[{1}], agg#0=[$SUM0($3)])\n"
                 + "    EnumerableCalc(expr#0..3=[{inputs}], expr#4=[10], expr#5=[<($t4, $t1)], "
                 + "proj#0..3=[{exprs}], $condition=[$t5])\n"
@@ -1176,7 +1176,7 @@ public class MaterializationTest {
         HR_FKUK_MODEL,
         CalciteAssert.checkResultContains(
             "EnumerableCalc(expr#0..1=[{inputs}], expr#2=[1], expr#3=[+($t0, $t2)], "
-                + "expr#4=[+($t1, $t2)], $f0=[$t3], $f1=[$t4])\n"
+                + "expr#4=[+($t1, $t2)], EXPR$0=[$t3], S=[$t4])\n"
                 + "  EnumerableAggregate(group=[{1}], agg#0=[$SUM0($3)])\n"
                 + "    EnumerableCalc(expr#0..3=[{inputs}], expr#4=[10], expr#5=[<($t4, $t1)], "
                 + "proj#0..3=[{exprs}], $condition=[$t5])\n"

--- a/core/src/test/java/org/apache/calcite/test/MutableRelTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MutableRelTest.java
@@ -33,7 +33,6 @@ import org.apache.calcite.rel.rules.ProjectToWindowRule;
 import org.apache.calcite.rel.rules.SemiJoinRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql2rel.RelDecorrelator;
-import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Litmus;
 
 import com.google.common.collect.ImmutableList;
@@ -189,9 +188,7 @@ public class MutableRelTest {
     };
     RelNode origRel = test.createTester().convertSqlToRel(sql).rel;
     if (decorrelate) {
-      final RelBuilder relBuilder =
-          RelFactories.LOGICAL_BUILDER.create(origRel.getCluster(), null);
-      origRel = RelDecorrelator.decorrelateQuery(origRel, relBuilder);
+      origRel = RelDecorrelator.decorrelateQuery(origRel, RelFactories.LOGICAL_BUILDER);
     }
     if (rules != null) {
       final HepProgram hepProgram =

--- a/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
@@ -33,7 +33,6 @@ import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql2rel.RelDecorrelator;
-import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Closer;
 
 import com.google.common.collect.ImmutableList;
@@ -208,9 +207,7 @@ abstract class RelOptTestBase extends SqlToRelTestBase {
       final String planMid = NL + RelOptUtil.toString(r);
       diffRepos.assertEquals("planMid", "${planMid}", planMid);
       SqlToRelTestBase.assertValid(r);
-      final RelBuilder relBuilder =
-          RelFactories.LOGICAL_BUILDER.create(cluster, null);
-      r = RelDecorrelator.decorrelateQuery(r, relBuilder);
+      r = RelDecorrelator.decorrelateQuery(r, RelFactories.LOGICAL_BUILDER);
     }
     final String planAfter = NL + RelOptUtil.toString(r);
     if (unchanged) {

--- a/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
@@ -268,11 +268,10 @@ public class ScannableTableTest {
         + "group by \"k\"";
     final Table table = new BeatlesProjectableFilterableTable(buf, false);
     final String explain = "PLAN="
-        + "EnumerableAggregate(group=[{0}], C=[COUNT()])\n"
+        + "EnumerableAggregate(group=[{1}], C=[COUNT()])\n"
         + "  EnumerableAggregate(group=[{0, 1}])\n"
         + "    EnumerableInterpreter\n"
-        + "      BindableTableScan(table=[[s, beatles]], "
-        + "filters=[[=($2, 1940)]], projects=[[2, 0]])";
+        + "      BindableTableScan(table=[[s, beatles]], filters=[[=($2, 1940)]], projects=[[0, 2]])";
     CalciteAssert.that()
         .with(newSchema("s", "beatles", table))
         .query(sql)

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -120,7 +120,7 @@ public class PlannerTest {
 
         "LogicalProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
         + "  LogicalFilter(condition=[LIKE($2, '%e%')])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n");
+        + "    LogicalTableScan(table=[[hr, emps]])\n");
   }
 
   @Test(expected = SqlParseException.class)
@@ -152,7 +152,7 @@ public class PlannerTest {
 
         "LogicalSort(sort0=[$1], dir0=[ASC], offset=[10])\n"
         + "  LogicalProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n");
+        + "    LogicalTableScan(table=[[hr, emps]])\n");
   }
 
   private String toString(RelNode rel) {
@@ -355,6 +355,7 @@ public class PlannerTest {
     Program program =
         Programs.ofRules(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
     Planner planner = getPlanner(null, program);
@@ -376,6 +377,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             SortRemoveRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE,
             EnumerableRules.ENUMERABLE_SORT_RULE);
     Planner planner = getPlanner(null, Programs.of(ruleSet));
@@ -456,6 +458,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             SortRemoveRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE,
             EnumerableRules.ENUMERABLE_WINDOW_RULE,
             EnumerableRules.ENUMERABLE_SORT_RULE,
@@ -481,6 +484,7 @@ public class PlannerTest {
   @Test public void testDuplicateSortPlanWORemoveSortRule() throws Exception {
     RuleSet ruleSet =
         RuleSets.ofList(
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE,
             EnumerableRules.ENUMERABLE_SORT_RULE);
     Planner planner = getPlanner(null, Programs.of(ruleSet));
@@ -509,6 +513,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
     final List<RelTraitDef> traitDefs = new ArrayList<>();
@@ -534,6 +539,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
     Planner planner = getPlanner(null, Programs.of(ruleSet));
@@ -582,6 +588,7 @@ public class PlannerTest {
     RuleSet ruleSet1 =
         RuleSets.ofList(
             rule1,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
 
@@ -631,6 +638,7 @@ public class PlannerTest {
     Program program0 =
         Programs.ofRules(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
 
@@ -1122,7 +1130,7 @@ public class PlannerTest {
         + "  LogicalProject(psPartkey=[$0])\n"
         + "    LogicalSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC])\n"
         + "      LogicalProject(psPartkey=[$0], psSupplyCost=[$1])\n"
-        + "        EnumerableTableScan(table=[[tpch, partsupp]])\n"));
+        + "        LogicalTableScan(table=[[tpch, partsupp]])\n"));
   }
 
   /** Test case for

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -1573,7 +1573,7 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[false], expr#5=[=($t2, $t4)], expr#
     EnumerableLimit(fetch=[1])
       EnumerableSort(sort0=[$0], dir0=[DESC])
         EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[CAST($t0):TINYINT], expr#6=[=($t4, $t5)], expr#7=[IS NULL($t5)], expr#8=[OR($t6, $t7)], cs=[$t3], $condition=[$t8])
+          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t4, $t0)], cs=[$t3], $condition=[$t5])
             EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 

--- a/core/src/test/resources/sql/winagg.iq
+++ b/core/src/test/resources/sql/winagg.iq
@@ -500,13 +500,14 @@ from
 !ok
 
 # NTH_VALUE
+select * from (
 select emp."ENAME", emp."DEPTNO",
- nth_value(emp."DEPTNO", 1) over() as "first_value",
- nth_value(emp."DEPTNO", 2) over() as "second_value",
- nth_value(emp."DEPTNO", 5) over() as "fifth_value",
- nth_value(emp."DEPTNO", 8) over() as "eighth_value",
- nth_value(emp."DEPTNO", 10) over() as "tenth_value"
-from emp order by emp."ENAME";
+ nth_value(emp."DEPTNO", 1) over( order by emp."DEPTNO") as "first_value",
+ nth_value(emp."DEPTNO", 2) over( order by emp."DEPTNO") as "second_value",
+ nth_value(emp."DEPTNO", 5) over( order by emp."DEPTNO") as "fifth_value",
+ nth_value(emp."DEPTNO", 8) over( order by emp."DEPTNO") as "eighth_value",
+ nth_value(emp."DEPTNO", 10) over( order by emp."DEPTNO") as "tenth_value"
+from emp) emp order by emp."ENAME";
 +-------+--------+-------------+--------------+-------------+--------------+-------------+
 | ENAME | DEPTNO | first_value | second_value | fifth_value | eighth_value | tenth_value |
 +-------+--------+-------------+--------------+-------------+--------------+-------------+

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-druid</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Druid</name>
   <description>Druid adapter for Calcite</description>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-druid</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Druid</name>
   <description>Druid adapter for Calcite</description>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -21,12 +21,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Elasticsearch</name>
   <description>Elasticsearch adapter for Calcite</description>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -21,12 +21,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Elasticsearch</name>
   <description>Elasticsearch adapter for Calcite</description>
 

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/function/pom.xml
+++ b/example/function/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-example-function</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Example Function</name>
   <description>Examples of user-defined Calcite functions</description>
 

--- a/example/function/pom.xml
+++ b/example/function/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-example-function</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Example Function</name>
   <description>Examples of user-defined Calcite functions</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -19,13 +19,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-file</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite File</name>
   <description>Calcite provider that reads files and URIs</description>
 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -19,13 +19,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-file</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite File</name>
   <description>Calcite provider that reads files and URIs</description>
 

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-geode</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Geode</name>
   <description>Geode adapter for Calcite</description>
 

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-geode</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Geode</name>
   <description>Geode adapter for Calcite</description>
 

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-pig</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Pig</name>
   <description>Pig adapter for Calcite</description>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-pig</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Pig</name>
   <description>Pig adapter for Calcite</description>
 

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigRel.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigRel.java
@@ -17,15 +17,24 @@
 package org.apache.calcite.adapter.pig;
 
 import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ImplicitTrait;
 import org.apache.calcite.rel.RelNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Relational expression that uses the Pig calling convention.
  */
+@ImplicitTrait(PigRel.ConventionFactory.class)
 public interface PigRel extends RelNode {
+  /** Returns PigRel.CONVENTION. © Captain Obvious */
+  class ConventionFactory implements Supplier<Convention> {
+    @Override public Convention get() {
+      return CONVENTION;
+    }
+  }
 
   /**
    * Converts this node to a Pig Latin statement.

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigRelFactories.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigRelFactories.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.CorrelationId;
@@ -38,7 +39,8 @@ import java.util.Set;
 public class PigRelFactories {
 
   public static final Context ALL_PIG_REL_FACTORIES =
-      Contexts.of(PigTableScanFactory.INSTANCE,
+      Contexts.of(RelTraitSet.createEmpty().plus(PigRel.CONVENTION),
+          PigTableScanFactory.INSTANCE,
           PigFilterFactory.INSTANCE,
           PigAggregateFactory.INSTANCE,
           PigJoinFactory.INSTANCE);

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-piglet</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Piglet</name>
   <description>Pig-like language built on top of Calcite algebra</description>
 

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-piglet</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Piglet</name>
   <description>Pig-like language built on top of Calcite algebra</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>org.apache.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
 
   <!-- More project information. -->
   <name>Calcite</name>
@@ -166,7 +166,7 @@ limitations under the License.
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/calcite.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/calcite.git</developerConnection>
     <url>https://github.com/apache/calcite</url>
-    <tag>HEAD</tag>
+    <tag>calcite-1.18.0</tag>
   </scm>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <top.dir>${project.basedir}</top.dir>
     <version.major>1</version.major>
-    <version.minor>17</version.minor>
+    <version.minor>18</version.minor>
 
     <!-- Don't fail the build for vulnerabilities below this threshold. -->
     <failBuildOnCVSS>8</failBuildOnCVSS>
@@ -793,6 +793,11 @@ limitations under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-api</artifactId>
+            <version>${maven-scm-provider.version}</version>
+          </dependency>
           <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>org.apache.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
 
   <!-- More project information. -->
   <name>Calcite</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Server</name>
   <description>Calcite Server</description>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Server</name>
   <description>Calcite Server</description>
 

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -28,15 +28,465 @@ For a full list of releases, see
 Downloads are available on the
 [downloads page]({{ site.baseurl }}/downloads/).
 
-## <a href="https://github.com/apache/calcite/releases/tag/calcite-1.18.0">1.18.0</a> / under development
+## <a href="https://github.com/apache/calcite/releases/tag/calcite-1.18.0">1.18.0</a> / 2018-12-07
 {: #v1-18-0}
+
+With over 200 commits from 36 contributors, this is the largest
+Calcite release ever. To the SQL dialect, we added
+<a href="https://issues.apache.org/jira/browse/CALCITE-2266">JSON
+functions</a> and
+<a href="https://issues.apache.org/jira/browse/CALCITE-2402">linear
+regression functions</a>, the
+<a href="https://issues.apache.org/jira/browse/CALCITE-2224">WITHIN
+GROUP</a> clause for aggregate functions; there is a new
+<a href="https://issues.apache.org/jira/browse/CALCITE-1870">utility
+to recommend lattices based on past queries</a>,
+and improvements to expression simplification ({{RexSimplify}}),
+the SQL advisor, and the Elasticsearch and Apache Geode adapters.
 
 Compatibility: This release is tested
 on Linux, macOS, Microsoft Windows;
-using Oracle JDK 8, 9, 10;
-Guava versions 19.0 to 23.0;
+using Oracle JDK 8, 9, 10, 11 and OpenJDK 10, 11;
+Guava versions 19.0 to 27.0.1-jre;
 Druid version 0.11.0;
 other software versions as specified in `pom.xml`.
+
+#### New features
+
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2662">CALCITE-2662</a>]
+  In `Planner`, allow parsing a stream (`Reader`) instead of a `String`
+  (Enrico Olivelli)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2699">CALCITE-2699</a>]
+  `TIMESTAMPADD` function now applies to `DATE` and `TIME` as well as `TIMESTAMP`
+  (xuqianjin)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-563">CALCITE-563</a>]
+  In JDBC adapter, push bindable parameters down to the underlying JDBC data
+  source (Vladimir Sitnikov, Piotr Bojko)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2663">CALCITE-2663</a>]
+  In DDL parser, add `CREATE` and `DROP FUNCTION` (ambition119)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2266">CALCITE-2266</a>]
+  Implement SQL:2016 JSON functions: `JSON_EXISTS`, `JSON_VALUE`, `JSON_QUERY`,
+  `JSON_OBJECT`, `JSON_OBJECTAGG`, `JSON_ARRAY`, `JSON_ARRAYAGG`, `x IS JSON`
+  predicate (Hongze Zhang)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2224">CALCITE-2224</a>]
+  Support `WITHIN GROUP` clause for aggregate functions (Hongze Zhang)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2405">CALCITE-2405</a>]
+  In Babel parser, make 400 reserved keywords including `YEAR`, `SECOND`, `DESC`
+  non-reserved
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-1870">CALCITE-1870</a>]
+  Lattice suggester
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2571">CALCITE-2571</a>]
+  `TRIM` function now trims more than one character (Andrew Pilloud)
+* Elasticsearch adapter:
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2679">CALCITE-2679</a>]
+    Implement `DISTINCT` and `GROUP BY` without aggregate functions (Siyuan Liu)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2689">CALCITE-2689</a>]
+    Allow grouping on non-textual fields like `DATE` and `NUMBER`
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2651">CALCITE-2651</a>]
+    Enable scrolling for basic search queries
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2585">CALCITE-2585</a>]
+    Support `NOT` operator
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2578">CALCITE-2578</a>]
+    Support `ANY_VALUE` aggregate function
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2528">CALCITE-2528</a>]
+    Support `Aggregate` (Andrei Sereda)
+* Apache Geode adapter:
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2709">CALCITE-2709</a>]
+    Allow filtering on `DATE`, `TIME`, `TIMESTAMP` fields (Sandeep Chada)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2671">CALCITE-2671</a>]
+    `GeodeFilter` now converts multiple `OR` predicates (on same attribute) into
+    a single `IN SET` (Sandeep Chada)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2498">CALCITE-2498</a>]
+    Geode adapter wrongly quotes `BOOLEAN` values as strings (Andrei Sereda)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2112">CALCITE-2112</a>]
+  Add Maven wrapper for Calcite (Ratandeep S. Ratti)
+* `SqlAdvisor`:
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2479">CALCITE-2479</a>]
+    Automatically quote identifiers that look like SQL keywords
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2478">CALCITE-2478</a>]
+    Purge `from_clause` when `_suggest_` token is located in one of the
+    `FROM` sub-queries
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2477">CALCITE-2477</a>]
+    Scalar sub-queries
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2476">CALCITE-2476</a>]
+    Produce hints when sub-query with `*` is present in query
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2475">CALCITE-2475</a>]
+    Support `MINUS`
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2473">CALCITE-2473</a>]
+    Support `--` comments
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2434">CALCITE-2434</a>]
+    Hints for nested tables and schemas
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2433">CALCITE-2433</a>]
+    Configurable quoting characters
+* `RelBuilder`:
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2661">CALCITE-2661</a>]
+    Add methods for creating `Exchange` and `SortExchange`
+    relational expressions (Chunwei Lei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2654">CALCITE-2654</a>]
+    Add a fluent API for building complex aggregate calls
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2441">CALCITE-2441</a>]
+    `RelBuilder.scan` should expand `TranslatableTable` and views
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2647">CALCITE-2647</a>]
+    Add a `groupKey` method that assumes only one grouping set
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2470">CALCITE-2470</a>]
+    `project` method should combine expressions if the underlying
+    node is a `Project`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-1026">CALCITE-1026</a>]
+  Allow models in YAML format
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2402">CALCITE-2402</a>]
+  Implement regression functions: `COVAR_POP`, `COVAR_SAMP`, `REGR_COUNT`,
+  `REGR_SXX`, `REGR_SYY`
+
+#### Bug-fixes, API changes and minor enhancements
+
+* Upgrades:
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2716">CALCITE-2716</a>]
+    Upgrade to Avatica 1.13.0
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2711">CALCITE-2711</a>]
+    Upgrade SQLLine to 1.6.0
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2570">CALCITE-2570</a>]
+    Upgrade `forbiddenapis` to 2.6 for JDK 11 support
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2486">CALCITE-2486</a>]
+    Upgrade Apache parent POM to version 21
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2467">CALCITE-2467</a>]
+    Upgrade `owasp-dependency-check` maven plugin to 3.3.1
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2559">CALCITE-2559</a>]
+    Update Checkstyle to 7.8.2
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2497">CALCITE-2497</a>]
+    Update Janino version to 3.0.9
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2596">CALCITE-2596</a>]
+  When translating correlated variables in enumerable convention, convert
+  not-null boxed primitive values to primitive (Stamatis Zampetakis)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2684">CALCITE-2684</a>]
+  `RexBuilder` gives `AssertionError` when creating integer literal larger than
+  2<sup>63</sup> (Ruben Quesada Lopez)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2719">CALCITE-2719</a>]
+  In JDBC adapter for MySQL, fix cast to `INTEGER` and `BIGINT` (Piotr Bojko)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2713">CALCITE-2713</a>]
+  JDBC adapter may generate casts on PostgreSQL for `VARCHAR` type exceeding max
+  length
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2529">CALCITE-2529</a>]
+  All numbers are in the same type family (Andrew Pilloud)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2701">CALCITE-2701</a>]
+  Make generated `Baz` classes immutable (Stamatis Zampetakis)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2619">CALCITE-2619</a>]
+  Reduce string literal creation cost by deferring and caching charset
+  conversion (Ted Xu)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2720">CALCITE-2720</a>]
+  `RelMetadataQuery.getTableOrigin` throws `IndexOutOfBoundsException` if
+  `RelNode` has no columns (Zoltan Haindrich)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2717">CALCITE-2717</a>]
+  Use `Interner` instead of `LoadingCache` to cache traits, and so allow traits
+  to be garbage-collected (Haisheng Yuan)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2542">CALCITE-2542</a>]
+  In SQL parser, allow `.field` to follow any expression, not just tables and
+  columns (Rong Rong)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2637">CALCITE-2637</a>]
+  In SQL parser, allow prefix '-' between `BETWEEN` and `AND` (Qi Yu)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2632">CALCITE-2632</a>]
+  Ensure that `RexNode` and its sub-classes implement `hashCode` and `equals`
+  methods (Zoltan Haindrich)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2494">CALCITE-2494</a>]
+  `RexFieldAccess` should implement `equals` and `hashCode` methods
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2715">CALCITE-2715</a>]
+  In JDBC adapter, do not generate character set in data types for MS SQL Server
+  (Piotr Bojko)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2714">CALCITE-2714</a>]
+  Make `BasicSqlType` immutable, and now `SqlTypeFactory.createWithNullability`
+  can reuse existing type if possible (Ruben Quesada Lopez)
+* `RexSimplify`:
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2695">CALCITE-2695</a>]
+    Simplify casts that are only widening nullability (Zoltan Haindrich)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2631">CALCITE-2631</a>]
+    General improvements in simplifying `CASE`
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2620">CALCITE-2620</a>]
+    Simplify `COALESCE(NULL, x)` &rarr; `x` (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-1413">CALCITE-1413</a>]
+    Enhance boolean case statement simplifications (Zoltan Haindrich)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2615">CALCITE-2615</a>]
+    When simplifying `NOT-AND-OR`, `RexSimplify` incorrectly applies predicates
+    deduced for operands to the same operands (Zoltan Haindrich)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2604">CALCITE-2604</a>]
+    When simplifying an expression, say whether an `UNKNOWN` value will be
+    interpreted as is, or as `TRUE` or `FALSE`
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2438">CALCITE-2438</a>]
+    Fix wrong results for `IS NOT FALSE(FALSE)` (zhiwei.pzw) (Zoltan Haindrich)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2506">CALCITE-2506</a>]
+    Simplifying `COALESCE(+ nullInt, +vInt())` results in
+    `AssertionError: result mismatch` (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2580">CALCITE-2580</a>]
+    Simplifying `COALESCE(NULL > NULL, TRUE)` produces wrong result filter
+    expressions (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2586">CALCITE-2586</a>]
+    `CASE` with repeated branches gives `AssertionError`
+    (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2590">CALCITE-2590</a>]
+    Remove redundant `CAST` when operand has exactly the same type as it is casted to
+  * Implement fuzzy generator for `CASE` expressions
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2556">CALCITE-2556</a>]
+    Simplify `NOT TRUE` &rarr; `FALSE`, and `NOT FALSE` &rarr; `TRUE` (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2581">CALCITE-2581</a>]
+    Avoid errors in simplifying `UNKNOWN AND NOT (UNKNOWN OR ...)` (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2527">CALCITE-2527</a>]
+    Simplify `(c IS NULL) OR (c IS ...)` might result in AssertionError: result
+    mismatch (pengzhiwei)
+  * Display random failure of Rex fuzzer in build logs to inspire further fixes
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2567">CALCITE-2567</a>]
+    Simplify `IS NULL(NULL)` to `TRUE` (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2555">CALCITE-2555</a>]
+    RexSimplify: Simplify `x >= NULL` to `UNKNOWN` (pengzhiwei)
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2504">CALCITE-2504</a>]
+    Add randomized test for better code coverage of rex node create and
+    simplification
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2469">CALCITE-2469</a>]
+    Simplify `(NOT x) IS NULL` &rarr; `x IS NULL` (pengzhiwei);
+    also, simplify `f(x, y) IS NULL` &rarr; `x IS NULL OR y IS NULL` if `f` is a
+    strong operator
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2327">CALCITE-2327</a>]
+    Simplify `AND(x, y, NOT(y))` &rarr; `AND(x, null, IS NULL(y))`
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2327">CALCITE-2327</a>]
+    Avoid simplification of `x AND NOT(x)` to `FALSE` for nullable `x`
+  * [<a href="https://issues.apache.org/jira/browse/CALCITE-2505">CALCITE-2505</a>]
+    `AssertionError` when simplifying `IS [NOT] DISTINCT` expressions
+    (Haisheng Yuan)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2687">CALCITE-2687</a>]
+  `IS DISTINCT FROM` could lead to exceptions in `ReduceExpressionsRule`
+  (Zoltan Haindrich)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2673">CALCITE-2673</a>]
+  `SqlDialect` supports pushing of all functions by default
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2675">CALCITE-2675</a>]
+  Type validation error as `ReduceExpressionsRule` fails to preserve type
+  nullability (Zoltan Haindrich)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2669">CALCITE-2669</a>]
+  `RelMdTableReferences` should check whether references inferred from input are
+  null for `Union`/`Join` operators
+* Following
+  [<a href="https://issues.apache.org/jira/browse/CALCITE-2031">CALCITE-2031</a>]
+  remove incorrect "Not implemented" message
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2668">CALCITE-2668</a>]
+  Support for left/right outer join in `RelMdExpressionLineage`
+* Fix invocation of deprecated constructor of `SqlAggFunction` (Hongze Zhang)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2652">CALCITE-2652</a>]
+  `SqlNode` to SQL conversion fails if the join condition references a `BOOLEAN`
+  column (Zoltan Haindrich)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2657">CALCITE-2657</a>]
+  In `RexShuttle`, use `RexCall.clone` instead of `new RexCall` (Chunwei Lei)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2605">CALCITE-2605</a>]
+  Support semi-join via `EnumerableCorrelate` (Ruben Quesada Lopez)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2605">CALCITE-2605</a>]
+  Support left outer join via `EnumerableCorrelate`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-1174">CALCITE-1174</a>]
+  When generating SQL, translate `SUM0(x)` to `COALESCE(SUM(x), 0)`
+* `RelBuilder.toString()`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2617">CALCITE-2617</a>]
+  Add a variant of `FilterProjectTransposeRule` that can push down a `Filter`
+  that contains correlated variables (Stamatis Zampetakis)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2638">CALCITE-2638</a>]
+  Constant reducer should not treat as constant an `RexInputRef` that points to a
+  call to a dynamic or non-deterministic function (Danny Chan)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2639">CALCITE-2639</a>]
+  `FilterReduceExpressionsRule` causes `ArithmeticException` at execution time
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2628">CALCITE-2628</a>]
+  JDBC adapter throws `NullPointerException` while generating `GROUP BY` query
+  for MySQL
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2404">CALCITE-2404</a>]
+  Implement access to structured-types in enumerable runtime
+  (Stamatis Zampetakis)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2622">CALCITE-2622</a>]
+  `RexFieldCollation.toString()` method is not deterministic
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2611">CALCITE-2611</a>]
+  Linq4j code generation failure if one side of an `OR` contains `UNKNOWN`
+  (Zoltan Haindrich)
+* Canonize simple cases for composite traits in trait factory
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2591">CALCITE-2591</a>]
+  `EnumerableDefaults#mergeJoin` should throw error and not return incorrect
+  results when inputs are not ordered (Enrico Olivelli)
+* Test case for
+  [<a href="https://issues.apache.org/jira/browse/CALCITE-2592">CALCITE-2592</a>]
+  `EnumerableMergeJoin` is never taken
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2526">CALCITE-2526</a>]
+  Add test for `OR` with nullable comparisons (pengzhiwei)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2413">CALCITE-2413</a>]
+  Use raw signatures for classes with generics when producing Java code
+* In Elasticsearch adapter, remove redundant null check in
+  `CompoundQueryExpression`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2562">CALCITE-2562</a>]
+  Remove dead code in `StandardConvertletTable#convertDatetimeMinus`
+* Avoid `NullPointerException` when `FlatList` contains null elements
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2561">CALCITE-2561</a>]
+  Remove dead code in `Lattice` constructor
+* Apply small refactorings to Calcite codebase (Java 5, Java 7, Java 8)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2572">CALCITE-2572</a>]
+  SQL standard semantics for `SUBSTRING` function (Andrew Pilloud)
+* Remove dead code: `Compatible`, `CompatibleGuava11`
+* Remove "Now, do something with table" from standard output when implementing
+  sequences
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2444">CALCITE-2444</a>]
+  Handle `IN` expressions when converting `SqlNode` to SQL (Zoltan Haindrich)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2537">CALCITE-2537</a>]
+  Use litmus for `VolcanoPlanner#validate`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2546">CALCITE-2546</a>]
+  Reduce precision of `Profiler`'s `surprise` and `cardinality` attributes to
+  avoid floating point discrepancies (Alisha Prabhu)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2563">CALCITE-2563</a>]
+  Materialized view rewriting may swap columns in equivalent classes incorrectly
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2551">CALCITE-2551</a>]
+  `SqlToRelConverter` gives `ClassCastException` while handling `IN` inside
+  `WHERE NOT CASE` (pengzhiwei)
+* Remove redundant `new` expression in constant array creation
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2474">CALCITE-2474</a>]
+  SqlAdvisor: avoid NPE in lookupFromHints where FROM is empty
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2418">CALCITE-2418</a>]
+  Remove `matchRecognize` field of `SqlSelect`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2514">CALCITE-2514</a>]
+  Add `SqlIdentifier` conversion to `ITEM` operator for dynamic tables in
+  `ExtendedExpander` (Arina Ielchiieva)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2491">CALCITE-2491</a>]
+  Refactor `NameSet`, `NameMap`, and `NameMultimap`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2520">CALCITE-2520</a>]
+  Make `SparkHandlerImpl#compile` silent by default, print code in
+  `calcite.debug=true` mode only
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-1026">CALCITE-1026</a>]
+  Remove unused import
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2483">CALCITE-2483</a>]
+  Druid adapter, when querying Druid segment metadata, throws when row number is
+  larger than `Integer.MAX_VALUE` (Hongze Zhang)
+* Support `AND`, `OR`, `COALESCE`, `IS [NOT] DISTINCT` in `RexUtil#op`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2495">CALCITE-2495</a>]
+  Support encoded URLs in `org.apache.calcite.util.Source`, and use it for URL
+  &rarr; File conversion in tests
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2271">CALCITE-2271</a>]
+  Join of two views with window aggregates produces incorrect results or throws
+  `NullPointerException`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2481">CALCITE-2481</a>]
+  `NameSet` assumes lower-case characters have greater codes, which does not hold
+  for certain characters
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2480">CALCITE-2480</a>]
+  `NameSet.contains` wrongly returns `false` when element in set is upper-case
+  and `seek` is lower-case
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2465">CALCITE-2465</a>]
+  Enable use of materialized views for any planner
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2446">CALCITE-2446</a>]
+  Lateral joins do not work when saved as custom views (Piotr Bojko)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2447">CALCITE-2447</a>]
+  `POWER`, `ATAN2` functions fail with `NoSuchMethodException`
+* Typo in `HepPlanner` trace message (Dylan)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2416">CALCITE-2416</a>]
+  `AssertionError` when determining monotonicity (Alina Ipatina)
+* Java 8: use `Map.computeIfAbsent` when possible
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2431">CALCITE-2431</a>]
+  `SqlUtil.getAncestry` throws `AssertionError` when providing completion hints
+  for sub-schema
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2430">CALCITE-2430</a>]
+  `RelDataTypeImpl.getFieldList` throws `AssertionError` when SQL Advisor inspects
+  non-struct field
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2429">CALCITE-2429</a>]
+  `SqlValidatorImpl.lookupFieldNamespace` throws `NullPointerException` when SQL
+  Advisor observes non-existing field
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2422">CALCITE-2422</a>]
+  Query with unnest of column from nested sub-query fails when dynamic table is
+  used
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2417">CALCITE-2417</a>]
+  `RelToSqlConverter` throws `ClassCastException` with structs (Benoit Hanotte)
+
+#### Build and test suite
+
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2678">CALCITE-2678</a>]
+  `RelBuilderTest#testRelBuilderToString` fails on Windows (Stamatis Zampetakis)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2660">CALCITE-2660</a>]
+  `OsAdapterTest` now checks whether required commands are available
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2655">CALCITE-2655</a>]
+  Enable Travis to test against JDK 12
+* Ensure that tests are not calling `checkSimplify3` with `expected`,
+  `expectedFalse`, `expectedTrue` all the same
+* Geode adapter tests: Removed unnecessary `try/final` block in `RefCountPolicy`
+* Add license to `TestKtTest` and add `apache-rat:check` to Travis CI
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2112">CALCITE-2112</a>]
+  Add Apache license header to `maven-wrapper.properties`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2588">CALCITE-2588</a>]
+  Run Geode adapter tests with an embedded instance
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2594">CALCITE-2594</a>]
+  Ensure `forbiddenapis` and `maven-compiler` use the correct JDK version
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2642">CALCITE-2642</a>]
+  Checkstyle complains that `maven-wrapper.properties` is missing a header
+* `commons:commons-pool2` is used in tests only, so use `scope=test` for it
+* Make `findbugs:jsr305` dependency optional
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2458">CALCITE-2458</a>]
+  Add Kotlin as a test dependency
+* Make build scripts Maven 3.3 compatible
+* Fix JavaDoc warnings for Java 9+, and check JavaDoc in Travis CI
+* Unwrap invocation target exception from QuidemTest#test
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2518">CALCITE-2518</a>]
+  Add `failOnWarnings` to `maven-javadoc-plugin` configuration
+* Silence Pig, Spark, and Elasticsearch logs in tests
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-1894">CALCITE-1894</a>]
+  `CsvTest.testCsvStream` failing often: add `@Ignore` since the test is known to
+  fail
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2535">CALCITE-2535</a>]
+  Enable `SqlTester.checkFails` (previously it was a no-op) (Hongze Zhang)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2558">CALCITE-2558</a>]
+  Improve re-compilation times by skipping `parser.java` update on each build
+* Increase timeout for Cassandra daemon startup for `CassandraAdapterTest`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2412">CALCITE-2412</a>]
+  Add Windows CI via AppVeyor (Sergey Nuyanzin)
+* Reduce `HepPlannerTest#testRuleApplyCount` complexity
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2523">CALCITE-2523</a>]
+  Guard `PartiallyOrderedSetTest#testPosetBitsLarge` with
+  `CalciteAssert.ENABLE_SLOW`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2521">CALCITE-2521</a>]
+  Guard `RelMetadataTest#testMetadataHandlerCacheLimit` with
+  `CalciteAssert.ENABLE_SLOW`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2484">CALCITE-2484</a>]
+  Add `SqlValidatorDynamicTest` to `CalciteSuite`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2484">CALCITE-2484</a>]
+  Move dynamic tests to a separate class like `SqlValidatorDynamicTest`, and
+  avoid reuse of `MockCatalogReaderDynamic`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2522">CALCITE-2522</a>]
+  Remove `e.printStackTrace()` from `CalciteAssert#returns`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2512">CALCITE-2512</a>]
+  Move `StreamTest#ROW_GENERATOR` to `Table.scan().iterator` to make it not
+  shared between threads (Sergey Nuyanzin)
+* Skip second Checkstyle execution during Travis CI build
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2519">CALCITE-2519</a>]
+  Silence ERROR logs from `CalciteException`, `SqlValidatorException` during
+  tests
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-1026">CALCITE-1026</a>]
+  Fix `ModelTest#testYamlFileDetection` when source folder has spaces
+* `MockCatalogReader` is used in testing, so cache should be disabled there to
+  avoid thread conflicts and/or stale results
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-311">CALCITE-311</a>]
+  Add a test-case for Filter after Window aggregate
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2462">CALCITE-2462</a>]
+  `RexProgramTest`: replace `nullLiteral` &rarr; `nullInt`,
+  `unknownLiteral` &rarr; `nullBool` for brevity
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2462">CALCITE-2462</a>]
+  `RexProgramTest`: move "rex building" methods to base class
+* `SqlTestFactory`: use lazy initialization of objects
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2435">CALCITE-2435</a>]
+  Refactor `SqlTestFactory`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2428">CALCITE-2428</a>]
+  Cassandra unit test fails to parse JDK version string (Andrei Sereda)
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2419">CALCITE-2419</a>]
+  Use embedded Cassandra for tests
+
+#### Web site and documentation
+
+* Add geospatial category to DOAP file
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2577">CALCITE-2577</a>]
+  Update links on download page to HTTPS
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2574">CALCITE-2574</a>]
+  Update download page to include instructions for verifying a downloaded
+  artifact
+* Update build status badges in `README.md`
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-2705">CALCITE-2705</a>]
+  Site: Remove duplicate "selectivity" in list of metadata types (Alan Jin)
+* Site: Add Andrei Sereda as committer
+* Site: Update Julian Hyde's affiliation
+* Update Michael Mior's affiliation
+* Site: Add instructions for updating PRs based on the discussion in the dev
+  list (Stamatis Zampetakis)
+* Site: Add committer Sergey Nuyanzin
+* Site: News item for release 1.17.0
 
 ## <a href="https://github.com/apache/calcite/releases/tag/calcite-1.17.0">1.17.0</a> / 2018-07-16
 {: #v1-17-0}
@@ -255,7 +705,8 @@ Calcite has been upgraded to use <a href='https://issues.apache.org/jira/browse/
 * [<a href='https://issues.apache.org/jira/browse/CALCITE-2403'>CALCITE-2403</a>]
   Upgrade quidem to 0.9
 * [<a href='https://issues.apache.org/jira/browse/CALCITE-2409'>CALCITE-2409</a>]
-  SparkAdapterTest fails on Windows when '/tmp' directory does not exist (Sergey Nuyanzin)
+  `SparkAdapterTest` fails on Windows when '/tmp' directory does not exist
+  (Sergey Nuyanzin)
 
 ## <a href="https://github.com/apache/calcite/releases/tag/calcite-1.16.0">1.16.0</a> / 2018-03-14
 {: #v1-16-0}

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -31,15 +31,15 @@ adapters.
 
 ## Building from a source distribution
 
-Prerequisite is Java (JDK 8, 9 or 10) on your path.
+Prerequisite is Java (JDK 8, 9, 10 or 11) on your path.
 
 Unpack the source distribution `.tar.gz` file,
 `cd` to the root directory of the unpacked source,
 then build using the included maven wrapper:
 
 {% highlight bash %}
-$ tar xvfz calcite-1.17.0-source.tar.gz
-$ cd calcite-1.17.0
+$ tar xvfz calcite-1.18.0-source.tar.gz
+$ cd calcite-1.18.0
 $ ./mvnw install
 {% endhighlight %}
 
@@ -49,7 +49,7 @@ tests.
 ## Building from git
 
 Prerequisites are git
-and Java (JDK 8, 9 or 10) on your path.
+and Java (JDK 8, 9, 10 or 11) on your path.
 
 Create a local copy of the github repository,
 `cd` to its root directory,
@@ -486,18 +486,18 @@ Follow the instructions [here](http://www.apache.org/dev/publishing-maven-artifa
 Before you start:
 
 * Set up signing keys as described above.
-* Make sure you are using JDK 8 (not 9 or 10).
+* Make sure you are using JDK 11.
 * Make sure build and tests succeed with `-Dcalcite.test.db=hsqldb` (the default)
 
 {% highlight bash %}
-# Set passphrase variable without putting it into shell history
-read -s GPG_PASSPHRASE
+# Tell GPG how to read a password from your terminal
+export GPG_TTY=$(tty)
 
 # Make sure that there are no junk files in the sandbox
 git clean -xn
 ./mvnw clean
 
-./mvnw -Papache-release -Dgpg.passphrase=${GPG_PASSPHRASE} install
+./mvnw -Papache-release install
 {% endhighlight %}
 
 When the dry-run has succeeded, change `install` to `deploy`.
@@ -581,21 +581,21 @@ If any of the steps fail, clean up (see below), fix the problem, and
 start again from the top.
 
 {% highlight bash %}
-# Set passphrase variable without putting it into shell history
-read -s GPG_PASSPHRASE
+# Tell GPG how to read a password from your terminal
+export GPG_TTY=$(tty)
 
 # Make sure that there are no junk files in the sandbox
 git clean -xn
 ./mvnw clean
 
 # Do a dry run of the release:prepare step, which sets version numbers
-# (accept the default tag name of calcite-X.Y.Z)
-# Note X.Y.Z is the current version we're trying to release, and X.Y+1.Z is the next development version.
-# For example, if I am currently building a release for 1.16.0, X.Y.Z would be 1.16.0 and X.Y+1.Z would be 1.17.0.
-./mvnw -DdryRun=true -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y+1.Z-SNAPSHOT -Papache-release -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE}" release:prepare 2>&1 | tee /tmp/prepare-dry.log
+# (accept the default tag name of calcite-x.y.z).
+# Note X.Y.Z is the current version we're trying to release (e.g. 1.8.0),
+# and X.(Y+1).Z is the next development version (e.g. 1.9.0).
+./mvnw -DdryRun=true -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.(Y+1).Z-SNAPSHOT -Papache-release release:prepare 2>&1 | tee /tmp/prepare-dry.log
 
 # If you have multiple GPG keys, you can select the key used to sign the release by adding `-Dgpg.keyname=${GPG_KEY_ID}` to `-Darguments`:
-./mvnw -DdryRun=true -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y+1.Z-SNAPSHOT -Papache-release -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEY_ID}" release:prepare 2>&1 | tee /tmp/prepare-dry.log
+./mvnw -DdryRun=true -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.(Y+1).Z-SNAPSHOT -Papache-release -Darguments="-Dgpg.keyname=${GPG_KEY_ID}" release:prepare 2>&1 | tee /tmp/prepare-dry.log
 {% endhighlight %}
 
 Check the artifacts.
@@ -632,13 +632,13 @@ For this step you'll have to add the [Apache servers](https://maven.apache.org/d
 # Prepare sets the version numbers, creates a tag, and pushes it to git
 # Note X.Y.Z is the current version we're trying to release, and X.Y+1.Z is the next development version.
 # For example, if I am currently building a release for 1.16.0, X.Y.Z would be 1.16.0 and X.Y+1.Z would be 1.17.0.
-./mvnw -DdryRun=false -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y+1.Z-SNAPSHOT -Papache-release -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE}" release:prepare 2>&1 | tee /tmp/prepare.log
+./mvnw -DdryRun=false -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y+1.Z-SNAPSHOT -Papache-release release:prepare 2>&1 | tee /tmp/prepare.log
 
 # If you have multiple GPG keys, you can select the key used to sign the release by adding `-Dgpg.keyname=${GPG_KEY_ID}` to `-Darguments`:
-./mvnw -DdryRun=false -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y+1.Z-SNAPSHOT -Papache-release -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEY_ID}" release:prepare 2>&1 | tee /tmp/prepare-dry.log
+./mvnw -DdryRun=false -DskipTests -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y+1.Z-SNAPSHOT -Papache-release -Darguments="-Dgpg.keyname=${GPG_KEY_ID}" release:prepare 2>&1 | tee /tmp/prepare.log
 
 # Perform checks out the tagged version, builds, and deploys to the staging repository
-./mvnw -DskipTests -Papache-release -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE}" release:perform 2>&1 | tee /tmp/perform.log
+./mvnw -DskipTests -Papache-release release:perform 2>&1 | tee /tmp/perform.log
 {% endhighlight %}
 
 Verify the staged artifacts in the Nexus repository:

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.0</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>1.18.0</version>
+  <version>1.18.0-1019</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.0-1019</version>
   </parent>
 
   <properties>

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
The idea here is RelBuilderFactory can optionally provide a convention.
For instance, if RelBuilderFactory would create rels of NONE convention (==LogicalProject and friends), then `operand(Filter.class)` would match `LogicalFilter.class` only.

This should enable use of `Filter.class`, `Project.class` in rule definition while still avoid accidentally consuming EnumerableFilter and producing LogicalFilter out of it.

See https://issues.apache.org/jira/browse/CALCITE-2223?focusedCommentId=16754345&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16754345