### PR TITLE
[CALCITE-3210] Fix the bug that RelToSqlConverter converts "cast(null as $type)" just as null

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -41,6 +41,7 @@ import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
@@ -64,6 +65,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlUpdate;
+import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.fun.SqlRowOperator;
 import org.apache.calcite.sql.fun.SqlSingleValueAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -199,11 +201,25 @@ public class RelToSqlConverter extends SqlImplementor
     final List<SqlNode> selectList = new ArrayList<>();
     for (RexNode ref : e.getChildExps()) {
       SqlNode sqlExpr = builder.context.toSql(null, ref);
+      if (SqlUtil.isNullLiteral(sqlExpr, false)) {
+        sqlExpr = castNullType(sqlExpr, e.getRowType().getFieldList().get(selectList.size()));
+      }
       addSelect(selectList, sqlExpr, e.getRowType());
     }
 
     builder.setSelect(new SqlNodeList(selectList, POS));
     return builder.result();
+  }
+
+  /**
+   * Wrap the {@code sqlNodeNull} in a CAST operator with target type as {@code field}.
+   * @param sqlNodeNull null literal
+   * @param field field description of sqlNodeNull
+   * @return null literal wrapped in CAST call.
+   */
+  private SqlNode castNullType(SqlNode sqlNodeNull, RelDataTypeField field) {
+    return SqlStdOperatorTable.CAST.createCall(POS,
+            sqlNodeNull, dialect.getCastSpec(field.getType()));
   }
 
   /** @see #dispatch */

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3754,12 +3754,13 @@ public class RelToSqlConverterTest {
   }
 
   @Test public void testSelectNullWithInsertFromJoin() {
-    String query = "insert into "
-            + "\"account\"(\"account_id\",\"account_parent\",\"account_type\",\"account_rollup\")"
-            + "\tselect \"product\".\"product_id\", \n"
-            + "\tcast(NULL AS INT), \n"
-            + "\tcast(\"product\".\"product_id\" as varchar), \n"
-            + "\tcast(\"sales_fact_1997\".\"store_id\" as varchar)\n"
+    String query = "insert into \n"
+            + "\"account\"(\"account_id\",\"account_parent\",\n"
+            + "\"account_type\",\"account_rollup\")\n"
+            + "select \"product\".\"product_id\", \n"
+            + "cast(NULL AS INT), \n"
+            + "cast(\"product\".\"product_id\" as varchar), \n"
+            + "cast(\"sales_fact_1997\".\"store_id\" as varchar)\n"
             + "    from \"product\"\n"
             + "    inner join \"sales_fact_1997\"\n"
             + "    on \"product\".\"product_id\" = \"sales_fact_1997\".\"product_id\"";

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3761,9 +3761,9 @@ public class RelToSqlConverterTest {
             + "cast(NULL AS INT), \n"
             + "cast(\"product\".\"product_id\" as varchar), \n"
             + "cast(\"sales_fact_1997\".\"store_id\" as varchar)\n"
-            + "    from \"product\"\n"
-            + "    inner join \"sales_fact_1997\"\n"
-            + "    on \"product\".\"product_id\" = \"sales_fact_1997\".\"product_id\"";
+            + "from \"product\"\n"
+            + "inner join \"sales_fact_1997\"\n"
+            + "on \"product\".\"product_id\" = \"sales_fact_1997\".\"product_id\"";
     final String expected = "INSERT INTO \"foodmart\".\"account\" "
             + "(\"account_id\", \"account_parent\", \"account_description\", "
             + "\"account_type\", \"account_rollup\", \"Custom_Members\")\n"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3738,16 +3738,50 @@ public class RelToSqlConverterTest {
     String query = "insert into "
             + "\"account\"(\"account_id\",\"account_parent\",\"account_type\",\"account_rollup\")"
             + " select 1, cast(NULL AS INT), cast(123 as varchar), cast(123 as varchar)";
-    final String expected = "INSERT INTO \"foodmart\".\"account\" (\"account_id\", \"account_parent\", \"account_description\", "
+    final String expected = "INSERT INTO \"foodmart\".\"account\" ("
+            + "\"account_id\", \"account_parent\", \"account_description\", "
             + "\"account_type\", \"account_rollup\", \"Custom_Members\")\n"
-            + "(SELECT 1 AS \"account_id\", CAST(NULL AS INTEGER) AS \"account_parent\", CAST(NULL AS VARCHAR(30) CHARACTER SET "
-            + "\"ISO-8859-1\") AS \"account_description\", '123' AS \"account_type\", '123' AS \"account_rollup\", CAST(NULL AS VARCHAR"
+            + "(SELECT 1 AS \"account_id\", CAST(NULL AS INTEGER) AS \"account_parent\","
+            + " CAST(NULL AS VARCHAR(30) CHARACTER SET "
+            + "\"ISO-8859-1\") AS \"account_description\", '123' AS \"account_type\", "
+            + ""
+            + "'123' AS \"account_rollup\", CAST(NULL AS VARCHAR"
             + "(255) CHARACTER SET \"ISO-8859-1\") AS \"Custom_Members\"\n"
             + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\"))";
     sql(query).ok(expected);
     // validate
     sql(expected).exec();
   }
+
+  @Test public void testSelectNullWithInsertFromJoin() {
+    String query = "insert into "
+            + "\"account\"(\"account_id\",\"account_parent\",\"account_type\",\"account_rollup\")"
+            + "\tselect \"product\".\"product_id\", \n"
+            + "\tcast(NULL AS INT), \n"
+            + "\tcast(\"product\".\"product_id\" as varchar), \n"
+            + "\tcast(\"sales_fact_1997\".\"store_id\" as varchar)\n"
+            + "    from \"product\"\n"
+            + "    inner join \"sales_fact_1997\"\n"
+            + "    on \"product\".\"product_id\" = \"sales_fact_1997\".\"product_id\"";
+    final String expected = "INSERT INTO \"foodmart\".\"account\" "
+            + "(\"account_id\", \"account_parent\", \"account_description\", "
+            + "\"account_type\", \"account_rollup\", \"Custom_Members\")\n"
+            + "(SELECT \"product\".\"product_id\" AS \"account_id\", "
+            + "CAST(NULL AS INTEGER) AS \"account_parent\", CAST(NULL AS VARCHAR"
+            + "(30) CHARACTER SET \"ISO-8859-1\") AS \"account_description\", "
+            + "CAST(\"product\".\"product_id\" AS VARCHAR CHARACTER SET "
+            + "\"ISO-8859-1\") AS \"account_type\", "
+            + "CAST(\"sales_fact_1997\".\"store_id\" AS VARCHAR CHARACTER SET \"ISO-8859-1\") AS "
+            + "\"account_rollup\", "
+            + "CAST(NULL AS VARCHAR(255) CHARACTER SET \"ISO-8859-1\") AS \"Custom_Members\"\n"
+            + "FROM \"foodmart\".\"product\"\n"
+            + "INNER JOIN \"foodmart\".\"sales_fact_1997\" "
+            + "ON \"product\".\"product_id\" = \"sales_fact_1997\".\"product_id\")";
+    sql(query).ok(expected);
+    // validate
+    sql(expected).exec();
+  }
+
 
   @Test public void testDialectQuoteStringLiteral() {
     dialects().forEach((dialect, databaseProduct) -> {


### PR DESCRIPTION
Fix the bug described in https://issues.apache.org/jira/browse/CALCITE-3210?filter=-1