### PR TITLE
[CALCITE-2735] support load data like mysql or hive statement

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1095,6 +1095,9 @@ public enum SqlKind {
   /** {@code DROP FUNCTION} DDL statement. */
   DROP_FUNCTION,
 
+  /** {@code LOAD DATA} DML statement. */
+  LOAD_DATA,
+
   /** DDL statement not handled above.
    *
    * <p><b>Note to other projects</b>: If you are extending Calcite's SQL parser

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -25,8 +25,8 @@ data: {
         "org.apache.calcite.sql.SqlCreate"
         "org.apache.calcite.sql.SqlDrop"
         "org.apache.calcite.sql.ddl.SqlDdlNodes"
-        "java.util.Map"
-        "java.util.HashMap"
+        "org.apache.calcite.sql.dml.SqlDmlNodes"
+        "org.apache.calcite.sql.dml.SqlLoadData"
       ]
 
       # List of keywords.
@@ -38,6 +38,9 @@ data: {
         "JAR"
         "FILE"
         "ARCHIVE"
+        "LOAD"
+        "INFILE"
+        "OVERWRITE"
       ]
 
       # List of keywords from "keywords" section that are not reserved.
@@ -354,6 +357,9 @@ data: {
         "JAR"
         "FILE"
         "ARCHIVE"
+        "LOAD"
+        "INFILE"
+        "OVERWRITE"
       ]
 
       # List of additional join types. Each is a method with no arguments.
@@ -363,6 +369,7 @@ data: {
 
       # List of methods for parsing custom SQL statements.
       statementParserMethods: [
+        "SqlLoadData()"
       ]
 
       # List of methods for parsing custom literals.

--- a/server/src/main/codegen/includes/parserImpls.ftl
+++ b/server/src/main/codegen/includes/parserImpls.ftl
@@ -423,4 +423,42 @@ SqlDrop SqlDropFunction(Span s, boolean replace) :
     }
 }
 
+boolean IfLocalOpt() :
+{
+}
+{
+    <LOCAL> { return true; }
+|
+    { return false; }
+}
+
+boolean IfOverwriteOpt() :
+{
+}
+{
+    <OVERWRITE> { return true; }
+|
+    { return false; }
+}
+
+SqlLoadData SqlLoadData() :
+{
+    SqlParserPos pos;
+    boolean local;
+    SqlNode filePath;
+    boolean overwrite;
+    SqlIdentifier id;
+}
+{
+    { pos = getPos(); }
+    <LOAD> <DATA>
+    local = IfLocalOpt()
+    <INFILE>  filePath = StringLiteral()
+    overwrite = IfOverwriteOpt()
+    <INTO> <TABLE> id = CompoundIdentifier()
+    {
+        return SqlDmlNodes.loadData(pos, local, filePath, overwrite, id);
+    }
+}
+
 // End parserImpls.ftl

--- a/server/src/main/java/org/apache/calcite/sql/dml/SqlDmlNodes.java
+++ b/server/src/main/java/org/apache/calcite/sql/dml/SqlDmlNodes.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.dml;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Utilities concerning {@link SqlNode} for DML.
+ */
+public class SqlDmlNodes {
+  private SqlDmlNodes() {}
+
+  /** Creates a LOAD DATA. */
+  public static SqlLoadData loadData(SqlParserPos pos, boolean local, SqlNode filePath,
+                                     boolean overwrite, SqlIdentifier name) {
+    return new SqlLoadData(pos, local, filePath, overwrite, name);
+  }
+
+}
+
+// End SqlDmlNodes.java

--- a/server/src/main/java/org/apache/calcite/sql/dml/SqlLoadData.java
+++ b/server/src/main/java/org/apache/calcite/sql/dml/SqlLoadData.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.dml;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * A <code>SqlLoadData</code> is a node of a parse tree which represents an LOAD DATA
+ * statement.
+ */
+public class SqlLoadData extends SqlCall {
+  public static final SqlSpecialOperator OPERATOR =
+        new SqlSpecialOperator("LOAD DATA", SqlKind.LOAD_DATA);
+
+  boolean local;
+  private final SqlNode filePath;
+  boolean overwrite;
+  private final SqlIdentifier name;
+
+  public SqlLoadData(SqlParserPos pos, boolean local, SqlNode filePath,
+                     boolean overwrite, SqlIdentifier name) {
+    super(pos);
+    this.local = local;
+    this.filePath = filePath;
+    this.overwrite = overwrite;
+    this.name = name;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(filePath, name);
+  }
+
+  @Override  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword(getLocal() ? "LOAD DATA LOCAL" : "LOAD DATA");
+    writer.keyword("INFILE");
+    filePath.unparse(writer, 0, 0);
+    writer.keyword(getOverwrite() ? "OVERWRITE INTO TABLE" : "INTO TABLE");
+    name.unparse(writer, 0, 0);
+  }
+
+  public boolean getLocal() {
+    return local;
+  }
+
+  public boolean getOverwrite() {
+    return overwrite;
+  }
+}
+
+// End SqlLoadData.java

--- a/server/src/main/java/org/apache/calcite/sql/dml/package-info.java
+++ b/server/src/main/java/org/apache/calcite/sql/dml/package-info.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parse tree for SQL DML statements.
+ *
+ * <p>These are available in the extended SQL parser that is part of Calcite's
+ * "server" module; the core parser in the "core" module only supports SELECT
+ * and DML.
+ *
+ * <p>If you are writing a project that requires DML it is likely that your
+ * DML syntax is different than ours. We recommend that you copy-paste this
+ * the parser and its supporting classes into your own module, rather than try
+ * to extend this one.
+ */
+@PackageMarker
+package org.apache.calcite.sql.dml;
+
+import org.apache.calcite.avatica.util.PackageMarker;
+
+// End package-info.java

--- a/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
+++ b/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
@@ -301,6 +301,12 @@ public class ServerParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testLoadData() {
+    final String sql = "load data infile '/root/student.txt' overwrite into table x.t";
+    final String expected = "LOAD DATA INFILE '/root/student.txt' OVERWRITE INTO TABLE `X`.`T`";
+    sql(sql).ok(expected);
+  }
+
 }
 
 // End ServerParserTest.java

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -121,6 +121,7 @@ statement:
   |   explain
   |   describe
   |   insert
+  |   load
   |   update
   |   merge
   |   delete
@@ -154,6 +155,9 @@ insert:
       ( INSERT | UPSERT ) INTO tablePrimary
       [ '(' column [, column ]* ')' ]
       query
+      
+load:
+    LOAD DATA [LOCAL] INFILE 'filepath' [OVERWRITE] INTO TABLE tableName      
 
 update:
       UPDATE tablePrimary


### PR DESCRIPTION
Fix [ISSUE #CALCITE-2735](https://issues.apache.org/jira/browse/CALCITE-2735)

relink old [PR 964](https://github.com/apache/calcite/pull/964), the PR closed and repo branch deleted. 

support load data statement, like mysql or apache hive, dml sql is:
```sql
LOAD DATA [LOCAL] INFILE 'filePath' [OVERWRITE] INTO TABLE tableName 
```