### PR TITLE
[CALCITE-2925] - Exclude maven-wrapper.jar from source distribution

### DIFF
--- a/src/main/config/assemblies/source-assembly.xml
+++ b/src/main/config/assemblies/source-assembly.xml
@@ -66,6 +66,8 @@ limitations under the License.
         <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.wtpmodules(/.*)?]
         </exclude>
 
+        <!-- Maven Wrapper -->
+        <exclude>**/maven-wrapper.jar</exclude>
 
         <!-- scm -->
         <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.gitignore(/.*)?]


### PR DESCRIPTION
Performed dryrun release steps to ensure that maven-wrapper.jar is not in the source distribution.

```bash
./mvnw -DdryRun=true -DskipTests -DreleaseVersion=1.19.0 -DdevelopmentVersion=1.20.0-SNAPSHOT -Papache-release -Darguments=-DskipTests release:prepare 2>&1 | tee /tmp/prepare-dry.log
```