### PR TITLE
[CALCITE-2990] Fix document misspelling in RelInput (Shuming Li)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/RelInput.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelInput.java
@@ -62,7 +62,7 @@ public interface RelInput {
   Object get(String tag);
 
   /**
-   * Returns a {@code float} value. Throws if wrong type.
+   * Returns a {@code string} value. Throws if wrong type.
    */
   String getString(String tag);
 


### PR DESCRIPTION
@zhztheplayer 
As https://github.com/apache/calcite/pull/1093 discussed, I created a issue and fix it again.