### PR TITLE
[CALCITE-2877] Make GeodeSchema constructor public to pass client cache object

### DIFF
--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSchema.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSchema.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.calcite.adapter.geode.util.GeodeUtils.createClientCache;
-
 /**
  * Schema mapped onto a Geode Region.
  */
@@ -41,13 +39,7 @@ public class GeodeSchema extends AbstractSchema {
   private final List<String> regionNames;
   private ImmutableMap<String, Table> tableMap;
 
-  GeodeSchema(String locatorHost, int locatorPort,
-      Iterable<String> regionNames, String pdxAutoSerializerPackageExp) {
-    this(createClientCache(locatorHost, locatorPort, pdxAutoSerializerPackageExp, true),
-        regionNames);
-  }
-
-  GeodeSchema(final GemFireCache cache, final Iterable<String> regionNames) {
+  public GeodeSchema(final GemFireCache cache, final Iterable<String> regionNames) {
     super();
     this.cache = Objects.requireNonNull(cache, "clientCache");
     this.regionNames = ImmutableList.copyOf(Objects.requireNonNull(regionNames, "regionNames"));

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSchemaFactory.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSchemaFactory.java
@@ -27,6 +27,8 @@ import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.Map;
 
+import static org.apache.calcite.adapter.geode.util.GeodeUtils.createClientCache;
+
 /**
  * Factory that creates a {@link GeodeSchema}.
  */
@@ -62,8 +64,9 @@ public class GeodeSchemaFactory implements SchemaFactory {
           GeoFunctions.class.getName(), "*", true);
     }
 
-    return new GeodeSchema(locatorHost, locatorPort, Arrays.asList(regionNames),
-        pbxSerializablePackagePath);
+    return new GeodeSchema(
+        createClientCache(locatorHost, locatorPort, pbxSerializablePackagePath, true),
+        Arrays.asList(regionNames));
   }
 }
 

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/util/GeodeUtils.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/util/GeodeUtils.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionExistsException;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
@@ -131,8 +132,9 @@ public class GeodeUtils {
         region = ((ClientCache) cache)
             .createClientRegionFactory(ClientRegionShortcut.PROXY)
             .create(regionName);
-      } catch (IllegalStateException e) {
-        // means this is a server cache (probably part of embedded testing)
+      } catch (IllegalStateException | RegionExistsException e) {
+        // means this is a server cache (probably part of embedded testing
+        // or clientCache is passed directly)
         region = cache.getRegion(regionName);
       }
 


### PR DESCRIPTION
[CALCITE-2877] Make GeodeSchema constructor public to pass client cache object