### PR TITLE
[CALCITE-2937] Linq4j: implement LazyEnumerable

### DIFF
--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ForwardingEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ForwardingEnumerable.java
@@ -41,223 +41,221 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Abstract implementation of the {@link Enumerable} interface that
- * forwards all methods to another wrappee {@link Enumerable}.
- *
- * <p>There is one abstract method: {@link #getEnumerable()}, to be implemented by
- * the derived class, that will be used to obtained the wrappee {@link Enumerable}.</p>
+ * Abstract implementation of the {@link Enumerable} interface that forwards all methods
+ * to another {@link Enumerable}, accessible via the abstract method {@link #delegate()}
+ * (to be overridden by the derived classes).
  *
  * @param <E> Element type
  */
-public abstract class WrapperEnumerable<E> implements Enumerable<E> {
+abstract class ForwardingEnumerable<E> implements Enumerable<E> {
 
   /**
-   * @return the wrapee {@link Enumerable} where all methods will be forwarded to
+   * @return the {@link Enumerable} where all methods will be forwarded to
    */
-  protected abstract Enumerable<E> getEnumerable();
+  protected abstract Enumerable<E> delegate();
 
   @Override public Enumerator<E> enumerator() {
-    return getEnumerable().enumerator();
+    return delegate().enumerator();
   }
 
   @Override public Iterator<E> iterator() {
-    return getEnumerable().iterator();
+    return delegate().iterator();
   }
 
   @Override public <R> R foreach(Function1<E, R> func) {
-    return getEnumerable().foreach(func);
+    return delegate().foreach(func);
   }
 
   @Override public E aggregate(Function2<E, E, E> func) {
-    return getEnumerable().aggregate(func);
+    return delegate().aggregate(func);
   }
 
   @Override public <TAccumulate> TAccumulate aggregate(
           TAccumulate seed,
           Function2<TAccumulate, E, TAccumulate> func) {
-    return getEnumerable().aggregate(seed, func);
+    return delegate().aggregate(seed, func);
   }
 
   @Override public <TAccumulate, TResult> TResult aggregate(
           TAccumulate seed,
           Function2<TAccumulate, E, TAccumulate> func,
           Function1<TAccumulate, TResult> selector) {
-    return getEnumerable().aggregate(seed, func, selector);
+    return delegate().aggregate(seed, func, selector);
   }
 
   @Override public boolean all(Predicate1<E> predicate) {
-    return getEnumerable().all(predicate);
+    return delegate().all(predicate);
   }
 
   @Override public boolean any() {
-    return getEnumerable().any();
+    return delegate().any();
   }
 
   @Override public boolean any(Predicate1<E> predicate) {
-    return getEnumerable().any(predicate);
+    return delegate().any(predicate);
   }
 
   @Override public Enumerable<E> asEnumerable() {
-    return getEnumerable().asEnumerable();
+    return delegate().asEnumerable();
   }
 
   @Override public Queryable<E> asQueryable() {
-    return getEnumerable().asQueryable();
+    return delegate().asQueryable();
   }
 
   @Override public BigDecimal average(BigDecimalFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public BigDecimal average(NullableBigDecimalFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public double average(DoubleFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public Double average(NullableDoubleFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public int average(IntegerFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public Integer average(NullableIntegerFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public long average(LongFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public Long average(NullableLongFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public float average(FloatFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public Float average(NullableFloatFunction1<E> selector) {
-    return getEnumerable().average(selector);
+    return delegate().average(selector);
   }
 
   @Override public <T2> Enumerable<T2> cast(Class<T2> clazz) {
-    return getEnumerable().cast(clazz);
+    return delegate().cast(clazz);
   }
 
   @Override public Enumerable<E> concat(Enumerable<E> enumerable1) {
-    return getEnumerable().concat(enumerable1);
+    return delegate().concat(enumerable1);
   }
 
   @Override public boolean contains(E element) {
-    return getEnumerable().contains(element);
+    return delegate().contains(element);
   }
 
   @Override public boolean contains(E element, EqualityComparer<E> comparer) {
-    return getEnumerable().contains(element, comparer);
+    return delegate().contains(element, comparer);
   }
 
   @Override public int count() {
-    return getEnumerable().count();
+    return delegate().count();
   }
 
   @Override public int count(Predicate1<E> predicate) {
-    return getEnumerable().count(predicate);
+    return delegate().count(predicate);
   }
 
   @Override public Enumerable<E> defaultIfEmpty() {
-    return getEnumerable().defaultIfEmpty();
+    return delegate().defaultIfEmpty();
   }
 
   @Override public Enumerable<E> defaultIfEmpty(E value) {
-    return getEnumerable().defaultIfEmpty(value);
+    return delegate().defaultIfEmpty(value);
   }
 
   @Override public Enumerable<E> distinct() {
-    return getEnumerable().distinct();
+    return delegate().distinct();
   }
 
   @Override public Enumerable<E> distinct(EqualityComparer<E> comparer) {
-    return getEnumerable().distinct(comparer);
+    return delegate().distinct(comparer);
   }
 
   @Override public E elementAt(int index) {
-    return getEnumerable().elementAt(index);
+    return delegate().elementAt(index);
   }
 
   @Override public E elementAtOrDefault(int index) {
-    return getEnumerable().elementAtOrDefault(index);
+    return delegate().elementAtOrDefault(index);
   }
 
   @Override public Enumerable<E> except(Enumerable<E> enumerable1) {
-    return getEnumerable().except(enumerable1);
+    return delegate().except(enumerable1);
   }
 
   @Override public Enumerable<E> except(Enumerable<E> enumerable1, EqualityComparer<E> comparer) {
-    return getEnumerable().except(enumerable1, comparer);
+    return delegate().except(enumerable1, comparer);
   }
 
   @Override public E first() {
-    return getEnumerable().first();
+    return delegate().first();
   }
 
   @Override public E first(Predicate1<E> predicate) {
-    return getEnumerable().first(predicate);
+    return delegate().first(predicate);
   }
 
   @Override public E firstOrDefault() {
-    return getEnumerable().firstOrDefault();
+    return delegate().firstOrDefault();
   }
 
   @Override public E firstOrDefault(Predicate1<E> predicate) {
-    return getEnumerable().firstOrDefault(predicate);
+    return delegate().firstOrDefault(predicate);
   }
 
   @Override public <TKey> Enumerable<Grouping<TKey, E>> groupBy(Function1<E, TKey> keySelector) {
-    return getEnumerable().groupBy(keySelector);
+    return delegate().groupBy(keySelector);
   }
 
   @Override public <TKey> Enumerable<Grouping<TKey, E>> groupBy(
           Function1<E, TKey> keySelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().groupBy(keySelector, comparer);
+    return delegate().groupBy(keySelector, comparer);
   }
 
   @Override public <TKey, TElement> Enumerable<Grouping<TKey, TElement>> groupBy(
           Function1<E, TKey> keySelector,
           Function1<E, TElement> elementSelector) {
-    return getEnumerable().groupBy(keySelector, elementSelector);
+    return delegate().groupBy(keySelector, elementSelector);
   }
 
   @Override public <TKey, TElement> Enumerable<Grouping<TKey, TElement>> groupBy(
           Function1<E, TKey> keySelector,
           Function1<E, TElement> elementSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().groupBy(keySelector, elementSelector, comparer);
+    return delegate().groupBy(keySelector, elementSelector, comparer);
   }
 
   @Override public <TKey, TResult> Enumerable<TResult> groupBy(
           Function1<E, TKey> keySelector,
           Function2<TKey, Enumerable<E>, TResult> resultSelector) {
-    return getEnumerable().groupBy(keySelector, resultSelector);
+    return delegate().groupBy(keySelector, resultSelector);
   }
 
   @Override public <TKey, TResult> Enumerable<TResult> groupBy(
           Function1<E, TKey> keySelector,
           Function2<TKey, Enumerable<E>, TResult> resultSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().groupBy(keySelector, resultSelector, comparer);
+    return delegate().groupBy(keySelector, resultSelector, comparer);
   }
 
   @Override public <TKey, TElement, TResult> Enumerable<TResult> groupBy(
           Function1<E, TKey> keySelector,
           Function1<E, TElement> elementSelector,
           Function2<TKey, Enumerable<TElement>, TResult> resultSelector) {
-    return getEnumerable().groupBy(keySelector, elementSelector, resultSelector);
+    return delegate().groupBy(keySelector, elementSelector, resultSelector);
   }
 
   @Override public <TKey, TElement, TResult> Enumerable<TResult> groupBy(
@@ -265,7 +263,7 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           Function1<E, TElement> elementSelector,
           Function2<TKey, Enumerable<TElement>, TResult> resultSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().groupBy(keySelector, elementSelector, resultSelector, comparer);
+    return delegate().groupBy(keySelector, elementSelector, resultSelector, comparer);
   }
 
   @Override public <TKey, TAccumulate, TResult> Enumerable<TResult> groupBy(
@@ -273,7 +271,7 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           Function0<TAccumulate> accumulatorInitializer,
           Function2<TAccumulate, E, TAccumulate> accumulatorAdder,
           Function2<TKey, TAccumulate, TResult> resultSelector) {
-    return getEnumerable().groupBy(keySelector, accumulatorInitializer,
+    return delegate().groupBy(keySelector, accumulatorInitializer,
             accumulatorAdder, resultSelector);
   }
 
@@ -283,7 +281,7 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           Function2<TAccumulate, E, TAccumulate> accumulatorAdder,
           Function2<TKey, TAccumulate, TResult> resultSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().groupBy(keySelector, accumulatorInitializer, accumulatorAdder,
+    return delegate().groupBy(keySelector, accumulatorInitializer, accumulatorAdder,
             resultSelector, comparer);
   }
 
@@ -292,7 +290,7 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           Function1<E, TKey> outerKeySelector,
           Function1<TInner, TKey> innerKeySelector,
           Function2<E, Enumerable<TInner>, TResult> resultSelector) {
-    return getEnumerable().groupJoin(inner, outerKeySelector, innerKeySelector, resultSelector);
+    return delegate().groupJoin(inner, outerKeySelector, innerKeySelector, resultSelector);
   }
 
   @Override public <TInner, TKey, TResult> Enumerable<TResult> groupJoin(
@@ -301,26 +299,26 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           Function1<TInner, TKey> innerKeySelector,
           Function2<E, Enumerable<TInner>, TResult> resultSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().groupJoin(inner, outerKeySelector, innerKeySelector,
+    return delegate().groupJoin(inner, outerKeySelector, innerKeySelector,
             resultSelector, comparer);
   }
 
   @Override public Enumerable<E> intersect(Enumerable<E> intersect) {
-    return getEnumerable().intersect(intersect);
+    return delegate().intersect(intersect);
   }
 
   @Override public Enumerable<E> intersect(
           Enumerable<E> enumerable1,
           EqualityComparer<E> comparer) {
-    return getEnumerable().intersect(enumerable1, comparer);
+    return delegate().intersect(enumerable1, comparer);
   }
 
   @Override public <C extends Collection<? super E>> C into(C sink) {
-    return getEnumerable().into(sink);
+    return delegate().into(sink);
   }
 
   @Override public <C extends Collection<? super E>> C removeAll(C sink) {
-    return getEnumerable().removeAll(sink);
+    return delegate().removeAll(sink);
   }
 
   @Override public <TInner, TKey, TResult> Enumerable<TResult> join(
@@ -328,7 +326,7 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           Function1<E, TKey> outerKeySelector,
           Function1<TInner, TKey> innerKeySelector,
           Function2<E, TInner, TResult> resultSelector) {
-    return getEnumerable().join(inner, outerKeySelector, innerKeySelector, resultSelector);
+    return delegate().join(inner, outerKeySelector, innerKeySelector, resultSelector);
   }
 
   @Override public <TInner, TKey, TResult> Enumerable<TResult> join(
@@ -337,7 +335,7 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           Function1<TInner, TKey> innerKeySelector,
           Function2<E, TInner, TResult> resultSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().join(inner, outerKeySelector,
+    return delegate().join(inner, outerKeySelector,
             innerKeySelector, resultSelector, comparer);
   }
 
@@ -349,7 +347,7 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           EqualityComparer<TKey> comparer,
           boolean generateNullsOnLeft,
           boolean generateNullsOnRight) {
-    return getEnumerable().join(inner, outerKeySelector, innerKeySelector, resultSelector,
+    return delegate().join(inner, outerKeySelector, innerKeySelector, resultSelector,
             comparer, generateNullsOnLeft, generateNullsOnRight);
   }
 
@@ -357,350 +355,350 @@ public abstract class WrapperEnumerable<E> implements Enumerable<E> {
           CorrelateJoinType joinType,
           Function1<E, Enumerable<TInner>> inner,
           Function2<E, TInner, TResult> resultSelector) {
-    return getEnumerable().correlateJoin(joinType, inner, resultSelector);
+    return delegate().correlateJoin(joinType, inner, resultSelector);
   }
 
   @Override public E last() {
-    return getEnumerable().last();
+    return delegate().last();
   }
 
   @Override public E last(Predicate1<E> predicate) {
-    return getEnumerable().last(predicate);
+    return delegate().last(predicate);
   }
 
   @Override public E lastOrDefault() {
-    return getEnumerable().lastOrDefault();
+    return delegate().lastOrDefault();
   }
 
   @Override public E lastOrDefault(Predicate1<E> predicate) {
-    return getEnumerable().lastOrDefault(predicate);
+    return delegate().lastOrDefault(predicate);
   }
 
   @Override public long longCount() {
-    return getEnumerable().longCount();
+    return delegate().longCount();
   }
 
   @Override public long longCount(Predicate1<E> predicate) {
-    return getEnumerable().longCount(predicate);
+    return delegate().longCount(predicate);
   }
 
   @Override public E max() {
-    return getEnumerable().max();
+    return delegate().max();
   }
 
   @Override public BigDecimal max(BigDecimalFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public BigDecimal max(NullableBigDecimalFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public double max(DoubleFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public Double max(NullableDoubleFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public int max(IntegerFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public Integer max(NullableIntegerFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public long max(LongFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public Long max(NullableLongFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public float max(FloatFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public Float max(NullableFloatFunction1<E> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public <TResult extends Comparable<TResult>> TResult max(
           Function1<E, TResult> selector) {
-    return getEnumerable().max(selector);
+    return delegate().max(selector);
   }
 
   @Override public E min() {
-    return getEnumerable().min();
+    return delegate().min();
   }
 
   @Override public BigDecimal min(BigDecimalFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public BigDecimal min(NullableBigDecimalFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public double min(DoubleFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public Double min(NullableDoubleFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public int min(IntegerFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public Integer min(NullableIntegerFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public long min(LongFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public Long min(NullableLongFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public float min(FloatFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public Float min(NullableFloatFunction1<E> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public <TResult extends Comparable<TResult>> TResult min(
           Function1<E, TResult> selector) {
-    return getEnumerable().min(selector);
+    return delegate().min(selector);
   }
 
   @Override public <TResult> Enumerable<TResult> ofType(Class<TResult> clazz) {
-    return getEnumerable().ofType(clazz);
+    return delegate().ofType(clazz);
   }
 
   @Override public <TKey extends Comparable> Enumerable<E> orderBy(
           Function1<E, TKey> keySelector) {
-    return getEnumerable().orderBy(keySelector);
+    return delegate().orderBy(keySelector);
   }
 
   @Override public <TKey> Enumerable<E> orderBy(
           Function1<E, TKey> keySelector,
           Comparator<TKey> comparator) {
-    return getEnumerable().orderBy(keySelector, comparator);
+    return delegate().orderBy(keySelector, comparator);
   }
 
   @Override public <TKey extends Comparable> Enumerable<E> orderByDescending(
           Function1<E, TKey> keySelector) {
-    return getEnumerable().orderByDescending(keySelector);
+    return delegate().orderByDescending(keySelector);
   }
 
   @Override public <TKey> Enumerable<E> orderByDescending(
           Function1<E, TKey> keySelector,
           Comparator<TKey> comparator) {
-    return getEnumerable().orderByDescending(keySelector, comparator);
+    return delegate().orderByDescending(keySelector, comparator);
   }
 
   @Override public Enumerable<E> reverse() {
-    return getEnumerable().reverse();
+    return delegate().reverse();
   }
 
   @Override public <TResult> Enumerable<TResult> select(Function1<E, TResult> selector) {
-    return getEnumerable().select(selector);
+    return delegate().select(selector);
   }
 
   @Override public <TResult> Enumerable<TResult> select(Function2<E, Integer, TResult> selector) {
-    return getEnumerable().select(selector);
+    return delegate().select(selector);
   }
 
   @Override public <TResult> Enumerable<TResult> selectMany(
           Function1<E, Enumerable<TResult>> selector) {
-    return getEnumerable().selectMany(selector);
+    return delegate().selectMany(selector);
   }
 
   @Override public <TResult> Enumerable<TResult> selectMany(
           Function2<E, Integer, Enumerable<TResult>> selector) {
-    return getEnumerable().selectMany(selector);
+    return delegate().selectMany(selector);
   }
 
   @Override public <TCollection, TResult> Enumerable<TResult> selectMany(
           Function2<E, Integer, Enumerable<TCollection>> collectionSelector,
           Function2<E, TCollection, TResult> resultSelector) {
-    return getEnumerable().selectMany(collectionSelector, resultSelector);
+    return delegate().selectMany(collectionSelector, resultSelector);
   }
 
   @Override public <TCollection, TResult> Enumerable<TResult> selectMany(
           Function1<E, Enumerable<TCollection>> collectionSelector,
           Function2<E, TCollection, TResult> resultSelector) {
-    return getEnumerable().selectMany(collectionSelector, resultSelector);
+    return delegate().selectMany(collectionSelector, resultSelector);
   }
 
   @Override public boolean sequenceEqual(Enumerable<E> enumerable1) {
-    return getEnumerable().sequenceEqual(enumerable1);
+    return delegate().sequenceEqual(enumerable1);
   }
 
   @Override public boolean sequenceEqual(Enumerable<E> enumerable1, EqualityComparer<E> comparer) {
-    return getEnumerable().sequenceEqual(enumerable1, comparer);
+    return delegate().sequenceEqual(enumerable1, comparer);
   }
 
   @Override public E single() {
-    return getEnumerable().single();
+    return delegate().single();
   }
 
   @Override public E single(Predicate1<E> predicate) {
-    return getEnumerable().single(predicate);
+    return delegate().single(predicate);
   }
 
   @Override public E singleOrDefault() {
-    return getEnumerable().singleOrDefault();
+    return delegate().singleOrDefault();
   }
 
   @Override public E singleOrDefault(Predicate1<E> predicate) {
-    return getEnumerable().singleOrDefault(predicate);
+    return delegate().singleOrDefault(predicate);
   }
 
   @Override public Enumerable<E> skip(int count) {
-    return getEnumerable().skip(count);
+    return delegate().skip(count);
   }
 
   @Override public Enumerable<E> skipWhile(Predicate1<E> predicate) {
-    return getEnumerable().skipWhile(predicate);
+    return delegate().skipWhile(predicate);
   }
 
   @Override public Enumerable<E> skipWhile(Predicate2<E, Integer> predicate) {
-    return getEnumerable().skipWhile(predicate);
+    return delegate().skipWhile(predicate);
   }
 
   @Override public BigDecimal sum(BigDecimalFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public BigDecimal sum(NullableBigDecimalFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public double sum(DoubleFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public Double sum(NullableDoubleFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public int sum(IntegerFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public Integer sum(NullableIntegerFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public long sum(LongFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public Long sum(NullableLongFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public float sum(FloatFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public Float sum(NullableFloatFunction1<E> selector) {
-    return getEnumerable().sum(selector);
+    return delegate().sum(selector);
   }
 
   @Override public Enumerable<E> take(int count) {
-    return getEnumerable().take(count);
+    return delegate().take(count);
   }
 
   @Override public Enumerable<E> takeWhile(Predicate1<E> predicate) {
-    return getEnumerable().takeWhile(predicate);
+    return delegate().takeWhile(predicate);
   }
 
   @Override public Enumerable<E> takeWhile(Predicate2<E, Integer> predicate) {
-    return getEnumerable().takeWhile(predicate);
+    return delegate().takeWhile(predicate);
   }
 
   @Override public <TKey> Map<TKey, E> toMap(Function1<E, TKey> keySelector) {
-    return getEnumerable().toMap(keySelector);
+    return delegate().toMap(keySelector);
   }
 
   @Override public <TKey> Map<TKey, E> toMap(
           Function1<E, TKey> keySelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().toMap(keySelector, comparer);
+    return delegate().toMap(keySelector, comparer);
   }
 
   @Override public <TKey, TElement> Map<TKey, TElement> toMap(
           Function1<E, TKey> keySelector,
           Function1<E, TElement> elementSelector) {
-    return getEnumerable().toMap(keySelector, elementSelector);
+    return delegate().toMap(keySelector, elementSelector);
   }
 
   @Override public <TKey, TElement> Map<TKey, TElement> toMap(
           Function1<E, TKey> keySelector,
           Function1<E, TElement> elementSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().toMap(keySelector, elementSelector, comparer);
+    return delegate().toMap(keySelector, elementSelector, comparer);
   }
 
   @Override public List<E> toList() {
-    return getEnumerable().toList();
+    return delegate().toList();
   }
 
   @Override public <TKey> Lookup<TKey, E> toLookup(Function1<E, TKey> keySelector) {
-    return getEnumerable().toLookup(keySelector);
+    return delegate().toLookup(keySelector);
   }
 
   @Override public <TKey> Lookup<TKey, E> toLookup(
           Function1<E, TKey> keySelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().toLookup(keySelector, comparer);
+    return delegate().toLookup(keySelector, comparer);
   }
 
   @Override public <TKey, TElement> Lookup<TKey, TElement> toLookup(
           Function1<E, TKey> keySelector,
           Function1<E, TElement> elementSelector) {
-    return getEnumerable().toLookup(keySelector, elementSelector);
+    return delegate().toLookup(keySelector, elementSelector);
   }
 
   @Override public <TKey, TElement> Lookup<TKey, TElement> toLookup(
           Function1<E, TKey> keySelector,
           Function1<E, TElement> elementSelector,
           EqualityComparer<TKey> comparer) {
-    return getEnumerable().toLookup(keySelector, elementSelector, comparer);
+    return delegate().toLookup(keySelector, elementSelector, comparer);
   }
 
   @Override public Enumerable<E> union(Enumerable<E> source1) {
-    return getEnumerable().union(source1);
+    return delegate().union(source1);
   }
 
   @Override public Enumerable<E> union(Enumerable<E> source1, EqualityComparer<E> comparer) {
-    return getEnumerable().union(source1, comparer);
+    return delegate().union(source1, comparer);
   }
 
   @Override public Enumerable<E> where(Predicate1<E> predicate) {
-    return getEnumerable().where(predicate);
+    return delegate().where(predicate);
   }
 
   @Override public Enumerable<E> where(Predicate2<E, Integer> predicate) {
-    return getEnumerable().where(predicate);
+    return delegate().where(predicate);
   }
 
   @Override public <T1, TResult> Enumerable<TResult> zip(
           Enumerable<T1> source1,
           Function2<E, T1, TResult> resultSelector) {
-    return getEnumerable().zip(source1, resultSelector);
+    return delegate().zip(source1, resultSelector);
   }
 }
 
-// End WrapperEnumerable.java
+// End ForwardingEnumerable.java

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.linq4j;
 
+import org.apache.calcite.linq4j.function.Function0;
 import org.apache.calcite.linq4j.function.Function1;
 
 import java.lang.reflect.Method;
@@ -27,7 +28,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
-import java.util.function.Supplier;
 
 /**
  * Utility and factory methods for Linq4j.
@@ -526,7 +526,7 @@ public abstract class Linq4j {
   }
 
   /**
-   * Returns an {@link Enumerable} whose computation (via a {@link Supplier}) will be
+   * Returns an {@link Enumerable} whose computation (via a {@link Function0}) will be
    * postponed until it is actually required
    *
    * @param supplier Enumerable supplier
@@ -534,7 +534,7 @@ public abstract class Linq4j {
    *
    * @return Lazy enumerable
    */
-  public static <E> Enumerable<E> lazyEnumerable(Supplier<Enumerable<E>> supplier) {
+  public static <E> Enumerable<E> lazyEnumerable(Function0<Enumerable<E>> supplier) {
     return new LazyEnumerable<>(supplier);
   }
 
@@ -542,17 +542,18 @@ public abstract class Linq4j {
   /** Lazy enumerable.
    *
    * @param <E> element type */
-  static class LazyEnumerable<E> extends WrapperEnumerable<E> {
-    private final Supplier<Enumerable<E>> supplier;
+  static class LazyEnumerable<E> extends ForwardingEnumerable<E> {
+    private final Function0<Enumerable<E>> supplier;
     private Enumerable<E> enumerable = null;
 
-    LazyEnumerable(Supplier<Enumerable<E>> supplier) {
+    LazyEnumerable(Function0<Enumerable<E>> supplier) {
       this.supplier = supplier;
     }
 
-    @Override protected Enumerable<E> getEnumerable() {
+    @Override protected Enumerable<E> delegate() {
       if (enumerable == null) {
-        enumerable = supplier.get();
+        enumerable = supplier.apply();
+        Objects.requireNonNull(enumerable);
       }
       return enumerable;
     }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.function.Supplier;
 
 /**
  * Utility and factory methods for Linq4j.
@@ -521,6 +522,39 @@ public abstract class Linq4j {
           current = emptyEnumerator();
         }
       };
+    }
+  }
+
+  /**
+   * Returns an {@link Enumerable} whose computation (via a {@link Supplier}) will be
+   * postponed until it is actually required
+   *
+   * @param supplier Enumerable supplier
+   * @param <E> Element type
+   *
+   * @return Lazy enumerable
+   */
+  public static <E> Enumerable<E> lazyEnumerable(Supplier<Enumerable<E>> supplier) {
+    return new LazyEnumerable<>(supplier);
+  }
+
+
+  /** Lazy enumerable.
+   *
+   * @param <E> element type */
+  static class LazyEnumerable<E> extends WrapperEnumerable<E> {
+    private final Supplier<Enumerable<E>> supplier;
+    private Enumerable<E> enumerable = null;
+
+    LazyEnumerable(Supplier<Enumerable<E>> supplier) {
+      this.supplier = supplier;
+    }
+
+    @Override protected Enumerable<E> getEnumerable() {
+      if (enumerable == null) {
+        enumerable = supplier.get();
+      }
+      return enumerable;
     }
   }
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/WrapperEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/WrapperEnumerable.java
@@ -1,0 +1,706 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.linq4j;
+
+import org.apache.calcite.linq4j.function.BigDecimalFunction1;
+import org.apache.calcite.linq4j.function.DoubleFunction1;
+import org.apache.calcite.linq4j.function.EqualityComparer;
+import org.apache.calcite.linq4j.function.FloatFunction1;
+import org.apache.calcite.linq4j.function.Function0;
+import org.apache.calcite.linq4j.function.Function1;
+import org.apache.calcite.linq4j.function.Function2;
+import org.apache.calcite.linq4j.function.IntegerFunction1;
+import org.apache.calcite.linq4j.function.LongFunction1;
+import org.apache.calcite.linq4j.function.NullableBigDecimalFunction1;
+import org.apache.calcite.linq4j.function.NullableDoubleFunction1;
+import org.apache.calcite.linq4j.function.NullableFloatFunction1;
+import org.apache.calcite.linq4j.function.NullableIntegerFunction1;
+import org.apache.calcite.linq4j.function.NullableLongFunction1;
+import org.apache.calcite.linq4j.function.Predicate1;
+import org.apache.calcite.linq4j.function.Predicate2;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract implementation of the {@link Enumerable} interface that
+ * forwards all methods to another wrappee {@link Enumerable}.
+ *
+ * <p>There is one abstract method: {@link #getEnumerable()}, to be implemented by
+ * the derived class, that will be used to obtained the wrappee {@link Enumerable}.</p>
+ *
+ * @param <E> Element type
+ */
+public abstract class WrapperEnumerable<E> implements Enumerable<E> {
+
+  /**
+   * @return the wrapee {@link Enumerable} where all methods will be forwarded to
+   */
+  protected abstract Enumerable<E> getEnumerable();
+
+  @Override public Enumerator<E> enumerator() {
+    return getEnumerable().enumerator();
+  }
+
+  @Override public Iterator<E> iterator() {
+    return getEnumerable().iterator();
+  }
+
+  @Override public <R> R foreach(Function1<E, R> func) {
+    return getEnumerable().foreach(func);
+  }
+
+  @Override public E aggregate(Function2<E, E, E> func) {
+    return getEnumerable().aggregate(func);
+  }
+
+  @Override public <TAccumulate> TAccumulate aggregate(
+          TAccumulate seed,
+          Function2<TAccumulate, E, TAccumulate> func) {
+    return getEnumerable().aggregate(seed, func);
+  }
+
+  @Override public <TAccumulate, TResult> TResult aggregate(
+          TAccumulate seed,
+          Function2<TAccumulate, E, TAccumulate> func,
+          Function1<TAccumulate, TResult> selector) {
+    return getEnumerable().aggregate(seed, func, selector);
+  }
+
+  @Override public boolean all(Predicate1<E> predicate) {
+    return getEnumerable().all(predicate);
+  }
+
+  @Override public boolean any() {
+    return getEnumerable().any();
+  }
+
+  @Override public boolean any(Predicate1<E> predicate) {
+    return getEnumerable().any(predicate);
+  }
+
+  @Override public Enumerable<E> asEnumerable() {
+    return getEnumerable().asEnumerable();
+  }
+
+  @Override public Queryable<E> asQueryable() {
+    return getEnumerable().asQueryable();
+  }
+
+  @Override public BigDecimal average(BigDecimalFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public BigDecimal average(NullableBigDecimalFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public double average(DoubleFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public Double average(NullableDoubleFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public int average(IntegerFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public Integer average(NullableIntegerFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public long average(LongFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public Long average(NullableLongFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public float average(FloatFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public Float average(NullableFloatFunction1<E> selector) {
+    return getEnumerable().average(selector);
+  }
+
+  @Override public <T2> Enumerable<T2> cast(Class<T2> clazz) {
+    return getEnumerable().cast(clazz);
+  }
+
+  @Override public Enumerable<E> concat(Enumerable<E> enumerable1) {
+    return getEnumerable().concat(enumerable1);
+  }
+
+  @Override public boolean contains(E element) {
+    return getEnumerable().contains(element);
+  }
+
+  @Override public boolean contains(E element, EqualityComparer<E> comparer) {
+    return getEnumerable().contains(element, comparer);
+  }
+
+  @Override public int count() {
+    return getEnumerable().count();
+  }
+
+  @Override public int count(Predicate1<E> predicate) {
+    return getEnumerable().count(predicate);
+  }
+
+  @Override public Enumerable<E> defaultIfEmpty() {
+    return getEnumerable().defaultIfEmpty();
+  }
+
+  @Override public Enumerable<E> defaultIfEmpty(E value) {
+    return getEnumerable().defaultIfEmpty(value);
+  }
+
+  @Override public Enumerable<E> distinct() {
+    return getEnumerable().distinct();
+  }
+
+  @Override public Enumerable<E> distinct(EqualityComparer<E> comparer) {
+    return getEnumerable().distinct(comparer);
+  }
+
+  @Override public E elementAt(int index) {
+    return getEnumerable().elementAt(index);
+  }
+
+  @Override public E elementAtOrDefault(int index) {
+    return getEnumerable().elementAtOrDefault(index);
+  }
+
+  @Override public Enumerable<E> except(Enumerable<E> enumerable1) {
+    return getEnumerable().except(enumerable1);
+  }
+
+  @Override public Enumerable<E> except(Enumerable<E> enumerable1, EqualityComparer<E> comparer) {
+    return getEnumerable().except(enumerable1, comparer);
+  }
+
+  @Override public E first() {
+    return getEnumerable().first();
+  }
+
+  @Override public E first(Predicate1<E> predicate) {
+    return getEnumerable().first(predicate);
+  }
+
+  @Override public E firstOrDefault() {
+    return getEnumerable().firstOrDefault();
+  }
+
+  @Override public E firstOrDefault(Predicate1<E> predicate) {
+    return getEnumerable().firstOrDefault(predicate);
+  }
+
+  @Override public <TKey> Enumerable<Grouping<TKey, E>> groupBy(Function1<E, TKey> keySelector) {
+    return getEnumerable().groupBy(keySelector);
+  }
+
+  @Override public <TKey> Enumerable<Grouping<TKey, E>> groupBy(
+          Function1<E, TKey> keySelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().groupBy(keySelector, comparer);
+  }
+
+  @Override public <TKey, TElement> Enumerable<Grouping<TKey, TElement>> groupBy(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector) {
+    return getEnumerable().groupBy(keySelector, elementSelector);
+  }
+
+  @Override public <TKey, TElement> Enumerable<Grouping<TKey, TElement>> groupBy(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().groupBy(keySelector, elementSelector, comparer);
+  }
+
+  @Override public <TKey, TResult> Enumerable<TResult> groupBy(
+          Function1<E, TKey> keySelector,
+          Function2<TKey, Enumerable<E>, TResult> resultSelector) {
+    return getEnumerable().groupBy(keySelector, resultSelector);
+  }
+
+  @Override public <TKey, TResult> Enumerable<TResult> groupBy(
+          Function1<E, TKey> keySelector,
+          Function2<TKey, Enumerable<E>, TResult> resultSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().groupBy(keySelector, resultSelector, comparer);
+  }
+
+  @Override public <TKey, TElement, TResult> Enumerable<TResult> groupBy(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector,
+          Function2<TKey, Enumerable<TElement>, TResult> resultSelector) {
+    return getEnumerable().groupBy(keySelector, elementSelector, resultSelector);
+  }
+
+  @Override public <TKey, TElement, TResult> Enumerable<TResult> groupBy(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector,
+          Function2<TKey, Enumerable<TElement>, TResult> resultSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().groupBy(keySelector, elementSelector, resultSelector, comparer);
+  }
+
+  @Override public <TKey, TAccumulate, TResult> Enumerable<TResult> groupBy(
+          Function1<E, TKey> keySelector,
+          Function0<TAccumulate> accumulatorInitializer,
+          Function2<TAccumulate, E, TAccumulate> accumulatorAdder,
+          Function2<TKey, TAccumulate, TResult> resultSelector) {
+    return getEnumerable().groupBy(keySelector, accumulatorInitializer,
+            accumulatorAdder, resultSelector);
+  }
+
+  @Override public <TKey, TAccumulate, TResult> Enumerable<TResult> groupBy(
+          Function1<E, TKey> keySelector,
+          Function0<TAccumulate> accumulatorInitializer,
+          Function2<TAccumulate, E, TAccumulate> accumulatorAdder,
+          Function2<TKey, TAccumulate, TResult> resultSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().groupBy(keySelector, accumulatorInitializer, accumulatorAdder,
+            resultSelector, comparer);
+  }
+
+  @Override public <TInner, TKey, TResult> Enumerable<TResult> groupJoin(
+          Enumerable<TInner> inner,
+          Function1<E, TKey> outerKeySelector,
+          Function1<TInner, TKey> innerKeySelector,
+          Function2<E, Enumerable<TInner>, TResult> resultSelector) {
+    return getEnumerable().groupJoin(inner, outerKeySelector, innerKeySelector, resultSelector);
+  }
+
+  @Override public <TInner, TKey, TResult> Enumerable<TResult> groupJoin(
+          Enumerable<TInner> inner,
+          Function1<E, TKey> outerKeySelector,
+          Function1<TInner, TKey> innerKeySelector,
+          Function2<E, Enumerable<TInner>, TResult> resultSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().groupJoin(inner, outerKeySelector, innerKeySelector,
+            resultSelector, comparer);
+  }
+
+  @Override public Enumerable<E> intersect(Enumerable<E> intersect) {
+    return getEnumerable().intersect(intersect);
+  }
+
+  @Override public Enumerable<E> intersect(
+          Enumerable<E> enumerable1,
+          EqualityComparer<E> comparer) {
+    return getEnumerable().intersect(enumerable1, comparer);
+  }
+
+  @Override public <C extends Collection<? super E>> C into(C sink) {
+    return getEnumerable().into(sink);
+  }
+
+  @Override public <C extends Collection<? super E>> C removeAll(C sink) {
+    return getEnumerable().removeAll(sink);
+  }
+
+  @Override public <TInner, TKey, TResult> Enumerable<TResult> join(
+          Enumerable<TInner> inner,
+          Function1<E, TKey> outerKeySelector,
+          Function1<TInner, TKey> innerKeySelector,
+          Function2<E, TInner, TResult> resultSelector) {
+    return getEnumerable().join(inner, outerKeySelector, innerKeySelector, resultSelector);
+  }
+
+  @Override public <TInner, TKey, TResult> Enumerable<TResult> join(
+          Enumerable<TInner> inner,
+          Function1<E, TKey> outerKeySelector,
+          Function1<TInner, TKey> innerKeySelector,
+          Function2<E, TInner, TResult> resultSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().join(inner, outerKeySelector,
+            innerKeySelector, resultSelector, comparer);
+  }
+
+  @Override public <TInner, TKey, TResult> Enumerable<TResult> join(
+          Enumerable<TInner> inner,
+          Function1<E, TKey> outerKeySelector,
+          Function1<TInner, TKey> innerKeySelector,
+          Function2<E, TInner, TResult> resultSelector,
+          EqualityComparer<TKey> comparer,
+          boolean generateNullsOnLeft,
+          boolean generateNullsOnRight) {
+    return getEnumerable().join(inner, outerKeySelector, innerKeySelector, resultSelector,
+            comparer, generateNullsOnLeft, generateNullsOnRight);
+  }
+
+  @Override public <TInner, TResult> Enumerable<TResult> correlateJoin(
+          CorrelateJoinType joinType,
+          Function1<E, Enumerable<TInner>> inner,
+          Function2<E, TInner, TResult> resultSelector) {
+    return getEnumerable().correlateJoin(joinType, inner, resultSelector);
+  }
+
+  @Override public E last() {
+    return getEnumerable().last();
+  }
+
+  @Override public E last(Predicate1<E> predicate) {
+    return getEnumerable().last(predicate);
+  }
+
+  @Override public E lastOrDefault() {
+    return getEnumerable().lastOrDefault();
+  }
+
+  @Override public E lastOrDefault(Predicate1<E> predicate) {
+    return getEnumerable().lastOrDefault(predicate);
+  }
+
+  @Override public long longCount() {
+    return getEnumerable().longCount();
+  }
+
+  @Override public long longCount(Predicate1<E> predicate) {
+    return getEnumerable().longCount(predicate);
+  }
+
+  @Override public E max() {
+    return getEnumerable().max();
+  }
+
+  @Override public BigDecimal max(BigDecimalFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public BigDecimal max(NullableBigDecimalFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public double max(DoubleFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public Double max(NullableDoubleFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public int max(IntegerFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public Integer max(NullableIntegerFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public long max(LongFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public Long max(NullableLongFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public float max(FloatFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public Float max(NullableFloatFunction1<E> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public <TResult extends Comparable<TResult>> TResult max(
+          Function1<E, TResult> selector) {
+    return getEnumerable().max(selector);
+  }
+
+  @Override public E min() {
+    return getEnumerable().min();
+  }
+
+  @Override public BigDecimal min(BigDecimalFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public BigDecimal min(NullableBigDecimalFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public double min(DoubleFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public Double min(NullableDoubleFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public int min(IntegerFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public Integer min(NullableIntegerFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public long min(LongFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public Long min(NullableLongFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public float min(FloatFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public Float min(NullableFloatFunction1<E> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public <TResult extends Comparable<TResult>> TResult min(
+          Function1<E, TResult> selector) {
+    return getEnumerable().min(selector);
+  }
+
+  @Override public <TResult> Enumerable<TResult> ofType(Class<TResult> clazz) {
+    return getEnumerable().ofType(clazz);
+  }
+
+  @Override public <TKey extends Comparable> Enumerable<E> orderBy(
+          Function1<E, TKey> keySelector) {
+    return getEnumerable().orderBy(keySelector);
+  }
+
+  @Override public <TKey> Enumerable<E> orderBy(
+          Function1<E, TKey> keySelector,
+          Comparator<TKey> comparator) {
+    return getEnumerable().orderBy(keySelector, comparator);
+  }
+
+  @Override public <TKey extends Comparable> Enumerable<E> orderByDescending(
+          Function1<E, TKey> keySelector) {
+    return getEnumerable().orderByDescending(keySelector);
+  }
+
+  @Override public <TKey> Enumerable<E> orderByDescending(
+          Function1<E, TKey> keySelector,
+          Comparator<TKey> comparator) {
+    return getEnumerable().orderByDescending(keySelector, comparator);
+  }
+
+  @Override public Enumerable<E> reverse() {
+    return getEnumerable().reverse();
+  }
+
+  @Override public <TResult> Enumerable<TResult> select(Function1<E, TResult> selector) {
+    return getEnumerable().select(selector);
+  }
+
+  @Override public <TResult> Enumerable<TResult> select(Function2<E, Integer, TResult> selector) {
+    return getEnumerable().select(selector);
+  }
+
+  @Override public <TResult> Enumerable<TResult> selectMany(
+          Function1<E, Enumerable<TResult>> selector) {
+    return getEnumerable().selectMany(selector);
+  }
+
+  @Override public <TResult> Enumerable<TResult> selectMany(
+          Function2<E, Integer, Enumerable<TResult>> selector) {
+    return getEnumerable().selectMany(selector);
+  }
+
+  @Override public <TCollection, TResult> Enumerable<TResult> selectMany(
+          Function2<E, Integer, Enumerable<TCollection>> collectionSelector,
+          Function2<E, TCollection, TResult> resultSelector) {
+    return getEnumerable().selectMany(collectionSelector, resultSelector);
+  }
+
+  @Override public <TCollection, TResult> Enumerable<TResult> selectMany(
+          Function1<E, Enumerable<TCollection>> collectionSelector,
+          Function2<E, TCollection, TResult> resultSelector) {
+    return getEnumerable().selectMany(collectionSelector, resultSelector);
+  }
+
+  @Override public boolean sequenceEqual(Enumerable<E> enumerable1) {
+    return getEnumerable().sequenceEqual(enumerable1);
+  }
+
+  @Override public boolean sequenceEqual(Enumerable<E> enumerable1, EqualityComparer<E> comparer) {
+    return getEnumerable().sequenceEqual(enumerable1, comparer);
+  }
+
+  @Override public E single() {
+    return getEnumerable().single();
+  }
+
+  @Override public E single(Predicate1<E> predicate) {
+    return getEnumerable().single(predicate);
+  }
+
+  @Override public E singleOrDefault() {
+    return getEnumerable().singleOrDefault();
+  }
+
+  @Override public E singleOrDefault(Predicate1<E> predicate) {
+    return getEnumerable().singleOrDefault(predicate);
+  }
+
+  @Override public Enumerable<E> skip(int count) {
+    return getEnumerable().skip(count);
+  }
+
+  @Override public Enumerable<E> skipWhile(Predicate1<E> predicate) {
+    return getEnumerable().skipWhile(predicate);
+  }
+
+  @Override public Enumerable<E> skipWhile(Predicate2<E, Integer> predicate) {
+    return getEnumerable().skipWhile(predicate);
+  }
+
+  @Override public BigDecimal sum(BigDecimalFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public BigDecimal sum(NullableBigDecimalFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public double sum(DoubleFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public Double sum(NullableDoubleFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public int sum(IntegerFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public Integer sum(NullableIntegerFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public long sum(LongFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public Long sum(NullableLongFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public float sum(FloatFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public Float sum(NullableFloatFunction1<E> selector) {
+    return getEnumerable().sum(selector);
+  }
+
+  @Override public Enumerable<E> take(int count) {
+    return getEnumerable().take(count);
+  }
+
+  @Override public Enumerable<E> takeWhile(Predicate1<E> predicate) {
+    return getEnumerable().takeWhile(predicate);
+  }
+
+  @Override public Enumerable<E> takeWhile(Predicate2<E, Integer> predicate) {
+    return getEnumerable().takeWhile(predicate);
+  }
+
+  @Override public <TKey> Map<TKey, E> toMap(Function1<E, TKey> keySelector) {
+    return getEnumerable().toMap(keySelector);
+  }
+
+  @Override public <TKey> Map<TKey, E> toMap(
+          Function1<E, TKey> keySelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().toMap(keySelector, comparer);
+  }
+
+  @Override public <TKey, TElement> Map<TKey, TElement> toMap(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector) {
+    return getEnumerable().toMap(keySelector, elementSelector);
+  }
+
+  @Override public <TKey, TElement> Map<TKey, TElement> toMap(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().toMap(keySelector, elementSelector, comparer);
+  }
+
+  @Override public List<E> toList() {
+    return getEnumerable().toList();
+  }
+
+  @Override public <TKey> Lookup<TKey, E> toLookup(Function1<E, TKey> keySelector) {
+    return getEnumerable().toLookup(keySelector);
+  }
+
+  @Override public <TKey> Lookup<TKey, E> toLookup(
+          Function1<E, TKey> keySelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().toLookup(keySelector, comparer);
+  }
+
+  @Override public <TKey, TElement> Lookup<TKey, TElement> toLookup(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector) {
+    return getEnumerable().toLookup(keySelector, elementSelector);
+  }
+
+  @Override public <TKey, TElement> Lookup<TKey, TElement> toLookup(
+          Function1<E, TKey> keySelector,
+          Function1<E, TElement> elementSelector,
+          EqualityComparer<TKey> comparer) {
+    return getEnumerable().toLookup(keySelector, elementSelector, comparer);
+  }
+
+  @Override public Enumerable<E> union(Enumerable<E> source1) {
+    return getEnumerable().union(source1);
+  }
+
+  @Override public Enumerable<E> union(Enumerable<E> source1, EqualityComparer<E> comparer) {
+    return getEnumerable().union(source1, comparer);
+  }
+
+  @Override public Enumerable<E> where(Predicate1<E> predicate) {
+    return getEnumerable().where(predicate);
+  }
+
+  @Override public Enumerable<E> where(Predicate2<E, Integer> predicate) {
+    return getEnumerable().where(predicate);
+  }
+
+  @Override public <T1, TResult> Enumerable<TResult> zip(
+          Enumerable<T1> source1,
+          Function2<E, T1, TResult> resultSelector) {
+    return getEnumerable().zip(source1, resultSelector);
+  }
+}
+
+// End WrapperEnumerable.java


### PR DESCRIPTION
Implement a LazyEnumerable: an Enumerable whose computation (via a Supplier) will be postponed until it is actually required.
An example of use case could be CALCITE-2909, where a semiJoin implementation can be optimized by delaying the computation of the innerLookup until the moment when we are sure that it will be really needed, i.e. when the first outer enumerator item is processed.