### PR TITLE
[CALCITE-3067] Splunk adapter cannot parse right session keys from Splunk 7.2

### DIFF
--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
@@ -58,7 +58,7 @@ public class SplunkConnectionImpl implements SplunkConnection {
 
   private static final Pattern SESSION_KEY =
       Pattern.compile(
-          "<response>\\s*<sessionKey>([0-9a-f]+)</sessionKey>\\s*</response>");
+          "<sessionKey>([0-9a-zA-Z^_]+)</sessionKey>");
 
   final URL url;
   final String username;

--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/search/SplunkConnectionImpl.java
@@ -58,7 +58,7 @@ public class SplunkConnectionImpl implements SplunkConnection {
 
   private static final Pattern SESSION_KEY =
       Pattern.compile(
-          "<sessionKey>([0-9a-zA-Z^_]+)</sessionKey>");
+          "<sessionKey>([0-9a-zA-Z^_]+)<\\/sessionKey>");
 
   final URL url;
   final String username;


### PR DESCRIPTION
Fix the previous commit as discussed: [https://github.com/apache/calcite/pull/1218](url)