### PR TITLE
[CALCITE-2878] Avoid use of new RuntimeException(e) in tests

### DIFF
--- a/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
@@ -29,6 +29,7 @@ import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.JdbcFrontLinqBackTest;
 import org.apache.calcite.test.JdbcTest;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
@@ -106,7 +107,7 @@ public class CalciteRemoteDriverTest {
         try {
           return connection.getMetaData().getSchemas();
         } catch (SQLException e) {
-          throw new RuntimeException(e);
+          throw TestUtil.rethrow(e);
         }
       };
 
@@ -115,7 +116,7 @@ public class CalciteRemoteDriverTest {
         try {
           return connection.getMetaData().getCatalogs();
         } catch (SQLException e) {
-          throw new RuntimeException(e);
+          throw TestUtil.rethrow(e);
         }
       };
 
@@ -124,7 +125,7 @@ public class CalciteRemoteDriverTest {
         try {
           return connection.getMetaData().getColumns(null, null, null, null);
         } catch (SQLException e) {
-          throw new RuntimeException(e);
+          throw TestUtil.rethrow(e);
         }
       };
 
@@ -133,7 +134,7 @@ public class CalciteRemoteDriverTest {
         try {
           return connection.getMetaData().getTypeInfo();
         } catch (SQLException e) {
-          throw new RuntimeException(e);
+          throw TestUtil.rethrow(e);
         }
       };
 
@@ -142,7 +143,7 @@ public class CalciteRemoteDriverTest {
         try {
           return connection.getMetaData().getTableTypes();
         } catch (SQLException e) {
-          throw new RuntimeException(e);
+          throw TestUtil.rethrow(e);
         }
       };
 
@@ -615,7 +616,7 @@ public class CalciteRemoteDriverTest {
             new CalciteMetaImpl(conn.unwrap(CalciteConnectionImpl.class));
         return new LocalService(meta);
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
   }
@@ -771,7 +772,7 @@ public class CalciteRemoteDriverTest {
         final Connection connection = CalciteAssert.hr().connect();
         return new CalciteMetaImpl((CalciteConnectionImpl) connection);
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
   }
@@ -785,7 +786,7 @@ public class CalciteRemoteDriverTest {
             .getMeta((CalciteConnectionImpl) localConnection);
         return new LocalJsonService(new LocalService(meta));
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
   }
@@ -800,7 +801,7 @@ public class CalciteRemoteDriverTest {
                 conn.unwrap(CalciteConnectionImpl.class));
         return new LocalService(meta);
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
   }

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -40,6 +40,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.test.JdbcTest;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.TestUtil;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -407,7 +408,7 @@ public class RelWriterTest {
           try {
             node = reader.read(XX);
           } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
           return RelOptUtil.dumpPlan("", node, SqlExplainFormat.TEXT,
               SqlExplainLevel.EXPPLAN_ATTRIBUTES);
@@ -434,7 +435,7 @@ public class RelWriterTest {
           try {
             node = reader.read(XX2);
           } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
           return RelOptUtil.dumpPlan("", node, SqlExplainFormat.TEXT,
               SqlExplainLevel.EXPPLAN_ATTRIBUTES);
@@ -462,7 +463,7 @@ public class RelWriterTest {
           try {
             node = reader.read(XXNULL);
           } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
           return RelOptUtil.dumpPlan("", node, SqlExplainFormat.TEXT,
               SqlExplainLevel.EXPPLAN_ATTRIBUTES);

--- a/core/src/test/java/org/apache/calcite/profile/ProfilerTest.java
+++ b/core/src/test/java/org/apache/calcite/profile/ProfilerTest.java
@@ -25,6 +25,7 @@ import org.apache.calcite.test.Matchers;
 import org.apache.calcite.test.SlowTests;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.JsonBuilder;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.HashMultimap;
@@ -560,7 +561,7 @@ public class ProfilerTest {
                       .collect(Collectors.toList());
               assertThat(strings, matcher);
             } catch (SQLException e) {
-              throw new RuntimeException(e);
+              throw TestUtil.rethrow(e);
             }
           });
       return this;
@@ -573,7 +574,7 @@ public class ProfilerTest {
             final ResultSet r = s.executeQuery();
             return getListEnumerator(r, r.getMetaData().getColumnCount());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         }
       };
