### PR TITLE
[CALCITE-3218] Syntax error while parsing DATEADD function (which is valid on Redshift)

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4765,7 +4765,9 @@ SqlNode BuiltinFunctionCall() :
     final Span s;
     SqlDataTypeSpec dt;
     TimeUnit interval;
+    TimeUnit unit;
     final SqlNode node;
+    final SqlIdentifier qualifiedName;
 }
 {
     //~ FUNCTIONS WITH SPECIAL SYNTAX ---------------------------------------
@@ -4784,7 +4786,6 @@ SqlNode BuiltinFunctionCall() :
     |
         <EXTRACT> {
             s = span();
-            TimeUnit unit;
         }
         <LPAREN>
         (
@@ -4797,6 +4798,24 @@ SqlNode BuiltinFunctionCall() :
         e = Expression(ExprContext.ACCEPT_SUB_QUERY) { args.add(e); }
         <RPAREN> {
             return SqlStdOperatorTable.EXTRACT.createCall(s.end(this), args);
+        }
+    |
+        (<DATEADD> | <DATEDIFF> | <DATE_PART>){
+            s = span();
+            qualifiedName = new SqlIdentifier(unquotedIdentifier(), getPos());
+        }
+        <LPAREN>
+        unit = TimeUnit()
+        { args = startList(new SqlIntervalQualifier(unit, null, getPos())); }
+        (
+             <COMMA> e = Expression(ExprContext.ACCEPT_SUB_QUERY)
+             {
+                args.add(e);
+             }
+        )*
+        <RPAREN> {
+            final SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+            return createCall(qualifiedName, s.end(this), funcType, null, args);
         }
     |
         <POSITION> { s = span(); }
@@ -6344,6 +6363,9 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < DATA: "DATA" >
 |   < DATABASE: "DATABASE" >
 |   < DATE: "DATE" >
+|   < DATE_PART: "DATE_PART" >
+|   < DATEADD: "DATEADD" >
+|   < DATEDIFF: "DATEDIFF" >
 |   < DATETIME_INTERVAL_CODE: "DATETIME_INTERVAL_CODE" >
 |   < DATETIME_INTERVAL_PRECISION: "DATETIME_INTERVAL_PRECISION" >
 |   < DAY: "DAY" >

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8829,6 +8829,16 @@ public class SqlParserTest {
     sql(sql2).ok(expected);
   }
 
+  @Test public void testRedshiftFunctionsWithDateParts() {
+    final String expected = "SELECT `DATEADD`(DAY, 1, `T`), "
+            + "`DATEDIFF`(DAY, 1, `T`), `DATE_PART`(DAY, `T`)\n"
+            + "FROM `MYTABLE`";
+
+    final String sql = "SELECT DATEADD(day, 1, t), "
+            + "DATEDIFF(day, 1, t), DATE_PART(day, t) FROM mytable";
+    sql(sql).ok(expected);
+  }
+
   protected void checkDialect(SqlDialect dialect, String sql,
       Matcher<String> matcher) throws SqlParseException {
     final SqlParser parser = getDialectSqlParser(sql, dialect);


### PR DESCRIPTION
Queries like this: 

```
SELECT DATEADD(day, 1, t) from mytable
``` 

would fail the parser when it reached `day`. This PR adds functions with unquoted dateparts to the parser for `DATEADD`, `DATEDIFF`, and `DATE_PART` on Redshift.

discussed with @julianhyde and he is going to move this logic to the babel parser, as mentioned in https://issues.apache.org/jira/browse/CALCITE-3218