### PR TITLE
[CALCITE-2848] Simplifying a case statement's first branch should ign…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -952,7 +952,8 @@ public class RexSimplify {
     // but not interfere with the normal simplifcation recursion
     List<CaseBranch> branches = new ArrayList<>();
     for (CaseBranch branch : inputBranches) {
-      if (!isSafeExpression(branch.cond) || !isSafeExpression(branch.value)) {
+      if ((branches.size() > 0 && !isSafeExpression(branch.cond))
+          || !isSafeExpression(branch.value)) {
         return null;
       }
       RexNode cond;

--- a/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexProgramTest.java
@@ -1874,6 +1874,13 @@ public class RexProgramTest extends RexProgramBuilderBase {
     checkSimplifyUnchanged(caseNode);
   }
 
+  @Test public void testSimplifyCaseFirstBranchIsSafe() {
+    RexNode caseNode = case_(
+        gt(div(vIntNotNull(), literal(1)), literal(1)), falseLiteral,
+        trueLiteral);
+    checkSimplify(caseNode, "<=(/(?0.notNullInt0, 1), 1)");
+  }
+
   @Test public void testSimplifyAnd() {
     RelDataType booleanNotNullableType =
         typeFactory.createTypeWithNullability(


### PR DESCRIPTION
…ore its safety

Earlier when a CASE expression had any condition/value which contained probably dangerous instructions,
the rewrite to a boolean expression was abandoned.
This change relaxes the check to omit it for first branch's condition - because that would be evaluated anyway.