### PR TITLE
[CALCITE-3211] List of MutableRel may fail to be identified by SubstitutionVisitor during matching

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
@@ -62,6 +62,7 @@ import com.google.common.collect.Lists;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /** Utilities for dealing with {@link MutableRel}s. */
 public abstract class MutableRels {
@@ -399,7 +400,8 @@ public abstract class MutableRels {
   }
 
   private static List<MutableRel> toMutables(List<RelNode> nodes) {
-    return Lists.transform(nodes, MutableRels::toMutable);
+    return nodes.stream().map(MutableRels::toMutable)
+        .collect(Collectors.toList());
   }
 }
 

--- a/core/src/test/java/org/apache/calcite/test/MutableRelTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MutableRelTest.java
@@ -195,6 +195,15 @@ public class MutableRelTest {
     MatcherAssert.assertThat(actual, Matchers.isLinux(expected));
   }
 
+  @Test public void testParentInfoOfUnion() {
+    MutableRel mutableRel = createMutableRel(
+        "select sal from emp where deptno = 10"
+            + "union select sal from emp where ename like 'John%'");
+    for (MutableRel input: mutableRel.getInputs()) {
+      Assert.assertTrue(input.getParent() == mutableRel);
+    }
+  }
+
   /** Verifies that after conversion to and from a MutableRel, the new
    * RelNode remains identical to the original RelNode. */
   private static void checkConvertMutableRel(String rel, String sql) {


### PR DESCRIPTION
Current implementation of MutableRels::toMutables is as below:
```
  private static List<MutableRel> toMutables(List<RelNode> nodes) {
    return Lists.transform(nodes, MutableRels::toMutable);
  }
```
Thus every time we get from the result list, a new `MutableRel` will be created:
```
  private static class TransformingRandomAccessList<F, T> extends AbstractList<T>
      implements RandomAccess, Serializable {
    final List<F> fromList;
    final Function<? super F, ? extends T> function;

    TransformingRandomAccessList(List<F> fromList, Function<? super F, ? extends T> function) {
      this.fromList = checkNotNull(fromList);
      this.function = checkNotNull(function);
    }

    @Override
    public T get(int index) {
      return function.apply(fromList.get(index));
    }
......
```
As a result, https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java#L514 SubstitutionVisitor will fail to check whether a node has been met/matched before