### PR TITLE
[CALCITE-3289] Disable test pending fix for Wikipedia format change

### DIFF
--- a/file/src/test/java/org/apache/calcite/adapter/file/FileReaderTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/FileReaderTest.java
@@ -68,6 +68,7 @@ public class FileReaderTest {
   }
 
   /** Tests {@link FileReader} URL instantiation - no path. */
+  @Ignore("[CALCITE-3289] Wikipedia format change breaks file adapter test")
   @Test public void testFileReaderUrlNoPath() throws FileReaderException {
     Assume.assumeTrue(FileSuite.hazNetwork());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-3289
when i run the 'testFileReaderUrlNoPath'，then get a exception as below.
![image](https://user-images.githubusercontent.com/23030751/63668690-60c0ff80-c80a-11e9-9ad9-c3b38b35ab4d.png)
