### PR TITLE
[CALCITE-2808] Add the JSON_LENGTH function

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -141,6 +141,8 @@ data: {
         "JSON"
         "JSON_TYPE"
         "JSON_DEPTH"
+        "JSON_LENGTH"
+        "JSON_PRETTY"
         "K"
         "KEY"
         "KEY_MEMBER"
@@ -555,9 +557,6 @@ data: {
         "JSON_ARRAYAGG",
         "JSON_EXISTS",
         "JSON_VALUE",
-        "JSON_TYPE",
-        "JSON_DEPTH"
-        "JSON_PRETTY",
         "JSON_OBJECT",
         "JSON_OBJECTAGG",
         "JSON_QUERY",

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -161,6 +161,7 @@ data: {
         "JSON"
         "JSON_TYPE"
         "JSON_DEPTH"
+        "JSON_LENGTH"
         "JSON_PRETTY"
         "K"
         "KEY"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4833,6 +4833,8 @@ SqlNode BuiltinFunctionCall() :
     |
         node = JsonDepthFunctionCall() { return node; }
     |
+        node = JsonLengthFunctionCall() { return node; }
+    |
         node = JsonObjectAggFunctionCall() { return node; }
     |
         node = JsonArrayFunctionCall() { return node; }
@@ -4927,21 +4929,32 @@ SqlNode JsonPathSpec() :
     }
 }
 
-SqlNode JsonApiCommonSyntax() :
+SqlNode JsonApiCommonSyntax(boolean acceptNonPath) :
 {
     SqlNode e;
     List<SqlNode> args = new ArrayList<SqlNode>();
     Span span;
+    SqlOperator op;
 }
 {
     e = JsonValueExpression(true) {
         args.add(e);
         span = Span.of(e);
     }
-    <COMMA>
-    e = Expression(ExprContext.ACCEPT_NON_QUERY) {
-        args.add(e);
-    }
+    (
+        <COMMA>
+        e = Expression(ExprContext.ACCEPT_NON_QUERY) {
+            op = SqlStdOperatorTable.JSON_API_COMMON_SYNTAX;
+            args.add(e);
+        }
+    |
+        {
+            if (!acceptNonPath) {
+              throw new ParseException(RESOURCE.jsonPathMustBeSpecified().str());
+            }
+            op = SqlStdOperatorTable.JSON_API_COMMON_SYNTAX;
+        }
+    )
     [
         <PASSING> e = JsonValueExpression(false) {
             args.add(e);
@@ -4960,9 +4973,8 @@ SqlNode JsonApiCommonSyntax() :
         )*
     ]
     {
-        return SqlStdOperatorTable.JSON_API_COMMON_SYNTAX.createCall(span.end(this), args);
+        return op.createCall(span.end(this), args);
     }
-
 }
 
 SqlJsonExistsErrorBehavior JsonExistsErrorBehavior() :
@@ -4988,7 +5000,7 @@ SqlCall JsonExistsFunctionCall() :
 }
 {
     <JSON_EXISTS> { span = span(); }
-    <LPAREN> e = JsonApiCommonSyntax() {
+    <LPAREN> e = JsonApiCommonSyntax(false) {
         args = new ArrayList<SqlNode>();
         args.add(e);
     }
@@ -5045,7 +5057,7 @@ SqlCall JsonValueFunctionCall() :
 }
 {
     <JSON_VALUE> { span = span(); }
-    <LPAREN> e = JsonApiCommonSyntax() {
+    <LPAREN> e = JsonApiCommonSyntax(false) {
         args[0] = e;
     }
     [
@@ -5154,7 +5166,7 @@ SqlCall JsonQueryFunctionCall() :
 }
 {
     <JSON_QUERY> { span = span(); }
-    <LPAREN> e = JsonApiCommonSyntax() {
+    <LPAREN> e = JsonApiCommonSyntax(false) {
         args[0] = e;
     }
     [
@@ -5297,6 +5309,23 @@ SqlCall JsonDepthFunctionCall() :
     }
     <RPAREN> {
         return SqlStdOperatorTable.JSON_DEPTH.createCall(span.end(this), args);
+    }
+}
+
+SqlCall JsonLengthFunctionCall() :
+{
+    final SqlNode[] args = new SqlNode[1];
+    SqlNode e;
+    final Span span;
+    List<SqlNode> behavior;
+}
+{
+    <JSON_LENGTH> { span = span(); }
+    <LPAREN> e = JsonApiCommonSyntax(true) {
+       args[0] = e;
+    }
+    <RPAREN> {
+        return SqlStdOperatorTable.JSON_LENGTH.createCall(span.end(this), args);
     }
 }
 
@@ -6377,6 +6406,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < JSON_OBJECT: "JSON_OBJECT">
 |   < JSON_TYPE: "JSON_TYPE">
 |   < JSON_DEPTH: "JSON_DEPTH">
+|   < JSON_LENGTH: "JSON_LENGTH">
 |   < JSON_OBJECTAGG: "JSON_OBJECTAGG">
 |   < JSON_QUERY: "JSON_QUERY" >
 |   < K: "K" >

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -165,6 +165,7 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_ARRAY;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_ARRAYAGG;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_DEPTH;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_EXISTS;
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_LENGTH;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECT;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECTAGG;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_PRETTY;
@@ -449,7 +450,7 @@ public class RexImpTable {
     defineMethod(JSON_STRUCTURED_VALUE_EXPRESSION,
         BuiltInMethod.JSON_STRUCTURED_VALUE_EXPRESSION.method, NullPolicy.STRICT);
     defineMethod(JSON_API_COMMON_SYNTAX, BuiltInMethod.JSON_API_COMMON_SYNTAX.method,
-        NullPolicy.NONE);
+            NullPolicy.NONE);
     defineMethod(JSON_EXISTS, BuiltInMethod.JSON_EXISTS.method, NullPolicy.NONE);
     defineMethod(JSON_VALUE_ANY, BuiltInMethod.JSON_VALUE_ANY.method, NullPolicy.NONE);
     defineMethod(JSON_QUERY, BuiltInMethod.JSON_QUERY.method, NullPolicy.NONE);
@@ -458,6 +459,7 @@ public class RexImpTable {
     defineMethod(JSON_TYPE, BuiltInMethod.JSON_TYPE.method, NullPolicy.NONE);
     defineMethod(JSON_DEPTH, BuiltInMethod.JSON_DEPTH.method, NullPolicy.NONE);
     defineMethod(JSON_PRETTY, BuiltInMethod.JSON_PRETTY.method, NullPolicy.NONE);
+    defineMethod(JSON_LENGTH, BuiltInMethod.JSON_LENGTH.method, NullPolicy.NONE);
     aggMap.put(JSON_OBJECTAGG.with(SqlJsonConstructorNullClause.ABSENT_ON_NULL),
         JsonObjectAggImplementor
             .supplierFor(BuiltInMethod.JSON_OBJECTAGG_ADD.method));

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -43,6 +43,9 @@ public interface CalciteResource {
   @BaseMessage("APPLY operator is not allowed under the current SQL conformance level")
   ExInst<CalciteException> applyNotAllowed();
 
+  @BaseMessage("JSON path expression must be specified after the JSON value expression")
+  ExInst<CalciteException> jsonPathMustBeSpecified();
+
   @BaseMessage("Illegal {0} literal {1}: {2}")
   ExInst<CalciteException> illegalLiteral(String a0, String a1, String a2);
 
@@ -864,6 +867,9 @@ public interface CalciteResource {
 
   @BaseMessage("Cannot serialize object to JSON, and the object is: ''{0}''")
   ExInst<CalciteException> exceptionWhileSerializingToJson(String value);
+
+  @BaseMessage("Unknown JSON length in JSON_LENGTH function, and the object is: ''{0}''")
+  ExInst<CalciteException> unknownContextOfJsonLength(String value);
 }
 
 // End CalciteResource.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonApiCommonSyntaxOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonApiCommonSyntaxOperator.java
@@ -36,12 +36,13 @@ public class SqlJsonApiCommonSyntaxOperator extends SqlSpecialOperator {
   public SqlJsonApiCommonSyntaxOperator() {
     super("JSON_API_COMMON_SYNTAX", SqlKind.JSON_API_COMMON_SYNTAX, 100, true,
         ReturnTypes.explicit(SqlTypeName.ANY), null,
-        OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.STRING));
+        OperandTypes.or(OperandTypes.family(SqlTypeFamily.ANY),
+        OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.STRING)));
   }
 
   @Override protected void checkOperandCount(SqlValidator validator,
       SqlOperandTypeChecker argType, SqlCall call) {
-    if (call.operandCount() != 2) {
+    if (call.operandCount() < 1) {
       throw new UnsupportedOperationException("json passing syntax is not yet supported");
     }
   }
@@ -50,14 +51,16 @@ public class SqlJsonApiCommonSyntaxOperator extends SqlSpecialOperator {
       int rightPrec) {
     SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.SIMPLE);
     call.operand(0).unparse(writer, 0, 0);
-    writer.sep(",", true);
-    call.operand(1).unparse(writer, 0, 0);
-    if (call.operandCount() > 2) {
-      writer.keyword("PASSING");
-      for (int i = 2; i < call.getOperandList().size(); i += 2) {
-        call.operand(i).unparse(writer, 0, 0);
-        writer.keyword("AS");
-        call.operand(i + 1).unparse(writer, 0, 0);
+    if (call.operandCount() > 1) {
+      writer.sep(",", true);
+      call.operand(1).unparse(writer, 0, 0);
+      if (call.operandCount() > 2) {
+        writer.keyword("PASSING");
+        for (int i = 2; i < call.getOperandList().size(); i += 2) {
+          call.operand(i).unparse(writer, 0, 0);
+          writer.keyword("AS");
+          call.operand(i + 1).unparse(writer, 0, 0);
+        }
       }
     }
     writer.endFunCall(frame);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonLengthFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonLengthFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
+
+/**
+ * The <code>JSON_LENGTH</code> function.
+ */
+public class SqlJsonLengthFunction extends SqlFunction {
+  public SqlJsonLengthFunction() {
+    super("JSON_LENGTH", SqlKind.OTHER_FUNCTION,
+        ReturnTypes.cascade(ReturnTypes.INTEGER,
+            SqlTypeTransforms.FORCE_NULLABLE),
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.SYSTEM);
+  }
+
+  @Override public String getSignatureTemplate(int operandsCount) {
+    assert operandsCount == 1 || operandsCount == 2;
+    if (operandsCount == 1) {
+      return "{0}({1})";
+    }
+    return "{0}({1} {2})";
+  }
+
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec,
+      int rightPrec) {
+    final SqlWriter.Frame frame = writer.startFunCall(getName());
+    call.operand(0).unparse(writer, 0, 0);
+    writer.endFunCall(frame);
+  }
+
+  @Override public SqlCall createCall(SqlLiteral functionQualifier,
+      SqlParserPos pos, SqlNode... operands) {
+    return super.createCall(functionQualifier, pos, operands);
+  }
+}
+
+// End SqlJsonLengthFunction.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1309,7 +1309,10 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
 
   public static final SqlFunction JSON_TYPE = new SqlJsonTypeFunction();
 
+
   public static final SqlFunction JSON_DEPTH = new SqlJsonDepthFunction();
+
+  public static final SqlFunction JSON_LENGTH = new SqlJsonLengthFunction();
 
   public static final SqlJsonObjectAggAggFunction JSON_OBJECTAGG =
       new SqlJsonObjectAggAggFunction(SqlKind.JSON_OBJECTAGG,

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -286,6 +286,7 @@ public enum BuiltInMethod {
   JSON_TYPE(SqlFunctions.class, "jsonType", Object.class),
   JSON_DEPTH(SqlFunctions.class, "jsonDepth", Object.class),
   JSON_PRETTY(SqlFunctions.class, "jsonPretty", Object.class),
+  JSON_LENGTH(SqlFunctions.class, "jsonLength", Object.class),
   JSON_OBJECTAGG_ADD(SqlFunctions.class, "jsonObjectAggAdd", Map.class,
       String.class, Object.class, SqlJsonConstructorNullClause.class),
   JSON_ARRAY(SqlFunctions.class, "jsonArray",

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -21,6 +21,7 @@ BangEqualNotAllowed=Bang equal ''!='' is not allowed under the current SQL confo
 PercentRemainderNotAllowed=Percent remainder ''%'' is not allowed under the current SQL conformance level
 LimitStartCountNotAllowed=''LIMIT start, count'' is not allowed under the current SQL conformance level
 ApplyNotAllowed=APPLY operator is not allowed under the current SQL conformance level
+JsonPathMustBeSpecified=JSON path expression must be specified after the JSON value expression
 IllegalLiteral=Illegal {0} literal {1}: {2}
 IdentifierTooLong=Length of identifier ''{0}'' must be less than or equal to {1,number,#} characters
 BadFormat=not in format ''{0}''
@@ -281,4 +282,5 @@ ExceptionWhilePerformingQueryOnJdbcSubSchema = While executing SQL [{0}] on JDBC
 UnknownObjectOfJsonType=Unknown JSON type in JSON_TYPE function, and the object is: ''{0}''
 UnknownObjectOfJsonDepth=Unknown JSON depth in JSON_DEPTH function, and the object is: ''{0}''
 ExceptionWhileSerializingToJson=Cannot serialize object to JSON, and the object is: ''{0}''
+UnknownContextOfJsonLength=Unknown JSON length in JSON_LENGTH function, and the object is: ''{0}''
 # End CalciteResource.properties

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -145,6 +145,7 @@ data: {
         "JSON"
         "JSON_TYPE"
         "JSON_DEPTH"
+        "JSON_LENGTH"
         "JSON_PRETTY"
         "K"
         "KEY"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3096,6 +3096,15 @@ public class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  @Test public void testJsonLength() {
+    String query = "select json_length(\"product_name\", 'lax $'), "
+            + "json_length(\"product_name\") from \"product\"";
+    final String expected = "SELECT JSON_LENGTH(\"product_name\" FORMAT JSON, 'lax $'), "
+            + "JSON_LENGTH(\"product_name\" FORMAT JSON)\n"
+            + "FROM \"foodmart\".\"product\"";
+    sql(query).ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final SchemaPlus schema;

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8399,6 +8399,17 @@ public class SqlParserTest {
             "JSON_DEPTH('{\"foo\": \"100\"}' FORMAT JSON)");
   }
 
+  @Test public void testJsonLength() {
+    checkExp("json_length('{\"foo\": \"bar\"}')",
+            "JSON_LENGTH('{\"foo\": \"bar\"}' FORMAT JSON)");
+    checkExp("json_length('{\"foo\": \"bar\"}', 'lax $')",
+            "JSON_LENGTH('{\"foo\": \"bar\"}' FORMAT JSON, 'lax $')");
+    checkExp("json_length('{\"foo\": \"bar\"}', 'strict $')",
+            "JSON_LENGTH('{\"foo\": \"bar\"}' FORMAT JSON, 'strict $')");
+    checkExp("json_length('{\"foo\": \"bar\"}', 'invalid $')",
+            "JSON_LENGTH('{\"foo\": \"bar\"}' FORMAT JSON, 'invalid $')");
+  }
+
   @Test public void testJsonObjectAgg() {
     checkExp("json_objectagg(k_column: v_column)",
         "JSON_OBJECTAGG(KEY `K_COLUMN` VALUE `V_COLUMN` NULL ON NULL)");

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4521,7 +4521,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkString("json_depth('{}')",
             "1", "INTEGER");
     tester.checkString("json_depth('[]')",
-              "1", "INTEGER");
+            "1", "INTEGER");
     tester.checkString("json_depth('null')",
             null, "INTEGER");
     tester.checkString("json_depth(cast(null as varchar(1)))",
@@ -4529,11 +4529,61 @@ public abstract class SqlOperatorBaseTest {
     tester.checkString("json_depth('[10, true]')",
             "2", "INTEGER");
     tester.checkString("json_depth('[[], {}]')",
-              "2", "INTEGER");
+            "2", "INTEGER");
     tester.checkString("json_depth('{\"a\": [10, true]}')",
             "3", "INTEGER");
     tester.checkString("json_depth('[10, {\"a\": [[1,2]]}]')",
             "5", "INTEGER");
+  }
+
+  @Test public void testJsonLength() {
+    // no path context
+    tester.checkString("json_length('{}')",
+            "0", "INTEGER");
+    tester.checkString("json_length('[]')",
+            "0", "INTEGER");
+    tester.checkString("json_length('{\"foo\":100}')",
+            "1", "INTEGER");
+    tester.checkString("json_length('{\"a\": 1, \"b\": {\"c\": 30}}')",
+            "2", "INTEGER");
+    tester.checkString("json_length('[1, 2, {\"a\": 3}]')",
+            "3", "INTEGER");
+
+    // lax test
+    tester.checkString("json_length('{}', 'lax $')",
+            "0", "INTEGER");
+    tester.checkString("json_length('[]', 'lax $')",
+            "0", "INTEGER");
+    tester.checkString("json_length('{\"foo\":100}', 'lax $')",
+            "1", "INTEGER");
+    tester.checkString("json_length('{\"a\": 1, \"b\": {\"c\": 30}}', 'lax $')",
+            "2", "INTEGER");
+    tester.checkString("json_length('[1, 2, {\"a\": 3}]', 'lax $')",
+            "3", "INTEGER");
+    tester.checkString("json_length('{\"a\": 1, \"b\": {\"c\": 30}}', 'lax $.b')",
+            "1", "INTEGER");
+    tester.checkString("json_length('{\"foo\":100}', 'lax $.foo1')",
+            null, "INTEGER");
+
+    // strict test
+    tester.checkString("json_length('{}', 'strict $')",
+            "0", "INTEGER");
+    tester.checkString("json_length('[]', 'strict $')",
+            "0", "INTEGER");
+    tester.checkString("json_length('{\"foo\":100}', 'strict $')",
+            "1", "INTEGER");
+    tester.checkString("json_length('{\"a\": 1, \"b\": {\"c\": 30}}', 'strict $')",
+            "2", "INTEGER");
+    tester.checkString("json_length('[1, 2, {\"a\": 3}]', 'strict $')",
+            "3", "INTEGER");
+    tester.checkString("json_length('{\"a\": 1, \"b\": {\"c\": 30}}', 'strict $.b')",
+            "1", "INTEGER");
+
+    // catch error test
+    tester.checkFails("json_length('{\"foo\":100}', 'invalid $.foo')",
+            "(?s).*Illegal jsonpath spec.*", true);
+    tester.checkFails("json_length('{\"foo\":100}', 'strict $.foo1')",
+            "(?s).*No results for path.*", true);
   }
 
   @Test public void testJsonObjectAgg() {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -6793,7 +6793,6 @@ public class JdbcTest {
         .returns("EXPR$0=[250, 500, 1000]\n");
   }
 
-  @Ignore
   @Test public void testJsonType() {
     CalciteAssert.that()
         .query("SELECT JSON_TYPE(v) AS c1\n"
@@ -6805,16 +6804,26 @@ public class JdbcTest {
         .returns("C1=OBJECT; C2=ARRAY; C3=INTEGER; C4=BOOLEAN\n");
   }
 
-  @Ignore
   @Test public void testJsonDepth() {
     CalciteAssert.that()
-        .query("SELECT JSON_DEPTH(v) AS c1\n"
-            + ",JSON_DEPTH(JSON_VALUE(v, 'lax $.b' ERROR ON ERROR)) AS c2\n"
-            + ",JSON_DEPTH(JSON_VALUE(v, 'strict $.a[0]' ERROR ON ERROR)) AS c3\n"
-            + ",JSON_DEPTH(JSON_VALUE(v, 'strict $.a[1]' ERROR ON ERROR)) AS c4\n"
-            + "FROM (VALUES ('{\"a\": [10, true],\"b\": \"[10, true]\"}')) AS t(v)\n"
+            .query("SELECT JSON_DEPTH(v) AS c1\n"
+                    + ",JSON_DEPTH(JSON_VALUE(v, 'lax $.b' ERROR ON ERROR)) AS c2\n"
+                    + ",JSON_DEPTH(JSON_VALUE(v, 'strict $.a[0]' ERROR ON ERROR)) AS c3\n"
+                    + ",JSON_DEPTH(JSON_VALUE(v, 'strict $.a[1]' ERROR ON ERROR)) AS c4\n"
+                    + "FROM (VALUES ('{\"a\": [10, true],\"b\": \"[10, true]\"}')) AS t(v)\n"
+                    + "limit 10")
+            .returns("C1=3; C2=2; C3=1; C4=1\n");
+  }
+
+  @Test public void testJsonLength() {
+    CalciteAssert.that()
+        .query("SELECT JSON_LENGTH(v) AS c1\n"
+            + ",JSON_LENGTH(v, 'lax $.a') AS c2\n"
+            + ",JSON_LENGTH(v, 'strict $.a[0]') AS c3\n"
+            + ",JSON_LENGTH(v, 'strict $.a[1]') AS c4\n"
+            + "FROM (VALUES ('{\"a\": [10, true]}')) AS t(v)\n"
             + "limit 10")
-        .returns("C1=3; C2=2; C3=1; C4=1\n");
+        .returns("C1=1; C2=2; C3=1; C4=1\n");
   }
 
   @Test

--- a/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
@@ -495,6 +495,26 @@ public class SqlJsonFunctionsTest {
   }
 
   @Test
+  public void testJsonLength() {
+    assertJsonLength(
+        SqlFunctions.PathContext
+            .withReturned(SqlFunctions.PathMode.LAX, Collections.singletonList("bar")),
+        is(1));
+    assertJsonLength(
+        SqlFunctions.PathContext
+            .withReturned(SqlFunctions.PathMode.LAX, null),
+        nullValue());
+    assertJsonLength(
+        SqlFunctions.PathContext
+            .withReturned(SqlFunctions.PathMode.STRICT, Collections.singletonList("bar")),
+        is(1));
+    assertJsonLength(
+        SqlFunctions.PathContext
+            .withReturned(SqlFunctions.PathMode.LAX, "bar"),
+        is(1));
+  }
+
+  @Test
   public void testJsonObjectAggAdd() {
     Map<String, Object> map = new HashMap<>();
     Map<String, Object> expected = new HashMap<>();
@@ -664,6 +684,22 @@ public class SqlJsonFunctionsTest {
       Matcher<? super Throwable> matcher) {
     assertFailed(invocationDesc(BuiltInMethod.JSON_PRETTY.getMethodName(), input),
         () -> SqlFunctions.jsonPretty(input),
+        matcher);
+  }
+
+  private void assertJsonLength(Object input,
+      Matcher<? super Integer> matcher) {
+    assertThat(
+        invocationDesc(BuiltInMethod.JSON_LENGTH.getMethodName(), input),
+        SqlFunctions.jsonLength(input),
+        matcher);
+  }
+
+  private void assertJsonLengthFailed(Object input,
+      Matcher<? super Throwable> matcher) {
+    assertFailed(
+        invocationDesc(BuiltInMethod.JSON_LENGTH.getMethodName(), input),
+        () -> SqlFunctions.jsonLength(input),
         matcher);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10794,6 +10794,14 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             "(.*)JSON_VALUE_EXPRESSION(.*)");
   }
 
+  @Test public void testJsonLength() {
+    checkExp("json_length('{\"foo\":\"bar\"}')");
+    checkExp("json_length('{\"foo\":\"bar\"}', 'lax $')");
+    checkExpType("json_length('{\"foo\":\"bar\"}')", "INTEGER");
+    checkExpType("json_length('{\"foo\":\"bar\"}', 'lax $')", "INTEGER");
+    checkExpType("json_length('{\"foo\":\"bar\"}', 'strict $')", "INTEGER");
+  }
+
   @Test public void testJsonObjectAgg() {
     check("select json_objectagg(ename: empno) from emp");
     checkFails("select ^json_objectagg(empno: ename)^ from emp",

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -153,6 +153,7 @@ data: {
         "JSON"
         "JSON_TYPE"
         "JSON_DEPTH"
+        "JSON_LENGTH"
         "JSON_PRETTY"
         "K"
         "KEY"

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -565,6 +565,7 @@ JSON,
 **JSON_ARRAYAGG**,
 JSON_DEPTH,
 **JSON_EXISTS**,
+JSON_LENGTH,
 **JSON_OBJECT**,
 **JSON_OBJECTAGG**,
 JSON_PRETTY,
@@ -2005,6 +2006,7 @@ Note:
 | JSON_TYPE(value)                                  | Returns a string indicating the type of a JSON **value**. This can be an object, an array, or a scalar type
 | JSON_DEPTH(value)                                 | Returns a integer indicating the depth of a JSON **value**. This can be an object, an array, or a scalar type
 | JSON_PRETTY(value)                                | Returns a pretty-printing of JSON **value**.
+| JSON_LENGTH(value)                                | Returns a integer indicating the length of a JSON **value**. This can be an object, an array, or a scalar type
 
 * JSON_TYPE
 
@@ -2043,6 +2045,25 @@ Result:
 | c1     | c2    | c3      | c4      |
 | ------ | ----- | ------- | ------- |
 | 3      | 2     | 1       | 1       |
+
+* JSON_LENGTH
+
+Example SQL:
+
+```SQL
+SELECT JSON_LENGTH(v) AS c1
+,JSON_LENGTH(v, 'lax $.a') AS c2
+,JSON_LENGTH(v, 'strict $.a[0]') AS c3
+,JSON_LENGTH(v, 'strict $.a[1]') AS c4
+FROM (VALUES ('{"a": [10, true]}')) AS t(v)
+LIMIT 10;
+```
+
+Result:
+
+| c1     | c2    | c3      | c4      |
+| ------ | ----- | ------- | ------- |
+| 1      | 2     | 1       | 1       |
 
 ## User-defined functions
 


### PR DESCRIPTION
```
JSON_LENGTH(**json_doc**[, *path*])
```

Returns the length of a JSON document, or, if a *path* argument is given, the length of the value within the document identified by the path. Returns `NULL` if any argument is `NULL` or the *path* argument does not identify a value in the document. An error occurs if the *json_doc* argument is not a valid JSON document or the *path* argument is not a valid path expression or contains a {**} or }}**{{`*` wildcard.

The length of a document is determined as follows:

- The length of a scalar is 1.

- The length of an array is the number of array elements.

- The length of an object is the number of object members.

- The length does not count the length of nested arrays or objects.

Example Sql:

```SQL
SELECT JSON_LENGTH(v) AS c1
,JSON_LENGTH(v, 'lax $.a') AS c2
,JSON_LENGTH(v, 'strict $.a[0]') AS c3
,JSON_LENGTH(v, 'strict $.a[1]') AS c4
FROM (VALUES ('{"a": [10, true]}')) AS t(v)
LIMIT 10;
```
Result:

| c1   | c2   | c3   | c4   |
| ---- | ---- | ---- | ---- |
| 1    | 2    | 1    | 1    |

