### PR TITLE
[CALCITE-3113] Equivalent MutableAggregates with different row types should match with each other.

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -596,7 +596,7 @@ public class SubstitutionVisitor {
   /**
    * Equivalence checking for row types, but except for the field names.
    */
-  private Boolean rowTypesAreEquivalent(
+  private boolean rowTypesAreEquivalent(
       MutableRel rel0, MutableRel rel1, Litmus litmus) {
     // Validation checking for row type, but except for the field names.
     assert rel0.rowType.getFieldCount() == rel1.rowType.getFieldCount()

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -598,13 +598,13 @@ public class SubstitutionVisitor {
    */
   private boolean rowTypesAreEquivalent(
       MutableRel rel0, MutableRel rel1, Litmus litmus) {
-    // Validation checking for row type, but except for the field names.
-    assert rel0.rowType.getFieldCount() == rel1.rowType.getFieldCount()
-        : Pair.of(rel0, rel1);
+    if (rel0.rowType.getFieldCount() != rel1.rowType.getFieldCount()) {
+      return litmus.fail("Mismatch for column count: [{}]", Pair.of(rel0, rel1));
+    }
     for (Pair<RelDataTypeField, RelDataTypeField> pair
         : Pair.zip(rel0.rowType.getFieldList(), rel0.rowType.getFieldList())) {
       if (!pair.left.getType().equals(pair.right.getType())) {
-        return litmus.fail(Pair.of(rel0, rel1).toString());
+        return litmus.fail("Mismatch for column type: [{}]", Pair.of(rel0, rel1));
       }
     }
     return litmus.succeed();

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -529,7 +529,22 @@ public class MaterializationTest {
 
   /** Aggregation query at same level of aggregation as aggregation
    * materialization. */
-  @Test public void testAggregate() {
+  @Test public void testAggregate0() {
+    checkMaterialize(
+        "select count(*) as c from \"emps\" group by \"empid\"",
+        "select count(*) + 1 as c from \"emps\" group by \"empid\"");
+  }
+
+  /**
+   * Aggregation query at same level of aggregation as aggregation
+   * materialization but with different row types. */
+  @Test public void testAggregate1() {
+    checkMaterialize(
+        "select count(*) as c0 from \"emps\" group by \"empid\"",
+        "select count(*) as c1 from \"emps\" group by \"empid\"");
+  }
+
+  @Test public void testAggregate2() {
     checkMaterialize(
         "select \"deptno\", count(*) as c, sum(\"empid\") as s from \"emps\" group by \"deptno\"",
         "select count(*) + 1 as c, \"deptno\" from \"emps\" group by \"deptno\"");


### PR DESCRIPTION
In current code, below test case fails:
```
  @Test public void testAggregate1() {
    checkMaterialize(
        "select count(*) as c0 from \"emps\" group by \"empid\"",
        "select count(*) as c1 from \"emps\" group by \"empid\"");
  }

java.lang.AssertionError
    at org.apache.calcite.plan.SubstitutionVisitor.go(SubstitutionVisitor.java:504)
    at org.apache.calcite.plan.SubstitutionVisitor.go(SubstitutionVisitor.java:465)
    at org.apache.calcite.plan.MaterializedViewSubstitutionVisitor.go(MaterializedViewSubstitutionVisitor.java:56)
    at org.apache.calcite.plan.RelOptMaterializations.substitute(RelOptMaterializations.java:200)
    at org.apache.calcite.plan.RelOptMaterializations.useMaterializedViews(RelOptMaterializations.java:72)
    at org.apache.calcite.plan.volcano.VolcanoPlanner.registerMaterializations(VolcanoPlanner.java:347)
```
The reason is that `MutableRel` self-defined the identity mechanism. Obviously the materialization above should be used.

This PR proposes to do equivalence checking for row types but except for the field names.

I added two test cases in `MaterializationTest`, without this change, both of them fails.