### PR TITLE
Following [CALCITE-2744] Remove usage of deprecated api in MockSqlOpe…

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
+++ b/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.calcite.sql.util.ListSqlOperatorTable;
@@ -130,12 +131,13 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
     }
   }
 
-  /** "MY_AVG" user-defined aggregate function, with two arguments. */
+  /** "MYAGG" user-defined aggregate function. This agg function accept two numeric arguments
+   * in order to reproduce the throws of CALCITE-2744. */
   public static class MyAvgAggFunction extends SqlAggFunction {
     public MyAvgAggFunction() {
-      super("MY_AVG", null, SqlKind.AVG, ReturnTypes.AVG_AGG_FUNCTION,
-          null, OperandTypes.NUMERIC_NUMERIC, SqlFunctionCategory.NUMERIC,
-          false, false, Optionality.FORBIDDEN);
+      super("MYAGG", null, SqlKind.AVG, ReturnTypes.AVG_AGG_FUNCTION,
+          null, OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+          SqlFunctionCategory.NUMERIC, false, false, Optionality.FORBIDDEN);
     }
 
     @Override public boolean isDeterministic() {

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5296,8 +5296,8 @@ public class RelOptRulesTest extends RelOptTestBase {
   /** Test case for CALCITE-2744 for aggregate decorrelate with multi-param agg call
    * but without group key. */
   @Test public void testDecorrelateAggWithMultiParamsAggCall() {
-    final String sql = "SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp) as m,\n"
-                       + " LATERAL TABLE(ramp(m.c)) AS T(s)";
+    final String sql = "SELECT * FROM (SELECT MYAGG(sal, 1) AS c FROM emp) as m,\n"
+        + " LATERAL TABLE(ramp(m.c)) AS T(s)";
     sql(sql)
         .withLateDecorrelation(true)
         .withTrim(true)
@@ -5306,10 +5306,10 @@ public class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Same as {@link #testDecorrelateAggWithMultiParamsAggCall}
-   * but with constant grouping key. */
+   * but with a constant group key. */
   @Test public void testDecorrelateAggWithMultiParamsAggCall2() {
     final String sql = "SELECT * FROM "
-        + "(SELECT MY_AVG(sal, 1) AS c FROM emp group by empno, 'abc') as m,\n"
+        + "(SELECT MYAGG(sal, 1) AS c FROM emp group by empno, 'abc') as m,\n"
         + " LATERAL TABLE(ramp(m.c)) AS T(s)";
     sql(sql)
         .withLateDecorrelation(true)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -2732,14 +2732,14 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     </TestCase>
     <TestCase name="testDecorrelateAggWithMultiParamsAggCall">
         <Resource name="sql">
-            <![CDATA[SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp) as m,
+            <![CDATA[SELECT * FROM (SELECT MYAGG(sal, 1) AS c FROM emp) as m,
  LATERAL TABLE(ramp(m.c)) AS T(s)]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(C=[$0], S=[$1])
   LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
-    LogicalAggregate(group=[{}], C=[MY_AVG($0, $1)])
+    LogicalAggregate(group=[{}], C=[MYAGG($0, $1)])
       LogicalProject(SAL=[$5], $f1=[1])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
@@ -2749,7 +2749,7 @@ LogicalProject(C=[$0], S=[$1])
             <![CDATA[
 LogicalProject(C=[$0], S=[$1])
   LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
-    LogicalAggregate(group=[{}], C=[MY_AVG($0, $1)])
+    LogicalAggregate(group=[{}], C=[MYAGG($0, $1)])
       LogicalProject(SAL=[$5], $f1=[1])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
@@ -2758,7 +2758,7 @@ LogicalProject(C=[$0], S=[$1])
     </TestCase>
     <TestCase name="testDecorrelateAggWithMultiParamsAggCall2">
         <Resource name="sql">
-            <![CDATA[SELECT * FROM (SELECT MY_AVG(sal, 1) AS c FROM emp group by empno, 'abc') as m,
+            <![CDATA[SELECT * FROM (SELECT MYAGG(sal, 1) AS c FROM emp group by empno, 'abc') as m,
  LATERAL TABLE(ramp(m.c)) AS T(s)]]>
         </Resource>
         <Resource name="planBefore">
@@ -2766,7 +2766,7 @@ LogicalProject(C=[$0], S=[$1])
 LogicalProject(C=[$0], S=[$1])
   LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
     LogicalProject(C=[$2])
-      LogicalAggregate(group=[{0, 1}], C=[MY_AVG($2, $3)])
+      LogicalAggregate(group=[{0, 1}], C=[MYAGG($2, $3)])
         LogicalProject(EMPNO=[$0], $f1=['abc'], SAL=[$5], $f3=[1])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])
@@ -2777,7 +2777,7 @@ LogicalProject(C=[$0], S=[$1])
 LogicalProject(C=[$0], S=[$1])
   LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
     LogicalProject(C=[$2])
-      LogicalAggregate(group=[{0, 1}], C=[MY_AVG($2, $3)])
+      LogicalAggregate(group=[{0, 1}], C=[MYAGG($2, $3)])
         LogicalProject(EMPNO=[$0], $f1=['abc'], SAL=[$5], $f3=[1])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalTableFunctionScan(invocation=[RAMP($cor0.C)], rowType=[RecordType(INTEGER I)])


### PR DESCRIPTION
…ratorTable