### PR TITLE
[CALCITE-1956] Allow MultiJoin to chain multiple FULL joins

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinToMultiJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinToMultiJoinRule.java
@@ -210,7 +210,7 @@ public class JoinToMultiJoinRule extends RelOptRule {
 
     // leave the null generating sides of an outer join intact; don't
     // pull up those children inputs into the array we're constructing
-    if (canCombine(left, join.getJoinType().generatesNullsOnLeft())) {
+    if (canCombine(left, join.getJoinType(), join.getJoinType().generatesNullsOnLeft())) {
       final MultiJoin leftMultiJoin = (MultiJoin) left;
       for (int i = 0; i < left.getInputs().size(); i++) {
         newInputs.add(leftMultiJoin.getInput(i));
@@ -225,7 +225,7 @@ public class JoinToMultiJoinRule extends RelOptRule {
           new int[left.getRowType().getFieldCount()]);
     }
 
-    if (canCombine(right, join.getJoinType().generatesNullsOnRight())) {
+    if (canCombine(right, join.getJoinType(), join.getJoinType().generatesNullsOnRight())) {
       final MultiJoin rightMultiJoin = (MultiJoin) right;
       for (int i = 0; i < right.getInputs().size(); i++) {
         newInputs.add(rightMultiJoin.getInput(i));
@@ -266,9 +266,9 @@ public class JoinToMultiJoinRule extends RelOptRule {
       List<Pair<JoinRelType, RexNode>> joinSpecs) {
     JoinRelType joinType = joinRel.getJoinType();
     boolean leftCombined =
-        canCombine(left, joinType.generatesNullsOnLeft());
+        canCombine(left, joinType, joinType.generatesNullsOnLeft());
     boolean rightCombined =
-        canCombine(right, joinType.generatesNullsOnRight());
+        canCombine(right, joinType, joinType.generatesNullsOnRight());
     switch (joinType) {
     case LEFT:
       if (leftCombined) {
@@ -394,12 +394,12 @@ public class JoinToMultiJoinRule extends RelOptRule {
     if ((joinType != JoinRelType.LEFT) && (joinType != JoinRelType.RIGHT)) {
       filters.add(joinRel.getCondition());
     }
-    if (canCombine(left, joinType.generatesNullsOnLeft())) {
+    if (canCombine(left, joinType, joinType.generatesNullsOnLeft())) {
       filters.add(((MultiJoin) left).getJoinFilter());
     }
     // Need to adjust the RexInputs of the right child, since
     // those need to shift over to the right
-    if (canCombine(right, joinType.generatesNullsOnRight())) {
+    if (canCombine(right, joinType, joinType.generatesNullsOnRight())) {
       MultiJoin multiJoin = (MultiJoin) right;
       filters.add(
           shiftRightFilter(joinRel, left, multiJoin,
@@ -417,7 +417,14 @@ public class JoinToMultiJoinRule extends RelOptRule {
    * @param nullGenerating true if the input is null generating
    * @return true if the input can be combined into a parent MultiJoin
    */
-  private boolean canCombine(RelNode input, boolean nullGenerating) {
+  private boolean canCombine(RelNode input, JoinRelType type, boolean nullGenerating) {
+    // If the current join is full outer join, and the multi-join only contains full outer joins
+    if (type == JoinRelType.FULL
+        && input instanceof MultiJoin
+        && ((MultiJoin) input).isFullOuterJoin()
+        && !((MultiJoin) input).containsOuter()) {
+      return true;
+    }
     return input instanceof MultiJoin
         && !((MultiJoin) input).isFullOuterJoin()
         && !((MultiJoin) input).containsOuter()

--- a/core/src/main/java/org/apache/calcite/rel/rules/LoptOptimizeJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/LoptOptimizeJoinRule.java
@@ -835,15 +835,7 @@ public class LoptOptimizeJoinRule extends RelOptRule {
    * original MultiJoin input factors.
    */
   private boolean isJoinTree(RelNode rel) {
-    // full outer joins were already optimized in a prior instantiation
-    // of this rule; therefore we should never see a join input that's
-    // a full outer join
-    if (rel instanceof Join) {
-      assert ((Join) rel).getJoinType() != JoinRelType.FULL;
-      return true;
-    } else {
-      return false;
-    }
+    return rel instanceof Join;
   }
 
   /**
@@ -1195,7 +1187,6 @@ public class LoptOptimizeJoinRule extends RelOptRule {
     // factors in the join, so create the join as a full outer join
     JoinRelType joinType;
     if (multiJoin.getMultiJoinRel().isFullOuterJoin()) {
-      assert multiJoin.getNumJoinFactors() == 2;
       joinType = JoinRelType.FULL;
     } else if (multiJoin.isNullGenerating(factorToAdd)) {
       joinType = JoinRelType.LEFT;

--- a/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinProjectTransposeRule.java
@@ -67,7 +67,7 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
               operand(LogicalProject.class,
                   operand(MultiJoin.class, any()))),
           RelFactories.LOGICAL_BUILDER,
-          "MultiJoinProjectTransposeRule: with two LogicalProject children");
+          "MultiJoinProjectTransposeRule:TwoLogicalProjects");
 
   public static final MultiJoinProjectTransposeRule MULTI_LEFT_PROJECT =
       new MultiJoinProjectTransposeRule(
@@ -76,7 +76,7 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
                   operand(LogicalProject.class,
                       operand(MultiJoin.class, any())))),
           RelFactories.LOGICAL_BUILDER,
-          "MultiJoinProjectTransposeRule: with LogicalProject on left");
+          "MultiJoinProjectTransposeRule:LeftLogicalProject");
 
   public static final MultiJoinProjectTransposeRule MULTI_RIGHT_PROJECT =
       new MultiJoinProjectTransposeRule(
@@ -85,7 +85,7 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
               operand(LogicalProject.class,
                   operand(MultiJoin.class, any()))),
           RelFactories.LOGICAL_BUILDER,
-          "MultiJoinProjectTransposeRule: with LogicalProject on right");
+          "MultiJoinProjectTransposeRule:RightLogicalProject");
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4378,6 +4378,131 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testConvertMultiFullOuterJoinRule">
+        <Resource name="sql">
+            <![CDATA[select e1.ename from emp e1 full outer join dept d on e1.deptno = d.deptno full outer join emp e2 on d.deptno = e2.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  LogicalJoin(condition=[=($9, $18)], joinType=[full])
+    LogicalJoin(condition=[=($7, $9)], joinType=[full])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  MultiJoin(joinFilter=[AND(=($9, $18), =($7, $9))], isFullOuterJoin=[true], joinTypes=[[INNER, INNER, INNER]], outerJoinConditions=[[NULL, NULL, NULL]], projFields=[[ALL, ALL, ALL]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testConvertMultiFullOuterJoinRuleLoptOptimizeJoinRule">
+        <Resource name="sql">
+            <![CDATA[select e1.ename from emp e1 full outer join dept d on e1.deptno = d.deptno full outer join emp e2 on d.deptno = e2.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  MultiJoin(joinFilter=[AND(=($9, $18), =($7, $9))], isFullOuterJoin=[true], joinTypes=[[INNER, INNER, INNER]], outerJoinConditions=[[NULL, NULL, NULL]], projFields=[[ALL, ALL, ALL]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  LogicalProject(EMPNO=[$9], ENAME=[$10], JOB=[$11], MGR=[$12], HIREDATE=[$13], SAL=[$14], COMM=[$15], DEPTNO=[$16], SLACKER=[$17], DEPTNO0=[$18], NAME=[$19], EMPNO0=[$0], ENAME0=[$1], JOB0=[$2], MGR0=[$3], HIREDATE0=[$4], SAL0=[$5], COMM0=[$6], DEPTNO1=[$7], SLACKER0=[$8])
+    LogicalJoin(condition=[=($18, $7)], joinType=[full])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalJoin(condition=[=($7, $9)], joinType=[full])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testConvertMultiLeftOuterJoinRuleShouldNotCollapse">
+        <Resource name="sql">
+            <![CDATA[select e1.ename from emp e1 left outer join dept d on e1.deptno = d.deptno full outer join emp e2 on d.deptno = e2.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  LogicalJoin(condition=[=($9, $18)], joinType=[full])
+    LogicalJoin(condition=[=($7, $9)], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  MultiJoin(joinFilter=[=($9, $18)], isFullOuterJoin=[true], joinTypes=[[INNER, INNER]], outerJoinConditions=[[NULL, NULL]], projFields=[[ALL, ALL]])
+    MultiJoin(joinFilter=[true], isFullOuterJoin=[false], joinTypes=[[INNER, LEFT]], outerJoinConditions=[[NULL, =($7, $9)]], projFields=[[ALL, ALL]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testConvertMultiFullOuterJoinRuleShouldNotCollapse">
+        <Resource name="sql">
+            <![CDATA[select e1.ename from emp e1 full outer join dept d on e1.deptno = d.deptno inner join emp e2 on d.deptno = e2.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  LogicalJoin(condition=[=($9, $18)], joinType=[inner])
+    LogicalJoin(condition=[=($7, $9)], joinType=[full])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  MultiJoin(joinFilter=[=($9, $18)], isFullOuterJoin=[false], joinTypes=[[INNER, INNER]], outerJoinConditions=[[NULL, NULL]], projFields=[[ALL, ALL]])
+    MultiJoin(joinFilter=[=($7, $9)], isFullOuterJoin=[true], joinTypes=[[INNER, INNER]], outerJoinConditions=[[NULL, NULL]], projFields=[[ALL, ALL]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testConvertMultiFullOuterJoinRuleShouldNotCollapseLopOptimizeJoinRule">
+        <Resource name="sql">
+            <![CDATA[select e1.ename from emp e1 full outer join dept d on e1.deptno = d.deptno inner join emp e2 on d.deptno = e2.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  MultiJoin(joinFilter=[=($9, $18)], isFullOuterJoin=[false], joinTypes=[[INNER, INNER]], outerJoinConditions=[[NULL, NULL]], projFields=[[ALL, ALL]])
+    MultiJoin(joinFilter=[=($7, $9)], isFullOuterJoin=[true], joinTypes=[[INNER, INNER]], outerJoinConditions=[[NULL, NULL]], projFields=[[ALL, ALL]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(ENAME=[$1])
+  LogicalProject(EMPNO=[$9], ENAME=[$10], JOB=[$11], MGR=[$12], HIREDATE=[$13], SAL=[$14], COMM=[$15], DEPTNO=[$16], SLACKER=[$17], DEPTNO0=[$18], NAME=[$19], EMPNO0=[$0], ENAME0=[$1], JOB0=[$2], MGR0=[$3], HIREDATE0=[$4], SAL0=[$5], COMM0=[$6], DEPTNO1=[$7], SLACKER0=[$8])
+    LogicalJoin(condition=[=($18, $7)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalJoin(condition=[=($7, $9)], joinType=[full])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testRemoveSemiJoinWithFilter">
         <Resource name="sql">
             <![CDATA[select e.ename from emp e, dept d where e.deptno = d.deptno and e.ename = 'foo']]>


### PR DESCRIPTION
Currently, JoinToMultiJoinRule does not collapse well joins if they are
null-generating (e.g. full/left/right).  In particular, if all the joins
are FULL joins, then it should be able to collapse all the joins into a
single MultiJoin and apply LoptOptimizeJoinRule to re-order the join inputs.

Change-Id: Ia6f72df9c4dfd0a8317a884dc28835b34011fb4e