### PR TITLE
[CALCITE-3067] Splunk Calcite adapter cannot parse right session keys from Splunk 7.2

### DIFF
--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
@@ -58,7 +58,7 @@ public class SplunkConnectionImpl implements SplunkConnection {
 
   private static final Pattern SESSION_KEY =
       Pattern.compile(
-          "<response>\\s*<sessionKey>([0-9a-f]+)</sessionKey>\\s*</response>");
+          "<sessionKey>(.+)<\\/sessionKey>");
 
   final URL url;
   final String username;


### PR DESCRIPTION
Fix the regular expression for parsing session keys from Splunk 7.2+