### PR TITLE
CALCITE-3179: Bump Jackson from 2.9.8 to 2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ limitations under the License.
     <hydromatic-resource.version>0.6</hydromatic-resource.version>
     <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
     <hydromatic-tpcds.version>0.4</hydromatic-tpcds.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <janino.version>3.0.11</janino.version>
     <java-diff.version>1.1.2</java-diff.version>
     <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>


### PR DESCRIPTION
To harmonize the versions of Jackson among the different projects.