### PR TITLE
[CALCITE-3039] In Interpreter, min() incorrectly returns maximum double value

### DIFF
--- a/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
@@ -536,7 +536,7 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
    */
   public static class MinDouble extends NumericComparison<Double> {
     public MinDouble() {
-      super(Double.MAX_VALUE, Math::max);
+      super(Double.MAX_VALUE, Math::min);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -6744,6 +6744,20 @@ public class JdbcTest {
     connection.close();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3039">[CALCITE-3039]
+   * In Interpreter, min() incorrectly returns maximum double value</a>. */
+  @Test public void testAggWithSelectList() throws SQLException {
+    Hook.ENABLE_BINDABLE.addThread(Hook.propertyJ(true));
+    CalciteAssert.hr()
+        .query(
+            "select min(div) as _min from ("
+                + "select \"empid\", \"deptno\", CAST(\"empid\" AS DOUBLE)/\"deptno\" as div from \"hr\".\"emps\")")
+        .explainContains("BindableAggregate(group=[{}], _MIN=[MIN($0)])\n"
+            + "  BindableProject(DIV=[/(CAST($0):DOUBLE NOT NULL, $1)])\n"
+            + "    BindableTableScan(table=[[hr, emps]])")
+        .returns("_MIN=10.0\n");
+  }
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2224">[CALCITE-2224]


### PR DESCRIPTION
…ax as its comparision in AggragateNode ?

MinDouble should use Math::min to compare