### PR TITLE
[CALCITE-2985] Implement JSON_STORAGE_SIZE function

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -139,7 +139,6 @@ data: {
         "ISOYEAR"
         "ISOLATION"
         "JAVA"
-        "JSON"
         "K"
         "KEY"
         "KEY_MEMBER"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -5137,6 +5137,7 @@ SqlCall JsonValueFunctionCall() :
     }
 }
 
+
 List<SqlNode> JsonQueryEmptyOrErrorBehavior() :
 {
     final List<SqlNode> list = new ArrayList<SqlNode>();

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -97,6 +97,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_KEYS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_LENGTH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_PRETTY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_REMOVE;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_STORAGE_SIZE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_TYPE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REPEAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REVERSE;
@@ -474,6 +475,7 @@ public class RexImpTable {
     defineMethod(JSON_PRETTY, BuiltInMethod.JSON_PRETTY.method, NullPolicy.ARG0);
     defineMethod(JSON_LENGTH, BuiltInMethod.JSON_LENGTH.method, NullPolicy.ARG0);
     defineMethod(JSON_REMOVE, BuiltInMethod.JSON_REMOVE.method, NullPolicy.ARG0);
+    defineMethod(JSON_STORAGE_SIZE, BuiltInMethod.JSON_STORAGE_SIZE.method, NullPolicy.ARG0);
     defineMethod(JSON_OBJECT, BuiltInMethod.JSON_OBJECT.method, NullPolicy.NONE);
     defineMethod(JSON_ARRAY, BuiltInMethod.JSON_ARRAY.method, NullPolicy.NONE);
     aggMap.put(JSON_OBJECTAGG.with(SqlJsonConstructorNullClause.ABSENT_ON_NULL),

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -885,6 +885,9 @@ public interface CalciteResource {
 
   @BaseMessage("Invalid input for JSON_REMOVE: document: ''{0}'', jsonpath expressions: ''{1}''")
   ExInst<CalciteException> invalidInputForJsonRemove(String value, String pathSpecs);
+
+  @BaseMessage("Not a valid input for JSON_STORAGE_SIZE: ''{0}''")
+  ExInst<CalciteException> invalidInputForJsonStorageSize(String value);
 }
 
 // End CalciteResource.java

--- a/core/src/main/java/org/apache/calcite/runtime/JsonFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/JsonFunctions.java
@@ -631,6 +631,15 @@ public class JsonFunctions {
     }
   }
 
+  public static Integer jsonStorageSize(Object input) {
+    try {
+      return input == null ? null : JSON_PATH_JSON_PROVIDER.getObjectMapper()
+              .writeValueAsBytes(dejsonize(input.toString())).length;
+    } catch (Exception e) {
+      throw RESOURCE.invalidInputForJsonStorageSize(input.toString()).ex();
+    }
+  }
+
   public static boolean isJsonValue(String input) {
     try {
       dejsonize(input);

--- a/core/src/main/java/org/apache/calcite/runtime/JsonFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/JsonFunctions.java
@@ -631,12 +631,12 @@ public class JsonFunctions {
     }
   }
 
-  public static Integer jsonStorageSize(Object input) {
+  public static Integer jsonStorageSize(String input) {
     try {
       return input == null ? null : JSON_PATH_JSON_PROVIDER.getObjectMapper()
-              .writeValueAsBytes(dejsonize(input.toString())).length;
+              .writeValueAsBytes(dejsonize(input)).length;
     } catch (Exception e) {
-      throw RESOURCE.invalidInputForJsonStorageSize(input.toString()).ex();
+      throw RESOURCE.invalidInputForJsonStorageSize(input).ex();
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonStorageSizeFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonStorageSizeFunction.java
@@ -16,20 +16,12 @@
  */
 package org.apache.calcite.sql.fun;
 
-import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlLiteral;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlOperandCountRange;
-import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
-import org.apache.calcite.sql.type.SqlOperandCountRanges;
-import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
-import org.apache.calcite.sql.validate.SqlValidator;
 
 /**
  * The <code>JSON_STORAGE_SIZE</code> function.
@@ -44,20 +36,6 @@ public class SqlJsonStorageSizeFunction extends SqlFunction {
         null,
         OperandTypes.ANY,
         SqlFunctionCategory.SYSTEM);
-  }
-
-  @Override public SqlOperandCountRange getOperandCountRange() {
-    return SqlOperandCountRanges.of(1);
-  }
-
-  @Override protected void checkOperandCount(SqlValidator validator,
-      SqlOperandTypeChecker argType, SqlCall call) {
-    assert call.operandCount() == 1;
-  }
-
-  @Override public SqlCall createCall(SqlLiteral functionQualifier,
-      SqlParserPos pos, SqlNode... operands) {
-    return super.createCall(functionQualifier, pos, operands);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonStorageSizeFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonStorageSizeFunction.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+/**
+ * The <code>JSON_STORAGE_SIZE</code> function.
+ */
+public class SqlJsonStorageSizeFunction extends SqlFunction {
+
+  public SqlJsonStorageSizeFunction() {
+    super("JSON_STORAGE_SIZE",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.cascade(ReturnTypes.INTEGER_NULLABLE,
+                SqlTypeTransforms.FORCE_NULLABLE),
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.SYSTEM);
+  }
+
+  @Override public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.of(1);
+  }
+
+  @Override protected void checkOperandCount(SqlValidator validator,
+      SqlOperandTypeChecker argType, SqlCall call) {
+    assert call.operandCount() == 1;
+  }
+
+  @Override public SqlCall createCall(SqlLiteral functionQualifier,
+      SqlParserPos pos, SqlNode... operands) {
+    return super.createCall(functionQualifier, pos, operands);
+  }
+}
+
+// End SqlJsonStorageSizeFunction.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -150,6 +150,9 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {MYSQL})
   public static final SqlFunction JSON_REMOVE = new SqlJsonRemoveFunction();
 
+  @LibraryOperator(libraries = {MYSQL})
+  public static final SqlFunction JSON_STORAGE_SIZE = new SqlJsonStorageSizeFunction();
+
   @LibraryOperator(libraries = {MYSQL, POSTGRESQL})
   public static final SqlFunction REPEAT =
       new SqlFunction(

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1330,6 +1330,9 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   @Deprecated // to be removed before 2.0
   public static final SqlFunction JSON_REMOVE = SqlLibraryOperators.JSON_REMOVE;
 
+  @Deprecated // to be removed before 2.0
+  public static final SqlFunction JSON_STORAGE_SIZE = SqlLibraryOperators.JSON_STORAGE_SIZE;
+
   public static final SqlJsonArrayAggAggFunction JSON_ARRAYAGG =
       new SqlJsonArrayAggAggFunction(SqlKind.JSON_ARRAYAGG,
           SqlJsonConstructorNullClause.ABSENT_ON_NULL);

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -297,6 +297,7 @@ public enum BuiltInMethod {
   JSON_PRETTY(JsonFunctions.class, "jsonPretty", String.class),
   JSON_LENGTH(JsonFunctions.class, "jsonLength", String.class),
   JSON_REMOVE(JsonFunctions.class, "jsonRemove", String.class),
+  JSON_STORAGE_SIZE(JsonFunctions.class, "jsonStorageSize", String.class),
   JSON_OBJECTAGG_ADD(JsonFunctions.class, "jsonObjectAggAdd", Map.class,
       String.class, Object.class, SqlJsonConstructorNullClause.class),
   JSON_ARRAY(JsonFunctions.class, "jsonArray",

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -288,4 +288,5 @@ ExceptionWhileSerializingToJson=Cannot serialize object to JSON: ''{0}''
 InvalidInputForJsonLength=Not a valid input for JSON_LENGTH: ''{0}''
 InvalidInputForJsonKeys=Not a valid input for JSON_KEYS: ''{0}''
 InvalidInputForJsonRemove=Invalid input for JSON_REMOVE: document: ''{0}'', jsonpath expressions: ''{1}''
+InvalidInputForJsonStorageSize=Not a valid input for JSON_STORAGE_SIZE: ''{0}''
 # End CalciteResource.properties

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3291,10 +3291,17 @@ public class RelToSqlConverterTest {
 
   @Test public void testNumericFloorInSpark() {
     final String query = "select floor(\"salary\") "
-        + "from \"employee\"";
+            + "from \"employee\"";
     final String expected = "SELECT FLOOR(salary)\n"
-        + "FROM foodmart.employee";
+            + "FROM foodmart.employee";
     sql(query).withSpark().ok(expected);
+  }
+
+  @Test public void testJsonStorageSize() {
+    String query = "select json_storage_size(\"product_name\") from \"product\"";
+    final String expected = "SELECT JSON_STORAGE_SIZE(\"product_name\")\n"
+            + "FROM \"foodmart\".\"product\"";
+    sql(query).ok(expected);
   }
 
   @Test public void testJsonType() {

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8676,6 +8676,13 @@ public class SqlParserTest {
             "JSON_PRETTY(NULL)");
   }
 
+  @Test public void testJsonStorageSize() {
+    checkExp("json_storage_size('foo')",
+            "JSON_STORAGE_SIZE('foo')");
+    checkExp("json_storage_size(null)",
+            "JSON_STORAGE_SIZE(NULL)");
+  }
+
   @Test public void testJsonArrayAgg1() {
     checkExp("json_arrayagg(\"column\")",
         "JSON_ARRAYAGG(`column` ABSENT ON NULL)");

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4575,6 +4575,25 @@ public abstract class SqlOperatorBaseTest {
     tester.checkNull("json_pretty(cast(null as varchar))");
   }
 
+  @Test public void testJsonStorageSize() {
+    tester.checkString("json_storage_size('[100, \"sakila\", [1, 3, 5], 425.05]')",
+            "29", "INTEGER");
+    tester.checkString("json_storage_size('{\"a\": 1000,\"b\": \"aa\", \"c\": \"[1, 3, 5]\"}')",
+            "35", "INTEGER");
+    tester.checkString("json_storage_size('{\"a\": 1000, \"b\": \"wxyz\", \"c\": \"[1, 3]\"}')",
+            "34", "INTEGER");
+    tester.checkString("json_storage_size('[100, \"json\", [[10, 20, 30], 3, 5], 425.05]')",
+            "36", "INTEGER");
+    tester.checkString("json_storage_size('12')",
+            "2", "INTEGER");
+    tester.checkString("json_storage_size('null')",
+            "4", "INTEGER");
+    tester.checkString("json_storage_size(cast(null as varchar(1)))",
+            null, "INTEGER");
+    tester.checkFails("json_storage_size('{]')",
+            "(?s).*Not a valid input.*", true);
+  }
+
   @Test public void testJsonType() {
     tester.setFor(SqlLibraryOperators.JSON_TYPE);
     tester.checkString("json_type('\"1\"')",

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -6893,10 +6893,22 @@ public class JdbcTest {
 
   @Test public void testJsonRemove() {
     CalciteAssert.that()
-        .query("SELECT JSON_REMOVE(v, '$[1]') AS c1\n"
-            + "FROM (VALUES ('[\"a\", [\"b\", \"c\"], \"d\"]')) AS t(v)\n"
+            .query("SELECT JSON_REMOVE(v, '$[1]') AS c1\n"
+                    + "FROM (VALUES ('[\"a\", [\"b\", \"c\"], \"d\"]')) AS t(v)\n"
+                    + "limit 10")
+            .returns("C1=[\"a\",\"d\"]\n");
+  }
+
+  @Test
+  public void testJsonStorageSize() {
+    CalciteAssert.that()
+        .query("SELECT\n"
+            + "JSON_STORAGE_SIZE('[100, \"sakila\", [1, 3, 5], 425.05]') AS A,\n"
+            + "JSON_STORAGE_SIZE('{\"a\": 10, \"b\": \"a\", \"c\": \"[1, 3, 5, 7]\"}') AS B,\n"
+            + "JSON_STORAGE_SIZE('{\"a\": 10, \"b\": \"xyz\", \"c\": \"[1, 3, 5, 7]\"}') AS C,\n"
+            + "JSON_STORAGE_SIZE('[100, \"json\", [[10, 20, 30], 3, 5], 425.05]') AS D\n"
             + "limit 10")
-        .returns("C1=[\"a\",\"d\"]\n");
+        .returns("A=29; B=35; C=37; D=36\n");
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
@@ -534,13 +534,13 @@ public class SqlJsonFunctionsTest {
   @Test
   public void testJsonRemove() {
     assertJsonRemove(
-            JsonFunctions.jsonValueExpression("{\"a\": 1, \"b\": [2]}"),
-            new String[]{"$.a"},
-            is("{\"b\":[2]}"));
+        JsonFunctions.jsonValueExpression("{\"a\": 1, \"b\": [2]}"),
+        new String[]{"$.a"},
+        is("{\"b\":[2]}"));
     assertJsonRemove(
-            JsonFunctions.jsonValueExpression("{\"a\": 1, \"b\": [2]}"),
-            new String[]{"$.a", "$.b"},
-            is("{}"));
+        JsonFunctions.jsonValueExpression("{\"a\": 1, \"b\": [2]}"),
+        new String[]{"$.a", "$.b"},
+        is("{}"));
   }
 
   public void testJsonStorageSize() {
@@ -548,9 +548,7 @@ public class SqlJsonFunctionsTest {
     assertJsonStorageSize("null", is(4));
     assertJsonStorageSize(null, nullValue());
 
-    Object input = new Object() {
-      private final Object self = this;
-    };
+    String input = null;
     CalciteException expected = new CalciteException(
             "Not a valid input for JSON_STORAGE_SIZE: '" + input + "'", null);
     assertJsonStorageSizeFailed(input, errorMatches(expected));
@@ -768,15 +766,15 @@ public class SqlJsonFunctionsTest {
             matcher);
   }
 
-  private void assertJsonStorageSize(Object input,
-                                Matcher<? super Integer> matcher) {
+  private void assertJsonStorageSize(String input,
+      Matcher<? super Integer> matcher) {
     assertThat(invocationDesc(BuiltInMethod.JSON_STORAGE_SIZE.getMethodName(), input),
             JsonFunctions.jsonStorageSize(input),
             matcher);
   }
 
-  private void assertJsonStorageSizeFailed(Object input,
-                                    Matcher<? super Throwable> matcher) {
+  private void assertJsonStorageSizeFailed(String input,
+      Matcher<? super Throwable> matcher) {
     assertFailed(invocationDesc(BuiltInMethod.JSON_STORAGE_SIZE.getMethodName(), input),
         () -> JsonFunctions.jsonStorageSize(input),
         matcher);

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11011,6 +11011,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             "(.*)JSON_VALUE_EXPRESSION(.*)");
   }
 
+  @Test public void testJsonStorageSize() {
+    check("select json_storage_size(ename) from emp");
+    checkExp("json_storage_size('{\"foo\":\"bar\"}')");
+    checkExpType("json_storage_size('{\"foo\":\"bar\"}')", "INTEGER");
+  }
+
   @Test public void testJsonType() {
     check("select json_type(ename) from emp");
     checkExp("json_type('{\"foo\":\"bar\"}')");

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2099,6 +2099,7 @@ semantics.
 | m | JSON_KEYS(jsonValue [, path ])                 | Returns a string indicating the keys of a JSON *jsonValue*
 | m | JSON_REMOVE(jsonValue, path[, path])           | Removes data from *jsonValue* using a series of *path* expressions and returns the result
 | m | REVERSE(string)                                | Returns the reverse order of *string*
+| m | JSON_STORAGE_SIZE(jsonValue)                   | Returns an integer value indicating the size of a *jsonValue*
 | o | DECODE(value, value1, result1 [, valueN, resultN ]* [, default ]) | Compares *value* to each *valueN* value one by one; if *value* is equal to a *valueN*, returns the corresponding *resultN*, else returns *default*, or NULL if *default* is not specified
 | o | NVL(value1, value2)                            | Returns *value1* if *value1* is not null, otherwise *value2*
 | o | LTRIM(string)                                  | Returns *string* with all blanks removed from the start
@@ -2111,6 +2112,7 @@ semantics.
 | p | DIFFERENCE(string, string)                     | Returns the difference between the SOUNDEX values of two character expressions as an integer. For example, returns 4 if the SOUNDEX values are same and returns 0 if the SOUNDEX values are totally different.
 | m p | REPEAT(string, integer)                      | Returns a string of *integer* times *string*; Returns an empty string if *integer* is less than 1
 | m | SPACE(integer)                                 | Returns a string of *integer* spaces; Returns an empty string if *integer* is less than 1
+
 
 Note:
 
@@ -2230,6 +2232,27 @@ LIMIT 10;
 | c1         |
 | ---------- |
 | ["a", "d"] |
+
+
+##### JSON_STORAGE_SIZE example
+
+SQL
+
+ ```SQL
+SELECT
+JSON_STORAGE_SIZE('[100, \"sakila\", [1, 3, 5], 425.05]') AS c1,
+JSON_STORAGE_SIZE('{\"a\": 10, \"b\": \"a\", \"c\": \"[1, 3, 5, 7]\"}') AS c2,
+JSON_STORAGE_SIZE('{\"a\": 10, \"b\": \"xyz\", \"c\": \"[1, 3, 5, 7]\"}') AS c3,
+JSON_STORAGE_SIZE('[100, \"json\", [[10, 20, 30], 3, 5], 425.05]') AS c4
+limit 10;
+```
+
+ Result
+
+| c1 | c2 | c3 | c4 |
+| -- | ---| ---| -- |
+| 29 | 35 | 37 | 36 |
+
 
 #### DECODE example
 

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2100,6 +2100,7 @@ semantics.
 | m | JSON_REMOVE(jsonValue, path[, path])           | Removes data from *jsonValue* using a series of *path* expressions and returns the result
 | m | REVERSE(string)                                | Returns the reverse order of *string*
 | m | JSON_STORAGE_SIZE(jsonValue)                   | Returns an integer value indicating the size of a *jsonValue*
+| m | JSON_STORAGE_SIZE(jsonValue)                   | Returns the number of bytes used to store the binary representation of a *jsonValue*
 | o | DECODE(value, value1, result1 [, valueN, resultN ]* [, default ]) | Compares *value* to each *valueN* value one by one; if *value* is equal to a *valueN*, returns the corresponding *resultN*, else returns *default*, or NULL if *default* is not specified
 | o | NVL(value1, value2)                            | Returns *value1* if *value1* is not null, otherwise *value2*
 | o | LTRIM(string)                                  | Returns *string* with all blanks removed from the start


### PR DESCRIPTION
`JSON_STORAGE_SIZE`(json_val)

This function returns the number of bytes used to store the binary representation of a JSON document. When the argument is a JSON column, this is the space used to store the JSON document. json_val must be a valid JSON document or a string which can be parsed as one. In the case where it is string, the function returns the amount of storage space in the JSON binary representation that is created by parsing the string as JSON and converting it to binary. It returns NULL if the argument is NULL.

An error results when json_val is not NULL, and is not—or cannot be successfully parsed as—a JSON document.

To illustrate this function's behavior when used with a JSON column as its argument, we create a table named jtable containing a JSON column jcol, insert a JSON value into the table, then obtain the storage space used by this column with `JSON_STORAGE_SIZE`(), as shown here:

SQL:

```
SELECT
JSON_STORAGE_SIZE('[100, \"sakila\", [1, 3, 5], 425.05]') AS A,
JSON_STORAGE_SIZE('{\"a\": 10, \"b\": \"a\", \"c\": \"[1, 3, 5, 7]\"}') AS B,
JSON_STORAGE_SIZE('{\"a\": 10, \"b\": \"xyz\", \"c\": \"[1, 3, 5, 7]\"}') AS C,
JSON_STORAGE_SIZE('[100, \"json\", [[10, 20, 30], 3, 5], 425.05]') AS D
limit 10;
```
Result:

| A    | B    | C    | D    |
| ---- | ---- | ---- | ---- |
| 29   | 35   | 37   | 36   |
