### PR TITLE
[CALCITE-2899] Deprecate RelTraitPropagationVisitor and remove its usages

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -553,10 +553,6 @@ public abstract class RelOptRule {
   public static RelNode convert(RelNode rel, RelTraitSet toTraits) {
     RelOptPlanner planner = rel.getCluster().getPlanner();
 
-    if (rel.getTraitSet().size() < toTraits.size()) {
-      new RelTraitPropagationVisitor(planner, toTraits).go(rel);
-    }
-
     RelTraitSet outTraits = rel.getTraitSet();
     for (int i = 0; i < toTraits.size(); i++) {
       RelTrait toTrait = toTraits.getTrait(i);

--- a/core/src/main/java/org/apache/calcite/plan/RelTraitPropagationVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTraitPropagationVisitor.java
@@ -25,7 +25,19 @@ import org.apache.calcite.util.Util;
  * children, making sure that each has a full complement of traits. When a
  * RelNode is found to be missing one or more traits, they are copied from a
  * RelTraitSet given during construction.
+ *
+ * @deprecated As of 1.19, if you need to perform certain assertions regarding a RelNode tree and
+ * the contained traits you are encouraged to implement your own RelVisitor or
+ * {@link org.apache.calcite.rel.RelShuttle} directly. The reasons for deprecating this class are
+ * the following:
+ * <ul>
+ *   <li>The contract (Javadoc and naming) and the behavior of the class are inconsistent.</li>
+ *   <li>The class is no longer used by any other components of the framework.</li>
+ *   <li>The class was used only for debugging purposes.</li>
+ * </ul>
+ *
  */
+@Deprecated
 public class RelTraitPropagationVisitor extends RelVisitor {
   //~ Instance fields --------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -19,8 +19,6 @@ package org.apache.calcite.plan.volcano;
 import org.apache.calcite.plan.RelOptListener;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
-import org.apache.calcite.plan.RelTraitPropagationVisitor;
-import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 
 import com.google.common.collect.ImmutableList;
@@ -98,13 +96,6 @@ public class VolcanoRuleCall extends RelOptRuleCall {
       // It's possible that rel is a subset or is already registered.
       // Is there still a point in continuing? Yes, because we might
       // discover that two sets of expressions are actually equivalent.
-
-      // Make sure traits that the new rel doesn't know about are
-      // propagated.
-      RelTraitSet rels0Traits = rels[0].getTraitSet();
-      new RelTraitPropagationVisitor(
-          getPlanner(),
-          rels0Traits).go(rel);
 
       if (LOGGER.isTraceEnabled()) {
         // Cannot call RelNode.toString() yet, because rel has not


### PR DESCRIPTION
The class is deprecated for the following reasons:
1. The contract and behavior of RelTraitPropagationVisitor are not consistent.
2. It traverses RelNode subtrees after every rule transformation affecting performance.
3. It exists only for debugging purposes and we have no proof that helps discover issues.
4. It not modified for the past five years.
5. It is unlikely to be used in the future.