### PR TITLE
 [CALCITE-3281] Support mixed Primitive types for BinaryExpression evaluate method.

### DIFF
--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BinaryExpression.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BinaryExpression.java
@@ -56,46 +56,34 @@ public class BinaryExpression extends Expression {
     case Add:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator) + (Integer) expression1
-            .evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) + evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator) + (Short) expression1
-            .evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) + evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator) + (Byte) expression1
-            .evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) + evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator) + (Float) expression1
-            .evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) + evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-               + (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) + evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-               + (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) + evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
     case Divide:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator) / (Integer) expression1
-            .evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) / evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator) / (Short) expression1
-            .evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) / evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator) / (Byte) expression1
-            .evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) / evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator) / (Float) expression1
-            .evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) / evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-            / (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) / evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-            / (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) / evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
@@ -105,115 +93,85 @@ public class BinaryExpression extends Expression {
     case GreaterThan:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator) > (Integer) expression1
-            .evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) > evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator) > (Short) expression1
-            .evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) > evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator) > (Byte) expression1
-            .evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) > evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator) > (Float) expression1
-            .evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) > evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-               > (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) > evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-               > (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) > evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
     case GreaterThanOrEqual:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator)
-               >= (Integer) expression1.evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) >= evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator)
-               >= (Short) expression1.evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) >= evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator)
-               >= (Byte) expression1.evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) >= evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator)
-               >= (Float) expression1.evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) >= evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-               >= (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) >= evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-               >= (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) >= evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
     case LessThan:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator) < (Integer) expression1
-            .evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) < evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator) < (Short) expression1
-              .evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) < evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator) < (Byte) expression1
-            .evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) < evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator) < (Float) expression1
-            .evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) < evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-               < (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) < evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-               < (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) < evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
     case LessThanOrEqual:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator)
-               <= (Integer) expression1.evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) <= evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator)
-               <= (Short) expression1.evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) <= evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator)
-               <= (Byte) expression1.evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) <= evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator)
-               <= (Float) expression1.evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) <= evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-               <= (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) <= evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-               <= (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) <= evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
     case Multiply:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator) * (Integer) expression1
