### PR TITLE
[CALCITE-2827] Allow Convention.NONE planning with VolcanoPlanner

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -227,6 +227,11 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
    */
   private boolean locked;
 
+  /**
+   * Whether rels with Convention.NONE has infinite cost.
+   */
+  private boolean noneConventionHasInfiniteCost = true;
+
   private final List<RelOptMaterialization> materializations =
       new ArrayList<>();
 
@@ -931,13 +936,22 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     }
   }
 
+  /**
+   * Sets whether this planner should consider rel nodes with Convention.NONE
+   * to have inifinte cost or not.
+   * @param infinite Whether to make none convention rel nodes inifite cost
+   */
+  public void setNoneConventionHasInfiniteCost(boolean infinite) {
+    this.noneConventionHasInfiniteCost = infinite;
+  }
+
   public RelOptCost getCost(RelNode rel, RelMetadataQuery mq) {
     assert rel != null : "pre-condition: rel != null";
     if (rel instanceof RelSubset) {
       return ((RelSubset) rel).bestCost;
     }
-    if (rel.getTraitSet().getTrait(ConventionTraitDef.INSTANCE)
-        == Convention.NONE) {
+    if (noneConventionHasInfiniteCost
+        && rel.getTraitSet().getTrait(ConventionTraitDef.INSTANCE) == Convention.NONE) {
       return costFactory.makeInfiniteCost();
     }
     RelOptCost cost = mq.getNonCumulativeCost(rel);

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
@@ -258,6 +258,21 @@ public class VolcanoPlannerTraitTest {
     assertTrue(child instanceof PhysLeafRel);
   }
 
+  @Test public void testPlanWithNoneConvention() {
+    VolcanoPlanner planner = new VolcanoPlanner();
+    planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+    RelOptCluster cluster = newCluster(planner);
+    NoneTinyLeafRel leaf = new NoneTinyLeafRel(cluster, "noneLeafRel");
+    planner.setRoot(leaf);
+    RelOptCost cost = planner.getCost(leaf, RelMetadataQuery.instance());
+
+    assertTrue(cost.isInfinite());
+
+    planner.setNoneConventionHasInfiniteCost(false);
+    cost = planner.getCost(leaf, RelMetadataQuery.instance());
+    assertTrue(!cost.isInfinite());
+  }
+
   //~ Inner Classes ----------------------------------------------------------
 
   /** Implementation of {@link RelTrait} for testing. */
@@ -550,6 +565,27 @@ public class VolcanoPlannerTraitTest {
           new PhysLeafRel(
               leafRel.getCluster(),
               leafRel.getLabel()));
+    }
+  }
+
+  /** Relational expression with zero input, of NONE convention, and tiny cost. */
+  private static class NoneTinyLeafRel extends TestLeafRel {
+    protected NoneTinyLeafRel(
+        RelOptCluster cluster,
+        String label) {
+      super(
+          cluster,
+          cluster.traitSetOf(Convention.NONE),
+          label);
+    }
+
+    @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      return new NoneTinyLeafRel(getCluster(), getLabel());
+    }
+
+    public RelOptCost computeSelfCost(RelOptPlanner planner,
+                                      RelMetadataQuery mq) {
+      return planner.getCostFactory().makeTinyCost();
     }
   }
 


### PR DESCRIPTION
By default, cost for Convention.NONE is infinity.
- Add option to allow Convention.None planning with VolcanoPlanner
- Add a unit test

Change-Id: Idcee2ca923c9b10b58cc9352a390a87f899b64ee