### PR TITLE
[CALCITE-3224] New RexNode-to-Expression CodeGen Implementation

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/NullPolicy.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/NullPolicy.java
@@ -33,14 +33,5 @@ public enum NullPolicy {
   ANY,
   /** If the first argument is null, return null. */
   ARG0,
-  /** If any of the arguments are false, result is false; else if any
-   * arguments are null, result is null; else true. */
-  AND,
-  /** If any of the arguments are true, result is true; else if any
-   * arguments are null, result is null; else false. */
-  OR,
-  /** If any argument is true, result is false; else if any argument is null,
-   * result is null; else true. */
-  NOT,
   NONE
 }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.adapter.enumerable;
 
+import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.avatica.util.TimeUnitRange;
@@ -48,6 +49,7 @@ import org.apache.calcite.schema.impl.AggregateFunctionImpl;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlJsonConstructorNullClause;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlMatchFunction;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlTypeConstructorFunction;
@@ -60,6 +62,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlUserDefinedAggFunction;
 import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
+import org.apache.calcite.sql.validate.SqlUserDefinedTableFunction;
+import org.apache.calcite.sql.validate.SqlUserDefinedTableMacro;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Util;
 
@@ -77,12 +81,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.apache.calcite.linq4j.tree.ExpressionType.Add;
-import static org.apache.calcite.linq4j.tree.ExpressionType.AndAlso;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Divide;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Equal;
 import static org.apache.calcite.linq4j.tree.ExpressionType.GreaterThan;
@@ -91,9 +96,7 @@ import static org.apache.calcite.linq4j.tree.ExpressionType.LessThan;
 import static org.apache.calcite.linq4j.tree.ExpressionType.LessThanOrEqual;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Multiply;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Negate;
-import static org.apache.calcite.linq4j.tree.ExpressionType.Not;
 import static org.apache.calcite.linq4j.tree.ExpressionType.NotEqual;
-import static org.apache.calcite.linq4j.tree.ExpressionType.OrElse;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Subtract;
 import static org.apache.calcite.linq4j.tree.ExpressionType.UnaryPlus;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CHR;
