### PR TITLE
[CALCITE-3029] Java-oriented field type is wrongly forced to be NOT N…

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
@@ -37,8 +37,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Lists;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -49,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of {@link JavaTypeFactory}.
@@ -240,26 +239,21 @@ public class JavaTypeFactoryImpl
   /** Converts a type in Java format to a SQL-oriented type. */
   public static RelDataType toSql(final RelDataTypeFactory typeFactory,
       RelDataType type) {
-    return toSql(typeFactory, type, true);
-  }
-
-  private static RelDataType toSql(final RelDataTypeFactory typeFactory,
-      RelDataType type, boolean mustSetNullability) {
-    RelDataType sqlType = type;
     if (type instanceof RelRecordType) {
-      // We do not need to change the nullability of the nested fields,
-      // since it can be overridden by the existing implementation of createTypeWithNullability
-      // when we treat the nullability of the root struct type.
-      sqlType = typeFactory.createStructType(
-              Lists.transform(type.getFieldList(),
-                field -> toSql(typeFactory, field.getType(), false)),
-              type.getFieldNames());
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createStructType(
+              type.getFieldList()
+                  .stream()
+                  .map(field -> toSql(typeFactory, field.getType()))
+                  .collect(Collectors.toList()),
+              type.getFieldNames()),
+          type.isNullable());
     } else if (type instanceof JavaType) {
-      sqlType = typeFactory.createSqlType(type.getSqlTypeName());
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createSqlType(type.getSqlTypeName()),
+          type.isNullable());
     }
-    return mustSetNullability
-            ? typeFactory.createTypeWithNullability(sqlType, type.isNullable())
-            : sqlType;
+    return type;
   }
 
   public Type createSyntheticType(List<Type> types) {

--- a/core/src/test/java/org/apache/calcite/jdbc/JavaTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/JavaTypeFactoryTest.java
@@ -18,6 +18,7 @@ package org.apache.calcite.jdbc;
 
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.test.SqlTests;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import com.google.common.collect.ImmutableList;
@@ -71,6 +72,21 @@ public final class JavaTypeFactoryTest {
             TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR)),
         ImmutableList.of("intField", "strField"));
     assertRecordType(TYPE_FACTORY.getJavaClass(structWithTwoFields));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3029">[CALCITE-3029]
+   * Java-oriented field type is wrongly forced to be NOT NULL after being converted to
+   * SQL-oriented</a>. */
+  @Test public void testFieldNullabilityAfterConvertingToSqlStructType() {
+    RelDataType javaStructType = TYPE_FACTORY.createStructType(
+        ImmutableList.of(
+            TYPE_FACTORY.createJavaType(Integer.class),
+            TYPE_FACTORY.createJavaType(int.class)),
+        ImmutableList.of("a", "b"));
+    RelDataType sqlStructType = TYPE_FACTORY.toSql(javaStructType);
+    assertEquals("RecordType(INTEGER a, INTEGER NOT NULL b) NOT NULL",
+        SqlTests.getTypeString(sqlStructType));
   }
 
   private void assertRecordType(Type actual) {


### PR DESCRIPTION
…ULL after being converted to SQL-oriented

JIRA: https://issues.apache.org/jira/browse/CALCITE-3029