### PR TITLE
[CALCITE-3067] Splunk Calcite adapter cannot parse right session keys from Splunk 7.2

### DIFF
--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
@@ -58,7 +58,7 @@ public class SplunkConnectionImpl implements SplunkConnection {
 
   private static final Pattern SESSION_KEY =
       Pattern.compile(
-          "<sessionKey>(.+)<\\/sessionKey>");
+          "<sessionKey>([0-9a-zA-Z^_]+)<\\/sessionKey>");
 
   final URL url;
   final String username;
@@ -100,7 +100,6 @@ public class SplunkConnectionImpl implements SplunkConnection {
       StringBuilder data = new StringBuilder();
       appendURLEncodedArgs(
           data, "username", username, "password", password);
-
       rd = Util.reader(post(loginUrl, data, requestHeaders));
 
       String line;

--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
@@ -100,6 +100,7 @@ public class SplunkConnectionImpl implements SplunkConnection {
       StringBuilder data = new StringBuilder();
       appendURLEncodedArgs(
           data, "username", username, "password", password);
+
       rd = Util.reader(post(loginUrl, data, requestHeaders));
 
       String line;

--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
@@ -58,7 +58,7 @@ public class SplunkConnectionImpl implements SplunkConnection {
 
   private static final Pattern SESSION_KEY =
       Pattern.compile(
-          "<response>\\s*<sessionKey>([0-9a-f]+)</sessionKey>\\s*</response>");
+          "<sessionKey>(.+)<\\/sessionKey>");
 
   final URL url;
   final String username;


### PR DESCRIPTION
Fix some regular expression as suggested in [https://github.com/apache/calcite/pull/1218](url)