### PR TITLE
[CALCITE-3087] AggregateOnProjectToAggregateUnifyRule ignores Project incorrectly when its Mapping breaks ordering

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1340,10 +1340,29 @@ public class SubstitutionVisitor {
       if (mapping == null) {
         return null;
       }
+      Mapping inverseMapping = mapping.inverse();
       final MutableAggregate aggregate2 =
-          permute(query, project.getInput(), mapping.inverse());
-      final MutableRel result = unifyAggregates(aggregate2, target);
-      return result == null ? null : call.result(result);
+          permute(query, project.getInput(), inverseMapping);
+      final MutableRel unifiedAggregate = unifyAggregates(aggregate2, target);
+      if (unifiedAggregate == null) {
+        return null;
+      }
+      MutableRel result = unifiedAggregate;
+      // Add Project if the mapping breaks order of fields in GroupSet
+      if (!Mappings.keepsOrdering(mapping)) {
+        final List<Integer> posList = new ArrayList<>();
+        final int fieldCount = aggregate2.rowType.getFieldCount();
+        for (int group: aggregate2.groupSet) {
+          if (inverseMapping.getTargetOpt(group) != -1) {
+            posList.add(inverseMapping.getTarget(group));
+          }
+        }
+        for (int i = posList.size(); i < fieldCount; i++) {
+          posList.add(i);
+        }
+        result = MutableRels.createProject(unifiedAggregate, posList);
+      }
+      return call.result(result);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableAggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableAggregate.java
@@ -40,6 +40,11 @@ public class MutableAggregate extends MutableSingleRel {
     this.groupSets = groupSets == null
         ? ImmutableList.of(groupSet)
         : ImmutableList.copyOf(groupSets);
+    assert ImmutableBitSet.ORDERING.isStrictlyOrdered(
+        this.groupSets) : this.groupSets;
+    for (ImmutableBitSet set : this.groupSets) {
+      assert groupSet.contains(set);
+    }
     this.aggCalls = aggCalls;
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
@@ -138,7 +138,7 @@ public abstract class MutableRels {
     }
     return MutableProject.of(
         RelOptUtil.permute(child.cluster.getTypeFactory(), rowType,
-            Mappings.bijection(posList)),
+            Mappings.bijection(posList).inverse()),
         child,
         new AbstractList<RexNode>() {
           public int size() {

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -214,12 +214,13 @@ public abstract class Mappings {
    *
    * @param mapping Mapping
    * @param bitSets Collection of bit sets
-   * @return Bit sets with mapping applied
+   * @return Sorted bit sets with mapping applied
    */
   public static ImmutableList<ImmutableBitSet> apply2(final Mapping mapping,
       Iterable<ImmutableBitSet> bitSets) {
     return ImmutableList.copyOf(
-        Iterables.transform(bitSets, input1 -> apply(mapping, input1)));
+        ImmutableBitSet.ORDERING.sortedCopy(
+            Iterables.transform(bitSets, input1 -> apply(mapping, input1))));
   }
 
   /**
@@ -416,6 +417,24 @@ public abstract class Mappings {
       if (mapping.getTargetOpt(i) != i) {
         return false;
       }
+    }
+    return true;
+  }
+
+  /**
+   * Returns whether a mapping keeps order.
+   *
+   * <p>For example, {0:0, 1:1} and {0:1, 1:1} keeps order,
+   * and {0:1, 1:0} breaks the initial order.
+   */
+  public static boolean keepsOrdering(TargetMapping mapping) {
+    int prevTarget = -1;
+    for (int i = 0; i < mapping.getSourceCount(); i++) {
+      int target = mapping.getTargetOpt(i);
+      if (target != -1 && target < prevTarget) {
+        return false;
+      }
+      prevTarget = target;
     }
     return true;
   }


### PR DESCRIPTION
As described in [CALCITE-3087](https://issues.apache.org/jira/browse/CALCITE-3087), AggregateOnProjectToAggregateUnifyRule cannot ignore Project when its Mapping breaks ordering.
This PR: (1) adds validation in MutableAggreagte, as that in Aggregate, (2) adds a Project after UnifyAggregate to recover the field order and ensure the result's rowtype when the mapping breaks ordering.