### PR TITLE
[CALCITE-3138] RelStructuredTypeFlattener doesn't restructure ROW type fields

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -18,6 +18,7 @@ package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlKind;
@@ -100,6 +101,8 @@ class SqlItemOperator extends SqlSpecialOperator {
     case MAP:
       return OperandTypes.family(
           operandType.getKeyType().getSqlTypeName().getFamily());
+    case ROW:
+      return OperandTypes.CHARACTER;
     case ANY:
     case DYNAMIC_STAR:
       return OperandTypes.or(
@@ -125,6 +128,15 @@ class SqlItemOperator extends SqlSpecialOperator {
     case MAP:
       return typeFactory.createTypeWithNullability(operandType.getValueType(),
           true);
+    case ROW:
+      String fieldName = opBinding.getOperandLiteralValue(1, String.class);
+      RelDataTypeField field = operandType.getField(fieldName, false, false);
+      if (field == null) {
+        throw new AssertionError("Cannot infer type of field '"
+            + fieldName + "' within ROW type: " + operandType);
+      } else {
+        return field.getType();
+      }
     case ANY:
     case DYNAMIC_STAR:
       return typeFactory.createTypeWithNullability(

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeFamily;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
@@ -920,26 +921,6 @@ public abstract class SqlTypeUtil {
       List<RelDataTypeField> list,
       int[] flatteningMap) {
     boolean nested = false;
-    if (needsNullIndicator(type)) {
-      // NOTE jvs 9-Mar-2005:  other code
-      // (e.g. RelStructuredTypeFlattener) relies on the
-      // null indicator field coming first.
-      RelDataType indicatorType =
-          typeFactory.createSqlType(SqlTypeName.BOOLEAN);
-      if (type.isNullable()) {
-        indicatorType =
-            typeFactory.createTypeWithNullability(
-                indicatorType,
-                true);
-      }
-      RelDataTypeField nullIndicatorField =
-          new RelDataTypeFieldImpl(
-              "NULL_VALUE",
-              0,
-              indicatorType);
-      list.add(nullIndicatorField);
-      nested = true;
-    }
     for (RelDataTypeField field : type.getFieldList()) {
       if (flatteningMap != null) {
         flatteningMap[field.getIndex()] = list.size();
@@ -1197,6 +1178,19 @@ public abstract class SqlTypeUtil {
       }
     }
     return true;
+  }
+
+  /**
+   * Checks that there is no expression inside list which may
+   * return struct type.
+   *
+   * @param exprList list of expressions to check
+   * @return true if all expressions don't return struct type
+   */
+  public static boolean isFlat(List<RexNode> exprList) {
+    return exprList.stream()
+        .map(RexNode::getType)
+        .noneMatch(RelDataType::isStruct);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -79,6 +79,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.type.TableFunctionReturnTypeInference;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.Holder;
@@ -1295,7 +1296,8 @@ public class RelBuilder {
     }
 
     if (frame.rel instanceof Project
-        && shouldMergeProject()) {
+        && shouldMergeProject()
+        && isNotRestructuringProjection(frame.rel.getRowType(), nodeList)) {
       final Project project = (Project) frame.rel;
       // Populate field names. If the upper expression is an input ref and does
       // not have a recommended name, use the name of the underlying field.
@@ -1402,6 +1404,21 @@ public class RelBuilder {
     stack.pop();
     stack.push(new Frame(project, fields.build()));
     return this;
+  }
+
+  /**
+   * Restructuring projection is when inputProjection returns flat type
+   * but new projection collects flatten types back into struct columns.
+   * Given method negates the condition to know whether projects can be merged.
+   *
+   * @param inputProjectionType input projection result type
+   * @param newProjects         new projections
+   * @return whether new projections don't do restructuring
+   * (collection of flattened fields back into struct fields)
+   */
+  private boolean isNotRestructuringProjection(RelDataType inputProjectionType,
+      List<RexNode> newProjects) {
+    return SqlTypeUtil.isFlat(newProjects) || !SqlTypeUtil.isFlat(inputProjectionType);
   }
 
   /** Whether to attempt to merge consecutive {@link Project} operators.

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
@@ -98,26 +98,33 @@ public class RelToSqlConverterStructsTest {
     }
   };
 
-  // Table schema is as following:
-  // { a: INT, n1: { n11: { b INT }, n12: {c: Int } }, n2: { d: Int }, e: Int }
   private static final Table TABLE = new Table() {
-    @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-      final RelDataType aType = typeFactory.createSqlType(SqlTypeName.BIGINT);
-      final RelDataType bType = typeFactory.createSqlType(SqlTypeName.BIGINT);
-      final RelDataType cType = typeFactory.createSqlType(SqlTypeName.BIGINT);
-      final RelDataType dType = typeFactory.createSqlType(SqlTypeName.BIGINT);
-      final RelDataType eType = typeFactory.createSqlType(SqlTypeName.BIGINT);
-      final RelDataType n11Type = typeFactory
-          .createStructType(ImmutableList.of(bType), ImmutableList.of("b"));
-      final RelDataType n12Type = typeFactory
-          .createStructType(ImmutableList.of(cType), ImmutableList.of("c"));
-      final RelDataType n1Type = typeFactory
-          .createStructType(ImmutableList.of(n11Type, n12Type), ImmutableList.of("n11", "n12"));
-      final RelDataType n2Type = typeFactory
-          .createStructType(ImmutableList.of(dType), ImmutableList.of("d"));
-      return typeFactory.createStructType(
-              ImmutableList.of(aType, n1Type, n2Type, eType),
-              ImmutableList.of("a", "n1", "n2", "e"));
+    /**
+     * Table schema is as following:
+     *  myTable(
+     *          a: BIGINT,
+     *          n1: STRUCT<
+     *                n11: STRUCT<b: BIGINT>,
+     *                n12: STRUCT<c: BIGINT>
+     *              >,
+     *          n2: STRUCT<d: BIGINT>,
+     *          e: BIGINT
+     *  )
+     */
+    @Override public RelDataType getRowType(RelDataTypeFactory tf) {
+      RelDataType bigint = tf.createSqlType(SqlTypeName.BIGINT);
+      RelDataType n1Type = tf.createStructType(
+          ImmutableList.of(
+              tf.createStructType(ImmutableList.of(bigint), ImmutableList.of("b")),
+              tf.createStructType(ImmutableList.of(bigint), ImmutableList.of("c"))
+          ),
+          ImmutableList.of("n11", "n12"));
+      RelDataType n2Type = tf.createStructType(
+          ImmutableList.of(bigint),
+          ImmutableList.of("d"));
+      return tf.createStructType(
+          ImmutableList.of(bigint, n1Type, n2Type, bigint),
+          ImmutableList.of("a", "n1", "n2", "e"));
     }
 
     @Override public Statistic getStatistic() {
@@ -174,9 +181,8 @@ public class RelToSqlConverterStructsTest {
   @Test public void testNestedSchemaSelectStar() {
     String query = "SELECT * FROM \"myTable\"";
     String expected = "SELECT \"a\", "
-        + "\"n1\".\"n11\".\"b\" AS \"n1\", "
-        + "\"n1\".\"n12\".\"c\" AS \"n12\", "
-        + "\"n2\".\"d\" AS \"n2\", "
+        + "ROW(ROW(\"n1\".\"n11\".\"b\"), ROW(\"n1\".\"n12\".\"c\")) AS \"n1\", "
+        + "ROW(\"n2\".\"d\") AS \"n2\", "
         + "\"e\"\n"
         + "FROM \"myDb\".\"myTable\"";
     sql(query).ok(expected);

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2783,6 +2783,56 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test
+  public void testNestedStructFieldAccess() {
+    final String sql =
+        "select dn.skill['others'] from sales.dept_nested dn";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testNestedStructPrimitiveFieldAccess() {
+    final String sql =
+        "select dn.skill['others']['a'] from sales.dept_nested dn";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testNestedPrimitiveFieldAccess() {
+    final String sql =
+        "select dn.skill['desc'] from sales.dept_nested dn";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testArrayElementNestedPrimitive() {
+    final String sql =
+        "select dn.employees[0]['empno'] from sales.dept_nested dn";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testArrayElementDoublyNestedPrimitive() {
+    final String sql =
+        "select dn.employees[0]['detail']['skills'][0]['type'] from sales.dept_nested dn";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testArrayElementDoublyNestedStruct() {
+    final String sql =
+        "select dn.employees[0]['detail']['skills'][0] from sales.dept_nested dn";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testArrayElementThreeTimesNestedStruct() {
+    final String sql =
+        "select dn.employees[0]['detail']['skills'][0]['others'] from sales.dept_nested dn";
+    sql(sql).ok();
+  }
+
+
   /**
    * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-3003">[CALCITE-3003]
    * AssertionError when GROUP BY nested field</a>.

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -947,14 +947,13 @@ public class PlannerTest {
         + "left join \"depts\" as d on e.\"deptno\" = d.\"deptno\"\n"
         + "join \"dependents\" as p on e.\"empid\" = p.\"empid\"";
     final String expected = ""
-        + "EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], location=[$8], location9=[$9], empid0=[$10], name1=[$11])\n"
-        + "  EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], x=[$10], y=[$11], empid0=[$0], name1=[$1])\n"
-        + "    EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
-        + "      EnumerableTableScan(table=[[hr, dependents]])\n"
-        + "      EnumerableHashJoin(condition=[=($1, $5)], joinType=[left])\n"
-        + "        EnumerableTableScan(table=[[hr, emps]])\n"
-        + "        EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
-        + "          EnumerableTableScan(table=[[hr, depts]])";
+        + "EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], location=[ROW($10, $11)], empid0=[$0], name1=[$1])\n"
+        + "  EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
+        + "    EnumerableTableScan(table=[[hr, dependents]])\n"
+        + "    EnumerableHashJoin(condition=[=($1, $5)], joinType=[left])\n"
+        + "      EnumerableTableScan(table=[[hr, emps]])\n"
+        + "      EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
+        + "        EnumerableTableScan(table=[[hr, depts]])";
     checkHeuristic(sql, expected);
   }
 
@@ -969,15 +968,14 @@ public class PlannerTest {
         + "right join \"depts\" as d on e.\"deptno\" = d.\"deptno\"\n"
         + "join \"dependents\" as p on e.\"empid\" = p.\"empid\"";
     final String expected = ""
-        + "EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], location=[$8], location9=[$9], empid0=[$10], name1=[$11])\n"
-        + "  EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], x=[$10], y=[$11], empid0=[$0], name1=[$1])\n"
-        + "    EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
-        + "      EnumerableTableScan(table=[[hr, dependents]])\n"
-        + "      EnumerableProject(empid=[$5], deptno=[$6], name=[$7], salary=[$8], commission=[$9], deptno0=[$0], name0=[$1], employees=[$2], x=[$3], y=[$4])\n"
-        + "        EnumerableHashJoin(condition=[=($0, $6)], joinType=[left])\n"
-        + "          EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
-        + "            EnumerableTableScan(table=[[hr, depts]])\n"
-        + "          EnumerableTableScan(table=[[hr, emps]])";
+        + "EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], location=[ROW($10, $11)], empid0=[$0], name1=[$1])\n"
+        + "  EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
+        + "    EnumerableTableScan(table=[[hr, dependents]])\n"
+        + "    EnumerableProject(empid=[$5], deptno=[$6], name=[$7], salary=[$8], commission=[$9], deptno0=[$0], name0=[$1], employees=[$2], x=[$3], y=[$4])\n"
+        + "      EnumerableHashJoin(condition=[=($0, $6)], joinType=[left])\n"
+        + "        EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
+        + "          EnumerableTableScan(table=[[hr, depts]])\n"
+        + "        EnumerableTableScan(table=[[hr, emps]])";
     checkHeuristic(sql, expected);
   }
 
@@ -988,14 +986,13 @@ public class PlannerTest {
         + "join \"depts\" as d on e.\"deptno\" = d.\"deptno\"\n"
         + "right join \"dependents\" as p on e.\"empid\" = p.\"empid\"";
     final String expected = ""
-        + "EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], location=[$8], location9=[$9], empid0=[$10], name1=[$11])\n"
-        + "  EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], x=[$10], y=[$11], empid0=[$0], name1=[$1])\n"
-        + "    EnumerableHashJoin(condition=[=($0, $2)], joinType=[left])\n"
-        + "      EnumerableTableScan(table=[[hr, dependents]])\n"
-        + "      EnumerableHashJoin(condition=[=($1, $5)], joinType=[inner])\n"
-        + "        EnumerableTableScan(table=[[hr, emps]])\n"
-        + "        EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
-        + "          EnumerableTableScan(table=[[hr, depts]])";
+        + "EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], location=[ROW($10, $11)], empid0=[$0], name1=[$1])\n"
+        + "  EnumerableHashJoin(condition=[=($0, $2)], joinType=[left])\n"
+        + "    EnumerableTableScan(table=[[hr, dependents]])\n"
+        + "    EnumerableHashJoin(condition=[=($1, $5)], joinType=[inner])\n"
+        + "      EnumerableTableScan(table=[[hr, emps]])\n"
+        + "      EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
+        + "        EnumerableTableScan(table=[[hr, depts]])";
     checkHeuristic(sql, expected);
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -491,8 +491,8 @@ LogicalProject(EXPR$0=[ITEM(ITEM($3, 1).DETAIL.SKILLS, +(2, 3)).DESC])
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalProject(EXPR$0=[$0])
-  LogicalProject(EXPR$0$0=[ITEM($3, 1).EMPNO], EXPR$0$1=[ITEM($3, 1).ENAME], EXPR$0$2=[ITEM($3, 1).DETAIL])
+LogicalProject(EXPR$0=[ROW($0, $1, ROW($2))])
+  LogicalProject(EXPR$0$0=[ITEM($3, 1).EMPNO], EXPR$0$1=[ITEM($3, 1).ENAME], EXPR$0$2$0=[ITEM($3, 1).DETAIL.SKILLS])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
 ]]>
         </Resource>
@@ -873,8 +873,8 @@ LogicalProject(FAKE2=[ITEM($0, 'fake_col2')])
     <TestCase name="testNestedColumnType">
         <Resource name="plan">
             <![CDATA[
-LogicalProject(ZIP=[$4])
-  LogicalFilter(condition=[=($3, 'abc':VARCHAR(20))])
+LogicalProject(ZIP=[$3])
+  LogicalFilter(condition=[=($2, 'abc')])
     LogicalProject(EMPNO=[$0], STREET=[$1.STREET], CITY=[$1.CITY], ZIP=[$1.ZIP], STATE=[$1.STATE], STREET5=[$2.STREET], CITY6=[$2.CITY], ZIP7=[$2.ZIP], STATE8=[$2.STATE])
       LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
 ]]>
@@ -882,6 +882,65 @@ LogicalProject(ZIP=[$4])
         <Resource name="sql">
             <![CDATA[select empa.home_address.zip from sales.emp_address empa where empa.home_address.city = 'abc']]>
         </Resource>
+    </TestCase>
+    <TestCase name="testNestedStructFieldAccess">
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[ROW($0, $1)])
+  LogicalProject(EXPR$0=[$2.OTHERS.A], EXPR$01=[$2.OTHERS.B])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testNestedStructPrimitiveFieldAccess">
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[$2.OTHERS.A])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testNestedPrimitiveFieldAccess">
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[$2.DESC])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testArrayElementNestedPrimitive">
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[ITEM(ITEM($3, 0), 'empno')])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testArrayElementDoublyNestedPrimitive">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM(ITEM(ITEM(ITEM(ITEM($3, 0), 'detail'), 'skills'), 0), 'type')])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+    </Resource>
+    </TestCase>
+    <TestCase name="testArrayElementDoublyNestedStruct">
+      <Resource name="plan">
+        <![CDATA[
+LogicalProject(EXPR$0=[ROW($0, $1, ROW($2, $3))])
+  LogicalProject(EXPR$0$0=[ITEM(ITEM(ITEM(ITEM($3, 0), 'detail'), 'skills'), 0).TYPE], EXPR$0$1=[ITEM(ITEM(ITEM(ITEM($3, 0), 'detail'), 'skills'), 0).DESC], EXPR$0$2$0=[ITEM(ITEM(ITEM(ITEM($3, 0), 'detail'), 'skills'), 0).OTHERS.A], EXPR$0$2$1=[ITEM(ITEM(ITEM(ITEM($3, 0), 'detail'), 'skills'), 0).OTHERS.B])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+      </Resource>
+    </TestCase>
+    <TestCase name="testArrayElementThreeTimesNestedStruct">
+      <Resource name="plan">
+        <![CDATA[
+LogicalProject(EXPR$0=[ROW($0, $1)])
+  LogicalProject(EXPR$0$0$2$0=[ITEM(ITEM(ITEM(ITEM($3, 0), 'detail'), 'skills'), 0).OTHERS.A], EXPR$0$0$2$1=[ITEM(ITEM(ITEM(ITEM($3, 0), 'detail'), 'skills'), 0).OTHERS.B])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+      </Resource>
     </TestCase>
     <TestCase name="testSelectNestedColumnType">
         <Resource name="plan">
@@ -1716,8 +1775,9 @@ from (select row(row(1)) r from dept) t]]>
         </Resource>
         <Resource name="plan">
             <![CDATA[
-LogicalProject(MYROW$$0$$0=[1])
-  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+LogicalProject(MYROW=[ROW(ROW($0))])
+  LogicalProject(MYROW$$0$$0=[1])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
     </TestCase>


### PR DESCRIPTION
PR for [CALCITE-3138](https://issues.apache.org/jira/browse/CALCITE-3138). 

- Fixed restructuring of ROW type
- Removed null indicator because there are cases when it's impossible to track correct new indices using getNewForOldInput(...) method
- Increased depth of flattening for ITEM(...) which gets struct from array by index and the returned struct contains another struct 
- Some ITEM(struct, 'fieldName') expressions are replaced by simple refs after flatten operation
- Added ROW support to SqlItemOperator type inference 
- Increased amount of local variables to simplify debugging 
- Updated tests expected results
- Added check to avoid merging of flatten and restructuring projects