### PR TITLE
[CALCITE-2894] NullPointerException thrown by RelMdPercentageOriginalRows when explaining plan with all attributes (Ruben Quesada Lopez)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
@@ -80,8 +80,14 @@ public class RelMdPercentageOriginalRows
     // case where a huge table has been completely filtered away.
 
     for (RelNode input : rel.getInputs()) {
-      double rowCount = mq.getRowCount(input);
-      double percentage = mq.getPercentageOriginalRows(input);
+      Double rowCount = mq.getRowCount(input);
+      if (rowCount == null) {
+        continue;
+      }
+      Double percentage = mq.getPercentageOriginalRows(input);
+      if (percentage == null) {
+        continue;
+      }
       if (percentage != 0.0) {
         denominator += rowCount / percentage;
         numerator += rowCount;
@@ -100,8 +106,14 @@ public class RelMdPercentageOriginalRows
 
     // REVIEW jvs 28-Mar-2006:  need any special casing for SemiJoin?
 
-    double left = mq.getPercentageOriginalRows(rel.getLeft());
-    double right = mq.getPercentageOriginalRows(rel.getRight());
+    Double left = mq.getPercentageOriginalRows(rel.getLeft());
+    if (left == null) {
+      return null;
+    }
+    Double right = mq.getPercentageOriginalRows(rel.getRight());
+    if (right == null) {
+      return null;
+    }
     return left * right;
   }
 

--- a/core/src/test/java/org/apache/calcite/test/RelMdPercentageOriginalRowsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMdPercentageOriginalRowsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.apache.calcite.adapter.java.ReflectiveSchema;
+import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.config.Lex;
+
+import org.junit.Test;
+
+/** Test case for CALCITE-2894 */
+public class RelMdPercentageOriginalRowsTest {
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2894">[CALCITE-2894]
+   * NullPointerException thrown by RelMdPercentageOriginalRows when explaining
+   * plan with all attributes</a>. */
+  @Test public void testExplainAllAttributesSemiJoinUnionCorrelate() {
+    CalciteAssert.that()
+            .with(CalciteConnectionProperty.LEX, Lex.JAVA)
+            .with(CalciteConnectionProperty.FORCE_DECORRELATE, false)
+            .withSchema("s", new ReflectiveSchema(new JdbcTest.HrSchema()))
+            .query(
+                    "select deptno, name from depts where deptno in (\n"
+                            + " select e.deptno from emps e where exists (select 1 from depts d where d.deptno=e.deptno)\n"
+                            + " union select e.deptno from emps e where e.salary > 10000) ")
+            .explainMatches("including all attributes ",
+                    CalciteAssert.checkResultContains("EnumerableSemiJoin"));
+  }
+}
+
+// End RelMdPercentageOriginalRowsTest.java


### PR DESCRIPTION
Fixes NullPointerException thrown by RelMdPercentageOriginalRows when explaining plan with all attributes