### PR TITLE
[CALCITE-3223] Non-RexInputRef may fails the matching of FilterToProjectUnifyRule during 'invert' by mistake

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1121,6 +1121,10 @@ public class SubstitutionVisitor {
       return MutableProject.of(input, exprList, Pair.right(namedProjects));
     }
 
+    /**
+     * Project the "input" to achieve the same schema as "model" by analying
+     * the mapping information from "project".
+     */
     protected MutableRel invert(MutableRel model, MutableRel input,
         MutableProject project) {
       LOGGER.trace("SubstitutionVisitor: invert:\nmodel: {}\ninput: {}\nproject: {}\n",
@@ -1130,9 +1134,13 @@ public class SubstitutionVisitor {
       }
       final List<RexNode> exprList = new ArrayList<>();
       final RexBuilder rexBuilder = model.cluster.getRexBuilder();
+
+      // Initialize "exprList" with nulls.
       for (int i = 0; i < model.rowType.getFieldCount(); i++) {
         exprList.add(null);
       }
+      // Fill in "exprList" with list of "RexInputRef" by
+      // analyzing mapping information from "project".
       for (Ord<RexNode> expr : Ord.zip(project.projects)) {
         if (expr.e instanceof RexInputRef) {
           final int target = ((RexInputRef) expr.e).getIndex();
@@ -1144,6 +1152,7 @@ public class SubstitutionVisitor {
           }
         }
       }
+      // If a column failed to be projected from "input", matching fails.
       if (exprList.indexOf(null) != -1) {
         throw MatchFailed.INSTANCE;
       }

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1130,19 +1130,22 @@ public class SubstitutionVisitor {
       }
       final List<RexNode> exprList = new ArrayList<>();
       final RexBuilder rexBuilder = model.cluster.getRexBuilder();
-      for (RelDataTypeField field : model.rowType.getFieldList()) {
-        exprList.add(rexBuilder.makeZeroLiteral(field.getType()));
+      for (int i = 0; i < model.rowType.getFieldCount(); i++) {
+        exprList.add(null);
       }
       for (Ord<RexNode> expr : Ord.zip(project.projects)) {
         if (expr.e instanceof RexInputRef) {
           final int target = ((RexInputRef) expr.e).getIndex();
-          exprList.set(target,
-              rexBuilder.ensureType(expr.e.getType(),
-                  RexInputRef.of(expr.i, input.rowType),
-                  false));
-        } else {
-          throw MatchFailed.INSTANCE;
+          if (exprList.get(target) == null) {
+            exprList.set(target,
+                rexBuilder.ensureType(expr.e.getType(),
+                    RexInputRef.of(expr.i, input.rowType),
+                    false));
+          }
         }
+      }
+      if (exprList.indexOf(null) != -1) {
+        throw MatchFailed.INSTANCE;
       }
       return MutableProject.of(model.rowType, input, exprList);
     }


### PR DESCRIPTION
In current code of FilterToProjectUnifyRule::invert(https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java#L1124), the implementation 
1. Fails the matching when there is Non-RexInputRef in the `projects`
2. Didn't check if all `exprList` has already ben set correctly.
As a result below tests fails.
```
  @Test public void testFilterToProject0() {
    String union =
        "select * from \"emps\" where \"empid\" > 300\n"
            + "union all select * from \"emps\" where \"empid\" < 200";
    String mv = "select *, \"empid\" * 2 from (" + union + ")";
    String query = "select * from (" + union + ") where (\"empid\" * 2) > 3";
    checkMaterialize(mv, query);
  }

  @Test public void testFilterToProject1() {
    String agg =
        "select \"deptno\", count(*) as \"c\", sum(\"salary\") as \"s\"\n"
            + "from \"emps\" group by \"deptno\"";
    String mv = "select \"c\", \"s\", \"s\" from (" + agg + ")";
    String query = "select * from (" + agg + ") where (\"s\" * 0.8) > 10000";
    checkNoMaterialize(mv, query, HR_FKUK_MODEL);
  }
```
This PR proposes to refine the method of `invert`:
1. `Projects` is regarded as valid as long as all the input fields are projected
2.  Check if all items of `exprList` has already ben set correctly.