### PR TITLE
[CALCITE-2828] Fix VolcanoPlanner.validate() to handle cost propagati…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -93,7 +93,7 @@ public class RelSubset extends AbstractRelNode {
   /**
    * Timestamp for metadata validity
    */
-  long timestamp;
+  long timestamp = 0;
 
   /**
    * Flag indicating whether this RelSubset's importance was artificially
@@ -334,7 +334,6 @@ public class RelSubset extends AbstractRelNode {
 
   void propagateCostImprovements0(VolcanoPlanner planner, RelMetadataQuery mq,
       RelNode rel, Set<RelSubset> activeSet) {
-    ++timestamp;
 
     if (!activeSet.add(this)) {
       // This subset is already in the chain being propagated to. This
@@ -344,6 +343,7 @@ public class RelSubset extends AbstractRelNode {
       return;
     }
     try {
+      ++timestamp;
       final RelOptCost cost = planner.getCost(rel, mq);
       if (cost.isLt(bestCost)) {
         LOGGER.trace("Subset cost improved: subset [{}] cost was {} now {}", this, bestCost, cost);

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -1856,12 +1856,14 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
 
   // implement RelOptPlanner
   public long getRelMetadataTimestamp(RelNode rel) {
-    RelSubset subset = getSubset(rel);
-    if (subset == null) {
-      return 0;
-    } else {
-      return subset.timestamp;
+    List<Long> inputSubsets = new ArrayList<>();
+    for (RelNode input : rel.getInputs()) {
+      RelSubset inputSubset = getSubset(input);
+      if (inputSubset != null) {
+        inputSubsets.add(inputSubset.timestamp);
+      }
     }
+    return inputSubsets.hashCode();
   }
 
   /**


### PR DESCRIPTION
…on properly

When getCost(rel) is called, a node's nonCumulativeCost() is computed.  When using CachingRelMetadataProvider is used, metadata is cached (rowCount, cost, etc.) for future use.  In order to make sure that we do not use stale metadata, each RelOptPlanner provides getRelMetadataTimestamp(rel) which is used to invalidate the cache (if the cached entry has timestamp != getRelMetadataTimestamp(rel), it is not used.

The problem in this case was due to the fact that VolcanoPlanner uses the rel's current RelSubset's timestamp as getRelMetadataTimestamp().  Since a rel can belong to multiple RelSubset, this results in inconsistent cache hits/misses.  For example, if a rel belongs to RelSubset#1 and RelSubset#2 with relMetadataTimestamp of 1 and 2, respectively.  If rel happens to update its cost with RelSubset#1 first, then the cache will be updated with timestamp 1 so when the same rel in RelSubset#2's context try to look up its metadata, it will fail.  This results in inefficient use of the cache.  The main problem occurs when we get incorrect cache hits (e.g. previous iteration of metadata query on RelSubset#2 populated the cache with timestamp 2, but later in the context of RelSubset#1, we think there is a valid cache and use the stale metadata).

Change-Id: Iefb630f5813ba497b7fbc0144c8fd6050e59b1a3