### PR TITLE
[CALCITE-3257] RelMetadataQuery cache is not invalidated when log trace is enabled

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -405,6 +405,7 @@ class RuleQueue {
       dump(pw);
       pw.flush();
       LOGGER.trace(sw.toString());
+      planner.getRoot().getCluster().invalidateMetadataQuery();
     }
   }
 


### PR DESCRIPTION
Based on current design, RelMetadataQuery.map needs to be cleared between each rule firing. This is achieved through RelOptCluster.invalidateMetadataQuery() by VolcanoRuleCall.transformTo(). But when trace is enabled, the dump process would actually rebuild the meta data cache from previous rel tree. Then the subsequent rule firing doesn't get a chance to update rel node cost as it's been in the cache.

A simple fix will just add a call to RelOptCluster.invalidateMetadataQuery() after dumping rel nodes.

https://issues.apache.org/jira/browse/CALCITE-3257