### PR TITLE
[CALCITE-2829] Use consistent types when processing ranges

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5477,6 +5477,14 @@ public class RelOptRulesTest extends RelOptTestBase {
         "select e.sal + b.comm from emp e inner join bonus b "
             + "on (e.ename || e.job) IS NOT DISTINCT FROM (b.ename || b.job) and e.deptno = 10");
   }
+
+  @Test public void testRangeSimplification() {
+    final String sql = "select *"
+        + "FROM (VALUES({ts '2018-01-01 01:23:45'})) tbl(d) "
+        + "WHERE d = '2018-01-01 01:23:45' AND d > '2018-01-01 01:23:45'";
+
+    checkPlanning(ReduceExpressionsRule.FILTER_INSTANCE, sql);
+  }
 }
 
 // End RelOptRulesTest.java

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -10855,4 +10855,25 @@ LogicalProject(EXPR$0=[+($0, $3)])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testRangeSimplification">
+        <Resource name="sql">
+            <![CDATA[select *
+             FROM (VALUES({ts '2018-01-01 01:23:45'})) tbl(d)
+             WHERE d = '2018-01-01 01:23:45' AND d > '2018-01-01 01:23:45'
+             ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(D=[$0])
+  LogicalFilter(condition=[AND(=($0, '2018-01-01 01:23:45'), >($0, CAST('2018-01-01 01:23:45'):TIMESTAMP(0) NOT NULL))])
+    LogicalValues(tuples=[[{ 2018-01-01 01:23:45 }]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(D=[$0])
+  LogicalValues(tuples=[[]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
Change-Id: Iaac13c5add2699c4a3f5bc1881436e47068784fa