### PR TITLE
[CALCITE-3077] Rewrite CUBE&ROLLUP queries in SparkSqlDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -895,6 +895,13 @@ public class SqlDialect {
     return false;
   }
 
+  /**
+   * Returns whether this dialect supports "WITH CUBE" in "GROUP BY" clause.
+   */
+  public boolean supportsGroupByWithCube() {
+    return false;
+  }
+
   /** Returns how NULL values are sorted if an ORDER BY item does not contain
    * NULLS ASCENDING or NULLS DESCENDING. */
   public NullCollation getNullCollation() {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -65,6 +65,13 @@ public class SparkSqlDialect extends SqlDialect {
     return JoinType.CROSS;
   }
 
+  @Override public boolean supportsGroupByWithRollup() {
+    return true;
+  }
+
+  @Override public boolean supportsGroupByWithCube() {
+    return true;
+  }
 
   @Override public void unparseOffsetFetch(SqlWriter writer, SqlNode offset,
       SqlNode fetch) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlRollupOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlRollupOperator.java
@@ -41,18 +41,31 @@ class SqlRollupOperator extends SqlInternalOperator {
         // MySQL version 5: generate "GROUP BY x, y WITH ROLLUP".
         // MySQL version 8 and higher is SQL-compliant,
         // so generate "GROUP BY ROLLUP(x, y)"
-        final SqlWriter.Frame groupFrame =
-            writer.startList(SqlWriter.FrameTypeEnum.GROUP_BY_LIST);
-        for (SqlNode operand : call.getOperandList()) {
-          writer.sep(",");
-          operand.unparse(writer, 2, 3);
-        }
-        writer.endList(groupFrame);
-        writer.keyword("WITH ROLLUP");
+        unparseKeyword(writer, call, "WITH ROLLUP");
         return;
       }
+      break;
+    case CUBE:
+      if (!writer.getDialect().supportsAggregateFunction(kind)
+          && writer.getDialect().supportsGroupByWithCube()) {
+        // Spark SQL: generate "GROUP BY x, y WITH CUBE".
+        unparseKeyword(writer, call, "WITH CUBE");
+        return;
+      }
+      break;
     }
     unparseCube(writer, call);
+  }
+
+  private void unparseKeyword(SqlWriter writer, SqlCall call, String keyword) {
+    final SqlWriter.Frame groupFrame =
+        writer.startList(SqlWriter.FrameTypeEnum.GROUP_BY_LIST);
+    for (SqlNode operand : call.getOperandList()) {
+      writer.sep(",");
+      operand.unparse(writer, 2, 3);
+    }
+    writer.endList(groupFrame);
+    writer.keyword(keyword);
   }
 
   private static void unparseCube(SqlWriter writer, SqlCall call) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3319,6 +3319,38 @@ public class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  @Test public void testCubeInSpark() {
+    final String query = "select count(*) "
+        + "from \"foodmart\".\"product\" "
+        + "group by cube(\"product_id\",\"product_class_id\")";
+    final String expected = "SELECT COUNT(*)\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "GROUP BY CUBE(\"product_id\", \"product_class_id\")";
+    final String expectedInSpark = "SELECT COUNT(*)\n"
+        + "FROM foodmart.product\n"
+        + "GROUP BY product_id, product_class_id WITH CUBE";
+    sql(query)
+        .ok(expected)
+        .withSpark()
+        .ok(expectedInSpark);
+  }
+
+  @Test public void testRollupInSpark() {
+    final String query = "select count(*) "
+        + "from \"foodmart\".\"product\" "
+        + "group by rollup(\"product_id\",\"product_class_id\")";
+    final String expected = "SELECT COUNT(*)\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "GROUP BY ROLLUP(\"product_id\", \"product_class_id\")";
+    final String expectedInSpark = "SELECT COUNT(*)\n"
+        + "FROM foodmart.product\n"
+        + "GROUP BY product_id, product_class_id WITH ROLLUP";
+    sql(query)
+        .ok(expected)
+        .withSpark()
+        .ok(expectedInSpark);
+  }
+
   @Test public void testJsonType() {
     String query = "select json_type(\"product_name\") from \"product\"";
     final String expected = "SELECT "


### PR DESCRIPTION
As described in [CALCITE-3077](https://issues.apache.org/jira/browse/CALCITE-3077), we need to rewrite CUBE(...)&ROLLUP(...) clauses as WITH CUBE and WITH ROLLUP in Spark SQL.