### PR TITLE
CALCITE-3107 Bump commons-dbcp2 from 2.5.0 to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ limitations under the License.
     <checksum-maven-plugin.version>1.2</checksum-maven-plugin.version>
     <chinook-data-hsqldb.version>0.1</chinook-data-hsqldb.version>
     <commons-codec.version>1.12</commons-codec.version>
-    <commons-dbcp2.version>2.5.0</commons-dbcp2.version>
+    <commons-dbcp2.version>2.6.0</commons-dbcp2.version>
     <commons-lang3.version>3.8</commons-lang3.version>
     <commons-pool2.version>2.6.0</commons-pool2.version>
     <elasticsearch.version>7.0.1</elasticsearch.version>


### PR DESCRIPTION
https://jira.apache.org/jira/browse/CALCITE-3107