### PR TITLE
[CALCITE-3307] PigRelExTest, PigRelOpTest and PigScriptTest fail on Windows

### DIFF
--- a/piglet/src/test/java/org/apache/calcite/test/PigRelTestBase.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelTestBase.java
@@ -20,6 +20,7 @@ import org.apache.calcite.piglet.PigConverter;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.tools.FrameworkConfig;
 
+import org.junit.Assume;
 import org.junit.Before;
 
 /**
@@ -30,6 +31,9 @@ public abstract class PigRelTestBase {
 
   @Before
   public void testSetup() throws Exception {
+    Assume.assumeFalse("Skip: Pig/Hadoop tests do not work on Windows",
+        System.getProperty("os.name").startsWith("Windows"));
+
     final FrameworkConfig config = PigRelBuilderTest.config().build();
     converter = PigConverter.create(config);
   }


### PR DESCRIPTION
Jira: [CALCITE-3307](https://issues.apache.org/jira/browse/CALCITE-3307) 