### PR TITLE
[CALCITE-3119] Deprecate Linq4j CorrelateJoinType (in favor of JoinType)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.linq4j.JoinType;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.linq4j.function.Function2;
 import org.apache.calcite.linq4j.tree.BlockStatement;
@@ -246,6 +247,26 @@ public class EnumUtils {
       }
     }
     return e;
+  }
+
+  /** Transforms a JoinRelType to Linq4j JoinType. **/
+  static JoinType toLinq4jJoinType(JoinRelType joinRelType) {
+    switch (joinRelType) {
+    case INNER:
+      return JoinType.INNER;
+    case LEFT:
+      return JoinType.LEFT;
+    case RIGHT:
+      return JoinType.RIGHT;
+    case FULL:
+      return JoinType.FULL;
+    case SEMI:
+      return JoinType.SEMI;
+    case ANTI:
+      return JoinType.ANTI;
+    }
+    throw new IllegalStateException(
+        "Unable to convert " + joinRelType + " to Linq4j JoinType");
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelate.java
@@ -130,7 +130,7 @@ public class EnumerableCorrelate extends Correlate
 
     builder.append(
         Expressions.call(leftExpression, BuiltInMethod.CORRELATE_JOIN.method,
-            Expressions.constant(joinType.toLinq4jCorrelateJoinType()),
+            Expressions.constant(EnumUtils.toLinq4jJoinType(joinType)),
             Expressions.lambda(corrBlock.toBlock(), corrArg),
             selector));
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
@@ -151,7 +151,7 @@ public class EnumerableNestedLoopJoin extends Join implements EnumerableRel {
                     physType,
                     ImmutableList.of(leftResult.physType,
                         rightResult.physType)),
-                Expressions.constant(joinType.toLinq4jJoinType())))
+                Expressions.constant(EnumUtils.toLinq4jJoinType(joinType))))
             .toBlock());
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/JoinRelType.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/JoinRelType.java
@@ -16,9 +16,6 @@
  */
 package org.apache.calcite.rel.core;
 
-import org.apache.calcite.linq4j.CorrelateJoinType;
-import org.apache.calcite.linq4j.JoinType;
-
 import java.util.Locale;
 
 /**
@@ -150,42 +147,6 @@ public enum JoinRelType {
     default:
       return this;
     }
-  }
-
-  /** Transform this JoinRelType to CorrelateJoinType. **/
-  public CorrelateJoinType toLinq4jCorrelateJoinType() {
-    switch (this) {
-    case INNER:
-      return CorrelateJoinType.INNER;
-    case LEFT:
-      return CorrelateJoinType.LEFT;
-    case SEMI:
-      return CorrelateJoinType.SEMI;
-    case ANTI:
-      return CorrelateJoinType.ANTI;
-    }
-    throw new IllegalStateException(
-        "Unable to convert " + this + " to CorrelateJoinType");
-  }
-
-  /** Transform this JoinRelType to Linq4j JoinType. **/
-  public JoinType toLinq4jJoinType() {
-    switch (this) {
-    case INNER:
-      return JoinType.INNER;
-    case LEFT:
-      return JoinType.LEFT;
-    case RIGHT:
-      return JoinType.RIGHT;
-    case FULL:
-      return JoinType.FULL;
-    case SEMI:
-      return JoinType.SEMI;
-    case ANTI:
-      return JoinType.ANTI;
-    }
-    throw new IllegalStateException(
-        "Unable to convert " + this + " to Linq4j JoinType");
   }
 
   public boolean projectsRight() {

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -30,7 +30,6 @@ import org.apache.calcite.interpreter.Context;
 import org.apache.calcite.interpreter.Row;
 import org.apache.calcite.interpreter.Scalar;
 import org.apache.calcite.linq4j.AbstractEnumerable;
-import org.apache.calcite.linq4j.CorrelateJoinType;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.EnumerableDefaults;
 import org.apache.calcite.linq4j.Enumerator;
@@ -171,7 +170,7 @@ public enum BuiltInMethod {
   NESTED_LOOP_JOIN(EnumerableDefaults.class, "nestedLoopJoin", Enumerable.class,
       Enumerable.class, Predicate2.class, Function2.class, JoinType.class),
   CORRELATE_JOIN(ExtendedEnumerable.class, "correlateJoin",
-      CorrelateJoinType.class, Function1.class, Function2.class),
+      JoinType.class, Function1.class, Function2.class),
   SELECT(ExtendedEnumerable.class, "select", Function1.class),
   SELECT2(ExtendedEnumerable.class, "select", Function2.class),
   SELECT_MANY(ExtendedEnumerable.class, "selectMany", Function1.class),

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/CorrelateJoinType.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/CorrelateJoinType.java
@@ -18,7 +18,9 @@ package org.apache.calcite.linq4j;
 
 /**
  * Specifies the type of correlation operation: inner, left, semi, or anti.
+ * @deprecated Use {@link JoinType}
  */
+@Deprecated // to be removed before 1.21
 public enum CorrelateJoinType {
   /**
    * Inner join
@@ -45,6 +47,22 @@ public enum CorrelateJoinType {
    * <p>Note: if B.b is nullable and B has nulls, no rows must be returned.
    */
   ANTI;
+
+  /** Transforms this CorrelateJoinType to JoinType. **/
+  public JoinType toJoinType() {
+    switch (this) {
+    case INNER:
+      return JoinType.INNER;
+    case LEFT:
+      return JoinType.LEFT;
+    case SEMI:
+      return JoinType.SEMI;
+    case ANTI:
+      return JoinType.ANTI;
+    }
+    throw new IllegalStateException(
+        "Unable to convert " + this + " to JoinType");
+  }
 }
 
 // End CorrelateJoinType.java

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
@@ -372,8 +372,16 @@ public abstract class DefaultEnumerable<T> implements OrderedEnumerable<T> {
         generateNullsOnRight);
   }
 
