### PR TITLE
[CALCITE-3313] Add operand type checker for builtin REGEXP_REPLACE function

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -192,8 +192,9 @@ public abstract class SqlOperator {
    * @return acceptable range
    */
   public SqlOperandCountRange getOperandCountRange() {
-    if (operandTypeChecker != null) {
-      return operandTypeChecker.getOperandCountRange();
+    SqlOperandTypeChecker checker = getOperandTypeChecker();
+    if (checker != null) {
+      return checker.getOperandCountRange();
     }
 
     // If you see this error you need to override this method
@@ -425,7 +426,7 @@ public abstract class SqlOperator {
     preValidateCall(validator, scope, call);
 
     // Check the number of operands
-    checkOperandCount(validator, operandTypeChecker, call);
+    checkOperandCount(validator, getOperandTypeChecker(), call);
 
     SqlCallBinding opBinding = new SqlCallBinding(validator, scope, call);
 
@@ -647,7 +648,8 @@ public abstract class SqlOperator {
       SqlCallBinding callBinding,
       boolean throwOnFailure) {
     // Check that all of the operands are of the right type.
-    if (null == operandTypeChecker) {
+    SqlOperandTypeChecker checker = getOperandTypeChecker();
+    if (null == checker) {
       // If you see this you must either give operandTypeChecker a value
       // or override this method.
       throw Util.needToImplement(this);
@@ -657,7 +659,7 @@ public abstract class SqlOperator {
       for (Ord<SqlNode> operand : Ord.zip(callBinding.operands())) {
         if (operand.e != null
             && operand.e.getKind() == SqlKind.DEFAULT
-            && !operandTypeChecker.isOptional(operand.i)) {
+            && !checker.isOptional(operand.i)) {
           throw callBinding.getValidator().newValidationError(
               callBinding.getCall(),
               RESOURCE.defaultForOptionalParameter());
@@ -665,7 +667,7 @@ public abstract class SqlOperator {
       }
     }
 
-    return operandTypeChecker.checkOperandTypes(
+    return checker.checkOperandTypes(
         callBinding,
         throwOnFailure);
   }
@@ -727,10 +729,11 @@ public abstract class SqlOperator {
    * example) can be replaced by a specified name.
    */
   public String getAllowedSignatures(String opNameToUse) {
-    assert operandTypeChecker != null
+    SqlOperandTypeChecker checker = getOperandTypeChecker();
+    assert  checker != null
         : "If you see this, assign operandTypeChecker a value "
         + "or override this function";
-    return operandTypeChecker.getAllowedSignatures(this, opNameToUse)
+    return checker.getAllowedSignatures(this, opNameToUse)
         .trim();
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -4570,10 +4570,25 @@ public abstract class SqlOperatorBaseTest {
               "VARCHAR NOT NULL");
           t.checkString("regexp_replace('abc\t\ndef\t\nghi', '\\w+', '+')", "+\t\n+\t\n+",
               "VARCHAR NOT NULL");
+          t.checkString("regexp_replace(cast('abc DC' as char(6)), 'abc', 'hello world')",
+              "hello world DC", "VARCHAR NOT NULL");
+          t.checkString("regexp_replace('abc DC', cast('abc' as char(3)), 'hello world')",
+              "hello world DC", "VARCHAR NOT NULL");
           t.checkQuery("select regexp_replace('a b c', 'b', 'X')");
           t.checkQuery("select regexp_replace('a b c', 'b', 'X', 1)");
           t.checkQuery("select regexp_replace('a b c', 'b', 'X', 1, 3)");
           t.checkQuery("select regexp_replace('a b c', 'b', 'X', 1, 3, 'i')");
+          final String errorMsg = "Cannot apply 'REGEXP_REPLACE' to arguments of type"
+              + " 'REGEXP_REPLACE(<INTEGER ARRAY>, <CHAR(1)>, <CHAR(1)>, <INTEGER>, <INTEGER>, <CHAR(1)>)'."
+              + " Supported form(s): "
+              + "'REGEXP_REPLACE(<[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>)'\n"
+              + "'REGEXP_REPLACE(<[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>,"
+              + " <INTEGER>)'\n"
+              + "'REGEXP_REPLACE(<[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>,"
+              + " <INTEGER>, <INTEGER>)'\n"
+              + "'REGEXP_REPLACE(<[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>, <[CHAR, VARCHAR]>,"
+              + " <INTEGER>, <INTEGER>, <[CHAR, VARCHAR]>)'";
+          t.checkQueryFails("select ^regexp_replace(Array[1,2,3], 'b', 'X', 1, 3, 'i')^", errorMsg);
         });
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
@@ -469,8 +469,10 @@ public abstract class SqlTests {
       actualMessage = Util.toLinux(actualMessage);
     }
 
+    // Sometimes, it's easier to check equals.
     if (actualMessage == null
-        || !actualMessage.matches(expectedMsgPattern)) {
+        || (!actualMessage.matches(expectedMsgPattern)
+          && !actualMessage.equals(expectedMsgPattern))) {
       actualException.printStackTrace();
       final String actualJavaRegexp =
           (actualMessage == null)


### PR DESCRIPTION
The `getAllowedSignatures` of class `SqlRegexpReplaceFunction` is not overrided, and `operandTypeChecker ` is null. So when using `REGEXP_REPLACE` incorrectly, we get an AssertionError as described in jira: [CALCITE-3306](https://issues.apache.org/jira/browse/CALCITE-3306).
This PR tries to implements the getAllowedSignatures.