### PR TITLE
[CALCITE-3175] AssertionError during serializing RexLiteral with Enum type.

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/JsonBuilder.java
+++ b/core/src/main/java/org/apache/calcite/util/JsonBuilder.java
@@ -93,6 +93,9 @@ public class JsonBuilder {
               ((String) o).replace("\"", "\\\"")
                   .replace("\n", "\\n"))
           .append('"');
+    } else if (o instanceof Enum) {
+      // for some Enum type like Flag.BOTH.
+      buf.append('"').append(o.toString()).append('"');
     } else {
       assert o instanceof Number || o instanceof Boolean;
       buf.append(o);


### PR DESCRIPTION
Serialize RelNode with RexCall of `trim` will cause `java.lang.AssertionError`, becase it contains an `Enum` type operand. Add json serialize and deserialize of Enum operand in this patch.
