### PR TITLE
[CALCITE-2840] Simplification should use more specific UnknownAs mode…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexUnknownAs.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUnknownAs.java
@@ -94,6 +94,17 @@ public enum RexUnknownAs {
       throw new IllegalArgumentException("unknown");
     }
   }
+
+  public RexUnknownAs negate() {
+    switch (this) {
+    case TRUE:
+      return FALSE;
+    case FALSE:
+      return TRUE;
+    default:
+      return UNKNOWN;
+    }
+  }
 }
 
 // End RexUnknownAs.java

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8818,7 +8818,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[AND(>($3, 0), CASE(>($3, 0), >(/($7, $3), 1), null:BOOLEAN))])
+  LogicalFilter(condition=[AND(>($3, 0), CASE(>($3, 0), >(/($7, $3), 1), false))])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>


### PR DESCRIPTION
…s during simplification

Earlier nested AND/OR expressions might not were able to exploit the specific simplification rules
targeted for IS TRUE alike expressions.