### PR TITLE
[CALCITE-2975] Implement JSON_REMOVE function

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -143,6 +143,7 @@ data: {
         "JSON_KEYS"
         "JSON_LENGTH"
         "JSON_PRETTY"
+        "JSON_REMOVE"
         "JSON_TYPE"
         "K"
         "KEY"

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -164,6 +164,7 @@ data: {
         "JSON_KEYS"
         "JSON_LENGTH"
         "JSON_PRETTY"
+        "JSON_REMOVE"
         "JSON_TYPE"
         "K"
         "KEY"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4873,6 +4873,8 @@ SqlNode BuiltinFunctionCall() :
         node = JsonArrayFunctionCall() { return node; }
     |
         node = JsonArrayAggFunctionCall() { return node; }
+    |
+        node = JsonRemoveFunctionCall() { return node; }
     )
 }
 
@@ -5376,6 +5378,32 @@ SqlCall JsonLengthFunctionCall() :
     }
     <RPAREN> {
         return SqlStdOperatorTable.JSON_LENGTH.createCall(span.end(this), args);
+    }
+}
+
+SqlCall JsonRemoveFunctionCall() :
+{
+    final List<SqlNode> pathExprs = new ArrayList<SqlNode>();
+    final SqlNode[] jsonDoc = new SqlNode[1];
+    SqlNode e;
+    final Span span;
+}
+{
+    <JSON_REMOVE> { span = span(); }
+    <LPAREN> e = JsonValueExpression(true) {
+        jsonDoc[0] = e;
+     }
+     (
+         <COMMA>
+         e = Expression(ExprContext.ACCEPT_NON_QUERY) {
+             pathExprs.add(e);
+         }
+     )*
+    <RPAREN> {
+        final List<SqlNode> args = new ArrayList();
+        args.addAll(Arrays.asList(jsonDoc));
+        args.addAll(pathExprs);
+        return SqlStdOperatorTable.JSON_REMOVE.createCall(span.end(this), args);
     }
 }
 
@@ -6480,6 +6508,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < JSON_OBJECTAGG: "JSON_OBJECTAGG">
 |   < JSON_PRETTY: "JSON_PRETTY" >
 |   < JSON_QUERY: "JSON_QUERY" >
