### PR TITLE
[CALCITE-3207] Fail to convert Join RelNode with like condition to sql statement

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -223,6 +223,7 @@ public abstract class SqlImplementor {
     case GREATER_THAN_OR_EQUAL:
     case LESS_THAN:
     case LESS_THAN_OR_EQUAL:
+    case LIKE:
       node = stripCastFromString(node);
       operands = ((RexCall) node).getOperands();
       op = ((RexCall) node).getOperator();


### PR DESCRIPTION
Calcite cannot convert rel node to sql statement, which case is the condition of join is 'like' expression.