### PR TITLE
[CALCITE-3109] Improvements on algebraic operators to express recursive queries (RepeatUnion & TableSpool)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnion.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnion.java
@@ -42,14 +42,14 @@ public class EnumerableRepeatUnion extends RepeatUnion implements EnumerableRel 
    * Creates an EnumerableRepeatUnion.
    */
   EnumerableRepeatUnion(RelOptCluster cluster, RelTraitSet traitSet,
-      RelNode seed, RelNode iterative, boolean all, int maxRep) {
-    super(cluster, traitSet, seed, iterative, all, maxRep);
+      RelNode seed, RelNode iterative, boolean all, int iterationLimit) {
+    super(cluster, traitSet, seed, iterative, all, iterationLimit);
   }
 
   @Override public EnumerableRepeatUnion copy(RelTraitSet traitSet, List<RelNode> inputs) {
     assert inputs.size() == 2;
     return new EnumerableRepeatUnion(getCluster(), traitSet,
-        inputs.get(0), inputs.get(1), all, maxRep);
+        inputs.get(0), inputs.get(1), all, iterationLimit);
   }
 
   @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
@@ -58,7 +58,7 @@ public class EnumerableRepeatUnion extends RepeatUnion implements EnumerableRel 
           "Only EnumerableRepeatUnion ALL is supported");
     }
 
-    // return repeatUnionAll(<seedExp>, <iterativeExp>, maxRep);
+    // return repeatUnionAll(<seedExp>, <iterativeExp>, iterationLimit);
 
     BlockBuilder builder = new BlockBuilder();
     RelNode seed = getSeedRel();
@@ -74,7 +74,7 @@ public class EnumerableRepeatUnion extends RepeatUnion implements EnumerableRel 
         BuiltInMethod.REPEAT_UNION_ALL.method,
         seedExp,
         iterativeExp,
-        Expressions.constant(maxRep, int.class));
+        Expressions.constant(iterationLimit, int.class));
     builder.add(unionExp);
 
     PhysType physType = PhysTypeImpl.of(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnionRule.java
@@ -49,7 +49,7 @@ public class EnumerableRepeatUnionRule extends ConverterRule {
         convert(seedRel, seedRel.getTraitSet().replace(out)),
         convert(iterativeRel, iterativeRel.getTraitSet().replace(out)),
         union.all,
-        union.maxRep);
+        union.iterationLimit);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableSpoolRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableSpoolRule.java
@@ -46,7 +46,7 @@ public class EnumerableTableSpoolRule extends ConverterRule {
             spool.getInput().getTraitSet().replace(EnumerableConvention.INSTANCE)),
         spool.readType,
         spool.writeType,
-        spool.getTableName());
+        spool.getTable());
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -599,7 +599,7 @@ public class RelFactories {
   public interface SpoolFactory {
     /** Creates a {@link TableSpool}. */
     RelNode createTableSpool(RelNode input, Spool.Type readType,
-        Spool.Type writeType, String tableName);
+        Spool.Type writeType, RelOptTable table);
   }
 
   /**
@@ -608,8 +608,8 @@ public class RelFactories {
    */
   private static class SpoolFactoryImpl implements SpoolFactory {
     public RelNode createTableSpool(RelNode input, Spool.Type readType,
-        Spool.Type writeType, String tableName) {
-      return LogicalTableSpool.create(input, readType, writeType, tableName);
+        Spool.Type writeType, RelOptTable table) {
+      return LogicalTableSpool.create(input, readType, writeType, table);
     }
   }
 
