### PR TITLE
[CALCITE-3260] Add method for evaluate node directly.

### DIFF
--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
@@ -3051,6 +3051,15 @@ public abstract class Expressions {
     return new FluentArrayList<>(toList(ts));
   }
 
+  /**
+   * The {@link Evaluator} class is not public access, add this method for evaluate node directly.
+   */
+  public static Object evaluate(AbstractNode node) {
+    assert node != null;
+    final Evaluator evaluator = new Evaluator();
+    return node.evaluate(evaluator);
+  }
+
   // ~ Private helper methods ------------------------------------------------
 
   private static boolean shouldLift(Expression left, Expression right,

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
@@ -52,6 +52,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
+import static org.apache.calcite.linq4j.test.BlockBuilderBase.ONE;
+import static org.apache.calcite.linq4j.test.BlockBuilderBase.TWO;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -1297,6 +1300,12 @@ public class ExpressionTest {
             + ".put(\"key_8\", \"value_8\")\n"
             + ".put(\"key_9\", \"value_9\").build()",
         Expressions.toString(Expressions.constant(map)));
+  }
+
+  @Test public void testEvaluate() {
+    Expression x = Expressions.add(ONE, TWO);
+    Object value = Expressions.evaluate(x);
+    assertEquals((int) value, 3);
   }
 
   /** An enum. */


### PR DESCRIPTION
In some cases, we need to do evaluation for an Expression, but the evaluate method needs an Evaluator object as parameter, which has default access control privilege.
This PR is an improvement to add support of evaluate method for Expression with default Evaluator.