@@ -590,7 +591,7 @@ public class ProfilerTest {
               final Comparable value = (Comparable) r.getObject(i + 1);
               values[i] = NullSentinel.mask(value);
             } catch (SQLException e) {
-              throw new RuntimeException(e);
+              throw TestUtil.rethrow(e);
             }
           }
           return ImmutableList.copyOf(values);
@@ -600,7 +601,7 @@ public class ProfilerTest {
           try {
             return r.next();
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         }
 
@@ -611,7 +612,7 @@ public class ProfilerTest {
           try {
             r.close();
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         }
       };

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -54,6 +54,7 @@ import org.apache.calcite.tools.Programs;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
+import org.apache.calcite.util.TestUtil;
 
 import com.google.common.collect.ImmutableList;
 
@@ -3212,10 +3213,8 @@ public class RelToSqlConverterTest {
           rel = transform.apply(rel);
         }
         return toSql(rel, dialect);
-      } catch (RuntimeException e) {
-        throw e;
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
 

--- a/core/src/test/java/org/apache/calcite/rex/RexSqlStandardConvertletTableTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexSqlStandardConvertletTableTest.java
@@ -30,6 +30,7 @@ import org.apache.calcite.tools.Planner;
 import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.calcite.util.Closer;
+import org.apache.calcite.util.TestUtil;
 
 import org.junit.Test;
 
@@ -89,7 +90,7 @@ public class RexSqlStandardConvertletTableTest extends SqlToRelTestBase {
       final SqlNode validated = planner.validate(parsed);
       return planner.rel(validated).rel;
     } catch (SqlParseException | RelConversionException | ValidationException e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8556,7 +8556,7 @@ public class SqlParserTest {
         final SqlNode sqlNode = getSqlParser(sap.sql).parseStmt();
         assertThat(sqlNode, matcher);
       } catch (SqlParseException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
 

--- a/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
@@ -567,7 +567,7 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
     try {
       x = parseQuery(sql);
     } catch (SqlParseException e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
     final Collection<SqlNode> literalSet = new LinkedHashSet<>();
     x.accept(

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -54,6 +54,7 @@ import org.apache.calcite.test.SqlLimitsTest;
 import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.Util;
 
@@ -1516,7 +1517,7 @@ public abstract class SqlOperatorBaseTest {
           throw new AssertionError("unexpected time unit: " + timeUnit);
         }
       } catch (InterruptedException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
   }
@@ -8180,10 +8181,8 @@ public abstract class SqlOperatorBaseTest {
         final ResultSet resultSet =
             statement.executeQuery(query);
         resultChecker.checkResult(resultSet);
-      } catch (RuntimeException e) {
-        throw e;
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
 

--- a/core/src/test/java/org/apache/calcite/test/DiffTestCase.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffTestCase.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.test;
 
 import org.apache.calcite.util.ReflectUtil;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import org.incava.diff.Diff;
@@ -461,7 +462,7 @@ public abstract class DiffTestCase {
       return lines;
     } catch (IOException e) {
       e.printStackTrace();
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
   }
 
@@ -481,7 +482,7 @@ public abstract class DiffTestCase {
       }
       return writer.toString(StandardCharsets.UTF_8.name());
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -19,6 +19,7 @@ package org.apache.calcite.test;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.test.CalciteAssert.AssertThat;
 import org.apache.calcite.test.CalciteAssert.DatabaseInstance;
+import org.apache.calcite.util.TestUtil;
 
 import org.hsqldb.jdbcDriver;
 import org.junit.Test;
@@ -652,7 +653,7 @@ public class JdbcAdapterTest {
                 connection.getMetaData().getTables(null, null, "%", null);
             assertFalse(CalciteAssert.toString(resultSet).isEmpty());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -746,7 +747,7 @@ public class JdbcAdapterTest {
             .explainContains(explain)
             .planUpdateHasSql(jdbcSql, 1);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
   }
@@ -778,7 +779,7 @@ public class JdbcAdapterTest {
             .explainContains(explain)
             .planUpdateHasSql(jdbcSql, 2);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
   }
@@ -815,7 +816,7 @@ public class JdbcAdapterTest {
             .explainContains(explain)
             .planUpdateHasSql(jdbcSql, 1);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
   }
@@ -843,7 +844,7 @@ public class JdbcAdapterTest {
             .planUpdateHasSql(jdbcSql, 1);
         return null;
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
   }
@@ -867,7 +868,7 @@ public class JdbcAdapterTest {
             .explainContains(explain)
             .planUpdateHasSql(jdbcSql, 1);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
   }

--- a/core/src/test/java/org/apache/calcite/test/JdbcFrontJdbcBackTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcFrontJdbcBackTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.util.TestUtil;
+
 import org.hamcrest.Matcher;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -65,7 +67,7 @@ public class JdbcFrontJdbcBackTest {
                 "account;agg_c_10_sales_fact_1997;agg_c_14_sales_fact_1997;agg_c_special_sales_fact_1997;agg_g_ms_pcat_sales_fact_1997;agg_l_03_sales_fact_1997;agg_l_04_sales_fact_1997;agg_l_05_sales_fact_1997;agg_lc_06_sales_fact_1997;agg_lc_100_sales_fact_1997;agg_ll_01_sales_fact_1997;agg_pl_01_sales_fact_1997;category;currency;customer;days;department;employee;employee_closure;expense_fact;inventory_fact_1997;inventory_fact_1998;position;product;product_class;products;promotion;region;reserve_employee;salary;sales_fact_1997;sales_fact_1998;sales_fact_dec_1998;store;store_ragged;time_by_day;warehouse;warehouse_class;COLUMNS;TABLES;",
                 buf.toString());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -90,7 +92,7 @@ public class JdbcFrontJdbcBackTest {
             }
             assertThat(buf.toString(), matcher);
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -111,7 +113,7 @@ public class JdbcFrontJdbcBackTest {
                 "product_id;time_id;customer_id;promotion_id;store_id;store_sales;store_cost;unit_sales;",
                 buf.toString());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -129,7 +131,7 @@ public class JdbcFrontJdbcBackTest {
                     null, null, "sales_fact_1997");
             assertFalse(rset.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }

--- a/core/src/test/java/org/apache/calcite/test/JdbcFrontLinqBackTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcFrontLinqBackTest.java
@@ -29,6 +29,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.AbstractTableQueryable;
+import org.apache.calcite.util.TestUtil;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -255,7 +256,7 @@ public class JdbcFrontLinqBackTest {
           assertThat(count, is(1));
         }
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
     with.query("select count(*) as c from \"foo\".\"bar\"")

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -90,6 +90,7 @@ import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.JsonBuilder;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Smalls;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.TryThreadLocal;
 import org.apache.calcite.util.Util;
 
@@ -308,7 +309,7 @@ public class JdbcTest {
 
           statement.close();
         } catch (SQLException e) {
-          throw new RuntimeException(e);
+          throw TestUtil.rethrow(e);
         }
       });
     }
@@ -950,7 +951,7 @@ public class JdbcTest {
                   equalTo("invalid column ordinal: 5"));
             }
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -1458,7 +1459,7 @@ public class JdbcTest {
             final BigDecimal bigDecimal = resultSet.getBigDecimal(1);
             assertThat(bigDecimal, equalTo(BigDecimal.valueOf(2008)));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -1944,7 +1945,7 @@ public class JdbcTest {
             assertThat(subResultSet.isAfterLast(), is(true));
             statement.close();
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -2980,7 +2981,7 @@ public class JdbcTest {
           numbers.add((Number) resultSet.getObject(2));
         }
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
       assertThat(msg, numbers.size(), is(3));
       assertThat(msg, numbers.get(nullCollation.last(desc) ? 2 : 0),
@@ -4831,7 +4832,7 @@ public class JdbcTest {
             resultSet.close();
             statement.close();
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -4898,7 +4899,7 @@ public class JdbcTest {
             preparedStatement2.close();
             preparedStatement.close();
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -4932,7 +4933,7 @@ public class JdbcTest {
               assertThat(r, matcher);
             }
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5080,7 +5081,7 @@ public class JdbcTest {
       try {
         assertEquals("adhoc", connection.getSchema());
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
     that.query("select * from \"adhoc\".ELVIS where \"deptno\" = 10")
@@ -5383,7 +5384,7 @@ public class JdbcTest {
               CalciteAssert.toString(r));
         }
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
   }
@@ -5508,7 +5509,7 @@ public class JdbcTest {
                 .executeQuery(sql);
             assertThat(objects.size(), is(1));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5645,7 +5646,7 @@ public class JdbcTest {
             try {
               Thread.sleep(1000);
             } catch (InterruptedException e) {
-              throw new RuntimeException(e);
+              throw TestUtil.rethrow(e);
             }
 
             resultSet = statement.executeQuery();
@@ -5658,7 +5659,7 @@ public class JdbcTest {
                     + "s1=" + s1 + "\n",
                 s0.compareTo(s1) < 0);
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5671,7 +5672,7 @@ public class JdbcTest {
           try {
             checkGetTimestamp(connection);
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5821,7 +5822,7 @@ public class JdbcTest {
                 rs.getDate(1));
             assertFalse(rs.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5848,7 +5849,7 @@ public class JdbcTest {
                 rs.getTimestamp(1));
             assertFalse(rs.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5920,7 +5921,7 @@ public class JdbcTest {
             assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
                 equalTo(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5950,7 +5951,7 @@ public class JdbcTest {
             assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
                 equalTo(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -5980,7 +5981,7 @@ public class JdbcTest {
             assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
                 equalTo(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -6014,7 +6015,7 @@ public class JdbcTest {
             assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
                 equalTo(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -6045,7 +6046,7 @@ public class JdbcTest {
             assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
                 equalTo(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -6080,7 +6081,7 @@ public class JdbcTest {
             assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
                 equalTo(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -6674,7 +6675,7 @@ public class JdbcTest {
               }
             }
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }

--- a/core/src/test/java/org/apache/calcite/test/LatticeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LatticeTest.java
@@ -334,7 +334,7 @@ public class LatticeTest {
                   + "  LogicalProject(DUMMY=[0])\n"
                   + "    StarTableScan(table=[[adhoc, star]])\n",
                   counter));
-    } catch (RuntimeException e) {
+    } catch (Throwable e) {
       assertThat(Throwables.getStackTraceAsString(e),
           containsString("CannotPlanException"));
     }

--- a/core/src/test/java/org/apache/calcite/test/Matchers.java
+++ b/core/src/test/java/org/apache/calcite/test/Matchers.java
@@ -18,6 +18,7 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.base.Preconditions;
@@ -79,7 +80,7 @@ public class Matchers {
           CalciteAssert.toStringList(resultSet, actualList);
           resultSet.close();
         } catch (SQLException e) {
-          throw new RuntimeException(e);
+          throw TestUtil.rethrow(e);
         }
         Collections.sort(actualList);
 

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -34,6 +34,7 @@ import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.TableMacroImpl;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.util.Smalls;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
@@ -432,7 +433,7 @@ public class ReflectiveSchemaTest {
                     ++n;
                   }
                 } catch (SQLException e) {
-                  throw new RuntimeException(e);
+                  throw TestUtil.rethrow(e);
                 }
                 assertThat(n, equalTo(1));
               });
@@ -499,7 +500,7 @@ public class ReflectiveSchemaTest {
                 check(metaData, "utilDate", Timestamp.class);
                 check(metaData, "string", String.class);
               } catch (SQLException e) {
-                throw new RuntimeException(e);
+                throw TestUtil.rethrow(e);
               }
             });
   }
@@ -658,7 +659,7 @@ public class ReflectiveSchemaTest {
               buf.append(input.getInt(2)).append("\n");
             }
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
           assertThat(buf.toString(), equalTo("0\n2147483647\n"));
         });

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -91,6 +91,7 @@ import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.SaffronProperties;
+import org.apache.calcite.util.TestUtil;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -1108,7 +1109,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
       join = EnumerableMergeJoin.create(project, deptSort,
           rexBuilder.makeLiteral(true), leftKeys, rightKeys, JoinRelType.INNER);
     } catch (InvalidRelException e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
     collations =
         RelMdCollation.mergeJoin(mq, project, deptSort, leftKeys,

--- a/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
@@ -22,12 +22,11 @@ import org.apache.calcite.sql.test.SqlTester;
 import org.apache.calcite.sql.test.SqlValidatorTester;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.BarfingInvocationHandler;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
@@ -56,11 +55,8 @@ public class SqlTestGen {
         final Object result = method.invoke(test);
         assert result == null;
       }
-    } catch (IOException | IllegalAccessException
-        | IllegalArgumentException e) {
-      throw new RuntimeException(e);
-    } catch (InvocationTargetException e) {
-      throw new RuntimeException(e.getCause());
+    } catch (Exception e) {
+      throw TestUtil.rethrow(e);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.externalize.RelJsonReader;
 import org.apache.calcite.rel.externalize.RelJsonWriter;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.util.TestUtil;
 
 import org.junit.After;
 import org.junit.Before;
@@ -71,7 +72,7 @@ public class SqlToRelConverterExtendedTest extends SqlToRelConverterTest {
       try {
         RelNode x = reader.read(json);
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
       return null;
     });

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
@@ -64,6 +64,7 @@ import org.apache.calcite.test.catalog.MockCatalogReaderDynamic;
 import org.apache.calcite.test.catalog.MockCatalogReaderSimple;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.TestUtil;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -578,7 +579,7 @@ public abstract class SqlToRelTestBase {
       } catch (RuntimeException | Error e) {
         throw e;
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
       final RelDataTypeFactory typeFactory = getTypeFactory();
       final Prepare.CatalogReader catalogReader =

--- a/core/src/test/java/org/apache/calcite/test/StreamTest.java
+++ b/core/src/test/java/org/apache/calcite/test/StreamTest.java
@@ -36,6 +36,7 @@ import org.apache.calcite.schema.TableFactory;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.TestUtil;
 
 import com.google.common.collect.ImmutableList;
 
@@ -337,7 +338,7 @@ public class StreamTest {
           assertThat(actualRow, equalTo(expectedRow));
         }
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     };
   }

--- a/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
@@ -26,6 +26,7 @@ import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.TableFunctionImpl;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.util.Smalls;
+import org.apache.calcite.util.TestUtil;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -389,7 +390,7 @@ public class TableFunctionTest {
             assertThat(numbers.toString(),
                 is("[1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233]"));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }

--- a/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
@@ -68,6 +68,7 @@ import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
@@ -292,7 +293,7 @@ public class FrameworksTest {
             RelRunner runner2 = connection.unwrap(RelRunner.class);
             runner2.prepare(values).executeQuery();
           } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -396,7 +397,7 @@ public class DruidAdapterIT {
             assertThat(map.get("BIGINT").size(), is(1));
             assertThat(map.get(VARCHAR_TYPE).size(), is(88));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -502,7 +503,7 @@ public class DruidAdapterIT {
             assertThat(input.wasNull(), is(false));
             assertThat(input.next(), is(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -795,7 +796,7 @@ public class DruidAdapterIT {
             }
             assertFalse(resultSet.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         })
         .queryContains(druidChecker(druidQuery));
@@ -824,7 +825,7 @@ public class DruidAdapterIT {
             }
             assertFalse(resultSet.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         })
         .queryContains(druidChecker(druidQuery));
@@ -870,7 +871,7 @@ public class DruidAdapterIT {
             }
             assertFalse(resultSet.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         })
         .queryContains(druidChecker(druidQuery, druidFilter, druidQuery2));

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT2.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT2.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -156,7 +157,7 @@ public class DruidAdapterIT2 {
             assertThat(map.get("BIGINT").size(), is(1));
             assertThat(map.get(VARCHAR_TYPE).size(), is(88));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -262,7 +263,7 @@ public class DruidAdapterIT2 {
             assertThat(input.wasNull(), is(false));
             assertThat(input.next(), is(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -552,7 +553,7 @@ public class DruidAdapterIT2 {
             }
             assertFalse(resultSet.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         })
         .queryContains(druidChecker(druidQuery));
@@ -581,7 +582,7 @@ public class DruidAdapterIT2 {
             }
             assertFalse(resultSet.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         })
         .queryContains(druidChecker(druidQuery));
@@ -627,7 +628,7 @@ public class DruidAdapterIT2 {
             }
             assertFalse(resultSet.next());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         })
         .queryContains(druidChecker(druidQuery, druidFilter, druidQuery2));

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -23,6 +23,7 @@ import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.ElasticsearchChecker;
+import org.apache.calcite.util.TestUtil;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
@@ -257,7 +258,7 @@ public class ElasticSearchAdapterTest {
           }
         }
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     };
   }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchNode.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchNode.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.adapter.elasticsearch;
 
+import org.apache.calcite.util.TestUtil;
+
 import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
 
@@ -96,7 +98,7 @@ class EmbeddedElasticsearchNode implements AutoCloseable {
       node.start();
       this.isStarted = true;
     } catch (NodeValidationException e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
   }
 

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
@@ -21,6 +21,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.util.TestUtil;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
@@ -256,7 +257,7 @@ public class Projection2Test {
           fail("Should have failed on previous line, but for some reason didn't");
         }
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     };
   }

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -57,6 +57,12 @@ limitations under the License.
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
+++ b/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
@@ -22,6 +22,7 @@ import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.util.Sources;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableMap;
@@ -199,7 +200,7 @@ public class CsvTest {
         assertThat(o, is(300L));
         assertThat(resultSet.next(), is(false));
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }).ok();
   }
@@ -320,7 +321,7 @@ public class CsvTest {
         CsvTest.collect(lines, resultSet);
         Assert.assertEquals(Arrays.asList(expected), lines);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     };
   }
@@ -337,7 +338,7 @@ public class CsvTest {
         Collections.sort(lines);
         Assert.assertEquals(expectedLines, lines);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     };
   }
@@ -951,7 +952,7 @@ public class CsvTest {
     try {
       output(resultSet, System.out);
     } catch (SQLException e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
     return null;
   }
@@ -1016,7 +1017,7 @@ public class CsvTest {
         checkSql(sql, model, expect);
         return this;
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
 

--- a/file/src/test/java/org/apache/calcite/adapter/file/SqlTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/SqlTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.adapter.file;
 
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.Ordering;
@@ -71,7 +72,7 @@ public class SqlTest {
         }
         assertEquals(expected, actual);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
       return null;
     };
@@ -89,7 +90,7 @@ public class SqlTest {
         Collections.sort(lines);
         Assert.assertEquals(expectedLines, lines);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
       return null;
     };
@@ -263,7 +264,7 @@ public class SqlTest {
         String actual = toString(resultSet);
         assertThat(actual, is(""));
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
       return null;
     });
@@ -322,7 +323,7 @@ public class SqlTest {
         checkSql(sql, model, expect);
         return this;
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     }
 

--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -22,6 +22,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.MongoAssertions;
 import org.apache.calcite.util.Bug;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.io.LineProcessor;
@@ -725,7 +726,7 @@ public class MongoAdapterTest implements SchemaFactory {
             Assert.assertThat(input.next(), CoreMatchers.is(true));
             Assert.assertThat(input.getInt(1), CoreMatchers.is(ZIPS_SIZE));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }

--- a/mongodb/src/test/java/org/apache/calcite/test/MongoAssertions.java
+++ b/mongodb/src/test/java/org/apache/calcite/test/MongoAssertions.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.Ordering;
@@ -66,7 +67,7 @@ public class MongoAssertions {
         assertThat(Ordering.natural().immutableSortedCopy(actualList),
             equalTo(expectedList));
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     };
   }

--- a/pig/src/test/java/org/apache/calcite/test/PigRelBuilderStyleTest.java
+++ b/pig/src/test/java/org/apache/calcite/test/PigRelBuilderStyleTest.java
@@ -35,6 +35,7 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.TestUtil;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.pig.pigunit.Cluster;
@@ -266,7 +267,7 @@ public class PigRelBuilderStyleTest extends AbstractPigTest {
       PigTest pigTest = new PigTest(script.split("[\\r\\n]+"));
       pigTest.assertOutputAnyOrder(expectedResults);
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
   }
 

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -60,6 +60,12 @@ limitations under the License.
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/piglet/src/test/java/org/apache/calcite/test/CalciteHandler.java
+++ b/piglet/src/test/java/org/apache/calcite/test/CalciteHandler.java
@@ -20,6 +20,7 @@ import org.apache.calcite.piglet.Handler;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.tools.PigRelBuilder;
 import org.apache.calcite.tools.RelRunners;
+import org.apache.calcite.util.TestUtil;
 
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -46,7 +47,7 @@ class CalciteHandler extends Handler {
       final ResultSet resultSet = preparedStatement.executeQuery();
       dump(resultSet, true);
     } catch (SQLException e) {
-      throw new RuntimeException(e);
+      throw TestUtil.rethrow(e);
     }
   }
 

--- a/plus/src/test/java/org/apache/calcite/adapter/os/OsAdapterTest.java
+++ b/plus/src/test/java/org/apache/calcite/adapter/os/OsAdapterTest.java
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.Sources;
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import org.hamcrest.CoreMatchers;
@@ -114,7 +115,7 @@ public class OsAdapterTest {
             assertThat(r.getString(2), CoreMatchers.startsWith("./"));
             assertThat(r.wasNull(), is(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -134,7 +135,7 @@ public class OsAdapterTest {
             assertThat(r.next(), is(true));
             assertThat(r.next(), is(false)); // because of "limit 2"
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -163,7 +164,7 @@ public class OsAdapterTest {
             }
             assertThat(b.toString(), notNullValue());
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -179,7 +180,7 @@ public class OsAdapterTest {
             assertThat(r.getString(1), notNullValue());
             assertThat(r.wasNull(), is(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -193,7 +194,7 @@ public class OsAdapterTest {
             assertThat(r.getString(1), notNullValue());
             assertThat(r.wasNull(), is(false));
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }
@@ -220,7 +221,7 @@ public class OsAdapterTest {
               assertThat(r.wasNull(), is(false));
             }
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }

--- a/splunk/src/test/java/org/apache/calcite/test/SplunkAdapterTest.java
+++ b/splunk/src/test/java/org/apache/calcite/test/SplunkAdapterTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableSet;
@@ -201,7 +202,7 @@ public class SplunkAdapterTest {
         }
         return null;
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     });
   }
@@ -224,7 +225,7 @@ public class SplunkAdapterTest {
         assertThat(actual, equalTo(expected));
         return null;
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw TestUtil.rethrow(e);
       }
     };
   }
@@ -243,7 +244,7 @@ public class SplunkAdapterTest {
             assertThat(actual.contains("404"), is(true));
             return null;
           } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw TestUtil.rethrow(e);
           }
         });
   }


### PR DESCRIPTION
`new RuntimeException(e)` adds very little info in tests, and it makes stacktraces harder to read.
So it makes sense to just sneaky-throw in those cases, especially for test purposes.