+|   < JSON_REMOVE: "JSON_REMOVE" >
 |   < JSON_TYPE: "JSON_TYPE">
 |   < JSON_VALUE: "JSON_VALUE" >
 |   < K: "K" >

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -173,6 +173,7 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECT;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECTAGG;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_PRETTY;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_QUERY;
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_REMOVE;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_STRUCTURED_VALUE_EXPRESSION;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_TYPE;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_VALUE_ANY;
@@ -470,6 +471,7 @@ public class RexImpTable {
     defineMethod(JSON_KEYS, BuiltInMethod.JSON_KEYS.method, NullPolicy.NONE);
     defineMethod(JSON_PRETTY, BuiltInMethod.JSON_PRETTY.method, NullPolicy.NONE);
     defineMethod(JSON_LENGTH, BuiltInMethod.JSON_LENGTH.method, NullPolicy.NONE);
+    defineMethod(JSON_REMOVE, BuiltInMethod.JSON_REMOVE.method, NullPolicy.NONE);
     aggMap.put(JSON_OBJECTAGG.with(SqlJsonConstructorNullClause.ABSENT_ON_NULL),
         JsonObjectAggImplementor
             .supplierFor(BuiltInMethod.JSON_OBJECTAGG_ADD.method));

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -882,6 +882,9 @@ public interface CalciteResource {
 
   @BaseMessage("Not a valid input for JSON_KEYS: ''{0}''")
   ExInst<CalciteException> invalidInputForJsonKeys(String value);
+
+  @BaseMessage("Invalid input for JSON_REMOVE: jsonDoc: ''{0}'', jsonPaths: ''{1}''")
+  ExInst<CalciteException> invalidInputForJsonRemove(String jsonDoc, String jsonPaths);
 }
 
 // End CalciteResource.java

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -2869,6 +2869,27 @@ public class SqlFunctions {
     return jsonize(list);
   }
 
+  public static String jsonRemove(Object jsonDoc, Object... jsonPaths) {
+    try {
+      DocumentContext ctx = JsonPath.parse(jsonDoc,
+          Configuration
+              .builder()
+              .options(Option.SUPPRESS_EXCEPTIONS)
+              .jsonProvider(JSON_PATH_JSON_PROVIDER)
+              .mappingProvider(JSON_PATH_MAPPING_PROVIDER)
+              .build());
+      for (Object jsonPath : jsonPaths) {
+        if ((jsonPath != null) && (ctx.read(jsonPath.toString()) != null)) {
+          ctx.delete(jsonPath.toString());
+        }
+      }
+      return ctx.jsonString();
+    } catch (Exception ex) {
+      throw RESOURCE.invalidInputForJsonRemove(
+                  jsonDoc.toString(), jsonize(jsonPaths)).ex();
+    }
+  }
+
   public static boolean isJsonPathContext(Object input) {
     try {
       PathContext context = (PathContext) input;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonRemoveFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonRemoveFunction.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+import java.util.Locale;
+
+/**
+ * The <code>JSON_REMOVE</code> function.
+ */
+public class SqlJsonRemoveFunction extends SqlFunction {
+  public SqlJsonRemoveFunction() {
+    super("JSON_REMOVE", SqlKind.OTHER_FUNCTION, ReturnTypes.VARCHAR_2000, null,
+        OperandTypes.VARIADIC, SqlFunctionCategory.SYSTEM);
+  }
+
+  @Override public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.from(2);
+  }
+
+  @Override protected void checkOperandCount(SqlValidator validator,
+      SqlOperandTypeChecker argType, SqlCall call) {
+    assert call.operandCount() >= 2;
+  }
+
+  @Override public String getSignatureTemplate(int operandsCount) {
+    assert operandsCount >= 2;
+    final StringBuilder sb = new StringBuilder();
+    sb.append("{0}(");
+    for (int i = 1; i < operandsCount; i++) {
+      sb.append(String.format(Locale.ROOT, "{%d} ", i + 1));
+    }
+    sb.append("{1})");
+    return sb.toString();
+  }
+
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec,
+      int rightPrec) {
+    assert call.operandCount() >= 2;
+    final SqlWriter.Frame frame = writer.startFunCall(getName());
+    call.operand(0).unparse(writer, leftPrec, rightPrec);
+    SqlWriter.Frame listFrame = writer.startList("", "");
+    writer.sep(",");
+    for (int i = 1; i < call.operandCount(); i++) {
+      writer.sep(",");
+      call.operand(i).unparse(writer, leftPrec, rightPrec);
+    }
+    writer.endList(listFrame);
+    writer.endFunCall(frame);
+  }
+}
+
+// End SqlJsonRemoveFunction.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1327,6 +1327,8 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
 
   public static final SqlFunction JSON_LENGTH = new SqlJsonLengthFunction();
 
+  public static final SqlFunction JSON_REMOVE = new SqlJsonRemoveFunction();
+
   public static final SqlJsonObjectAggAggFunction JSON_OBJECTAGG =
       new SqlJsonObjectAggAggFunction(SqlKind.JSON_OBJECTAGG,
           SqlJsonConstructorNullClause.NULL_ON_NULL);

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -292,6 +292,7 @@ public enum BuiltInMethod {
   JSON_KEYS(SqlFunctions.class, "jsonKeys", Object.class),
   JSON_PRETTY(SqlFunctions.class, "jsonPretty", Object.class),
   JSON_LENGTH(SqlFunctions.class, "jsonLength", Object.class),
+  JSON_REMOVE(SqlFunctions.class, "jsonRemove", Object.class, Object.class),
   JSON_OBJECTAGG_ADD(SqlFunctions.class, "jsonObjectAggAdd", Map.class,
       String.class, Object.class, SqlJsonConstructorNullClause.class),
   JSON_ARRAY(SqlFunctions.class, "jsonArray",

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -287,4 +287,5 @@ InvalidInputForJsonDepth=Not a valid input for JSON_DEPTH: ''{0}''
 ExceptionWhileSerializingToJson=Cannot serialize object to JSON, and the object is: ''{0}''
 InvalidInputForJsonLength=Not a valid input for JSON_LENGTH: ''{0}''
 InvalidInputForJsonKeys=Not a valid input for JSON_KEYS: ''{0}''
+InvalidInputForJsonRemove=Invalid input for JSON_REMOVE: jsonDoc: ''{0}'', jsonPaths: ''{1}''
 # End CalciteResource.properties

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -147,6 +147,7 @@ data: {
         "JSON_KEYS"
         "JSON_LENGTH"
         "JSON_PRETTY"
+        "JSON_REMOVE"
         "JSON_TYPE"
         "K"
         "KEY"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3246,6 +3246,13 @@ public class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  @Test public void testJsonRemove() {
+    String query = "select json_remove(\"product_name\", '$[0]') from \"product\"";
+    final String expected = "SELECT JSON_REMOVE(\"product_name\" FORMAT JSON, '$[0]')\n"
+           + "FROM \"foodmart\".\"product\"";
+    sql(query).ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final SchemaPlus schema;

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8481,6 +8481,13 @@ public class SqlParserTest {
             "JSON_KEYS('{\"foo\": \"bar\"}' FORMAT JSON, 'invalid $')");
   }
 
+  @Test public void testJsonRemove() {
+    checkExp("json_remove('[\"a\", [\"b\", \"c\"], \"d\"]', '$')",
+            "JSON_REMOVE('[\"a\", [\"b\", \"c\"], \"d\"]' FORMAT JSON, '$')");
+    checkExp("json_remove('[\"a\", [\"b\", \"c\"], \"d\"]', '$[1]', '$[0]')",
+            "JSON_REMOVE('[\"a\", [\"b\", \"c\"], \"d\"]' FORMAT JSON, '$[1]', '$[0]')");
+  }
+
   @Test public void testJsonObjectAgg() {
     checkExp("json_objectagg(k_column: v_column)",
         "JSON_OBJECTAGG(KEY `K_COLUMN` VALUE `V_COLUMN` NULL ON NULL)");

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4643,6 +4643,21 @@ public abstract class SqlOperatorBaseTest {
             "(?s).*No results for path.*", true);
   }
 
+  @Test public void testJsonRemove() {
+    tester.checkString("json_remove('{\"foo\":100}', '$.foo')",
+            "{}", "VARCHAR(2000) NOT NULL");
+    tester.checkString("json_remove('{\"foo\":100, \"foo1\":100}', '$.foo')",
+            "{\"foo1\":100}", "VARCHAR(2000) NOT NULL");
+    tester.checkString("json_remove('[\"a\", [\"b\", \"c\"], \"d\"]', '$[1][0]')",
+            "[\"a\",[\"c\"],\"d\"]", "VARCHAR(2000) NOT NULL");
+    tester.checkString("json_remove('[\"a\", [\"b\", \"c\"], \"d\"]', '$[1]')",
+            "[\"a\",\"d\"]", "VARCHAR(2000) NOT NULL");
+    tester.checkString("json_remove('[\"a\", [\"b\", \"c\"], \"d\"]', '$[0]', '$[0]')",
+            "[\"d\"]", "VARCHAR(2000) NOT NULL");
+    tester.checkFails("json_remove('[\"a\", [\"b\", \"c\"], \"d\"]', '$')",
+            "(?s).*Invalid input for.*", true);
+  }
+
   @Test public void testJsonObjectAgg() {
     checkAggType(tester, "json_objectagg('foo': 'bar')", "VARCHAR(2000) NOT NULL");
     tester.checkFails("^json_objectagg(100: 'bar')^",

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -6876,6 +6876,14 @@ public class JdbcTest {
         .returns("C1=[\"a\",\"b\"]; C2=null; C3=[\"c\"]; C4=null; C5=null\n");
   }
 
+  @Test public void testJsonRemove() {
+    CalciteAssert.that()
+        .query("SELECT JSON_REMOVE(v, '$[1]') AS c1\n"
+            + "FROM (VALUES ('[\"a\", [\"b\", \"c\"], \"d\"]')) AS t(v)\n"
+            + "limit 10")
+        .returns("C1=[\"a\",\"d\"]\n");
+  }
+
   /**
    * Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2609">[CALCITE-2609]

--- a/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
@@ -534,6 +534,18 @@ public class SqlJsonFunctionsTest {
   }
 
   @Test
+  public void testJsonRemove() {
+    assertJsonRemove(
+        SqlFunctions.jsonValueExpression("{\"a\": 1, \"b\": [2]}"),
+        new Object[]{"$.a"},
+        is("{\"b\":[2]}"));
+    assertJsonRemove(
+        SqlFunctions.jsonValueExpression("{\"a\": 1, \"b\": [2]}"),
+        new Object[]{"$.a", "$.b"},
+        is("{}"));
+  }
+
+  @Test
   public void testJsonObjectAggAdd() {
     Map<String, Object> map = new HashMap<>();
     Map<String, Object> expected = new HashMap<>();
@@ -735,6 +747,13 @@ public class SqlJsonFunctionsTest {
     assertFailed(invocationDesc(BuiltInMethod.JSON_KEYS.getMethodName(), input),
         () -> SqlFunctions.jsonKeys(input),
         matcher);
+  }
+
+  private void assertJsonRemove(Object jsonDoc, Object[] elems,
+      Matcher<? super String> matcher) {
+    assertThat(invocationDesc(BuiltInMethod.JSON_REMOVE.getMethodName(), jsonDoc, elems),
+             SqlFunctions.jsonRemove(jsonDoc, elems),
+             matcher);
   }
 
   private void assertDejsonize(String input,

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10968,6 +10968,13 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     checkExpType("json_keys('{\"foo\":\"bar\"}', 'strict $')", "VARCHAR(2000) NOT NULL");
   }
 
+  @Test public void testJsonRemove() {
+    checkExp("json_remove('{\"foo\":\"bar\"}', '$')");
+    checkExpType("json_remove('{\"foo\":\"bar\"}', '$')", "VARCHAR(2000) NOT NULL");
+    checkFails("select ^json_remove('{\"foo\":\"bar\"}')^",
+            "(?s).*Invalid number of arguments.*");
+  }
+
   @Test public void testJsonObjectAgg() {
     check("select json_objectagg(ename: empno) from emp");
     checkFails("select ^json_objectagg(empno: ename)^ from emp",

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -155,6 +155,7 @@ data: {
         "JSON_KEYS"
         "JSON_LENGTH"
         "JSON_PRETTY"
+        "JSON_REMOVE"
         "JSON_TYPE"
         "K"
         "KEY"

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -573,6 +573,7 @@ JSON_LENGTH,
 **JSON_OBJECTAGG**,
 JSON_PRETTY,
 **JSON_QUERY**,
+JSON_REMOVE,
 JSON_TYPE,
 **JSON_VALUE**,
 K,
@@ -2054,6 +2055,7 @@ Note:
 | JSON_PRETTY(jsonValue)            | Returns a pretty-printing of *jsonValue*
 | JSON_LENGTH(jsonValue [, path ])  | Returns a integer indicating the length of *jsonValue*
 | JSON_KEYS(jsonValue [, path ])    | Returns a string indicating the keys of a JSON *jsonValue*
+| JSON_REMOVE(jsonValue, path[, path])  | Returns a JSON document by remove a data of *path*
 
 Note:
 
@@ -2157,12 +2159,27 @@ LIMIT 10;
 | ---------- | ---- | ----- | ---- | ---- |
 | ["a", "b"] | NULL | ["c"] | NULL | NULL |
 
+##### JSON_REMOVE example
+
+SQL
+
+ ```SQL
+SELECT JSON_REMOVE(v, '$[1]') AS c1
+FROM (VALUES ('["a", ["b", "c"], "d"]')) AS t(v)
+LIMIT 10;
+```
+
+ Result
+
+| c1         |
+| ---------- | 
+| ["a", "d"] |
+
 Not implemented:
 
 * JSON_INSERT
 * JSON_SET
 * JSON_REPLACE
-* JSON_REMOVE
 
 ## User-defined functions
 


### PR DESCRIPTION
`JSON_REMOVE`(json_doc, path[, path] ...)

Removes data from a JSON document and returns the result. Returns NULL if any argument is NULL. An error occurs if the json_doc argument is not a valid JSON document or any path argument is not a valid path expression or is $ or contains a * or ** wildcard.
The path arguments are evaluated left to right. The document produced by evaluating one path becomes the new value against which the next path is evaluated.
It is not an error if the element to be removed does not exist in the document; in that case, the path does not affect the document.
JSON_REMOVE SQL:
```
SELECT JSON_REMOVE(v, '$[1]') AS c1
 FROM (VALUES ('["a", ["b", "c"], "d"]')) AS t(v);
```
RESULT:

| c1         |
| ---------- |
| ["a", "d"] |