+  @Deprecated // to be removed before 1.21
   public <TInner, TResult> Enumerable<TResult> correlateJoin(
-      CorrelateJoinType joinType, Function1<T, Enumerable<TInner>> inner,
+      CorrelateJoinType correlateJoinType, Function1<T, Enumerable<TInner>> inner,
+      Function2<T, TInner, TResult> resultSelector) {
+    return EnumerableDefaults.correlateJoin(correlateJoinType.toJoinType(), getThis(), inner,
+        resultSelector);
+  }
+
+  public <TInner, TResult> Enumerable<TResult> correlateJoin(
+      JoinType joinType, Function1<T, Enumerable<TInner>> inner,
       Function2<T, TInner, TResult> resultSelector) {
     return EnumerableDefaults.correlateJoin(joinType, getThis(), inner,
         resultSelector);

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -1151,14 +1151,17 @@ public abstract class EnumerableDefaults {
   }
 
   /**
-   * Returns elements of {@code outer} for which there is a member of
-   * {@code inner} with a matching key. A specified
-   * {@code EqualityComparer<TSource>} is used to compare keys.
+   * For each row of the {@code outer} enumerable returns the correlated rows
+   * from the {@code inner} enumerable.
    */
   public static <TSource, TInner, TResult> Enumerable<TResult> correlateJoin(
-      final CorrelateJoinType joinType, final Enumerable<TSource> outer,
+      final JoinType joinType, final Enumerable<TSource> outer,
       final Function1<TSource, Enumerable<TInner>> inner,
       final Function2<TSource, TInner, TResult> resultSelector) {
+    if (joinType == JoinType.RIGHT || joinType == JoinType.FULL) {
+      throw new IllegalArgumentException("JoinType " + joinType + " is not valid for correlation");
+    }
+
     return new AbstractEnumerable<TResult>() {
       public Enumerator<TResult> enumerator() {
         return new Enumerator<TResult>() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
@@ -541,14 +541,46 @@ public interface ExtendedEnumerable<TSource> {
    * For each row of the current enumerable returns the correlated rows
    * from the {@code inner} enumerable (nested loops join).
    *
+   * @deprecated Use {@link #correlateJoin(JoinType, Function1, Function2)}
+   *
    * @param joinType inner, left, semi or anti join type
    * @param inner generator of inner enumerable
    * @param resultSelector selector of the result. For semi/anti join
    *                       inner argument is always null.
    */
+  @Deprecated // to be removed before 1.21
   <TInner, TResult> Enumerable<TResult> correlateJoin(
       CorrelateJoinType joinType, Function1<TSource, Enumerable<TInner>> inner,
       Function2<TSource, TInner, TResult> resultSelector);
+
+  /**
+   * For each row of the current enumerable returns the correlated rows
+   * from the {@code inner} enumerable (nested loops join).
+   *
+   * @param joinType inner, left, semi or anti join type
+   * @param inner generator of inner enumerable
+   * @param resultSelector selector of the result. For semi/anti join
+   *                       inner argument is always null.
+   */
+  @SuppressWarnings("deprecation")
+  default <TInner, TResult> Enumerable<TResult> correlateJoin(
+      JoinType joinType, Function1<TSource, Enumerable<TInner>> inner,
+      Function2<TSource, TInner, TResult> resultSelector) {
+    // temporary default implementation for backwards compatibility
+    switch (joinType) {
+    case INNER:
+      return correlateJoin(CorrelateJoinType.INNER, inner, resultSelector);
+    case LEFT:
+      return correlateJoin(CorrelateJoinType.LEFT, inner, resultSelector);
+    case SEMI:
+      return correlateJoin(CorrelateJoinType.SEMI, inner, resultSelector);
+    case ANTI:
+      return correlateJoin(CorrelateJoinType.ANTI, inner, resultSelector);
+    default:
+      throw new IllegalArgumentException("JoinType " + joinType + " is not valid for correlation");
+    }
+  }
+
 
   /**
    * Returns the last element of a sequence. (Defined

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/CorrelateJoinTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/CorrelateJoinTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.calcite.linq4j.test;
 
-import org.apache.calcite.linq4j.CorrelateJoinType;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.ExtendedEnumerable;
+import org.apache.calcite.linq4j.JoinType;
 import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.linq4j.function.Function1;
 import org.apache.calcite.linq4j.function.Function2;
 
 import com.google.common.collect.ImmutableList;
@@ -32,14 +34,14 @@ import java.util.List;
 import static org.junit.Assert.assertArrayEquals;
 
 /**
- * Tests {@link org.apache.calcite.linq4j.ExtendedEnumerable#correlateJoin}
+ * Tests {@link ExtendedEnumerable#correlateJoin(JoinType, Function1, Function2)}
  */
 public class CorrelateJoinTest {
   static final Function2<Integer, Integer, Integer[]> SELECT_BOTH =
       (v0, v1) -> new Integer[]{v0, v1};
 
   @Test public void testInner() {
-    testJoin(CorrelateJoinType.INNER, new Integer[][]{
+    testJoin(JoinType.INNER, new Integer[][]{
         {2, 20},
         {3, -30},
         {3, -60},
@@ -49,7 +51,7 @@ public class CorrelateJoinTest {
   }
 
   @Test public void testLeft() {
-    testJoin(CorrelateJoinType.LEFT, new Integer[][]{
+    testJoin(JoinType.LEFT, new Integer[][]{
         {1, null},
         {2, 20},
         {3, -30},
@@ -61,7 +63,7 @@ public class CorrelateJoinTest {
   }
 
   @Test public void testSemi() {
-    testJoin(CorrelateJoinType.SEMI, new Integer[][]{
+    testJoin(JoinType.SEMI, new Integer[][]{
         {2, null},
         {3, null},
         {20, null},
@@ -69,12 +71,12 @@ public class CorrelateJoinTest {
   }
 
   @Test public void testAnti() {
-    testJoin(CorrelateJoinType.ANTI, new Integer[][]{
+    testJoin(JoinType.ANTI, new Integer[][]{
         {1, null},
         {10, null}});
   }
 
-  public void testJoin(CorrelateJoinType joinType, Integer[][] expected) {
+  public void testJoin(JoinType joinType, Integer[][] expected) {
     Enumerable<Integer[]> join =
         Linq4j.asEnumerable(ImmutableList.of(1, 2, 3, 10, 20, 30))
             .correlateJoin(joinType, a0 -> {

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/JoinPreserveOrderTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/JoinPreserveOrderTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.linq4j.test;
 
-import org.apache.calcite.linq4j.CorrelateJoinType;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.EnumerableDefaults;
 import org.apache.calcite.linq4j.JoinType;
@@ -192,19 +191,19 @@ public final class JoinPreserveOrderTest {
 
 
   @Test public void testLeftCorrelateJoinPreservesOrderOfLeftInput() {
-    testJoin(correlateJoin(CorrelateJoinType.LEFT), AssertOrder.PRESERVED, AssertOrder.IGNORED);
+    testJoin(correlateJoin(JoinType.LEFT), AssertOrder.PRESERVED, AssertOrder.IGNORED);
   }
 
   @Test public void testInnerCorrelateJoinPreservesOrderOfLeftInput() {
-    testJoin(correlateJoin(CorrelateJoinType.INNER), AssertOrder.PRESERVED, AssertOrder.IGNORED);
+    testJoin(correlateJoin(JoinType.INNER), AssertOrder.PRESERVED, AssertOrder.IGNORED);
   }
 
   @Test public void testAntiCorrelateJoinPreservesOrderOfLeftInput() {
-    testJoin(correlateJoin(CorrelateJoinType.ANTI), AssertOrder.PRESERVED, AssertOrder.IGNORED);
+    testJoin(correlateJoin(JoinType.ANTI), AssertOrder.PRESERVED, AssertOrder.IGNORED);
   }
 
   @Test public void testSemiCorrelateJoinPreservesOrderOfLeftInput() {
-    testJoin(correlateJoin(CorrelateJoinType.SEMI), AssertOrder.PRESERVED, AssertOrder.IGNORED);
+    testJoin(correlateJoin(JoinType.SEMI), AssertOrder.PRESERVED, AssertOrder.IGNORED);
   }
 
   @Test public void testSemiDefaultJoinPreservesOrderOfLeftInput() {
@@ -237,7 +236,7 @@ public final class JoinPreserveOrderTest {
   }
 
   private JoinAlgorithm<Employee, Department, List<Integer>> correlateJoin(
-      CorrelateJoinType joinType) {
+      JoinType joinType) {
     return (left, right) ->
         left.correlateJoin(
             joinType,


### PR DESCRIPTION
Jira ticket: [CALCITE-3119](https://issues.apache.org/jira/browse/CALCITE-3119) 