### PR TITLE
[CALCITE-2931] Mongo Adapter. Compare Bson (not string) query representation in tests

### DIFF
--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -37,6 +37,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.Document;
+import org.bson.json.JsonWriterSettings;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -57,6 +58,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Testing mongo adapter functionality. By default runs with
@@ -732,20 +734,40 @@ public class MongoAdapterTest implements SchemaFactory {
   }
 
   /**
-   * Returns a function that checks that a particular MongoDB pipeline is
-   * generated to implement a query.
+   * Returns a function that checks that a particular MongoDB query
+   * has been called.
    *
-   * @param strings Expected expressions
+   * @param expected Expected query (as array)
    * @return validation function
    */
-  private static Consumer<List> mongoChecker(final String... strings) {
+  private static Consumer<List> mongoChecker(final String... expected) {
     return actual -> {
-      Object[] actualArray =
-          actual == null || actual.isEmpty()
-              ? null
-              : ((List) actual.get(0)).toArray();
-      CalciteAssert.assertArrayEqual("expected MongoDB query not found",
-          strings, actualArray);
+      if (expected == null) {
+        Assert.assertThat("null mongo Query", actual, CoreMatchers.nullValue());
+        return;
+      }
+
+      if (expected.length == 0) {
+        CalciteAssert.assertArrayEqual("empty Mongo query", expected,
+            actual.toArray(new Object[0]));
+        return;
+      }
+
+      final BsonDocument expectedBson = BsonDocument.parse(String.join(",", expected));
+      final BsonDocument actualBson = BsonDocument.parse(((List<?>) actual.get(0))
+          .stream()
+          .map(Objects::toString)
+          .collect(Collectors.joining("\n")));
+
+      // compare Bson (not string) representation
+      if (!expectedBson.equals(actualBson)) {
+        final JsonWriterSettings settings = JsonWriterSettings.builder().indent(true).build();
+        // used to pretty print Assertion error
+        Assert.assertEquals("expected and actual Mongo queries do not match",
+            expectedBson.toJson(settings),
+            actualBson.toJson(settings));
+        Assert.fail("Should have failed previously because (expected != actual) is already known");
+      }
     };
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-2931

Some tests currently fail because of wrong order of keys in Bson.

```text
// Expected
{$project: {POP: '$pop', STATE: '$state'}}

// Actual
{$project: {STATE: '$state', POP: '$pop'}}
```