### PR TITLE
make every SqlDialect parse their own data type

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
@@ -211,41 +211,7 @@ public class SqlDataTypeSpec extends SqlNode {
       SqlWriter writer,
       int leftPrec,
       int rightPrec) {
-    String name = typeName.getSimple();
-    if (SqlTypeName.get(name) != null) {
-      SqlTypeName sqlTypeName = SqlTypeName.get(name);
-
-      // we have a built-in data type
-      writer.keyword(name);
-
-      if (sqlTypeName.allowsPrec() && (precision >= 0)) {
-        final SqlWriter.Frame frame =
-            writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
-        writer.print(precision);
-        if (sqlTypeName.allowsScale() && (scale >= 0)) {
-          writer.sep(",", true);
-          writer.print(scale);
-        }
-        writer.endList(frame);
-      }
-
-      if (charSetName != null) {
-        writer.keyword("CHARACTER SET");
-        writer.identifier(charSetName, false);
-      }
-
-      if (collectionsTypeName != null) {
-        writer.keyword(collectionsTypeName.getSimple());
-      }
-    } else if (name.startsWith("_")) {
-      // We're generating a type for an alien system. For example,
-      // UNSIGNED is a built-in type in MySQL.
-      // (Need a more elegant way than '_' of flagging this.)
-      writer.keyword(name.substring(1));
-    } else {
-      // else we have a user defined type
-      typeName.unparse(writer, leftPrec, rightPrec);
-    }
+    writer.getDialect().unparseDataType(writer, this, leftPrec, rightPrec);
   }
 
   public void validate(SqlValidator validator, SqlValidatorScope scope) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
@@ -18,6 +18,7 @@ package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -53,6 +54,16 @@ public class HiveSqlDialect extends SqlDialect {
   @Override public void unparseOffsetFetch(SqlWriter writer, SqlNode offset,
       SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);
+  }
+
+  @Override public void unparseDataType(final SqlWriter writer,
+      final SqlDataTypeSpec sqlDataTypeSpec, final int leftPrec, final int rightPrec) {
+    String name = sqlDataTypeSpec.getTypeName().getSimple();
+    if (name.equals("INTEGER")) {
+      writer.keyword("INT");
+    } else {
+      super.unparseDataType(writer, sqlDataTypeSpec, leftPrec, rightPrec);
+    }
   }
 
   @Override public SqlNode emulateNullDirection(SqlNode node,

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -803,6 +803,14 @@ public class RelToSqlConverterTest {
     sql(query).withHive().ok(expected);
   }
 
+  @Test public void testHiveDataType() {
+    String query = "select cast( cast(\"employee_id\" as varchar) as int) "
+        + "from \"foodmart\".\"reserve_employee\" ";
+    final String expected = "SELECT CAST(CAST(employee_id AS VARCHAR) AS INT)\n"
+        + "FROM foodmart.reserve_employee";
+    sql(query).withHive().ok(expected);
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2715">[CALCITE-2715]
    * MS SQL Server does not support character set as part of data type</a>. */


### PR DESCRIPTION
Every database might have different type or same type but different type name,  therefore making every SqlDialect parse their own data type is suitable way.
 for example, “select cast(col as int) from table”  change to hive sql "select cast(col as integer) from table", but "integer" is not allowed in hive.