### PR TITLE
[CALCITE-3243] Incomplete validation of operands in JSON functions

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonDepthFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonDepthFunction.java
@@ -41,7 +41,7 @@ public class SqlJsonDepthFunction extends SqlFunction {
         ReturnTypes.cascade(ReturnTypes.INTEGER,
             SqlTypeTransforms.FORCE_NULLABLE),
         null,
-        OperandTypes.ANY,
+        OperandTypes.CHARACTER,
         SqlFunctionCategory.SYSTEM);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonExistsFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonExistsFunction.java
@@ -34,14 +34,15 @@ public class SqlJsonExistsFunction extends SqlFunction {
     super("JSON_EXISTS", SqlKind.OTHER_FUNCTION,
         ReturnTypes.cascade(ReturnTypes.BOOLEAN, SqlTypeTransforms.FORCE_NULLABLE), null,
         OperandTypes.or(
-            OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER),
-            OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.ANY)),
+            OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER),
+            OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER,
+                SqlTypeFamily.ANY)),
         SqlFunctionCategory.SYSTEM);
   }
 
   @Override public String getSignatureTemplate(int operandsCount) {
-    assert operandsCount == 1 || operandsCount == 2;
-    if (operandsCount == 1) {
+    assert operandsCount == 2 || operandsCount == 3;
+    if (operandsCount == 2) {
       return "{0}({1} {2})";
     }
     return "{0}({1} {2} {3} ON ERROR)";

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonKeysFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonKeysFunction.java
@@ -32,8 +32,8 @@ public class SqlJsonKeysFunction extends SqlFunction {
     super("JSON_KEYS", SqlKind.OTHER_FUNCTION,
           ReturnTypes.cascade(ReturnTypes.VARCHAR_2000, SqlTypeTransforms.FORCE_NULLABLE),
           null,
-          OperandTypes.or(OperandTypes.ANY,
-              OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER)),
+          OperandTypes.or(OperandTypes.CHARACTER,
+              OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
           SqlFunctionCategory.SYSTEM);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonLengthFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonLengthFunction.java
@@ -33,8 +33,8 @@ public class SqlJsonLengthFunction extends SqlFunction {
         ReturnTypes.cascade(ReturnTypes.INTEGER,
             SqlTypeTransforms.FORCE_NULLABLE),
         null,
-        OperandTypes.or(OperandTypes.ANY,
-            OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER)),
+        OperandTypes.or(OperandTypes.CHARACTER,
+            OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
         SqlFunctionCategory.SYSTEM);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonPrettyFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonPrettyFunction.java
@@ -41,7 +41,7 @@ public class SqlJsonPrettyFunction extends SqlFunction {
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.cascade(ReturnTypes.VARCHAR_2000, SqlTypeTransforms.FORCE_NULLABLE),
         null,
-        OperandTypes.ANY,
+        OperandTypes.CHARACTER,
         SqlFunctionCategory.SYSTEM);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonQueryFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonQueryFunction.java
@@ -40,7 +40,7 @@ public class SqlJsonQueryFunction extends SqlFunction {
         ReturnTypes.cascade(ReturnTypes.VARCHAR_2000,
             SqlTypeTransforms.FORCE_NULLABLE),
         null,
-        OperandTypes.family(SqlTypeFamily.ANY,
+        OperandTypes.family(SqlTypeFamily.CHARACTER,
             SqlTypeFamily.CHARACTER, SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.ANY),
         SqlFunctionCategory.SYSTEM);
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonStorageSizeFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonStorageSizeFunction.java
@@ -34,7 +34,7 @@ public class SqlJsonStorageSizeFunction extends SqlFunction {
         ReturnTypes.cascade(ReturnTypes.INTEGER,
             SqlTypeTransforms.FORCE_NULLABLE),
         null,
-        OperandTypes.ANY,
+        OperandTypes.CHARACTER,
         SqlFunctionCategory.SYSTEM);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonTypeFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonTypeFunction.java
@@ -43,7 +43,7 @@ public class SqlJsonTypeFunction extends SqlFunction {
             ReturnTypes.explicit(SqlTypeName.VARCHAR, 20),
             SqlTypeTransforms.FORCE_NULLABLE),
         null,
-        OperandTypes.ANY,
+        OperandTypes.CHARACTER,
         SqlFunctionCategory.SYSTEM);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonValueFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonValueFunction.java
@@ -70,7 +70,7 @@ public class SqlJsonValueFunction extends SqlFunction {
           operandTypes[3] = typeFactory.createSqlType(SqlTypeName.ANY);
           operandTypes[5] = typeFactory.createSqlType(SqlTypeName.ANY);
         },
-        OperandTypes.family(SqlTypeFamily.ANY,
+        OperandTypes.family(SqlTypeFamily.CHARACTER,
             SqlTypeFamily.CHARACTER, SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.ANY,
             SqlTypeFamily.ANY, SqlTypeFamily.ANY),
         SqlFunctionCategory.SYSTEM);

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4566,6 +4566,12 @@ public abstract class SqlOperatorBaseTest {
     tester.checkNull("json_exists(cast(null as varchar), "
         + "'lax $.foo1' unknown on error)");
 
+    // type check
+    tester.checkFails("json_exists(1, 'strict $')",
+        "(?s).*Cannot apply 'JSON_EXISTS' to arguments of type.*", false);
+    tester.checkFails("json_exists(true, 'strict $')",
+        "(?s).*Cannot apply 'JSON_EXISTS' to arguments of type.*", false);
+
   }
 
   @Test public void testJsonValue() {
@@ -4644,6 +4650,13 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails("json_value(^null^, 'strict $')",
         "(?s).*Illegal use of 'NULL'.*", false);
     tester.checkNull("json_value(cast(null as varchar), 'strict $')");
+
+    // type check
+    tester.checkFails("json_value(1, 'strict $')",
+        "(?s).*Cannot apply 'JSON_VALUE' to arguments of type.*", false);
+    tester.checkFails("json_value(true, 'strict $')",
+        "(?s).*Cannot apply 'JSON_VALUE' to arguments of type.*", false);
+
   }
 
   @Test public void testJsonQuery() {
@@ -4737,6 +4750,12 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails("json_query(^null^, 'lax $')",
         "(?s).*Illegal use of 'NULL'.*", false);
     tester.checkNull("json_query(cast(null as varchar), 'lax $')");
+
+    // type check
+    tester.checkFails("json_query(1, 'strict $')",
+        "(?s).*Cannot apply 'JSON_QUERY' to arguments of type.*", false);
+    tester.checkFails("json_query(true, 'strict $')",
+        "(?s).*Cannot apply 'JSON_QUERY' to arguments of type.*", false);
   }
 
   @Test public void testJsonPretty() {
@@ -4751,6 +4770,12 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails("json_pretty(^null^)",
         "(?s).*Illegal use of 'NULL'.*", false);
     tester.checkNull("json_pretty(cast(null as varchar))");
+
+    // type check
+    tester.checkFails("json_pretty(1)",
+        "(?s).*Cannot apply 'JSON_PRETTY' to arguments of type.*", false);
+    tester.checkFails("json_pretty(true)",
+        "(?s).*Cannot apply 'JSON_PRETTY' to arguments of type.*", false);
   }
 
   @Test public void testJsonStorageSize() {
@@ -4773,6 +4798,13 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails("json_storage_size(^null^)",
         "(?s).*Illegal use of 'NULL'.*", false);
     tester.checkNull("json_storage_size(cast(null as varchar))");
+
+    //type check
+    tester.checkFails("json_storage_size(1)",
+        "(?s).*Cannot apply 'JSON_STORAGE_SIZE' to arguments of type.*", false);
+
+    tester.checkFails("json_storage_size(true)",
+        "(?s).*Cannot apply 'JSON_STORAGE_SIZE' to arguments of type.*", false);
   }
 
   @Test public void testJsonType() {
@@ -4801,6 +4833,12 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails("json_type(^null^)",
         "(?s).*Illegal use of 'NULL'.*", false);
     tester.checkNull("json_type(cast(null as varchar))");
+
+    // type check
+    tester.checkFails("json_type(1)",
+        "(?s).*Cannot apply 'JSON_TYPE' to arguments of type.*", false);
+    tester.checkFails("json_type(true)",
+        "(?s).*Cannot apply 'JSON_TYPE' to arguments of type.*", false);
   }
 
   @Test public void testJsonDepth() {
@@ -4834,6 +4872,12 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails("json_depth(^null^)",
         "(?s).*Illegal use of 'NULL'.*", false);
     tester.checkNull("json_depth(cast(null as varchar))");
+
+    // type check
+    tester.checkFails("json_depth(1)",
+        "(?s).*Cannot apply 'JSON_DEPTH' to arguments of type.*", false);
+    tester.checkFails("json_depth(true)",
+        "(?s).*Cannot apply 'JSON_DEPTH' to arguments of type.*", false);
   }
 
   @Test public void testJsonLength() {
@@ -4944,6 +4988,12 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails("json_keys(^null^)",
         "(?s).*Illegal use of 'NULL'.*", false);
     tester.checkNull("json_keys(cast(null as varchar))");
+
+    // type check
+    tester.checkFails("json_keys(1, 'strict $')",
+        "(?s).*Cannot apply 'JSON_KEYS' to arguments of type.*", false);
+    tester.checkFails("json_keys(true, 'strict $')",
+        "(?s).*Cannot apply 'JSON_KEYS' to arguments of type.*", false);
   }
 
   @Test public void testJsonRemove() {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
@@ -37,7 +37,6 @@ import java.util.regex.Pattern;
 import static org.apache.calcite.sql.test.SqlTester.ParameterChecker;
 import static org.apache.calcite.sql.test.SqlTester.ResultChecker;
 import static org.apache.calcite.sql.test.SqlTester.TypeChecker;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -350,6 +349,14 @@ public abstract class SqlTests {
     }
     Throwable actualException = ex;
     String actualMessage = actualException.getMessage();
+
+    // If sap does not contain an error location, just check whether an exception
+    // matches the expected pattern.
+    if (sap.pos == null && expectedMsgPattern != null
+        && actualMessage.matches(expectedMsgPattern)) {
+      return;
+    }
+
     int actualLine = -1;
     int actualColumn = -1;
     int actualEndLine = 100;


### PR DESCRIPTION
The operands of various JSON functions are not validated correctly. 
If you run this test

```java
json_value(1, 'strict $.foo')"
```

It will fail at runtime when compiling generated code, I think this error should be captured by the validator and we should not even arrive at the code generation step. 
