### PR TITLE
[CALCITE-3079] Successive dependent windows cannot be implemented in same expression level

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -352,6 +352,22 @@ public class RelOptRulesTest extends RelOptTestBase {
     checkPlanning(tester, preProgram, hepPlanner, sql);
   }
 
+  @Test public void testProjectToWindowRuleForSuccessiveDependentWindows() {
+    HepProgram preProgram = new HepProgramBuilder()
+        .build();
+
+    HepProgramBuilder builder = new HepProgramBuilder();
+    builder.addRuleClass(ProjectToWindowRule.class);
+    HepPlanner hepPlanner = new HepPlanner(builder.build());
+    hepPlanner.addRule(ProjectToWindowRule.PROJECT);
+
+    final String sql = "select sum(max1) over(partition by job) as sum1\n"
+        + "from (\n"
+        + " select job, max(sal) over(partition by deptno) as max1\n"
+        + " from emp) t1";
+    checkPlanning(tester, preProgram, hepPlanner, sql);
+  }
+
   @Test public void testUnionToDistinctRule() {
     checkPlanning(UnionToDistinctRule.INSTANCE,
         "select * from dept union select * from dept");

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -267,6 +267,29 @@ LogicalProject(COUNT1=[COUNT() OVER (PARTITION BY $0 ORDER BY $5 RANGE BETWEEN U
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testProjectToWindowRuleForSuccessiveDependentWindows">
+        <Resource name="sql">
+            <![CDATA[select sum(max1) over(partition by job) as sum1
+from emp (
+ select job, max(sal) over(partition by deptno) as max1
+ from emp) t1]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject($0=[$2])
+  LogicalWindow(window#0=[window(partition {0} order by [] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [SUM($1)])])
+    LogicalProject(JOB=[$2], $1=[$9])
+      LogicalWindow(window#0=[window(partition {7} order by [] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [MAX($5)])])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(SUM1=[SUM(MAX($5) OVER (PARTITION BY $7 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)) OVER (PARTITION BY $2 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testUnionToDistinctRule">
         <Resource name="sql">
             <![CDATA[select * from dept union select * from dept]]>


### PR DESCRIPTION
As described in [CALCITE-3079](https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-3079).
We need to check such case and split window expressions into different levels.