### PR TITLE
[CALCITE-2864]Add the JSON_DEPTH function

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -140,6 +140,7 @@ data: {
         "JAVA"
         "JSON"
         "JSON_TYPE"
+        "JSON_DEPTH"
         "K"
         "KEY"
         "KEY_MEMBER"

--- a/core/custom-schema-model.json
+++ b/core/custom-schema-model.json
@@ -1,0 +1,15 @@
+{
+  version: '1.0',
+  defaultSchema: 'adhoc',
+  schemas: [
+    {
+      name: 'empty'
+    },
+    {
+      name: 'adhoc',
+      type: 'custom',
+      factory: 'org.apache.calcite.test.JdbcTest$MySchemaFactory',
+      operand: {'tableName': 'ELVIS'}
+    }
+  ]
+}

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -160,6 +160,7 @@ data: {
         "JAVA"
         "JSON"
         "JSON_TYPE"
+        "JSON_DEPTH"
         "K"
         "KEY"
         "KEY_MEMBER"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4829,6 +4829,8 @@ SqlNode BuiltinFunctionCall() :
     |
         node = JsonTypeFunctionCall() { return node; }
     |
+        node = JsonDepthFunctionCall() { return node; }
+    |
         node = JsonObjectAggFunctionCall() { return node; }
     |
         node = JsonArrayFunctionCall() { return node; }
@@ -5261,6 +5263,22 @@ SqlCall JsonTypeFunctionCall() :
     }
     <RPAREN> {
         return SqlStdOperatorTable.JSON_TYPE.createCall(span.end(this), args);
+    }
+}
+
+SqlCall JsonDepthFunctionCall() :
+{
+    final SqlNode[] args = new SqlNode[1];
+    SqlNode e;
+    final Span span;
+}
+{
+    <JSON_DEPTH> { span = span(); }
+    <LPAREN> e = JsonValueExpression(true) {
+        args[0] = e;
+    }
+    <RPAREN> {
+        return SqlStdOperatorTable.JSON_DEPTH.createCall(span.end(this), args);
     }
 }
 
@@ -6293,6 +6311,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < JSON_VALUE: "JSON_VALUE" >
 |   < JSON_OBJECT: "JSON_OBJECT">
 |   < JSON_TYPE: "JSON_TYPE">
+|   < JSON_DEPTH: "JSON_DEPTH">
 |   < JSON_OBJECTAGG: "JSON_OBJECTAGG">
 |   < JSON_QUERY: "JSON_QUERY" >
 |   < K: "K" >

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -162,6 +162,7 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ITEM;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_API_COMMON_SYNTAX;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_ARRAY;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_ARRAYAGG;
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_DEPTH;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_EXISTS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECT;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECTAGG;
@@ -452,6 +453,7 @@ public class RexImpTable {
     defineMethod(JSON_QUERY, BuiltInMethod.JSON_QUERY.method, NullPolicy.NONE);
     defineMethod(JSON_OBJECT, BuiltInMethod.JSON_OBJECT.method, NullPolicy.NONE);
     defineMethod(JSON_TYPE, BuiltInMethod.JSON_TYPE.method, NullPolicy.NONE);
+    defineMethod(JSON_DEPTH, BuiltInMethod.JSON_DEPTH.method, NullPolicy.NONE);
     aggMap.put(JSON_OBJECTAGG,
         JsonObjectAggImplementor
             .supplierFor(BuiltInMethod.JSON_OBJECTAGG_ADD.method));

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -855,6 +855,9 @@ public interface CalciteResource {
 
   @BaseMessage("Unknown JSON type in JSON_TYPE function, and the object is: ''{0}''")
   ExInst<CalciteException> unknownObjectOfJsonType(String value);
+
+  @BaseMessage("Unknown JSON depth in JSON_DEPTH function, and the object is: ''{0}''")
+  ExInst<CalciteException> unknownObjectOfJsonDepth(String value);
 }
 
 // End CalciteResource.java

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -67,12 +67,14 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
@@ -2710,6 +2712,48 @@ public class SqlFunctions {
     } catch (Exception ex) {
       throw RESOURCE.unknownObjectOfJsonType(o.toString()).ex();
     }
+  }
+
+  public static Integer jsonDepth(Object o) {
+    final Integer result;
+    try {
+      if (o == null) {
+        result = null;
+      } else {
+        result = getJsonDepth(o);
+      }
+      return result;
+    } catch (Exception ex) {
+      throw RESOURCE.unknownObjectOfJsonDepth(o.toString()).ex();
+    }
+  }
+
+  private static Integer getJsonDepth(Object o) {
+    if (isScalarObject(o)) {
+      return 1;
+    }
+    Queue<Object> q = new LinkedList<>();
+    int depth = 0;
+    q.add(o);
+
+    while (!q.isEmpty()) {
+      int size = q.size();
+      for (int i = 0; i < size; ++i) {
+        Object obj = q.poll();
+        if (obj instanceof Map) {
+          for (Object value : ((LinkedHashMap) obj).values()) {
+            q.add(value);
+          }
+        } else if (obj instanceof Collection) {
+          for (Object value : (Collection) obj) {
+            q.add(value);
+          }
+        }
+      }
+      ++depth;
+    }
+
+    return depth;
   }
 
   public static boolean isJsonValue(String input) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonDepthFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonDepthFunction.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+