@@ -143,7 +146,6 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.BIT_AND;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.BIT_OR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.BIT_XOR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CARDINALITY;
-import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CASE;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CAST;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CBRT;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CEIL;
@@ -253,7 +255,6 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.PI;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.PLUS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.POSITION;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.POWER;
-import static org.apache.calcite.sql.fun.SqlStdOperatorTable.PREV;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.RADIANS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.RAND;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.RAND_INTEGER;
@@ -303,7 +304,7 @@ public class RexImpTable {
   public static final MemberExpression BOXED_TRUE_EXPR =
       Expressions.field(null, Boolean.class, "TRUE");
 
-  private final Map<SqlOperator, CallImplementor> map = new HashMap<>();
+  private final Map<SqlOperator, RexCallImplementor> map = new HashMap<>();
   private final Map<SqlAggFunction, Supplier<? extends AggImplementor>> aggMap =
       new HashMap<>();
   private final Map<SqlAggFunction, Supplier<? extends WinAggImplementor>> winAggMap =
@@ -314,7 +315,7 @@ public class RexImpTable {
       tvfImplementorMap = new HashMap<>();
 
   RexImpTable() {
-    defineMethod(ROW, BuiltInMethod.ARRAY.method, NullPolicy.ANY);
+    defineMethod(ROW, BuiltInMethod.ARRAY.method, NullPolicy.NONE);
     defineMethod(UPPER, BuiltInMethod.UPPER.method, NullPolicy.STRICT);
     defineMethod(LOWER, BuiltInMethod.LOWER.method, NullPolicy.STRICT);
     defineMethod(INITCAP,  BuiltInMethod.INITCAP.method, NullPolicy.STRICT);
@@ -346,20 +347,18 @@ public class RexImpTable {
     defineMethod(DIFFERENCE, BuiltInMethod.DIFFERENCE.method, NullPolicy.STRICT);
     defineMethod(REVERSE, BuiltInMethod.REVERSE.method, NullPolicy.STRICT);
 
-    final TrimImplementor trimImplementor = new TrimImplementor();
-    defineImplementor(TRIM, NullPolicy.STRICT, trimImplementor, false);
+    map.put(TRIM, new TrimImplementor());
 
     // logical
-    defineBinary(AND, AndAlso, NullPolicy.AND, null);
-    defineBinary(OR, OrElse, NullPolicy.OR, null);
-    defineUnary(NOT, Not, NullPolicy.NOT);
+    map.put(AND, new LogicalAndImplementor());
+    map.put(OR, new LogicalOrImplementor());
+    map.put(NOT, new LogicalNotImplementor());
 
     // comparisons
     defineBinary(LESS_THAN, LessThan, NullPolicy.STRICT, "lt");
     defineBinary(LESS_THAN_OR_EQUAL, LessThanOrEqual, NullPolicy.STRICT, "le");
     defineBinary(GREATER_THAN, GreaterThan, NullPolicy.STRICT, "gt");
-    defineBinary(GREATER_THAN_OR_EQUAL, GreaterThanOrEqual, NullPolicy.STRICT,
-        "ge");
+    defineBinary(GREATER_THAN_OR_EQUAL, GreaterThanOrEqual, NullPolicy.STRICT, "ge");
     defineBinary(EQUALS, Equal, NullPolicy.STRICT, "eq");
     defineBinary(NOT_EQUALS, NotEqual, NullPolicy.STRICT, "ne");
 
@@ -379,33 +378,8 @@ public class RexImpTable {
     defineMethod(LOG10, "log10", NullPolicy.STRICT);
     defineMethod(ABS, "abs", NullPolicy.STRICT);
 
-    defineImplementor(RAND, NullPolicy.STRICT,
-        new NotNullImplementor() {
-          final NotNullImplementor[] implementors = {
-              new ReflectiveCallNotNullImplementor(BuiltInMethod.RAND.method),
-              new ReflectiveCallNotNullImplementor(BuiltInMethod.RAND_SEED.method)
-          };
-          public Expression implement(RexToLixTranslator translator,
-              RexCall call, List<Expression> translatedOperands) {
-            return implementors[call.getOperands().size()]
-                .implement(translator, call, translatedOperands);
-          }
-        }, false);
-    defineImplementor(RAND_INTEGER, NullPolicy.STRICT,
-        new NotNullImplementor() {
-          final NotNullImplementor[] implementors = {
-              null,
-              new ReflectiveCallNotNullImplementor(
-                BuiltInMethod.RAND_INTEGER.method),
-              new ReflectiveCallNotNullImplementor(
-                BuiltInMethod.RAND_INTEGER_SEED.method)
-          };
-          public Expression implement(RexToLixTranslator translator,
-              RexCall call, List<Expression> translatedOperands) {
-            return implementors[call.getOperands().size()]
-                .implement(translator, call, translatedOperands);
-          }
-        }, false);
+    map.put(RAND, new RandImplementor());
+    map.put(RAND_INTEGER, new RandIntegerImplementor());
 
     defineMethod(ACOS, "acos", NullPolicy.STRICT);
     defineMethod(ASIN, "asin", NullPolicy.STRICT);
@@ -425,100 +399,76 @@ public class RexImpTable {
     defineMethod(TANH, "tanh", NullPolicy.STRICT);
     defineMethod(TRUNCATE, "struncate", NullPolicy.STRICT);
 
-    map.put(PI, (translator, call, nullAs) -> Expressions.constant(Math.PI));
+    map.put(PI, new PiImplementor());
 
     // datetime
-    defineImplementor(DATETIME_PLUS, NullPolicy.STRICT,
-        new DatetimeArithmeticImplementor(), false);
-    defineImplementor(MINUS_DATE, NullPolicy.STRICT,
-        new DatetimeArithmeticImplementor(), false);
-    defineImplementor(EXTRACT, NullPolicy.STRICT,
-        new ExtractImplementor(), false);
-    defineImplementor(FLOOR, NullPolicy.STRICT,
-        new FloorImplementor(BuiltInMethod.FLOOR.method.getName(),
-            BuiltInMethod.UNIX_TIMESTAMP_FLOOR.method,
-            BuiltInMethod.UNIX_DATE_FLOOR.method), false);
-    defineImplementor(CEIL, NullPolicy.STRICT,
-        new FloorImplementor(BuiltInMethod.CEIL.method.getName(),
-            BuiltInMethod.UNIX_TIMESTAMP_CEIL.method,
-            BuiltInMethod.UNIX_DATE_CEIL.method), false);
+    map.put(DATETIME_PLUS, new DatetimeArithmeticImplementor());
+    map.put(MINUS_DATE, new DatetimeArithmeticImplementor());
+    map.put(EXTRACT, new ExtractImplementor());
+    map.put(FLOOR,
+            new FloorImplementor(
+                BuiltInMethod.FLOOR.method.getName(),
+                BuiltInMethod.UNIX_TIMESTAMP_FLOOR.method,
+                BuiltInMethod.UNIX_DATE_FLOOR.method));
+    map.put(CEIL,
+            new FloorImplementor(
+                BuiltInMethod.CEIL.method.getName(),
+                BuiltInMethod.UNIX_TIMESTAMP_CEIL.method,
+                BuiltInMethod.UNIX_DATE_CEIL.method));
 
     defineMethod(LAST_DAY, "lastDay", NullPolicy.STRICT);
-    defineImplementor(DAYNAME, NullPolicy.STRICT,
-        new PeriodNameImplementor("dayName",
-            BuiltInMethod.DAYNAME_WITH_TIMESTAMP,
-            BuiltInMethod.DAYNAME_WITH_DATE), false);
-    defineImplementor(MONTHNAME, NullPolicy.STRICT,
-        new PeriodNameImplementor("monthName",
-            BuiltInMethod.MONTHNAME_WITH_TIMESTAMP,
-            BuiltInMethod.MONTHNAME_WITH_DATE), false);
+    map.put(DAYNAME,
+            new PeriodNameImplementor("dayName",
+                BuiltInMethod.DAYNAME_WITH_TIMESTAMP,
+                BuiltInMethod.DAYNAME_WITH_DATE));
+    map.put(MONTHNAME,
+            new PeriodNameImplementor("monthName",
+                BuiltInMethod.MONTHNAME_WITH_TIMESTAMP,
+                BuiltInMethod.MONTHNAME_WITH_DATE));
 
-    map.put(IS_NULL, new IsXxxImplementor(null, false));
-    map.put(IS_NOT_NULL, new IsXxxImplementor(null, true));
-    map.put(IS_TRUE, new IsXxxImplementor(true, false));
-    map.put(IS_NOT_TRUE, new IsXxxImplementor(true, true));
-    map.put(IS_FALSE, new IsXxxImplementor(false, false));
-    map.put(IS_NOT_FALSE, new IsXxxImplementor(false, true));
+    map.put(IS_NULL, new IsNullImplementor());
+    map.put(IS_NOT_NULL, new IsNotNullImplementor());
+    map.put(IS_TRUE, new IsTrueImplementor());
+    map.put(IS_NOT_TRUE, new IsNotTrueImplementor());
+    map.put(IS_FALSE, new IsFalseImplementor());
+    map.put(IS_NOT_FALSE, new IsNotFalseImplementor());
 
     // LIKE and SIMILAR
     final MethodImplementor likeImplementor =
-        new MethodImplementor(BuiltInMethod.LIKE.method);
-    defineImplementor(LIKE, NullPolicy.STRICT, likeImplementor, false);
-    defineImplementor(NOT_LIKE, NullPolicy.STRICT,
-        NotImplementor.of(likeImplementor), false);
+        new MethodImplementor(BuiltInMethod.LIKE.method, NullPolicy.STRICT, false);
+    map.put(LIKE, likeImplementor);
+    map.put(NOT_LIKE, likeImplementor);
     final MethodImplementor similarImplementor =
-        new MethodImplementor(BuiltInMethod.SIMILAR.method);
-    defineImplementor(SIMILAR_TO, NullPolicy.STRICT, similarImplementor, false);
-    defineImplementor(NOT_SIMILAR_TO, NullPolicy.STRICT,
-        NotImplementor.of(similarImplementor), false);
+        new MethodImplementor(BuiltInMethod.SIMILAR.method, NullPolicy.STRICT, false);
+    map.put(SIMILAR_TO, similarImplementor);
+    map.put(NOT_SIMILAR_TO, NotImplementor.of(similarImplementor));
 
     // POSIX REGEX
     final MethodImplementor posixRegexImplementor =
-        new MethodImplementor(BuiltInMethod.POSIX_REGEX.method);
-    defineImplementor(SqlStdOperatorTable.POSIX_REGEX_CASE_INSENSITIVE, NullPolicy.STRICT,
-        posixRegexImplementor, false);
-    defineImplementor(SqlStdOperatorTable.POSIX_REGEX_CASE_SENSITIVE, NullPolicy.STRICT,
-        posixRegexImplementor, false);
-    defineImplementor(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_INSENSITIVE, NullPolicy.STRICT,
-        NotImplementor.of(posixRegexImplementor), false);
-    defineImplementor(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_SENSITIVE, NullPolicy.STRICT,
-        NotImplementor.of(posixRegexImplementor), false);
-    defineImplementor(REGEXP_REPLACE, NullPolicy.STRICT,
-        new NotNullImplementor() {
-          final NotNullImplementor[] implementors = {
-              new ReflectiveCallNotNullImplementor(
-                  BuiltInMethod.REGEXP_REPLACE3.method),
-              new ReflectiveCallNotNullImplementor(
-                  BuiltInMethod.REGEXP_REPLACE4.method),
-              new ReflectiveCallNotNullImplementor(
-                  BuiltInMethod.REGEXP_REPLACE5.method),
-              new ReflectiveCallNotNullImplementor(
-                  BuiltInMethod.REGEXP_REPLACE6.method)
-          };
-          public Expression implement(RexToLixTranslator translator, RexCall call,
-              List<Expression> translatedOperands) {
-            return implementors[call.getOperands().size() - 3]
-                .implement(translator, call, translatedOperands);
-          }
-        }, false);
+        new MethodImplementor(BuiltInMethod.POSIX_REGEX.method,
+            NullPolicy.STRICT, false);
+    map.put(SqlStdOperatorTable.POSIX_REGEX_CASE_INSENSITIVE, posixRegexImplementor);
+    map.put(SqlStdOperatorTable.POSIX_REGEX_CASE_SENSITIVE, posixRegexImplementor);
+    map.put(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_INSENSITIVE,
+            NotImplementor.of(posixRegexImplementor));
+    map.put(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_SENSITIVE,
+            NotImplementor.of(posixRegexImplementor));
+    map.put(REGEXP_REPLACE, new RegexpReplaceImplementor());
 
     // Multisets & arrays
-    defineMethod(CARDINALITY, BuiltInMethod.COLLECTION_SIZE.method,
-        NullPolicy.STRICT);
+    defineMethod(CARDINALITY, BuiltInMethod.COLLECTION_SIZE.method, NullPolicy.STRICT);
     defineMethod(SLICE, BuiltInMethod.SLICE.method, NullPolicy.NONE);
     defineMethod(ELEMENT, BuiltInMethod.ELEMENT.method, NullPolicy.STRICT);
     defineMethod(STRUCT_ACCESS, BuiltInMethod.STRUCT_ACCESS.method, NullPolicy.ANY);
     defineMethod(MEMBER_OF, BuiltInMethod.MEMBER_OF.method, NullPolicy.NONE);
     final MethodImplementor isEmptyImplementor =
-        new MethodImplementor(BuiltInMethod.IS_EMPTY.method);
-    defineImplementor(IS_EMPTY, NullPolicy.NONE, isEmptyImplementor, false);
-    defineImplementor(IS_NOT_EMPTY, NullPolicy.NONE,
-        NotImplementor.of(isEmptyImplementor), false);
+        new MethodImplementor(BuiltInMethod.IS_EMPTY.method, NullPolicy.NONE, false);
+    map.put(IS_EMPTY, isEmptyImplementor);
+    map.put(IS_NOT_EMPTY, NotImplementor.of(isEmptyImplementor));
     final MethodImplementor isASetImplementor =
-        new MethodImplementor(BuiltInMethod.IS_A_SET.method);
-    defineImplementor(IS_A_SET, NullPolicy.NONE, isASetImplementor, false);
-    defineImplementor(IS_NOT_A_SET, NullPolicy.NONE,
-        NotImplementor.of(isASetImplementor), false);
+        new MethodImplementor(BuiltInMethod.IS_A_SET.method, NullPolicy.NONE, false);
+    map.put(IS_A_SET, isASetImplementor);
+    map.put(IS_NOT_A_SET, NotImplementor.of(isASetImplementor));
     defineMethod(MULTISET_INTERSECT_DISTINCT,
         BuiltInMethod.MULTISET_INTERSECT_DISTINCT.method, NullPolicy.NONE);
     defineMethod(MULTISET_INTERSECT,
@@ -530,24 +480,21 @@ public class RexImpTable {
         BuiltInMethod.MULTISET_UNION_DISTINCT.method, NullPolicy.NONE);
     defineMethod(MULTISET_UNION, BuiltInMethod.MULTISET_UNION_ALL.method, NullPolicy.NONE);
     final MethodImplementor subMultisetImplementor =
-        new MethodImplementor(BuiltInMethod.SUBMULTISET_OF.method);
-    defineImplementor(SUBMULTISET_OF, NullPolicy.NONE, subMultisetImplementor, false);
-    defineImplementor(NOT_SUBMULTISET_OF,
-        NullPolicy.NONE, NotImplementor.of(subMultisetImplementor), false);
+        new MethodImplementor(BuiltInMethod.SUBMULTISET_OF.method, NullPolicy.NONE, false);
+    map.put(SUBMULTISET_OF, subMultisetImplementor);
+    map.put(NOT_SUBMULTISET_OF, NotImplementor.of(subMultisetImplementor));
 
-    map.put(CASE, new CaseImplementor());
     map.put(COALESCE, new CoalesceImplementor());
-    map.put(CAST, new CastOptimizedImplementor());
+    map.put(CAST, new CastImplementor());
 
-    defineImplementor(REINTERPRET, NullPolicy.STRICT,
-        new ReinterpretImplementor(), false);
+    map.put(REINTERPRET, new ReinterpretImplementor());
 
-    final CallImplementor value = new ValueConstructorImplementor();
+    final RexCallImplementor value = new ValueConstructorImplementor();
     map.put(MAP_VALUE_CONSTRUCTOR, value);
     map.put(ARRAY_VALUE_CONSTRUCTOR, value);
     map.put(ITEM, new ItemImplementor());
 
-    map.put(DEFAULT, (translator, call, nullAs) -> Expressions.constant(null));
+    map.put(DEFAULT, new DefaultImplementor());
 
     // Sequences
     defineMethod(CURRENT_VALUE, BuiltInMethod.SEQUENCE_CURRENT_VALUE.method, NullPolicy.STRICT);
@@ -589,26 +536,38 @@ public class RexImpTable {
     aggMap.put(JSON_ARRAYAGG.with(SqlJsonConstructorNullClause.NULL_ON_NULL),
         JsonArrayAggImplementor
             .supplierFor(BuiltInMethod.JSON_ARRAYAGG_ADD.method));
-    defineImplementor(IS_JSON_VALUE, NullPolicy.NONE,
-        new MethodImplementor(BuiltInMethod.IS_JSON_VALUE.method), false);
-    defineImplementor(IS_JSON_OBJECT, NullPolicy.NONE,
-        new MethodImplementor(BuiltInMethod.IS_JSON_OBJECT.method), false);
-    defineImplementor(IS_JSON_ARRAY, NullPolicy.NONE,
-        new MethodImplementor(BuiltInMethod.IS_JSON_ARRAY.method), false);
-    defineImplementor(IS_JSON_SCALAR, NullPolicy.NONE,
-        new MethodImplementor(BuiltInMethod.IS_JSON_SCALAR.method), false);
-    defineImplementor(IS_NOT_JSON_VALUE, NullPolicy.NONE,
-        NotImplementor.of(
-            new MethodImplementor(BuiltInMethod.IS_JSON_VALUE.method)), false);
-    defineImplementor(IS_NOT_JSON_OBJECT, NullPolicy.NONE,
-        NotImplementor.of(
-            new MethodImplementor(BuiltInMethod.IS_JSON_OBJECT.method)), false);
-    defineImplementor(IS_NOT_JSON_ARRAY, NullPolicy.NONE,
-        NotImplementor.of(
-            new MethodImplementor(BuiltInMethod.IS_JSON_ARRAY.method)), false);
-    defineImplementor(IS_NOT_JSON_SCALAR, NullPolicy.NONE,
-        NotImplementor.of(
-            new MethodImplementor(BuiltInMethod.IS_JSON_SCALAR.method)), false);
+    map.put(IS_JSON_VALUE,
+            new MethodImplementor(BuiltInMethod.IS_JSON_VALUE.method, NullPolicy.NONE, false));
+    map.put(IS_JSON_OBJECT,
+            new MethodImplementor(BuiltInMethod.IS_JSON_OBJECT.method, NullPolicy.NONE, false));
+    map.put(IS_JSON_ARRAY,
+            new MethodImplementor(BuiltInMethod.IS_JSON_ARRAY.method, NullPolicy.NONE, false));
+    map.put(IS_JSON_SCALAR,
+            new MethodImplementor(BuiltInMethod.IS_JSON_SCALAR.method, NullPolicy.NONE, false));
+    map.put(IS_NOT_JSON_VALUE,
+            NotImplementor.of(
+                new MethodImplementor(
+                    BuiltInMethod.IS_JSON_VALUE.method,
+                    NullPolicy.NONE,
+                    false)));
+    map.put(IS_NOT_JSON_OBJECT,
+            NotImplementor.of(
+                new MethodImplementor(
+                    BuiltInMethod.IS_JSON_OBJECT.method,
+                    NullPolicy.NONE,
+                    false)));
+    map.put(IS_NOT_JSON_ARRAY,
+            NotImplementor.of(
+                new MethodImplementor(
+                    BuiltInMethod.IS_JSON_ARRAY.method,
+                    NullPolicy.NONE,
+                    false)));
+    map.put(IS_NOT_JSON_SCALAR,
+            NotImplementor.of(
+                new MethodImplementor(
+                    BuiltInMethod.IS_JSON_SCALAR.method,
+                    NullPolicy.NONE,
+                    false)));
 
     // System functions
     final SystemFunctionImplementor systemFunctionImplementor =
@@ -668,7 +627,6 @@ public class RexImpTable {
     // Functions for MATCH_RECOGNIZE
     matchMap.put(CLASSIFIER, ClassifierImplementor::new);
     matchMap.put(LAST, LastImplementor::new);
-    map.put(PREV, new PrevImplementor());
     tvfImplementorMap.put(TUMBLE_TVF, TumbleImplementor::new);
   }
 
@@ -691,16 +649,6 @@ public class RexImpTable {
     };
   }
 
-  private void defineImplementor(
-      SqlOperator operator,
-      NullPolicy nullPolicy,
-      NotNullImplementor implementor,
-      boolean harmonize) {
-    CallImplementor callImplementor =
-        createImplementor(implementor, nullPolicy, harmonize);
-    map.put(operator, callImplementor);
-  }
-
   private static RexCall call2(
       boolean harmonize,
       RexToLixTranslator translator,
@@ -720,182 +668,40 @@ public class RexImpTable {
       final NotNullImplementor implementor,
       final NullPolicy nullPolicy,
       final boolean harmonize) {
-    switch (nullPolicy) {
-    case ANY:
-    case STRICT:
-    case SEMI_STRICT:
-    case ARG0:
-      return (translator, call, nullAs) -> implementNullSemantics0(
-          translator, call, nullAs, nullPolicy, harmonize,
-          implementor);
-    case AND:
-/* TODO:
-            if (nullAs == NullAs.FALSE) {
-                nullPolicy2 = NullPolicy.ANY;
-            }
-*/
-      // If any of the arguments are false, result is false;
-      // else if any arguments are null, result is null;
-      // else true.
-      //
-      // b0 == null ? (b1 == null || b1 ? null : Boolean.FALSE)
-      //   : b0 ? b1
-      //   : Boolean.FALSE;
-      return (translator, call, nullAs) -> {
-        assert call.getOperator() == AND
-            : "AND null semantics is supported only for AND operator. Actual operator is "
-            + String.valueOf(call.getOperator());
-        final RexCall call2 = call2(false, translator, call);
-        switch (nullAs) {
-        case NOT_POSSIBLE:
-          // This doesn't mean that none of the arguments might be null, ex: (s and s is not null)
-          nullAs = NullAs.TRUE;
-          // fallthru
-        case TRUE:
-          // AND call should return false iff has FALSEs,
-          // thus if we convert nulls to true then no harm is made
-        case FALSE:
-          // AND call should return false iff has FALSEs or has NULLs,
-          // thus if we convert nulls to false, no harm is made
-          final List<Expression> expressions =
-              translator.translateList(call2.getOperands(), nullAs);
-          return Expressions.foldAnd(expressions);
-        case NULL:
-        case IS_NULL:
-        case IS_NOT_NULL:
-          final List<Expression> nullAsTrue =
-              translator.translateList(call2.getOperands(), NullAs.TRUE);
-          final List<Expression> nullAsIsNull =
-              translator.translateList(call2.getOperands(), NullAs.IS_NULL);
-          Expression hasFalse =
-              Expressions.not(Expressions.foldAnd(nullAsTrue));
-          Expression hasNull = Expressions.foldOr(nullAsIsNull);
-          return nullAs.handle(
-              Expressions.condition(hasFalse, BOXED_FALSE_EXPR,
-                  Expressions.condition(hasNull, NULL_EXPR, BOXED_TRUE_EXPR)));
-        default:
-          throw new IllegalArgumentException(
-              "Unknown nullAs when implementing AND: " + nullAs);
-        }
-      };
-    case OR:
-      // If any of the arguments are true, result is true;
-      // else if any arguments are null, result is null;
-      // else false.
-      //
-      // b0 == null ? (b1 == null || !b1 ? null : Boolean.TRUE)
-      //   : !b0 ? b1
-      //   : Boolean.TRUE;
-      return (translator, call, nullAs) -> {
-        assert call.getOperator() == OR
-            : "OR null semantics is supported only for OR operator. Actual operator is "
-            + String.valueOf(call.getOperator());
-        final RexCall call2 = call2(harmonize, translator, call);
-        switch (nullAs) {
-        case NOT_POSSIBLE:
-          // This doesn't mean that none of the arguments might be null, ex: (s or s is null)
-          nullAs = NullAs.FALSE;
-          // fallthru
-        case TRUE:
-          // This should return false iff all arguments are FALSE,
-          // thus we convert nulls to TRUE and foldOr
-        case FALSE:
-          // This should return true iff has TRUE arguments,
-          // thus we convert nulls to FALSE and foldOr
-          final List<Expression> expressions =
-              translator.translateList(call2.getOperands(), nullAs);
-          return Expressions.foldOr(expressions);
-        case NULL:
-        case IS_NULL:
-        case IS_NOT_NULL:
-          final List<Expression> nullAsFalse =
-              translator.translateList(call2.getOperands(), NullAs.FALSE);
-          final List<Expression> nullAsIsNull =
-              translator.translateList(call2.getOperands(), NullAs.IS_NULL);
-          Expression hasTrue = Expressions.foldOr(nullAsFalse);
-          Expression hasNull = Expressions.foldOr(nullAsIsNull);
-          Expression result = nullAs.handle(
-              Expressions.condition(hasTrue, BOXED_TRUE_EXPR,
-                  Expressions.condition(hasNull, NULL_EXPR, BOXED_FALSE_EXPR)));
-          return result;
-        default:
-          throw new IllegalArgumentException(
-              "Unknown nullAs when implementing OR: " + nullAs);
-        }
-      };
-    case NOT:
-      // If any of the arguments are false, result is true;
-      // else if any arguments are null, result is null;
-      // else false.
-      return new CallImplementor() {
-        public Expression implement(RexToLixTranslator translator, RexCall call,
-            NullAs nullAs) {
-          switch (nullAs) {
-          case NULL:
-            return Expressions.call(BuiltInMethod.NOT.method,
-                translator.translateList(call.getOperands(), nullAs));
-          default:
-            return Expressions.not(
-                translator.translate(call.getOperands().get(0),
-                    negate(nullAs)));
-          }
-        }
-
-        private NullAs negate(NullAs nullAs) {
-          switch (nullAs) {
-          case FALSE:
-            return NullAs.TRUE;
-          case TRUE:
-            return NullAs.FALSE;
-          case IS_NULL:
-            return NullAs.IS_NOT_NULL;
-          case IS_NOT_NULL:
-            return NullAs.IS_NULL;
-          default:
-            return nullAs;
-          }
-        }
-      };
-    case NONE:
-      return (translator, call, nullAs) -> {
-        final RexCall call2 = call2(false, translator, call);
-        return implementCall(
-            translator, call2, implementor, nullAs);
-      };
-    default:
-      throw new AssertionError(nullPolicy);
-    }
+    return (translator, call, nullAs) -> {
+      final RexCallImplementor rexCallImplementor =
+          createRexCallImplementor(
+              implementor, nullPolicy, harmonize);
+      final List<RexToLixTranslator.Result> arguments =
+          translator.getCallOperandResult(call);
+      assert arguments != null;
+      final RexToLixTranslator.Result result =
+          rexCallImplementor.implement(
+              translator, call, arguments);
+      return nullAs.handle(result.valueVariable);
+    };
   }
 
   private void defineMethod(
       SqlOperator operator, String functionName, NullPolicy nullPolicy) {
-    defineImplementor(
-        operator,
-        nullPolicy,
-        new MethodNameImplementor(functionName),
-        false);
+    RexCallImplementor implementor =
+        new MethodNameImplementor(functionName, nullPolicy, false);
+    map.put(operator, implementor);
   }
 
   private void defineMethod(
       SqlOperator operator, Method method, NullPolicy nullPolicy) {
-    defineImplementor(
-        operator, nullPolicy, new MethodImplementor(method), false);
-  }
-
-  private void defineMethodReflective(
-      SqlOperator operator, Method method, NullPolicy nullPolicy) {
-    defineImplementor(
-        operator, nullPolicy, new ReflectiveCallNotNullImplementor(method),
-        false);
+    RexCallImplementor implementor =
+        new MethodImplementor(method, nullPolicy, false);
+    map.put(operator, implementor);
   }
 
   private void defineUnary(
       SqlOperator operator, ExpressionType expressionType,
       NullPolicy nullPolicy) {
-    defineImplementor(
-        operator,
-        nullPolicy,
-        new UnaryImplementor(expressionType), false);
+    RexCallImplementor implementor =
+        new UnaryImplementor(expressionType, nullPolicy);
+    map.put(operator, implementor);
   }
 
   private void defineBinary(
@@ -903,16 +709,45 @@ public class RexImpTable {
       ExpressionType expressionType,
       NullPolicy nullPolicy,
       String backupMethodName) {
-    defineImplementor(
-        operator,
-        nullPolicy,
-        new BinaryImplementor(expressionType, backupMethodName),
-        true);
+    RexCallImplementor implementor =
+        new BinaryImplementor(nullPolicy, true, expressionType, backupMethodName);
+    map.put(operator, implementor);
   }
 
   public static final RexImpTable INSTANCE = new RexImpTable();
 
-  public CallImplementor get(final SqlOperator operator) {
+  private static RexCallImplementor createRexCallImplementor(
+      final NotNullImplementor implementor,
+      final NullPolicy nullPolicy,
+      final boolean harmonize) {
+    return new AbstractRexCallImplementor(nullPolicy, harmonize) {
+      @Override String getVariableName() {
+        return "not_null_udf";
+      }
+
+      @Override Expression implementSafe(
+          RexToLixTranslator translator, RexCall call,
+          List<Expression> argValueList) {
+        return implementor.implement(translator, call, argValueList);
+      }
+    };
+  }
+
+  private static RexCallImplementor wrapAsRexCallImplementor(
+      final CallImplementor implementor) {
+    return new AbstractRexCallImplementor(NullPolicy.NONE, false) {
+      @Override String getVariableName() {
+        return "udf";
+      }
+
+      @Override Expression implementSafe(RexToLixTranslator translator,
+          RexCall call, List<Expression> argValueList) {
+        return implementor.implement(translator, call, RexImpTable.NullAs.NULL);
+      }
+    };
+  }
+
+  public RexCallImplementor get(final SqlOperator operator) {
     if (operator instanceof SqlUserDefinedFunction) {
       org.apache.calcite.schema.Function udf =
           ((SqlUserDefinedFunction) operator).getFunction();
@@ -920,7 +755,9 @@ public class RexImpTable {
         throw new IllegalStateException("User defined function " + operator
             + " must implement ImplementableFunction");
       }
-      return ((ImplementableFunction) udf).getImplementor();
+      CallImplementor implementor =
+          ((ImplementableFunction) udf).getImplementor();
+      return wrapAsRexCallImplementor(implementor);
     } else if (operator instanceof SqlTypeConstructorFunction) {
       return map.get(SqlStdOperatorTable.ROW);
     }
@@ -2171,12 +2008,21 @@ public class RexImpTable {
   }
 
   /** Implementor for the {@code TRIM} function. */
-  private static class TrimImplementor implements NotNullImplementor {
-    public Expression implement(RexToLixTranslator translator, RexCall call,
-        List<Expression> translatedOperands) {
+  private static class TrimImplementor extends AbstractRexCallImplementor {
+
+    TrimImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "trim";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       final boolean strict = !translator.conformance.allowExtendedTrim();
       final Object value =
-          ((ConstantExpression) translatedOperands.get(0)).value;
+          ((ConstantExpression) translator.getLiteral(argValueList.get(0))).value;
       SqlTrimFunction.Flag flag = (SqlTrimFunction.Flag) value;
       return Expressions.call(
           BuiltInMethod.TRIM.method,
@@ -2186,8 +2032,8 @@ public class RexImpTable {
           Expressions.constant(
               flag == SqlTrimFunction.Flag.BOTH
               || flag == SqlTrimFunction.Flag.TRAILING),
-          translatedOperands.get(1),
-          translatedOperands.get(2),
+          argValueList.get(1),
+          argValueList.get(2),
           Expressions.constant(strict));
     }
   }
@@ -2200,14 +2046,18 @@ public class RexImpTable {
 
     PeriodNameImplementor(String methodName, BuiltInMethod timestampMethod,
         BuiltInMethod dateMethod) {
-      super(methodName);
+      super(methodName, NullPolicy.STRICT, false);
       this.timestampMethod = timestampMethod;
       this.dateMethod = dateMethod;
     }
 
-    @Override public Expression implement(RexToLixTranslator translator,
-        RexCall call, List<Expression> translatedOperands) {
-      Expression operand = translatedOperands.get(0);
+    @Override String getVariableName() {
+      return "periodName";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      Expression operand = argValueList.get(0);
       final RelDataType type = call.operands.get(0).getType();
       switch (type.getSqlTypeName()) {
       case TIMESTAMP:
@@ -2235,13 +2085,17 @@ public class RexImpTable {
 
     FloorImplementor(String methodName, Method timestampMethod,
         Method dateMethod) {
-      super(methodName);
+      super(methodName, NullPolicy.STRICT, false);
       this.timestampMethod = timestampMethod;
       this.dateMethod = dateMethod;
     }
 
-    public Expression implement(RexToLixTranslator translator, RexCall call,
-        List<Expression> translatedOperands) {
+    @Override String getVariableName() {
+      return "floor";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       switch (call.getOperands().size()) {
       case 1:
         switch (call.getType().getSqlTypeName()) {
@@ -2249,16 +2103,16 @@ public class RexImpTable {
         case INTEGER:
         case SMALLINT:
         case TINYINT:
-          return translatedOperands.get(0);
+          return argValueList.get(0);
         default:
-          return super.implement(translator, call, translatedOperands);
+          return super.implementSafe(translator, call, argValueList);
         }
 
       case 2:
         final Type type;
         final Method floorMethod;
         final boolean preFloor;
-        Expression operand = translatedOperands.get(0);
+        Expression operand = argValueList.get(0);
         switch (call.getType().getSqlTypeName()) {
         case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
           operand = Expressions.call(
@@ -2277,7 +2131,7 @@ public class RexImpTable {
           preFloor = false;
         }
         final ConstantExpression tur =
-            (ConstantExpression) translatedOperands.get(1);
+            (ConstantExpression) translator.getLiteral(argValueList.get(1));
         final TimeUnitRange timeUnitRange = (TimeUnitRange) tur.value;
         switch (timeUnitRange) {
         case YEAR:
@@ -2308,29 +2162,35 @@ public class RexImpTable {
   }
 
   /** Implementor for a function that generates calls to a given method. */
-  private static class MethodImplementor implements NotNullImplementor {
+  private static class MethodImplementor extends AbstractRexCallImplementor {
     protected final Method method;
 
-    MethodImplementor(Method method) {
+    MethodImplementor(Method method, NullPolicy nullPolicy, boolean harmonize) {
+      super(nullPolicy, harmonize);
       this.method = method;
     }
 
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        List<Expression> translatedOperands) {
+    @Override String getVariableName() {
+      return "method_call";
+    }
+
+    @Override Expression implementSafe(RexToLixTranslator translator,
+        RexCall call, List<Expression> argValueList) {
+      List<Expression> unboxValueList = argValueList;
+      if (nullPolicy == NullPolicy.STRICT) {
+        unboxValueList = argValueList.stream()
+            .map(RexImpTable.NullAs.NOT_POSSIBLE::handle)
+                .collect(Collectors.toList());
+      }
       final Expression expression;
       Class clazz = method.getDeclaringClass();
       if (Modifier.isStatic(method.getModifiers())) {
-        expression = EnumUtils.call(clazz, method.getName(), translatedOperands);
+        expression = EnumUtils.call(clazz, method.getName(), unboxValueList);
       } else {
         expression = EnumUtils.call(clazz, method.getName(),
-            Util.skip(translatedOperands, 1), translatedOperands.get(0));
+            Util.skip(unboxValueList, 1), unboxValueList.get(0));
       }
-
-      final Type returnType =
-          translator.typeFactory.getJavaClass(call.getType());
-      return EnumUtils.convert(expression, returnType);
+      return expression;
     }
   }
 
@@ -2338,26 +2198,36 @@ public class RexImpTable {
    *
    * <p>Use this, as opposed to {@link MethodImplementor}, if the SQL function
    * is overloaded; then you can use one implementor for several overloads. */
-  private static class MethodNameImplementor implements NotNullImplementor {
+  private static class MethodNameImplementor extends AbstractRexCallImplementor {
     protected final String methodName;
 
-    MethodNameImplementor(String methodName) {
+    MethodNameImplementor(String methodName,
+        NullPolicy nullPolicy, boolean harmonize) {
+      super(nullPolicy, harmonize);
       this.methodName = methodName;
     }
 
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        List<Expression> translatedOperands) {
+    @Override String getVariableName() {
+      return "method_name_call";
+    }
+
+    @Override Expression implementSafe(RexToLixTranslator translator,
+        RexCall call, List<Expression> argValueList) {
+      List<Expression> unboxValueList = argValueList;
+      if (nullPolicy == NullPolicy.STRICT) {
+        unboxValueList = argValueList.stream()
+            .map(RexImpTable.NullAs.NOT_POSSIBLE::handle)
+                .collect(Collectors.toList());
+      }
       return EnumUtils.call(
           SqlFunctions.class,
           methodName,
-          translatedOperands);
+          unboxValueList);
     }
   }
 
   /** Implementor for binary operators. */
-  private static class BinaryImplementor implements NotNullImplementor {
+  private static class BinaryImplementor extends AbstractRexCallImplementor {
     /** Types that can be arguments to comparison operators such as
      * {@code <}. */
     private static final List<Primitive> COMP_OP_TYPES =
@@ -2387,17 +2257,21 @@ public class RexImpTable {
     private final ExpressionType expressionType;
     private final String backupMethodName;
 
-    BinaryImplementor(
-        ExpressionType expressionType,
-        String backupMethodName) {
+    BinaryImplementor(NullPolicy nullPolicy, boolean harmonize,
+        ExpressionType expressionType, String backupMethodName) {
+      super(nullPolicy, harmonize);
       this.expressionType = expressionType;
       this.backupMethodName = backupMethodName;
     }
 
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        List<Expression> expressions) {
+    @Override String getVariableName() {
+      return "binary_call";
+    }
+
+    @Override Expression implementSafe(
+        final RexToLixTranslator translator,
+        final RexCall call,
+        final List<Expression> argValueList) {
       // neither nullable:
       //   return x OP y
       // x nullable
@@ -2414,19 +2288,20 @@ public class RexImpTable {
         // If one or both operands have ANY type, use the late-binding backup
         // method.
         if (anyAnyOperands(call)) {
-          return callBackupMethodAnyType(translator, call, expressions);
+          return callBackupMethodAnyType(translator, call, argValueList);
         }
 
-        final Type type0 = expressions.get(0).getType();
-        final Type type1 = expressions.get(1).getType();
+        final Type type0 = argValueList.get(0).getType();
+        final Type type1 = argValueList.get(1).getType();
         final SqlBinaryOperator op = (SqlBinaryOperator) call.getOperator();
         final Primitive primitive = Primitive.ofBoxOr(type0);
         if (primitive == null
             || type1 == BigDecimal.class
+            || shouldUseEquals(type0)
             || COMPARISON_OPERATORS.contains(op)
             && !COMP_OP_TYPES.contains(primitive)) {
           return Expressions.call(SqlFunctions.class, backupMethodName,
-              expressions);
+              argValueList);
         }
         // When checking equals or not equals on two primitive boxing classes
         // (i.e. Long x, Long y), we should fall back to call `SqlFunctions.eq(x, y)`
@@ -2436,16 +2311,11 @@ public class RexImpTable {
         if (EQUALS_OPERATORS.contains(op)
             && boxPrimitive0 != null && boxPrimitive1 != null) {
           return Expressions.call(SqlFunctions.class, backupMethodName,
-              expressions);
+              argValueList);
         }
       }
-
-      final Type returnType =
-          translator.typeFactory.getJavaClass(call.getType());
-      return EnumUtils.convert(
-          Expressions.makeBinary(expressionType, expressions.get(0),
-              expressions.get(1)),
-          returnType);
+      return Expressions.makeBinary(expressionType,
+          argValueList.get(0), argValueList.get(1));
     }
 
     /** Returns whether any of a call's operands have ANY type. */
@@ -2456,6 +2326,13 @@ public class RexImpTable {
         }
       }
       return false;
+    }
+
+    /** For Boxed types, we should use {@code equals} rather than {@code ==}. */
+    private boolean shouldUseEquals(Type type) {
+      return Primitive.isBox(type)
+         && (expressionType == ExpressionType.Equal
+            || expressionType == ExpressionType.NotEqual);
     }
 
     private Expression callBackupMethodAnyType(RexToLixTranslator translator,
@@ -2480,36 +2357,55 @@ public class RexImpTable {
   }
 
   /** Implementor for unary operators. */
-  private static class UnaryImplementor implements NotNullImplementor {
+  private static class UnaryImplementor extends AbstractRexCallImplementor {
     private final ExpressionType expressionType;
 
-    UnaryImplementor(ExpressionType expressionType) {
+    UnaryImplementor(ExpressionType expressionType, NullPolicy nullPolicy) {
+      super(nullPolicy, false);
       this.expressionType = expressionType;
     }
 
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        List<Expression> translatedOperands) {
-      final Expression operand = translatedOperands.get(0);
-      final UnaryExpression e = Expressions.makeUnary(expressionType, operand);
-      if (e.type.equals(operand.type)) {
+    @Override String getVariableName() {
+      return "unary_call";
+    }
+
+    @Override Expression implementSafe(RexToLixTranslator translator,
+        RexCall call, List<Expression> argValueList) {
+      final Expression argValue = argValueList.get(0);
+      Expression unboxedArgValue = argValue;
+      if (nullPolicy == NullPolicy.STRICT
+          || nullPolicy == NullPolicy.SEMI_STRICT
+          || nullPolicy == NullPolicy.ARG0) {
+        unboxedArgValue = RexImpTable.NullAs.NOT_POSSIBLE.handle(argValue);
+      }
+      final UnaryExpression e = Expressions.makeUnary(expressionType, unboxedArgValue);
+      if (e.type.equals(unboxedArgValue.type)) {
         return e;
       }
       // Certain unary operators do not preserve type. For example, the "-"
       // operator applied to a "byte" expression returns an "int".
-      return Expressions.convert_(e, operand.type);
+      return Expressions.convert_(e, unboxedArgValue.type);
     }
   }
 
   /** Implementor for the {@code EXTRACT(unit FROM datetime)} function. */
-  private static class ExtractImplementor implements NotNullImplementor {
-    public Expression implement(RexToLixTranslator translator, RexCall call,
-        List<Expression> translatedOperands) {
+  private static class ExtractImplementor extends AbstractRexCallImplementor {
+
+    ExtractImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "extract";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       final TimeUnitRange timeUnitRange =
-          (TimeUnitRange) ((ConstantExpression) translatedOperands.get(0)).value;
+          (TimeUnitRange) (
+              (ConstantExpression) translator.getLiteral(argValueList.get(0))).value;
       final TimeUnit unit = timeUnitRange.startUnit;
-      Expression operand = translatedOperands.get(1);
+      Expression operand = argValueList.get(1);
       final SqlTypeName sqlTypeName =
           call.operands.get(1).getType().getSqlTypeName();
       switch (unit) {
@@ -2552,7 +2448,7 @@ public class RexImpTable {
           // fall through
         case DATE:
           return Expressions.call(BuiltInMethod.UNIX_DATE_EXTRACT.method,
-              translatedOperands.get(0), operand);
+              argValueList.get(0), operand);
         default:
           throw new AssertionError("unexpected " + sqlTypeName);
         }
@@ -2622,7 +2518,6 @@ public class RexImpTable {
       }
       return operand;
     }
-
   }
 
   private static Expression mod(Expression operand, long factor) {
@@ -2660,175 +2555,185 @@ public class RexImpTable {
     }
   }
 
-  /** Implementor for the SQL {@code CASE} operator. */
-  private static class CaseImplementor implements CallImplementor {
-    public Expression implement(RexToLixTranslator translator, RexCall call,
-        NullAs nullAs) {
-      return implementRecurse(translator, call, nullAs, 0);
-    }
-
-    private Expression implementRecurse(RexToLixTranslator translator,
-        RexCall call, NullAs nullAs, int i) {
-      List<RexNode> operands = call.getOperands();
-      if (i == operands.size() - 1) {
-        // the "else" clause
-        return translator.translate(
-            translator.builder.ensureType(
-                call.getType(), operands.get(i), false), nullAs);
-      } else {
-        Expression ifTrue;
-        try {
-          ifTrue = translator.translate(
-              translator.builder.ensureType(call.getType(),
-                  operands.get(i + 1),
-                  false), nullAs);
-        } catch (RexToLixTranslator.AlwaysNull e) {
-          ifTrue = null;
-        }
-
-        Expression ifFalse;
-        try {
-          ifFalse = implementRecurse(translator, call, nullAs, i + 2);
-        } catch (RexToLixTranslator.AlwaysNull e) {
-          if (ifTrue == null) {
-            throw RexToLixTranslator.AlwaysNull.INSTANCE;
-          }
-          ifFalse = null;
-        }
-
-        Expression test = translator.translate(operands.get(i), NullAs.FALSE);
-
-        return ifTrue == null || ifFalse == null
-            ? Util.first(ifTrue, ifFalse)
-            : Expressions.condition(test, ifTrue, ifFalse);
-      }
-    }
-  }
-
   /** Implementor for the SQL {@code COALESCE} operator. */
-  private static class CoalesceImplementor implements CallImplementor {
-    public Expression implement(RexToLixTranslator translator, RexCall call,
-        NullAs nullAs) {
-      return implementRecurse(translator, call.operands, nullAs);
+  private static class CoalesceImplementor extends AbstractRexCallImplementor {
+    CoalesceImplementor() {
+      super(NullPolicy.NONE, false);
+    }
+
+    @Override String getVariableName() {
+      return "coalesce";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return implementRecurse(translator, argValueList);
     }
 
     private Expression implementRecurse(RexToLixTranslator translator,
-        List<RexNode> operands, NullAs nullAs) {
-      if (operands.size() == 1) {
-        return translator.translate(operands.get(0), nullAs);
+        final List<Expression> argValueList) {
+      if (argValueList.size() == 1) {
+        return argValueList.get(0);
       } else {
         return Expressions.condition(
-            translator.translate(operands.get(0), NullAs.IS_NOT_NULL),
-            translator.translate(operands.get(0), nullAs),
-            implementRecurse(translator, Util.skip(operands), nullAs));
+            translator.checkNotNull(argValueList.get(0)),
+            argValueList.get(0),
+            implementRecurse(translator, Util.skip(argValueList)));
       }
-    }
-  }
-
-  /** Implementor for the SQL {@code CAST} function that optimizes if, say, the
-   * argument is already of the desired type. */
-  private static class CastOptimizedImplementor implements CallImplementor {
-    private final CallImplementor accurate;
-
-    private CastOptimizedImplementor() {
-      accurate = createImplementor(new CastImplementor(),
-          NullPolicy.STRICT, false);
-    }
-
-    public Expression implement(RexToLixTranslator translator, RexCall call,
-        NullAs nullAs) {
-      // Short-circuit if no cast is required
-      RexNode arg = call.getOperands().get(0);
-      if (call.getType().equals(arg.getType())) {
-        // No cast required, omit cast
-        return translator.translate(arg, nullAs);
-      }
-      if (SqlTypeUtil.equalSansNullability(translator.typeFactory,
-          call.getType(), arg.getType())
-          && nullAs == NullAs.NULL
-          && translator.deref(arg) instanceof RexLiteral) {
-        return RexToLixTranslator.translateLiteral(
-            (RexLiteral) translator.deref(arg), call.getType(),
-            translator.typeFactory, nullAs);
-      }
-      return accurate.implement(translator, call, nullAs);
     }
   }
 
   /** Implementor for the SQL {@code CAST} operator. */
-  private static class CastImplementor implements NotNullImplementor {
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        List<Expression> translatedOperands) {
+  private static class CastImplementor extends AbstractRexCallImplementor {
+
+    CastImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "cast";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       assert call.getOperands().size() == 1;
       final RelDataType sourceType = call.getOperands().get(0).getType();
-      // It's only possible for the result to be null if both expression
-      // and target type are nullable. We assume that the caller did not
-      // make a mistake. If expression looks nullable, caller WILL have
-      // checked that expression is not null before calling us.
-      final boolean nullable =
-          translator.isNullable(call)
-              && sourceType.isNullable()
-              && !Primitive.is(translatedOperands.get(0).getType());
+
+      // Short-circuit if no cast is required
+      RexNode arg = call.getOperands().get(0);
+      if (call.getType().equals(sourceType)) {
+        // No cast required, omit cast
+        return argValueList.get(0);
+      }
+      if (SqlTypeUtil.equalSansNullability(translator.typeFactory,
+          call.getType(), arg.getType())
+          && translator.deref(arg) instanceof RexLiteral) {
+        return RexToLixTranslator.translateLiteral(
+            (RexLiteral) translator.deref(arg), call.getType(),
+            translator.typeFactory, NullAs.NULL);
+      }
       final RelDataType targetType =
-          translator.nullifyType(call.getType(), nullable);
+          nullifyType(translator.typeFactory, call.getType(), false);
       return translator.translateCast(sourceType,
-          targetType,
-          translatedOperands.get(0));
+              targetType, argValueList.get(0));
+    }
+
+    private RelDataType nullifyType(JavaTypeFactory typeFactory,
+        final RelDataType type, final boolean nullable) {
+      if (type instanceof RelDataTypeFactoryImpl.JavaType) {
+        final Primitive primitive = Primitive.ofBox(
+            ((RelDataTypeFactoryImpl.JavaType) type).getJavaClass());
+        if (primitive != null) {
+          return typeFactory.createJavaType(primitive.primitiveClass);
+        }
+      }
+      return typeFactory.createTypeWithNullability(type, nullable);
     }
   }
 
   /** Implementor for the {@code REINTERPRET} internal SQL operator. */
-  private static class ReinterpretImplementor implements NotNullImplementor {
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        List<Expression> translatedOperands) {
+  private static class ReinterpretImplementor extends AbstractRexCallImplementor {
+    ReinterpretImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "reInterpret";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       assert call.getOperands().size() == 1;
-      return translatedOperands.get(0);
+      return argValueList.get(0);
     }
   }
 
   /** Implementor for a value-constructor. */
   private static class ValueConstructorImplementor
-      implements CallImplementor {
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        NullAs nullAs) {
-      return translator.translateConstructor(call.getOperands(),
-          call.getOperator().getKind());
+      extends AbstractRexCallImplementor {
+
+    ValueConstructorImplementor() {
+      super(NullPolicy.NONE, false);
+    }
+
+    @Override String getVariableName() {
+      return "value_constructor";
+    }
+
+    @Override Expression implementSafe(RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      SqlKind kind = call.getOperator().getKind();
+      final BlockBuilder blockBuilder = translator.getBlockBuilder();
+      switch (kind) {
+      case MAP_VALUE_CONSTRUCTOR:
+        Expression map =
+            blockBuilder.append(
+                "map",
+                Expressions.new_(LinkedHashMap.class),
+                false);
+        for (int i = 0; i < argValueList.size(); i++) {
+          Expression key = argValueList.get(i++);
+          Expression value = argValueList.get(i);
+          blockBuilder.add(
+              Expressions.statement(
+                  Expressions.call(
+                      map,
+                      BuiltInMethod.MAP_PUT.method,
+                      Expressions.box(key),
+                      Expressions.box(value))));
+        }
+        return map;
+      case ARRAY_VALUE_CONSTRUCTOR:
+        Expression lyst =
+            blockBuilder.append(
+                "list",
+                Expressions.new_(ArrayList.class),
+                false);
+        for (Expression value : argValueList) {
+          blockBuilder.add(
+              Expressions.statement(
+                  Expressions.call(
+                      lyst,
+                      BuiltInMethod.COLLECTION_ADD.method,
+                      Expressions.box(value))));
+        }
+        return lyst;
+      default:
+        throw new AssertionError("unexpected: " + kind);
+      }
     }
   }
 
   /** Implementor for the {@code ITEM} SQL operator. */
-  private static class ItemImplementor
-      implements CallImplementor {
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        NullAs nullAs) {
+  private static class ItemImplementor extends AbstractRexCallImplementor {
+
+    ItemImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "item";
+    }
+
+    // Since we follow PostgreSQL's semantics that an out-of-bound reference
+    // returns NULL, x[y] can return null even if x and y are both NOT NULL.
+    // (In SQL standard semantics, an out-of-bound reference to an array
+    // throws an exception.)
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       final MethodImplementor implementor =
-          getImplementor(
-              call.getOperands().get(0).getType().getSqlTypeName());
-      // Since we follow PostgreSQL's semantics that an out-of-bound reference
-      // returns NULL, x[y] can return null even if x and y are both NOT NULL.
-      // (In SQL standard semantics, an out-of-bound reference to an array
-      // throws an exception.)
-      final NullPolicy nullPolicy = NullPolicy.ANY;
-      return implementNullSemantics0(translator, call, nullAs, nullPolicy,
-          false, implementor);
+          getImplementor(call.getOperands().get(0).getType().getSqlTypeName());
+      return implementor.implementSafe(translator, call, argValueList);
     }
 
     private MethodImplementor getImplementor(SqlTypeName sqlTypeName) {
       switch (sqlTypeName) {
       case ARRAY:
-        return new MethodImplementor(BuiltInMethod.ARRAY_ITEM.method);
+        return new MethodImplementor(BuiltInMethod.ARRAY_ITEM.method, nullPolicy, false);
       case MAP:
-        return new MethodImplementor(BuiltInMethod.MAP_ITEM.method);
+        return new MethodImplementor(BuiltInMethod.MAP_ITEM.method, nullPolicy, false);
       default:
-        return new MethodImplementor(BuiltInMethod.ANY_ITEM.method);
+        return new MethodImplementor(BuiltInMethod.ANY_ITEM.method, nullPolicy, false);
       }
     }
   }
@@ -2837,18 +2742,18 @@ public class RexImpTable {
    *
    * <p>Several of these are represented internally as constant values, set
    * per execution. */
-  private static class SystemFunctionImplementor
-      implements CallImplementor {
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        NullAs nullAs) {
-      switch (nullAs) {
-      case IS_NULL:
-        return Expressions.constant(false);
-      case IS_NOT_NULL:
-        return Expressions.constant(true);
-      }
+  private static class SystemFunctionImplementor extends AbstractRexCallImplementor {
+
+    SystemFunctionImplementor() {
+      super(NullPolicy.NONE, false);
+    }
+
+    @Override String getVariableName() {
+      return "system_func";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       final SqlOperator op = call.getOperator();
       final Expression root = translator.getRoot();
       if (op == CURRENT_USER
@@ -2919,37 +2824,48 @@ public class RexImpTable {
   }
 
   /** Implementor for the {@code NOT} operator. */
-  private static class NotImplementor implements NotNullImplementor {
-    private final NotNullImplementor implementor;
+  private static class NotImplementor extends AbstractRexCallImplementor {
+    private AbstractRexCallImplementor implementor;
 
-    NotImplementor(NotNullImplementor implementor) {
+    private NotImplementor(AbstractRexCallImplementor implementor) {
+      super(null, false);
       this.implementor = implementor;
     }
 
-    private static NotNullImplementor of(NotNullImplementor implementor) {
+    static AbstractRexCallImplementor of(AbstractRexCallImplementor implementor) {
       return new NotImplementor(implementor);
     }
 
-    public Expression implement(
-        RexToLixTranslator translator,
-        RexCall call,
-        List<Expression> translatedOperands) {
+    @Override String getVariableName() {
+      return "not";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       final Expression expression =
-          implementor.implement(translator, call, translatedOperands);
+          implementor.implementSafe(translator, call, argValueList);
       return Expressions.not(expression);
     }
   }
 
   /** Implementor for various datetime arithmetic. */
   private static class DatetimeArithmeticImplementor
-      implements NotNullImplementor {
-    public Expression implement(RexToLixTranslator translator, RexCall call,
-        List<Expression> translatedOperands) {
+      extends AbstractRexCallImplementor {
+
+    DatetimeArithmeticImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+    @Override String getVariableName() {
+      return "dateTime_arithmetic";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
       final RexNode operand0 = call.getOperands().get(0);
-      Expression trop0 = translatedOperands.get(0);
+      Expression trop0 = argValueList.get(0);
       final SqlTypeName typeName1 =
           call.getOperands().get(1).getType().getSqlTypeName();
-      Expression trop1 = translatedOperands.get(1);
+      Expression trop1 = argValueList.get(1);
       final SqlTypeName typeName = call.getType().getSqlTypeName();
       switch (operand0.getType().getSqlTypeName()) {
       case DATE:
@@ -3111,16 +3027,580 @@ public class RexImpTable {
     }
   }
 
-  /** Implements PREV match-recognize function. */
-  private static class PrevImplementor implements CallImplementor {
-    @Override public Expression implement(RexToLixTranslator translator, RexCall call,
-        NullAs nullAs) {
-      final RexNode node = call.getOperands().get(0);
-      final RexNode offset = call.getOperands().get(1);
-      final Expression offs = Expressions.multiply(translator.translate(offset),
-          Expressions.constant(-1));
-      ((EnumerableMatch.PrevInputGetter) translator.inputGetter).setOffset(offs);
-      return translator.translate(node, nullAs);
+  /**
+   * Null safe RexCall Implementor
+   */
+  public interface RexCallImplementor {
+    RexToLixTranslator.Result implement(
+        RexToLixTranslator translator,
+        RexCall call,
+        List<RexToLixTranslator.Result> arguments);
+  }
+
+  /**
+   * Abstract implementation of the {@link RexCallImplementor} interface.
+   *
+   * <p>It is not always safe to execute the {@link RexCall} directly due to
+   * the special null arguments. Therefore, the generated code logic is
+   * conditional correspondingly.</p>
+   *
+   * <p>For example, {@code a + b} will generate two declaration statements:
+   * {@code
+   *   final Integer xxx_value = (a_isNull || b_isNull) ? null : plus(a, b);
+   *   final boolean xxx_isNull = xxx_value == null;
+   * }
+   * </p>
+   */
+  private abstract static class AbstractRexCallImplementor implements RexCallImplementor {
+
+    final NullPolicy nullPolicy;
+    private final boolean harmonize;
+
+    AbstractRexCallImplementor(NullPolicy nullPolicy, boolean harmonize) {
+      this.nullPolicy = nullPolicy;
+      this.harmonize = harmonize;
+    }
+
+    @Override public RexToLixTranslator.Result implement(
+        final RexToLixTranslator translator,
+        final RexCall call,
+        final List<RexToLixTranslator.Result> arguments) {
+      final List<Expression> argIsNullList = new ArrayList<>();
+      final List<Expression> argValueList = new ArrayList<>();
+      for (RexToLixTranslator.Result result: arguments) {
+        argIsNullList.add(result.isNullVariable);
+        argValueList.add(result.valueVariable);
+      }
+      final Expression condition = getCondition(argIsNullList);
+      final ParameterExpression valueVariable =
+          genValueStatement(translator, call, argValueList, condition);
+      final ParameterExpression isNullVariable =
+          genIsNullStatement(translator, valueVariable);
+      return new RexToLixTranslator.Result(isNullVariable, valueVariable);
+    }
+
+    // Variable name facilitates reasoning about issues when necessary
+    abstract String getVariableName();
+
+    /**Figure out conditional expression according to NullPolicy*/
+    Expression getCondition(final List<Expression> argIsNullList) {
+      if (argIsNullList.size() == 0 || nullPolicy == null
+          || nullPolicy == NullPolicy.NONE) {
+        return FALSE_EXPR;
+      }
+      if (nullPolicy == NullPolicy.ARG0) {
+        return argIsNullList.get(0);
+      }
+      return Expressions.foldOr(argIsNullList);
+    }
+
+    // E.g., "final Integer xxx_value = (a_isNull || b_isNull) ? null : plus(a, b)"
+    private ParameterExpression genValueStatement(
+        final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList,
+        final Expression condition) {
+      List<Expression> harmonizedArgValueList = argValueList;
+      if (harmonize) {
+        harmonizedArgValueList =
+            harmonize(argValueList, translator, call);
+      }
+
+      final Expression callValue = implementSafe(translator, call, harmonizedArgValueList);
+
+      // In general, RexCall's type is correct for code generation
+      // and thus we should ensure the consistency.
+      // However, for some special cases (e.g., TableFunction),
+      // the implementation's type is correct, we can't convert it.
+      final SqlOperator op = call.getOperator();
+      final Type returnType = translator.typeFactory.getJavaClass(call.getType());
+      final boolean noConvert = (returnType == null)
+              || (returnType == callValue.getType())
+              || (op instanceof SqlUserDefinedTableMacro)
+              || (op instanceof SqlUserDefinedTableFunction);
+      final Expression convertedCallValue =
+              noConvert
+              ? callValue
+              : EnumUtils.convert(callValue, returnType);
+
+      final Expression valueExpression =
+          Expressions.condition(
+              condition,
+              getIfTrue(convertedCallValue.getType(), argValueList),
+              convertedCallValue);
+      final ParameterExpression value =
+          Expressions.parameter(convertedCallValue.getType(),
+              translator.getBlockBuilder().newName(getVariableName() + "_value"));
+      translator.getBlockBuilder().add(
+          Expressions.declare(Modifier.FINAL, value, valueExpression));
+      return value;
+    }
+
+    Expression getIfTrue(Type type, final List<Expression> argValueList) {
+      return getDefaultValue(type);
+    }
+
+    // E.g., "final boolean xxx_isNull = xxx_value == null"
+    private ParameterExpression genIsNullStatement(
+        final RexToLixTranslator translator, final ParameterExpression value) {
+      final ParameterExpression isNullVariable =
+          Expressions.parameter(Boolean.TYPE,
+              translator.getBlockBuilder().newName(getVariableName() + "_isNull"));
+      final Expression isNullExpression = translator.checkNull(value);
+      translator.getBlockBuilder().add(
+          Expressions.declare(Modifier.FINAL, isNullVariable, isNullExpression));
+      return isNullVariable;
+    }
+
+    /** Ensures that operands have identical type. */
+    private List<Expression> harmonize(final List<Expression> argValueList,
+        final RexToLixTranslator translator, final RexCall call) {
+      int nullCount = 0;
+      final List<RelDataType> types = new ArrayList<>();
+      final RelDataTypeFactory typeFactory =
+          translator.builder.getTypeFactory();
+      for (RexNode operand : call.getOperands()) {
+        RelDataType type = operand.getType();
+        type = toSql(typeFactory, type);
+        if (translator.isNullable(operand)) {
+          ++nullCount;
+        } else {
+          type = typeFactory.createTypeWithNullability(type, false);
+        }
+        types.add(type);
+      }
+      if (allSame(types)) {
+        // Operands have the same nullability and type. Return them
+        // unchanged.
+        return argValueList;
+      }
+      final RelDataType type = typeFactory.leastRestrictive(types);
+      if (type == null) {
+        // There is no common type. Presumably this is a binary operator with
+        // asymmetric arguments (e.g. interval / integer) which is not intended
+        // to be harmonized.
+        return argValueList;
+      }
+      assert (nullCount > 0) == type.isNullable();
+      final Type javaClass =
+          translator.typeFactory.getJavaClass(type);
+      final List<Expression> harmonizedArgValues = new ArrayList<>();
+      for (Expression argValue : argValueList) {
+        harmonizedArgValues.add(
+            EnumUtils.convert(argValue, javaClass));
+      }
+      return harmonizedArgValues;
+    }
+
+    abstract Expression implementSafe(RexToLixTranslator translator,
+        RexCall call, List<Expression> argValueList);
+  }
+
+  /**
+   * Logical And Implementor
+   *
+   * <p>If any of the arguments are false, result is false;
+   * else if any arguments are null, result is null;
+   * else true.</p>
+   */
+  private static class LogicalAndImplementor extends AbstractRexCallImplementor {
+
+    LogicalAndImplementor() {
+      super(NullPolicy.NONE, true);
+    }
+
+    @Override String getVariableName() {
+      return "logical_and";
+    }
+
+    @Override public RexToLixTranslator.Result implement(final RexToLixTranslator translator,
+        final RexCall call, final List<RexToLixTranslator.Result> arguments) {
+      final List<Expression> argIsNullList = new ArrayList<>();
+      for (RexToLixTranslator.Result result: arguments) {
+        argIsNullList.add(result.isNullVariable);
+      }
+      final List<Expression> nullAsTrue =
+          arguments.stream()
+              .map(result ->
+                  Expressions.condition(
+                      result.isNullVariable,
+                      TRUE_EXPR,
+                      result.valueVariable))
+              .collect(Collectors.toList());
+      final Expression hasFalse =
+          Expressions.not(Expressions.foldAnd(nullAsTrue));
+      final Expression hasNull = Expressions.foldOr(argIsNullList);
+      final Expression callExpression =
+          Expressions.condition(
+              hasFalse,
+              BOXED_FALSE_EXPR,
+              Expressions.condition(hasNull, NULL_EXPR, BOXED_TRUE_EXPR));
+      final RexImpTable.NullAs nullAs = translator.isNullable(call)
+          ? RexImpTable.NullAs.NULL : RexImpTable.NullAs.NOT_POSSIBLE;
+      final Expression valueExpression = nullAs.handle(callExpression);
+      final ParameterExpression valueVariable =
+          Expressions.parameter(valueExpression.getType(),
+              translator.getBlockBuilder().newName(getVariableName() + "_value"));
+      final Expression isNullExpression = translator.checkNull(valueVariable);
+      final ParameterExpression isNullVariable =
+          Expressions.parameter(Boolean.TYPE,
+              translator.getBlockBuilder().newName(getVariableName() + "_isNull"));
+      translator.getBlockBuilder().add(
+          Expressions.declare(Modifier.FINAL, valueVariable, valueExpression));
+      translator.getBlockBuilder().add(
+          Expressions.declare(Modifier.FINAL, isNullVariable, isNullExpression));
+      return new RexToLixTranslator.Result(isNullVariable, valueVariable);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return null;
+    }
+  }
+
+  /**
+   * Logical Or Implementor
+   *
+   * <p>If any of the arguments are true, result is true;
+   * else if any arguments are null, result is null;
+   * else false.</p>
+   */
+  private static class LogicalOrImplementor extends AbstractRexCallImplementor {
+
+    LogicalOrImplementor() {
+      super(NullPolicy.NONE, true);
+    }
+
+    @Override String getVariableName() {
+      return "logical_or";
+    }
+
+    @Override public RexToLixTranslator.Result implement(final RexToLixTranslator translator,
+        final RexCall call, final List<RexToLixTranslator.Result> arguments) {
+      final List<Expression> argIsNullList = new ArrayList<>();
+      for (RexToLixTranslator.Result result: arguments) {
+        argIsNullList.add(result.isNullVariable);
+      }
+      final List<Expression> nullAsFalse =
+          arguments.stream()
+              .map(result ->
+                  Expressions.condition(
+                      result.isNullVariable,
+                      FALSE_EXPR,
+                      result.valueVariable))
+              .collect(Collectors.toList());
+      final Expression hasTrue = Expressions.foldOr(nullAsFalse);
+      final Expression hasNull = Expressions.foldOr(argIsNullList);
+      final Expression callExpression =
+          Expressions.condition(
+              hasTrue,
+              BOXED_TRUE_EXPR,
+              Expressions.condition(hasNull, NULL_EXPR, BOXED_FALSE_EXPR));
+      final RexImpTable.NullAs nullAs = translator.isNullable(call)
+          ? RexImpTable.NullAs.NULL : RexImpTable.NullAs.NOT_POSSIBLE;
+      final Expression valueExpression = nullAs.handle(callExpression);
+      final ParameterExpression valueVariable =
+          Expressions.parameter(valueExpression.getType(),
+              translator.getBlockBuilder().newName(getVariableName() + "_value"));
+      final Expression isNullExpression = translator.checkNull(valueExpression);
+      final ParameterExpression isNullVariable =
+          Expressions.parameter(Boolean.TYPE,
+              translator.getBlockBuilder().newName(getVariableName() + "_isNull"));
+      translator.getBlockBuilder().add(
+          Expressions.declare(Modifier.FINAL, valueVariable, valueExpression));
+      translator.getBlockBuilder().add(
+          Expressions.declare(Modifier.FINAL, isNullVariable, isNullExpression));
+      return new RexToLixTranslator.Result(isNullVariable, valueVariable);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return null;
+    }
+  }
+
+  /**
+   * Logical Not Implementor
+   *
+   * <p>If any of the arguments are false, result is true;
+   * else if any arguments are null, result is null;
+   * else false.</p>
+   */
+  private static class LogicalNotImplementor extends AbstractRexCallImplementor {
+
+    LogicalNotImplementor() {
+      super(NullPolicy.NONE, true);
+    }
+
+    @Override String getVariableName() {
+      return "logical_not";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.call(BuiltInMethod.NOT.method, argValueList);
+    }
+  }
+
+  /**
+   * Implementation that calls a given {@link java.lang.reflect.Method}.
+   *
+   * <p>When method is not static, a new instance of the required class is
+   * created.
+   */
+  private static class ReflectiveImplementor extends AbstractRexCallImplementor {
+    protected final Method method;
+
+    ReflectiveImplementor(Method method, NullPolicy nullPolicy) {
+      super(nullPolicy, false);
+      this.method = method;
+    }
+
+    @Override String getVariableName() {
+      return "reflective_" + method.getName();
+    }
+
+    @Override Expression implementSafe(RexToLixTranslator translator,
+        RexCall call, List<Expression> argValueList) {
+      List<Expression> argValueList0 =
+          EnumUtils.fromInternal(method.getParameterTypes(), argValueList);
+      if ((method.getModifiers() & Modifier.STATIC) != 0) {
+        return Expressions.call(method, argValueList0);
+      } else {
+        // The UDF class must have a public zero-args constructor.
+        // Assume that the validator checked already.
+        final Expression target = Expressions.new_(method.getDeclaringClass());
+        return Expressions.call(target, method, argValueList0);
+      }
+    }
+  }
+
+
+  /** Implementor for the {@code RAND} function. */
+  private static class RandImplementor extends AbstractRexCallImplementor {
+    private final AbstractRexCallImplementor[] implementors = {
+        new ReflectiveImplementor(BuiltInMethod.RAND.method, nullPolicy),
+        new ReflectiveImplementor(BuiltInMethod.RAND_SEED.method, nullPolicy)
+    };
+
+    RandImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "rand";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return implementors[call.getOperands().size()]
+          .implementSafe(translator, call, argValueList);
+    }
+  }
+
+  /** Implementor for the {@code RAND_INTEGER} function. */
+  private static class RandIntegerImplementor extends AbstractRexCallImplementor {
+    private final AbstractRexCallImplementor[] implementors = {
+        null,
+        new ReflectiveImplementor(BuiltInMethod.RAND_INTEGER.method, nullPolicy),
+        new ReflectiveImplementor(BuiltInMethod.RAND_INTEGER_SEED.method, nullPolicy)
+    };
+
+    RandIntegerImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "rand_integer";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return implementors[call.getOperands().size()]
+          .implementSafe(translator, call, argValueList);
+    }
+  }
+
+  /** Implementor for the {@code PI} operator. */
+  private static class PiImplementor extends AbstractRexCallImplementor {
+
+    PiImplementor() {
+      super(NullPolicy.NONE, false);
+    }
+
+    @Override String getVariableName() {
+      return "pi";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.constant(Math.PI);
+    }
+  }
+
+  /** Implementor for the {@code IS_FALSE} SQL operator. */
+  private static class IsFalseImplementor extends AbstractRexCallImplementor {
+
+    IsFalseImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "is_false";
+    }
+
+    @Override Expression getIfTrue(Type type, final List<Expression> argValueList) {
+      return Expressions.constant(false, type);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.equal(argValueList.get(0), FALSE_EXPR);
+    }
+  }
+
+  /** Implementor for the {@code IS_NOT_FALSE} SQL operator. */
+  private static class IsNotFalseImplementor extends AbstractRexCallImplementor {
+
+    IsNotFalseImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "is_not_false";
+    }
+
+    @Override Expression getIfTrue(Type type, final List<Expression> argValueList) {
+      return Expressions.constant(true, type);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.notEqual(argValueList.get(0), FALSE_EXPR);
+    }
+  }
+
+  /** Implementor for the {@code IS_NOT_NULL} SQL operator. */
+  private static class IsNotNullImplementor extends AbstractRexCallImplementor {
+
+    IsNotNullImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "is_not_null";
+    }
+
+    @Override Expression getIfTrue(Type type, final List<Expression> argValueList) {
+      return Expressions.constant(false, type);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.notEqual(argValueList.get(0), NULL_EXPR);
+    }
+  }
+
+  /** Implementor for the {@code IS_NOT_TRUE} SQL operator. */
+  private static class IsNotTrueImplementor extends AbstractRexCallImplementor {
+
+    IsNotTrueImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "is_not_true";
+    }
+
+    @Override Expression getIfTrue(Type type, final List<Expression> argValueList) {
+      return Expressions.constant(true, type);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.notEqual(argValueList.get(0), TRUE_EXPR);
+    }
+  }
+
+  /** Implementor for the {@code IS_NULL} SQL operator. */
+  private static class IsNullImplementor extends AbstractRexCallImplementor {
+
+    IsNullImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "is_null";
+    }
+
+    @Override Expression getIfTrue(Type type, final List<Expression> argValueList) {
+      return Expressions.constant(true, type);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.equal(argValueList.get(0), NULL_EXPR);
+    }
+  }
+
+  /** Implementor for the {@code IS_TRUE} SQL operator. */
+  private static class IsTrueImplementor extends AbstractRexCallImplementor {
+
+    IsTrueImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "is_true";
+    }
+
+    @Override Expression getIfTrue(Type type, final List<Expression> argValueList) {
+      return Expressions.constant(false, type);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.equal(argValueList.get(0), TRUE_EXPR);
+    }
+  }
+
+  /** Implementor for the {@code REGEXP_REPLACE} function. */
+  private static class RegexpReplaceImplementor extends AbstractRexCallImplementor {
+    private final AbstractRexCallImplementor[] implementors = {
+        new ReflectiveImplementor(BuiltInMethod.REGEXP_REPLACE3.method, nullPolicy),
+        new ReflectiveImplementor(BuiltInMethod.REGEXP_REPLACE4.method, nullPolicy),
+        new ReflectiveImplementor(BuiltInMethod.REGEXP_REPLACE5.method, nullPolicy),
+        new ReflectiveImplementor(BuiltInMethod.REGEXP_REPLACE6.method, nullPolicy),
+    };
+
+    RegexpReplaceImplementor() {
+      super(NullPolicy.STRICT, false);
+    }
+
+    @Override String getVariableName() {
+      return "regexp_replace";
+    }
+
+    @Override Expression implementSafe(RexToLixTranslator translator,
+        RexCall call, List<Expression> argValueList) {
+      return implementors[call.getOperands().size() - 3]
+          .implementSafe(translator, call, argValueList);
+    }
+  }
+
+  /** Implementor for the {@code DEFAULT} function. */
+  private static class DefaultImplementor extends AbstractRexCallImplementor {
+
+    DefaultImplementor() {
+      super(NullPolicy.NONE, false);
+    }
+
+    @Override String getVariableName() {
+      return "default";
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      return Expressions.constant(null);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/schema/impl/TableFunctionImpl.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/TableFunctionImpl.java
@@ -137,7 +137,7 @@ public class TableFunctionImpl extends ReflectiveFunctionBase implements
             }
             return expr;
           }
-        }, NullPolicy.ANY, false);
+        }, NullPolicy.NONE, false);
   }
 
   private Table apply(List<Object> arguments) {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -2478,12 +2478,14 @@ public class JdbcTest {
     CalciteAssert.hr()
         .query(
             "select upper((case when \"empid\">\"deptno\"*10 then 'y' else null end)) T from \"hr\".\"emps\"")
-        .planContains("static final String "
-            + "$L4J$C$org_apache_calcite_runtime_SqlFunctions_upper_y_ = "
-            + "org.apache.calcite.runtime.SqlFunctions.upper(\"y\");")
-        .planContains("return current.empid <= current.deptno * 10 "
-            + "? (String) null "
-            + ": $L4J$C$org_apache_calcite_runtime_SqlFunctions_upper_y_;")
+        .planContains("      String case_when_value;\n"
+            + "              final org.apache.calcite.test.JdbcTest.Employee current = (org.apache.calcite.test.JdbcTest.Employee) inputEnumerator.current();\n"
+            + "              if (current.empid > current.deptno * 10) {\n"
+            + "                case_when_value = \"y\";\n"
+            + "              } else {\n"
+            + "                case_when_value = (String) null;\n"
+            + "              }\n"
+            + "              return case_when_value == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.upper(case_when_value);")
         .returns("T=null\n"
             + "T=null\n"
             + "T=Y\n"
@@ -2494,12 +2496,14 @@ public class JdbcTest {
     CalciteAssert.hr()
         .query(
             "select upper((case when \"empid\">\"deptno\"*10 then \"name\" end)) T from \"hr\".\"emps\"")
-        .planContains(
-            "final String inp2_ = current.name;")
-        .planContains("return current.empid <= current.deptno * 10 "
-            + "|| inp2_ == null "
-            + "? (String) null "
-            + ": org.apache.calcite.runtime.SqlFunctions.upper(inp2_);")
+        .planContains("      String case_when_value;\n"
+            + "              final org.apache.calcite.test.JdbcTest.Employee current = (org.apache.calcite.test.JdbcTest.Employee) inputEnumerator.current();\n"
+            + "              if (current.empid > current.deptno * 10) {\n"
+            + "                case_when_value = current.name;\n"
+            + "              } else {\n"
+            + "                case_when_value = (String) null;\n"
+            + "              }\n"
+            + "              return case_when_value == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.upper(case_when_value);")
         .returns("T=null\n"
             + "T=null\n"
             + "T=SEBASTIAN\n"
@@ -2511,17 +2515,16 @@ public class JdbcTest {
         .query(
             "select substring(\"name\", \"deptno\"+case when CURRENT_PATH <> '' then 1 end) from \"hr\".\"emps\"")
         .planContains(
-            "final String inp2_ = current.name;")
-        .planContains("static final boolean "
-            + "$L4J$C$org_apache_calcite_runtime_SqlFunctions_ne_ = "
-            + "org.apache.calcite.runtime.SqlFunctions.ne(\"\", \"\");")
-        .planContains("static final boolean "
-            + "$L4J$C$_org_apache_calcite_runtime_SqlFunctions_ne_ = "
-            + "!$L4J$C$org_apache_calcite_runtime_SqlFunctions_ne_;")
-        .planContains("return inp2_ == null "
-            + "|| $L4J$C$_org_apache_calcite_runtime_SqlFunctions_ne_ ? (String) null"
-            + " : org.apache.calcite.runtime.SqlFunctions.substring(inp2_, "
-            + "Integer.valueOf(current.deptno + 1).intValue());");
+              "              final org.apache.calcite.test.JdbcTest.Employee current = (org.apache.calcite.test.JdbcTest.Employee) inputEnumerator.current();\n"
+            + "              final String input_value = current.name;\n"
+            + "              Integer case_when_value;\n"
+            + "              if ($L4J$C$org_apache_calcite_runtime_SqlFunctions_ne_) {\n"
+            + "                case_when_value = $L4J$C$Integer_valueOf_1_;\n"
+            + "              } else {\n"
+            + "                case_when_value = (Integer) null;\n"
+            + "              }\n"
+            + "              final Integer binary_call_value0 = case_when_value == null ? (Integer) null : Integer.valueOf(Integer.valueOf(current.deptno) + case_when_value);\n"
+            + "              return input_value == null || binary_call_value0 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(input_value, binary_call_value0.intValue());\n");
   }
 
   @Test public void testReuseExpressionWhenNullChecking4() {
@@ -2536,23 +2539,32 @@ public class JdbcTest {
             + "from\n"
             + "\"hr\".\"emps\"")
         .planContains(
-            "final String inp2_ = current.name;")
-        .planContains(
-            "final int inp1_ = current.deptno;")
-        .planContains("static final boolean "
-            + "$L4J$C$org_apache_calcite_runtime_SqlFunctions_eq_ = "
-            + "org.apache.calcite.runtime.SqlFunctions.eq(\"\", \"\");")
-        .planContains("static final boolean "
-            + "$L4J$C$_org_apache_calcite_runtime_SqlFunctions_eq_ = "
-            + "!$L4J$C$org_apache_calcite_runtime_SqlFunctions_eq_;")
-        .planContains("return inp2_ == null "
-            + "|| $L4J$C$_org_apache_calcite_runtime_SqlFunctions_eq_ "
-            + "|| !v5 && inp1_ * 8 <= 8 "
-            + "? (String) null "
-            + ": org.apache.calcite.runtime.SqlFunctions.substring("
-            + "org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", "
-            + "org.apache.calcite.runtime.SqlFunctions.substring(inp2_, "
-            + "Integer.valueOf(inp1_ * 0 + 1).intValue()), true), Integer.valueOf((v5 ? 4 : 5) - 2).intValue());")
+              "              final org.apache.calcite.test.JdbcTest.Employee current = (org.apache.calcite.test.JdbcTest.Employee) inputEnumerator.current();\n"
+            + "              final String input_value = current.name;\n"
+            + "              final int input_value0 = current.deptno;\n"
+            + "              Integer case_when_value;\n"
+            + "              if ($L4J$C$org_apache_calcite_runtime_SqlFunctions_eq_) {\n"
+            + "                case_when_value = $L4J$C$Integer_valueOf_1_;\n"
+            + "              } else {\n"
+            + "                case_when_value = (Integer) null;\n"
+            + "              }\n"
+            + "              final Integer binary_call_value1 = case_when_value == null ? (Integer) null : Integer.valueOf(Integer.valueOf(input_value0 * 0) + case_when_value);\n"
+            + "              final String method_call_value = input_value == null || binary_call_value1 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(input_value, binary_call_value1.intValue());\n"
+            + "              final String trim_value = method_call_value == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", method_call_value, true);\n"
+            + "              Integer case_when_value0;\n"
+            + "              if (current.empid > input_value0) {\n"
+            + "                case_when_value0 = $L4J$C$Integer_valueOf_4_;\n"
+            + "              } else {\n"
+            + "                Integer case_when_value1;\n"
+            + "                if (current.deptno * 8 > 8) {\n"
+            + "                  case_when_value1 = $L4J$C$Integer_valueOf_5_;\n"
+            + "                } else {\n"
+            + "                  case_when_value1 = (Integer) null;\n"
+            + "                }\n"
+            + "                case_when_value0 = case_when_value1;\n"
+            + "              }\n"
+            + "              final Integer binary_call_value3 = case_when_value0 == null ? (Integer) null : Integer.valueOf(case_when_value0 - $L4J$C$Integer_valueOf_2_);\n"
+            + "              return trim_value == null || binary_call_value3 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(trim_value, binary_call_value3.intValue());\n")
         .returns("T=ill\n"
             + "T=ric\n"
             + "T=ebastian\n"
@@ -2571,33 +2583,139 @@ public class JdbcTest {
             + "from\n"
             + "\"hr\".\"emps\"")
         .planContains(
-            "final String inp2_ = current.name;")
-        .planContains(
-            "final int inp1_ = current.deptno;")
-        .planContains(
-            "static final int $L4J$C$5_2 = 5 - 2;")
-        .planContains(
-            "static final Integer $L4J$C$Integer_valueOf_5_2_ = Integer.valueOf($L4J$C$5_2);")
-        .planContains(
-            "static final int $L4J$C$Integer_valueOf_5_2_intValue_ = $L4J$C$Integer_valueOf_5_2_.intValue();")
-        .planContains("static final boolean "
-            + "$L4J$C$org_apache_calcite_runtime_SqlFunctions_eq_ = "
-            + "org.apache.calcite.runtime.SqlFunctions.eq(\"\", \"\");")
-        .planContains("static final boolean "
-            + "$L4J$C$_org_apache_calcite_runtime_SqlFunctions_eq_ = "
-            + "!$L4J$C$org_apache_calcite_runtime_SqlFunctions_eq_;")
-        .planContains("return inp2_ == null "
-            + "|| $L4J$C$_org_apache_calcite_runtime_SqlFunctions_eq_ "
-            + "|| current.empid <= inp1_ && inp1_ * 8 <= 8 "
-            + "? (String) null "
-            + ": org.apache.calcite.runtime.SqlFunctions.substring("
-            + "org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", "
-            + "org.apache.calcite.runtime.SqlFunctions.substring(inp2_, "
-            + "Integer.valueOf(inp1_ * 0 + 1).intValue()), true), $L4J$C$Integer_valueOf_5_2_intValue_);")
+              "              final org.apache.calcite.test.JdbcTest.Employee current = (org.apache.calcite.test.JdbcTest.Employee) inputEnumerator.current();\n"
+            + "              final String input_value = current.name;\n"
+            + "              final int input_value0 = current.deptno;\n"
+            + "              Integer case_when_value;\n"
+            + "              if ($L4J$C$org_apache_calcite_runtime_SqlFunctions_eq_) {\n"
+            + "                case_when_value = $L4J$C$Integer_valueOf_1_;\n"
+            + "              } else {\n"
+            + "                case_when_value = (Integer) null;\n"
+            + "              }\n"
+            + "              final Integer binary_call_value1 = case_when_value == null ? (Integer) null : Integer.valueOf(Integer.valueOf(input_value0 * 0) + case_when_value);\n"
+            + "              final String method_call_value = input_value == null || binary_call_value1 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(input_value, binary_call_value1.intValue());\n"
+            + "              final String trim_value = method_call_value == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", method_call_value, true);\n"
+            + "              Integer case_when_value0;\n"
+            + "              if (current.empid > input_value0) {\n"
+            + "                case_when_value0 = $L4J$C$Integer_valueOf_5_;\n"
+            + "              } else {\n"
+            + "                Integer case_when_value1;\n"
+            + "                if (current.deptno * 8 > 8) {\n"
+            + "                  case_when_value1 = $L4J$C$Integer_valueOf_5_;\n"
+            + "                } else {\n"
+            + "                  case_when_value1 = (Integer) null;\n"
+            + "                }\n"
+            + "                case_when_value0 = case_when_value1;\n"
+            + "              }\n"
+            + "              final Integer binary_call_value3 = case_when_value0 == null ? (Integer) null : Integer.valueOf(case_when_value0 - $L4J$C$Integer_valueOf_2_);\n"
+            + "              return trim_value == null || binary_call_value3 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(trim_value, binary_call_value3.intValue());"
+        )
         .returns("T=ll\n"
             + "T=ic\n"
             + "T=bastian\n"
             + "T=eodore\n");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3142">[CALCITE-3142]
+   * An NPE when rounding a nullable numeric</a>. */
+  @Test public void testRoundingNPE() {
+    CalciteAssert.that()
+        .query("SELECT ROUND(CAST((X/Y) AS NUMERIC), 2) "
+            + "FROM (VALUES (1, 2), (NULLIF(5, 5), NULLIF(5, 5))) A(X, Y)")
+        .planContains("      final Object[] current = (Object[]) inputEnumerator.current();\n"
+            + "              final Integer input_value = (Integer) current[0];\n"
+            + "              final Integer input_value0 = (Integer) current[1];\n"
+            + "              final Integer binary_call_value = input_value == null || input_value0 == null ? (Integer) null : Integer.valueOf(input_value / input_value0);\n"
+            + "              final java.math.BigDecimal cast_value = binary_call_value == null ? (java.math.BigDecimal) null : binary_call_value == null ? (java.math.BigDecimal) null : new java.math.BigDecimal(\n"
+            + "                binary_call_value.intValue());\n"
+            + "              return cast_value == null ? (java.math.BigDecimal) null : org.apache.calcite.runtime.SqlFunctions.sround(cast_value, 2);")
+        .returns("EXPR$0=0.00\n"
+            + "EXPR$0=null\n");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3143">[CALCITE-3143]
+   * Dividing NULLIF clause may cause Division by zero error</a>. */
+  @Test public void testDividingZero() {
+    CalciteAssert.that()
+        .query("SELECT CASE WHEN \"Z\" < 77 AND \"Z\" > 0 THEN 99 ELSE 88 END FROM\n"
+            + "(\n"
+            + " SELECT SUM(\"X\") / NULLIF(SUM(0),0) AS Z\n"
+            + " FROM (VALUES (1.1, 2.5), (4.51, 32.5)) A(X, Y)\n"
+            + " GROUP BY \"Y\"\n"
+            + ")")
+        .planContains("      int case_when_value;\n"
+            + "              final Object[] current = (Object[]) inputEnumerator.current();\n"
+            + "              final java.math.BigDecimal input_value = current[1] == null ? (java.math.BigDecimal) null : org.apache.calcite.runtime.SqlFunctions.toBigDecimal(current[1]);\n"
+            + "              Integer case_when_value0;\n"
+            + "              if (org.apache.calcite.runtime.SqlFunctions.toInt(current[2]) == 0) {\n"
+            + "                case_when_value0 = (Integer) null;\n"
+            + "              } else {\n"
+            + "                case_when_value0 = Integer.valueOf(org.apache.calcite.runtime.SqlFunctions.toInt(current[2]));\n"
+            + "              }\n"
+            + "              final java.math.BigDecimal binary_call_value0 = input_value == null || case_when_value0 == null ? (java.math.BigDecimal) null : org.apache.calcite.runtime.SqlFunctions.divide(input_value, case_when_value0 == null ? (java.math.BigDecimal) null : new java.math.BigDecimal(\n"
+            + "                case_when_value0.intValue()));\n"
+            + "              final boolean binary_call_isNull0 = binary_call_value0 == null;\n"
+            + "              final Boolean binary_call_value1 = binary_call_isNull0 ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.lt(binary_call_value0, $L4J$C$new_java_math_BigDecimal_77_));\n"
+            + "              final boolean binary_call_isNull1 = binary_call_value1 == null;\n"
+            + "              final Boolean binary_call_value2 = binary_call_isNull0 ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.gt(binary_call_value0, $L4J$C$new_java_math_BigDecimal_0_));\n"
+            + "              final boolean binary_call_isNull2 = binary_call_value2 == null;\n"
+            + "              final Boolean logical_and_value = (binary_call_isNull1 ? true : binary_call_value1) && (binary_call_isNull2 ? true : binary_call_value2) ? (binary_call_isNull1 || binary_call_isNull2 ? (Boolean) null : Boolean.TRUE) : Boolean.FALSE;\n"
+            + "              if (logical_and_value != null && logical_and_value) {\n"
+            + "                case_when_value = 99;\n"
+            + "              } else {\n"
+            + "                case_when_value = 88;\n"
+            + "              }\n"
+            + "              return case_when_value;")
+        .returns("EXPR$0=88\n"
+            + "EXPR$0=88\n");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3150">[CALCITE-3150]
+   * NPE in UPPER when repeated and combine with LIKE</a>. */
+  @Test public void testUpperLikeNPE() {
+    CalciteAssert.that()
+        .query("SELECT \"NAME\" "
+            + "FROM (VALUES ('Bill'), NULLIF('x', 'x'), ('Eric')) A(NAME) "
+            + "WHERE UPPER(\"NAME\") LIKE 'B%' AND UPPER(\"NAME\") LIKE '%L'")
+        .planContains(
+              "        final String method_call_value = inputEnumerator.current() == null || inputEnumerator.current().toString() == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.upper(inputEnumerator.current() == null ? (String) null : inputEnumerator.current().toString());\n"
+            + "                final boolean method_call_isNull = method_call_value == null;\n"
+            + "                final Boolean method_call_value0 = method_call_isNull ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.like(method_call_value, \"B%\"));\n"
+            + "                final boolean method_call_isNull0 = method_call_value0 == null;\n"
+            + "                final Boolean method_call_value1 = method_call_isNull ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.like(method_call_value, \"%L\"));\n"
+            + "                final boolean method_call_isNull1 = method_call_value1 == null;\n"
+            + "                final Boolean logical_and_value = (method_call_isNull0 ? true : method_call_value0) && (method_call_isNull1 ? true : method_call_value1) ? (method_call_isNull0 || method_call_isNull1 ? (Boolean) null : Boolean.TRUE) : Boolean.FALSE;\n"
+            + "                if (logical_and_value == null ? false : logical_and_value) {\n"
+            + "                  return true;\n"
+            + "                }")
+        .returns("NAME=Bill\n");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3717">[CALCITE-3717]
+   * Query fails with "division by zero" exception</a>. */
+  @Test public void testNestedCaseWhen() {
+    CalciteAssert.that()
+        .query("SELECT "
+            + "CASE WHEN A=0 THEN (B+C+D)*1.0 "
+            + "WHEN B=0 THEN 1.0/A+(C+D)*1.0 "
+            + "WHEN C=0 THEN 1.0/A+1.0/B+D*1.0 "
+            + "WHEN D=0 THEN 1.0/A+1.0/B+1.0/C "
+            + "ELSE 1.0/A+1.0/B+1.0/C+1.0/D END AS V "
+            + "FROM (VALUES (0, 2, 4, 8), (1, 0, 4, 8), (1, 2, 0, 8),"
+            + " (1, 2, 4, 0), (0, 0, 0, 0), (1, 2, 4, 8),"
+            + " (CAST(null as int), CAST(null as int), CAST(null as int),"
+            + " CAST(null as int))) AS T(A,B,C,D)")
+        .returns("V=14.0\n"
+            + "V=13.0\n"
+            + "V=9.5\n"
+            + "V=1.75\n"
+            + "V=0.0\n"
+            + "V=1.875\n"
+            + "V=null\n");
   }
 
   @Test public void testValues() {
@@ -3643,11 +3761,16 @@ public class JdbcTest {
             + "        a1w0,\n"
             + "        a2w0,\n"
             + "        a3w0});")
+        .planContains("      Float case_when_value;\n"
+            + "              if (org.apache.calcite.runtime.SqlFunctions.toLong(current[4]) > 0L) {\n"
+            + "                case_when_value = Float.valueOf(org.apache.calcite.runtime.SqlFunctions.toFloat(current[5]));\n"
+            + "              } else {\n"
+            + "                case_when_value = (Float) null;\n"
+            + "              }")
         .planContains("return new Object[] {\n"
             + "                  current[1],\n"
             + "                  current[0],\n"
-            // Float.valueOf(SqlFunctions.toFloat(current[5])) comes from SUM0
-            + "                  org.apache.calcite.runtime.SqlFunctions.toLong(current[4]) > 0L ? Float.valueOf(org.apache.calcite.runtime.SqlFunctions.toFloat(current[5])) : (Float) null,\n"
+            + "                  case_when_value,\n"
             + "                  5,\n"
             + "                  current[6],\n"
             + "                  current[7]};\n");
@@ -6174,8 +6297,8 @@ public class JdbcTest {
             + "  select cast(null as timestamp) as time0,"
             + "         cast(null as timestamp) as time1"
             + ") calcs")
-        .planContains("org.apache.calcite.runtime.SqlFunctions.eq(inp0_, inp1_)")
-        .planContains("org.apache.calcite.runtime.SqlFunctions.ne(inp0_, inp1_)")
+        .planContains("org.apache.calcite.runtime.SqlFunctions.eq(input_value, input_value0)")
+        .planContains("org.apache.calcite.runtime.SqlFunctions.ne(input_value, input_value0)")
         .returns("EXPR$0=true; EXPR$1=false\n"
             + "EXPR$0=null; EXPR$1=null\n");
   }

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -2523,7 +2523,7 @@ public class JdbcTest {
             + "              } else {\n"
             + "                case_when_value = (Integer) null;\n"
             + "              }\n"
-            + "              final Integer binary_call_value0 = case_when_value == null ? (Integer) null : Integer.valueOf(Integer.valueOf(current.deptno) + case_when_value);\n"
+            + "              final Integer binary_call_value0 = case_when_value == null ? (Integer) null : Integer.valueOf(current.deptno + case_when_value.intValue());\n"
             + "              return input_value == null || binary_call_value0 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(input_value, binary_call_value0.intValue());\n");
   }
 
@@ -2548,7 +2548,7 @@ public class JdbcTest {
             + "              } else {\n"
             + "                case_when_value = (Integer) null;\n"
             + "              }\n"
-            + "              final Integer binary_call_value1 = case_when_value == null ? (Integer) null : Integer.valueOf(Integer.valueOf(input_value0 * 0) + case_when_value);\n"
+            + "              final Integer binary_call_value1 = case_when_value == null ? (Integer) null : Integer.valueOf(input_value0 * 0 + case_when_value.intValue());\n"
             + "              final String method_call_value = input_value == null || binary_call_value1 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(input_value, binary_call_value1.intValue());\n"
             + "              final String trim_value = method_call_value == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", method_call_value, true);\n"
             + "              Integer case_when_value0;\n"
@@ -2563,7 +2563,7 @@ public class JdbcTest {
             + "                }\n"
             + "                case_when_value0 = case_when_value1;\n"
             + "              }\n"
-            + "              final Integer binary_call_value3 = case_when_value0 == null ? (Integer) null : Integer.valueOf(case_when_value0 - $L4J$C$Integer_valueOf_2_);\n"
+            + "              final Integer binary_call_value3 = case_when_value0 == null ? (Integer) null : Integer.valueOf(case_when_value0.intValue() - 2);\n"
             + "              return trim_value == null || binary_call_value3 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(trim_value, binary_call_value3.intValue());\n")
         .returns("T=ill\n"
             + "T=ric\n"
@@ -2592,7 +2592,7 @@ public class JdbcTest {
             + "              } else {\n"
             + "                case_when_value = (Integer) null;\n"
             + "              }\n"
-            + "              final Integer binary_call_value1 = case_when_value == null ? (Integer) null : Integer.valueOf(Integer.valueOf(input_value0 * 0) + case_when_value);\n"
+            + "              final Integer binary_call_value1 = case_when_value == null ? (Integer) null : Integer.valueOf(input_value0 * 0 + case_when_value.intValue());\n"
             + "              final String method_call_value = input_value == null || binary_call_value1 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(input_value, binary_call_value1.intValue());\n"
             + "              final String trim_value = method_call_value == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.trim(true, true, \" \", method_call_value, true);\n"
             + "              Integer case_when_value0;\n"
@@ -2607,7 +2607,7 @@ public class JdbcTest {
             + "                }\n"
             + "                case_when_value0 = case_when_value1;\n"
             + "              }\n"
-            + "              final Integer binary_call_value3 = case_when_value0 == null ? (Integer) null : Integer.valueOf(case_when_value0 - $L4J$C$Integer_valueOf_2_);\n"
+            + "              final Integer binary_call_value3 = case_when_value0 == null ? (Integer) null : Integer.valueOf(case_when_value0.intValue() - 2);\n"
             + "              return trim_value == null || binary_call_value3 == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.substring(trim_value, binary_call_value3.intValue());"
         )
         .returns("T=ll\n"
@@ -2623,13 +2623,6 @@ public class JdbcTest {
     CalciteAssert.that()
         .query("SELECT ROUND(CAST((X/Y) AS NUMERIC), 2) "
             + "FROM (VALUES (1, 2), (NULLIF(5, 5), NULLIF(5, 5))) A(X, Y)")
-        .planContains("      final Object[] current = (Object[]) inputEnumerator.current();\n"
-            + "              final Integer input_value = (Integer) current[0];\n"
-            + "              final Integer input_value0 = (Integer) current[1];\n"
-            + "              final Integer binary_call_value = input_value == null || input_value0 == null ? (Integer) null : Integer.valueOf(input_value / input_value0);\n"
-            + "              final java.math.BigDecimal cast_value = binary_call_value == null ? (java.math.BigDecimal) null : binary_call_value == null ? (java.math.BigDecimal) null : new java.math.BigDecimal(\n"
-            + "                binary_call_value.intValue());\n"
-            + "              return cast_value == null ? (java.math.BigDecimal) null : org.apache.calcite.runtime.SqlFunctions.sround(cast_value, 2);")
         .returns("EXPR$0=0.00\n"
             + "EXPR$0=null\n");
   }
@@ -2645,29 +2638,6 @@ public class JdbcTest {
             + " FROM (VALUES (1.1, 2.5), (4.51, 32.5)) A(X, Y)\n"
             + " GROUP BY \"Y\"\n"
             + ")")
-        .planContains("      int case_when_value;\n"
-            + "              final Object[] current = (Object[]) inputEnumerator.current();\n"
-            + "              final java.math.BigDecimal input_value = current[1] == null ? (java.math.BigDecimal) null : org.apache.calcite.runtime.SqlFunctions.toBigDecimal(current[1]);\n"
-            + "              Integer case_when_value0;\n"
-            + "              if (org.apache.calcite.runtime.SqlFunctions.toInt(current[2]) == 0) {\n"
-            + "                case_when_value0 = (Integer) null;\n"
-            + "              } else {\n"
-            + "                case_when_value0 = Integer.valueOf(org.apache.calcite.runtime.SqlFunctions.toInt(current[2]));\n"
-            + "              }\n"
-            + "              final java.math.BigDecimal binary_call_value0 = input_value == null || case_when_value0 == null ? (java.math.BigDecimal) null : org.apache.calcite.runtime.SqlFunctions.divide(input_value, case_when_value0 == null ? (java.math.BigDecimal) null : new java.math.BigDecimal(\n"
-            + "                case_when_value0.intValue()));\n"
-            + "              final boolean binary_call_isNull0 = binary_call_value0 == null;\n"
-            + "              final Boolean binary_call_value1 = binary_call_isNull0 ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.lt(binary_call_value0, $L4J$C$new_java_math_BigDecimal_77_));\n"
-            + "              final boolean binary_call_isNull1 = binary_call_value1 == null;\n"
-            + "              final Boolean binary_call_value2 = binary_call_isNull0 ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.gt(binary_call_value0, $L4J$C$new_java_math_BigDecimal_0_));\n"
-            + "              final boolean binary_call_isNull2 = binary_call_value2 == null;\n"
-            + "              final Boolean logical_and_value = (binary_call_isNull1 ? true : binary_call_value1) && (binary_call_isNull2 ? true : binary_call_value2) ? (binary_call_isNull1 || binary_call_isNull2 ? (Boolean) null : Boolean.TRUE) : Boolean.FALSE;\n"
-            + "              if (logical_and_value != null && logical_and_value) {\n"
-            + "                case_when_value = 99;\n"
-            + "              } else {\n"
-            + "                case_when_value = 88;\n"
-            + "              }\n"
-            + "              return case_when_value;")
         .returns("EXPR$0=88\n"
             + "EXPR$0=88\n");
   }
@@ -2680,17 +2650,6 @@ public class JdbcTest {
         .query("SELECT \"NAME\" "
             + "FROM (VALUES ('Bill'), NULLIF('x', 'x'), ('Eric')) A(NAME) "
             + "WHERE UPPER(\"NAME\") LIKE 'B%' AND UPPER(\"NAME\") LIKE '%L'")
-        .planContains(
-              "        final String method_call_value = inputEnumerator.current() == null || inputEnumerator.current().toString() == null ? (String) null : org.apache.calcite.runtime.SqlFunctions.upper(inputEnumerator.current() == null ? (String) null : inputEnumerator.current().toString());\n"
-            + "                final boolean method_call_isNull = method_call_value == null;\n"
-            + "                final Boolean method_call_value0 = method_call_isNull ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.like(method_call_value, \"B%\"));\n"
-            + "                final boolean method_call_isNull0 = method_call_value0 == null;\n"
-            + "                final Boolean method_call_value1 = method_call_isNull ? (Boolean) null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.like(method_call_value, \"%L\"));\n"
-            + "                final boolean method_call_isNull1 = method_call_value1 == null;\n"
-            + "                final Boolean logical_and_value = (method_call_isNull0 ? true : method_call_value0) && (method_call_isNull1 ? true : method_call_value1) ? (method_call_isNull0 || method_call_isNull1 ? (Boolean) null : Boolean.TRUE) : Boolean.FALSE;\n"
-            + "                if (logical_and_value == null ? false : logical_and_value) {\n"
-            + "                  return true;\n"
-            + "                }")
         .returns("NAME=Bill\n");
   }
 
@@ -4413,9 +4372,9 @@ public class JdbcTest {
   @Test public void testMethodParameterTypeMatch() {
     CalciteAssert.that()
         .query("SELECT mod(12.5, cast(3 as bigint))")
-        .planContains("final java.math.BigDecimal v = "
+        .planContains("final java.math.BigDecimal literal_value = "
             + "$L4J$C$new_java_math_BigDecimal_12_5_")
-        .planContains("org.apache.calcite.runtime.SqlFunctions.mod(v, "
+        .planContains("org.apache.calcite.runtime.SqlFunctions.mod(literal_value, "
             + "$L4J$C$new_java_math_BigDecimal_3L_)")
         .returns("EXPR$0=0.5\n");
   }
@@ -6297,8 +6256,6 @@ public class JdbcTest {
             + "  select cast(null as timestamp) as time0,"
             + "         cast(null as timestamp) as time1"
             + ") calcs")
-        .planContains("org.apache.calcite.runtime.SqlFunctions.eq(input_value, input_value0)")
-        .planContains("org.apache.calcite.runtime.SqlFunctions.ne(input_value, input_value0)")
         .returns("EXPR$0=true; EXPR$1=false\n"
             + "EXPR$0=null; EXPR$1=null\n");
   }
@@ -7261,7 +7218,7 @@ public class JdbcTest {
             + "new java.math.BigDecimal(\n"
             + "              1)")
         .planContains("org.apache.calcite.runtime.GeoFunctions.ST_MakePoint("
-            + "$L4J$C$new_java_math_BigDecimal_1_, v)")
+            + "$L4J$C$new_java_math_BigDecimal_1_, literal_value0)")
         .returns("EXPR$0={\"x\":1,\"y\":2.1}\n");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -585,10 +585,9 @@ public class ReflectiveSchemaTest {
     with.query("select \"wrapperLong\" / \"primitiveLong\" as c\n"
         + " from \"s\".\"everyTypes\" where \"primitiveLong\" <> 0")
         .planContains(
-            "final Long inp13_ = current.wrapperLong;")
+            "final Long input_value = current.wrapperLong;")
         .planContains(
-            "return inp13_ == null ? (Long) null "
-                + ": Long.valueOf(inp13_.longValue() / current.primitiveLong);")
+            "return input_value == null ? (Long) null : Long.valueOf(input_value / Long.valueOf(current.primitiveLong));")
         .returns("C=null\n");
   }
 
@@ -606,10 +605,9 @@ public class ReflectiveSchemaTest {
     with.query("select \"wrapperLong\" / \"wrapperLong\" as c\n"
         + " from \"s\".\"everyTypes\" where \"primitiveLong\" <> 0")
         .planContains(
-            "final Long inp13_ = ((org.apache.calcite.test.ReflectiveSchemaTest.EveryType) inputEnumerator.current()).wrapperLong;")
+            "final Long input_value = ((org.apache.calcite.test.ReflectiveSchemaTest.EveryType) inputEnumerator.current()).wrapperLong;")
         .planContains(
-            "return inp13_ == null ? (Long) null "
-                + ": Long.valueOf(inp13_.longValue() / inp13_.longValue());")
+            "return input_value == null ? (Long) null : Long.valueOf(input_value / input_value);")
         .returns("C=null\n");
   }
 
@@ -620,11 +618,11 @@ public class ReflectiveSchemaTest {
         + "+ \"wrapperLong\" / \"wrapperLong\" as c\n"
         + " from \"s\".\"everyTypes\" where \"primitiveLong\" <> 0")
         .planContains(
-            "final Long inp13_ = ((org.apache.calcite.test.ReflectiveSchemaTest.EveryType) inputEnumerator.current()).wrapperLong;")
+            "final Long input_value = ((org.apache.calcite.test.ReflectiveSchemaTest.EveryType) inputEnumerator.current()).wrapperLong;")
         .planContains(
-            "return inp13_ == null ? (Long) null "
-                + ": Long.valueOf(Long.valueOf(inp13_.longValue() / inp13_.longValue()).longValue() "
-                + "+ Long.valueOf(inp13_.longValue() / inp13_.longValue()).longValue());")
+            "final Long binary_call_value = input_value == null ? (Long) null : Long.valueOf(input_value / input_value);")
+        .planContains(
+            "return binary_call_value == null ? (Long) null : Long.valueOf(binary_call_value + binary_call_value);")
         .returns("C=null\n");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -587,7 +587,7 @@ public class ReflectiveSchemaTest {
         .planContains(
             "final Long input_value = current.wrapperLong;")
         .planContains(
-            "return input_value == null ? (Long) null : Long.valueOf(input_value / Long.valueOf(current.primitiveLong));")
+            "return input_value == null ? (Long) null : Long.valueOf(input_value.longValue() / current.primitiveLong);")
         .returns("C=null\n");
   }
 
@@ -607,7 +607,7 @@ public class ReflectiveSchemaTest {
         .planContains(
             "final Long input_value = ((org.apache.calcite.test.ReflectiveSchemaTest.EveryType) inputEnumerator.current()).wrapperLong;")
         .planContains(
-            "return input_value == null ? (Long) null : Long.valueOf(input_value / input_value);")
+            "return input_value == null ? (Long) null : Long.valueOf(input_value.longValue() / input_value.longValue());")
         .returns("C=null\n");
   }
 
@@ -620,9 +620,9 @@ public class ReflectiveSchemaTest {
         .planContains(
             "final Long input_value = ((org.apache.calcite.test.ReflectiveSchemaTest.EveryType) inputEnumerator.current()).wrapperLong;")
         .planContains(
-            "final Long binary_call_value = input_value == null ? (Long) null : Long.valueOf(input_value / input_value);")
+            "final Long binary_call_value = input_value == null ? (Long) null : Long.valueOf(input_value.longValue() / input_value.longValue());")
         .planContains(
-            "return binary_call_value == null ? (Long) null : Long.valueOf(binary_call_value + binary_call_value);")
+            "return binary_call_value == null ? (Long) null : Long.valueOf(binary_call_value.longValue() + binary_call_value.longValue());")
         .returns("C=null\n");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableCalcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableCalcTest.java
@@ -47,7 +47,7 @@ public class EnumerableCalcTest {
                     builder.field("commission"),
                     builder.literal(0)))
                 .build())
-        .planContains("inp4_ != null ? inp4_.intValue() : 0;")
+        .planContains("input_value != null ? input_value : 0")
         .returnsUnordered(
             "$f0=0",
             "$f0=250",


### PR DESCRIPTION
This PR rewrites the codegen implementation for RexNode by visitor manner. 
It is proposed to solve the issues: [CALCITE-3142](https://issues.apache.org/jira/browse/CALCITE-3142), [CALCITE-3143](https://issues.apache.org/jira/browse/CALCITE-3143), [CALCITE-3150](https://issues.apache.org/jira/browse/CALCITE-3150), [CALCITE-3173](https://issues.apache.org/jira/browse/CALCITE-3173) and [CALCITE-3717](https://issues.apache.org/jira/browse/CALCITE-3717).

Discusssions and detailed illustrations can be found in [CALCITE-3224](https://issues.apache.org/jira/browse/CALCITE-3224).