### PR TITLE
[CALCITE-3250] Support nested collection type for  SqlDataTypeSpec

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -46,6 +46,7 @@ import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlCollation;
+import org.apache.calcite.sql.SqlCollectionTypeNameSpec;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDateLiteral;
 import org.apache.calcite.sql.SqlDelete;
@@ -4547,24 +4548,17 @@ int IntLiteral() :
 // Type name with optional scale and precision.
 SqlDataTypeSpec DataType() :
 {
-    final SqlTypeNameSpec typeName;
-    SqlIdentifier collectionTypeName = null;
+    SqlTypeNameSpec typeName;
     final Span s;
 }
 {
     typeName = TypeName() {
         s = span();
     }
-    [
-        collectionTypeName = CollectionsTypeName()
-    ]
+    (
+        typeName = CollectionsTypeName(typeName)
+    )*
     {
-        if (null != collectionTypeName) {
-            return new SqlDataTypeSpec(
-                collectionTypeName,
-                typeName,
-                s.end(collectionTypeName));
-        }
         return new SqlDataTypeSpec(
             typeName,
             s.end(this));
@@ -4758,19 +4752,24 @@ SqlLiteral JdbcOdbcDataType() :
     }
 }
 
-SqlIdentifier CollectionsTypeName() :
+/**
+* Parse a collection type name, the input element type name may
+* also be a collection type.
+*/
+SqlTypeNameSpec CollectionsTypeName(SqlTypeNameSpec elementTypeName) :
 {
+    final SqlTypeName collectionTypeName;
 }
 {
     (
-        <MULTISET> {
-            return new SqlIdentifier(SqlTypeName.MULTISET.name(), getPos());
-        }
+        <MULTISET> { collectionTypeName = SqlTypeName.MULTISET; }
     |
-        <ARRAY> {
-            return new SqlIdentifier(SqlTypeName.ARRAY.name(), getPos());
-        }
+        <ARRAY> { collectionTypeName = SqlTypeName.ARRAY; }
     )
+    {
+        return new SqlCollectionTypeNameSpec(elementTypeName,
+                collectionTypeName, getPos());
+    }
 }
 
 /**

--- a/core/src/main/java/org/apache/calcite/sql/SqlBasicTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBasicTypeNameSpec.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
 
 import java.nio.charset.Charset;
@@ -181,6 +182,11 @@ public class SqlBasicTypeNameSpec extends SqlTypeNameSpec {
       writer.keyword("CHARACTER SET");
       writer.identifier(charSetName, false);
     }
+  }
+
+  @Override public RelDataType deriveType(SqlValidator validator) {
+    final RelDataTypeFactory typeFactory = validator.getTypeFactory();
+    return deriveType(typeFactory);
   }
 
   @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.util.Litmus;
+import org.apache.calcite.util.Util;
+
+import java.util.Objects;
+
+/**
+ * A sql type name specification of collection type.
+ *
+ * <p>The grammar definition in SQL-2011 IWD 9075-2:201?(E)
+ * 6.1 &lt;collection type&gt; is as following:
+ * <blockquote><pre>
+ * &lt;collection type&gt; ::=
+ *     &lt;array type&gt;
+ *   | &lt;multiset type&gt;
+ *
+ * &lt;array type&gt; ::=
+ *   &lt;data type&gt; ARRAY
+ *   [ &lt;left bracket or trigraph&gt;
+ *     &lt;maximum cardinality&gt;
+ *     &lt;right bracket or trigraph&gt; ]
+ *
+ * &lt;maximum cardinality&gt; ::=
+ *   &lt;unsigned integer&gt;
+ *
+ * &lt;multiset type&gt; ::=
+ *   &lt;data type&gt; MULTISET
+ * </pre></blockquote>
+ *
+ * <p>This class is intended to be used in nested collection type, it can be used as the
+ * element type name of {@link SqlDataTypeSpec}. i.e. "int array array" or "int array multiset".
+ * For simple collection type like "int array", {@link SqlBasicTypeNameSpec} is descriptive enough.
+ */
+public class SqlCollectionTypeNameSpec extends SqlTypeNameSpec {
+  private final SqlTypeNameSpec elementTypeName;
+  private final SqlTypeName collectionTypeName;
+
+  /**
+   * Creates a {@code SqlCollectionTypeNameSpec}.
+   *
+   * @param elementTypeName    Type of the collection element.
+   * @param collectionTypeName Collection type name.
+   * @param pos                Parser position, must not be null.
+   */
+  public SqlCollectionTypeNameSpec(SqlTypeNameSpec elementTypeName,
+      SqlTypeName collectionTypeName,
+      SqlParserPos pos) {
+    super(new SqlIdentifier(collectionTypeName.name(), pos), pos);
+    this.elementTypeName = Objects.requireNonNull(elementTypeName);
+    this.collectionTypeName = Objects.requireNonNull(collectionTypeName);
+  }
+
+  public SqlTypeNameSpec getElementTypeName() {
+    return elementTypeName;
+  }
+
+  @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {
+    RelDataType type = elementTypeName.deriveType(typeFactory);
+    if (type == null) {
+      return null;
+    }
+    return createCollectionType(type, typeFactory);
+  }
+
+  @Override public RelDataType deriveType(SqlValidator validator) {
+    final RelDataType type = elementTypeName.deriveType(validator);
+    return createCollectionType(type, validator.getTypeFactory());
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    elementTypeName.unparse(writer, leftPrec, rightPrec);
+    writer.keyword(collectionTypeName.name());
+  }
+
+  @Override public boolean equalsDeep(SqlTypeNameSpec spec, Litmus litmus) {
+    if (!(spec instanceof SqlCollectionTypeNameSpec)) {
+      return litmus.fail("{} != {}", this, spec);
+    }
+    SqlCollectionTypeNameSpec that = (SqlCollectionTypeNameSpec) spec;
+    if (!this.elementTypeName.equalsDeep(that.elementTypeName, litmus)) {
+      return litmus.fail("{} != {}", this, spec);
+    }
+    if (!Objects.equals(this.collectionTypeName, that.collectionTypeName)) {
+      return litmus.fail("{} != {}", this, spec);
+    }
+    return litmus.succeed();
+  }
+
+  //~ Tools ------------------------------------------------------------------
+
+  /**
+   * Create collection data type.
+   * @param elementType Type of the collection element.
+   * @param typeFactory Type factory.
+   * @return The collection data type, or throw exception if the collection
+   *         type name does not belong to {@code SqlTypeName} enumerations.
+   */
+  private RelDataType createCollectionType(RelDataType elementType,
+      RelDataTypeFactory typeFactory) {
+    switch (collectionTypeName) {
+    case MULTISET:
+      return typeFactory.createMultisetType(elementType, -1);
+    case ARRAY:
+      return typeFactory.createArrayType(elementType, -1);
+
+    default:
+      throw Util.unexpected(collectionTypeName);
+    }
+  }
+}
+
+// End SqlCollectionTypeNameSpec.java

