### PR TITLE
[CALCITE-3245] CompileException in Janino when a query contains a division between a Double and a BigDecimal

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -503,7 +503,8 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     assert typeName != null;
     switch (typeName) {
     case DECIMAL:
-      return type;
+      return RelDataTypeFactoryImpl.isJavaType(type)
+          ? SqlTypeUtil.getMaxPrecisionScaleDecimal(this) : type;
     case TINYINT:
       return createSqlType(SqlTypeName.DECIMAL, 3, 0);
     case SMALLINT:

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -45,6 +45,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -291,8 +292,8 @@ public class ReflectiveSchemaTest {
             + "primitiveBoolean=true\n");
     with.query("select * from \"s\".\"everyTypes\"")
         .returns(""
-            + "primitiveBoolean=false; primitiveByte=0; primitiveChar=\u0000; primitiveShort=0; primitiveInt=0; primitiveLong=0; primitiveFloat=0.0; primitiveDouble=0.0; wrapperBoolean=false; wrapperByte=0; wrapperCharacter=\u0000; wrapperShort=0; wrapperInteger=0; wrapperLong=0; wrapperFloat=0.0; wrapperDouble=0.0; sqlDate=1970-01-01; sqlTime=00:00:00; sqlTimestamp=1970-01-01 00:00:00; utilDate=1970-01-01 00:00:00; string=1\n"
-            + "primitiveBoolean=true; primitiveByte=127; primitiveChar=\uffff; primitiveShort=32767; primitiveInt=2147483647; primitiveLong=9223372036854775807; primitiveFloat=3.4028235E38; primitiveDouble=1.7976931348623157E308; wrapperBoolean=null; wrapperByte=null; wrapperCharacter=null; wrapperShort=null; wrapperInteger=null; wrapperLong=null; wrapperFloat=null; wrapperDouble=null; sqlDate=null; sqlTime=null; sqlTimestamp=null; utilDate=null; string=null\n");
+            + "primitiveBoolean=false; primitiveByte=0; primitiveChar=\u0000; primitiveShort=0; primitiveInt=0; primitiveLong=0; primitiveFloat=0.0; primitiveDouble=0.0; wrapperBoolean=false; wrapperByte=0; wrapperCharacter=\u0000; wrapperShort=0; wrapperInteger=0; wrapperLong=0; wrapperFloat=0.0; wrapperDouble=0.0; sqlDate=1970-01-01; sqlTime=00:00:00; sqlTimestamp=1970-01-01 00:00:00; utilDate=1970-01-01 00:00:00; string=1; bigDecimal=0\n"
+            + "primitiveBoolean=true; primitiveByte=127; primitiveChar=\uffff; primitiveShort=32767; primitiveInt=2147483647; primitiveLong=9223372036854775807; primitiveFloat=3.4028235E38; primitiveDouble=1.7976931348623157E308; wrapperBoolean=null; wrapperByte=null; wrapperCharacter=null; wrapperShort=null; wrapperInteger=null; wrapperLong=null; wrapperFloat=null; wrapperDouble=null; sqlDate=null; sqlTime=null; sqlTimestamp=null; utilDate=null; string=null; bigDecimal=null\n");
   }
 
   /**
@@ -466,6 +467,8 @@ public class ReflectiveSchemaTest {
       return input.getTime(1);
     case java.sql.Types.TIMESTAMP:
       return input.getTimestamp(1);
+    case java.sql.Types.DECIMAL:
+      return input.getBigDecimal(1);
     default:
       throw new AssertionError(type);
     }
@@ -587,6 +590,14 @@ public class ReflectiveSchemaTest {
             "return inp13_ == null ? (Long) null "
                 + ": Long.valueOf(inp13_.longValue() / current.primitiveLong);")
         .returns("C=null\n");
+  }
+
+  @Test public void testDivideDoubleBigDecimal() {
+    final CalciteAssert.AssertThat with =
+        CalciteAssert.that().withSchema("s", CATCHALL);
+    with.query("select \"wrapperDouble\" / \"bigDecimal\" as c\n"
+        + " from \"s\".\"everyTypes\"")
+        .runs();
   }
 
   @Test public void testDivideWraperWrapper() throws Exception {
@@ -863,6 +874,7 @@ public class ReflectiveSchemaTest {
     public final Timestamp sqlTimestamp;
     public final Date utilDate;
     public final String string;
+    public final BigDecimal bigDecimal;
 
     public EveryType(
         boolean primitiveBoolean,
@@ -885,7 +897,8 @@ public class ReflectiveSchemaTest {
         Time sqlTime,
         Timestamp sqlTimestamp,
         Date utilDate,
-        String string) {
+        String string,
+        BigDecimal bigDecimal) {
       this.primitiveBoolean = primitiveBoolean;
       this.primitiveByte = primitiveByte;
       this.primitiveChar = primitiveChar;
@@ -907,6 +920,7 @@ public class ReflectiveSchemaTest {
       this.sqlTimestamp = sqlTimestamp;
       this.utilDate = utilDate;
       this.string = string;
+      this.bigDecimal = bigDecimal;
     }
 
     static Enumerable<Field> fields() {
@@ -958,13 +972,13 @@ public class ReflectiveSchemaTest {
             false, (byte) 0, (char) 0, (short) 0, 0, 0L, 0F, 0D,
             false, (byte) 0, (char) 0, (short) 0, 0, 0L, 0F, 0D,
             new java.sql.Date(0), new Time(0), new Timestamp(0),
-            new Date(0), "1"),
+            new Date(0), "1", BigDecimal.ZERO),
         new EveryType(
             true, Byte.MAX_VALUE, Character.MAX_VALUE, Short.MAX_VALUE,
             Integer.MAX_VALUE, Long.MAX_VALUE, Float.MAX_VALUE,
             Double.MAX_VALUE,
             null, null, null, null, null, null, null, null,
-            null, null, null, null, null),
+            null, null, null, null, null, null),
     };
 
     public final AllPrivate[] allPrivates = { new AllPrivate() };


### PR DESCRIPTION
This PR is proposed to handle the exception caused by Java `BigDecimal` type in [CALCITE-3245](https://issues.apache.org/jira/browse/CALCITE-3245).

(1) Implement `getPrecision` and `getScale` in JavaType. 
    As BigDecimal will trigger the computation on precision and scale (`deriveDecimalPlusType` , `deriveDecimalMultiplyType` in `RelDataTypeSystem`), but the default `PRECISION_NOT_SPECIFIED` and `SCALE_NOT_SPECIFIED` value will cause the assertions.

(2) Specially handle cast on `BigDecimal.class`. 
    Current now, there are more than one implementations for data type conversion, such as **`Types.castIfNecessary`**, **`RexToLixTranslator.convert`**, **`RexToLixTranslator.translateCast, and etc`**. We need to unify them later.