### PR TITLE
[CALCITE-3306] Add built-in REGEXP_SPLIT_TO_ARRAY function.

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -110,6 +110,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.LEFT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MD5;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MONTHNAME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_REPLACE;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_SPLIT_TO_ARRAY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REPEAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REVERSE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.RIGHT;
@@ -304,6 +305,8 @@ public class RexImpTable {
     defineMethod(MD5, BuiltInMethod.MD5.method, NullPolicy.STRICT);
     defineMethod(SHA1, BuiltInMethod.SHA1.method, NullPolicy.STRICT);
     defineMethod(SUBSTRING, BuiltInMethod.SUBSTRING.method, NullPolicy.STRICT);
+    defineMethod(REGEXP_SPLIT_TO_ARRAY, BuiltInMethod.REGEXP_SPLIT_TO_ARRAY.method,
+        NullPolicy.STRICT);
     defineMethod(LEFT, BuiltInMethod.LEFT.method, NullPolicy.ANY);
     defineMethod(RIGHT, BuiltInMethod.RIGHT.method, NullPolicy.ANY);
     defineMethod(REPLACE, BuiltInMethod.REPLACE.method, NullPolicy.STRICT);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -296,6 +296,11 @@ public class SqlFunctions {
     return substring(c, s, c.length() + 1);
   }
 
+  /** SQL REGEXP_SPLIT_TO_ARRAY(string, string) function. */
+  public static List<String> regexpSplitToArray(String s, String r) {
+    return Arrays.asList(s.split(r));
+  }
+
   /** SQL UPPER(string) function. */
   public static String upper(String s) {
     return s.toUpperCase(Locale.ROOT);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -120,6 +120,18 @@ public abstract class SqlLibraryOperators {
           ReturnTypes.ARG0_NULLABLE_VARYING, null, null,
           SqlFunctionCategory.STRING);
 
+  /** The "REGEXP_SPLIT_TO_ARRAY(string, regexp) function" */
+  @LibraryOperator(libraries = {POSTGRESQL})
+  public static final SqlFunction REGEXP_SPLIT_TO_ARRAY =
+      new SqlFunction("REGEXP_SPLIT_TO_ARRAY",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.cascade(ReturnTypes.ARG0_NULLABLE_VARYING,
+              SqlTypeTransforms.TO_ARRAY,
+              SqlTypeTransforms.TO_NULLABLE),
+          null,
+          OperandTypes.STRING_STRING,
+          SqlFunctionCategory.STRING);
+
   /** The "GREATEST(value, value)" function. */
   @LibraryOperator(libraries = {ORACLE})
   public static final SqlFunction GREATEST =

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
@@ -175,6 +175,13 @@ public abstract class SqlTypeTransforms {
         assert fields.size() == 1;
         return fields.get(0).getType();
       };
+
+  /**
+   * Parameter type-inference transform strategy that wraps a given type in an array.
+   */
+  public static final SqlTypeTransform TO_ARRAY =
+      (opBinding, typeToTransform) ->
+          opBinding.getTypeFactory().createArrayType(typeToTransform, -1);
 }
 
 // End SqlTypeTransforms.java

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -359,6 +359,7 @@ public enum BuiltInMethod {
   INITCAP(SqlFunctions.class, "initcap", String.class),
   SUBSTRING(SqlFunctions.class, "substring", String.class, int.class,
       int.class),
+  REGEXP_SPLIT_TO_ARRAY(SqlFunctions.class, "regexpSplitToArray", String.class, String.class),
   CHAR_LENGTH(SqlFunctions.class, "charLength", String.class),
   STRING_CONCAT(SqlFunctions.class, "concat", String.class, String.class),
   FLOOR_DIV(DateTimeUtils.class, "floorDiv", long.class, long.class),

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -6274,6 +6274,81 @@ public abstract class SqlOperatorBaseTest {
     tester.checkNull("substring(cast(null as varchar(1)),1,2)");
   }
 
+  @Test public void testRegexpSplitToArrayFunction() {
+    final SqlTester t = tester(SqlLibrary.POSTGRESQL);
+    t.setFor(SqlLibraryOperators.REGEXP_SPLIT_TO_ARRAY);
+    t.checkString(
+        "regexp_split_to_array('','a')",
+        "[]",
+        "VARCHAR(0) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('badac','a')",
+        "[b, d, c]",
+        "VARCHAR(5) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('badac','ad')",
+        "[b, ac]",
+        "VARCHAR(5) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('badac','[bd]')",
+        "[, a, ac]",
+        "VARCHAR(5) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('badac','[a-c]')",
+        "[, , d]",
+        "VARCHAR(5) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('100+200-300','0(\\+|-)')",
+        "[10, 20, 300]",
+        "VARCHAR(11) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('100+200-300','0+')",
+        "[1, +2, -3]",
+        "VARCHAR(11) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('100 + 200 - 300',' ')",
+        "[100, +, 200, -, 300]",
+        "VARCHAR(15) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('100 + 200 - 300','\\d+')",
+        "[,  + ,  - ]",
+        "VARCHAR(15) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('hello\tworld','\t')",
+        "[hello, world]",
+        "VARCHAR(11) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('hello\nworld','\n')",
+        "[hello, world]",
+        "VARCHAR(11) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array('hello\tworld\n','\n')",
+        "[hello\tworld]",
+        "VARCHAR(12) NOT NULL ARRAY NOT NULL");
+    // test for implicit type coercion
+    t.checkString(
+        "regexp_split_to_array('1234', 2)",
+        "[1, 34]",
+        "VARCHAR(4) NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array(1234, 2)",
+        "[1, 34]",
+        "VARCHAR NOT NULL ARRAY NOT NULL");
+    t.checkString(
+        "regexp_split_to_array(1234, '2')",
+        "[1, 34]",
+        "VARCHAR NOT NULL ARRAY NOT NULL");
+    t.checkQuery("select regexp_split_to_array('hello world', ' ')");
+    t.checkQuery("select regexp_split_to_array('hello\tworld', '\t')");
+    t.checkQuery("select regexp_split_to_array('hello\nworld', '\n')");
+    t.checkQuery("select regexp_split_to_array('hello###world', '###')");
+    t.checkNull("regexp_split_to_array(cast(NULL as varchar(1)), 'abc')");
+    t.checkNull("regexp_split_to_array('abc', cast(NULL as varchar(1)))");
+    t.checkFails("select ^regexp_split_to_array('hello###world', '###', 'adb')^",
+        "Invalid number of arguments to function 'REGEXP_SPLIT_TO_ARRAY'"
+            + ". Was expecting 2 arguments", false);
+  }
+
   @Test public void testTrimFunc() {
     tester.setFor(SqlStdOperatorTable.TRIM);
 

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -43,6 +43,7 @@ import static org.apache.calcite.runtime.SqlFunctions.ltrim;
 import static org.apache.calcite.runtime.SqlFunctions.md5;
 import static org.apache.calcite.runtime.SqlFunctions.posixRegex;
 import static org.apache.calcite.runtime.SqlFunctions.regexpReplace;
+import static org.apache.calcite.runtime.SqlFunctions.regexpSplitToArray;
 import static org.apache.calcite.runtime.SqlFunctions.rtrim;
 import static org.apache.calcite.runtime.SqlFunctions.sha1;
 import static org.apache.calcite.runtime.SqlFunctions.subtractMonths;
@@ -942,6 +943,23 @@ public class SqlFunctionsTest {
     } catch (NullPointerException e) {
       // ok
     }
+  }
+
+  @Test public void testRegexpSplitToArray() {
+    assertThat(regexpSplitToArray("", "a"), is(Arrays.asList("")));
+    assertThat(regexpSplitToArray("badac", "a"), is(Arrays.asList("b", "d", "c")));
+    assertThat(regexpSplitToArray("badac", "ad"), is(Arrays.asList("b", "ac")));
+    assertThat(regexpSplitToArray("badac", "[bd]"), is(Arrays.asList("", "a", "ac")));
+    assertThat(regexpSplitToArray("badac", "[a-c]"), is(Arrays.asList("", "", "d")));
+    assertThat(regexpSplitToArray("100+200-300", "0(\\+|-)"),
+        is(Arrays.asList("10", "20", "300")));
+    assertThat(regexpSplitToArray("100+200-300", "0+"), is(Arrays.asList("1", "+2", "-3")));
+    assertThat(regexpSplitToArray("100 + 200 - 300", " "),
+        is(Arrays.asList("100", "+", "200", "-", "300")));
+    assertThat(regexpSplitToArray("100 + 200 - 300", "\\d+"), is(Arrays.asList("", " + ", " - ")));
+    assertThat(regexpSplitToArray("hello\tworld", "\t"), is(Arrays.asList("hello", "world")));
+    assertThat(regexpSplitToArray("hello\nworld", "\n"), is(Arrays.asList("hello", "world")));
+    assertThat(regexpSplitToArray("hello\tworld\n", "\n"), is(Arrays.asList("hello\tworld")));
   }
 }
 

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2275,6 +2275,7 @@ semantics.
 | m | MONTHNAME(date)                                | Returns the name, in the connection's locale, of the month in *datetime*; for example, it returns '二月' for both DATE '2020-02-10' and TIMESTAMP '2020-02-10 10:10:10'
 | o | NVL(value1, value2)                            | Returns *value1* if *value1* is not null, otherwise *value2*
 | m o | REGEXP_REPLACE(string, regexp, rep, [, pos [, occurrence [, matchType]]]) | Replaces all substrings of *string* that match *regexp* with *rep* at the starting *pos* in expr (if omitted, the default is 1), *occurrence* means which occurrence of a match to search for (if omitted, the default is 1), *matchType* specifies how to perform matching
+| p | REGEXP_SPLIT_TO_ARRAY(string1, string2)        | Returns a list of string for the result of *string1* splited by *string2* regular expression
 | m p | REPEAT(string, integer)                      | Returns a string consisting of *string* repeated of *integer* times; returns an empty string if *integer* is less than 1
 | m | REVERSE(string)                                | Returns *string* with the order of the characters reversed
 | m p | RIGHT(string, length)                        | Returns the rightmost *length* characters from the *string*


### PR DESCRIPTION
This PR tries to add a built-in REGEXP_SPLIT_TO_ARRAY for calcite.
Currently, there exists no coresponding **split** function in calcite like the **regexp_split_to_array** in [PostgreSQL](https://www.postgresql.org/docs/9.1/functions-matching.html).
Although we can solve this by creating an udf, but a built in function might be better, in case some others may have the same need.