### PR TITLE
[CALCITE-3203] When matching materializations, match Project with child of Aggregate

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -550,6 +550,17 @@ public class MaterializationTest {
         "select count(*) + 1 as c, \"deptno\" from \"emps\" group by \"deptno\"");
   }
 
+  @Test public void testAggregate3() {
+    checkMaterialize(
+        "select \"deptno\", count(1), 2 * sum(\"empid\") from "
+            + "(select * from \"emps\" union all select * from \"emps\")"
+            + "group by \"deptno\"",
+        "select \"deptno\", 2 * sum(\"empid\") from "
+            + "(select * from \"emps\" union all select * from \"emps\")"
+            + "group by \"deptno\"");
+  }
+
+
   /** Aggregation query at same level of aggregation as aggregation
    * materialization with grouping sets. */
   @Test public void testAggregateGroupSets1() {


### PR DESCRIPTION
In current code, `SubstitutionVisitor` & `MaterializedViewSubstitutionVisitor` fail to support below matching:
```
   query:   Project(projects: [$0, *(2, $1)])
                  Aggregate(groupSet: {0}, groupSets: [{0}], calls: [SUM($1)])
                     Scan(table: [hr, emps])</li>
   target:  Project(projects: [$0, *(2, $1), *(2, $2)])
                  Aggregate(groupSet: {0}, groupSets: [{0}], calls: [SUM($1), COUNT()])
                     Scan(table: [hr, emps])</li>
```

And below test fails
```
// MaterializationTest.java
  @Test public void testAggregate() {
    checkMaterialize(
      "select \"deptno\", count(1), 2 * sum(\"empid\") from "
        + "(select * from \"emps\" union all select * from \"emps\")"
        + "group by \"deptno\"",
      "select \"deptno\", 2 * sum(\"empid\") from "
        + "(select * from \"emps\" union all select * from \"emps\")"
        + "group by \"deptno\"");
  }
```

The reason is that `Project&Aggregate` are not taken into consideration at the same time in current matching rules.
It might make sense to create a rule of `ProjectOnAggregateToProjectOnAggregateUnifyRule` to handle such case.
