### PR TITLE
Fix compiler warnings

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceDecimalsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceDecimalsRule.java
@@ -939,7 +939,8 @@ public class ReduceDecimalsRule extends RelOptRule {
       // a lower scale, then the number should be scaled down.
       int divisor = scaleA + scaleB - call.getType().getScale();
 
-      if (builder.getTypeFactory().useDoubleMultiplication(
+      if (builder.getTypeFactory().getTypeSystem().shouldUseDoubleMultiplication(
+          builder.getTypeFactory(),
           typeA,
           typeB)) {
         // Approximate implementation:

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -39,7 +39,6 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlQuantifyOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
@@ -198,7 +197,7 @@ public abstract class SubQueryRemoveRule extends RelOptRule {
                   builder.field("q", "m"))), builder.literal(true), builder
               .call(SqlStdOperatorTable.GREATER_THAN, builder.field("q", "c"),
                   builder.field("q", "d")),
-          e.rel.getCluster().getRexBuilder().makeNullLiteral(SqlTypeName.BOOLEAN), builder
+          builder.getRexBuilder().constantNull(), builder
               .call(RelOptUtil.op(op.comparisonKind, null), e.operands.get(0),
                   builder.field("q", "m")));
     } else {
@@ -241,7 +240,7 @@ public abstract class SubQueryRemoveRule extends RelOptRule {
                   builder.field("q", "m"))), builder.literal(true), builder
               .call(SqlStdOperatorTable.GREATER_THAN, builder.field("q", "c"),
                   builder.field("q", "d")),
-          e.rel.getCluster().getRexBuilder().makeNullLiteral(SqlTypeName.BOOLEAN), builder
+          builder.getRexBuilder().constantNull(), builder
               .call(RelOptUtil.op(op.comparisonKind, null), e.operands.get(0),
                   builder.field("q", "m")));
     }

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -460,6 +460,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
    * {@link RelDataTypeSystem#deriveDecimalMultiplyType(RelDataTypeFactory, RelDataType, RelDataType)}
    * to get the return type for the operation.
    */
+  @Deprecated
   public RelDataType createDecimalProduct(
       RelDataType type1,
       RelDataType type2) {
@@ -471,6 +472,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
    * {@link RelDataTypeSystem#shouldUseDoubleMultiplication(RelDataTypeFactory, RelDataType, RelDataType)}
    * to get if double should be used for multiplication.
    */
+  @Deprecated
   public boolean useDoubleMultiplication(
       RelDataType type1,
       RelDataType type2) {
@@ -482,6 +484,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
    * {@link RelDataTypeSystem#deriveDecimalDivideType(RelDataTypeFactory, RelDataType, RelDataType)}
    * to get the return type for the operation.
    */
+  @Deprecated
   public RelDataType createDecimalQuotient(
       RelDataType type1,
       RelDataType type2) {

--- a/pom.xml
+++ b/pom.xml
@@ -745,7 +745,10 @@ limitations under the License.
         <!-- If you are looking to change source/target,
              change the maven.compiler.{source,target} property -->
         <configuration>
-          <compilerArgument>-Xlint:deprecation</compilerArgument>
+          <compilerArgs>
+            <arg>-Xlint:deprecation</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Fix compiler warnings introduced by patches for issues CALCITE-3031 and
CALCITE-3187.
Also force compiler to stop if such warnings are detected.