### PR TITLE
[CALCITE-2552] Support for column alias in order by clause for BigQuerySqlDialect and HiveSqlDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -31,6 +31,8 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
@@ -136,6 +138,7 @@ public class SqlDialect {
   private final DatabaseProduct databaseProduct;
   protected final NullCollation nullCollation;
   private final RelDataTypeSystem dataTypeSystem;
+  private final SqlConformance sqlConformance;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -192,6 +195,7 @@ public class SqlDialect {
    * @param context All the information necessary to create a dialect
    */
   public SqlDialect(Context context) {
+    this.sqlConformance = Objects.requireNonNull(context.sqlConformance());
     this.nullCollation = Objects.requireNonNull(context.nullCollation());
     this.dataTypeSystem = Objects.requireNonNull(context.dataTypeSystem());
     this.databaseProduct =
@@ -218,7 +222,8 @@ public class SqlDialect {
   /** Creates an empty context. Use {@link #EMPTY_CONTEXT} if possible. */
   protected static Context emptyContext() {
     return new ContextImpl(DatabaseProduct.UNKNOWN, null, null, -1, -1, null,
-        NullCollation.HIGH, RelDataTypeSystemImpl.DEFAULT, JethroDataSqlDialect.JethroInfo.EMPTY);
+      NullCollation.HIGH, RelDataTypeSystemImpl.DEFAULT, JethroDataSqlDialect.JethroInfo.EMPTY,
+      SqlConformanceEnum.DEFAULT);
   }
 
   /**
@@ -862,6 +867,13 @@ public class SqlDialect {
     return nullCollation;
   }
 
+  /**
+   * Returns SqlConformance for current SqlDialect
+   */
+  public SqlConformance getSqlConformance() {
+    return this.sqlConformance;
+  }
+
   /** Returns whether NULL values are sorted first or last, in this dialect,
    * in an ORDER BY item of a given direction. */
   public RelFieldCollation.NullDirection defaultNullDirection(
@@ -1065,6 +1077,8 @@ public class SqlDialect {
     Context withDataTypeSystem(@Nonnull RelDataTypeSystem dataTypeSystem);
     JethroDataSqlDialect.JethroInfo jethroInfo();
     Context withJethroInfo(JethroDataSqlDialect.JethroInfo jethroInfo);
+    @Nonnull SqlConformance sqlConformance();
+    Context withSqlConformance(@Nonnull SqlConformance sqlConformance);
   }
 
   /** Implementation of Context. */
@@ -1078,13 +1092,15 @@ public class SqlDialect {
     private final NullCollation nullCollation;
     private final RelDataTypeSystem dataTypeSystem;
     private final JethroDataSqlDialect.JethroInfo jethroInfo;
+    private final SqlConformance sqlConformance;
 
     private ContextImpl(DatabaseProduct databaseProduct,
         String databaseProductName, String databaseVersion,
         int databaseMajorVersion, int databaseMinorVersion,
         String identifierQuoteString, NullCollation nullCollation,
         RelDataTypeSystem dataTypeSystem,
-        JethroDataSqlDialect.JethroInfo jethroInfo) {
+        JethroDataSqlDialect.JethroInfo jethroInfo,
+        SqlConformance sqlConformance) {
       this.databaseProduct = Objects.requireNonNull(databaseProduct);
       this.databaseProductName = databaseProductName;
       this.databaseVersion = databaseVersion;
@@ -1094,6 +1110,7 @@ public class SqlDialect {
       this.nullCollation = Objects.requireNonNull(nullCollation);
       this.dataTypeSystem = Objects.requireNonNull(dataTypeSystem);
       this.jethroInfo = Objects.requireNonNull(jethroInfo);
+      this.sqlConformance = Objects.requireNonNull(sqlConformance);
     }
 
     @Nonnull public DatabaseProduct databaseProduct() {
@@ -1104,7 +1121,7 @@ public class SqlDialect {
         @Nonnull DatabaseProduct databaseProduct) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     public String databaseProductName() {
@@ -1114,7 +1131,7 @@ public class SqlDialect {
     public Context withDatabaseProductName(String databaseProductName) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     public String databaseVersion() {
@@ -1124,7 +1141,7 @@ public class SqlDialect {
     public Context withDatabaseVersion(String databaseVersion) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     public int databaseMajorVersion() {
@@ -1134,7 +1151,7 @@ public class SqlDialect {
     public Context withDatabaseMajorVersion(int databaseMajorVersion) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     public int databaseMinorVersion() {
@@ -1144,7 +1161,7 @@ public class SqlDialect {
     public Context withDatabaseMinorVersion(int databaseMinorVersion) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     public String identifierQuoteString() {
@@ -1154,7 +1171,7 @@ public class SqlDialect {
     public Context withIdentifierQuoteString(String identifierQuoteString) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     @Nonnull public NullCollation nullCollation() {
@@ -1164,7 +1181,7 @@ public class SqlDialect {
     public Context withNullCollation(@Nonnull NullCollation nullCollation) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     @Nonnull public RelDataTypeSystem dataTypeSystem() {
@@ -1174,7 +1191,7 @@ public class SqlDialect {
     public Context withDataTypeSystem(@Nonnull RelDataTypeSystem dataTypeSystem) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
     }
 
     @Nonnull public JethroDataSqlDialect.JethroInfo jethroInfo() {
@@ -1184,7 +1201,17 @@ public class SqlDialect {
     public Context withJethroInfo(JethroDataSqlDialect.JethroInfo jethroInfo) {
       return new ContextImpl(databaseProduct, databaseProductName,
           databaseVersion, databaseMajorVersion, databaseMinorVersion,
-          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo);
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
+    }
+
+    public Context withSqlConformance(@Nonnull SqlConformance sqlConformance) {
+      return new ContextImpl(databaseProduct, databaseProductName,
+          databaseVersion, databaseMajorVersion, databaseMinorVersion,
+          identifierQuoteString, nullCollation, dataTypeSystem, jethroInfo, sqlConformance);
+    }
+
+    @Nonnull public SqlConformance sqlConformance() {
+      return sqlConformance;
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -20,10 +20,12 @@ import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSetOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 
 /**
  * A <code>SqlDialect</code> implementation for Google BigQuery's "Standard SQL"
@@ -34,7 +36,8 @@ public class BigQuerySqlDialect extends SqlDialect {
       new BigQuerySqlDialect(
           EMPTY_CONTEXT
               .withDatabaseProduct(SqlDialect.DatabaseProduct.BIG_QUERY)
-              .withNullCollation(NullCollation.LOW));
+              .withNullCollation(NullCollation.LOW)
+              .withSqlConformance(SqlConformanceEnum.BIG_QUERY));
 
   /** Creates a BigQuerySqlDialect. */
   public BigQuerySqlDialect(SqlDialect.Context context) {
@@ -73,6 +76,11 @@ public class BigQuerySqlDialect extends SqlDialect {
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }
+  }
+
+  @Override public SqlNode emulateNullDirection(SqlNode node,
+      boolean nullsFirst, boolean desc) {
+    return emulateNullDirectionWithIsNull(node, nullsFirst, desc);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
@@ -24,6 +24,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 
 /**
  * A <code>SqlDialect</code> implementation for the Apache Hive database.
@@ -32,7 +33,8 @@ public class HiveSqlDialect extends SqlDialect {
   public static final SqlDialect DEFAULT =
       new HiveSqlDialect(EMPTY_CONTEXT
           .withDatabaseProduct(DatabaseProduct.HIVE)
-          .withNullCollation(NullCollation.LOW));
+          .withNullCollation(NullCollation.LOW)
+          .withSqlConformance(SqlConformanceEnum.HIVE));
 
   private final boolean emulateNullDirection;
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -133,8 +133,10 @@ public interface SqlConformance {
    * {@link SqlConformanceEnum#MYSQL_5},
    * {@link SqlConformanceEnum#ORACLE_10},
    * {@link SqlConformanceEnum#ORACLE_12},
-   * {@link SqlConformanceEnum#STRICT_92};
-   * {@link SqlConformanceEnum#SQL_SERVER_2008};
+   * {@link SqlConformanceEnum#STRICT_92},
+   * {@link SqlConformanceEnum#SQL_SERVER_2008},
+   * {@link SqlConformanceEnum#BIG_QUERY},
+   * {@link SqlConformanceEnum#HIVE};
    * false otherwise.
    */
   boolean isSortByAlias();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -69,7 +69,15 @@ public enum SqlConformanceEnum implements SqlConformance {
 
   /** Conformance value that instructs Calcite to use SQL semantics
    * consistent with Microsoft SQL Server version 2008. */
-  SQL_SERVER_2008;
+  SQL_SERVER_2008,
+
+  /** Conformance value that instructs Calcite to use SQL semantics
+   * consistent with Google BigQuery. */
+  BIG_QUERY,
+
+  /** Conformance value that instructs Calcite to use SQL semantics
+   * consistent with Apache Hive. */
+  HIVE;
 
   public boolean isLiberal() {
     switch (this) {
@@ -141,6 +149,8 @@ public enum SqlConformanceEnum implements SqlConformance {
     case ORACLE_12:
     case STRICT_92:
     case SQL_SERVER_2008:
+    case HIVE:
+    case BIG_QUERY:
       return true;
     default:
       return false;

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -145,6 +145,32 @@ public class RelToSqlConverterTest {
     return sqlNode.toSqlString(dialect).getSql();
   }
 
+  @Test public void testSimpleSelectWithOrderByAliasAsc() {
+    final String query = "select sku+1 as a from \"product\" order by a";
+    final String bigQueryExpected = "SELECT SKU + 1 AS A\nFROM foodmart.product\n"
+        + "ORDER BY A IS NULL, A";
+    final String hiveExpected = "SELECT SKU + 1 A\nFROM foodmart.product\n"
+        + "ORDER BY A IS NULL, A";
+    sql(query)
+        .withBigquery()
+        .ok(bigQueryExpected)
+        .withHive()
+        .ok(hiveExpected);
+  }
+
+  @Test public void testSimpleSelectWithOrderByAliasDesc() {
+    final String query = "select sku+1 as a from \"product\" order by a desc";
+    final String bigQueryExpected = "SELECT SKU + 1 AS A\nFROM foodmart.product\n"
+        + "ORDER BY A IS NULL DESC, A DESC";
+    final String hiveExpected = "SELECT SKU + 1 A\nFROM foodmart.product\n"
+        + "ORDER BY A IS NULL DESC, A DESC";
+    sql(query)
+        .withBigquery()
+        .ok(bigQueryExpected)
+        .withHive()
+        .ok(hiveExpected);
+  }
+
   @Test public void testSimpleSelectStarFromProductTable() {
     String query = "select * from \"product\"";
     sql(query).ok("SELECT *\nFROM \"foodmart\".\"product\"");
@@ -676,40 +702,56 @@ public class RelToSqlConverterTest {
     sql(query).withBigquery().ok(expected);
   }
 
-  @Test public void testHiveSelectQueryWithOrderByDescAndNullsFirstShouldBeEmulated() {
+  @Test public void testSelectQueryWithOrderByDescAndNullsFirstShouldBeEmulated() {
     final String query = "select \"product_id\" from \"product\"\n"
         + "order by \"product_id\" desc nulls first";
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
         + "ORDER BY product_id IS NULL DESC, product_id DESC";
-    sql(query).dialect(HiveSqlDialect.DEFAULT).ok(expected);
+    sql(query)
+        .withHive()
+        .ok(expected)
+        .withBigquery()
+        .ok(expected);
   }
 
-  @Test public void testHiveSelectQueryWithOrderByAscAndNullsLastShouldBeEmulated() {
+  @Test public void testSelectQueryWithOrderByAscAndNullsLastShouldBeEmulated() {
     final String query = "select \"product_id\" from \"product\"\n"
         + "order by \"product_id\" nulls last";
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
         + "ORDER BY product_id IS NULL, product_id";
-    sql(query).dialect(HiveSqlDialect.DEFAULT).ok(expected);
+    sql(query)
+        .withHive()
+        .ok(expected)
+        .withBigquery()
+        .ok(expected);
   }
 
-  @Test public void testHiveSelectQueryWithOrderByAscNullsFirstShouldNotAddNullEmulation() {
+  @Test public void testSelectQueryWithOrderByAscNullsFirstShouldNotAddNullEmulation() {
     final String query = "select \"product_id\" from \"product\"\n"
         + "order by \"product_id\" nulls first";
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
         + "ORDER BY product_id";
-    sql(query).dialect(HiveSqlDialect.DEFAULT).ok(expected);
+    sql(query)
+        .withHive()
+        .ok(expected)
+        .withBigquery()
+        .ok(expected);
   }
 
-  @Test public void testHiveSelectQueryWithOrderByDescNullsLastShouldNotAddNullEmulation() {
+  @Test public void testSelectQueryWithOrderByDescNullsLastShouldNotAddNullEmulation() {
     final String query = "select \"product_id\" from \"product\"\n"
         + "order by \"product_id\" desc nulls last";
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
         + "ORDER BY product_id DESC";
-    sql(query).dialect(HiveSqlDialect.DEFAULT).ok(expected);
+    sql(query)
+        .withHive()
+        .ok(expected)
+        .withBigquery()
+        .ok(expected);
   }
 
   @Test public void testMysqlCastToBigint() {


### PR DESCRIPTION
CALCITE-2552
Pull request for JIRA https://issues.apache.org/jira/browse/CALCITE-2552

1. Added sqlConformance instance in SqlDialect for  dialect specific features.
2. Added enum entry for Hive and BigQuery in SqlConformanceEnum
3. SqlImplementor is checking whether dialect supports column name in alias by looking at SqlConformance.isSortByAlias()
4. Emulated null direction for BigQuerySqlDialect
5. Added test cases for order by alias desc and asc