### PR TITLE
[CALCITE-3309] Refactor generatePredicate method from EnumerableNestedLoopJoin/EnumerableHashJoin/EnumerableBatchNestedLoopJoin into a single location

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -20,6 +20,8 @@ import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.linq4j.JoinType;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.linq4j.function.Function2;
+import org.apache.calcite.linq4j.function.Predicate2;
+import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.BlockStatement;
 import org.apache.calcite.linq4j.tree.ConstantUntypedNull;
 import org.apache.calcite.linq4j.tree.Expression;
@@ -27,11 +29,15 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.MethodDeclaration;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
 import org.apache.calcite.linq4j.tree.Primitive;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.util.BuiltInMethod;
+import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
@@ -281,6 +287,41 @@ public class EnumUtils {
     }
     throw new IllegalStateException(
         "Unable to convert " + joinRelType + " to Linq4j JoinType");
+  }
+
+  /** Returns a predicate expression based on a join condition. **/
+  static Expression generatePredicate(
+      EnumerableRelImplementor implementor,
+      RexBuilder rexBuilder,
+      RelNode left,
+      RelNode right,
+      PhysType leftPhysType,
+      PhysType rightPhysType,
+      RexNode condition) {
+    final BlockBuilder builder = new BlockBuilder();
+    final ParameterExpression left_ =
+        Expressions.parameter(leftPhysType.getJavaRowType(), "left");
+    final ParameterExpression right_ =
+        Expressions.parameter(rightPhysType.getJavaRowType(), "right");
+    final RexProgramBuilder program =
+        new RexProgramBuilder(
+            implementor.getTypeFactory().builder()
+                .addAll(left.getRowType().getFieldList())
+                .addAll(right.getRowType().getFieldList())
+                .build(),
+            rexBuilder);
+    program.addCondition(condition);
+    builder.add(
+        Expressions.return_(null,
+            RexToLixTranslator.translateCondition(program.getProgram(),
+                implementor.getTypeFactory(),
+                builder,
+                new RexToLixTranslator.InputGetterImpl(
+                    ImmutableList.of(Pair.of(left_, leftPhysType),
+                        Pair.of(right_, rightPhysType))),
+                implementor.allCorrelateVariables,
+                implementor.getConformance())));
+    return Expressions.lambda(Predicate2.class, builder.toBlock(), left_, right_);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
@@ -16,11 +16,9 @@
  */
 package org.apache.calcite.adapter.enumerable;
 
-import org.apache.calcite.linq4j.function.Predicate2;
 import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
-import org.apache.calcite.linq4j.tree.ParameterExpression;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -34,9 +32,7 @@ import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.util.BuiltInMethod;
-import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableList;
 
@@ -127,53 +123,22 @@ public class EnumerableNestedLoopJoin extends Join implements EnumerableRel {
         PhysTypeImpl.of(implementor.getTypeFactory(),
             getRowType(),
             pref.preferArray());
-    final BlockBuilder builder2 = new BlockBuilder();
+    final Expression predicate =
+        EnumUtils.generatePredicate(implementor, getCluster().getRexBuilder(), left, right,
+            leftResult.physType, rightResult.physType, condition);
     return implementor.result(
         physType,
         builder.append(
             Expressions.call(BuiltInMethod.NESTED_LOOP_JOIN.method,
                 leftExpression,
                 rightExpression,
-                predicate(implementor,
-                    builder2,
-                    leftResult.physType,
-                    rightResult.physType,
-                    condition),
+                predicate,
                 EnumUtils.joinSelector(joinType,
                     physType,
                     ImmutableList.of(leftResult.physType,
                         rightResult.physType)),
                 Expressions.constant(EnumUtils.toLinq4jJoinType(joinType))))
             .toBlock());
-  }
-
-  Expression predicate(EnumerableRelImplementor implementor,
-      BlockBuilder builder, PhysType leftPhysType, PhysType rightPhysType,
-      RexNode condition) {
-    final ParameterExpression left_ =
-        Expressions.parameter(leftPhysType.getJavaRowType(), "left");
-    final ParameterExpression right_ =
-        Expressions.parameter(rightPhysType.getJavaRowType(), "right");
-    final RexProgramBuilder program =
-        new RexProgramBuilder(
-            implementor.getTypeFactory().builder()
-                .addAll(left.getRowType().getFieldList())
-                .addAll(right.getRowType().getFieldList())
-                .build(),
-            getCluster().getRexBuilder());
-    program.addCondition(condition);
-    builder.add(
-        Expressions.return_(null,
-            RexToLixTranslator.translateCondition(program.getProgram(),
-                implementor.getTypeFactory(),
-                builder,
-                new RexToLixTranslator.InputGetterImpl(
-                    ImmutableList.of(Pair.of((Expression) left_, leftPhysType),
-                        Pair.of((Expression) right_, rightPhysType))),
-                implementor.allCorrelateVariables,
-                implementor.getConformance())));
-    return Expressions.lambda(Predicate2.class, builder.toBlock(), left_,
-        right_);
   }
 }
 


### PR DESCRIPTION
Jira ticket:  [CALCITE-3309](https://issues.apache.org/jira/browse/CALCITE-3309) 

The method `EnumerableNestedLoopJoin#predicate` (that generates a predicate Expression based on a RexNode condition) has been copied-pasted as `EnumerableBatchNestedLoopJoin#generatePredicate` due to [CALCITE-2979](https://issues.apache.org/jira/browse/CALCITE-2979), and `EnumerableHashJoin#generatePredicate` due to [CALCITE-2973](https://issues.apache.org/jira/browse/CALCITE-2973).
The goal of this PR is to refactor that method into a single location (e.g. EnumUtils) where it can be accessible by all 3 Enumerable Joins.