### PR TITLE
[CALCITE-3292] SqlToRelConverter#substituteSubQuery fails with NullPo…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1102,6 +1102,16 @@ public class SqlToRelConverter {
       //   where emp.deptno <> null
       //         and q.indicator <> TRUE"
       //
+      // Note:
+      // Subquery can be used as SqlUpdate#condition like below:
+      // "update emp
+      //  set empno = 1 where emp.empno in (
+      //   select emp.empno from emp where emp.empno=2)"
+      // In such case, when converting SqlUpdate#condition, bb.root is null
+      // and it makes no sense to do the subquery substituion.
+      if (bb.root == null) {
+        return;
+      }
       final RelDataType targetRowType =
           SqlTypeUtil.promoteToRowType(typeFactory,
               validator.getValidatedNodeType(leftKeyNode), null);

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2202,6 +2202,18 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3292">[CALCITE-3292]
+   * NPE for UPDATE with IN query</a>.
+   */
+  @Test public void testUpdateSubQueryWithIn1() {
+    final String sql = "update emp\n"
+            + "set empno = 1 where emp.empno in (\n"
+            + "  select emp.empno from emp where emp.empno=2)";
+    sql(sql).ok();
+  }
+
   /** Similar to {@link #testUpdateSubQueryWithIn()} but with not in instead of in. */
   @Test public void testUpdateSubQueryWithNotIn() {
     final String sql = "update emp\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -4770,6 +4770,25 @@ LogicalTableModify(table=[[CATALOG, SALES, EMP]], operation=[UPDATE], updateColu
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testUpdateSubQueryWithIn1">
+        <Resource name="sql">
+            <![CDATA[update emp
+set empno = 1 where empno in (
+  select empno from emp where empno=2)]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalTableModify(table=[[CATALOG, SALES, EMP]], operation=[UPDATE], updateColumnList=[[EMPNO]], sourceExpressionList=[[1]], flattened=[true])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EXPR$0=[1])
+    LogicalJoin(condition=[=($0, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{0}])
+        LogicalProject(EMPNO=[$0])
+          LogicalFilter(condition=[=($0, 2)])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testOffset0">
         <Resource name="sql">
             <![CDATA[select * from emp offset 0]]>


### PR DESCRIPTION
interException when converting SqlUpdate

Current code fails below test
```
@Test public void testUpdateSubQueryWithIn1() {
  final String sql = "update emp\n"
          + "set empno = 1 where emp.empno in (\n"
          + "  select emp.empno from emp where emp.empno=2)";
  sql(sql).ok();
}

java.lang.NullPointerExceptionjava.lang.NullPointerException at org.apache.calcite.rel.logical.LogicalJoin.create(LogicalJoin.java:146) at org.apache.calcite.rel.logical.LogicalJoin.create(LogicalJoin.java:163) at org.apache.calcite.sql2rel.SqlToRelConverter.substituteSubQuery(SqlToRelConverter.java:1130) at org.apache.calcite.sql2rel.SqlToRelConverter.replaceSubQueries(SqlToRelConverter.java:1014) at org.apache.calcite.sql2rel.SqlToRelConverter.convertUpdate(SqlToRelConverter.java:3574) at org.apache.calcite.sql2rel.SqlToRelConverter.convertQueryRecursive(SqlToRelConverter.java:3176) at org.apache.calcite.sql2rel.SqlToRelConverter.convertQuery(SqlToRelConverter.java:563) at org.apache.calcite.test.SqlToRelTestBase$TesterImpl.convertSqlToRel(SqlToRelTestBase.java:616) at org.apache.calcite.test.SqlToRelTestBase$TesterImpl.assertConvertsTo(SqlToRelTestBase.java:731) at org.apache.calcite.test.SqlToRelConverterTest$Sql.convertsTo(SqlToRelConverterTest.java:3601) at org.apache.calcite.test.SqlToRelConverterTest$Sql.ok(SqlToRelConverterTest.java:3593)
```
 In above case, `Subquery` is used as `SqlUpdate#condition`, when converting and trying to replace the subquery in `SqlUpdate#condition`, `BalckBoard#root` is null and it makes no sense to do the subquery substitution.

