### PR TITLE
[CALCITE-2927] The Javadoc and implement of RuleQueue.computeImportance() is inconsistent

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -356,7 +356,7 @@ class RuleQueue {
    *
    * <ul>
    * <li>the root {@link RelSubset} has an importance of 1</li>
-   * <li>the importance of any other subset is the sum of its importance to
+   * <li>the importance of any other subset is the max of its importance to
    * its parents</li>
    * <li>The importance of children is pro-rated according to the cost of the
    * children. Consider a node which has a cost of 3, and children with costs
@@ -368,7 +368,7 @@ class RuleQueue {
    *
    * <p>The formula for the importance <i>I</i> of node n is:
    *
-   * <blockquote>I<sub>n</sub> = Sum<sub>parents p of n</sub>{I<sub>p</sub> .
+   * <blockquote>I<sub>n</sub> = Max<sub>parents p of n</sub>{I<sub>p</sub> .
    * W <sub>n, p</sub>}</blockquote>
    *
    * <p>where W<sub>n, p</sub>, the weight of n within its parent p, is


### PR DESCRIPTION
In the javadoc of computeImportance(), it shows the importance of node is Sum{computeImportanceOfChild()}, but in the implementation it shows Max{computeImportanceOfChild()}, this is inconsistent. The Javadoc has some errors, it will cause some confusion.