### PR TITLE
[CALCITE-3237] IndexOutOfBoundsException in Expression writer

### DIFF
--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -49,6 +49,10 @@ limitations under the License.
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.calcite.avatica</groupId>
+      <artifactId>avatica-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
@@ -16,19 +16,17 @@
  */
 package org.apache.calcite.linq4j.tree;
 
+import org.apache.calcite.avatica.util.Spacer;
+
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 
 /**
  * Converts an expression to Java code.
  */
 class ExpressionWriter {
-  static final Indent INDENT = new Indent(20);
-
+  static final Spacer SPACER = new Spacer(0);
   private final StringBuilder buf = new StringBuilder();
-  private int level;
   private String indent = "";
   private boolean indentPending;
   private final boolean generics;
@@ -75,14 +73,18 @@ class ExpressionWriter {
    * Increases the indentation level.
    */
   public void begin() {
-    indent = INDENT.of(++level);
+    System.out.println("BEGIN");
+    indent = SPACER.add(2).toString();
+//    indent = INDENT.of(++level);
   }
 
   /**
    * Decreases the indentation level.
    */
   public void end() {
-    indent = INDENT.of(--level);
+    System.out.println("END");
+    indent = SPACER.subtract(2).toString();
+//    indent = INDENT.of(--level);
   }
 
   public ExpressionWriter newlineAndIndent() {
@@ -192,31 +194,6 @@ class ExpressionWriter {
     if (buf.lastIndexOf("\n") == buf.length() - 1) {
       buf.delete(buf.length() - 1, buf.length());
       indentPending = false;
-    }
-  }
-
-  /** Helps generate strings of spaces, to indent text. */
-  private static class Indent extends ArrayList<String> {
-    Indent(int initialCapacity) {
-      super(initialCapacity);
-      ensureSize(initialCapacity);
-    }
-
-    public synchronized String of(int index) {
-      ensureSize(index + 1);
-      return get(index);
-    }
-
-    private void ensureSize(int targetSize) {
-      if (targetSize < size()) {
-        return;
-      }
-      char[] chars = new char[2 * targetSize];
-      Arrays.fill(chars, ' ');
-      clear();
-      for (int i = 0; i < targetSize; i++) {
-        add(String.valueOf(chars, 0, i * 2));
-      }
     }
   }
 }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
@@ -75,14 +75,14 @@ class ExpressionWriter {
    * Increases the indentation level.
    */
   public void begin() {
-    indent = INDENT.get(++level);
+    indent = INDENT.of(++level);
   }
 
   /**
    * Decreases the indentation level.
    */
   public void end() {
-    indent = INDENT.get(--level);
+    indent = INDENT.of(--level);
   }
 
   public ExpressionWriter newlineAndIndent() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
@@ -75,7 +75,6 @@ class ExpressionWriter {
   public void begin() {
     System.out.println("BEGIN");
     indent = SPACER.add(2).toString();
-//    indent = INDENT.of(++level);
   }
 
   /**
@@ -84,7 +83,6 @@ class ExpressionWriter {
   public void end() {
     System.out.println("END");
     indent = SPACER.subtract(2).toString();
-//    indent = INDENT.of(--level);
   }
 
   public ExpressionWriter newlineAndIndent() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionWriter.java
@@ -73,7 +73,6 @@ class ExpressionWriter {
    * Increases the indentation level.
    */
   public void begin() {
-    System.out.println("BEGIN");
     indent = SPACER.add(2).toString();
   }
 
@@ -81,7 +80,6 @@ class ExpressionWriter {
    * Decreases the indentation level.
    */
   public void end() {
-    System.out.println("END");
     indent = SPACER.subtract(2).toString();
   }
 


### PR DESCRIPTION
ExpressionWriter.begin was using ArrayList.get on the Indent which has an initial capacity of 20. I ran into issues where this limit was reached and thought this should be .of which ensures the capacity