--- a/core/src/main/java/org/apache/calcite/sql/SqlRowTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlRowTypeNameSpec.java
@@ -20,6 +20,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 
@@ -126,6 +127,17 @@ public class SqlRowTypeNameSpec extends SqlTypeNameSpec {
     return typeFactory.createStructType(
         fieldTypes.stream()
             .map(dt -> dt.deriveType(typeFactory))
+            .collect(Collectors.toList()),
+        fieldNames.stream()
+            .map(SqlIdentifier::toString)
+            .collect(Collectors.toList()));
+  }
+
+  @Override public RelDataType deriveType(SqlValidator sqlValidator) {
+    final RelDataTypeFactory typeFactory = sqlValidator.getTypeFactory();
+    return typeFactory.createStructType(
+        fieldTypes.stream()
+            .map(dt -> dt.deriveType(sqlValidator))
             .collect(Collectors.toList()),
         fieldNames.stream()
             .map(SqlIdentifier::toString)

--- a/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
@@ -19,6 +19,7 @@ package org.apache.calcite.sql;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
 
 /**
@@ -53,6 +54,15 @@ public abstract class SqlTypeNameSpec {
    *         builtin sql type name.
    */
   public abstract RelDataType deriveType(RelDataTypeFactory typeFactory);
+
+  /**
+   * Derive type from this SqlTypeNameSpec.
+   *
+   * @param validator The sql validator.
+   * @return the {@code RelDataType} instance, throws exception if we could not
+   *         deduce the type.
+   */
+  public abstract RelDataType deriveType(SqlValidator validator);
 
   /** Writes a SQL representation of this spec to a writer. */
   public abstract void unparse(SqlWriter writer, int leftPrec, int rightPrec);

--- a/core/src/main/java/org/apache/calcite/sql/SqlUserDefinedTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUserDefinedTypeNameSpec.java
@@ -19,6 +19,7 @@ package org.apache.calcite.sql;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
 
 /**
@@ -41,15 +42,19 @@ public class SqlUserDefinedTypeNameSpec extends SqlTypeNameSpec {
     super(typeName, pos);
   }
 
+  @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {
+    // Returns null to let the SqlValidator deduce the type.
+    return null;
+  }
+
   public SqlUserDefinedTypeNameSpec(String name, SqlParserPos pos) {
     this(new SqlIdentifier(name, pos), pos);
   }
 
-  @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {
+  @Override public RelDataType deriveType(SqlValidator validator) {
     // The type name is a compound identifier, that means it is a UDT,
-    // returns null to let the SqlValidator deduce its type from
-    // the Schema.
-    return null;
+    // use SqlValidator to deduce its type from the Schema.
+    return validator.getValidatedNodeType(getTypeName());
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4726,13 +4726,30 @@ public class SqlParserTest {
         "(ARRAY[(ROW(1, 'a')), (ROW(2, 'b'))])");
   }
 
-  @Test public void testCastAsArrayType() {
+  @Test public void testCastAsCollectionType() {
+    // test array type.
     checkExp("cast(a as int array)", "CAST(`A` AS INTEGER ARRAY)");
     checkExp("cast(a as varchar(5) array)", "CAST(`A` AS VARCHAR(5) ARRAY)");
-    checkExpFails("cast(a as int array ^array^)",
-        "(?s).*Encountered \"array\" at line 1, column 21.\n.*");
+    checkExp("cast(a as int array array)", "CAST(`A` AS INTEGER ARRAY ARRAY)");
+    checkExp("cast(a as varchar(5) array array)",
+        "CAST(`A` AS VARCHAR(5) ARRAY ARRAY)");
     checkExpFails("cast(a as int array^<^10>)",
         "(?s).*Encountered \"<\" at line 1, column 20.\n.*");
+    // test multiset type.
+    checkExp("cast(a as int multiset)", "CAST(`A` AS INTEGER MULTISET)");
+    checkExp("cast(a as varchar(5) multiset)", "CAST(`A` AS VARCHAR(5) MULTISET)");
+    checkExp("cast(a as int multiset array)", "CAST(`A` AS INTEGER MULTISET ARRAY)");
+    checkExp("cast(a as varchar(5) multiset array)",
+        "CAST(`A` AS VARCHAR(5) MULTISET ARRAY)");
+    // test row type nested in collection type.
+    checkExp("cast(a as row(f0 int array multiset, f1 varchar(5) array) array multiset)",
+        "CAST(`A` AS "
+            + "ROW(`F0` INTEGER ARRAY MULTISET, "
+            + "`F1` VARCHAR(5) ARRAY) "
+            + "ARRAY MULTISET)");
+    // test UDT collection type.
+    checkExp("cast(a as MyUDT array multiset)",
+        "CAST(`A` AS `MYUDT` ARRAY MULTISET)");
   }
 
   @Test public void testCastAsRowType() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7723,11 +7723,51 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .columnType("CHAR(3) ARRAY NOT NULL");
   }
 
-  @Test public void testCastAsArrayType() {
+  @Test public void testCastAsCollectionType() {
     sql("select cast(array[1,null,2] as int array) from (values (1))")
         .columnType("INTEGER NOT NULL ARRAY NOT NULL");
     sql("select cast(array['1',null,'2'] as varchar(5) array) from (values (1))")
         .columnType("VARCHAR(5) NOT NULL ARRAY NOT NULL");
+    // test array type.
+    sql("select cast(\"intArrayType\" as int array) from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("INTEGER NOT NULL ARRAY NOT NULL");
+    sql("select cast(\"varchar5ArrayType\" as varchar(5) array) from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("VARCHAR(5) NOT NULL ARRAY NOT NULL");
+    sql("select cast(\"intArrayArrayType\" as int array array) from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("INTEGER NOT NULL ARRAY NOT NULL ARRAY NOT NULL");
+    sql("select cast(\"varchar5ArrayArrayType\" as varchar(5) array array) "
+        + "from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("VARCHAR(5) NOT NULL ARRAY NOT NULL ARRAY NOT NULL");
+    // test multiset type.
+    sql("select cast(\"intMultisetType\" as int multiset) from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("INTEGER NOT NULL MULTISET NOT NULL");
+    sql("select cast(\"varchar5MultisetType\" as varchar(5) multiset) from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("VARCHAR(5) NOT NULL MULTISET NOT NULL");
+    sql("select cast(\"intMultisetArrayType\" as int multiset array) from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("INTEGER NOT NULL MULTISET NOT NULL ARRAY NOT NULL");
+    sql("select cast(\"varchar5MultisetArrayType\" as varchar(5) multiset array) "
+        + "from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("VARCHAR(5) NOT NULL MULTISET NOT NULL ARRAY NOT NULL");
+    // test row type nested in collection type.
+    sql("select cast(\"rowArrayMultisetType\" as row(f0 int array multiset, "
+        + "f1 varchar(5) array) array multiset) "
+        + "from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .columnType("RecordType(INTEGER NOT NULL ARRAY NOT NULL MULTISET NOT NULL F0, "
+            + "VARCHAR(5) NOT NULL ARRAY NOT NULL F1) NOT NULL "
+            + "ARRAY NOT NULL MULTISET NOT NULL");
+    // test UDT collection type.
+    sql("select cast(a as MyUDT array multiset) from COMPLEXTYPES.CTC_T1")
+        .withExtendedCatalog()
+        .fails("(?s).*class org\\.apache\\.calcite\\.sql\\.SqlIdentifier: MYUDT.*");
   }
 
   @Test public void testCastAsRowType() {

--- a/core/src/test/java/org/apache/calcite/test/catalog/Fixture.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/Fixture.java
@@ -38,6 +38,7 @@ final class Fixture {
   final RelDataType bigintTypeNull;
   final RelDataType decimalType;
   final RelDataType varcharType;
+  final RelDataType varchar5Type;
   final RelDataType varchar10Type;
   final RelDataType varchar10TypeNull;
   final RelDataType varchar20Type;
@@ -65,6 +66,17 @@ final class Fixture {
   final RelDataType recordType4;
   // Row(f0 varchar not null, f1 timestamp null) multiset
   final RelDataType recordType5;
+  final RelDataType intArrayType;
+  final RelDataType varchar5ArrayType;
+  final RelDataType intArrayArrayType;
+  final RelDataType varchar5ArrayArrayType;
+  final RelDataType intMultisetType;
+  final RelDataType varchar5MultisetType;
+  final RelDataType intMultisetArrayType;
+  final RelDataType varchar5MultisetArrayType;
+  final RelDataType intArrayMultisetType;
+  // Row(f0 int array multiset, f1 varchar(5) array) array multiset
+  final RelDataType rowArrayMultisetType;
 
   Fixture(RelDataTypeFactory typeFactory) {
     intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
@@ -73,6 +85,7 @@ final class Fixture {
     bigintTypeNull = typeFactory.createTypeWithNullability(bigintType, true);
     decimalType = typeFactory.createSqlType(SqlTypeName.DECIMAL);
     varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    varchar5Type = typeFactory.createSqlType(SqlTypeName.VARCHAR, 5);
     varchar10Type = typeFactory.createSqlType(SqlTypeName.VARCHAR, 10);
     varchar10TypeNull = typeFactory.createTypeWithNullability(varchar10Type, true);
     varchar20Type = typeFactory.createSqlType(SqlTypeName.VARCHAR, 20);
@@ -169,6 +182,23 @@ final class Fixture {
         typeFactory.createStructType(
             Arrays.asList(varcharType, nullable(typeFactory, timestampType)),
             Arrays.asList("f0", "f1")),
+        -1);
+    intArrayType = typeFactory.createArrayType(intType, -1);
+    varchar5ArrayType = typeFactory.createArrayType(varchar5Type, -1);
+    intArrayArrayType = typeFactory.createArrayType(intArrayType, -1);
+    varchar5ArrayArrayType = typeFactory.createArrayType(varchar5ArrayType, -1);
+    intMultisetType = typeFactory.createMultisetType(intType, -1);
+    varchar5MultisetType = typeFactory.createMultisetType(varchar5Type, -1);
+    intMultisetArrayType = typeFactory.createArrayType(intMultisetType, -1);
+    varchar5MultisetArrayType = typeFactory.createArrayType(varchar5MultisetType, -1);
+    intArrayMultisetType = typeFactory.createMultisetType(intArrayType, -1);
+    // Row(f0 int array multiset, f1 varchar(5) array) array multiset
+    rowArrayMultisetType = typeFactory.createMultisetType(
+        typeFactory.createArrayType(
+            typeFactory.createStructType(
+                Arrays.asList(intArrayMultisetType, varchar5ArrayType),
+                Arrays.asList("f0", "f1")),
+            -1),
         -1);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
@@ -148,6 +148,17 @@ public class MockCatalogReaderExtended extends MockCatalogReaderSimple {
     complexTypeColumnsTable.addColumn("C", f.recordType3);
     complexTypeColumnsTable.addColumn("D", f.recordType4);
     complexTypeColumnsTable.addColumn("E", f.recordType5);
+    complexTypeColumnsTable.addColumn("intArrayType", f.intArrayType);
+    complexTypeColumnsTable.addColumn("varchar5ArrayType", f.varchar5ArrayType);
+    complexTypeColumnsTable.addColumn("intArrayArrayType", f.intArrayArrayType);
+    complexTypeColumnsTable.addColumn("varchar5ArrayArrayType", f.varchar5ArrayArrayType);
+    complexTypeColumnsTable.addColumn("intMultisetType", f.intMultisetType);
+    complexTypeColumnsTable.addColumn("varchar5MultisetType", f.varchar5MultisetType);
+    complexTypeColumnsTable.addColumn("intMultisetArrayType", f.intMultisetArrayType);
+    complexTypeColumnsTable.addColumn("varchar5MultisetArrayType",
+        f.varchar5MultisetArrayType);
+    complexTypeColumnsTable.addColumn("intArrayMultisetType", f.intArrayMultisetType);
+    complexTypeColumnsTable.addColumn("rowArrayMultisetType", f.rowArrayMultisetType);
     registerTable(complexTypeColumnsTable);
 
     return this;

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1325,7 +1325,7 @@ Supported data types:
 {% highlight sql %}
 type:
       typeName
-      [ collectionsTypeName ]
+      [ collectionsTypeName ]*
 
 typeName:
       sqlTypeName


### PR DESCRIPTION
Changes:
* Add a new SqlTypeNameSpec SqlCollectionTypeNameSpec to describe nested
collections type
* Refactor SqlDataTypeSpec to only keep SqlTypeNameSpec, TimeZone and
nullble.
* Add a new method SqlTypeNameSpec#deriveType(SqlValidator) to support
derive type for UDT(throws exception when we can't deduce any type).