### PR TITLE
[CALCITE-3236] Handle issues found in static code analysis

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -757,7 +757,8 @@ public class SubstitutionVisitor {
 
   private UnifyResult apply(UnifyRule rule, MutableRel query,
       MutableRel target) {
-    final UnifyRuleCall call = new UnifyRuleCall(rule, query, target, null);
+    final UnifyRuleCall call =
+        new UnifyRuleCall(rule, query, target, ImmutableList.of());
     return rule.apply(call);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableTableFunctionScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableTableFunctionScan.java
@@ -69,7 +69,7 @@ public class MutableTableFunctionScan extends MutableMultiRel {
             ((MutableTableFunctionScan) obj).elementType)
         && Objects.equals(columnMappings,
             ((MutableTableFunctionScan) obj).columnMappings)
-        && inputs.equals(((MutableSetOp) obj).getInputs());
+        && inputs.equals(((MutableTableFunctionScan) obj).getInputs());
   }
 
   @Override public int hashCode() {

--- a/core/src/test/java/org/apache/calcite/test/MutableRelTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MutableRelTest.java
@@ -204,6 +204,18 @@ public class MutableRelTest {
     }
   }
 
+  @Test public void testMutableTableFunctionScanEquals() {
+    final String sql = "SELECT * FROM TABLE(RAMP(3))";
+    final MutableRel mutableRel1 = createMutableRel(sql);
+    final MutableRel mutableRel2 = createMutableRel(sql);
+    final String actual = RelOptUtil.toString(MutableRels.fromMutable(mutableRel1));
+    final String expected = ""
+        + "LogicalProject(I=[$0])\n"
+        + "  LogicalTableFunctionScan(invocation=[RAMP(3)], rowType=[RecordType(INTEGER I)])\n";
+    MatcherAssert.assertThat(actual, Matchers.isLinux(expected));
+    Assert.assertEquals(mutableRel1, mutableRel2);
+  }
+
   /** Verifies that after conversion to and from a MutableRel, the new
    * RelNode remains identical to the original RelNode. */
   private static void checkConvertMutableRel(String rel, String sql) {


### PR DESCRIPTION
As described in [CALCITE-3236](https://issues.apache.org/jira/browse/CALCITE-3236), we address two obvious issues in `MutableTableFunctionScan` and `SubstitutionVisitor`.