### PR TITLE
[CALCITE-3283] RelSubSet's best is not existed in the set

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -177,6 +177,14 @@ public final class CalciteSystemProperty<T> {
       booleanProperty("calcite.test.slow", false);
 
   /**
+   * Whether to do validation within VolcanoPlanner after each rule firing.
+   * Note that doing so would significantly slow down the planning. Should only
+   * enable for unit test.
+   */
+  public static final CalciteSystemProperty<Boolean> TEST_VALIDATE_VOLCANO_PLANNER =
+      booleanProperty("calcite.test.validate.volcano.planner", false);
+
+  /**
    * Whether to run MongoDB tests.
    */
   public static final CalciteSystemProperty<Boolean> TEST_MONGODB =

--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -177,14 +177,6 @@ public final class CalciteSystemProperty<T> {
       booleanProperty("calcite.test.slow", false);
 
   /**
-   * Whether to do validation within VolcanoPlanner after each rule firing.
-   * Note that doing so would significantly slow down the planning. Should only
-   * enable for unit test.
-   */
-  public static final CalciteSystemProperty<Boolean> TEST_VALIDATE_VOLCANO_PLANNER =
-      booleanProperty("calcite.test.validate.volcano.planner", false);
-
-  /**
    * Whether to run MongoDB tests.
    */
   public static final CalciteSystemProperty<Boolean> TEST_MONGODB =

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -885,7 +885,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
 
         // Make sure best RelNode is valid
         if (subset.best != null && !subset.set.rels.contains(subset.best)) {
-          return litmus.fail("RelSubSet [{}] does not contain its best RelNode [{}]",
+          return litmus.fail("RelSubset [{}] does not contain its best RelNode [{}]",
                   subset.getDescription(), subset.best.getDescription());
         }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -846,8 +846,10 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     final RelSubset subset = registerImpl(rel, set);
 
     // Checking if tree is valid considerably slows down planning
-    // Recommend doing it only at unit test
-    assert isValid(Litmus.THROW);
+    // Only doing it if logger level is debug or finer
+    if (LOGGER.isDebugEnabled()) {
+      assert isValid(Litmus.THROW);
+    }
 
     return subset;
   }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -885,7 +885,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
 
         // Make sure best RelNode is valid
         if (subset.best != null && !subset.set.rels.contains(subset.best)) {
-          return litmus.fail("RelSubSet [{}] has best RelNode [{}] which is not existed in its set.",
+          return litmus.fail("RelSubSet [{}] does not contain its best RelNode [{}]",
                   subset.getDescription(), subset.best.getDescription());
         }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -847,9 +847,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
 
     // Checking if tree is valid considerably slows down planning
     // Recommend doing it only at unit test
-    if (CalciteSystemProperty.TEST_VALIDATE_VOLCANO_PLANNER.value()) {
-      assert isValid(Litmus.THROW);
-    }
+    assert isValid(Litmus.THROW);
 
     return subset;
   }


### PR DESCRIPTION
In VolcanoPlanner.rename(), the given relnode will be removed when we find there's an equivalent rel after rename. But if the node to be removed happens to be the best relnode of its subset, the RelSubSet.best will not able to get updated under two scenarios -

1. If equivalent rel is in the same set as the original rel, currently we do nothing. So RelSubSet.best is not updated and points to a node that's removed after rename.
2. If we end up merging two sub set and equivalent rel cost is same as original rel cost, we won't update RelSubSet.best either.

Fix the issue by udpdating the RelSubSet.best if best is the RelNode that's supposed to be removed. Also add a new Calcite property TEST_VALIDATE_VOLCANO_PLANNER for turnning on validation during volcano planner rule firing.

JIRA - https://issues.apache.org/jira/browse/CALCITE-3283