### PR TITLE
[CALCITE-3295] Add aggregate call name in serialized json string for relnode.

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -237,6 +237,7 @@ public class RelJson {
     map.put("type", toJson(node.getType()));
     map.put("distinct", node.isDistinct());
     map.put("operands", node.getArgList());
+    map.put("name", node.getName());
     return map;
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
@@ -282,10 +282,11 @@ public class RelJsonReader {
     final Integer filterOperand = (Integer) jsonAggCall.get("filter");
     final RelDataType type =
         relJson.toType(cluster.getTypeFactory(), jsonAggCall.get("type"));
+    final String name = (String) jsonAggCall.get("name");
     return AggregateCall.create(aggregation, distinct, false, false, operands,
         filterOperand == null ? -1 : filterOperand,
         RelCollations.EMPTY,
-        type, null);
+        type, name);
   }
 
   private RelNode lookupInput(String jsonInput) {


### PR DESCRIPTION
The name of aggregate call is lost in the serialized json string of relnode.
This PR is to add the aggregate call name in the json string, and use it when deserialize a relnode.
See jira [CALCITE-3295](https://issues.apache.org/jira/browse/CALCITE-3295) for more details.