-            .evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) * evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator) * (Short) expression1
-            .evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) * evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator) * (Byte) expression1
-            .evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) * evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator) * (Float) expression1
-            .evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) * evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-               * (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) * evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-               * (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) * evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
@@ -226,23 +184,17 @@ public class BinaryExpression extends Expression {
     case Subtract:
       switch (primitive) {
       case INT:
-        return (Integer) expression0.evaluate(evaluator) - (Integer) expression1
-            .evaluate(evaluator);
+        return evaluateInt(expression0, evaluator) - evaluateInt(expression1, evaluator);
       case SHORT:
-        return (Short) expression0.evaluate(evaluator) - (Short) expression1
-            .evaluate(evaluator);
+        return evaluateShort(expression0, evaluator) - evaluateShort(expression1, evaluator);
       case BYTE:
-        return (Byte) expression0.evaluate(evaluator) - (Byte) expression1
-            .evaluate(evaluator);
+        return evaluateByte(expression0, evaluator) - evaluateByte(expression1, evaluator);
       case FLOAT:
-        return (Float) expression0.evaluate(evaluator) - (Float) expression1
-            .evaluate(evaluator);
+        return evaluateFloat(expression0, evaluator) - evaluateFloat(expression1, evaluator);
       case DOUBLE:
-        return (Double) expression0.evaluate(evaluator)
-               - (Double) expression1.evaluate(evaluator);
+        return evaluateDouble(expression0, evaluator) - evaluateDouble(expression1, evaluator);
       case LONG:
-        return (Long) expression0.evaluate(evaluator)
-               - (Long) expression1.evaluate(evaluator);
+        return evaluateLong(expression0, evaluator) - evaluateLong(expression1, evaluator);
       default:
         throw cannotEvaluate();
       }
@@ -263,6 +215,30 @@ public class BinaryExpression extends Expression {
   private RuntimeException cannotEvaluate() {
     return new RuntimeException("cannot evaluate " + this + ", nodeType="
       + nodeType + ", primitive=" + primitive);
+  }
+
+  private int evaluateInt(Expression expression, Evaluator evaluator) {
+    return ((Number) expression.evaluate(evaluator)).intValue();
+  }
+
+  private short evaluateShort(Expression expression, Evaluator evaluator) {
+    return ((Number) expression.evaluate(evaluator)).shortValue();
+  }
+
+  private long evaluateLong(Expression expression, Evaluator evaluator) {
+    return ((Number) expression.evaluate(evaluator)).longValue();
+  }
+
+  private byte evaluateByte(Expression expression, Evaluator evaluator) {
+    return ((Number) expression.evaluate(evaluator)).byteValue();
+  }
+
+  private float evaluateFloat(Expression expression, Evaluator evaluator) {
+    return ((Number) expression.evaluate(evaluator)).floatValue();
+  }
+
+  private double evaluateDouble(Expression expression, Evaluator evaluator) {
+    return ((Number) expression.evaluate(evaluator)).doubleValue();
   }
 
   @Override public boolean equals(Object o) {

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
@@ -317,6 +317,88 @@ public class ExpressionTest {
     assertEquals(3.0f, n, 0f);
   }
 
+  @Test public void testLambdaCallsBinaryOpMixType() {
+    // A parameter for the lambda expression.
+    ParameterExpression paramExpr =
+        Expressions.parameter(Long.TYPE, "arg");
+
+    // This expression represents a lambda expression
+    // that adds (int)10 to the parameter value.
+    FunctionExpression lambdaExpr = Expressions.lambda(
+        Expressions.add(
+            paramExpr,
+            Expressions.constant(10)),
+        Arrays.asList(paramExpr));
+    // Print out the expression.
+    String s = Expressions.toString(lambdaExpr);
+    assertEquals(
+        "new org.apache.calcite.linq4j.function.Function1() {\n"
+            + "  public long apply(long arg) {\n"
+            + "    return arg + 10;\n"
+            + "  }\n"
+            + "  public Object apply(Long arg) {\n"
+            + "    return apply(\n"
+            + "      arg.longValue());\n"
+            + "  }\n"
+            + "  public Object apply(Object arg) {\n"
+            + "    return apply(\n"
+            + "      (Long) arg);\n"
+            + "  }\n"
+            + "}\n",
+        s);
+
+    // Compile and run the lambda expression.
+    // The value of the parameter is 5L.
+    long n = (Long) lambdaExpr.compile().dynamicInvoke(5L);
+
+    // This code example produces the following output:
+    //
+    // arg => (arg +10)
+    // 15
+    assertEquals(15L, n, 0d);
+  }
+
+  @Test public void testLambdaCallsBinaryOpMixDoubleType() {
+    // A parameter for the lambda expression.
+    ParameterExpression paramExpr =
+        Expressions.parameter(Double.TYPE, "arg");
+
+    // This expression represents a lambda expression
+    // that adds 10.1d to the parameter value.
+    FunctionExpression lambdaExpr = Expressions.lambda(
+        Expressions.add(
+            paramExpr,
+            Expressions.constant(10.1d)),
+        Arrays.asList(paramExpr));
+    // Print out the expression.
+    String s = Expressions.toString(lambdaExpr);
+    assertEquals(
+        "new org.apache.calcite.linq4j.function.Function1() {\n"
+            + "  public double apply(double arg) {\n"
+            + "    return arg + 10.1D;\n"
+            + "  }\n"
+            + "  public Object apply(Double arg) {\n"
+            + "    return apply(\n"
+            + "      arg.doubleValue());\n"
+            + "  }\n"
+            + "  public Object apply(Object arg) {\n"
+            + "    return apply(\n"
+            + "      (Double) arg);\n"
+            + "  }\n"
+            + "}\n",
+        s);
+
+    // Compile and run the lambda expression.
+    // The value of the parameter is 5.0f.
+    double n = (Double) lambdaExpr.compile().dynamicInvoke(5.0f);
+
+    // This code example produces the following output:
+    //
+    // arg => (arg +10.1d)
+    // 15.1d
+    assertEquals(15.1d, n, 0d);
+  }
+
   @Test public void testLambdaPrimitiveTwoArgs() {
     // Parameters for the lambda expression.
     ParameterExpression paramExpr =


### PR DESCRIPTION
Currently, the value of [expression0 and expression1](https://github.com/apache/calcite/blob/master/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BinaryExpression.java#L26) must be the same type. Otherwise we might a ClassCastException, as shown in JIRA [CALCITE-3281](https://issues.apache.org/jira/browse/CALCITE-3281).

This PR is an improvement to support using different primitive types for expression0 and expression1 of BinaryExpression, so that, make it suite for evaluate in more cases.
