### PR TITLE
[CALCITE-3187] Make decimal type inference overridable

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
@@ -271,6 +271,7 @@ public interface RelDataTypeFactory {
    * @return the result type for a decimal multiplication, or null if decimal
    * multiplication should not be applied to the operands.
    */
+  @Deprecated // use RelDataTypeSystem#deriveDecimalMultiplyType instead.
   RelDataType createDecimalProduct(
       RelDataType type1,
       RelDataType type2);
@@ -295,6 +296,7 @@ public interface RelDataTypeFactory {
    * @return the result type for a decimal division, or null if decimal
    * division should not be applied to the operands.
    */
+  @Deprecated // use RelDataTypeSystem#deriveDecimalDivideType instead.
   RelDataType createDecimalQuotient(
       RelDataType type1,
       RelDataType type2);

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
@@ -21,6 +21,7 @@ import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 
 import java.nio.charset.Charset;
@@ -318,18 +319,64 @@ public interface RelDataTypeFactory {
    * @return the result type for a decimal addition, or null if decimal
    * addition should not be applied to the operands.
    */
-  RelDataType createDecimalAddition(RelDataType type1, RelDataType type2);
+  default RelDataType createDecimalAddition(RelDataType type1, RelDataType type2) {
+    /**
+     * Type-inference strategy whereby the result type of a call is the decimal
+     * sum of two exact numeric operands where at least one of the operands is a
+     * decimal. Let p1, s1 be the precision and scale of the first operand Let
+     * p2, s2 be the precision and scale of the second operand Let p, s be the
+     * precision and scale of the result, Then the result type is a decimal
+     * with:
+     *
+     * <ul>
+     * <li>s = max(s1, s2)</li>
+     * <li>p = max(p1 - s1, p2 - s2) + s + 1</li>
+     * </ul>
+     *
+     * <p>p and s are capped at their maximum values
+     *
+     * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+     */
+    if (SqlTypeUtil.isExactNumeric(type1)
+            && SqlTypeUtil.isExactNumeric(type2)) {
+      if (SqlTypeUtil.isDecimal(type1)
+              || SqlTypeUtil.isDecimal(type2)) {
+        int p1 = type1.getPrecision();
+        int p2 = type2.getPrecision();
+        int s1 = type1.getScale();
+        int s2 = type2.getScale();
+        int scale = Math.max(s1, s2);
+        final RelDataTypeSystem typeSystem = getTypeSystem();
+        assert scale <= typeSystem.getMaxNumericScale();
+        int precision = Math.max(p1 - s1, p2 - s2) + scale + 1;
+        precision =
+                Math.min(
+                        precision,
+                        typeSystem.getMaxNumericPrecision());
+        assert precision > 0;
+
+        return createSqlType(
+                SqlTypeName.DECIMAL,
+                precision,
+                scale);
+      }
+    }
+    return null;
+  }
 
   /**
-   * Infers the return type of a decimal mod operation. Currently only a hook point
-   * for clients to override.
+   * Infers the return type of a decimal mod operation. Decimal mod involves
+   * at least one decimal operand and requires both operands to have exact
+   * numeric types.
    *
    * @param type1 type of the first operand
    * @param type2 type of the second operand
    * @return the result type for a decimal mod, or null if decimal
    * mod should not be applied to the operands.
    */
-  RelDataType createDecimalMod(RelDataType type1, RelDataType type2);
+  default RelDataType createDecimalMod(RelDataType type1, RelDataType type2) {
+    return null;
+  }
 
   //~ Inner Interfaces -------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
@@ -308,6 +308,29 @@ public interface RelDataTypeFactory {
   @SuppressWarnings("deprecation")
   FieldInfoBuilder builder();
 
+  /**
+   * Infers the return type of a decimal addition. Decimal addition involves
+   * at least one decimal operand and requires both operands to have exact
+   * numeric types.
+   *
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return the result type for a decimal addition, or null if decimal
+   * addition should not be applied to the operands.
+   */
+  RelDataType createDecimalAddition(RelDataType type1, RelDataType type2);
+
+  /**
+   * Infers the return type of a decimal mod operation. Currently only a hook point
+   * for clients to override.
+   *
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return the result type for a decimal mod, or null if decimal
+   * mod should not be applied to the operands.
+   */
+  RelDataType createDecimalMod(RelDataType type1, RelDataType type2);
+
   //~ Inner Interfaces -------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
@@ -271,7 +271,8 @@ public interface RelDataTypeFactory {
    * @return the result type for a decimal multiplication, or null if decimal
    * multiplication should not be applied to the operands.
    */
-  @Deprecated // use RelDataTypeSystem#deriveDecimalMultiplyType instead.
+  /** @deprecated Use {@link RelDataTypeSystem#deriveDecimalMultiplyType} */
+  @Deprecated
   RelDataType createDecimalProduct(
       RelDataType type1,
       RelDataType type2);
@@ -296,7 +297,8 @@ public interface RelDataTypeFactory {
    * @return the result type for a decimal division, or null if decimal
    * division should not be applied to the operands.
    */
-  @Deprecated // use RelDataTypeSystem#deriveDecimalDivideType instead.
+  /** @deprecated Use {@link RelDataTypeSystem#deriveDecimalDivideType} */
+  @Deprecated
   RelDataType createDecimalQuotient(
       RelDataType type1,
       RelDataType type2);

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
@@ -262,6 +262,8 @@ public interface RelDataTypeFactory {
       SqlIntervalQualifier intervalQualifier);
 
   /**
+   * @deprecated Use {@link RelDataTypeSystem#deriveDecimalMultiplyType}
+   *
    * Infers the return type of a decimal multiplication. Decimal
    * multiplication involves at least one decimal operand and requires both
    * operands to have exact numeric types.
@@ -271,7 +273,6 @@ public interface RelDataTypeFactory {
    * @return the result type for a decimal multiplication, or null if decimal
    * multiplication should not be applied to the operands.
    */
-  /** @deprecated Use {@link RelDataTypeSystem#deriveDecimalMultiplyType} */
   @Deprecated
   RelDataType createDecimalProduct(
       RelDataType type1,
@@ -288,6 +289,8 @@ public interface RelDataTypeFactory {
       RelDataType type2);
 
   /**
+   * @deprecated Use {@link RelDataTypeSystem#deriveDecimalDivideType}
+   *
    * Infers the return type of a decimal division. Decimal division involves
    * at least one decimal operand and requires both operands to have exact
    * numeric types.
@@ -297,7 +300,6 @@ public interface RelDataTypeFactory {
    * @return the result type for a decimal division, or null if decimal
    * division should not be applied to the operands.
    */
-  /** @deprecated Use {@link RelDataTypeSystem#deriveDecimalDivideType} */
   @Deprecated
   RelDataType createDecimalQuotient(
       RelDataType type1,

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -578,63 +578,6 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     return null;
   }
 
-  /**
-   * Type-inference strategy whereby the result type of a call is the decimal
-   * sum of two exact numeric operands where at least one of the operands is a
-   * decimal. Let p1, s1 be the precision and scale of the first operand Let
-   * p2, s2 be the precision and scale of the second operand Let p, s be the
-   * precision and scale of the result, Then the result type is a decimal
-   * with:
-   *
-   * <ul>
-   * <li>s = max(s1, s2)</li>
-   * <li>p = max(p1 - s1, p2 - s2) + s + 1</li>
-   * </ul>
-   *
-   * <p>p and s are capped at their maximum values
-   *
-   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
-   */
-  public RelDataType createDecimalAddition(RelDataType type1, RelDataType type2) {
-    if (SqlTypeUtil.isExactNumeric(type1)
-            && SqlTypeUtil.isExactNumeric(type2)) {
-      if (SqlTypeUtil.isDecimal(type1)
-              || SqlTypeUtil.isDecimal(type2)) {
-        int p1 = type1.getPrecision();
-        int p2 = type2.getPrecision();
-        int s1 = type1.getScale();
-        int s2 = type2.getScale();
-        int scale = Math.max(s1, s2);
-        final RelDataTypeSystem typeSystem = getTypeSystem();
-        assert scale <= typeSystem.getMaxNumericScale();
-        int precision = Math.max(p1 - s1, p2 - s2) + scale + 1;
-        precision =
-                Math.min(
-                        precision,
-                        typeSystem.getMaxNumericPrecision());
-        assert precision > 0;
-
-        return createSqlType(
-                SqlTypeName.DECIMAL,
-                precision,
-                scale);
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Currently a no-op. Only a hook point for clients to override.
-   * @param type1 type of the first operand
-   * @param type2 type of the second operand
-   * @return type that is the result of mod operation
-   */
-  public RelDataType createDecimalMod(RelDataType type1, RelDataType type2) {
-    return null;
-  }
-
-
   public Charset getDefaultCharset() {
     return Util.getDefaultCharset();
   }

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -456,7 +456,8 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   }
 
   /**
-   * {@inheritDoc}
+   * Delegates to RelDataTypeSystem#deriveDecimalMultiplyType to get the return type
+   * for the operation.
    */
   public RelDataType createDecimalProduct(
       RelDataType type1,
@@ -473,7 +474,8 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   }
 
   /**
-   * {@inheritDoc}
+   * Delegates to RelDataTypeSystem#deriveDecimalDivideType to get the return type
+   * for the operation.
    */
   public RelDataType createDecimalQuotient(
       RelDataType type1,

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -628,7 +628,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
    * Currently a no-op. Only a hook point for clients to override.
    * @param type1 type of the first operand
    * @param type2 type of the second operand
-   * @return
+   * @return type that is the result of mod operation
    */
   public RelDataType createDecimalMod(RelDataType type1, RelDataType type2) {
     return null;

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -578,6 +578,63 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     return null;
   }
 
+  /**
+   * Type-inference strategy whereby the result type of a call is the decimal
+   * sum of two exact numeric operands where at least one of the operands is a
+   * decimal. Let p1, s1 be the precision and scale of the first operand Let
+   * p2, s2 be the precision and scale of the second operand Let p, s be the
+   * precision and scale of the result, Then the result type is a decimal
+   * with:
+   *
+   * <ul>
+   * <li>s = max(s1, s2)</li>
+   * <li>p = max(p1 - s1, p2 - s2) + s + 1</li>
+   * </ul>
+   *
+   * <p>p and s are capped at their maximum values
+   *
+   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   */
+  public RelDataType createDecimalAddition(RelDataType type1, RelDataType type2) {
+    if (SqlTypeUtil.isExactNumeric(type1)
+            && SqlTypeUtil.isExactNumeric(type2)) {
+      if (SqlTypeUtil.isDecimal(type1)
+              || SqlTypeUtil.isDecimal(type2)) {
+        int p1 = type1.getPrecision();
+        int p2 = type2.getPrecision();
+        int s1 = type1.getScale();
+        int s2 = type2.getScale();
+        int scale = Math.max(s1, s2);
+        final RelDataTypeSystem typeSystem = getTypeSystem();
+        assert scale <= typeSystem.getMaxNumericScale();
+        int precision = Math.max(p1 - s1, p2 - s2) + scale + 1;
+        precision =
+                Math.min(
+                        precision,
+                        typeSystem.getMaxNumericPrecision());
+        assert precision > 0;
+
+        return createSqlType(
+                SqlTypeName.DECIMAL,
+                precision,
+                scale);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Currently a no-op. Only a hook point for clients to override.
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return
+   */
+  public RelDataType createDecimalMod(RelDataType type1, RelDataType type2) {
+    return null;
+  }
+
+
   public Charset getDefaultCharset() {
     return Util.getDefaultCharset();
   }

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -22,7 +22,6 @@ import org.apache.calcite.sql.type.JavaToSqlTypeConversionRules;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
-import org.apache.calcite.util.Glossary;
 import org.apache.calcite.util.Util;
 
 import com.google.common.cache.CacheBuilder;
@@ -458,53 +457,11 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
 
   /**
    * {@inheritDoc}
-   *
-   * <p>Implement RelDataTypeFactory with SQL 2003 compliant behavior. Let p1,
-   * s1 be the precision and scale of the first operand Let p2, s2 be the
-   * precision and scale of the second operand Let p, s be the precision and
-   * scale of the result, Then the result type is a decimal with:
-   *
-   * <ul>
-   * <li>p = p1 + p2</li>
-   * <li>s = s1 + s2</li>
-   * </ul>
-   *
-   * <p>p and s are capped at their maximum values
-   *
-   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
    */
   public RelDataType createDecimalProduct(
       RelDataType type1,
       RelDataType type2) {
-    if (SqlTypeUtil.isExactNumeric(type1)
-        && SqlTypeUtil.isExactNumeric(type2)) {
-      if (SqlTypeUtil.isDecimal(type1)
-          || SqlTypeUtil.isDecimal(type2)) {
-        int p1 = type1.getPrecision();
-        int p2 = type2.getPrecision();
-        int s1 = type1.getScale();
-        int s2 = type2.getScale();
-
-        int scale = s1 + s2;
-        scale = Math.min(scale, typeSystem.getMaxNumericScale());
-        int precision = p1 + p2;
-        precision =
-            Math.min(
-                precision,
-                typeSystem.getMaxNumericPrecision());
-
-        RelDataType ret;
-        ret =
-            createSqlType(
-                SqlTypeName.DECIMAL,
-                precision,
-                scale);
-
-        return ret;
-      }
-    }
-
-    return null;
+    return  typeSystem.deriveDecimalMultiplyType(this, type1, type2);
   }
 
   // implement RelDataTypeFactory
@@ -516,66 +473,12 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   }
 
   /**
-   * Rules:
-   *
-   * <ul>
-   * <li>Let p1, s1 be the precision and scale of the first operand
-   * <li>Let p2, s2 be the precision and scale of the second operand
-   * <li>Let p, s be the precision and scale of the result
-   * <li>Let d be the number of whole digits in the result
-   * <li>Then the result type is a decimal with:
-   *   <ul>
-   *   <li>d = p1 - s1 + s2</li>
-   *   <li>s &lt; max(6, s1 + p2 + 1)</li>
-   *   <li>p = d + s</li>
-   *   </ul>
-   * </li>
-   * <li>p and s are capped at their maximum values</li>
-   * </ul>
-   *
-   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   * {@inheritDoc}
    */
   public RelDataType createDecimalQuotient(
       RelDataType type1,
       RelDataType type2) {
-    if (SqlTypeUtil.isExactNumeric(type1)
-        && SqlTypeUtil.isExactNumeric(type2)) {
-      if (SqlTypeUtil.isDecimal(type1)
-          || SqlTypeUtil.isDecimal(type2)) {
-        int p1 = type1.getPrecision();
-        int p2 = type2.getPrecision();
-        int s1 = type1.getScale();
-        int s2 = type2.getScale();
-
-        final int maxNumericPrecision = typeSystem.getMaxNumericPrecision();
-        int dout =
-            Math.min(
-                p1 - s1 + s2,
-                maxNumericPrecision);
-
-        int scale = Math.max(6, s1 + p2 + 1);
-        scale =
-            Math.min(
-                scale,
-                maxNumericPrecision - dout);
-        scale = Math.min(scale, getTypeSystem().getMaxNumericScale());
-
-        int precision = dout + scale;
-        assert precision <= maxNumericPrecision;
-        assert precision > 0;
-
-        RelDataType ret;
-        ret =
-            createSqlType(
-                SqlTypeName.DECIMAL,
-                precision,
-                scale);
-
-        return ret;
-      }
-    }
-
-    return null;
+    return typeSystem.deriveDecimalDivideType(this, type1, type2);
   }
 
   public Charset getDefaultCharset() {

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -456,7 +456,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   }
 
   /**
-   * Delegates to RelDataTypeSystem#deriveDecimalMultiplyType to get the return type
+   * Delegates to {@link RelDataTypeSystem#deriveDecimalMultiplyType} to get the return type
    * for the operation.
    */
   public RelDataType createDecimalProduct(
@@ -474,7 +474,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   }
 
   /**
-   * Delegates to RelDataTypeSystem#deriveDecimalDivideType to get the return type
+   * Delegates to {@link RelDataTypeSystem#deriveDecimalDivideType} to get the return type
    * for the operation.
    */
   public RelDataType createDecimalQuotient(

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -18,6 +18,7 @@ package org.apache.calcite.rel.type;
 
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.util.Glossary;
 
 /**
  * Type system.
@@ -121,7 +122,7 @@ public interface RelDataTypeSystem {
    *
    * <p>p and s are capped at their maximum values
    *
-   * @link Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
    *
    * @param typeFactory typeFactory used to create output type
    * @param type1 type of the first operand
@@ -173,7 +174,7 @@ public interface RelDataTypeSystem {
    *
    * <p>p and s are capped at their maximum values
    *
-   * @link Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
    *
    * @param typeFactory typeFactory used to create output type
    * @param type1 type of the first operand
@@ -234,7 +235,7 @@ public interface RelDataTypeSystem {
    * <li>p and s are capped at their maximum values</li>
    * </ul>
    *
-   * @link Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
    *
    * @param typeFactory typeFactory used to create output type
    * @param type1 type of the first operand

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -290,6 +290,8 @@ public interface RelDataTypeSystem {
    * at least one decimal operand and requires both operands to have exact
    * numeric types.
    *
+   * Always returns the type of the second argument as the return type
+   * for the operation.
    * @param type1 type of the first operand
    * @param type2 type of the second operand
    * @return the result type for a decimal mod, or null if decimal

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -217,7 +217,6 @@ public interface RelDataTypeSystem {
    * Infers the return type of a decimal division. Decimal division involves
    * at least one decimal operand and requires both operands to have exact
    * numeric types.
-   /**
    * Rules:
    *
    * <ul>

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.type;
 
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 
 /**
  * Type system.
@@ -100,6 +101,212 @@ public interface RelDataTypeSystem {
   /** Whether the least restrictive type of a number of CHAR types of different
    * lengths should be a VARCHAR type. And similarly BINARY to VARBINARY. */
   boolean shouldConvertRaggedUnionTypesToVarying();
+
+  /**
+   * Infers the return type of a decimal addition. Decimal addition involves
+   * at least one decimal operand and requires both operands to have exact
+   * numeric types.
+   *
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return the result type for a decimal addition.
+   */
+  default RelDataType deriveDecimalPlusType(RelDataTypeFactory typeFactory,
+                                            RelDataType type1, RelDataType type2) {
+    /**
+     * Type-inference strategy whereby the result type of a call is the decimal
+     * sum of two exact numeric operands where at least one of the operands is a
+     * decimal. Let p1, s1 be the precision and scale of the first operand Let
+     * p2, s2 be the precision and scale of the second operand Let p, s be the
+     * precision and scale of the result, Then the result type is a decimal
+     * with:
+     *
+     * <ul>
+     * <li>s = max(s1, s2)</li>
+     * <li>p = max(p1 - s1, p2 - s2) + s + 1</li>
+     * </ul>
+     *
+     * <p>p and s are capped at their maximum values
+     *
+     * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+     */
+    if (SqlTypeUtil.isExactNumeric(type1)
+            && SqlTypeUtil.isExactNumeric(type2)) {
+      if (SqlTypeUtil.isDecimal(type1)
+              || SqlTypeUtil.isDecimal(type2)) {
+        int p1 = type1.getPrecision();
+        int p2 = type2.getPrecision();
+        int s1 = type1.getScale();
+        int s2 = type2.getScale();
+        int scale = Math.max(s1, s2);
+        assert scale <= getMaxNumericScale();
+        int precision = Math.max(p1 - s1, p2 - s2) + scale + 1;
+        precision =
+                Math.min(
+                        precision,
+                        getMaxNumericPrecision());
+        assert precision > 0;
+
+        return typeFactory.createSqlType(
+                SqlTypeName.DECIMAL,
+                precision,
+                scale);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Infers the return type of a decimal multiplication. Decimal
+   * multiplication involves at least one decimal operand and requires both
+   * operands to have exact numeric types.
+   *
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return the result type for a decimal multiplication, or null if decimal
+   * multiplication should not be applied to the operands.
+   */
+  default RelDataType deriveDecimalMultiplyType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    /**
+     * <p>Implement RelDataTypeFactory with SQL 2003 compliant behavior. Let p1,
+     * s1 be the precision and scale of the first operand Let p2, s2 be the
+     * precision and scale of the second operand Let p, s be the precision and
+     * scale of the result, Then the result type is a decimal with:
+     *
+     * <ul>
+     * <li>p = p1 + p2</li>
+     * <li>s = s1 + s2</li>
+     * </ul>
+     *
+     * <p>p and s are capped at their maximum values
+     *
+     * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+     */
+    if (SqlTypeUtil.isExactNumeric(type1)
+            && SqlTypeUtil.isExactNumeric(type2)) {
+      if (SqlTypeUtil.isDecimal(type1)
+              || SqlTypeUtil.isDecimal(type2)) {
+        int p1 = type1.getPrecision();
+        int p2 = type2.getPrecision();
+        int s1 = type1.getScale();
+        int s2 = type2.getScale();
+
+        int scale = s1 + s2;
+        scale = Math.min(scale, getMaxNumericScale());
+        int precision = p1 + p2;
+        precision =
+                Math.min(
+                        precision,
+                        getMaxNumericPrecision());
+
+        RelDataType ret;
+        ret = typeFactory.createSqlType(
+                        SqlTypeName.DECIMAL,
+                        precision,
+                        scale);
+
+        return ret;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Infers the return type of a decimal division. Decimal division involves
+   * at least one decimal operand and requires both operands to have exact
+   * numeric types.
+   *
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return the result type for a decimal division, or null if decimal
+   * division should not be applied to the operands.
+   */
+  default RelDataType deriveDecimalDivideType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    /**
+     * Rules:
+     *
+     * <ul>
+     * <li>Let p1, s1 be the precision and scale of the first operand
+     * <li>Let p2, s2 be the precision and scale of the second operand
+     * <li>Let p, s be the precision and scale of the result
+     * <li>Let d be the number of whole digits in the result
+     * <li>Then the result type is a decimal with:
+     *   <ul>
+     *   <li>d = p1 - s1 + s2</li>
+     *   <li>s &lt; max(6, s1 + p2 + 1)</li>
+     *   <li>p = d + s</li>
+     *   </ul>
+     * </li>
+     * <li>p and s are capped at their maximum values</li>
+     * </ul>
+     *
+     * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+     */
+    if (SqlTypeUtil.isExactNumeric(type1)
+            && SqlTypeUtil.isExactNumeric(type2)) {
+      if (SqlTypeUtil.isDecimal(type1)
+              || SqlTypeUtil.isDecimal(type2)) {
+        int p1 = type1.getPrecision();
+        int p2 = type2.getPrecision();
+        int s1 = type1.getScale();
+        int s2 = type2.getScale();
+
+        final int maxNumericPrecision = getMaxNumericPrecision();
+        int dout =
+                Math.min(
+                        p1 - s1 + s2,
+                        maxNumericPrecision);
+
+        int scale = Math.max(6, s1 + p2 + 1);
+        scale =
+                Math.min(
+                        scale,
+                        maxNumericPrecision - dout);
+        scale = Math.min(scale, getMaxNumericScale());
+
+        int precision = dout + scale;
+        assert precision <= maxNumericPrecision;
+        assert precision > 0;
+
+        RelDataType ret;
+        ret = typeFactory.
+                createSqlType(
+                        SqlTypeName.DECIMAL,
+                        precision,
+                        scale);
+
+        return ret;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Infers the return type of a decimal mod operation. Decimal mod involves
+   * at least one decimal operand and requires both operands to have exact
+   * numeric types.
+   *
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return the result type for a decimal mod, or null if decimal
+   * mod should not be applied to the operands.
+   */
+  default RelDataType deriveDecimalModType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    if (SqlTypeUtil.isExactNumeric(type1)
+            && SqlTypeUtil.isExactNumeric(type2)) {
+      if (SqlTypeUtil.isDecimal(type1)
+              || SqlTypeUtil.isDecimal(type2)) {
+        return type2;
+      }
+    }
+    return null;
+  }
+
 }
 
 // End RelDataTypeSystem.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -107,29 +107,29 @@ public interface RelDataTypeSystem {
    * at least one decimal operand and requires both operands to have exact
    * numeric types.
    *
+   * Type-inference strategy whereby the result type of a call is the decimal
+   * sum of two exact numeric operands where at least one of the operands is a
+   * decimal. Let p1, s1 be the precision and scale of the first operand Let
+   * p2, s2 be the precision and scale of the second operand Let p, s be the
+   * precision and scale of the result, Then the result type is a decimal
+   * with:
+   *
+   * <ul>
+   * <li>s = max(s1, s2)</li>
+   * <li>p = max(p1 - s1, p2 - s2) + s + 1</li>
+   * </ul>
+   *
+   * <p>p and s are capped at their maximum values
+   *
+   * @link Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   *
+   * @param typeFactory typeFactory used to create output type
    * @param type1 type of the first operand
    * @param type2 type of the second operand
    * @return the result type for a decimal addition.
    */
   default RelDataType deriveDecimalPlusType(RelDataTypeFactory typeFactory,
                                             RelDataType type1, RelDataType type2) {
-    /**
-     * Type-inference strategy whereby the result type of a call is the decimal
-     * sum of two exact numeric operands where at least one of the operands is a
-     * decimal. Let p1, s1 be the precision and scale of the first operand Let
-     * p2, s2 be the precision and scale of the second operand Let p, s be the
-     * precision and scale of the result, Then the result type is a decimal
-     * with:
-     *
-     * <ul>
-     * <li>s = max(s1, s2)</li>
-     * <li>p = max(p1 - s1, p2 - s2) + s + 1</li>
-     * </ul>
-     *
-     * <p>p and s are capped at their maximum values
-     *
-     * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
-     */
     if (SqlTypeUtil.isExactNumeric(type1)
             && SqlTypeUtil.isExactNumeric(type2)) {
       if (SqlTypeUtil.isDecimal(type1)
@@ -161,6 +161,21 @@ public interface RelDataTypeSystem {
    * multiplication involves at least one decimal operand and requires both
    * operands to have exact numeric types.
    *
+   * Implemented with SQL 2003 compliant behavior. Let p1,
+   * s1 be the precision and scale of the first operand Let p2, s2 be the
+   * precision and scale of the second operand Let p, s be the precision and
+   * scale of the result, Then the result type is a decimal with:
+   *
+   * <ul>
+   * <li>p = p1 + p2</li>
+   * <li>s = s1 + s2</li>
+   * </ul>
+   *
+   * <p>p and s are capped at their maximum values
+   *
+   * @link Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   *
+   * @param typeFactory typeFactory used to create output type
    * @param type1 type of the first operand
    * @param type2 type of the second operand
    * @return the result type for a decimal multiplication, or null if decimal
@@ -168,21 +183,6 @@ public interface RelDataTypeSystem {
    */
   default RelDataType deriveDecimalMultiplyType(RelDataTypeFactory typeFactory,
       RelDataType type1, RelDataType type2) {
-    /**
-     * <p>Implement RelDataTypeFactory with SQL 2003 compliant behavior. Let p1,
-     * s1 be the precision and scale of the first operand Let p2, s2 be the
-     * precision and scale of the second operand Let p, s be the precision and
-     * scale of the result, Then the result type is a decimal with:
-     *
-     * <ul>
-     * <li>p = p1 + p2</li>
-     * <li>s = s1 + s2</li>
-     * </ul>
-     *
-     * <p>p and s are capped at their maximum values
-     *
-     * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
-     */
     if (SqlTypeUtil.isExactNumeric(type1)
             && SqlTypeUtil.isExactNumeric(type2)) {
       if (SqlTypeUtil.isDecimal(type1)
@@ -217,7 +217,27 @@ public interface RelDataTypeSystem {
    * Infers the return type of a decimal division. Decimal division involves
    * at least one decimal operand and requires both operands to have exact
    * numeric types.
+   /**
+   * Rules:
    *
+   * <ul>
+   * <li>Let p1, s1 be the precision and scale of the first operand
+   * <li>Let p2, s2 be the precision and scale of the second operand
+   * <li>Let p, s be the precision and scale of the result
+   * <li>Let d be the number of whole digits in the result
+   * <li>Then the result type is a decimal with:
+   *   <ul>
+   *   <li>d = p1 - s1 + s2</li>
+   *   <li>s &lt; max(6, s1 + p2 + 1)</li>
+   *   <li>p = d + s</li>
+   *   </ul>
+   * </li>
+   * <li>p and s are capped at their maximum values</li>
+   * </ul>
+   *
+   * @link Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
+   *
+   * @param typeFactory typeFactory used to create output type
    * @param type1 type of the first operand
    * @param type2 type of the second operand
    * @return the result type for a decimal division, or null if decimal
@@ -225,26 +245,7 @@ public interface RelDataTypeSystem {
    */
   default RelDataType deriveDecimalDivideType(RelDataTypeFactory typeFactory,
       RelDataType type1, RelDataType type2) {
-    /**
-     * Rules:
-     *
-     * <ul>
-     * <li>Let p1, s1 be the precision and scale of the first operand
-     * <li>Let p2, s2 be the precision and scale of the second operand
-     * <li>Let p, s be the precision and scale of the result
-     * <li>Let d be the number of whole digits in the result
-     * <li>Then the result type is a decimal with:
-     *   <ul>
-     *   <li>d = p1 - s1 + s2</li>
-     *   <li>s &lt; max(6, s1 + p2 + 1)</li>
-     *   <li>p = d + s</li>
-     *   </ul>
-     * </li>
-     * <li>p and s are capped at their maximum values</li>
-     * </ul>
-     *
-     * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
-     */
+
     if (SqlTypeUtil.isExactNumeric(type1)
             && SqlTypeUtil.isExactNumeric(type2)) {
       if (SqlTypeUtil.isDecimal(type1)
@@ -292,6 +293,7 @@ public interface RelDataTypeSystem {
    *
    * Always returns the type of the second argument as the return type
    * for the operation.
+   * @param typeFactory typeFactory used to create output type
    * @param type1 type of the first operand
    * @param type2 type of the second operand
    * @return the result type for a decimal mod, or null if decimal

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1557,7 +1557,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       new SqlFunction(
           "MOD",
           SqlKind.MOD,
-          ReturnTypes.ARG1_NULLABLE,
+          ReturnTypes.NULLABLE_MOD,
           null,
           OperandTypes.EXACT_NUMERIC_EXACT_NUMERIC,
           SqlFunctionCategory.NUMERIC);

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -515,16 +515,12 @@ public abstract class ReturnTypes {
    *
    * @see Glossary#SQL2003 SQL:2003 Part 2 Section 6.26
    */
-  public static final SqlReturnTypeInference DECIMAL_SUM =
-      new SqlReturnTypeInference() {
-        public RelDataType inferReturnType(
-            SqlOperatorBinding opBinding) {
-          RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
-          RelDataType type1 = opBinding.getOperandType(0);
-          RelDataType type2 = opBinding.getOperandType(1);
-          return typeFactory.createDecimalAddition(type1, type2);
-        }
-      };
+  public static final SqlReturnTypeInference DECIMAL_SUM = opBinding -> {
+    RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    RelDataType type1 = opBinding.getOperandType(0);
+    RelDataType type2 = opBinding.getOperandType(1);
+    return typeFactory.createDecimalAddition(type1, type2);
+  };
 
   /**
    * Same as {@link #DECIMAL_SUM} but returns with nullability if any
@@ -542,15 +538,12 @@ public abstract class ReturnTypes {
   public static final SqlReturnTypeInference NULLABLE_SUM =
       new SqlReturnTypeInferenceChain(DECIMAL_SUM_NULLABLE, LEAST_RESTRICTIVE);
 
-  public static final SqlReturnTypeInference DECIMAL_MOD =
-      new SqlReturnTypeInference() {
-        public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
-          RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
-          RelDataType type1 = opBinding.getOperandType(0);
-          RelDataType type2 = opBinding.getOperandType(1);
-          return typeFactory.createDecimalMod(type1, type2);
-        }
-      };
+  public static final SqlReturnTypeInference DECIMAL_MOD = opBinding -> {
+    RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    RelDataType type1 = opBinding.getOperandType(0);
+    RelDataType type2 = opBinding.getOperandType(1);
+    return typeFactory.createDecimalMod(type1, type2);
+  };
 
   private static final SqlReturnTypeInference DECIMAL_MOD_NULLABLE =
           cascade(DECIMAL_MOD, SqlTypeTransforms.TO_NULLABLE);
@@ -560,7 +553,7 @@ public abstract class ReturnTypes {
    * These rules are used for addition and subtraction.
    */
   public static final SqlReturnTypeInference NULLABLE_MOD =
-          new SqlReturnTypeInferenceChain(DECIMAL_MOD_NULLABLE, ARG1_NULLABLE);
+          chain(DECIMAL_MOD_NULLABLE, ARG1_NULLABLE);
 
   /**
    * Type-inference strategy whereby the result type of a call is

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -549,8 +549,8 @@ public abstract class ReturnTypes {
           cascade(DECIMAL_MOD, SqlTypeTransforms.TO_NULLABLE);
   /**
    * Type-inference strategy whereby the result type of a call is
-   * {@link #DECIMAL_SUM_NULLABLE} with a fallback to {@link #LEAST_RESTRICTIVE}
-   * These rules are used for addition and subtraction.
+   * {@link #DECIMAL_MOD_NULLABLE} with a fallback to {@link #ARG1_NULLABLE}
+   * These rules are used for modulo.
    */
   public static final SqlReturnTypeInference NULLABLE_MOD =
           chain(DECIMAL_MOD_NULLABLE, ARG1_NULLABLE);

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -449,7 +449,7 @@ public abstract class ReturnTypes {
     RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
     RelDataType type1 = opBinding.getOperandType(0);
     RelDataType type2 = opBinding.getOperandType(1);
-    return typeFactory.createDecimalProduct(type1, type2);
+    return typeFactory.getTypeSystem().deriveDecimalMultiplyType(typeFactory, type1, type2);
   };
   /**
    * Same as {@link #DECIMAL_PRODUCT} but returns with nullability if any of
@@ -479,7 +479,7 @@ public abstract class ReturnTypes {
     RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
     RelDataType type1 = opBinding.getOperandType(0);
     RelDataType type2 = opBinding.getOperandType(1);
-    return typeFactory.createDecimalQuotient(type1, type2);
+    return typeFactory.getTypeSystem().deriveDecimalDivideType(typeFactory, type1, type2);
   };
   /**
    * Same as {@link #DECIMAL_QUOTIENT} but returns with nullability if any of
@@ -519,7 +519,7 @@ public abstract class ReturnTypes {
     RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
     RelDataType type1 = opBinding.getOperandType(0);
     RelDataType type2 = opBinding.getOperandType(1);
-    return typeFactory.createDecimalAddition(type1, type2);
+    return typeFactory.getTypeSystem().deriveDecimalPlusType(typeFactory, type1, type2);
   };
 
   /**
@@ -542,7 +542,7 @@ public abstract class ReturnTypes {
     RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
     RelDataType type1 = opBinding.getOperandType(0);
     RelDataType type2 = opBinding.getOperandType(1);
-    return typeFactory.createDecimalMod(type1, type2);
+    return typeFactory.getTypeSystem().deriveDecimalModType(typeFactory, type1, type2);
   };
 
   private static final SqlReturnTypeInference DECIMAL_MOD_NULLABLE =

--- a/core/src/test/java/org/apache/calcite/sql/type/RelDataTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/RelDataTypeFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests return type inference using RelDataTypeFactory
+ */
+public class RelDataTypeFactoryTest {
+
+  private static final SqlTypeFixture TYPE_FIXTURE = new SqlTypeFixture();
+  private static final SqlTypeFactoryImpl TYPE_FACTORY = TYPE_FIXTURE.typeFactory;
+
+  @Test
+  public void testDecimalAdditionReturnTypeInference() {
+    RelDataType operand1 = TYPE_FACTORY.createSqlType(SqlTypeName.DECIMAL, 10, 1);
+    RelDataType operand2 = TYPE_FACTORY.createSqlType(SqlTypeName.DECIMAL, 10, 2);
+
+    RelDataType dataType = SqlStdOperatorTable.MINUS.inferReturnType(TYPE_FACTORY,
+            Lists.newArrayList(operand1, operand2));
+    Assert.assertEquals(12, dataType.getPrecision());
+    Assert.assertEquals(2, dataType.getScale());
+  }
+
+  @Test
+  public void testDecimalModReturnTypeInference() {
+    RelDataType operand1 = TYPE_FACTORY.createSqlType(SqlTypeName.DECIMAL, 10, 1);
+    RelDataType operand2 = TYPE_FACTORY.createSqlType(SqlTypeName.DECIMAL, 10, 2);
+
+    RelDataType dataType = SqlStdOperatorTable.MOD.inferReturnType(TYPE_FACTORY, Lists
+            .newArrayList(operand1, operand2));
+    Assert.assertEquals(10, dataType.getPrecision());
+    Assert.assertEquals(2, dataType.getScale());
+  }
+
+  @Test
+  public void testDoubleModReturnTypeInference() {
+    RelDataType operand1 = TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE);
+    RelDataType operand2 = TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE);
+
+    RelDataType dataType = SqlStdOperatorTable.MOD.inferReturnType(TYPE_FACTORY, Lists
+            .newArrayList(operand1, operand2));
+    Assert.assertEquals(SqlTypeName.DOUBLE, dataType.getSqlTypeName());
+  }
+}
+// End RelDataTypeFactoryTest.java


### PR DESCRIPTION
Decimal return type inference hard coded for mod and addition.
Extract them to methods on type factory which can be overriden if needed.

Change-Id: Id605c3478ac706cce588007597bd26f4abbe32ba