### PR TITLE
[CALCITE-3249] Substitution#getRexShuttle does not consider RexLiteral

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1420,6 +1420,14 @@ public class SubstitutionVisitor {
         }
         return super.visitCall(call);
       }
+
+      @Override public RexNode visitLiteral(RexLiteral literal) {
+        final Integer integer = map.get(literal);
+        if (integer != null) {
+          return new RexInputRef(integer, literal.getType());
+        }
+        return super.visitLiteral(literal);
+      }
     };
   }
 

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -550,6 +550,26 @@ public class MaterializationTest {
         "select count(*) + 1 as c, \"deptno\" from \"emps\" group by \"deptno\"");
   }
 
+  @Test public void testAggregate3() {
+    String deduplicated =
+        "(select \"empid\", \"deptno\", \"name\", \"salary\", \"commission\"\n"
+            + "from \"emps\"\n"
+            + "group by \"empid\", \"deptno\", \"name\", \"salary\", \"commission\")";
+    String mv =
+        "select \"deptno\", sum(\"salary\"), sum(\"commission\"), sum(\"k\")\n"
+            + "from\n"
+            + "  (select \"deptno\", \"salary\", \"commission\", 100 as \"k\"\n"
+            + "  from " + deduplicated + ")\n"
+            + "group by \"deptno\"";
+    String query =
+        "select \"deptno\", sum(\"salary\"), sum(\"k\")\n"
+            + "from\n"
+            + "  (select \"deptno\", \"salary\", 100 as \"k\"\n"
+            + "  from " + deduplicated + ")\n"
+            + "group by \"deptno\"";
+    checkMaterialize(mv, query);
+  }
+
   /** Aggregation query at same level of aggregation as aggregation
    * materialization with grouping sets. */
   @Test public void testAggregateGroupSets1() {


### PR DESCRIPTION
Current `Substitution#getRexShuttle` does not take `RexLiteral` into consideration.
Thus below query & mv fails matching:
```
MV:
select deptno, sum(salary), sum(commission), sum(k)
from
  (select deptno, salary, commission, 100 as k
  from emps)
group by deptno

Query:
select deptno, sum(salary), sum(k)
from
  (select deptno, salary, 100 as k
  from emps)
group by deptno
```
The root cause is that `ProjectToProjectUnifyRule` compensates a `Project` which contains `RexLiteral`, but `AggregateOnProjectToAggregateUnifyRule` works only when the `Project` in query is a mapping
https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java#L1357