### PR TITLE
[CALCITE-2824] Fix invalid usage of RexExecutorImpl

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -37,7 +37,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexExecutor;
-import org.apache.calcite.rex.RexExecutorImpl;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -1407,14 +1406,10 @@ public class SubstitutionVisitor {
       return false;
     }
 
-    RexExecutorImpl rexImpl =
-        (RexExecutorImpl) (rel.cluster.getPlanner().getExecutor());
-    RexImplicationChecker rexImplicationChecker =
-        new RexImplicationChecker(
-            rel.cluster.getRexBuilder(), rexImpl, rel.rowType);
+    RexExecutor rex = rel.cluster.getPlanner().getExecutor();
 
-    return rexImplicationChecker.implies(((MutableFilter) rel0).condition,
-        ((MutableFilter) rel).condition);
+    return rex.implies(rel.cluster.getRexBuilder(), rel.rowType,
+                       ((MutableFilter) rel0).condition, ((MutableFilter) rel).condition);
   }
 
   /** Returns whether two relational expressions have the same row-type. */

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutor.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutor.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.rex;
 
+import org.apache.calcite.rel.type.RelDataType;
+
 import java.util.List;
 
 /** Can reduce expressions, writing a literal for each into a list. */
@@ -32,6 +34,22 @@ public interface RexExecutor {
    * @param reducedValues List to which reduced expressions are appended
    */
   void reduce(RexBuilder rexBuilder, List<RexNode> constExps, List<RexNode> reducedValues);
+
+  /**
+   * Checks if condition first implies (&rArr;) condition second.
+   *
+   * <p>This reduces to SAT problem which is NP-Complete.
+   * When this method says first implies second then it is definitely true.
+   * But it cannot prove that first does not imply second.
+   *
+   * @param rexBuilder Rex builder
+   * @param rowType row type
+   * @param first first condition
+   * @param second second condition
+   * @return true if it can prove first &rArr; second; otherwise false i.e.,
+   * it doesn't know if implication holds
+   */
+  boolean implies(RexBuilder rexBuilder, RelDataType rowType, RexNode first, RexNode second);
 }
 
 // End RexExecutor.java

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
@@ -29,6 +29,7 @@ import org.apache.calcite.linq4j.tree.IndexExpression;
 import org.apache.calcite.linq4j.tree.MethodCallExpression;
 import org.apache.calcite.linq4j.tree.MethodDeclaration;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
+import org.apache.calcite.plan.RexImplicationChecker;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.validate.SqlConformance;
@@ -161,6 +162,12 @@ public class RexExecutorImpl implements RexExecutor {
       }
       return RexToLixTranslator.convert(recordAccess, storageType);
     }
+  }
+
+  @Override public boolean implies(RexBuilder rexBuilder, RelDataType rowType, RexNode first,
+                         RexNode second) {
+    RexImplicationChecker checker = new RexImplicationChecker(rexBuilder, this, rowType);
+    return checker.implies(first, second);
   }
 }
 


### PR DESCRIPTION
There's an attempt in SubstitutionVisitor of casting RexExecutor into
a RexExecutorImpl instance, which might break when a different executor
is used for planning.

Enhancing RexExecutor interface with an implies() method, with the
RexExecutorImpl implementation being to delegate to RexImplicationChecker,
and adapting SubstitutionVisitor code to use the new interface