### PR TITLE
[CALCITE-3118] VolcanoRuleCall should look at RelSubset rather than RelSet when checking child ordinal of a parent operand

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -335,7 +335,7 @@ public class VolcanoRuleCall extends RelOptRuleCall {
           // but now check that it is the *correct* child.
           final RelSubset input =
               (RelSubset) rel.getInput(previousOperand.ordinalInParent);
-          List<RelNode> inputRels = input.set.getRelsFromAllSubsets();
+          List<RelNode> inputRels = input.getRelList();
           if (!inputRels.contains(previous)) {
             continue;
           }


### PR DESCRIPTION
This PR fixes the bug described in https://issues.apache.org/jira/browse/CALCITE-3118, where VolcanoRuleCall match parent child ordinal is not properly checked