### PR TITLE
[hotfix]fix the javadoc typo in RelOptRule.java.(Wenhui Tang)

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -536,7 +536,7 @@ public abstract class RelOptRule {
    * Returns the description of this rule.
    *
    * <p>It must be unique (for rules that are not equal) and must consist of
-   * only the characters A-Z, a-z, 0-9, '_', '.', '(', ')'. It must start with
+   * only the characters A-Z, a-z, 0-9, '-', '_', '.', '(', ')'. It must start with
    * a letter. */
   public final String toString() {
     return description;


### PR DESCRIPTION
The rule description pattern of RelOptRule is [A-Za-z][-A-Za-z0-9_.():]*. So the description can include "-". 