### PR TITLE
[CALCITE-3256] Add ProjectOnProjectToProjectUnifyRule for materialization matching

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -596,7 +596,7 @@ public class SubstitutionVisitor {
   /**
    * Equivalence checking for row types, but except for the field names.
    */
-  private boolean rowTypesAreEquivalent(
+  private static boolean rowTypesAreEquivalent(
       MutableRel rel0, MutableRel rel1, Litmus litmus) {
     if (rel0.rowType.getFieldCount() != rel1.rowType.getFieldCount()) {
       return litmus.fail("Mismatch for column count: [{}]", Pair.of(rel0, rel1));
@@ -1321,7 +1321,8 @@ public class SubstitutionVisitor {
     } else {
       return null;
     }
-    return MutableRels.createCastRel(result, query.rowType, true);
+
+    return MutableRels.createCastRel(result, query.rowType, false);
   }
 
   /** Implementation of {@link UnifyRule} that matches a


### PR DESCRIPTION
In current implementation of rules in SubstitutionVisitor.java & MaterializedViewSubstitutionVisitor.java, it's quite common to add a compensating Project on top of child node of target(MV-rel) during matching. But afterwards the next round matching should be able to handle such a compensated Project and match upward along the plan tree. Otherwise we fail the matching. After all, the goal of matching is to transform the query and let a complete 'target' show up in the transformed query plan.

I found cases where the compensated Project cannot be properly handled.

```
MV:
select deptno, sum(salary) + 2, sum(commission)
from emps
group by deptno

Query:
select deptno, sum(salary) + 2
from emps
group by deptno
```
After matching of the Aggregates, a compensating Project is added, but afterwards matching fails to handle it.