### PR TITLE
[CALCITE-3214] Add UnionToUnionRule for materialization matching (refine rule name)

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
@@ -42,7 +42,7 @@ public class MaterializedViewSubstitutionVisitor extends SubstitutionVisitor {
           .add(ProjectToProjectUnifyRule1.INSTANCE)
           .add(FilterToFilterUnifyRule1.INSTANCE)
           .add(FilterToProjectUnifyRule1.INSTANCE)
-          .add(UnionToUnionRule.INSTANCE)
+          .add(UnionToUnionUnifyRule.INSTANCE)
           .build();
 
   public MaterializedViewSubstitutionVisitor(RelNode target_, RelNode query_) {
@@ -187,10 +187,10 @@ public class MaterializedViewSubstitutionVisitor extends SubstitutionVisitor {
    * {@link MutableUnion} to a {@link MutableUnion} where the query and target
    * have the same inputs but might not have the same order.
    */
-  private static class UnionToUnionRule extends AbstractUnifyRule {
-    public static final UnionToUnionRule INSTANCE = new UnionToUnionRule();
+  private static class UnionToUnionUnifyRule extends AbstractUnifyRule {
+    public static final UnionToUnionUnifyRule INSTANCE = new UnionToUnionUnifyRule();
 
-    private UnionToUnionRule() {
+    private UnionToUnionUnifyRule() {
       super(any(MutableUnion.class), any(MutableUnion.class), 0);
     }
 


### PR DESCRIPTION
https://github.com/apache/calcite/pull/1333 merged a materialization matching rule.

But the naming style of UnionToUnionRule is inconsistent with other rules like `ScanToProjectUnifyRule`, `ProjectToProjectUnifyRule`, `FilterToProjectUnifyRule`.
This PR propose to refine the name as `UnionToUnionUnifyRule`, and sorry for my carelessness in my previous PR.