### PR TITLE
Fix complitation warnings after mongo java driver upgrade

### DIFF
--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSchema.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSchema.java
@@ -27,7 +27,6 @@ import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoDatabase;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -42,16 +41,17 @@ public class MongoSchema extends AbstractSchema {
    * Creates a MongoDB schema.
    *
    * @param host Mongo host, e.g. "localhost"
-   * @param credentialsList Optional credentials (empty list for none)
+   * @param credential Optional credentials (null for none)
    * @param options Mongo connection options
    * @param database Mongo database name, e.g. "foodmart"
    */
   MongoSchema(String host, String database,
-      List<MongoCredential> credentialsList, MongoClientOptions options) {
+      MongoCredential credential, MongoClientOptions options) {
     super();
     try {
-      final MongoClient mongo =
-          new MongoClient(new ServerAddress(host), credentialsList, options);
+      final MongoClient mongo = credential == null
+          ? new MongoClient(new ServerAddress(host), options)
+          : new MongoClient(new ServerAddress(host), credential, options);
       this.mongoDb = mongo.getDatabase(database);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSchemaFactory.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSchemaFactory.java
@@ -24,8 +24,6 @@ import com.mongodb.AuthenticationMechanism;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,16 +44,17 @@ public class MongoSchemaFactory implements SchemaFactory {
 
     final MongoClientOptions.Builder options = MongoClientOptions.builder();
 
-    final List<MongoCredential> credentials = new ArrayList<>();
+    final MongoCredential credential;
     if (authMechanismName != null) {
-      final MongoCredential credential = createCredentials(operand);
-      credentials.add(credential);
+      credential = createCredential(operand);
+    } else {
+      credential = null;
     }
 
-    return new MongoSchema(host, database, credentials, options.build());
+    return new MongoSchema(host, database, credential, options.build());
   }
 
-  private MongoCredential createCredentials(Map<String, Object> map) {
+  private MongoCredential createCredential(Map<String, Object> map) {
     final String authMechanismName = (String) map.get("authMechanism");
     final AuthenticationMechanism authenticationMechanism =
         AuthenticationMechanism.fromMechanismName(authMechanismName);
@@ -70,11 +69,11 @@ public class MongoSchemaFactory implements SchemaFactory {
     case SCRAM_SHA_1:
       return MongoCredential.createScramSha1Credential(username, authDatabase,
           password.toCharArray());
+    case SCRAM_SHA_256:
+      return MongoCredential.createScramSha256Credential(username, authDatabase,
+          password.toCharArray());
     case GSSAPI:
       return MongoCredential.createGSSAPICredential(username);
-    case MONGODB_CR:
-      return MongoCredential.createMongoCRCredential(username, authDatabase,
-          password.toCharArray());
     case MONGODB_X509:
       return MongoCredential.createMongoX509Credential(username);
     }

--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -94,7 +94,7 @@ public class MongoAdapterTest implements SchemaFactory {
     // Manually insert data for data-time test.
     MongoCollection<BsonDocument> datatypes =  database.getCollection("datatypes")
         .withDocumentClass(BsonDocument.class);
-    if (datatypes.count() > 0) {
+    if (datatypes.countDocuments() > 0) {
       datatypes.deleteMany(new BsonDocument());
     }
 
@@ -112,7 +112,7 @@ public class MongoAdapterTest implements SchemaFactory {
       throws IOException {
     Objects.requireNonNull(collection, "collection");
 
-    if (collection.count() > 0) {
+    if (collection.countDocuments() > 0) {
       // delete any existing documents (run from a clean set)
       collection.deleteMany(new BsonDocument());
     }


### PR DESCRIPTION
Some methods were deprecated after client upgrade to 3.10.2 (see [CALCITE-3157])