### PR TITLE
[CALCITE-3167] Remove redundant overriding methods of equals&hashcode in EnumerableTableScan and make equals/hashCode methods final in AbstractRelNode

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
@@ -83,16 +83,6 @@ public class EnumerableTableScan
     return new EnumerableTableScan(cluster, traitSet, relOptTable, elementType);
   }
 
-  @Override public boolean equals(Object obj) {
-    return obj == this
-        || obj instanceof EnumerableTableScan
-        && table.equals(((EnumerableTableScan) obj).table);
-  }
-
-  @Override public int hashCode() {
-    return table.hashCode();
-  }
-
   /** Returns whether EnumerableTableScan can generate code to handle a
    * particular variant of the Table SPI. */
   public static boolean canHandle(Table table) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
@@ -189,6 +189,10 @@ public abstract class RelOptMaterializations {
             .addRuleInstance(ProjectRemoveRule.INSTANCE)
             .build();
 
+    // Note that we should use the same HEP planner for the two optimizations below.
+    // Thus different nodes with the same digest will share the same vertex in the plan graph.
+    // By this way we achieve to share the identical node objects. This is important for
+    // the matching process.
     final HepPlanner hepPlanner = new HepPlanner(program);
     hepPlanner.setRoot(target);
     target = hepPlanner.findBestExp();

--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -390,6 +390,26 @@ public abstract class AbstractRelNode implements RelNode {
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * <p>We make this method as final and forbid checking identity by it. The point is it's hard to
+   * find a universal identity checking mechanism and user should define one case by case.</p>
+   */
+  @Override public final boolean equals(Object obj) {
+    return super.equals(obj);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>We make this method as final and forbid checking identity by it. The point is it's hard to
+   * find a universal identity checking mechanism and user should define one case by case.</p>
+   */
+  @Override public final int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
    * A writer object used exclusively for computing the digest of a RelNode.
    *
    * <p>The writer is meant to be used only for computing a single digest and then thrown away.


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current code of EnumerableTableScan.java, methods of equals&hashCode are overrided for matching of EnumerableTableScans.
While after optimizing with the same HEP planner, EnumerableTableScans from two plans but with the same digest will the share the same Java object.
https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java#L192
I think it's ok to remove the redundant overriding methods in EnumerableTableScan.java

## How was this patch tested?
Existing tests