### PR TITLE
[CALCITE-3195] Handle UDF that throws checked exceptions in enumerable code generator

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -115,6 +115,12 @@ public class UdfTest {
         + "'\n"
         + "         },\n"
         + "         {\n"
+        + "           name: 'MY_EXCEPTION',\n"
+        + "           className: '"
+        + Smalls.MyExceptionFunction.class.getName()
+        + "'\n"
+        + "         },\n"
+        + "         {\n"
         + "           name: 'COUNT_ARGS',\n"
         + "           className: '"
         + Smalls.CountArgs0Function.class.getName()
@@ -217,6 +223,35 @@ public class UdfTest {
         + "P=20\n"
         + "P=20\n";
     withUdf().query(sql).returns(expected);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3195">[CALCITE-3195]
+   * Handle a UDF that throws checked exceptions in the Enumerable code generator</a>. */
+  @Test public void testUserDefinedFunctionWithException() throws Exception {
+    final String sql1 = "select \"adhoc\".my_exception(\"deptno\") as p\n"
+        + "from \"adhoc\".EMPLOYEES";
+    final String expected1 = "P=20\n"
+        + "P=30\n"
+        + "P=20\n"
+        + "P=20\n";
+    withUdf().query(sql1).returns(expected1);
+
+    final String sql2 = "select cast(\"adhoc\".my_exception(\"deptno\") as double) as p\n"
+        + "from \"adhoc\".EMPLOYEES";
+    final String expected2 = "P=20.0\n"
+        + "P=30.0\n"
+        + "P=20.0\n"
+        + "P=20.0\n";
+    withUdf().query(sql2).returns(expected2);
+
+    final String sql3 = "select \"adhoc\".my_exception(\"deptno\" * 2 + 11) as p\n"
+        + "from \"adhoc\".EMPLOYEES";
+    final String expected3 = "P=41\n"
+        + "P=61\n"
+        + "P=41\n"
+        + "P=41\n";
+    withUdf().query(sql3).returns(expected3);
   }
 
   /** Test case for

--- a/core/src/test/java/org/apache/calcite/util/Smalls.java
+++ b/core/src/test/java/org/apache/calcite/util/Smalls.java
@@ -50,6 +50,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 import com.google.common.collect.ImmutableList;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -465,6 +466,20 @@ public class Smalls {
   public static class MyIncrement {
     public float eval(int x, int y) {
       return x + x * y / 100;
+    }
+  }
+
+  /** User-defined function that declares exceptions. */
+  public static class MyExceptionFunction {
+    public MyExceptionFunction() {}
+
+    public static int eval(int x) throws IllegalArgumentException, IOException {
+      if (x < 0) {
+        throw new IllegalArgumentException("Illegal argument: " + x);
+      } else if (x > 100) {
+        throw new IOException("IOException when argument > 100");
+      }
+      return x + 10;
     }
   }
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Shuttle.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Shuttle.java
@@ -250,8 +250,17 @@ public class Shuttle {
     return switchStatement;
   }
 
-  public Statement visit(TryStatement tryStatement) {
-    return tryStatement;
+  public Shuttle preVisit(TryStatement tryStatement) {
+    return this;
+  }
+
+  public Statement visit(TryStatement tryStatement,
+      Statement body, List<CatchBlock> catchBlocks, Statement fynally) {
+    return body.equals(tryStatement.body)
+           && Objects.equals(catchBlocks, tryStatement.catchBlocks)
+           && Objects.equals(fynally, tryStatement.fynally)
+           ? tryStatement
+           : new TryStatement(body, catchBlocks, fynally);
   }
 
   public Expression visit(MemberInitExpression memberInitExpression) {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/TryStatement.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/TryStatement.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.linq4j.tree;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,7 +37,17 @@ public class TryStatement extends Statement {
   }
 
   @Override public Statement accept(Shuttle shuttle) {
-    return shuttle.visit(this);
+    shuttle = shuttle.preVisit(this);
+    Statement body1 = body.accept(shuttle);
+    List<CatchBlock> catchBlocks1 = new ArrayList<>();
+    for (CatchBlock cb: catchBlocks) {
+      Statement cbBody = cb.body.accept(shuttle);
+      catchBlocks1.add(
+          Expressions.catch_(cb.parameter, cbBody));
+    }
+    Statement fynally1 =
+        fynally == null ? null : fynally.accept(shuttle);
+    return shuttle.visit(this, body1, catchBlocks1, fynally1);
   }
 
   public <R> R accept(Visitor<R> visitor) {


### PR DESCRIPTION
Details are described in [JIRA](https://issues.apache.org/jira/browse/CALCITE-3195).
This PR handles checked exceptions declared in method.
(1) Wrap a method call in a `try...catch...` block;
(2) Enable BlockBuilder to inline variables in `TryStatement`.