### PR TITLE
[CALCITE-3082] Fix NPE in SqlUtil#getSelectListItem

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -692,7 +692,7 @@ public abstract class SqlUtil {
     case SELECT:
       SqlSelect select = (SqlSelect) query;
       final SqlNode from = stripAs(select.getFrom());
-      if (from.getKind() == SqlKind.VALUES) {
+      if (from != null && from.getKind() == SqlKind.VALUES) {
         // They wrote "VALUES (x, y)", but the validator has
         // converted this into "SELECT * FROM VALUES (x, y)".
         return getSelectListItem(from, i);

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -5626,6 +5626,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "select 1 from (values (^'x'^)) union\n"
             + "(values ('a'))",
         "Type mismatch in column 1 of UNION");
+
+    checkFails(
+        "select 1, ^2^, 3 union\n "
+            + "select deptno, name, deptno from dept",
+        "Type mismatch in column 2 of UNION");
   }
 
   @Test public void testValuesTypeMismatchFails() {


### PR DESCRIPTION
Queries similar to `SELECT 1 UNION SELECT 2, 3` might cause Calcite
validator to throw an NPE exception instead of a proper error message.

When validating operands of a set operation, if operands don't have
matching schema, and if one of the operand doesn't have a FROM clause,
SqlUtil#getSelectListItem throws NPE.

Fixing by adding a proper check.