### PR TITLE
[CALCITE-3085] Add RelBaseShuttle, implementation of RelShuttle without stack

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
@@ -17,8 +17,8 @@
 package org.apache.calcite.plan;
 
 import org.apache.calcite.config.CalciteSystemProperty;
+import org.apache.calcite.rel.RelBasicShuttle;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.TableScan;
@@ -92,7 +92,7 @@ public class RelOptMaterialization {
     final StarTable starTable = starRelOptTable.unwrap(StarTable.class);
     assert starTable != null;
     RelNode rel2 = rel.accept(
-        new RelShuttleImpl() {
+        new RelBasicShuttle() {
           @Override public RelNode visit(TableScan scan) {
             RelOptTable relOptTable = scan.getTable();
             final Table table = relOptTable.unwrap(Table.class);

--- a/core/src/main/java/org/apache/calcite/rel/RelBasicShuttle.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelBasicShuttle.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel;
+
+import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalExchange;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalIntersect;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalMatch;
+import org.apache.calcite.rel.logical.LogicalMinus;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.logical.LogicalValues;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Basic implementation of {@link RelShuttle} that calls
+ * {@link RelNode#accept(RelShuttle)} on each child, and
+ * {@link RelNode#copy(org.apache.calcite.plan.RelTraitSet, java.util.List)} if
+ * any children change.
+ */
+public class RelBasicShuttle implements RelShuttle {
+  /**
+   * Visits a particular child of a parent.
+   */
+  protected RelNode visitChild(RelNode parent, int i, RelNode child) {
+    RelNode child2 = child.accept(this);
+    if (child2 != child) {
+      final List<RelNode> newInputs = new ArrayList<>(parent.getInputs());
+      newInputs.set(i, child2);
+      return parent.copy(parent.getTraitSet(), newInputs);
+    }
+    return parent;
+  }
+
+  protected RelNode visitChildren(RelNode rel) {
+    for (Ord<RelNode> input : Ord.zip(rel.getInputs())) {
+      rel = visitChild(rel, input.i, input.e);
+    }
+    return rel;
+  }
+
+  public RelNode visit(LogicalAggregate aggregate) {
+    return visitChild(aggregate, 0, aggregate.getInput());
+  }
+
+  public RelNode visit(LogicalMatch match) {
+    return visitChild(match, 0, match.getInput());
+  }
+
+  public RelNode visit(TableScan scan) {
+    return scan;
+  }
+
+  public RelNode visit(TableFunctionScan scan) {
+    return visitChildren(scan);
+  }
+
+  public RelNode visit(LogicalValues values) {
+    return values;
+  }
+
+  public RelNode visit(LogicalFilter filter) {
+    return visitChild(filter, 0, filter.getInput());
+  }
+
+  public RelNode visit(LogicalProject project) {
+    return visitChild(project, 0, project.getInput());
+  }
+
+  public RelNode visit(LogicalJoin join) {
+    return visitChildren(join);
+  }
+
+  public RelNode visit(LogicalCorrelate correlate) {
+    return visitChildren(correlate);
+  }
+
+  public RelNode visit(LogicalUnion union) {
+    return visitChildren(union);
+  }
+
+  public RelNode visit(LogicalIntersect intersect) {
+    return visitChildren(intersect);
+  }
+
+  public RelNode visit(LogicalMinus minus) {
+    return visitChildren(minus);
+  }
+
+  public RelNode visit(LogicalSort sort) {
+    return visitChildren(sort);
+  }
+
+  public RelNode visit(LogicalExchange exchange) {
+    return visitChildren(exchange);
+  }
+
+  public RelNode visit(RelNode other) {
+    return visitChildren(other);
+  }
+}
+
+// End RelBasicShuttle.java

--- a/core/src/main/java/org/apache/calcite/rel/RelHomogeneousShuttle.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelHomogeneousShuttle.java
@@ -35,7 +35,7 @@ import org.apache.calcite.rel.logical.LogicalValues;
  * Visits all the relations in a homogeneous way: always redirects calls to
  * {@code accept(RelNode)}.
  */
-public class RelHomogeneousShuttle extends RelShuttleImpl {
+public class RelHomogeneousShuttle extends RelBasicShuttle {
   @Override public RelNode visit(LogicalAggregate aggregate) {
     return visit((RelNode) aggregate);
   }

--- a/core/src/main/java/org/apache/calcite/rel/RelShuttleImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelShuttleImpl.java
@@ -16,119 +16,27 @@
  */
 package org.apache.calcite.rel;
 
-import org.apache.calcite.linq4j.Ord;
-import org.apache.calcite.rel.core.TableFunctionScan;
-import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.rel.logical.LogicalAggregate;
-import org.apache.calcite.rel.logical.LogicalCorrelate;
-import org.apache.calcite.rel.logical.LogicalExchange;
-import org.apache.calcite.rel.logical.LogicalFilter;
-import org.apache.calcite.rel.logical.LogicalIntersect;
-import org.apache.calcite.rel.logical.LogicalJoin;
-import org.apache.calcite.rel.logical.LogicalMatch;
-import org.apache.calcite.rel.logical.LogicalMinus;
-import org.apache.calcite.rel.logical.LogicalProject;
-import org.apache.calcite.rel.logical.LogicalSort;
-import org.apache.calcite.rel.logical.LogicalUnion;
-import org.apache.calcite.rel.logical.LogicalValues;
-
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
-import java.util.List;
 
 /**
- * Basic implementation of {@link RelShuttle} that calls
+ * Implementation of {@link RelShuttle} that calls
  * {@link RelNode#accept(RelShuttle)} on each child, and
  * {@link RelNode#copy(org.apache.calcite.plan.RelTraitSet, java.util.List)} if
- * any children change.
+ * any children change. It also keeps track of parents by adding them to a
+ * protected stack before visiting the child node. When the stack is not required,
+ * user should consider using {@link RelBasicShuttle} instead.
  */
-public class RelShuttleImpl implements RelShuttle {
+public class RelShuttleImpl extends RelBasicShuttle {
   protected final Deque<RelNode> stack = new ArrayDeque<>();
 
-  /**
-   * Visits a particular child of a parent.
-   */
-  protected RelNode visitChild(RelNode parent, int i, RelNode child) {
+  @Override protected RelNode visitChild(RelNode parent, int i, RelNode child) {
     stack.push(parent);
     try {
-      RelNode child2 = child.accept(this);
-      if (child2 != child) {
-        final List<RelNode> newInputs = new ArrayList<>(parent.getInputs());
-        newInputs.set(i, child2);
-        return parent.copy(parent.getTraitSet(), newInputs);
-      }
-      return parent;
+      return super.visitChild(parent, i, child);
     } finally {
       stack.pop();
     }
-  }
-
-  protected RelNode visitChildren(RelNode rel) {
-    for (Ord<RelNode> input : Ord.zip(rel.getInputs())) {
-      rel = visitChild(rel, input.i, input.e);
-    }
-    return rel;
-  }
-
-  public RelNode visit(LogicalAggregate aggregate) {
-    return visitChild(aggregate, 0, aggregate.getInput());
-  }
-
-  public RelNode visit(LogicalMatch match) {
-    return visitChild(match, 0, match.getInput());
-  }
-
-  public RelNode visit(TableScan scan) {
-    return scan;
-  }
-
-  public RelNode visit(TableFunctionScan scan) {
-    return visitChildren(scan);
-  }
-
-  public RelNode visit(LogicalValues values) {
-    return values;
-  }
-
-  public RelNode visit(LogicalFilter filter) {
-    return visitChild(filter, 0, filter.getInput());
-  }
-
-  public RelNode visit(LogicalProject project) {
-    return visitChild(project, 0, project.getInput());
-  }
-
-  public RelNode visit(LogicalJoin join) {
-    return visitChildren(join);
-  }
-
-  public RelNode visit(LogicalCorrelate correlate) {
-    return visitChildren(correlate);
-  }
-
-  public RelNode visit(LogicalUnion union) {
-    return visitChildren(union);
-  }
-
-  public RelNode visit(LogicalIntersect intersect) {
-    return visitChildren(intersect);
-  }
-
-  public RelNode visit(LogicalMinus minus) {
-    return visitChildren(minus);
-  }
-
-  public RelNode visit(LogicalSort sort) {
-    return visitChildren(sort);
-  }
-
-  public RelNode visit(LogicalExchange exchange) {
-    return visitChildren(exchange);
-  }
-
-  public RelNode visit(RelNode other) {
-    return visitChildren(other);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectCorrelateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectCorrelateTransposeRule.java
@@ -20,8 +20,8 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.rel.RelBasicShuttle;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
@@ -190,7 +190,7 @@ public class ProjectCorrelateTransposeRule extends RelOptRule {
    * Visitor for RelNodes which applies specified {@link RexShuttle} visitor
    * for every node in the tree.
    */
-  public static class RelNodesExprsHandler extends RelShuttleImpl {
+  public static class RelNodesExprsHandler extends RelBasicShuttle {
     private final RexShuttle rexVisitor;
 
     public RelNodesExprsHandler(RexShuttle rexVisitor) {

--- a/core/src/main/java/org/apache/calcite/schema/impl/ViewTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ViewTable.java
@@ -22,9 +22,9 @@ import org.apache.calcite.linq4j.QueryProvider;
 import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelBasicShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
-import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -128,7 +128,7 @@ public class ViewTable
       final RelNode rel = RelOptUtil.createCastRel(root.rel, rowType, true);
       // Expand any views
       final RelNode rel2 = rel.accept(
-          new RelShuttleImpl() {
+          new RelBasicShuttle() {
             @Override public RelNode visit(TableScan scan) {
               final RelOptTable table = scan.getTable();
               final TranslatableTable translatableTable =

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -28,9 +28,9 @@ import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.rel.BiRel;
+import org.apache.calcite.rel.RelBasicShuttle;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Correlate;
@@ -2683,7 +2683,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
   }
 
   /** Builds a {@link org.apache.calcite.sql2rel.RelDecorrelator.CorelMap}. */
-  private static class CorelMapBuilder extends RelShuttleImpl {
+  private static class CorelMapBuilder extends RelBasicShuttle {
     final SortedMap<CorrelationId, RelNode> mapCorToCorRel =
         new TreeMap<>();
 
@@ -2707,12 +2707,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
     }
 
     @Override public RelNode visit(LogicalJoin join) {
-      try {
-        stack.push(join);
-        join.getCondition().accept(rexVisitor(join));
-      } finally {
-        stack.pop();
-      }
+      join.getCondition().accept(rexVisitor(join));
       return visitJoin(join);
     }
 
@@ -2736,23 +2731,13 @@ public class RelDecorrelator implements ReflectiveVisitor {
     }
 
     @Override public RelNode visit(final LogicalFilter filter) {
-      try {
-        stack.push(filter);
-        filter.getCondition().accept(rexVisitor(filter));
-      } finally {
-        stack.pop();
-      }
+      filter.getCondition().accept(rexVisitor(filter));
       return super.visit(filter);
     }
 
     @Override public RelNode visit(LogicalProject project) {
-      try {
-        stack.push(project);
-        for (RexNode node : project.getProjects()) {
-          node.accept(rexVisitor(project));
-        }
-      } finally {
-        stack.pop();
+      for (RexNode node : project.getProjects()) {
+        node.accept(rexVisitor(project));
       }
       return super.visit(project);
     }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
@@ -17,8 +17,8 @@
 package org.apache.calcite.test;
 
 import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.rel.RelBasicShuttle;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.externalize.RelJsonReader;
 import org.apache.calcite.rel.externalize.RelJsonWriter;
@@ -57,7 +57,7 @@ public class SqlToRelConverterExtendedTest extends SqlToRelConverterTest {
 
     // Find the schema. If there are no tables in the plan, we won't need one.
     final RelOptSchema[] schemas = {null};
-    rel.accept(new RelShuttleImpl() {
+    rel.accept(new RelBasicShuttle() {
       @Override public RelNode visit(TableScan scan) {
         schemas[0] = scan.getTable().getRelOptSchema();
         return super.visit(scan);


### PR DESCRIPTION
org.apache.calcite.rel.RelShuttleImpl class has a protected stack field
used to capture parent node when visiting children, but all subclasses
in Calcite codebase never read the content of the stack.

The change add a new implementation of RelShuttle named RelBasicShuttle.
The implementation do not use/populate a stack.

Also make the class the base class of RelShuttleImpl, along with all the
sub-classes of RelShuttleImpl (since none of them requires a stack).