### PR TITLE
[CALCITE-3027] Support like query in Elasticsearch

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
@@ -48,8 +48,8 @@ import java.util.stream.Collectors;
 import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.boolQuery;
 import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.existsQuery;
 import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.rangeQuery;
-import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.regexpQuery;
 import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.termQuery;
+import static org.apache.calcite.adapter.elasticsearch.QueryBuilders.wildcardQuery;
 
 import static java.lang.String.format;
 
@@ -349,7 +349,7 @@ class PredicateAnalyzer {
 
       switch (call.getKind()) {
       case LIKE:
-        throw new UnsupportedOperationException("LIKE not yet supported");
+        return QueryExpression.create(pair.getKey()).like(pair.getValue());
       case EQUALS:
         return QueryExpression.create(pair.getKey()).equals(pair.getValue());
       case NOT_EQUALS:
@@ -736,7 +736,7 @@ class PredicateAnalyzer {
     }
 
     @Override public QueryExpression like(LiteralExpression literal) {
-      builder = regexpQuery(getFieldReference(), literal.stringValue());
+      builder = wildcardQuery(getFieldReference(), literal.stringValue());
       return this;
     }
 
@@ -744,7 +744,7 @@ class PredicateAnalyzer {
       builder = boolQuery()
               // NOT LIKE should return false when field is NULL
               .must(existsQuery(getFieldReference()))
-              .mustNot(regexpQuery(getFieldReference(), literal.stringValue()));
+              .mustNot(wildcardQuery(getFieldReference(), literal.stringValue()));
       return this;
     }
 

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -220,6 +220,33 @@ public class ElasticSearchAdapterTest {
                 "size: 3"));
   }
 
+  @Test public void testLike() {
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select city from zips where city like '%RID%'")
+            .returnsCount(3);
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select city from zips where city not like '%RID%'")
+            .returnsCount(146);
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select city from zips where city like '%ON'")
+            .returnsCount(14);
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select city from zips where city like 'NEW YORK'")
+            .returnsCount(1);
+
+    CalciteAssert.that()
+            .with(newConnectionFactory())
+            .query("select city from zips where city like '_EW YO_K'")
+            .returnsCount(1);
+  }
+
   /**
    * Throws {@code AssertionError} if result set is not sorted by {@code column}.
    * {@code null}s are ignored.


### PR DESCRIPTION
In Elasticsearch, fuzzy matching is implemented by wildcard query:
```
GET /company/_search
{
  "query": {
    "constant_score": {
      "filter": {
        "wildcard":{
          "name_text":"*Alle_"
        }
      }
    }
  }
}
```
> The symbols % and _ in sql are equivalent to the symbols * and ? in es, respectively.

So in this PR, I added a new QueryBuilder called WildcardQueryBuilder to support wildcard queries, then to achieve like query with sql in Elasticsearch.
JIRA: https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-3027