### PR TITLE
[CALCITE-3214] Add UnionToUnionRule for materialization matching.

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -2430,6 +2430,12 @@ public class MaterializationTest {
     checkMaterialize(sql, sql);
   }
 
+  @Test public void testUnionToUnion() {
+    String sql0 = "select * from \"emps\" where \"empid\" < 300";
+    String sql1 = "select * from \"emps\" where \"empid\" > 200";
+    checkMaterialize(sql0 + " union all " + sql1, sql1 + " union all " + sql0);
+  }
+
   private static <E> List<List<List<E>>> list3(E[][][] as) {
     final ImmutableList.Builder<List<List<E>>> builder =
         ImmutableList.builder();


### PR DESCRIPTION
Below materialization matching fails now
```
  @Test public void testDEV() {
    String sql0 = "select * from \"emps\" where \"empid\" < 300";
    String sql1 = "select * from \"emps\" where \"empid\" > 200";
    checkMaterialize(sql0 + " union all " + sql1, sql1 + " union all " + sql0);
  }
```
This PR proposes to add a rule for Union matching