### PR TITLE
[CALCITE-3073] Support read from special timestamp in KafkaAdapter

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -63,10 +63,25 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -78,6 +93,20 @@ limitations under the License.
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${maven-dependency-plugin.version}</version>
         <executions>
+          <execution>
+            <id>analyze</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <failOnWarning>true</failOnWarning>
+              <!-- ignore "unused but declared" warnings -->
+              <ignoredUnusedDeclaredDependencies>
+                <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-api</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
           <execution>
             <id>copy-dependencies</id>
             <phase>package</phase>

--- a/kafka/src/main/java/org/apache/calcite/adapter/kafka/KafkaTableConstants.java
+++ b/kafka/src/main/java/org/apache/calcite/adapter/kafka/KafkaTableConstants.java
@@ -24,6 +24,7 @@ interface KafkaTableConstants {
   String SCHEMA_BOOTSTRAP_SERVERS = "bootstrap.servers";
   String SCHEMA_ROW_CONVERTER = "row.converter";
   String SCHEMA_CUST_CONSUMER = "consumer.cust";
+  String SCHEMA_TIMESTAMP = "timestamp";
   String SCHEMA_CONSUMER_PARAMS = "consumer.params";
 }
 

--- a/kafka/src/main/java/org/apache/calcite/adapter/kafka/KafkaTableFactory.java
+++ b/kafka/src/main/java/org/apache/calcite/adapter/kafka/KafkaTableFactory.java
@@ -45,6 +45,8 @@ public class KafkaTableFactory implements TableFactory<KafkaStreamTable> {
         (String) operand.getOrDefault(KafkaTableConstants.SCHEMA_BOOTSTRAP_SERVERS, null));
     tableOptionBuilder.setTopicName(
         (String) operand.getOrDefault(KafkaTableConstants.SCHEMA_TOPIC_NAME, null));
