### PR TITLE
[CALCITE-3084] Implement JDBC string functions: ASCII, REPEAT, SPACE, SOUNDEX, DIFFERENCE

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -702,6 +702,11 @@ public class SqlJdbcFunctionCall extends SqlFunction {
       map.put("LCASE", simple(SqlStdOperatorTable.LOWER));
       map.put("LENGTH", simple(SqlStdOperatorTable.CHARACTER_LENGTH));
       map.put("LOCATE", simple(SqlStdOperatorTable.POSITION));
+      map.put("ASCII", simple(SqlStdOperatorTable.ASCII));
+      map.put("DIFFERENCE", simple(SqlLibraryOperators.DIFFERENCE));
+      map.put("REPEAT", simple(SqlLibraryOperators.REPEAT));
+      map.put("SOUNDEX", simple(SqlLibraryOperators.SOUNDEX));
+      map.put("SPACE", simple(SqlLibraryOperators.SPACE));
       map.put("REVERSE", simple(SqlLibraryOperators.REVERSE));
       map.put("LTRIM",
           new SimpleMakeCall(SqlStdOperatorTable.TRIM) {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -1832,9 +1832,10 @@ public abstract class SqlOperatorBaseTest {
     tester.checkScalar("{fn TRUNCATE(-12.34, -1)}", -10, "DECIMAL(4, 2) NOT NULL");
 
     // String Functions
-    if (false) {
-      tester.checkScalar("{fn ASCII(string)}", null, "");
-    }
+    tester.checkScalar("{fn ASCII('a')}", 97, "INTEGER NOT NULL");
+    tester.checkScalar("{fn ASCII('ABC')}", "65", "INTEGER NOT NULL");
+    tester.checkNull("{fn ASCII(cast(null as varchar(1)))}");
+
     if (false) {
       tester.checkScalar("{fn CHAR(code)}", null, "");
     }
@@ -1842,13 +1843,12 @@ public abstract class SqlOperatorBaseTest {
         "{fn CONCAT('foo', 'bar')}",
         "foobar",
         "CHAR(6) NOT NULL");
-    if (false) {
-      tester.checkScalar(
-          "{fn DIFFERENCE(string1, string2)}",
-          null,
-          "");
-    }
+
+    tester.checkScalar("{fn DIFFERENCE('Miller', 'miller')}", "4", "INTEGER NOT NULL");
+    tester.checkNull("{fn DIFFERENCE('muller', cast(null as varchar(1)))}");
+
     tester.checkString("{fn REVERSE('abc')}", "cba", "VARCHAR(3) NOT NULL");
+    tester.checkNull("{fn REVERSE(cast(null as varchar(1)))}");
 
     // REVIEW: is this result correct? I think it should be "abcCdef"
     tester.checkScalar(
@@ -1880,9 +1880,9 @@ public abstract class SqlOperatorBaseTest {
         "xxx  ",
         "VARCHAR(6) NOT NULL");
 
-    if (false) {
-      tester.checkScalar("{fn REPEAT(string, count)}", null, "");
-    }
+    tester.checkScalar("{fn REPEAT('a', -100)}", "", "VARCHAR(1) NOT NULL");
+    tester.checkNull("{fn REPEAT('abc', cast(null as integer))}");
+    tester.checkNull("{fn REPEAT(cast(null as varchar(1)), cast(null as integer))}");
 
     tester.checkString("{fn REPLACE('JACK and JUE','J','BL')}",
         "BLACK and BLUE", "VARCHAR(12) NOT NULL");
@@ -1909,12 +1909,12 @@ public abstract class SqlOperatorBaseTest {
         " xxx",
         "VARCHAR(6) NOT NULL");
 
-    if (false) {
-      tester.checkScalar("{fn SOUNDEX(string)}", null, "");
-    }
-    if (false) {
-      tester.checkScalar("{fn SPACE(count)}", null, "");
-    }
+    tester.checkScalar("{fn SOUNDEX('Miller')}", "M460", "VARCHAR(4) NOT NULL");
+    tester.checkNull("{fn SOUNDEX(cast(null as varchar(1)))}");
+
+    tester.checkScalar("{fn SPACE(-100)}", "", "VARCHAR(2000) NOT NULL");
+    tester.checkNull("{fn SPACE(cast(null as integer))}");
+
     tester.checkScalar(
         "{fn SUBSTRING('abcdef', 2, 3)}",
         "bcd",


### PR DESCRIPTION
Fix [ISSUE #3048](https://issues.apache.org/jira/browse/CALCITE-3084)

Implement JDBC string functions:
```doc
{fn ASCII(string)}
{fn DIFFERENCE(string, string)}
{fn REPEAT(string, integer)}
{fn SOUNDEX(string)}
{fn SPACE(integer)}
```