### PR TITLE
[CALCITE-3136]Fix the default rule description of ConverterRule

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -100,7 +100,7 @@ public abstract class RelOptRule {
     if (description == null) {
       description = guessDescription(getClass().getName());
     }
-    if (!description.matches("[A-Za-z][-A-Za-z0-9_.():]*")) {
+    if (!description.matches("[A-Za-z][-A-Za-z0-9_.(),\\[\\]\\s:]*")) {
       throw new RuntimeException("Rule description '" + description
           + "' is not valid");
     }
@@ -536,8 +536,8 @@ public abstract class RelOptRule {
    * Returns the description of this rule.
    *
    * <p>It must be unique (for rules that are not equal) and must consist of
-   * only the characters A-Z, a-z, 0-9, '_', '.', '(', ')'. It must start with
-   * a letter. */
+   * only the characters A-Z, a-z, 0-9, '_', '.', '(', ')', '-', ',', '[', ']', ':', ' '.
+   * It must start with a letter. */
   public final String toString() {
     return description;
   }

--- a/core/src/main/java/org/apache/calcite/rel/convert/ConverterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/convert/ConverterRule.java
@@ -78,7 +78,7 @@ public abstract class ConverterRule extends RelOptRule {
     super(convertOperand(clazz, predicate, in),
         relBuilderFactory,
         description == null
-            ? "ConverterRule<in=" + in + ",out=" + out + ">"
+            ? "ConverterRule(in:" + in + ",out:" + out + ")"
             : description);
     this.inTrait = Objects.requireNonNull(in);
     this.outTrait = Objects.requireNonNull(out);


### PR DESCRIPTION
Since ConvertRule use RelTrait as part of default rule description, considering  RelCompositeTrait#toString(), RelCollationImpl#toString() including "[", "]" and ",". So it would be better to add "[", "]" and "," to rule description regular expression.