### PR TITLE
[CALCITE-2208]Schemas now uses the config of current connection to make context,

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -124,6 +124,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserImplFactory;
+import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.type.ExtraSqlTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
@@ -274,7 +275,22 @@ public class CalcitePrepareImpl implements CalcitePrepare {
             context.getDefaultSchemaPath(),
             typeFactory,
             context.config());
-    SqlParser parser = createParser(sql);
+
+    final CalciteConnectionConfig config = context.config();
+    final SqlParser.ConfigBuilder parserConfig = createParserConfig()
+        .setQuotedCasing(config.quotedCasing())
+        .setUnquotedCasing(config.unquotedCasing())
+        .setQuoting(config.quoting())
+        .setConformance(config.conformance())
+        .setCaseSensitive(config.caseSensitive());
+    final SqlParserImplFactory parserFactory =
+        context.config()
+            .parserFactory(SqlParserImplFactory.class, SqlParserImpl.FACTORY);
+    if (parserFactory != null) {
+      parserConfig.setParserFactory(parserFactory);
+    }
+
+    SqlParser parser = createParser(sql, parserConfig);
     SqlNode sqlNode;
     try {
       sqlNode = parser.parseStmt();

--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -352,8 +352,14 @@ public final class Schemas {
       return makeContext(config, context0.getTypeFactory(),
           context0.getDataContext(), schema, schemaPath, objectPath);
     } else {
+      /**
+       * workaround for issue:
+       * {@link https://issues.apache.org/jira/browse/CALCITE-2208?jql=project%20%3D%20CALCITE%20AND%20text%20~%20MATERIALIZATION_CONNECTION}
+       */
       final CalciteConnectionConfig config =
-          mutate(connection.config(), propValues);
+          mutate(CalcitePrepare.Dummy.peek() != null
+              ? CalcitePrepare.Dummy.peek().config()
+              : connection.config(), propValues);
       return makeContext(config, connection.getTypeFactory(),
           createDataContext(connection, schema.root().plus()), schema,
           schemaPath, objectPath);


### PR DESCRIPTION
Schemas now uses the config of current connection to make context,
and CalcitePrepareImpl now uses the context's config rather than a default config
to create a SqlParser in the 'parse_' method.