### PR TITLE
[CALCITE-2960] CalciteCatalogReader now uses config.caseSensitive() to get functions…

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -163,7 +163,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
               Iterables.concat(schemaNames, Util.skipLast(names)), nameMatcher);
       if (schema != null) {
         final String name = Util.last(names);
-        functions2.addAll(schema.getFunctions(name, true));
+        functions2.addAll(schema.getFunctions(name, config.caseSensitive()));
       }
     }
     return functions2;


### PR DESCRIPTION
CalciteCatalogReader now uses config.caseSensitive() to get functions, not a hard-coding `true`.