### PR TITLE
[CALCITE-3247] Wrong sql format when transforming function SUBSTRING to Hive sql

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.fun.SqlSubstringFunction;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 
 /**
@@ -86,6 +87,21 @@ public class HiveSqlDialect extends SqlDialect {
       break;
     case TRIM:
       unparseTrim(writer, call, leftPrec, rightPrec);
+      break;
+    case OTHER_FUNCTION:
+      if (call.getOperator() instanceof SqlSubstringFunction) {
+        final SqlWriter.Frame funCallFrame = writer.startFunCall(call.getOperator().getName());
+        call.operand(0).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",", true);
+        call.operand(1).unparse(writer, leftPrec, rightPrec);
+        if (3 == call.operandCount()) {
+          writer.sep(",", true);
+          call.operand(2).unparse(writer, leftPrec, rightPrec);
+        }
+        writer.endFunCall(funCallFrame);
+      } else {
+        super.unparseCall(writer, call, leftPrec, rightPrec);
+      }
       break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1054,6 +1054,38 @@ public class RelToSqlConverterTest {
     sql(query).dialect(HiveSqlDialect.DEFAULT).ok(expected);
   }
 
+  @Test public void testHiveSubstring() {
+    String query = "SELECT SUBSTRING('ABC', 2)"
+            + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT SUBSTRING('ABC', 2)\n"
+            + "FROM foodmart.reserve_employee";
+    sql(query).withHive().ok(expected);
+  }
+
+  @Test public void testHiveSubstringWithLength() {
+    String query = "SELECT SUBSTRING('ABC', 2, 3)"
+            + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT SUBSTRING('ABC', 2, 3)\n"
+            + "FROM foodmart.reserve_employee";
+    sql(query).withHive().ok(expected);
+  }
+
+  @Test public void testHiveSubstringWithANSI() {
+    String query = "SELECT SUBSTRING('ABC' FROM 2)"
+            + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT SUBSTRING('ABC', 2)\n"
+            + "FROM foodmart.reserve_employee";
+    sql(query).withHive().ok(expected);
+  }
+
+  @Test public void testHiveSubstringWithANSIAndLength() {
+    String query = "SELECT SUBSTRING('ABC' FROM 2 FOR 3)"
+            + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT SUBSTRING('ABC', 2, 3)\n"
+            + "FROM foodmart.reserve_employee";
+    sql(query).withHive().ok(expected);
+  }
+
   @Test public void testMysqlCastToBigint() {
     // MySQL does not allow cast to BIGINT; instead cast to SIGNED.
     final String query = "select cast(\"product_id\" as bigint) from \"product\"";


### PR DESCRIPTION
Let's assume sql = SELECT SUBSTRING('ABC', 2)

When we use HiveSqlDialect and transform "sql", we expect SUBSTRING(' abc', 2)，but get SUBSTRING(' abc' FROM 2) which is incorrect  sql format in hive.


So maybe HiveSqlDialect behavior should be changed when transform function SUBSTRING:

    1. SELECT SUBSTRING('ABC', 2)  =>  SELECT SUBSTRING('ABC', 2)
    2. SELECT SUBSTRING('ABC', 2, 3)  =>  SELECT SUBSTRING('ABC', 2, 3) 
    3. SELECT SUBSTRING('ABC' FROM 2) => SELECT SUBSTRING('ABC', 2) 
    4. SELECT SUBSTRING('ABC' FROM 2 FOR 3) => SELECT SUBSTRING('ABC', 2, 3) 