### PR TITLE
[hotfix] Fix typos of javadoc in RelOptPredicateList.java and FilterJoinRule.java.

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptPredicateList.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPredicateList.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  *
  * <p>For example, if you apply {@code Filter(x > 1)} to a relational
  * expression that has a predicate {@code y < 10} then the pulled up predicates
- * for the Filter are {@code [y < 10, x > ]}.
+ * for the Filter are {@code [y < 10, x > 1]}.
  *
  * <p><b>Inferred predicates</b> only apply to joins. If there there is a
  * predicate on the left input to a join, and that predicate is over columns

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterJoinRule.java
@@ -79,7 +79,7 @@ public abstract class FilterJoinRule extends RelOptRule {
   //~ Constructors -----------------------------------------------------------
 
   /**
-   * Creates a FilterProjectTransposeRule with an explicit root operand and
+   * Creates a FilterJoinRule with an explicit root operand and
    * factories.
    */
   protected FilterJoinRule(RelOptRuleOperand operand, String id,
@@ -102,7 +102,7 @@ public abstract class FilterJoinRule extends RelOptRule {
   }
 
   /**
-   * Creates a FilterProjectTransposeRule with an explicit root operand and
+   * Creates a FilterJoinRule with an explicit root operand and
    * factories.
    */
   @Deprecated // to be removed before 2.0


### PR DESCRIPTION
I noticed typos of javadoc in RelOptPredicateList.java and FilterJoinRule.java . So I submitted this PR.  Hope it helps.