### PR TITLE
CALCITE-2833- Select without from support & CALCITE-2834-Support for values clause for dialects which neither have values clause nor dual table

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -285,12 +285,12 @@ public class RelToSqlConverter extends SqlImplementor
         || !(Iterables.get(stack, 1).r instanceof TableModify);
     final List<String> fieldNames = e.getRowType().getFieldNames();
     if (!dialect.supportsAliasedValues() && rename) {
-      // Oracle does not support "AS t (c1, c2)". So instead of
-      //   (VALUES (v0, v1), (v2, v3)) AS t (c0, c1)
+      // Some dialects don't support "AS t (c1, c2)". So instead of
+      // (VALUES (v0, v1), (v2, v3)) AS t (c0, c1)
       // we generate
-      //   SELECT v0 AS c0, v1 AS c1 FROM DUAL
-      //   UNION ALL
-      //   SELECT v2 AS c0, v3 AS c1 FROM DUAL
+      // SELECT v0 AS c0, v1 AS c1
+      // UNION ALL
+      // SELECT v2 AS c0, v3 AS c1
       List<SqlSelect> list = new ArrayList<>();
       for (List<RexLiteral> tuple : e.getTuples()) {
         final List<SqlNode> values2 = new ArrayList<>();
@@ -303,7 +303,7 @@ public class RelToSqlConverter extends SqlImplementor
         list.add(
             new SqlSelect(POS, null,
                 new SqlNodeList(values2, POS),
-                new SqlIdentifier("DUAL", POS), null, null,
+              dialect.fromIdentifier(), null, null,
                 null, null, null, null, null));
       }
       if (list.size() == 1) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -756,6 +756,10 @@ public class SqlDialect {
     return node;
   }
 
+  public SqlIdentifier fromIdentifier() {
+    return null;
+  }
+
   /**
    * Returns whether the dialect supports OFFSET/FETCH clauses
    * introduced by SQL:2008, for instance

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -41,6 +41,10 @@ public class BigQuerySqlDialect extends SqlDialect {
     super(context);
   }
 
+  @Override public boolean supportsAliasedValues() {
+    return false;
+  }
+
   @Override public void unparseCall(final SqlWriter writer, final SqlCall call, final int leftPrec,
       final int rightPrec) {
     switch (call.getKind()) {
@@ -58,16 +62,22 @@ public class BigQuerySqlDialect extends SqlDialect {
     case UNION:
       if (!((SqlSetOperator) call.getOperator()).isAll()) {
         SqlSyntax.BINARY.unparse(writer, UNION_DISTINCT, call, leftPrec, rightPrec);
+      } else {
+        super.unparseCall(writer, call, leftPrec, rightPrec);
       }
       break;
     case EXCEPT:
       if (!((SqlSetOperator) call.getOperator()).isAll()) {
         SqlSyntax.BINARY.unparse(writer, EXCEPT_DISTINCT, call, leftPrec, rightPrec);
+      } else {
+        super.unparseCall(writer, call, leftPrec, rightPrec);
       }
       break;
     case INTERSECT:
       if (!((SqlSetOperator) call.getOperator()).isAll()) {
         SqlSyntax.BINARY.unparse(writer, INTERSECT_DISTINCT, call, leftPrec, rightPrec);
+      } else {
+        super.unparseCall(writer, call, leftPrec, rightPrec);
       }
       break;
     default:

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -67,18 +67,10 @@ public class BigQuerySqlDialect extends SqlDialect {
       }
       break;
     case EXCEPT:
-      if (!((SqlSetOperator) call.getOperator()).isAll()) {
-        SqlSyntax.BINARY.unparse(writer, EXCEPT_DISTINCT, call, leftPrec, rightPrec);
-      } else {
-        super.unparseCall(writer, call, leftPrec, rightPrec);
-      }
+      SqlSyntax.BINARY.unparse(writer, EXCEPT_DISTINCT, call, leftPrec, rightPrec);
       break;
     case INTERSECT:
-      if (!((SqlSetOperator) call.getOperator()).isAll()) {
-        SqlSyntax.BINARY.unparse(writer, INTERSECT_DISTINCT, call, leftPrec, rightPrec);
-      } else {
-        super.unparseCall(writer, call, leftPrec, rightPrec);
-      }
+      SqlSyntax.BINARY.unparse(writer, INTERSECT_DISTINCT, call, leftPrec, rightPrec);
       break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
@@ -50,6 +50,10 @@ public class HiveSqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean supportsAliasedValues() {
+    return false;
+  }
+
   @Override public void unparseOffsetFetch(SqlWriter writer, SqlNode offset,
       SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -19,12 +19,15 @@ package org.apache.calcite.sql.dialect;
 import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.OracleSqlOperatorTable;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+import static org.apache.calcite.rel.rel2sql.SqlImplementor.POS;
 
 /**
  * A <code>SqlDialect</code> implementation for the Oracle database.
@@ -50,6 +53,10 @@ public class OracleSqlDialect extends SqlDialect {
 
   @Override public boolean supportsAliasedValues() {
     return false;
+  }
+
+  @Override public SqlIdentifier fromIdentifier() {
+    return new SqlIdentifier("DUAL", POS);
   }
 
   @Override public void unparseCall(SqlWriter writer, SqlCall call,

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -666,24 +666,6 @@ public class RelToSqlConverterTest {
     sql(query).withBigquery().ok(expected);
   }
 
-  @Test public void testIntersectAllOperatorForBigQuery() {
-    final String query = "select mod(11,3) from \"product\"\n"
-        + "INTERSECT ALL select 1 from \"product\"";
-    final String expected = "SELECT MOD(11, 3)\n"
-        + "FROM foodmart.product\n"
-        + "INTERSECT ALL\nSELECT 1\nFROM foodmart.product";
-    sql(query).withBigquery().ok(expected);
-  }
-
-  @Test public void testExceptAllOperatorForBigQuery() {
-    final String query = "select mod(11,3) from \"product\"\n"
-        + "EXCEPT ALL select 1 from \"product\"";
-    final String expected = "SELECT MOD(11, 3)\n"
-        + "FROM foodmart.product\n"
-        + "EXCEPT ALL\nSELECT 1\nFROM foodmart.product";
-    sql(query).withBigquery().ok(expected);
-  }
-
   @Test public void testHiveSelectQueryWithOrderByDescAndNullsFirstShouldBeEmulated() {
     final String query = "select \"product_id\" from \"product\"\n"
         + "order by \"product_id\" desc nulls first";
@@ -3093,6 +3075,7 @@ public class RelToSqlConverterTest {
       .ok(expected)
       .withBigquery()
       .ok(expected);
+  }
 
   @Test public void testCrossJoinEmulationForSpark() {
     String query = "select * from \"employee\", \"department\"";


### PR DESCRIPTION
CALCITE-2833- Select without from support
CALCITE-2834-Support for values clause for dialects which neither have values clause nor dual table
BUX-FIX-UNION ALL bug fix for BigQuery