### PR TITLE
[CALCITE-3274] Add FilterOnProjectToFilterUnifyRule for materialization matching

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -527,6 +527,27 @@ public class MaterializationTest {
             + "(e.\"empid\" > 500 and e.\"salary\" > 6000)");
   }
 
+  @Test public void testFilterOnProject() {
+    String deduplicated =
+        "(select \"empid\", \"deptno\", \"name\", \"salary\", \"commission\"\n"
+            + "from \"emps\"\n"
+            + "group by \"empid\", \"deptno\", \"name\", \"salary\", \"commission\")";
+    String mv =
+        "select * from\n"
+            + "(select \"deptno\", sum(\"salary\") as \"sum_salary\", sum(\"commission\")\n"
+            + "from " + deduplicated + "\n"
+            + "group by \"deptno\")\n"
+            + "where \"sum_salary\" > 10";
+    String query =
+        "select * from\n"
+            + "(select \"deptno\", sum(\"salary\") as \"sum_salary\"\n"
+            + "from " + deduplicated + "\n"
+            + "group by \"deptno\")\n"
+            + "where \"sum_salary\" > 10";
+    checkMaterialize(mv, query);
+  }
+
+
   /** Aggregation query at same level of aggregation as aggregation
    * materialization. */
   @Test public void testAggregate0() {


### PR DESCRIPTION
With current implementation of MV matching, below case fails
```
  @Test public void testFilterOnProject() {
    String deduplicated =
        "(select \"empid\", \"deptno\", \"name\", \"salary\", \"commission\"\n"
            + "from \"emps\"\n"
            + "group by \"empid\", \"deptno\", \"name\", \"salary\", \"commission\")";
    String mv =
        "select * from\n"
            + "(select \"deptno\", sum(\"salary\") as \"sum_salary\", sum(\"commission\")\n"
            + "from " + deduplicated + "\n"
            + "group by \"deptno\")\n"
            + "where \"sum_salary\" > 10";
    String query =
        "select * from\n"
            + "(select \"deptno\", sum(\"salary\") as \"sum_salary\"\n"
            + "from " + deduplicated + "\n"
            + "group by \"deptno\")\n"
            + "where \"sum_salary\" > 10";
    checkMaterialize(mv, query);
  }
```

**Reason:**
After matching of the Aggregates, a compensating Project is added, but afterwards matching of filter fails to handle it.
This PR proposes to handle such case where query and target are Filters and query has a compensating Project child node
This PR also proposes to remove the unused rule of `ProjectToFilterUnifyRule` and `FilterToFilterUnifyRule `
