### PR TITLE
[CALCITE-3021] ArrayEqualityComparer should use Arrays#deepEquals/deepHashCode instead of Arrays#equals/hashCode (Ruben Quesada Lopez)

### DIFF
--- a/core/src/test/resources/sql/struct.iq
+++ b/core/src/test/resources/sql/struct.iq
@@ -34,4 +34,19 @@ select * from (values
 !ok
 !}
 
+# [CALCITE-3021] ArrayEqualityComparer should use Arrays#deepEquals/deepHashCode instead of Arrays#equals/hashCode
+select distinct * from (values
+    (1, ROW(1,1)),
+    (1, ROW(1,1)),
+    (2, ROW(2,2))) as v(id,struct);
++----+--------+
+| ID | STRUCT |
++----+--------+
+|  1 | {1, 1} |
+|  2 | {2, 2} |
++----+--------+
+(2 rows)
+
+!ok
+
 # End struct.iq

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/function/Functions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/function/Functions.java
@@ -465,11 +465,11 @@ public abstract class Functions {
   private static class ArrayEqualityComparer
       implements EqualityComparer<Object[]> {
     public boolean equal(Object[] v1, Object[] v2) {
-      return Arrays.equals(v1, v2);
+      return Arrays.deepEquals(v1, v2);
     }
 
     public int hashCode(Object[] t) {
-      return Arrays.hashCode(t);
+      return Arrays.deepHashCode(t);
     }
   }
 

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -57,6 +57,8 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.TreeSet;
 
+import static org.apache.calcite.linq4j.function.Functions.arrayComparer;
+
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -904,6 +906,19 @@ public class Linq4jTest {
                     return employee.deptno;
                   }
                 })
+            .count());
+  }
+
+  @Test public void testDistinctWithArrayEqualityComparer() {
+    final Object[][] items = {
+        {1, "a", new Object[]{1}},
+        {2, "b", new Object[]{2}},
+        {2, "b", new Object[]{2}},
+    };
+    assertEquals(
+        2,
+        Linq4j.asEnumerable(items)
+            .distinct(arrayComparer())
             .count());
   }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/CALCITE-3021