### PR TITLE
[CALCITE-3034] CSV test case description does not match it's code logic

### DIFF
--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvFilterableTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvFilterableTable.java
@@ -63,7 +63,11 @@ public class CsvFilterableTable extends CsvTable
   }
 
   private boolean addFilter(RexNode filter, Object[] filterValues) {
-    if (filter.isA(SqlKind.EQUALS)) {
+    if (filter.isA(SqlKind.AND)) {
+        // We cannot refine(remove) the operands of AND,
+        // it will cause o.a.c.i.TableScanNode.createFilterable filters check failed.
+      ((RexCall) filter).getOperands().forEach(subFilter -> addFilter(subFilter, filterValues));
+    } else if (filter.isA(SqlKind.EQUALS)) {
       final RexCall call = (RexCall) filter;
       RexNode left = call.getOperands().get(0);
       if (left.isA(SqlKind.CAST)) {

--- a/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
+++ b/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
@@ -297,6 +297,15 @@ public class CsvTest {
         .returns("EMPNO=130; GENDER=F; NAME=Alice").ok();
   }
 
+  /** Filter that can be slightly handled by CsvFilterableTable. */
+  @Test public void testFilterableWhere3() throws SQLException {
+    final String sql = "select empno, gender, name from EMPS\n"
+            + " where gender <> 'M' and empno > 125";
+    sql("filterable-model", sql)
+        .returns("EMPNO=130; GENDER=F; NAME=Alice")
+        .ok();
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2272">[CALCITE-2272]
    * Incorrect result for {@code name like '%E%' and city not like '%W%'}</a>.


### PR DESCRIPTION
The javadoc of the o.a.c.t.CsvTest#testFilterableWhere2 is 'Filter that can be partly handled by CsvFilterableTable.' 
Actually it never handle it, o.a.c.a.c.CsvFilterableTable#scan will get the whole WHERE condition RexNode and that's SqlKind is AND.
So, the code will return false directly.
By the way, due to o.a.c.i.TableScanNode#createFilterable will check whether optimized filters are belong to original filters. 
So, we cannot refine the operands of AND.