### PR TITLE
[CALCITE-3278] Simplify the use to translate RexNode to Expression for evaluating.

### DIFF
--- a/core/src/test/java/org/apache/calcite/adapter/enumerable/RexToLixTranslatorTest.java
+++ b/core/src/test/java/org/apache/calcite/adapter/enumerable/RexToLixTranslatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.enumerable;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.linq4j.tree.BlockBuilder;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.FunctionExpression;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+
+/**
+ * Test for {@link org.apache.calcite.adapter.enumerable.RexToLixTranslator}
+ */
+public class RexToLixTranslatorTest {
+
+  @Test public void testRawTranslateRexNode() {
+    final RelDataTypeFactory typeFactory =
+        new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    final RexBuilder b = new RexBuilder(typeFactory);
+    final RexNode rexNode = b.makeCall(
+        SqlStdOperatorTable.ABS,
+        b.makeBigintLiteral(new BigDecimal(300)));
+    BlockBuilder builder = new BlockBuilder();
+    RexToLixTranslator translator =
+        RexToLixTranslator.createRexToLixTranslator(
+            new JavaTypeFactoryImpl()).setBlock(builder);
+    Expression expr = translator.rawTranslate(rexNode);
+    Expression lambdaExpr = Expressions.lambda(expr);
+    FunctionExpression.Invokable invokable = ((FunctionExpression) lambdaExpr).compile();
+    Object result = invokable.dynamicInvoke();
+    assertEquals(result, 300L);
+  }
+}
+
+// End RexToLixTranslatorTest.java


### PR DESCRIPTION
Currently, the method **forAggregation** of **RexToLixTranslator** is designed to work for translating aggregate functions, with some parameters that we actually do not need, if we just want to translate a single RexNode. And, the translated expression is a ParameterExpression, not fit for evaluating.

This PR in an improvement to smplify the use of RexToLixTranslator.

Changes:
* Add a more universal create instance method for RexToLixTranslator to simplify the use.
* Add a translate method to just return the raw expression, do not wrap it to ParameterExpression.