### PR TITLE
[CALCITE-3182] Trim unused fields for plan of materialized-view before matching.

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalciteMaterializer.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteMaterializer.java
@@ -26,6 +26,7 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.core.TableScan;
@@ -84,8 +85,8 @@ class CalciteMaterializer extends CalcitePrepareImpl.CalcitePreparingStmt {
     SqlToRelConverter sqlToRelConverter2 =
         getSqlToRelConverter(getSqlValidator(), catalogReader, config);
 
-    materialization.queryRel =
-        sqlToRelConverter2.convertQuery(node, true, true).rel;
+    RelRoot root = sqlToRelConverter2.convertQuery(node, true, true);
+    materialization.queryRel = trimUnusedFields(root).rel;
 
     // Identify and substitute a StarTable in queryRel.
     //

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -1883,7 +1883,7 @@ public class MaterializationTest {
         CalciteAssert.checkResultContains(
             "EnumerableCalc(expr#0..2=[{inputs}], empid=[$t1])\n"
                 + "  EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
-                + "    EnumerableCalc(expr#0=[{inputs}], expr#1=[CAST($t0):VARCHAR], name=[$t1])\n"
+                + "    EnumerableCalc(expr#0=[{inputs}], expr#1=[CAST($t0):VARCHAR], name00=[$t1])\n"
                 + "      EnumerableTableScan(table=[[hr, m0]])\n"
                 + "    EnumerableCalc(expr#0..1=[{inputs}], expr#2=[CAST($t1):VARCHAR], empid=[$t0], name0=[$t2])\n"
                 + "      EnumerableTableScan(table=[[hr, dependents]])"));
@@ -2415,6 +2415,19 @@ public class MaterializationTest {
       substitutedNames.sort(CASE_INSENSITIVE_LIST_LIST_COMPARATOR);
       assertThat(substitutedNames, is(list3(expectedNames)));
     }
+  }
+
+  @Test public void testMaterializationAfterTrimingOfUnusedFields() {
+    String sql =
+        "select \"y\".\"deptno\", \"y\".\"name\", \"x\".\"sum_salary\"\n"
+            + "from\n"
+            + "  (select \"deptno\", sum(\"salary\") \"sum_salary\"\n"
+            + "  from \"emps\"\n"
+            + "  group by \"deptno\") \"x\"\n"
+            + "  join\n"
+            + "  \"depts\" \"y\"\n"
+            + "  on \"x\".\"deptno\"=\"y\".\"deptno\"\n";
+    checkMaterialize(sql, sql);
   }
 
   private static <E> List<List<List<E>>> list3(E[][][] as) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current code, before matching query with materialized-view, unused fields of query is trimmed but materialized-view is not. Thus below simple SQL fails to be matched though query and materialized-
 view are exactly the same:
```
@Test public void testMaterializationAfterTrimingOfUnusedFields() {
  String sql =
    "select \"y\".\"deptno\", \"y\".\"name\", \"x\".\"sum_salary\"\n" +
    "from\n" +
    " (select \"deptno\", sum(\"salary\") \"sum_salary\" from \"emps\" group by \"deptno\") \"x\"\n" +
    " join\n" +
    " \"depts\" \"y\"\n" +
    " on \"x\".\"deptno\"=\"y\".\"deptno\"\n";
    checkMaterialize(sql, sql);
}
```
Checking `CalciteMaterializer` https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/prepare/CalciteMaterializer.java#L83 , I think the code intends to do the trimming, but didn't call the method.
 Since unused fields of query is trimmed anyway https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java#L995 , thus I think there's no necessity to keep the materialized-view un-trimmed

## How was this patch tested?
Added new test.