### PR TITLE
[CALCITE-3197] Convert data of Timestamp/Time/Date as original form when enumerating from ArrayTable.

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -2427,6 +2427,12 @@ public class MaterializationTest {
             + "  join\n"
             + "  \"depts\" \"y\"\n"
             + "  on \"x\".\"deptno\"=\"y\".\"deptno\"\n";
+  }
+
+  @Test public void testTimestampType() {
+    String sql = "select \"eventid\", \"ts\"\n"
+          + "from \"events\"\n"
+          + "where \"eventid\" > 5";
     checkMaterialize(sql, sql);
   }
 


### PR DESCRIPTION
In current implementation of `ColumnLoader`, data of `Rep.JAVA_SQL_TIMESTAMP/Rep.JAVA_SQL_TIME/Rep.JAVA_SQL_DATE` are converted as numeric during loading. https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/adapter/clone/ColumnLoader.java#L234
But current code seems forgot to revert the data back to original form when enumerating.
As a result, below test is failing now
```
// MaterializationTest.java

@Test public void testTimestampType() {
  String sql = "select \"eventid\", \"ts\"\n"
        + "from \"events\"\n"
        + "where \"eventid\" > 5";
  checkMaterialize(sql, sql);
}

java.lang.ClassCastException: java.lang.Long cannot be cast to java.sql.Timestamp

	at org.apache.calcite.avatica.util.AbstractCursor$TimestampAccessor.getTimestamp(AbstractCursor.java:1118)
	at org.apache.calcite.avatica.util.AbstractCursor$TimestampAccessor.getLong(AbstractCursor.java:1157)
	at org.apache.calcite.avatica.util.AbstractCursor$TimestampAccessor.getString(AbstractCursor.java:1149)
	at org.apache.calcite.avatica.AvaticaResultSet.getString(AvaticaResultSet.java:239)
	at org.apache.calcite.test.CalciteAssert$ResultSetFormatter.rowToString(CalciteAssert.java:1905)
	at org.apache.calcite.test.CalciteAssert$ResultSetFormatter.toStringList(CalciteAssert.java:1923)
	at org.apache.calcite.test.CalciteAssert.toStringList(CalciteAssert.java:683)
	at org.apache.calcite.test.CalciteAssert$3.accept(CalciteAssert.java:355)
	at org.apache.calcite.test.CalciteAssert$3.accept(CalciteAssert.java:347)
	at org.apache.calcite.test.CalciteAssert.assertQuery(CalciteAssert.java:538)
	at org.apache.calcite.test.CalciteAssert$AssertQuery.lambda$returns$1(CalciteAssert.java:1440)
	at org.apache.calcite.test.CalciteAssert$AssertQuery.withConnection(CalciteAssert.java:1372)
	at org.apache.calcite.test.CalciteAssert$AssertQuery.returns(CalciteAssert.java:1438)
	at org.apache.calcite.test.CalciteAssert$AssertQuery.returns(CalciteAssert.java:1421)
	at org.apache.calcite.test.CalciteAssert$AssertQuery.sameResultWithMaterializationsDisabled(CalciteAssert.java:1625)
	at org.apache.calcite.test.MaterializationTest.checkMaterialize(MaterializationTest.java:210)
	at org.apache.calcite.test.MaterializationTest.checkMaterialize(MaterializationTest.java:188)
	at org.apache.calcite.test.MaterializationTest.testTimestampType(MaterializationTest.java:2409)
```
For type of `Rep.JAVA_SQL_TIMESTAMP/Rep.JAVA_SQL_TIME/Rep.JAVA_SQL_DATE`, cursor acesses by `TimestampAccessor/TimeAccessor/DateAccessor`, which expect column value as `Timestamp/Time/Date`.
It make sense to 'unwrap' the data as original form when enumerating from `ArrayTable`.

This PR proposes to add a `unwrapper` to `ArrayTable.Column` and use the `unwrapper` to do conversion for special types mentioned above

I added simple tests for type of `JAVA_SQL_TIMESTAMP` for illustration. If this PR is reviewed as valid. I can add more tests in `ArrayTableTest` for types of `Rep.JAVA_SQL_TIMESTAMP/Rep.JAVA_SQL_TIME/Rep.JAVA_SQL_DATE`