### PR TITLE
[CALCITE-3287] Let getRowCount for union in RelMdRowCount.java take into account 'union all'

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -83,15 +83,7 @@ public class RelMdRowCount
   }
 
   public Double getRowCount(Union rel, RelMetadataQuery mq) {
-    double rowCount = 0.0;
-    for (RelNode input : rel.getInputs()) {
-      Double partialRowCount = mq.getRowCount(input);
-      if (partialRowCount == null) {
-        return null;
-      }
-      rowCount += partialRowCount;
-    }
-    return rowCount;
+    return rel.estimateRowCount(mq);
   }
 
   public Double getRowCount(Intersect rel, RelMetadataQuery mq) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -83,7 +83,18 @@ public class RelMdRowCount
   }
 
   public Double getRowCount(Union rel, RelMetadataQuery mq) {
-    return rel.estimateRowCount(mq);
+    double rowCount = 0.0;
+    for (RelNode input : rel.getInputs()) {
+      Double partialRowCount = mq.getRowCount(input);
+      if (partialRowCount == null) {
+        return null;
+      }
+      rowCount += partialRowCount;
+    }
+    if (!rel.all) {
+      rowCount *= 0.5;
+    }
+    return rowCount;
   }
 
   public Double getRowCount(Intersect rel, RelMetadataQuery mq) {


### PR DESCRIPTION
Issue was illustrated in https://issues.apache.org/jira/browse/CALCITE-3287, Change getRowCount for union in RelMdRowCount.java to call Union.estimateRowCount.