@@ -621,7 +621,7 @@ public class RelFactories {
   public interface RepeatUnionFactory {
     /** Creates a {@link RepeatUnion}. */
     RelNode createRepeatUnion(RelNode seed, RelNode iterative, boolean all,
-        int maxRep);
+        int iterationLimit);
   }
 
   /**
@@ -630,8 +630,8 @@ public class RelFactories {
    */
   private static class RepeatUnionFactoryImpl implements RepeatUnionFactory {
     public RelNode createRepeatUnion(RelNode seed, RelNode iterative,
-        boolean all, int maxRep) {
-      return LogicalRepeatUnion.create(seed, iterative, all, maxRep);
+        boolean all, int iterationLimit) {
+      return LogicalRepeatUnion.create(seed, iterative, all, iterationLimit);
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/core/RepeatUnion.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RepeatUnion.java
@@ -58,36 +58,33 @@ public abstract class RepeatUnion extends BiRel {
   public final boolean all;
 
   /**
-   * Maximum number of times to repeat the iterative relational expression; -1
-   * means no limit, 0 means only seed will be evaluated
+   * Maximum number of times to repeat the iterative relational expression;
+   * negative value means no limit, 0 means only seed will be evaluated
    */
-  public final int maxRep;
+  public final int iterationLimit;
 
   //~ Constructors -----------------------------------------------------------
   protected RepeatUnion(RelOptCluster cluster, RelTraitSet traitSet,
-      RelNode seed, RelNode iterative, boolean all, int maxRep) {
+      RelNode seed, RelNode iterative, boolean all, int iterationLimit) {
     super(cluster, traitSet, seed, iterative);
-    if (maxRep < -1) {
-      throw new IllegalArgumentException("Wrong maxRep value");
-    }
-    this.maxRep = maxRep;
+    this.iterationLimit = iterationLimit;
     this.all = all;
   }
 
   @Override public double estimateRowCount(RelMetadataQuery mq) {
     // TODO implement a more accurate row count?
     double seedRowCount = mq.getRowCount(getSeedRel());
-    if (maxRep == 0) {
+    if (iterationLimit == 0) {
       return seedRowCount;
     }
     return seedRowCount
-        + mq.getRowCount(getIterativeRel()) * (maxRep != -1 ? maxRep : 10);
+        + mq.getRowCount(getIterativeRel()) * (iterationLimit < 0 ? 10 : iterationLimit);
   }
 
   @Override public RelWriter explainTerms(RelWriter pw) {
     super.explainTerms(pw);
-    if (maxRep != -1) {
-      pw.item("maxRep", maxRep);
+    if (iterationLimit >= 0) {
+      pw.item("iterationLimit", iterationLimit);
     }
     return pw.item("all", all);
   }

--- a/core/src/main/java/org/apache/calcite/rel/core/TableSpool.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/TableSpool.java
@@ -18,6 +18,7 @@ package org.apache.calcite.rel.core;
 
 import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
@@ -33,21 +34,21 @@ import java.util.Objects;
 @Experimental
 public abstract class TableSpool extends Spool {
 
-  protected final String tableName;
+  protected final RelOptTable table;
 
   protected TableSpool(RelOptCluster cluster, RelTraitSet traitSet,
-      RelNode input, Type readType, Type writeType, String tableName) {
+      RelNode input, Type readType, Type writeType, RelOptTable table) {
     super(cluster, traitSet, input, readType, writeType);
-    this.tableName = Objects.requireNonNull(tableName);
+    this.table = Objects.requireNonNull(table);
   }
 
-  public String getTableName() {
-    return tableName;
+  public RelOptTable getTable() {
+    return table;
   }
 
   @Override public RelWriter explainTerms(RelWriter pw) {
     super.explainTerms(pw);
-    return pw.item("tableName", tableName);
+    return pw.item("table", table.getQualifiedName());
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalRepeatUnion.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalRepeatUnion.java
@@ -37,8 +37,8 @@ public class LogicalRepeatUnion extends RepeatUnion {
 
   //~ Constructors -----------------------------------------------------------
   private LogicalRepeatUnion(RelOptCluster cluster, RelTraitSet traitSet,
-      RelNode seed, RelNode iterative, boolean all, int maxRep) {
-    super(cluster, traitSet, seed, iterative, all, maxRep);
+      RelNode seed, RelNode iterative, boolean all, int iterationLimit) {
+    super(cluster, traitSet, seed, iterative, all, iterationLimit);
   }
 
   /** Creates a LogicalRepeatUnion. */
@@ -49,10 +49,10 @@ public class LogicalRepeatUnion extends RepeatUnion {
 
   /** Creates a LogicalRepeatUnion. */
   public static LogicalRepeatUnion create(RelNode seed, RelNode iterative,
-      boolean all, int maxRep) {
+      boolean all, int iterationLimit) {
     RelOptCluster cluster = seed.getCluster();
     RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
-    return new LogicalRepeatUnion(cluster, traitSet, seed, iterative, all, maxRep);
+    return new LogicalRepeatUnion(cluster, traitSet, seed, iterative, all, iterationLimit);
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -62,7 +62,7 @@ public class LogicalRepeatUnion extends RepeatUnion {
     assert traitSet.containsIfApplicable(Convention.NONE);
     assert inputs.size() == 2;
     return new LogicalRepeatUnion(getCluster(), traitSet,
-        inputs.get(0), inputs.get(1), all, maxRep);
+        inputs.get(0), inputs.get(1), all, iterationLimit);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableSpool.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableSpool.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistributionTraitDef;
@@ -39,13 +40,13 @@ public class LogicalTableSpool extends TableSpool {
 
   //~ Constructors -----------------------------------------------------------
   public LogicalTableSpool(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
-      Type readType, Type writeType, String tableName) {
-    super(cluster, traitSet, input, readType, writeType, tableName);
+      Type readType, Type writeType, RelOptTable table) {
+    super(cluster, traitSet, input, readType, writeType, table);
   }
 
   /** Creates a LogicalTableSpool. */
   public static LogicalTableSpool create(RelNode input, Type readType,
-      Type writeType, String tableName) {
+      Type writeType, RelOptTable table) {
     RelOptCluster cluster = input.getCluster();
     RelMetadataQuery mq = cluster.getMetadataQuery();
     RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE)
@@ -53,8 +54,7 @@ public class LogicalTableSpool extends TableSpool {
             () -> mq.collations(input))
         .replaceIf(RelDistributionTraitDef.INSTANCE,
             () -> mq.distribution(input));
-    return new LogicalTableSpool(cluster, traitSet, input, readType, writeType,
-        tableName);
+    return new LogicalTableSpool(cluster, traitSet, input, readType, writeType, table);
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -62,7 +62,7 @@ public class LogicalTableSpool extends TableSpool {
   @Override protected Spool copy(RelTraitSet traitSet, RelNode input,
       Type readType, Type writeType) {
     return new LogicalTableSpool(input.getCluster(), traitSet, input,
-        readType, writeType, tableName);
+        readType, writeType, table);
   }
 }
 

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -1328,9 +1328,9 @@ public class RelBuilderTest {
             .repeatUnion("DELTA_TABLE", true)
             .build();
     final String expected = "LogicalRepeatUnion(all=[true])\n"
-        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], tableName=[DELTA_TABLE])\n"
+        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], table=[[DELTA_TABLE]])\n"
         + "    LogicalValues(tuples=[[{ 1 }]])\n"
-        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], tableName=[DELTA_TABLE])\n"
+        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], table=[[DELTA_TABLE]])\n"
         + "    LogicalProject($f0=[+($0, 1)])\n"
         + "      LogicalFilter(condition=[<($0, 10)])\n"
         + "        LogicalTableScan(table=[[DELTA_TABLE]])\n";
@@ -1368,9 +1368,9 @@ public class RelBuilderTest {
             .repeatUnion("AUX", true)
             .build();
     final String expected = "LogicalRepeatUnion(all=[true])\n"
-        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], tableName=[AUX])\n"
+        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], table=[[AUX]])\n"
         + "    LogicalValues(tuples=[[{ 0, 1 }]])\n"
-        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], tableName=[AUX])\n"
+        + "  LogicalTableSpool(readType=[LAZY], writeType=[LAZY], table=[[AUX]])\n"
         + "    LogicalProject(n=[+($0, 1)], fact=[*(+($0, 1), $1)])\n"
         + "      LogicalFilter(condition=[<($0, 7)])\n"
         + "        LogicalTableScan(table=[[AUX]])\n";

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
@@ -61,9 +61,9 @@ public class EnumerableRepeatUnionHierarchyTest {
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         { 1, true, -1, new String[]{EMP1} },
-        { 2, true, -1, new String[]{EMP2, EMP1} },
+        { 2, true, -2, new String[]{EMP2, EMP1} },
         { 3, true, -1, new String[]{EMP3, EMP2, EMP1} },
-        { 4, true, -1, new String[]{EMP4, EMP1} },
+        { 4, true, -5, new String[]{EMP4, EMP1} },
         { 5, true, -1, new String[]{EMP5, EMP2, EMP1} },
         { 3, true,  0, new String[]{EMP3} },
         { 3, true,  1, new String[]{EMP3, EMP2} },
@@ -71,8 +71,8 @@ public class EnumerableRepeatUnionHierarchyTest {
         { 3, true, 10, new String[]{EMP3, EMP2, EMP1} },
 
         { 1, false, -1, new String[]{EMP1, EMP2, EMP4, EMP3, EMP5} },
-        { 2, false, -1, new String[]{EMP2, EMP3, EMP5} },
-        { 3, false, -1, new String[]{EMP3} },
+        { 2, false, -10, new String[]{EMP2, EMP3, EMP5} },
+        { 3, false, -100, new String[]{EMP3} },
         { 4, false, -1, new String[]{EMP4} },
         { 1, false,  0, new String[]{EMP1} },
         { 1, false,  1, new String[]{EMP1, EMP2, EMP4} },

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -3379,21 +3379,21 @@ public abstract class EnumerableDefaults {
    * no results, or an optional maximum numbers of iterations is reached
    * @param seed seed enumerable
    * @param iteration iteration enumerable
-   * @param maxRep maximum numbers of repetitions for the iteration enumerable (-1 means no limit)
+   * @param iterationLimit maximum numbers of repetitions for the iteration enumerable
+   *                       (negative value means no limit)
    * @param <TSource> record type
    */
   @SuppressWarnings("unchecked")
   public static <TSource> Enumerable<TSource> repeatUnionAll(
           Enumerable<TSource> seed,
           Enumerable<TSource> iteration,
-          int maxRep) {
-    assert maxRep >= -1;
+          int iterationLimit) {
     return new AbstractEnumerable<TSource>() {
       @Override public Enumerator<TSource> enumerator() {
         return new Enumerator<TSource>() {
           private TSource current = (TSource) DUMMY;
           private boolean seedProcessed = false;
-          private int currentRep = 0;
+          private int currentIteration = 0;
           private final Enumerator<TSource> seedEnumerator = seed.enumerator();
           private Enumerator<TSource> iterativeEnumerator = null;
 
@@ -3417,7 +3417,7 @@ public abstract class EnumerableDefaults {
 
             // if we are done with the seed, moveNext on the iterative part
             while (true) {
-              if (maxRep != -1 && this.currentRep == maxRep) {
+              if (iterationLimit >= 0 && this.currentIteration == iterationLimit) {
                 // max number of iterations reached, we are done
                 this.current = (TSource) DUMMY;
                 return false;
@@ -3441,7 +3441,7 @@ public abstract class EnumerableDefaults {
               this.current = (TSource) DUMMY;
               this.iterativeEnumerator.close();
               this.iterativeEnumerator = null;
-              this.currentRep++;
+              this.currentIteration++;
             }
           }
 
@@ -3451,14 +3451,13 @@ public abstract class EnumerableDefaults {
               this.iterativeEnumerator.close();
               this.iterativeEnumerator = null;
             }
-            this.currentRep = 0;
+            this.currentIteration = 0;
           }
 
           @Override public void close() {
             this.seedEnumerator.close();
             if (this.iterativeEnumerator != null) {
               this.iterativeEnumerator.close();
-              this.iterativeEnumerator = null;
             }
           }
         };


### PR DESCRIPTION
Jira ticket: [CALCITE-3109](https://issues.apache.org/jira/browse/CALCITE-3109) 
Pending details from [CALCITE-2812](https://issues.apache.org/jira/browse/CALCITE-2812) to make the RepeatUnion and TableSpool more consistent:

TableSpool:
- Replace `String tableName` with `RelOptTable table`.

RepeatUnion:
- Rename `maxRep` as `iterationLimit`. Change this field to allow all integer values, and treat all negative values as "no limit".
- EnumerableDefaults#repeatUnionAll: make close method idempotent