### PR TITLE
[CALCITE-2888] Enhance RexImplicationChecker to better handle cast

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -37,7 +37,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexExecutor;
-import org.apache.calcite.rex.RexExecutorImpl;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -1407,11 +1406,10 @@ public class SubstitutionVisitor {
       return false;
     }
 
-    RexExecutorImpl rexImpl =
-        (RexExecutorImpl) (rel.cluster.getPlanner().getExecutor());
+    RexExecutor rexExec = rel.cluster.getPlanner().getExecutor();
     RexImplicationChecker rexImplicationChecker =
         new RexImplicationChecker(
-            rel.cluster.getRexBuilder(), rexImpl, rel.rowType);
+            rel.cluster.getRexBuilder(), rexExec, rel.rowType);
 
     return rexImplicationChecker.implies(((MutableFilter) rel0).condition,
         ((MutableFilter) rel).condition);

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutor.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutor.java
@@ -16,6 +16,9 @@
  */
 package org.apache.calcite.rex;
 
+import org.apache.calcite.DataContext;
+import org.apache.calcite.rel.type.RelDataType;
+
 import java.util.List;
 
 /** Can reduce expressions, writing a literal for each into a list. */
@@ -32,6 +35,18 @@ public interface RexExecutor {
    * @param reducedValues List to which reduced expressions are appended
    */
   void reduce(RexBuilder rexBuilder, List<RexNode> constExps, List<RexNode> reducedValues);
+
+  /**
+   * Applies generated code with {@link DataContext}
+   *
+   * @param rexBuilder Rexbuilder
+   * @param exps Expressions
+   * @param rowType describes the structure of the input row
+   * @param dataValues {@link DataContext} to execute with
+   * @return Objects returned after applying generated code with dataValues.
+   */
+  Object[] execute(RexBuilder rexBuilder, List<RexNode> exps,
+                   RelDataType rowType,  DataContext dataValues);
 }
 
 // End RexExecutor.java

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
@@ -162,6 +162,13 @@ public class RexExecutorImpl implements RexExecutor {
       return RexToLixTranslator.convert(recordAccess, storageType);
     }
   }
+
+  public Object[] execute(RexBuilder rexBuilder, List<RexNode> exps,
+                                     RelDataType rowType,  DataContext dataValues) {
+    final RexExecutable exec = getExecutable(rexBuilder, exps, rowType);
+    exec.setDataContext(dataValues);
+    return exec.execute();
+  }
 }
 
 // End RexExecutorImpl.java

--- a/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexImplicationCheckerTest.java
@@ -341,6 +341,24 @@ public class RexImplicationCheckerTest {
     f.checkNotImplies(f.gt(f.i, f.literal(10)), iIsNull);
   }
 
+  @Test public void testImpliesWithCast() {
+    final Fixture f = new Fixture();
+
+    final DateString dBeforeEpoch1 = DateString.fromDaysSinceEpoch(-3);
+    final DateString dBeforeEpoch2 = DateString.fromDaysSinceEpoch(-2);
+    final DateString dBeforeEpoch3 = DateString.fromDaysSinceEpoch(-1);
+
+    final RexNode iGe1 = f.ge(f.cast(f.dateDataType, f.str), f.dateLiteral(dBeforeEpoch1));
+    final RexNode iLe1 = f.le(f.cast(f.dateDataType, f.str), f.dateLiteral(dBeforeEpoch2));
+    final RexNode iGe1AndLe1 = f.and(iGe1, iLe1);
+
+    final RexNode iGe2 = f.ge(f.cast(f.dateDataType, f.str), f.dateLiteral(dBeforeEpoch1));
+    final RexNode iLe2 = f.le(f.cast(f.dateDataType, f.str), f.dateLiteral(dBeforeEpoch3));
+    final RexNode iGe2AndLe2 = f.and(iGe2, iLe2);
+
+    f.checkImplies(iGe1AndLe1, iGe2AndLe2);
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2041">[CALCITE-2041]
    * When simplifying a nullable expression, allow the result to change type to


### PR DESCRIPTION
- make RexImplicationChecker use executor's reduce function when generating a value for literal(VisitorDataContext)

- allow other implementations of RexExecutor

Change-Id: Ie343535c1061d0927356aa37332c048306c5739a