### PR TITLE
[CALCITE-3291] Fix testcase SqlFunctionsTest failed

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -881,7 +881,7 @@ public class SqlFunctionsTest {
     try {
       String o = md5((String) null);
       fail("Expected NPE, got " + o);
-    } catch (NullPointerException e) {
+    } catch (IllegalArgumentException e) {
       // ok
     }
   }
@@ -895,7 +895,7 @@ public class SqlFunctionsTest {
     try {
       String o = sha1((String) null);
       fail("Expected NPE, got " + o);
-    } catch (NullPointerException e) {
+    } catch (IllegalArgumentException e) {
       // ok
     }
   }


### PR DESCRIPTION
Issue was illustrated in https://issues.apache.org/jira/browse/CALCITE-3291 , change SqlFunctionsTest.testMd5 and SqlFunctionsTest.testSha1 from NullPointerException to IllegalArgumentException.