### PR TITLE
[CALCITE-2897] Reduce expensive calls to Class#getSimpleName

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -103,8 +103,11 @@ class RuleQueue {
       Ordering.from(new RelImportanceComparator());
 
   /**
-   * Maps a {@link VolcanoPlannerPhase} to a set of rule names.  Named rules
+   * Maps a {@link VolcanoPlannerPhase} to a set of rule descriptions. Named rules
    * may be invoked in their corresponding phase.
+   *
+   * See {@link VolcanoPlannerPhaseRuleMappingInitializer} for more information regarding the
+   * contents of this Map and how it is initialized.
    */
   private final Map<VolcanoPlannerPhase, Set<String>> phaseRuleMapping;
 
@@ -330,11 +333,10 @@ class RuleQueue {
         continue;
       }
 
-      String ruleClassName = match.getRule().getClass().getSimpleName();
-
       Set<String> phaseRuleSet = phaseRuleMapping.get(matchList.phase);
       if (phaseRuleSet != ALL_RULES) {
-        if (!phaseRuleSet.contains(ruleClassName)) {
+        String ruleDescription = match.getRule().toString();
+        if (!phaseRuleSet.contains(ruleDescription)) {
           continue;
         }
       }

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvFieldType.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvFieldType.java
@@ -56,7 +56,7 @@ enum CsvFieldType {
   }
 
   CsvFieldType(Primitive primitive) {
-    this(primitive.boxClass, primitive.primitiveClass.getSimpleName());
+    this(primitive.boxClass, primitive.primitiveName);
   }
 
   CsvFieldType(Class clazz, String simpleName) {

--- a/file/src/main/java/org/apache/calcite/adapter/file/FileFieldType.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/FileFieldType.java
@@ -59,7 +59,7 @@ enum FileFieldType {
       builder.put(value.clazz.getSimpleName(), value);
 
       if (value.primitive != null) {
-        builder.put(value.primitive.primitiveClass.getSimpleName(), value);
+        builder.put(value.primitive.primitiveName, value);
       }
     }
     MAP = builder.build();

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstantExpression.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstantExpression.java
@@ -132,7 +132,7 @@ public class ConstantExpression extends Expression {
     }
     final Primitive primitive2 = Primitive.ofBox(type);
     if (primitive2 != null) {
-      writer.append(primitive2.boxClass.getSimpleName() + ".valueOf(");
+      writer.append(primitive2.boxName + ".valueOf(");
       write(writer, value, primitive2.primitiveClass);
       return writer.append(")");
     }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/FunctionExpression.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/FunctionExpression.java
@@ -173,7 +173,7 @@ public final class FunctionExpression<F extends Function<?>>
     final String bridgeResultTypeName =
         isAbstractMethodPrimitive()
             ? Types.className(bridgeResultType)
-            : Types.boxClassName(bridgeResultType);
+            : Types.className(Types.box(bridgeResultType));
     if (!boxBridgeParams.equals(params)) {
       writer
           .append("public ")
@@ -204,7 +204,8 @@ public final class FunctionExpression<F extends Function<?>>
 
   private boolean isAbstractMethodPrimitive() {
     Method method = getAbstractMethod();
-    return method != null && Primitive.is(method.getReturnType());
+    assert method != null;
+    return Primitive.is(method.getReturnType());
   }
 
   private String getAbstractMethodName() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
@@ -57,6 +57,7 @@ public enum Primitive {
   public final Class primitiveClass;
   public final Class boxClass;
   public final String primitiveName; // e.g. "int"
+  public final String boxName;
   private final int family;
 
   /** The default value of this primitive class. This is the value
@@ -105,6 +106,7 @@ public enum Primitive {
     this.primitiveName =
         primitiveClass != null ? primitiveClass.getSimpleName() : null;
     this.boxClass = boxClass;
+    this.boxName = boxClass != null ? boxClass.getSimpleName() : null;
     this.defaultValue = defaultValue;
     this.min = min;
     this.maxNegative = maxNegative;

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
@@ -197,30 +197,6 @@ public abstract class Types {
     }
   }
 
-  /**
-   * Boxes a type, if it is primitive, and returns the type name.
-   * The type is abbreviated if it is in the "java.lang" package.
-   *
-   * <p>For example,
-   * boxClassName(int) returns "Integer";
-   * boxClassName(List&lt;String&gt;) returns "List&lt;String&gt;"</p>
-   *
-   * @param type Type
-   *
-   * @return Class name
-   */
-  static String boxClassName(Type type) {
-    if (!(type instanceof Class)) {
-      return type.toString();
-    }
-    Primitive primitive = Primitive.of(type);
-    if (primitive != null) {
-      return primitive.boxClass.getSimpleName();
-    } else {
-      return className(type);
-    }
-  }
-
   public static Type box(Type type) {
     Primitive primitive = Primitive.of(type);
     if (primitive != null) {


### PR DESCRIPTION
1. Replace rule.getClass().getSimpleName() with rule.toString():
(i) It conforms to the API VolcanoPlannerPhaseRuleMappingInitializer;
(ii) It is safer to use when the same rule class has many instances;
(iii) It is much more efficient.
2. Precompute the class name for Boxed primitives and use where necessary.
3. Remove Types#boxClassName since it is slightly redundant.