+    tableOptionBuilder.setTimestamp(
+        Long.valueOf((String) operand.getOrDefault(KafkaTableConstants.SCHEMA_TIMESTAMP, "-1")));
 
     final KafkaRowConverter rowConverter;
     if (operand.containsKey(KafkaTableConstants.SCHEMA_ROW_CONVERTER)) {

--- a/kafka/src/main/java/org/apache/calcite/adapter/kafka/KafkaTableOptions.java
+++ b/kafka/src/main/java/org/apache/calcite/adapter/kafka/KafkaTableOptions.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public final class KafkaTableOptions {
   private String bootstrapServers;
   private String topicName;
+  private long timestamp;
   private KafkaRowConverter rowConverter;
   private Map<String, String> consumerParams;
   //added to inject MockConsumer for testing.
@@ -46,6 +47,15 @@ public final class KafkaTableOptions {
 
   public KafkaTableOptions setTopicName(final String topicName) {
     this.topicName = topicName;
+    return this;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public KafkaTableOptions setTimestamp(final long timestamp) {
+    this.timestamp = timestamp;
     return this;
   }
 

--- a/kafka/src/test/java/org/apache/calcite/adapter/kafka/KafkaAdapterTest.java
+++ b/kafka/src/test/java/org/apache/calcite/adapter/kafka/KafkaAdapterTest.java
@@ -63,8 +63,8 @@ public class KafkaAdapterTest {
             + ", MSG_VALUE_BYTES VARBINARY NOT NULL]")
 
         .returnsUnordered(
-            "MSG_PARTITION=0; MSG_TIMESTAMP=-1; MSG_OFFSET=0; MSG_KEY_BYTES=mykey0; MSG_VALUE_BYTES=myvalue0",
-            "MSG_PARTITION=0; MSG_TIMESTAMP=-1; MSG_OFFSET=1"
+            "MSG_PARTITION=0; MSG_TIMESTAMP=0; MSG_OFFSET=0; MSG_KEY_BYTES=mykey0; MSG_VALUE_BYTES=myvalue0",
+            "MSG_PARTITION=0; MSG_TIMESTAMP=10000; MSG_OFFSET=1"
                 + "; MSG_KEY_BYTES=mykey1; MSG_VALUE_BYTES=myvalue1")
 
         .explainContains("PLAN=EnumerableInterpreter\n"
@@ -95,8 +95,8 @@ public class KafkaAdapterTest {
             + ", TIMESTAMP_TYPE VARCHAR]")
 
         .returnsUnordered(
-            "TOPIC_NAME=testtopic; PARTITION_ID=0; TIMESTAMP_TYPE=NoTimestampType",
-            "TOPIC_NAME=testtopic; PARTITION_ID=0; TIMESTAMP_TYPE=NoTimestampType")
+            "TOPIC_NAME=testTopic; PARTITION_ID=0; TIMESTAMP_TYPE=LogAppendTime",
+            "TOPIC_NAME=testTopic; PARTITION_ID=0; TIMESTAMP_TYPE=LogAppendTime")
 
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  BindableTableScan(table=[[KAFKA, MOCKTABLE_CUST_ROW_CONVERTER, (STREAM)]])\n");
@@ -107,6 +107,25 @@ public class KafkaAdapterTest {
     assertModel(MODEL)
         .query("SELECT * FROM KAFKA.MOCKTABLE")
         .failsAtValidation("Cannot convert stream 'MOCKTABLE' to relation");
+  }
+
+  @Test public void testSelectTimestamp() {
+    assertModel(MODEL)
+        .query("SELECT STREAM * FROM KAFKA.MOCKTABLE_CUST_ROW_CONVERTER_TIMESTAMP")
+        .limit(2)
+
+        .typeIs("[MSG_PARTITION INTEGER NOT NULL"
+            + ", MSG_TIMESTAMP BIGINT NOT NULL"
+            + ", MSG_OFFSET BIGINT NOT NULL"
+            + ", MSG_KEY_BYTES VARBINARY"
+            + ", MSG_VALUE_BYTES VARBINARY NOT NULL]")
+
+        .returnsUnordered(
+            "MSG_PARTITION=0; MSG_TIMESTAMP=50000; MSG_OFFSET=5; MSG_KEY_BYTES=mykey5; MSG_VALUE_BYTES=myvalue5",
+            "MSG_PARTITION=0; MSG_TIMESTAMP=60000; MSG_OFFSET=6; MSG_KEY_BYTES=mykey6; MSG_VALUE_BYTES=myvalue6")
+
+        .explainContains("PLAN=EnumerableInterpreter\n"
+            + "  BindableTableScan(table=[[KAFKA, MOCKTABLE_CUST_ROW_CONVERTER_TIMESTAMP, (STREAM)]])\n");
   }
 }
 

--- a/kafka/src/test/java/org/apache/calcite/adapter/kafka/KafkaMockConsumer.java
+++ b/kafka/src/test/java/org/apache/calcite/adapter/kafka/KafkaMockConsumer.java
@@ -16,33 +16,121 @@
  */
 package org.apache.calcite.adapter.kafka;
 
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * A mock consumer to test Kafka adapter.
  */
-public class KafkaMockConsumer extends MockConsumer {
+public class KafkaMockConsumer extends MockConsumer<byte[], byte[]> {
+  private String topic = "testTopic";
+
   public KafkaMockConsumer(final OffsetResetStrategy offsetResetStrategy) {
     super(OffsetResetStrategy.EARLIEST);
 
-    assign(Arrays.asList(new TopicPartition("testtopic", 0)));
+    updatePartitions(topic,
+        Arrays.asList(new PartitionInfo(topic, 0, Node.noNode(), new Node[0], new Node[0])));
 
     HashMap<TopicPartition, Long> beginningOffsets = new HashMap<>();
-    beginningOffsets.put(new TopicPartition("testtopic", 0), 0L);
+    beginningOffsets.put(new TopicPartition(topic, 0), 0L);
     updateBeginningOffsets(beginningOffsets);
+  }
 
+  /**
+   * Consumer calls {@link MockConsumer#rebalance(Collection)} to assign this TopicPartition.
+   */
+  public void doRebalance() {
+    rebalance(Arrays.asList(new TopicPartition(topic, 0)));
+  }
+
+  /**
+   * Calls {@link MockConsumer#addRecord(ConsumerRecord)} to add some test data,
+   * and the timestamp set from 10000 to 100000.
+   */
+  public void sendData() {
     for (int idx = 0; idx < 10; ++idx) {
-      addRecord(new ConsumerRecord<byte[], byte[]>("testtopic",
-          0, idx, ("mykey" + idx).getBytes(StandardCharsets.UTF_8),
+      addRecord(new ConsumerRecord<byte[], byte[]>(topic, 0,
+          idx, idx * 10000, TimestampType.LOG_APPEND_TIME, -1, -1, -1,
+          ("mykey" + idx).getBytes(StandardCharsets.UTF_8),
           ("myvalue" + idx).getBytes(StandardCharsets.UTF_8)));
     }
+  }
+
+  /**
+   * Get the topicPartition collection for the special topic.
+   *
+   * @param topic topic name;
+   * @return TopicPartition collection;
+   */
+  private Collection<TopicPartition> getTopicPartitions(String topic) {
+    List<PartitionInfo> partitionInfoList = partitionsFor(topic);
+    Collection<TopicPartition> partitions = new HashSet<>();
+    for (PartitionInfo partitionInfo : partitionInfoList) {
+      partitions.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
+    }
+    return partitions;
+  }
+
+  /**
+   * {@link MockConsumer} does not support offsetsForTimes, rewrite this method.
+   * No matter what the requested timestamp is, just return the special OffsetAndTimestamp.
+   *
+   * @param timestampsToSearch the mapping from partition to the timestamp to look up;
+   * @return a mapping from partition to the timestamp and offset of the first message
+   * with timestamp greater than or equal to the target timestamp;
+   */
+  @Override public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long>
+                                                                     timestampsToSearch) {
+    Map<TopicPartition, OffsetAndTimestamp> fetchedOffsets = new HashMap<>();
+    for (TopicPartition topicPartition : timestampsToSearch.keySet()) {
+      fetchedOffsets.put(topicPartition, new OffsetAndTimestamp(5, 5000));
+    }
+    return fetchedOffsets;
+  }
+
+  @Override public void subscribe(Collection<String> topics) {
+    super.subscribe(topics);
+    doRebalance();
+    sendData();
+  }
+
+  @Override public void subscribe(Collection<String> topics,
+                                  final ConsumerRebalanceListener listener) {
+    super.subscribe(topics, listener);
+    doRebalance();
+    // trigger onPartitionsAssigned method
+    listener.onPartitionsAssigned(getTopicPartitions(topic));
+    sendData();
+  }
+
+  @Override public void subscribe(Pattern pattern) {
+    super.subscribe(pattern);
+    doRebalance();
+    sendData();
+  }
+
+  @Override public void subscribe(Pattern pattern, final ConsumerRebalanceListener listener) {
+    super.subscribe(pattern, listener);
+    doRebalance();
+    // trigger onPartitionsAssigned method
+    listener.onPartitionsAssigned(getTopicPartitions(topic));
+    sendData();
   }
 }
 

--- a/kafka/src/test/resources/kafka.model.json
+++ b/kafka/src/test/resources/kafka.model.json
@@ -26,15 +26,33 @@
           "type": "custom",
           "factory": "org.apache.calcite.adapter.kafka.KafkaTableFactory",
           "operand": {
-            "consumer.cust": "org.apache.calcite.adapter.kafka.KafkaMockConsumer"
+            "consumer.cust": "org.apache.calcite.adapter.kafka.KafkaMockConsumer",
+            "topic.name": "testTopic",
+            "bootstrap.servers": "127.0.0.1:9092"
           }
         }, {
           "name": "MOCKTABLE_CUST_ROW_CONVERTER",
           "type": "custom",
           "factory": "org.apache.calcite.adapter.kafka.KafkaTableFactory",
           "operand": {
+            "bootstrap.servers": "127.0.0.1:9092",
             "consumer.cust": "org.apache.calcite.adapter.kafka.KafkaMockConsumer",
             "row.converter": "org.apache.calcite.adapter.kafka.KafkaRowConverterTest",
+            "topic.name": "testTopic",
+            "consumer.params": {
+              "key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+              "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer"
+            }
+          }
+        }, {
+          "name": "MOCKTABLE_CUST_ROW_CONVERTER_TIMESTAMP",
+          "type": "custom",
+          "factory": "org.apache.calcite.adapter.kafka.KafkaTableFactory",
+          "operand": {
+            "bootstrap.servers": "127.0.0.1:9092",
+            "timestamp": "5000",
+            "consumer.cust": "org.apache.calcite.adapter.kafka.KafkaMockConsumer",
+            "topic.name": "testTopic",
             "consumer.params": {
               "key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
               "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer"

--- a/site/_docs/kafka_adapter.md
+++ b/site/_docs/kafka_adapter.md
@@ -46,8 +46,8 @@ A basic example of a model file is given below:
           "name": "TABLE_NAME",
           "type": "custom",
           "factory": "org.apache.calcite.adapter.kafka.KafkaTableFactory",
-          "row.converter": "com.example.CustKafkaRowConverter",
           "operand": {
+            "row.converter": "com.example.CustKafkaRowConverter",
             "bootstrap.servers": "host1:port,host2:port",
             "topic.name": "kafka.topic.name",
             "consumer.params": {


### PR DESCRIPTION
There are some changes in this PR：
1. support KafkaConsumer to read from special timestamp in KafkaAdapter;
2. there is some error in kafka_adapter.md (the `row.converter` in the json example should in `operand` range)