### PR TITLE
[CALCITE-2744] RelDecorrelator throws RuntimeException when decorrelating an aggregate function with more than one argument

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
+++ b/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
@@ -18,6 +18,7 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -27,6 +28,8 @@ import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.calcite.sql.util.ListSqlOperatorTable;
@@ -64,6 +67,7 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
     opTab.addOperator(new RampFunction());
     opTab.addOperator(new DedupFunction());
     opTab.addOperator(new MyFunction());
+    opTab.addOperator(new MyAvgAggFunction());
   }
 
   /** "RAMP" user-defined function. */
@@ -125,6 +129,26 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
       return typeFactory.createSqlType(SqlTypeName.BIGINT);
     }
   }
+
+  /** "MY_AVG" user-defined aggregate function. */
+  public static class MyAvgAggFunction extends SqlAggFunction {
+    public MyAvgAggFunction() {
+      super("MY_AVG",
+          null,
+          SqlKind.AVG,
+          ReturnTypes.AVG_AGG_FUNCTION,
+          null,
+          OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+          SqlFunctionCategory.NUMERIC,
+          false,
+          false);
+    }
+
+    @Override public boolean isDeterministic() {
+      return false;
+    }
+  }
+
 }
 
 // End MockSqlOperatorTable.java

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5282,8 +5282,8 @@ public class RelOptRulesTest extends RelOptTestBase {
    * Throws RuntimeException in RelDecorrelator when optimizing a Semi-Join
    * query with a multi-param aggregate function in subquery</a> */
   @Test public void testDecorrelateWithMultiParamsAgg() {
-    final String sql = "SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp) as m,\n" +
-        " LATERAL TABLE(ramp(m.c)) AS T(s)";
+    final String sql = "SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp) as m,\n"
+        + " LATERAL TABLE(ramp(m.c)) AS T(s)";
     sql(sql)
         .withLateDecorrelation(true)
         .withTrim(true)

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5278,6 +5278,20 @@ public class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2744">[CALCITE-2744]
+   * Throws RuntimeException in RelDecorrelator when optimizing a Semi-Join
+   * query with a multi-param aggregate function in subquery</a> */
+  @Test public void testDecorrelateWithMultiParamsAgg() {
+    final String sql = "SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp) as m,\n" +
+        " LATERAL TABLE(ramp(m.c)) AS T(s)";
+    sql(sql)
+        .withLateDecorrelation(true)
+        .withTrim(true)
+        .with(HepProgram.builder().build())
+        .checkUnchanged();
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-434">[CALCITE-434]
    * Converting predicates on date dimension columns into date ranges</a>,
    * specifically a rule that converts {@code EXTRACT(YEAR FROM ...) = constant}

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -2684,7 +2684,53 @@ LogicalProject("K0"=[$0], "C1"=[$1], "F1"."A0"=[$2], "F2"."A0"=[$3], "F0"."C0"=[
 ]]>
         </Resource>
     </TestCase>
-    <TestCase name="testDecorrelateWithMultiParamsAgg">
+    <TestCase name="testDecorrelationWithConstantGroupKey">
+        <Resource name="sql">
+            <![CDATA[SELECT * FROM emp A where sal in
+(SELECT max(sal) FROM emp B where A.mgr = B.empno group by deptno, 'abc')]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{3, 5}])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalFilter(condition=[=($cor0.SAL, $0)])
+      LogicalAggregate(group=[{0}])
+        LogicalProject(EXPR$0=[$2])
+          LogicalAggregate(group=[{0, 1}], EXPR$0=[MAX($2)])
+            LogicalProject(DEPTNO=[$7], $f1=['abc'], SAL=[$5])
+              LogicalFilter(condition=[=($cor0.MGR, $0)])
+                LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planMid">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{3, 5}])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalFilter(condition=[=($cor0.SAL, $0)])
+      LogicalAggregate(group=[{0}])
+        LogicalProject(EXPR$0=[$2])
+          LogicalAggregate(group=[{0, 1}], EXPR$0=[MAX($2)])
+            LogicalProject(DEPTNO=[$7], $f1=['abc'], SAL=[$5])
+              LogicalFilter(condition=[=($cor0.MGR, $0)])
+                LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalJoin(condition=[AND(=($3, $10), =($5, $9))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}])
+      LogicalProject(EXPR$0=[$2], EMPNO=[$1])
+        LogicalAggregate(group=[{0, 1}], EXPR$0=[MAX($3)])
+          LogicalProject(DEPTNO=[$7], EMPNO=[$0], $f1=['abc'], SAL=[$5])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDecorrelationWithMultiParamsAggCall">
         <Resource name="sql">
             <![CDATA[SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp) as m,
  LATERAL TABLE(ramp(m.c)) AS T(s)]]>
@@ -2709,13 +2755,31 @@ LogicalProject(C=[$0], S=[$1])
     LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
 ]]>
         </Resource>
-        <Resource name="planAfter">
+    </TestCase>
+    <TestCase name="testDecorrelationWithMultiParamsAggCallAndConstantGroupKey">
+        <Resource name="sql">
+            <![CDATA[SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp group by empno, 'abc') as m,
+ LATERAL TABLE(ramp(m.c)) AS T(s)]]>
+        </Resource>
+        <Resource name="planBefore">
             <![CDATA[
 LogicalProject(C=[$0], S=[$1])
   LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
-    LogicalAggregate(group=[{}], C=[MY_AVG($0, $1)])
-      LogicalProject(SAL=[$5], $f1=[1])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(C=[$2])
+      LogicalAggregate(group=[{0, 1}], C=[MY_AVG($2, $3)])
+        LogicalProject(EMPNO=[$0], $f1=['abc'], SAL=[$5], $f3=[1])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+        <Resource name="planMid">
+            <![CDATA[
+LogicalProject(C=[$0], S=[$1])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+    LogicalProject(C=[$2])
+      LogicalAggregate(group=[{0, 1}], C=[MY_AVG($2, $3)])
+        LogicalProject(EMPNO=[$0], $f1=['abc'], SAL=[$5], $f3=[1])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
 ]]>
         </Resource>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -2684,6 +2684,42 @@ LogicalProject("K0"=[$0], "C1"=[$1], "F1"."A0"=[$2], "F2"."A0"=[$3], "F0"."C0"=[
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testDecorrelateWithMultiParamsAgg">
+        <Resource name="sql">
+            <![CDATA[SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp) as m,
+ LATERAL TABLE(ramp(m.c)) AS T(s)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(C=[$0], S=[$1])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+    LogicalAggregate(group=[{}], C=[MY_AVG($0, $1)])
+      LogicalProject(SAL=[$5], $f1=[1])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+        <Resource name="planMid">
+            <![CDATA[
+LogicalProject(C=[$0], S=[$1])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+    LogicalAggregate(group=[{}], C=[MY_AVG($0, $1)])
+      LogicalProject(SAL=[$5], $f1=[1])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(C=[$0], S=[$1])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+    LogicalAggregate(group=[{}], C=[MY_AVG($0, $1)])
+      LogicalProject(SAL=[$5], $f1=[1])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testExtractYearMonthToRange">
         <Resource name="sql">
             <![CDATA[select *


### PR DESCRIPTION
RelDecorrelator throws RuntimeException when decorrelating an aggregate function with more than one argument