### PR TITLE
[CALCITE-2769] CSV Adapter does not handle - Empty and malformed csv lines, space before or after comma

### DIFF
--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
@@ -201,7 +201,11 @@ class CsvEnumerator<E> implements Enumerator<E> {
             }
           }
         }
-        current = rowConverter.convertRow(strings);
+        try {
+          current = rowConverter.convertRow(strings);
+        } catch (Exception e) {
+          continue;
+        }
         return true;
       }
     } catch (IOException e) {
@@ -237,6 +241,9 @@ class CsvEnumerator<E> implements Enumerator<E> {
     abstract E convertRow(String[] rows);
 
     protected Object convert(CsvFieldType fieldType, String string) {
+      if (string != null) {
+        string = string.trim();
+      }
       if (fieldType == null) {
         return string;
       }

--- a/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
+++ b/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
@@ -471,6 +471,15 @@ public class CsvTest {
         .returns("NAME=Sales; CNT=1", "NAME=Marketing; CNT=2").ok();
   }
 
+  @Test public void testBlankLinesAndSpaces() throws SQLException {
+    final String sql = "SELECT d.name, COUNT(*) cnt"
+        + " FROM emps AS e"
+        + " JOIN mydepts AS d ON e.deptno = d.deptno"
+        + " GROUP BY d.name";
+    sql("smart", sql)
+        .returns("NAME=Sales; CNT=1", "NAME=Marketing; CNT=2").ok();
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-824">[CALCITE-824]
    * Type inference when converting IN clause to semijoin</a>. */

--- a/example/csv/src/test/resources/sales/MYDEPTS.csv
+++ b/example/csv/src/test/resources/sales/MYDEPTS.csv
@@ -1,0 +1,9 @@
+DEPTNO:int,NAME:string
+10,"Sales"
+
+20,"Marketing"
+30,"Accounts"
+
+ 31,"My Dept"
+32,  "My Another Depts"
+


### PR DESCRIPTION
CSV Adapter does not handle - Empty and malformed csv lines, space before or after comma

File: org.apache.calcite.adapter.csv.CsvEnumerator.java in example folder did not handle CSV with space between delimiter i.e."," and also did not handle empty lines or malformed lines in the middle of the file or to the end. The sqlline crashes is there is an empty line with java.lang.ArrayIndexOutOfBoundsException. 

Also test cases fail. Refer jira: https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-2769