+/**
+ * The <code>JSON_DEPTH</code> function.
+ */
+public class SqlJsonDepthFunction extends SqlFunction {
+  public SqlJsonDepthFunction() {
+    super("JSON_DEPTH",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.INTEGER_NULLABLE,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.SYSTEM);
+  }
+
+  @Override public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.of(1);
+  }
+
+  @Override protected void checkOperandCount(SqlValidator validator,
+                                             SqlOperandTypeChecker argType, SqlCall call) {
+    assert call.operandCount() == 1;
+  }
+
+  @Override public SqlCall createCall(SqlLiteral functionQualifier,
+                                      SqlParserPos pos, SqlNode... operands) {
+    return super.createCall(functionQualifier, pos, operands);
+  }
+
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec,
+                                int rightPrec) {
+    super.unparse(writer, call, 0, 0);
+  }
+}
+
+// End SqlJsonDepthFunction.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1305,6 +1305,8 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
 
   public static final SqlFunction JSON_TYPE = new SqlJsonTypeFunction();
 
+  public static final SqlFunction JSON_DEPTH = new SqlJsonDepthFunction();
+
   public static final SqlJsonObjectAggAggFunction JSON_OBJECTAGG =
       new SqlJsonObjectAggAggFunction("JSON_OBJECTAGG",
           SqlJsonConstructorNullClause.NULL_ON_NULL);

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -283,6 +283,7 @@ public enum BuiltInMethod {
   JSON_OBJECT(SqlFunctions.class, "jsonObject",
       SqlJsonConstructorNullClause.class),
   JSON_TYPE(SqlFunctions.class, "jsonType", Object.class),
+  JSON_DEPTH(SqlFunctions.class, "jsonDepth", Object.class),
   JSON_OBJECTAGG_ADD(SqlFunctions.class, "jsonObjectAggAdd", Map.class,
       String.class, Object.class, SqlJsonConstructorNullClause.class),
   JSON_ARRAY(SqlFunctions.class, "jsonArray",

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -278,4 +278,5 @@ NullKeyOfJsonObjectNotAllowed=Null key of JSON object is not allowed
 QueryExecutionTimeoutReached=Timeout of ''{0}'' ms for query execution is reached. Query execution started at ''{1}''
 ExceptionWhilePerformingQueryOnJdbcSubSchema = While executing SQL [{0}] on JDBC sub-schema
 UnknownObjectOfJsonType=Unknown JSON type in JSON_TYPE function, and the object is: ''{0}''
+UnknownObjectOfJsonDepth=Unknown JSON depth in JSON_DEPTH function, and the object is: ''{0}''
 # End CalciteResource.properties

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -144,6 +144,7 @@ data: {
         "JAVA"
         "JSON"
         "JSON_TYPE"
+        "JSON_DEPTH"
         "K"
         "KEY"
         "KEY_MEMBER"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3062,6 +3062,14 @@ public class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  @Test public void testJsonDepth() {
+    String query = "select json_depth(\"product_name\") from \"product\"";
+    final String expected = "SELECT "
+            + "JSON_DEPTH(\"product_name\" FORMAT JSON)\n"
+            + "FROM \"foodmart\".\"product\"";
+    sql(query).ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final SchemaPlus schema;

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8389,6 +8389,16 @@ public class SqlParserTest {
             "JSON_TYPE('{\"foo\": \"100\"}' FORMAT JSON)");
   }
 
+  @Test public void testJsonDepth() {
+    checkExp("json_depth('11.56')", "JSON_DEPTH('11.56' FORMAT JSON)");
+    checkExp("json_depth('{}')", "JSON_DEPTH('{}' FORMAT JSON)");
+    checkExp("json_depth(null)", "JSON_DEPTH(NULL FORMAT JSON)");
+    checkExp("json_depth('[\"foo\",null]')",
+            "JSON_DEPTH('[\"foo\",null]' FORMAT JSON)");
+    checkExp("json_depth('{\"foo\": \"100\"}')",
+            "JSON_DEPTH('{\"foo\": \"100\"}' FORMAT JSON)");
+  }
+
   @Test public void testJsonObjectAgg() {
     checkExp("json_objectagg(k_column: v_column)",
         "JSON_OBJECTAGG(KEY `K_COLUMN` VALUE `V_COLUMN` NULL ON NULL)");

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4497,6 +4497,34 @@ public abstract class SqlOperatorBaseTest {
             "STRING", "VARCHAR(20) NOT NULL");
   }
 
+  @Test public void testJsonDepth() {
+    tester.setFor(SqlStdOperatorTable.JSON_DEPTH);
+    tester.checkString("json_depth('1')",
+            "1", "INTEGER");
+    tester.checkString("json_depth('11.45')",
+            "1", "INTEGER");
+    tester.checkString("json_depth('true')",
+            "1", "INTEGER");
+    tester.checkString("json_depth('\"2019-01-27 21:24:00\"')",
+            "1", "INTEGER");
+    tester.checkString("json_depth('{}')",
+            "1", "INTEGER");
+    tester.checkString("json_depth('[]')",
+              "1", "INTEGER");
+    tester.checkString("json_depth('null')",
+            null, "INTEGER");
+    tester.checkString("json_depth(cast(null as varchar(1)))",
+            null, "INTEGER");
+    tester.checkString("json_depth('[10, true]')",
+            "2", "INTEGER");
+    tester.checkString("json_depth('[[], {}]')",
+              "2", "INTEGER");
+    tester.checkString("json_depth('{\"a\": [10, true]}')",
+            "3", "INTEGER");
+    tester.checkString("json_depth('[10, {\"a\": [[1,2]]}]')",
+            "5", "INTEGER");
+  }
+
   @Test public void testJsonObjectAgg() {
     checkAggType(tester, "json_objectagg('foo': 'bar')", "VARCHAR(2000) NOT NULL");
     tester.checkFails("^json_objectagg(100: 'bar')^",

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -6760,6 +6760,18 @@ public class JdbcTest {
         .returns("C1=OBJECT; C2=ARRAY; C3=INTEGER; C4=BOOLEAN\n");
   }
 
+  @Ignore
+  @Test public void testJsonDepth() {
+    CalciteAssert.that()
+        .query("SELECT JSON_DEPTH(v) AS c1\n"
+            + ",JSON_DEPTH(JSON_VALUE(v, 'lax $.b' ERROR ON ERROR)) AS c2\n"
+            + ",JSON_DEPTH(JSON_VALUE(v, 'strict $.a[0]' ERROR ON ERROR)) AS c3\n"
+            + ",JSON_DEPTH(JSON_VALUE(v, 'strict $.a[1]' ERROR ON ERROR)) AS c4\n"
+            + "FROM (VALUES ('{\"a\": [10, true],\"b\": \"[10, true]\"}')) AS t(v)\n"
+            + "limit 10")
+        .returns("C1=3; C2=2; C3=1; C4=1\n");
+  }
+
   /**
    * Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2609">[CALCITE-2609]

--- a/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
@@ -66,6 +66,7 @@ public class SqlJsonFunctionsTest {
   public static final String INVOC_DESC_DEJSONIZE = "dejsonize";
   public static final String INVOC_DESC_JSON_OBJECT = "jsonObject";
   public static final String INVOC_DESC_JSON_TYPE = "jsonType";
+  public static final String INVOC_DESC_JSON_DEPTH = "jsonDepth";
   public static final String INVOC_DESC_JSON_OBJECT_AGG_ADD =
       "jsonObjectAggAdd";
   public static final String INVOC_DESC_JSON_ARRAY = "jsonArray";
@@ -488,6 +489,19 @@ public class SqlJsonFunctionsTest {
   }
 
   @Test
+  public void testJsonDepth() {
+    assertJsonDepth(is(1), "{}");
+    assertJsonDepth(is(1), "false");
+    assertJsonDepth(is(1), "12");
+    assertJsonDepth(is(1), "11.22");
+    assertJsonDepth(is(2),
+            "[\"foo\",null]");
+    assertJsonDepth(is(3),
+            "{\"a\": [10, true]}");
+    assertJsonDepth(nullValue(), "null");
+  }
+
+  @Test
   public void testJsonObjectAggAdd() {
     Map<String, Object> map = new HashMap<>();
     Map<String, Object> expected = new HashMap<>();
@@ -675,6 +689,15 @@ public class SqlJsonFunctionsTest {
         SqlFunctions.jsonType(
                 SqlFunctions.dejsonize(input)),
         matcher);
+  }
+
+  private void assertJsonDepth(Matcher<? super Integer> matcher,
+                              String input) {
+    assertThat(
+            invocationDesc(INVOC_DESC_JSON_DEPTH, input),
+            SqlFunctions.jsonDepth(
+                    SqlFunctions.dejsonize(input)),
+            matcher);
   }
 
   private void assertJsonObjectAggAdd(Map map, String k, Object v,

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10777,6 +10777,14 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             "(.*)JSON_VALUE_EXPRESSION(.*)");
   }
 
+  @Test public void testJsonDepth() {
+    check("select json_depth(ename) from emp");
+    checkExp("json_depth('{\"foo\":\"bar\"}')");
+    checkExpType("json_depth('{\"foo\":\"bar\"}')", "INTEGER");
+    checkFails("select json_depth(^1^) from emp",
+            "(.*)JSON_VALUE_EXPRESSION(.*)");
+  }
+
   @Test public void testJsonObjectAgg() {
     check("select json_objectagg(ename: empno) from emp");
     checkFails("select ^json_objectagg(empno: ename)^ from emp",

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -152,6 +152,7 @@ data: {
         "JAVA"
         "JSON"
         "JSON_TYPE"
+        "JSON_DEPTH"
         "K"
         "KEY"
         "KEY_MEMBER"

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -563,6 +563,7 @@ JAVA,
 JSON,
 **JSON_ARRAY**,
 **JSON_ARRAYAGG**,
+JSON_DEPTH,
 **JSON_EXISTS**,
 **JSON_OBJECT**,
 **JSON_OBJECTAGG**,
@@ -1999,7 +2000,10 @@ Note:
 
 | Operator syntax                                   | Description
 |:------------------------------------------------- |:-----------
-| JSON_TYPE(value) | Returns a string indicating the type of a JSON **value**. This can be an object, an array, or a scalar type
+| JSON_TYPE(value)                                  | Returns a string indicating the type of a JSON **value**. This can be an object, an array, or a scalar type
+| JSON_DEPTH(value)                                 | Returns a integer indicating the depth of a JSON **value**. This can be an object, an array, or a scalar type
+
+* JSON_TYPE
 
 Example SQL:
 
@@ -2017,6 +2021,25 @@ Result:
 | c1     | c2    | c3      | c4      |
 | ------ | ----- | ------- | ------- |
 | OBJECT | ARRAY | INTEGER | BOOLEAN |
+
+* JSON_DEPTH
+
+Example SQL:
+
+```SQL
+SELECT JSON_DEPTH(v) AS c1
+,JSON_DEPTH(JSON_VALUE(v, 'lax $.b' ERROR ON ERROR)) AS c2
+,JSON_DEPTH(JSON_VALUE(v, 'strict $.a[0]' ERROR ON ERROR)) AS c3
+,JSON_DEPTH(JSON_VALUE(v, 'strict $.a[1]' ERROR ON ERROR)) AS c4
+FROM (VALUES ('{"a": [10, true],"b": "[10, true]"}')) AS t(v)
+LIMIT 10;
+```
+
+Result:
+
+| c1     | c2    | c3      | c4      |
+| ------ | ----- | ------- | ------- |
+| 3      | 2     | 1       | 1       |
 
 ## User-defined functions
 


### PR DESCRIPTION
Returns the maximum depth of a JSON document. Returns NULL if the argument is NULL. An error occurs if the argument is not a valid JSON document.

An empty array, empty object, or scalar value has depth 1. A nonempty array containing only elements of depth 1 or nonempty object containing only member values of depth 1 has depth 2. Otherwise, a JSON document has depth greater than 2.

Example Sql:

```sql
SELECT JSON_DEPTH(v) AS c1
,JSON_DEPTH(JSON_VALUE(v, 'lax $.b' ERROR ON ERROR)) AS c2
,JSON_DEPTH(JSON_VALUE(v, 'strict $.a[0]' ERROR ON ERROR)) AS c3
,JSON_DEPTH(JSON_VALUE(v, 'strict $.a[1]' ERROR ON ERROR)) AS c4
FROM (VALUES ('{"a": [10, true],"b": "[10, true]"}')) AS t(v)
limit 10;
```

Result:

| c1   | c2   | c3   | c4   |
| ---- | ---- | ---- | ---- |
| 3    | 2    | 1    | 1    |

