### PR TITLE
[CALCITE-3177]Ensure correct deserialization of relational algebra.

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
@@ -273,9 +273,9 @@ public class RelJsonReader {
   }
 
   private AggregateCall toAggCall(RelInput relInput, Map<String, Object> jsonAggCall) {
-    final String aggName = (String) jsonAggCall.get("agg");
+    final Map<String, Object> aggMap = (Map) jsonAggCall.get("agg");
     final SqlAggFunction aggregation =
-        relJson.toAggregation(relInput, aggName, jsonAggCall);
+        relJson.toAggregation(relInput, (String) aggMap.get("name"), aggMap);
     final Boolean distinct = (Boolean) jsonAggCall.get("distinct");
     @SuppressWarnings("unchecked")
     final List<Integer> operands = (List<Integer>) jsonAggCall.get("operands");


### PR DESCRIPTION
When deserialize from json string, in some cases, different SqlOperators may have the same name, for example, "PLUS" and "PLUS_PREFIX". So the kind of SqlOperator should also be used for searching.