### PR TITLE
[CALCITE-3315] Multiple failures in Druid IT tests due to implicit casts

### DIFF
--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.test;
 
-import org.apache.calcite.adapter.druid.DruidQuery;
 import org.apache.calcite.adapter.druid.DruidSchema;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionProperty;
@@ -37,10 +36,7 @@ import java.net.URL;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.List;
-import java.util.function.Consumer;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -83,19 +79,6 @@ public class DruidAdapter2IT {
   /** Whether to run this test. */
   protected boolean enabled() {
     return CalciteSystemProperty.TEST_DRUID.value();
-  }
-
-  /** Returns a function that checks that a particular Druid query is
-   * generated to implement a query. */
-  private static Consumer<List> druidChecker(final String... lines) {
-    return list -> {
-      assertThat(list.size(), is(1));
-      DruidQuery.QuerySpec querySpec = (DruidQuery.QuerySpec) list.get(0);
-      for (String line : lines) {
-        final String s = line.replace('\'', '"');
-        assertThat(querySpec.getQueryString(null, -1), containsString(s));
-      }
-    };
   }
 
   /**
@@ -170,7 +153,7 @@ public class DruidAdapter2IT {
             "state_province=OR",
             "state_province=WA")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testSelectGroupBySum() {
@@ -193,7 +176,8 @@ public class DruidAdapter2IT {
         + "where \"product_id\" = 1020" + "group by \"store_sales\" ,\"product_id\" ";
     final String plan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
-        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], filter=[=($1, 1020)],"
+        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
+        + "filter=[=(CAST($1):INTEGER, 1020)],"
         + " projects=[[$90, $1]], groups=[{0, 1}], aggs=[[]])";
     final String druidQuery = "{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
         + "'dimensions':[{'type':'default','dimension':'store_sales',\"outputName\":\"store_sales\","
@@ -204,7 +188,7 @@ public class DruidAdapter2IT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
     sql(sql)
         .explainContains(plan)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("store_sales=0.51; product_id=1020",
             "store_sales=1.02; product_id=1020",
             "store_sales=1.53; product_id=1020",
@@ -222,7 +206,7 @@ public class DruidAdapter2IT {
         + "'lower':'1020','lowerStrict':false,'upper':'1020','upperStrict':false,"
         + "'ordering':'numeric'},'aggregations':[],"
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
-    sql(sql).returnsUnordered("product_id=1020").queryContains(druidChecker(druidQuery));
+    sql(sql).returnsUnordered("product_id=1020").queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testComplexPushGroupBy() {
@@ -238,7 +222,7 @@ public class DruidAdapter2IT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
     sql(sql)
         .returnsUnordered("id=1020")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -276,7 +260,7 @@ public class DruidAdapter2IT {
             "gender=M; state_province=WA",
             "gender=F; state_province=WA")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
                 + "'dimensions':[{'type':'default','dimension':'gender','outputName':'gender',"
                 + "'outputType':'STRING'},{'type':'default','dimension':'state_province',"
                 + "'outputName':'state_province','outputType':'STRING'}],'limitSpec':"
@@ -315,7 +299,7 @@ public class DruidAdapter2IT {
         + "'resultFormat':'compactedList'}";
     sql(sql)
         .runs()
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testLimit() {
@@ -327,7 +311,7 @@ public class DruidAdapter2IT {
         + "'resultFormat':'compactedList','limit':3";
     sql(sql)
         .runs()
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testDistinctLimit() {
@@ -348,7 +332,7 @@ public class DruidAdapter2IT {
     sql(sql)
         .runs()
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("gender=F; state_province=CA", "gender=F; state_province=OR",
             "gender=F; state_province=WA");
   }
@@ -379,7 +363,7 @@ public class DruidAdapter2IT {
             "brand_name=Hermanos; gender=F; S=4183",
             "brand_name=Tell Tale; gender=F; S=4033")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -427,7 +411,7 @@ public class DruidAdapter2IT {
             "brand_name=Tell Tale; S=7877",
             "brand_name=Ebony; S=7438")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -455,7 +439,7 @@ public class DruidAdapter2IT {
             "brand_name=Hermanos; D=1997-05-09 00:00:00; S=115")
         .explainContains(explain)
         .queryContains(
-            druidChecker("'queryType':'groupBy'", "'granularity':'all'", "'limitSpec"
+            new DruidChecker("'queryType':'groupBy'", "'granularity':'all'", "'limitSpec"
                 + "':{'type':'default','limit':30,'columns':[{'dimension':'S',"
                 + "'direction':'descending','dimensionOrder':'numeric'}]}"));
   }
@@ -491,7 +475,7 @@ public class DruidAdapter2IT {
             "brand_name=Tri-State; D=1997-05-09 00:00:00; S=120",
             "brand_name=Hermanos; D=1997-05-09 00:00:00; S=115")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQueryPart1, druidQueryPart2));
+        .queryContains(new DruidChecker(druidQueryPart1, druidQueryPart2));
   }
 
   /** Test case for
@@ -519,7 +503,7 @@ public class DruidAdapter2IT {
             "brand_name=ADJ; D=1997-01-12 00:00:00; S=3",
             "brand_name=ADJ; D=1997-01-17 00:00:00; S=3")
         .explainContains(explain)
-        .queryContains(druidChecker(subDruidQuery));
+        .queryContains(new DruidChecker(subDruidQuery));
   }
 
   /** Tests a query that contains no GROUP BY and is therefore executed as a
@@ -549,7 +533,7 @@ public class DruidAdapter2IT {
             throw TestUtil.rethrow(e);
           }
         })
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** As {@link #testFilterSortDesc()} but the bounds are numeric. */
@@ -578,7 +562,7 @@ public class DruidAdapter2IT {
             throw TestUtil.rethrow(e);
           }
         })
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Tests a query whose filter removes all rows. */
@@ -594,7 +578,7 @@ public class DruidAdapter2IT {
     sql(sql)
         .limit(4)
         .returnsUnordered()
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** As {@link #testFilterSortDescNumeric()} but with a filter that cannot
@@ -624,7 +608,7 @@ public class DruidAdapter2IT {
             throw TestUtil.rethrow(e);
           }
         })
-        .queryContains(druidChecker(druidQuery, druidFilter, druidQuery2));
+        .queryContains(new DruidChecker(druidQuery, druidFilter, druidQuery2));
   }
 
   @Test public void testUnionPlan() {
@@ -675,7 +659,7 @@ public class DruidAdapter2IT {
     final String sql = "select count(*) from \"foodmart\"";
     sql(sql)
         .returns("EXPR$0=86829\n")
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .explainContains(explain);
   }
 
@@ -701,7 +685,7 @@ public class DruidAdapter2IT {
         .returnsOrdered("c=4070; month=1997-12-01 00:00:00",
             "c=4033; month=1997-11-01 00:00:00",
             "c=3511; month=1997-07-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'"));
+        .queryContains(new DruidChecker("'queryType':'groupBy'"));
   }
 
   @Test public void testGroupByTimeAndOneMetricNotProjected() {
@@ -714,7 +698,7 @@ public class DruidAdapter2IT {
             + "order by \"c\" desc limit 3";
     sql(sql).returnsOrdered("c=494; month=1997-11-01 00:00:00; SALES=5.0",
         "c=475; month=1997-12-01 00:00:00; SALES=5.0",
-        "c=468; month=1997-03-01 00:00:00; SALES=5.0").queryContains(druidChecker("'queryType':'groupBy'"));
+        "c=468; month=1997-03-01 00:00:00; SALES=5.0").queryContains(new DruidChecker("'queryType':'groupBy'"));
   }
 
   @Test public void testGroupByTimeAndOneColumnNotProjected() {
@@ -727,7 +711,7 @@ public class DruidAdapter2IT {
         .returnsUnordered("c=3511; month=1997-07-01 00:00:00",
             "c=4033; month=1997-11-01 00:00:00",
             "c=4070; month=1997-12-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'"));
+        .queryContains(new DruidChecker("'queryType':'groupBy'"));
   }
 
   @Test public void testOrderByOneColumnNotProjected() {
@@ -787,7 +771,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$30, $89, $71]], groups=[{0}], "
             + "aggs=[[$SUM0($1), COUNT($1), COUNT($2), COUNT()]], sort0=[0], dir0=[ASC])")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"
                 + ",'dimensions':[{'type':'default','dimension':'state_province','outputName':'state_province'"
                 + ",'outputType':'STRING'}],'limitSpec':"
                 + "{'type':'default','columns':[{'dimension':'state_province',"
@@ -815,7 +799,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], projects=[[FLOOR($0, FLAG(MONTH)), $89, $71]], "
             + "groups=[{0}], aggs=[[SUM($1), COUNT($2)]], sort0=[1], dir0=[ASC])")
         .returnsOrdered("S=19958; C=5606", "S=20179; C=5523", "S=20388; C=5591")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -875,7 +859,7 @@ public class DruidAdapter2IT {
     String druidQuery = "{'queryType':'groupBy','dataSource':'foodmart'";
     sql(sql)
         .limit(3)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsOrdered("S=3850; C=1230", "S=3342; C=1071", "S=3219; C=1024");
   }
 
@@ -891,7 +875,7 @@ public class DruidAdapter2IT {
     sql(sql)
         .limit(3)
         .returnsOrdered("S=19958; C=5606", "S=20179; C=5523", "S=20388; C=5591")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testTopNMonthGranularity() {
@@ -926,7 +910,7 @@ public class DruidAdapter2IT {
             "S=12297; M=7; P=WA",
             "S=10640; M=6; P=WA")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQueryPart1, druidQueryPart2));
+        .queryContains(new DruidChecker(druidQueryPart1, druidQueryPart2));
   }
 
   @Test public void testTopNDayGranularityFiltered() {
@@ -956,7 +940,7 @@ public class DruidAdapter2IT {
             "S=1691; M=5; P=OR",
             "S=1629; M=5; P=WA")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQueryType, limitSpec));
+        .queryContains(new DruidChecker(druidQueryType, limitSpec));
   }
 
   @Test public void testGroupByHaving() {
@@ -1011,7 +995,7 @@ public class DruidAdapter2IT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
     sql(sql)
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("state_province=CA; CDC=45",
             "state_province=WA; CDC=22");
   }
@@ -1057,7 +1041,7 @@ public class DruidAdapter2IT {
         + " =($30, 'WA'))],"
         + " projects=[[$30, $29, $3]], groups=[{0, 1, 2}], aggs=[[]])\n";
     sql(sql)
-        .queryContains(druidChecker(druidQuery1, druidQuery2))
+        .queryContains(new DruidChecker(druidQuery1, druidQuery2))
         .explainContains(explain)
         .returnsUnordered(
             "state_province=WA; city=Bremerton; product_name=High Top Dried Mushrooms",
@@ -1097,7 +1081,7 @@ public class DruidAdapter2IT {
         + "OR(=($87, 'Q2'), =($87, 'Q3')), =($30, 'WA'))], "
         + "projects=[[$30, $29, $3]])\n";
     sql(sql)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .explainContains(explain)
         .returnsUnordered(
             "state_province=WA; city=Bremerton; product_name=High Top Dried Mushrooms",
@@ -1147,7 +1131,7 @@ public class DruidAdapter2IT {
         + "'value':'High Top Dried Mushrooms'}";
     sql(sql)
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testGroupByMetricAndExtractTime() {
@@ -1156,14 +1140,14 @@ public class DruidAdapter2IT {
             + "FROM \"foodmart\"\n"
             + "GROUP BY \"store_sales\", floor(\"timestamp\" to DAY)\n ORDER BY \"store_sales\" DESC\n"
             + "LIMIT 10\n";
-    sql(sql).queryContains(druidChecker("{\"queryType\":\"groupBy\""));
+    sql(sql).queryContains(new DruidChecker("{\"queryType\":\"groupBy\""));
   }
 
   @Test public void testFilterOnDouble() {
     String sql = "select \"product_id\" from \"foodmart\"\n"
         + "where cast(\"product_id\" as double) < 0.41024 and \"product_id\" < 12223";
     sql(sql).queryContains(
-        druidChecker("'type':'bound','dimension':'product_id','upper':'0.41024'",
+        new DruidChecker("'type':'bound','dimension':'product_id','upper':'0.41024'",
             "'upper':'12223'"));
   }
 
@@ -1180,7 +1164,7 @@ public class DruidAdapter2IT {
         + "'extractionFn':{'type':'timeFormat','format':'yyyy-MM-dd";
     sql(sql)
         .returnsUnordered("product_id=1016; time=1997-01-02 00:00:00")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testPushAggregateOnTimeWithExtractYear() {
@@ -1191,7 +1175,7 @@ public class DruidAdapter2IT {
         + " EXTRACT( year from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_year',"
@@ -1208,7 +1192,7 @@ public class DruidAdapter2IT {
         + " EXTRACT( month from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_month',"
@@ -1227,7 +1211,7 @@ public class DruidAdapter2IT {
         + " EXTRACT( day from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
@@ -1246,7 +1230,7 @@ public class DruidAdapter2IT {
             + "('1997-01-01' as timestamp)" + " group by "
             + " EXTRACT( hour from \"timestamp\"), \"product_id\" ";
     sql(sql)
-        .queryContains(druidChecker("'queryType':'groupBy'"))
+        .queryContains(new DruidChecker("'queryType':'groupBy'"))
         .returnsUnordered("hourOfDay=0; product_id=1016");
   }
 
@@ -1261,7 +1245,7 @@ public class DruidAdapter2IT {
         + " EXTRACT( year from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
@@ -1276,7 +1260,7 @@ public class DruidAdapter2IT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.001Z/1997-01-20T00:00:00.000Z]], "
-            + "filter=[=($1, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
+            + "filter=[=(CAST($1):INTEGER, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
             + "EXTRACT(FLAG(YEAR), $0), $1]], groups=[{0, 1, 2, 3}], aggs=[[]])\n")
         .returnsUnordered("day=2; month=1; year=1997; product_id=1016",
             "day=10; month=1; year=1997; product_id=1016",
@@ -1295,7 +1279,7 @@ public class DruidAdapter2IT {
         + " EXTRACT( year from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'", "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
                     + "'extractionFn':{'type':'timeFormat','format':'d',"
@@ -1309,7 +1293,7 @@ public class DruidAdapter2IT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.001Z/1997-01-20T00:00:00.000Z]], "
-            + "filter=[=($1, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
+            + "filter=[=(CAST($1):INTEGER, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
             + "EXTRACT(FLAG(YEAR), $0), $1]], groups=[{0, 1, 2, 3}], aggs=[[]])\n")
         .returnsUnordered("EXPR$0=2; EXPR$1=1; EXPR$2=1997; product_id=1016",
             "EXPR$0=10; EXPR$1=1; EXPR$2=1997; product_id=1016",
@@ -1327,7 +1311,7 @@ public class DruidAdapter2IT {
         + " \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'", "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
                     + "'extractionFn':{'type':'timeFormat','format':'d',"
@@ -1335,7 +1319,7 @@ public class DruidAdapter2IT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.001Z/1997-01-20T00:00:00.000Z]], "
-            + "filter=[=($1, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), $1]], "
+            + "filter=[=(CAST($1):INTEGER, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), $1]], "
             + "groups=[{0, 1}], aggs=[[]])\n")
         .returnsUnordered("EXPR$0=2; dayOfMonth=1016", "EXPR$0=10; dayOfMonth=1016",
             "EXPR$0=13; dayOfMonth=1016", "EXPR$0=16; dayOfMonth=1016");
@@ -1358,11 +1342,11 @@ public class DruidAdapter2IT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.000Z/1998-01-01T00:00:00.000Z]], "
-            + "filter=[AND(>=(CAST($11):BIGINT, 8), <=(CAST($11):BIGINT, 10), "
-            + "<(CAST($10):BIGINT, 15))], groups=[{}], "
+            + "filter=[AND(>=(CAST($11):INTEGER, 8), <=(CAST($11):INTEGER, 10), "
+            + "<(CAST($10):INTEGER, 15))], groups=[{}], "
             + "aggs=[[SUM($90)]])\n")
         .returnsUnordered("EXPR$0=75364.1")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testPushOfFilterExtractionOnDayAndMonth() {
@@ -1387,7 +1371,7 @@ public class DruidAdapter2IT {
         .returnsUnordered("product_id=1549; EXPR$1=30; EXPR$2=11; EXPR$3=1997",
             "product_id=1553; EXPR$1=30; EXPR$2=11; EXPR$3=1997")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
   }
 
   @Test public void testFilterExtractionOnMonthWithBetween() {
@@ -1398,7 +1382,7 @@ public class DruidAdapter2IT {
     sql(sqlQuery)
         .returnsUnordered("product_id=1558; EXPR$1=10", "product_id=1558; EXPR$1=11",
             "product_id=1559; EXPR$1=11")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testFilterExtractionOnMonthWithIn() {
@@ -1409,7 +1393,7 @@ public class DruidAdapter2IT {
         .returnsUnordered("product_id=1558; EXPR$1=10", "product_id=1558; EXPR$1=11",
             "product_id=1559; EXPR$1=11")
         .queryContains(
-            druidChecker("{'queryType':'groupBy',"
+            new DruidChecker("{'queryType':'groupBy',"
                 + "'dataSource':'foodmart','granularity':'all',"
                 + "'dimensions':[{'type':'default','dimension':'product_id','outputName':'product_id','outputType':'STRING'},"
                 + "{'type':'extraction','dimension':'__time','outputName':'extract_month',"
@@ -1435,7 +1419,7 @@ public class DruidAdapter2IT {
         + " GROUP BY extract(month from \"timestamp\"), \"product_id\" order by m, s, "
         + "\"product_id\"";
     sql(sqlQuery).queryContains(
-        druidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
+        new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
             + "'granularity':'all','dimensions':[{'type':'extraction',"
             + "'dimension':'__time','outputName':'extract_month',"
             + "'extractionFn':{'type':'timeFormat','format':'M','timeZone':'UTC',"
@@ -1453,7 +1437,7 @@ public class DruidAdapter2IT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-            + "filter=[>=(CAST($1):BIGINT, 1558)], projects=[[EXTRACT(FLAG(MONTH), $0), $1, $89]], "
+            + "filter=[>=(CAST($1):INTEGER, 1558)], projects=[[EXTRACT(FLAG(MONTH), $0), $1, $89]], "
             + "groups=[{0, 1}], aggs=[[SUM($2)]], sort0=[0], sort1=[2], sort2=[1], "
             + "dir0=[ASC], dir1=[ASC], dir2=[ASC])");
   }
@@ -1465,7 +1449,7 @@ public class DruidAdapter2IT {
         + "group by floor(\"timestamp\" to MONTH)\n"
         + "order by \"month\" DESC";
     sql(sql)
-        .queryContains(druidChecker("'queryType':'timeseries'", "'descending':true"))
+        .queryContains(new DruidChecker("'queryType':'timeseries'", "'descending':true"))
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z"
             + "/2992-01-10T00:00:00.000Z]], projects=[[FLOOR($0, FLAG(MONTH))]], groups=[{0}], "
@@ -1488,7 +1472,7 @@ public class DruidAdapter2IT {
         .explainContains(explain)
         .returnsOrdered("floorOfMonth=1997-12-01 00:00:00", "floorOfMonth=1997-11-01 00:00:00",
             "floorOfMonth=1997-10-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'", "'direction':'descending'"));
+        .queryContains(new DruidChecker("'queryType':'groupBy'", "'direction':'descending'"));
   }
 
   @Test public void testPushofOrderByYearWithYearMonthExtract() {
@@ -1501,7 +1485,7 @@ public class DruidAdapter2IT {
     final String expectedPlan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[>=(CAST($1):BIGINT, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
+        + "filter=[>=(CAST($1):INTEGER, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
         + "EXTRACT(FLAG(MONTH), $0), $1, $89]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], sort0=[0], "
         + "sort1=[1], sort2=[3], sort3=[2], dir0=[DESC], "
         + "dir1=[ASC], dir2=[DESC], dir3=[ASC], fetch=[3])";
@@ -1524,7 +1508,7 @@ public class DruidAdapter2IT {
         + "'ordering':'numeric'},'aggregations':[{'type':'longSum','name':'S',"
         + "'fieldName':'unit_sales'}],"
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
-    sql(sqlQuery).explainContains(expectedPlan).queryContains(druidChecker(expectedDruidQuery))
+    sql(sqlQuery).explainContains(expectedPlan).queryContains(new DruidChecker(expectedDruidQuery))
         .returnsOrdered("Y=1997; M=1; product_id=1558; S=6", "Y=1997; M=1; product_id=1559; S=6",
             "Y=1997; M=2; product_id=1558; S=24");
   }
@@ -1538,7 +1522,7 @@ public class DruidAdapter2IT {
     final String expectedPlan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[>=(CAST($1):BIGINT, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
+        + "filter=[>=(CAST($1):INTEGER, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
         + "EXTRACT(FLAG(MONTH), $0), $1, $89]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], "
         + "sort0=[3], sort1=[1], sort2=[2], dir0=[DESC], dir1=[DESC], dir2=[ASC], fetch=[3])";
     final String expectedDruidQueryType = "'queryType':'groupBy'";
@@ -1546,7 +1530,7 @@ public class DruidAdapter2IT {
         .returnsOrdered("Y=1997; M=12; product_id=1558; S=30", "Y=1997; M=3; product_id=1558; S=29",
             "Y=1997; M=5; product_id=1558; S=27")
         .explainContains(expectedPlan)
-        .queryContains(druidChecker(expectedDruidQueryType));
+        .queryContains(new DruidChecker(expectedDruidQueryType));
   }
 
   @Test public void testGroupByTimeSortOverMetrics() {
@@ -1566,7 +1550,7 @@ public class DruidAdapter2IT {
             "C=6662; S=20388; EXPR$2=1997-09-01 00:00:00",
             "C=6588; S=20179; EXPR$2=1997-04-01 00:00:00",
             "C=6478; S=19958; EXPR$2=1997-10-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'"))
+        .queryContains(new DruidChecker("'queryType':'groupBy'"))
         .explainContains("DruidQuery(table=[[foodmart, foodmart]],"
             + " intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]],"
             + " projects=[[FLOOR($0, FLAG(MONTH)), $89]], groups=[{0}], "
@@ -1587,7 +1571,7 @@ public class DruidAdapter2IT {
     sql(sqlQuery).returnsOrdered("timestamp=1997-12-30 00:00:00; C=22; S=36\ntimestamp=1997-12-29"
         + " 00:00:00; C=321; S=982\ntimestamp=1997-12-28 00:00:00; C=480; "
         + "S=1496\ntimestamp=1997-12-27 00:00:00; C=363; S=1156\ntimestamp=1997-12-26 00:00:00; "
-        + "C=144; S=420").queryContains(druidChecker(druidSubQuery));
+        + "C=144; S=420").queryContains(new DruidChecker(druidSubQuery));
 
   }
 
@@ -1605,7 +1589,7 @@ public class DruidAdapter2IT {
         + "'dimensionOrder':'numeric'}]}";
     sql(sqlQuery).returnsOrdered("D=30; M=3; Y=1997; C=114; S=351\nD=30; M=5; Y=1997; "
         + "C=24; S=34\nD=30; M=6; Y=1997; C=73; S=183\nD=30; M=7; Y=1997; C=29; S=54\nD=30; M=8; "
-        + "Y=1997; C=137; S=422").queryContains(druidChecker(druidSubQuery));
+        + "Y=1997; C=137; S=422").queryContains(new DruidChecker(druidSubQuery));
 
   }
 
@@ -1618,7 +1602,7 @@ public class DruidAdapter2IT {
         + "'dimensionOrder':'lexicographic'}]}";
     sql(sqlQuery).returnsOrdered("brand_name=Washington; C=576; S=1775\nbrand_name=Walrus; C=457;"
         + " S=1399\nbrand_name=Urban; C=299; S=924\nbrand_name=Tri-State; C=2339; "
-        + "S=7270\nbrand_name=Toucan; C=123; S=380").queryContains(druidChecker(druidSubQuery));
+        + "S=7270\nbrand_name=Toucan; C=123; S=380").queryContains(new DruidChecker(druidSubQuery));
 
   }
 
@@ -1644,7 +1628,7 @@ public class DruidAdapter2IT {
         + "'timeZone':'UTC','locale':'en-US'}}]}]},"
         + "'aggregations':[],"
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
-    sql(sql).returnsOrdered("EXPR$0=10\nEXPR$0=11").queryContains(druidChecker(druidQuery));
+    sql(sql).returnsOrdered("EXPR$0=10\nEXPR$0=11").queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -1659,8 +1643,8 @@ public class DruidAdapter2IT {
         + "    BindableProject(EXPR$0=[EXTRACT(FLAG(CENTURY), $0)])\n"
         + "      DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[=($1, 1558)], projects=[[$0]])\n";
-    sql(sql).explainContains(plan).queryContains(druidChecker("'queryType':'scan'"))
+        + "filter=[=(CAST($1):INTEGER, 1558)], projects=[[$0]])\n";
+    sql(sql).explainContains(plan).queryContains(new DruidChecker("'queryType':'scan'"))
         .returnsUnordered("EXPR$0=20");
   }
 
@@ -1693,7 +1677,7 @@ public class DruidAdapter2IT {
   @Test public void testFalseFilterCaseConjectionWithTrue() {
     String sql = "Select count(*) as c from \"foodmart\" where "
         + "\"product_id\" = 1558 and (true or false)";
-    sql(sql).returnsUnordered("C=60").queryContains(druidChecker("'queryType':'timeseries'"));
+    sql(sql).returnsUnordered("C=60").queryContains(new DruidChecker("'queryType':'timeseries'"));
   }
 
   /** Test case for
@@ -1721,7 +1705,7 @@ public class DruidAdapter2IT {
               .project(b.field("product_id"))
               .build();
         })
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testPushFieldEqualsLiteral() {
@@ -1740,7 +1724,7 @@ public class DruidAdapter2IT {
         // Should return one row, "c=0"; logged
         // [CALCITE-1775] "GROUP BY ()" on empty relation should return 1 row
         .returnsUnordered("c=0")
-        .queryContains(druidChecker("'queryType':'timeseries'"));
+        .queryContains(new DruidChecker("'queryType':'timeseries'"));
   }
 
   @Test public void testPlusArithmeticOperation() {
@@ -1756,7 +1740,7 @@ public class DruidAdapter2IT {
             "A=222698.26509999996; store_state=CA",
             "A=199049.57059999998; store_state=OR")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideArithmeticOperation() {
@@ -1772,7 +1756,7 @@ public class DruidAdapter2IT {
             "store_state=CA; A=2.505379741272971",
             "store_state=WA; A=2.5045806163801996")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testMultiplyArithmeticOperation() {
@@ -1788,7 +1772,7 @@ public class DruidAdapter2IT {
             "store_state=CA; A=1.0112000537448784E10",
             "store_state=OR; A=8.077425041941243E9")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testMinusArithmeticOperation() {
@@ -1805,7 +1789,7 @@ public class DruidAdapter2IT {
             "store_state=CA; A=95637.41489999992",
             "store_state=OR; A=85504.56939999988")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testConstantPostAggregator() {
@@ -1821,7 +1805,7 @@ public class DruidAdapter2IT {
             "store_state=CA; A=159267.83999999994",
             "store_state=OR; A=142377.06999999992")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testRecursiveArithmeticOperation() {
@@ -1841,7 +1825,7 @@ public class DruidAdapter2IT {
             "store_state=CA; C=-74749.30433035882",
             "store_state=WA; C=-124367.29537914316")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   /**
@@ -1859,7 +1843,7 @@ public class DruidAdapter2IT {
     foodmartApprox(sqlQuery)
         .runs()
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testExtractFilterWorkWithPostAggregations() {
@@ -1876,7 +1860,7 @@ public class DruidAdapter2IT {
         .returnsOrdered("store_state=CA; brand_name=Bird Call; A=34.364599999999996",
             "store_state=OR; brand_name=Bird Call; A=39.16359999999999",
             "store_state=WA; brand_name=Bird Call; A=53.742500000000014")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testExtractFilterWorkWithPostAggregationsWithConstant() {
@@ -1897,7 +1881,7 @@ public class DruidAdapter2IT {
             "store_state=OR; brand_name=Bird Call; A=39.16359999999999",
             "store_state=WA; brand_name=Bird Call; A=53.742500000000014")
         .explainContains(plan)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testSingleAverageFunction() {
@@ -1914,7 +1898,7 @@ public class DruidAdapter2IT {
             "store_state=CA; A=2.599338206292706",
             "store_state=WA; A=2.5828708592868717")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testPartiallyPostAggregation() {
@@ -1935,7 +1919,7 @@ public class DruidAdapter2IT {
             "store_state=CA; A=2.505379741272971; B=74748.0",
             "store_state=WA; A=2.5045806163801996; B=124366.0")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDuplicateReferenceOnPostAggregation() {
@@ -1954,7 +1938,7 @@ public class DruidAdapter2IT {
             "store_state=CA; A=159267.83999999994; C=95737.41489999992",
             "store_state=OR; A=142377.06999999992; C=85604.56939999988")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroDoubleTypeInfinity() {
@@ -1970,7 +1954,7 @@ public class DruidAdapter2IT {
             "store_state=OR; A=Infinity",
             "store_state=WA; A=Infinity")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroDoubleTypeNegInfinity() {
@@ -1988,7 +1972,7 @@ public class DruidAdapter2IT {
             "store_state=OR; A=-Infinity",
             "store_state=WA; A=-Infinity")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroDoubleTypeNaN() {
@@ -2005,7 +1989,7 @@ public class DruidAdapter2IT {
             "store_state=OR; A=NaN",
             "store_state=WA; A=NaN")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroIntegerType() {
@@ -2044,7 +2028,7 @@ public class DruidAdapter2IT {
             "store_state=WA; brand_name=King; A=34.6104",
             "store_state=OR; brand_name=Toretti; A=36.3")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testInterleaveBetweenAggregateAndGroupOrderByOnDimension() {
@@ -2065,7 +2049,7 @@ public class DruidAdapter2IT {
             "store_state=CA; brand_name=Akron; A=250.349",
             "store_state=OR; brand_name=Akron; A=278.69720000000007")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testOrderByOnMetricsInSelectDruidQuery() {
@@ -2086,7 +2070,7 @@ public class DruidAdapter2IT {
             "A=0.5; B=0.21; C=0.29000000000000004",
             "A=0.57; B=0.2793; C=0.29069999999999996")
         .explainContains(plan)
-        .queryContains(druidChecker(queryType));
+        .queryContains(new DruidChecker(queryType));
   }
 
   /**
@@ -2104,7 +2088,7 @@ public class DruidAdapter2IT {
         + ":'EXPR$0','fieldName':'store_sales'}],'intervals':['1900-01-09T00:00:00.000Z/2992-01"
         + "-10T00:00:00.000Z'],'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2119,7 +2103,7 @@ public class DruidAdapter2IT {
         + "'store_sales'}],'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
         + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2137,7 +2121,7 @@ public class DruidAdapter2IT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
         + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2159,7 +2143,7 @@ public class DruidAdapter2IT {
         + "['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
         + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2179,7 +2163,7 @@ public class DruidAdapter2IT {
         + "['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
         + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2195,7 +2179,7 @@ public class DruidAdapter2IT {
             + "filter=[false], projects=[[$90, false]], groups=[{}], aggs=[[SUM($0)]])";
     sql(sql)
         .queryContains(
-            druidChecker("{\"queryType\":\"timeseries\","
+            new DruidChecker("{\"queryType\":\"timeseries\","
                 + "\"dataSource\":\"foodmart\",\"descending\":false,\"granularity\":\"all\","
                 + "\"filter\":{\"type\":\"expression\",\"expression\":\"1 == 2\"},"
                 + "\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"EXPR$0\","
@@ -2222,7 +2206,7 @@ public class DruidAdapter2IT {
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"filter\":{\"type"
+            new DruidChecker("\"filter\":{\"type"
                 + "\":\"and\",\"fields\":[{\"type\":\"expression\",\"expression\":\"1 == 2\"},"
                 + "{\"type\":\"selector\",\"dimension\":\"store_city\",\"value\":\"Seattle\"}]}"));
   }
@@ -2243,7 +2227,7 @@ public class DruidAdapter2IT {
         + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .returnsUnordered("EXPR$0=52644.07000000001");
   }
 
@@ -2261,7 +2245,7 @@ public class DruidAdapter2IT {
         + ":'store_cost'}],'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
         + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2281,7 +2265,7 @@ public class DruidAdapter2IT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
         + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2305,7 +2289,7 @@ public class DruidAdapter2IT {
         + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .returnsUnordered("EXPR$0=159167.83999999994; EXPR$1=263793.2200000001");
   }
 
@@ -2331,7 +2315,7 @@ public class DruidAdapter2IT {
         + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .returnsUnordered("EXPR$0=2600.01; EXPR$1=4486.4400000000005");
   }
 
@@ -2359,7 +2343,7 @@ public class DruidAdapter2IT {
         + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .explainContains(expectedAggregateExplain)
         .returnsUnordered("EXPR$0=2600.01; EXPR$1=1013.162");
   }
@@ -2383,7 +2367,7 @@ public class DruidAdapter2IT {
         + "'dimension':'the_year','upper':'1997','upperStrict':false,'ordering':'numeric'}]}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedFilter));
+        .queryContains(new DruidChecker(expectedFilter));
   }
 
   /**
@@ -2404,7 +2388,7 @@ public class DruidAdapter2IT {
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"filter\":{\"type"
+            new DruidChecker("\"filter\":{\"type"
                 + "\":\"expression\",\"expression\":\"like(\\\"the_year\\\","));
   }
 
@@ -2420,7 +2404,7 @@ public class DruidAdapter2IT {
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"", "\"filter\":{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"timeseries\"", "\"filter\":{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"10\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .returnsUnordered("EXPR$0=25.060000000000002");
@@ -2434,12 +2418,12 @@ public class DruidAdapter2IT {
             + "  BindableProject(EXPR$0=[$1], product_id=[$0])\n"
             + "    DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], filter=[AND(>"
-            + "(CAST($1):BIGINT, 1553), >($91, 5))], groups=[{1}], aggs=[[SUM($90)]])";
+            + "(CAST($1):INTEGER, 1553), >($91, 5))], groups=[{1}], aggs=[[SUM($90)]])";
 
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"5\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .returnsUnordered("EXPR$0=10.16; product_id=1554\n"
@@ -2454,7 +2438,7 @@ public class DruidAdapter2IT {
         + "group by floor(\"timestamp\" to DAY),\"product_id\"";
     sql(sql)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"5\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .returnsUnordered("EXPR$0=10.6; product_id=1556\n"
@@ -2483,8 +2467,8 @@ public class DruidAdapter2IT {
             + "'name':'EXPR$0','fieldName':'store_sales'}]";
 
     sql(sql)
-        .queryContains(druidChecker(expectedFilterJson))
-        .queryContains(druidChecker(expectedAggregateJson))
+        .queryContains(new DruidChecker(expectedFilterJson))
+        .queryContains(new DruidChecker(expectedAggregateJson))
         .returnsUnordered("EXPR$0=301444.9099999999");
   }
 
@@ -2517,8 +2501,8 @@ public class DruidAdapter2IT {
         + "'aggregator':{'type':'doubleSum','name':'EXPR$1','fieldName':'store_cost'}}]";
 
     sql(sql)
-        .queryContains(druidChecker(expectedFilterJson))
-        .queryContains(druidChecker(expectedAggregatesJson))
+        .queryContains(new DruidChecker(expectedFilterJson))
+        .queryContains(new DruidChecker(expectedAggregatesJson))
         .returnsUnordered("EXPR$0=13077.789999999992; EXPR$1=9830.7799");
   }
 
@@ -2527,7 +2511,7 @@ public class DruidAdapter2IT {
     final String druidQuery = "{'queryType':'timeseries','dataSource':'foodmart'";
     sql(sql)
         .returnsUnordered("EXPR$0=86829")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /**
@@ -2540,7 +2524,7 @@ public class DruidAdapter2IT {
         + "'field':{'type':'selector','dimension':'the_month','value':'October'}}";
     // Check that the filter actually worked, and that druid was responsible for the filter
     sql(sql, FOODMART)
-        .queryContains(druidChecker(druidFilter))
+        .queryContains(new DruidChecker(druidFilter))
         .returnsOrdered("EXPR$0=11");
   }
 
@@ -2658,7 +2642,7 @@ public class DruidAdapter2IT {
         .query(sql)
         .runs()
         .explainContains(expectedExplain)
-        .queryContains(druidChecker(expectedDruidQuery));
+        .queryContains(new DruidChecker(expectedDruidQuery));
   }
 
   /**
@@ -2673,7 +2657,7 @@ public class DruidAdapter2IT {
     foodmartApprox("select count(distinct \"the_month\"), \"customer_id\" "
         + "from \"foodmart\" group by \"customer_id\"")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
                 + "'granularity':'all','dimensions':[{'type':'default','dimension':"
                 + "'customer_id','outputName':'customer_id','outputType':'STRING'}],"
                 + "'limitSpec':{'type':'default'},'aggregations':[{"
@@ -2707,7 +2691,7 @@ public class DruidAdapter2IT {
             + "'context':{'skipEmptyBuckets':false}}";
     sql(sqlQuery, FOODMART)
         .explainContains(plan)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("A=85.31639999999999");
 
     final String sqlQuery2 = "select sum(\"store_cost\") as a "
@@ -2734,7 +2718,7 @@ public class DruidAdapter2IT {
     sql(sqlQuery, FOODMART)
         .explainContains(plan)
         .returnsUnordered("A=225541.91720000014")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
 
     final String sqlQuery2 = "select sum(\"store_cost\") as a "
         + "from \"foodmart\" "
@@ -2755,7 +2739,7 @@ public class DruidAdapter2IT {
             + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
     sql(sql, FOODMART)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("C=0")
         .returnsCount(1);
   }
@@ -2771,7 +2755,7 @@ public class DruidAdapter2IT {
             + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
     sql(sql, FOODMART)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("C=86829");
   }
 
@@ -2788,7 +2772,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("T=1997-01-01 00:00:00", "T=1997-01-01 00:00:00")
         .queryContains(
-            druidChecker(druidQuery));
+            new DruidChecker(druidQuery));
   }
 
   @Test
@@ -2815,7 +2799,7 @@ public class DruidAdapter2IT {
         + "'lowerStrict':false,'ordering':'lexicographic','";
     sql(sql, FOODMART)
         .returnsOrdered("T=1997-05-01 00:00:00")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -2827,7 +2811,7 @@ public class DruidAdapter2IT {
         + "EXTRACT(MONTH FROM \"timestamp\") = 01 AND EXTRACT(YEAR FROM \"timestamp\") = 1996 ";
     sql(sql, FOODMART)
         .runs()
-        .queryContains(druidChecker("{\"queryType\":\"timeseries\""));
+        .queryContains(new DruidChecker("{\"queryType\":\"timeseries\""));
   }
 
   @Test public void testFloorToDateRangeWithTimeZone() {
@@ -2843,7 +2827,7 @@ public class DruidAdapter2IT {
         .withModel(FOODMART)
         .query(sql)
         .runs()
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsOrdered("T=1997-05-01 00:00:00");
   }
 
@@ -2852,7 +2836,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where ABS(-EXP(LN(SQRT"
         + "(\"store_sales\")))) = 1";
     sql(sql, FOODMART)
-        .queryContains(druidChecker("pow(\\\"store_sales\\\""))
+        .queryContains(new DruidChecker("pow(\\\"store_sales\\\""))
         .returnsUnordered("EXPR$0=32");
   }
 
@@ -2861,7 +2845,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where CAST(SQRT(ABS(-\"store_sales\"))"
         + " /2 as INTEGER) = 1";
     sql(sql, FOODMART)
-        .queryContains(druidChecker("(CAST((pow(abs((- \\\"store_sales\\\")),0.5) / 2),"))
+        .queryContains(new DruidChecker("(CAST((pow(abs((- \\\"store_sales\\\")),0.5) / 2),"))
         .returnsUnordered("EXPR$0=62449");
   }
 
@@ -2870,7 +2854,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where \"product_id\" LIKE '1%'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"like"))
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"like"))
         .returnsUnordered("EXPR$0=36839");
   }
 
@@ -2879,7 +2863,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where CHAR_LENGTH(\"product_id\") = 2";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"expression\":\"(strlen(\\\"product_id\\\") == 2"))
+            new DruidChecker("\"expression\":\"(strlen(\\\"product_id\\\") == 2"))
         .returnsUnordered("EXPR$0=4876");
   }
 
@@ -2889,7 +2873,7 @@ public class DruidAdapter2IT {
         + "'SPOKANE'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
                 + "(lower(\\\"city\\\")) ==", "SPOKANE"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -2900,7 +2884,7 @@ public class DruidAdapter2IT {
         + "'spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
                 + "(upper(\\\"city\\\")) ==", "spokane"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -2910,7 +2894,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where lower(\"city\") = 'Spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
                 + "(\\\"city\\\") ==", "Spokane"))
         .returnsUnordered("EXPR$0=0");
   }
@@ -2920,7 +2904,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where lower(\"city\") = 'spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
                 + "(\\\"city\\\") ==", "spokane"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -2930,7 +2914,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where upper(\"city\") = 'Spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
                 + "(\\\"city\\\") ==", "Spokane"))
         .returnsUnordered("EXPR$0=0");
   }
@@ -2940,7 +2924,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where upper(\"city\") = 'SPOKANE'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
                 + "(\\\"city\\\") ==", "SPOKANE"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -2951,7 +2935,7 @@ public class DruidAdapter2IT {
         + "'Spokane_extra'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
+            new DruidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
                 + "(\\\"city\\\",", "Spokane_extra"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -2961,7 +2945,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where (\"city\" || 'extra') IS NOT NULL";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
+            new DruidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
                 + "(\\\"city\\\",", "!= null"))
         .returnsUnordered("EXPR$0=86829");
   }
@@ -2976,7 +2960,7 @@ public class DruidAdapter2IT {
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "projects=[[0]], groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "{\"queryType\":\"timeseries\",\"dataSource\":\"foodmart\",\"descending\":false,"
                     + "\"granularity\":\"all\",\"aggregations\":[{\"type\":\"count\","
                     + "\"name\":\"EXPR$0\"}],\"intervals\":[\"1900-01-09T00:00:00.000Z/"
@@ -2989,7 +2973,8 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where (\"city\" || \"state_province\")"
         + " = 'SpokaneWA'";
     sql(sql, FOODMART)
-        .queryContains(druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==", "SpokaneWA"))
+        .queryContains(
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==", "SpokaneWA"))
         .returnsUnordered("EXPR$0=7394");
   }
 
@@ -3000,7 +2985,7 @@ public class DruidAdapter2IT {
         + "AND \"state_province\" = 'WA'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
                 "SpokaneWA",
                 "{\"type\":\"selector\",\"dimension\":\"state_province\",\"value\":\"WA\"}]}"))
         .returnsUnordered("EXPR$0=7394");
@@ -3013,7 +2998,7 @@ public class DruidAdapter2IT {
         + "OR (\"state_province\" = 'CA' AND \"city\" IS NOT NULL)";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
                 "SpokaneWA", "{\"type\":\"and\",\"fields\":[{\"type\":\"selector\","
                     + "\"dimension\":\"state_province\",\"value\":\"CA\"},{\"type\":\"not\","
                     + "\"field\":{\"type\":\"selector\",\"dimension\":\"city\",\"value\":null}}]}"))
@@ -3025,7 +3010,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where \"city\" = \"state_province\"";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                 + "(\\\"city\\\" == \\\"state_province\\\")\"}"))
         .returnsUnordered("EXPR$0=0");
   }
@@ -3035,7 +3020,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where \"city\" <> \"state_province\"";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                 + "(\\\"city\\\" != \\\"state_province\\\")\"}"))
         .returnsUnordered("EXPR$0=86829");
   }
@@ -3052,7 +3037,7 @@ public class DruidAdapter2IT {
             + "(||($29, $30), 'SpokaneWA'), =(||($29, '_extra'), 'Spokane_extra')), =($30, 'WA'))"
             + "], groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
                 "SpokaneWA", "{\"type\":\"selector\",\"dimension\":\"state_province\","
                     + "\"value\":\"WA\"}]}"))
         .returnsUnordered("EXPR$0=7394");
@@ -3064,7 +3049,7 @@ public class DruidAdapter2IT {
         + ") / 3 + 1 AS INTEGER) > 1";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("(CAST((((pow(\\\"store_sales\\\",0.5) - 1) / 3) + 1)", "LONG"))
+            new DruidChecker("(CAST((((pow(\\\"store_sales\\\",0.5) - 1) / 3) + 1)", "LONG"))
         .returnsUnordered("EXPR$0=476");
   }
 
@@ -3079,7 +3064,7 @@ public class DruidAdapter2IT {
             + "filter=[=(CAST(CAST($0):DATE NOT NULL):VARCHAR NOT NULL, '1997-01-01')], "
             + "groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker("{\"type\":\"expression\","
+            new DruidChecker("{\"type\":\"expression\","
                 + "\"expression\":\"(timestamp_format(timestamp_floor(\\\"__time\\\""))
         .returnsUnordered("EXPR$0=117");
   }
@@ -3090,7 +3075,7 @@ public class DruidAdapter2IT {
         + "\"timestamp\") - 1 ) / 3 + 1 AS INTEGER) = 1";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker(",\"filter\":{\"type\":\"expression\",\"expression\":\"((("
+            new DruidChecker(",\"filter\":{\"type\":\"expression\",\"expression\":\"((("
                 + "(timestamp_extract(\\\"__time\\\"", "MONTH", ") - 1) / 3) + 1) == 1"))
         .returnsUnordered("EXPR$0=21587");
   }
@@ -3107,7 +3092,7 @@ public class DruidAdapter2IT {
         .query(sql)
         .runs()
         .returnsOrdered("EXPR$0=86829")
-        .queryContains(druidChecker(filterPart1));
+        .queryContains(new DruidChecker(filterPart1));
   }
 
   @Test
@@ -3122,7 +3107,7 @@ public class DruidAdapter2IT {
         .query(sql)
         .runs()
         .returnsOrdered("EXPR$0=7033")
-        .queryContains(druidChecker(filterPart1, "MONTH", "== 2"));
+        .queryContains(new DruidChecker(filterPart1, "MONTH", "== 2"));
   }
 
   @Test
@@ -3151,7 +3136,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("timestamp=1997-01-01 00:00:00; EXPR$1=117")
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                     + "(timestamp_floor(timestamp_parse(concat(concat(",
                 "== timestamp_floor(\\\"__time\\\""));
   }
@@ -3164,7 +3149,7 @@ public class DruidAdapter2IT {
         + "GROUP BY \"timestamp\"";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                 + "(timestamp_parse(concat(concat("))
         .returnsOrdered("timestamp=1997-01-01 00:00:00; EXPR$1=117");
   }
@@ -3179,7 +3164,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=2")
         .explainContains(plan)
-        .queryContains(druidChecker("\"queryType\":\"timeseries\""));
+        .queryContains(new DruidChecker("\"queryType\":\"timeseries\""));
   }
 
 
@@ -3192,7 +3177,7 @@ public class DruidAdapter2IT {
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "filter=[=($1, $29)], groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\","
+            new DruidChecker("\"filter\":{\"type\":\"expression\","
                 + "\"expression\":\"(\\\"product_id\\\" == \\\"city\\\")\"}"))
         .returnsOrdered("EXPR$0=0");
   }
@@ -3204,7 +3189,7 @@ public class DruidAdapter2IT {
         + "<= floor(\"store_sales\") * 25 + 2";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "\"filter\":{\"type\":\"expression\",\"expression\":\"(((CAST(\\\"product_id\\\", ",
                 "LONG",
                 ") + (1 * \\\"store_sales\\\")) / (\\\"store_cost\\\" - 5))",
@@ -3225,7 +3210,7 @@ public class DruidAdapter2IT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], filter=[<>($1, '1')], groups=[{}], aggs=[[COUNT()]])")
-        .queryContains(druidChecker("\"queryType\":\"timeseries\""))
+        .queryContains(new DruidChecker("\"queryType\":\"timeseries\""))
         .returnsOrdered("EXPR$0=86803");
   }
 
@@ -3272,7 +3257,7 @@ public class DruidAdapter2IT {
         .returnsOrdered("EXPR$0=36")
         .explainContains(plan)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 queryType, filterExp1, filterExpPart2, likeExpressionFilter, likeExpressionFilter2,
                 simpleBound, timeSimpleFilter, simpleExtractFilterMonth, simpleExtractFilterDay,
                 quarterAsExpressionFilter, quarterAsExpressionFilterTimeZone,
@@ -3319,7 +3304,7 @@ public class DruidAdapter2IT {
         .returnsOrdered("C=60; EXPR$1=1227")
         .explainContains(plan)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "substring(\\\"product_id\\\"",
+            new DruidChecker("\"queryType\":\"groupBy\"", "substring(\\\"product_id\\\"",
                 "\"(strlen(\\\"product_id\\\")",
                 ",\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\","
                     + "\"expression\":\"substring(\\\"product_id\\\", 0, 4)\","
@@ -3335,7 +3320,7 @@ public class DruidAdapter2IT {
 
     sql(sql, FOODMART).returnsOrdered("EXPR$0=10893")
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"", "like(substring(\\\"product_id\\\""))
+            new DruidChecker("\"queryType\":\"timeseries\"", "like(substring(\\\"product_id\\\""))
         .explainContains(
             "PLAN=EnumerableInterpreter\n  DruidQuery(table=[[foodmart, foodmart]], "
                 + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
@@ -3350,7 +3335,7 @@ public class DruidAdapter2IT {
         + " WHERE SUBSTRING(\"product_id\" from CAST(\"store_cost\" as INT)/1000 + 1) like '1%'";
 
     sql(sql, FOODMART).returnsOrdered("EXPR$0=36839")
-        .queryContains(druidChecker("like(substring(\\\"product_id\\\""))
+        .queryContains(new DruidChecker("like(substring(\\\"product_id\\\""))
         .explainContains(
             "PLAN=EnumerableInterpreter\n  DruidQuery(table=[[foodmart, foodmart]], "
                 + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
@@ -3372,7 +3357,7 @@ public class DruidAdapter2IT {
         + "group by floor(\"timestamp\" to DAY),\"product_id\"";
     sql(sql)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"5\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .runs();
@@ -3384,12 +3369,16 @@ public class DruidAdapter2IT {
   @Test
   public void testBetweenFilterWithCastOverNumeric() {
     final String sql = "SELECT COUNT(*) FROM " + FOODMART_TABLE + " WHERE \"product_id\" = 16.0";
+    // After CALCITE-2302 the Druid query changed a bit and the type of the
+    // filter became an expression (instead of a bound filter) but it still
+    // seems correct.
     sql(sql, FOODMART).runs().queryContains(
-        druidChecker(
-            "\"filter\":{\"type\":\"bound\",\"dimension\":\"product_id\",\"lower\":\"16.0\","
-                + "\"lowerStrict\":false,\"upper\":\"16.0\","
-                + "\"upperStrict\":false,\"ordering\":\"numeric\"}"));
-
+        new DruidChecker(
+            false,
+            "\"filter\":{"
+                + "\"type\":\"expression\","
+                + "\"expression\":\"(CAST(\\\"product_id\\\", \'DOUBLE\') == 16.0)\""
+                + "}"));
   }
 
   @Test
@@ -3416,7 +3405,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=117")
         .queryContains(
-            druidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
+            new DruidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
                     + "'descending':false,'granularity':'all','filter':{'type':'and','fields':"
                     + "[{'type':'bound','dimension':'__time','upper':'1997-01-02T00:00:00.000Z',"
                     + "'upperStrict':true,'ordering':'lexicographic',"
@@ -3437,7 +3426,8 @@ public class DruidAdapter2IT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-            + "filter=[AND(IS NOT TRUE(=($1, 1020)), <>($1, 1020))], groups=[{}], "
+            + "filter=[AND(IS NOT TRUE(=(CAST($1):INTEGER, 1020)), <>(CAST($1):INTEGER, 1020))], "
+            + "groups=[{}], "
             + "aggs=[[COUNT()]])");
     final String sql2 = "SELECT COUNT(*) FROM " + FOODMART_TABLE + "WHERE "
         + "\"product_id\" <> 1020";
@@ -3490,7 +3480,7 @@ public class DruidAdapter2IT {
             + "[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "projects=[[EXTRACT(FLAG(YEAR), $0)]])")
         .queryContains(
-            druidChecker("\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\","
+            new DruidChecker("\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\","
                 + "\"expression\":\"timestamp_extract(\\\"__time\\\""));
   }
 
@@ -3504,7 +3494,7 @@ public class DruidAdapter2IT {
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "projects=[[+($90, 1)]], groups=[{}], aggs=[[SUM($0)]])")
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"",
+            new DruidChecker("\"queryType\":\"timeseries\"",
                 "\"doubleSum\",\"name\":\"EXPR$0\",\"expression\":\"(\\\"store_sales\\\" + 1)\""));
   }
 
@@ -3519,7 +3509,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$0, *(-($90), 2)]], groups=[{0}], "
             + "aggs=[[SUM($1)]], sort0=[1], dir0=[ASC], fetch=[2])")
         .queryContains(
-            druidChecker("'queryType':'groupBy'", "'granularity':'all'",
+            new DruidChecker("'queryType':'groupBy'", "'granularity':'all'",
                 "{'dimension':'S','direction':'ascending','dimensionOrder':'numeric'}",
                 "{'type':'doubleSum','name':'S','expression':'((- \\'store_sales\\') * 2)'}]"));
   }
@@ -3538,7 +3528,7 @@ public class DruidAdapter2IT {
             + " groups=[{0}], aggs=[[SUM($1), MAX($2), MIN($3)]], post_projects=[[-($1, $2), $3]],"
             + " sort0=[0], dir0=[ASC], fetch=[2])")
         .queryContains(
-            druidChecker(",\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"$f1\","
+            new DruidChecker(",\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"$f1\","
                 + "\"expression\":\"((- \\\"store_sales\\\") * 2)\"},{\"type\":\"doubleMax\",\"name\""
                 + ":\"$f2\",\"expression\":\"(\\\"store_cost\\\" * \\\"store_cost\\\")\"},"
                 + "{\"type\":\"doubleMin\",\"name\":\"S2\",\"expression\":\"(\\\"store_sales\\\" "
@@ -3559,7 +3549,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], projects=[[||(||($1, '_'), $29), "
             + "+($90, CAST($53):DOUBLE)]], groups=[{0}], aggs=[[SUM($1)]], fetch=[2])")
         .queryContains(
-            druidChecker("'queryType':'groupBy'",
+            new DruidChecker("'queryType':'groupBy'",
                 "{'type':'doubleSum','name':'S','expression':'(\\'store_sales\\' + CAST(\\'cost\\'",
                 "'expression':'concat(concat(\\'product_id\\'",
                 "{'type':'default','dimension':'vc','outputName':'vc','outputType':'STRING'}],"
@@ -3577,7 +3567,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], filter=[=($30, 'CA')], projects=[[||(||($1, '_'), $29)]],"
             + " groups=[{}], aggs=[[COUNT($0)]])")
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"",
+            new DruidChecker("\"queryType\":\"timeseries\"",
                 "\"aggregator\":{\"type\":\"count\",\"name\":\"EXPR$0\",\"expression\":"
                     + "\"concat(concat(\\\"product_id\\\"",
                 "\"aggregations\":[{\"type\":\"filtered\",\"filter\":{\"type\":\"not\",\"field\":"
@@ -3589,7 +3579,7 @@ public class DruidAdapter2IT {
     final String sql = "SELECT SUM(cast(\"product_id\" AS INTEGER)) FROM " + FOODMART_TABLE;
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
+            new DruidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
                 + "'descending':false,'granularity':'all','aggregations':[{'type':'longSum',"
                 + "'name':'EXPR$0','expression':'CAST(\\'product_id\\'", "LONG"))
         .returnsOrdered("EXPR$0=68222919");
@@ -3601,7 +3591,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=12")
         .queryContains(
-            druidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
+            new DruidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
                 + "'descending':false,'granularity':'all','aggregations':[{"
                 + "'type':'longMax','name':'EXPR$0','expression':'timestamp_extract(\\'__time\\'"));
   }
@@ -3623,7 +3613,7 @@ public class DruidAdapter2IT {
 
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=24441; EXPR$1=86829")
-        .queryContains(druidChecker(query));
+        .queryContains(new DruidChecker(query));
   }
 
   @Test
@@ -3666,7 +3656,8 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered(
             "QR_TIMESTAMP_OK=1; SUM_STORE_SALES=139628.34999999971; YR_TIMESTAMP_OK=1997")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\"", extract_year, extract_expression))
+        .queryContains(
+            new DruidChecker("\"queryType\":\"groupBy\"", extract_year, extract_expression))
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  BindableProject(QR_TIMESTAMP_OK=[$0], SUM_STORE_SALES=[$2], YR_TIMESTAMP_OK=[$1])\n"
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
@@ -3690,7 +3681,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], projects=[[+(+(*(EXTRACT(FLAG(YEAR), $0), 10000), "
             + "*(EXTRACT(FLAG(MONTH), $0), 100)), EXTRACT(FLAG(DAY), $0)), $90]], groups=[{0}], "
             + "aggs=[[SUM($1)]], fetch=[1])")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\""));
+        .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
   }
 
   @Test
@@ -3712,7 +3703,7 @@ public class DruidAdapter2IT {
             + " "
             + "NOT NULL, 12, 2)):INTEGER NOT NULL, EXTRACT(FLAG(MINUTE), $0), "
             + "EXTRACT(FLAG(HOUR), $0), $90]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], fetch=[1])")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\""));
+        .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
   }
 
   @Test
@@ -3728,7 +3719,7 @@ public class DruidAdapter2IT {
             + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[EXTRACT(FLAG(SECOND), $0), "
             + "EXTRACT(FLAG(MINUTE), $0), $90]], groups=[{0, 1}], aggs=[[SUM($2)]], fetch=[1])")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\""));
+        .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
   }
 
   @Test
@@ -3756,7 +3747,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $90]], groups=[{0}], aggs=[[SUM($1)]], "
             + "filter=[>($1, 220)], sort0=[0], dir0=[ASC], fetch=[2])")
         .queryContains(
-            druidChecker("'having':{'type':'filter','filter':{'type':'bound',"
+            new DruidChecker("'having':{'type':'filter','filter':{'type':'bound',"
                 + "'dimension':'S','lower':'220','lowerStrict':true,'ordering':'numeric'}}"));
   }
 
@@ -3772,7 +3763,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], filter=[>($1, '10')], projects=[[$1, $90]], groups=[{0}],"
             + " aggs=[[SUM($1)]], filter=[>($1, 220)], sort0=[0], dir0=[ASC], fetch=[2])\n")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
   }
 
   @Test
@@ -3787,7 +3778,7 @@ public class DruidAdapter2IT {
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $1, $90, $90]])")
         .queryContains(
-            druidChecker("{'queryType':'scan','dataSource':'foodmart','intervals':"
+            new DruidChecker("{'queryType':'scan','dataSource':'foodmart','intervals':"
                 + "['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],'virtualColumns':["
                 + "{'type':'expression','name':'vc','expression':'\\'product_id\\'','outputType':"
                 + "'STRING'},{'type':'expression','name':'vc0','expression':'\\'store_sales\\'',"
@@ -3808,7 +3799,7 @@ public class DruidAdapter2IT {
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $1, $90, $90]])")
         .queryContains(
-            druidChecker("{\"queryType\":\"scan\",\"dataSource\":\"foodmart\",\"intervals\":"
+            new DruidChecker("{\"queryType\":\"scan\",\"dataSource\":\"foodmart\",\"intervals\":"
                 + "[\"1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z\"],\"virtualColumns\":"
                 + "[{\"type\":\"expression\",\"name\":\"vc\",\"expression\":\"\\\"product_id\\\"\","
                 + "\"outputType\":\"STRING\"},{\"type\":\"expression\",\"name\":\"vc0\","
@@ -3829,7 +3820,7 @@ public class DruidAdapter2IT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $90]], groups=[{0}], aggs=[[SUM($1)]], "
             + "sort0=[0], dir0=[ASC], fetch=[1])")
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\""))
+            new DruidChecker("\"queryType\":\"groupBy\""))
         .returnsOrdered("PROD_ID1=1; PROD_ID2=1; S1=236.55; S2=236.55");
   }
 
@@ -3840,7 +3831,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=565238.1299999986")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
                 + "'dimensions':[{'type':'default','dimension':'vc','outputName':'vc','outputType':'LONG'}],"
                 + "'virtualColumns':[{'type':'expression','name':'vc','expression':'1','outputType':'LONG'}],"
                 + "'limitSpec':{'type':'default'},'aggregations':[{'type':'doubleSum','name':'EXPR$0',"
@@ -3857,7 +3848,7 @@ public class DruidAdapter2IT {
         + " GROUP BY floor(\"timestamp\" TO quarter)";
 
     sql(sql, FOODMART).queryContains(
-        druidChecker(
+        new DruidChecker(
             "{\"queryType\":\"timeseries\",\"dataSource\":\"foodmart\",\"descending\":false,"
                 + "\"granularity\":{\"type\":\"period\",\"period\":\"P3M\",\"timeZone\":\"UTC\"},"
                 + "\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"EXPR$1\",\"fieldName\":\"store_sales\"}],"
@@ -3872,7 +3863,7 @@ public class DruidAdapter2IT {
             + " GROUP BY floor(\"timestamp\" TO quarter), \"product_id\"";
 
     sql(sql, FOODMART).queryContains(
-        druidChecker(
+        new DruidChecker(
             "{\"queryType\":\"groupBy\",\"dataSource\":\"foodmart\",\"granularity\":\"all\",\"dimensions\":"
                 + "[{\"type\":\"extraction\",\"dimension\":\"__time\",\"outputName\":\"floor_quarter\",\"extractionFn\":{\"type\":\"timeFormat\"",
             "\"granularity\":{\"type\":\"period\",\"period\":\"P3M\",\"timeZone\":\"UTC\"},\"timeZone\":\"UTC\",\"locale\":\"und\"}},"
@@ -3895,7 +3886,7 @@ public class DruidAdapter2IT {
         + "EXPR$0=3; product_id=1; EXPR$2=88.35\n"
         + "EXPR$0=4; product_id=1; EXPR$2=48.45")
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "{\"queryType\":\"groupBy\",\"dataSource\":\"foodmart\",\"granularity\":\"all\",\"dimensions\":"
                     + "[{\"type\":\"default\",\"dimension\":\"vc\",\"outputName\":\"vc\",\"outputType\":\"LONG\"},"
                     + "{\"type\":\"default\",\"dimension\":\"product_id\",\"outputName\":\"product_id\",\"outputType\":\"STRING\"}],"
@@ -3914,7 +3905,7 @@ public class DruidAdapter2IT {
         + "EXPR$0=3; EXPR$1=140271.88999999964\n"
         + "EXPR$0=4; EXPR$1=152671.61999999985")
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "{\"queryType\":\"groupBy\",\"dataSource\":\"foodmart\",\"granularity\":\"all\","
                     + "\"dimensions\":[{\"type\":\"default\",\"dimension\":\"vc\",\"outputName\":\"vc\",\"outputType\":\"LONG\"}],"
                     + "\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\",\"expression\":\"timestamp_extract(\\\"__time\\\",",
@@ -3929,7 +3920,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("T=1997-01-01 00:00:00")
         .queryContains(
-            druidChecker("UTC"));
+            new DruidChecker("UTC"));
   }
 
   @Test
@@ -3940,7 +3931,7 @@ public class DruidAdapter2IT {
     sql(sql, FOODMART)
         .returnsOrdered("T=1997-01-01 00:00:00")
         .queryContains(
-            druidChecker("UTC"));
+            new DruidChecker("UTC"));
   }
 }
 

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.test;
 
-import org.apache.calcite.adapter.druid.DruidQuery;
 import org.apache.calcite.adapter.druid.DruidSchema;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionProperty;
@@ -37,10 +36,7 @@ import java.net.URL;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.List;
-import java.util.function.Consumer;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -99,32 +95,6 @@ public class DruidAdapterIT {
   /** Whether to run this test. */
   protected boolean enabled() {
     return CalciteSystemProperty.TEST_DRUID.value();
-  }
-
-  /** Returns a consumer that checks that a particular Druid query is
-   * generated to implement a query. */
-  private static Consumer<List> druidChecker(final String... lines) {
-    return list -> {
-      assertThat(list.size(), is(1));
-      DruidQuery.QuerySpec querySpec = (DruidQuery.QuerySpec) list.get(0);
-      for (String line : lines) {
-        final String s = line.replace('\'', '"');
-        assertThat(querySpec.getQueryString(null, -1), containsString(s));
-      }
-    };
-  }
-
-  /** Returns a consumer that checks that a particular Druid query is
-   * generated to implement a query. Expected lines should be exactly
-   * included in the actual query text, without changing quote types. */
-  private Consumer<List> druidOriginalChecker(final String... lines) {
-    return list -> {
-      assertThat(list.size(), is(1));
-      DruidQuery.QuerySpec querySpec = (DruidQuery.QuerySpec) list.get(0);
-      for (String line : lines) {
-        assertThat(querySpec.getQueryString(null, -1), containsString(line));
-      }
-    };
   }
 
   /**
@@ -212,7 +182,7 @@ public class DruidAdapterIT {
         .returnsUnordered("countryName=United Kingdom",
             "countryName=null")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
     // Because no tables are declared, foodmart is automatically present.
     sql("select count(*) as c from \"foodmart\"", WIKI_AUTO2)
         .returnsUnordered("C=86829");
@@ -235,7 +205,7 @@ public class DruidAdapterIT {
         + "'context':{'skipEmptyBuckets':true}}";
     sql(sql, WIKI_AUTO2)
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testSelectTimestampColumnNoTables2() {
@@ -277,7 +247,7 @@ public class DruidAdapterIT {
     sql(sql, WIKI_AUTO2)
         .returnsUnordered("day=2015-09-12 00:00:00; EXPR$1=9385573")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testSelectTimestampColumnNoTables4() {
@@ -296,7 +266,7 @@ public class DruidAdapterIT {
             + "day=2015-09-12 00:00:00")
         .explainContains(explain)
         .queryContains(
-            druidChecker("'queryType':'groupBy'", "'limitSpec':{'type':'default',"
+            new DruidChecker("'queryType':'groupBy'", "'limitSpec':{'type':'default',"
             + "'columns':[{'dimension':'s','direction':'descending','dimensionOrder':'numeric'}]}"));
   }
 
@@ -316,7 +286,7 @@ public class DruidAdapterIT {
         .limit(1)
         // Result without 'skipEmptyBuckets':true => "second=2015-09-12 00:46:58; EXPR$1=0"
         .returnsUnordered("second=2015-09-12 01:20:19; EXPR$1=1075")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   private CalciteAssert.AssertQuery checkSelectDistinctWiki(URL url, String tableName) {
@@ -333,7 +303,7 @@ public class DruidAdapterIT {
     return sql(sql, url)
         .returnsUnordered("countryName=United Kingdom",
             "countryName=null")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -357,7 +327,7 @@ public class DruidAdapterIT {
         .returnsUnordered("__time=2015-09-12 00:46:58",
             "__time=2015-09-12 00:47:00")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testFilterTimeDistinct() {
@@ -378,7 +348,7 @@ public class DruidAdapterIT {
         .returnsUnordered("time=2015-09-12 00:46:58",
             "time=2015-09-12 00:47:00")
         .explainContains(explain)
-        .queryContains(druidChecker(subDruidQuery));
+        .queryContains(new DruidChecker(subDruidQuery));
   }
 
   @Test public void testMetadataColumns() throws Exception {
@@ -423,7 +393,7 @@ public class DruidAdapterIT {
             "state_province=OR",
             "state_province=WA")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testSelectGroupBySum() {
@@ -446,7 +416,8 @@ public class DruidAdapterIT {
         + "where \"product_id\" = 1020" + "group by \"store_sales\" ,\"product_id\" ";
     final String plan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
-        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], filter=[=($1, 1020)],"
+        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
+        + "filter=[=(CAST($1):INTEGER, 1020)],"
         + " projects=[[$90, $1]], groups=[{0, 1}], aggs=[[]])";
     final String druidQuery = "{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
         + "'dimensions':[{'type':'default','dimension':'store_sales',\"outputName\":\"store_sales\","
@@ -457,7 +428,7 @@ public class DruidAdapterIT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
     sql(sql)
         .explainContains(plan)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("store_sales=0.51; product_id=1020",
             "store_sales=1.02; product_id=1020",
             "store_sales=1.53; product_id=1020",
@@ -475,7 +446,7 @@ public class DruidAdapterIT {
         + "'lower':'1020','lowerStrict':false,'upper':'1020','upperStrict':false,"
         + "'ordering':'numeric'},'aggregations':[],"
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
-    sql(sql).returnsUnordered("product_id=1020").queryContains(druidChecker(druidQuery));
+    sql(sql).returnsUnordered("product_id=1020").queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testComplexPushGroupBy() {
@@ -491,7 +462,7 @@ public class DruidAdapterIT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
     sql(sql)
         .returnsUnordered("id=1020")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -529,7 +500,7 @@ public class DruidAdapterIT {
             "gender=M; state_province=WA",
             "gender=F; state_province=WA")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
                 + "'dimensions':[{'type':'default','dimension':'gender','outputName':'gender',"
                 + "'outputType':'STRING'},{'type':'default','dimension':'state_province',"
                 + "'outputName':'state_province','outputType':'STRING'}],'limitSpec':"
@@ -568,7 +539,7 @@ public class DruidAdapterIT {
         + "'resultFormat':'compactedList'}";
     sql(sql)
         .runs()
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testLimit() {
@@ -580,7 +551,7 @@ public class DruidAdapterIT {
         + "'resultFormat':'compactedList','limit':3";
     sql(sql)
         .runs()
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /**
@@ -600,7 +571,7 @@ public class DruidAdapterIT {
         .with(CalciteConnectionProperty.TIME_ZONE.camelName(), "America/New_York")
         .query(sql)
         .runs()
-        .queryContains(druidOriginalChecker(druidQuery));
+        .queryContains(new DruidChecker(false, druidQuery));
   }
 
   @Test public void testDistinctLimit() {
@@ -621,7 +592,7 @@ public class DruidAdapterIT {
     sql(sql)
         .runs()
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("gender=F; state_province=CA", "gender=F; state_province=OR",
             "gender=F; state_province=WA");
   }
@@ -652,7 +623,7 @@ public class DruidAdapterIT {
             "brand_name=Hermanos; gender=F; S=4183",
             "brand_name=Tell Tale; gender=F; S=4033")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -700,7 +671,7 @@ public class DruidAdapterIT {
             "brand_name=Tell Tale; S=7877",
             "brand_name=Ebony; S=7438")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -729,7 +700,7 @@ public class DruidAdapterIT {
             "brand_name=Hermanos; D=1997-05-09 00:00:00; S=115")
         .explainContains(explain)
         .queryContains(
-            druidChecker("'queryType':'groupBy'", "'granularity':'all'", "'limitSpec"
+            new DruidChecker("'queryType':'groupBy'", "'granularity':'all'", "'limitSpec"
                 + "':{'type':'default','limit':30,'columns':[{'dimension':'S',"
                 + "'direction':'descending','dimensionOrder':'numeric'}]}"));
   }
@@ -766,7 +737,7 @@ public class DruidAdapterIT {
             "brand_name=Tri-State; D=1997-05-09 00:00:00; S=120",
             "brand_name=Hermanos; D=1997-05-09 00:00:00; S=115")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQueryPart1, druidQueryPart2));
+        .queryContains(new DruidChecker(druidQueryPart1, druidQueryPart2));
   }
 
   /** Test case for
@@ -795,7 +766,7 @@ public class DruidAdapterIT {
             "brand_name=ADJ; D=1997-01-12 00:00:00; S=3",
             "brand_name=ADJ; D=1997-01-17 00:00:00; S=3")
         .explainContains(explain)
-        .queryContains(druidChecker(subDruidQuery));
+        .queryContains(new DruidChecker(subDruidQuery));
   }
 
   /** Tests a query that contains no GROUP BY and is therefore executed as a
@@ -825,7 +796,7 @@ public class DruidAdapterIT {
             throw TestUtil.rethrow(e);
           }
         })
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** As {@link #testFilterSortDesc()} but the bounds are numeric. */
@@ -854,7 +825,7 @@ public class DruidAdapterIT {
             throw TestUtil.rethrow(e);
           }
         })
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Tests a query whose filter removes all rows. */
@@ -870,7 +841,7 @@ public class DruidAdapterIT {
     sql(sql)
         .limit(4)
         .returnsUnordered()
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** As {@link #testFilterSortDescNumeric()} but with a filter that cannot
@@ -900,7 +871,7 @@ public class DruidAdapterIT {
             throw TestUtil.rethrow(e);
           }
         })
-        .queryContains(druidChecker(druidQuery, druidFilter, druidQuery2));
+        .queryContains(new DruidChecker(druidQuery, druidFilter, druidQuery2));
   }
 
   @Test public void testUnionPlan() {
@@ -951,7 +922,7 @@ public class DruidAdapterIT {
     final String sql = "select count(*) from \"foodmart\"";
     sql(sql)
         .returns("EXPR$0=86829\n")
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .explainContains(explain);
   }
 
@@ -977,7 +948,7 @@ public class DruidAdapterIT {
         .returnsOrdered("c=4070; month=1997-12-01 00:00:00",
             "c=4033; month=1997-11-01 00:00:00",
             "c=3511; month=1997-07-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'"));
+        .queryContains(new DruidChecker("'queryType':'groupBy'"));
   }
 
   @Test public void testGroupByTimeAndOneMetricNotProjected() {
@@ -990,7 +961,7 @@ public class DruidAdapterIT {
                     + "order by \"c\" desc limit 3";
     sql(sql).returnsOrdered("c=494; month=1997-11-01 00:00:00; SALES=5.0",
             "c=475; month=1997-12-01 00:00:00; SALES=5.0",
-            "c=468; month=1997-03-01 00:00:00; SALES=5.0").queryContains(druidChecker("'queryType':'groupBy'"));
+            "c=468; month=1997-03-01 00:00:00; SALES=5.0").queryContains(new DruidChecker("'queryType':'groupBy'"));
   }
 
   @Test public void testGroupByTimeAndOneColumnNotProjected() {
@@ -1003,7 +974,7 @@ public class DruidAdapterIT {
         .returnsUnordered("c=3511; month=1997-07-01 00:00:00",
             "c=4033; month=1997-11-01 00:00:00",
             "c=4070; month=1997-12-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'"));
+        .queryContains(new DruidChecker("'queryType':'groupBy'"));
   }
 
   @Test public void testOrderByOneColumnNotProjected() {
@@ -1063,7 +1034,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$30, $89, $71]], groups=[{0}], "
             + "aggs=[[$SUM0($1), COUNT($1), COUNT($2), COUNT()]], sort0=[0], dir0=[ASC])")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"
                 + ",'dimensions':[{'type':'default','dimension':'state_province','outputName':'state_province'"
                 + ",'outputType':'STRING'}],'limitSpec':"
                 + "{'type':'default','columns':[{'dimension':'state_province',"
@@ -1091,7 +1062,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], projects=[[FLOOR($0, FLAG(MONTH)), $89, $71]], "
             + "groups=[{0}], aggs=[[SUM($1), COUNT($2)]], sort0=[1], dir0=[ASC])")
         .returnsOrdered("S=19958; C=5606", "S=20179; C=5523", "S=20388; C=5591")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -1152,7 +1123,7 @@ public class DruidAdapterIT {
     String druidQuery = "{'queryType':'groupBy','dataSource':'foodmart'";
     sql(sql)
         .limit(3)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsOrdered("S=3850; C=1230", "S=3342; C=1071", "S=3219; C=1024");
   }
 
@@ -1168,7 +1139,7 @@ public class DruidAdapterIT {
     sql(sql)
         .limit(3)
         .returnsOrdered("S=19958; C=5606", "S=20179; C=5523", "S=20388; C=5591")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testTopNMonthGranularity() {
@@ -1203,7 +1174,7 @@ public class DruidAdapterIT {
             "S=12297; M=7; P=WA",
             "S=10640; M=6; P=WA")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQueryPart1, druidQueryPart2));
+        .queryContains(new DruidChecker(druidQueryPart1, druidQueryPart2));
   }
 
   @Test public void testTopNDayGranularityFiltered() {
@@ -1233,7 +1204,7 @@ public class DruidAdapterIT {
             "S=1691; M=5; P=OR",
             "S=1629; M=5; P=WA")
         .explainContains(explain)
-        .queryContains(druidChecker(druidQueryType, limitSpec));
+        .queryContains(new DruidChecker(druidQueryType, limitSpec));
   }
 
   @Test public void testGroupByHaving() {
@@ -1288,7 +1259,7 @@ public class DruidAdapterIT {
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
     sql(sql)
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("state_province=CA; CDC=45",
             "state_province=WA; CDC=22");
   }
@@ -1334,7 +1305,7 @@ public class DruidAdapterIT {
         + " =($30, 'WA'))],"
         + " projects=[[$30, $29, $3]], groups=[{0, 1, 2}], aggs=[[]])\n";
     sql(sql)
-        .queryContains(druidChecker(druidQuery1, druidQuery2))
+        .queryContains(new DruidChecker(druidQuery1, druidQuery2))
         .explainContains(explain)
         .returnsUnordered(
             "state_province=WA; city=Bremerton; product_name=High Top Dried Mushrooms",
@@ -1374,7 +1345,7 @@ public class DruidAdapterIT {
         + "OR(=($87, 'Q2'), =($87, 'Q3')), =($30, 'WA'))], "
         + "projects=[[$30, $29, $3]])\n";
     sql(sql)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .explainContains(explain)
         .returnsUnordered(
             "state_province=WA; city=Bremerton; product_name=High Top Dried Mushrooms",
@@ -1424,7 +1395,7 @@ public class DruidAdapterIT {
         + "'value':'High Top Dried Mushrooms'}";
     sql(sql)
         .explainContains(explain)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /** Tests a query that exposed several bugs in the interpreter. */
@@ -1440,7 +1411,7 @@ public class DruidAdapterIT {
         + "group by \"wikipedia\".\"countryName\"";
     String druidQuery = "{'type':'selector','dimension':'countryName','value':null}";
     sql(sql, WIKI)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsCount(9);
   }
 
@@ -1450,14 +1421,14 @@ public class DruidAdapterIT {
         + "FROM \"foodmart\"\n"
         + "GROUP BY \"store_sales\", floor(\"timestamp\" to DAY)\n ORDER BY \"store_sales\" DESC\n"
         + "LIMIT 10\n";
-    sql(sql).queryContains(druidChecker("{\"queryType\":\"groupBy\""));
+    sql(sql).queryContains(new DruidChecker("{\"queryType\":\"groupBy\""));
   }
 
   @Test public void testFilterOnDouble() {
     String sql = "select \"product_id\" from \"foodmart\"\n"
         + "where cast(\"product_id\" as double) < 0.41024 and \"product_id\" < 12223";
     sql(sql).queryContains(
-        druidChecker("'type':'bound','dimension':'product_id','upper':'0.41024'",
+        new DruidChecker("'type':'bound','dimension':'product_id','upper':'0.41024'",
             "'upper':'12223'"));
   }
 
@@ -1474,7 +1445,7 @@ public class DruidAdapterIT {
         + "'extractionFn':{'type':'timeFormat','format':'yyyy-MM-dd";
     sql(sql)
         .returnsUnordered("product_id=1016; time=1997-01-02 00:00:00")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testPushAggregateOnTimeWithExtractYear() {
@@ -1485,7 +1456,7 @@ public class DruidAdapterIT {
         + " EXTRACT( year from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_year',"
@@ -1502,7 +1473,7 @@ public class DruidAdapterIT {
         + " EXTRACT( month from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_month',"
@@ -1521,7 +1492,7 @@ public class DruidAdapterIT {
         + " EXTRACT( day from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
@@ -1540,7 +1511,7 @@ public class DruidAdapterIT {
             + "('1997-01-01' as timestamp)" + " group by "
             + " EXTRACT( hour from \"timestamp\"), \"product_id\" ";
     sql(sql)
-        .queryContains(druidChecker("'queryType':'groupBy'"))
+        .queryContains(new DruidChecker("'queryType':'groupBy'"))
         .returnsUnordered("hourOfDay=0; product_id=1016");
   }
 
@@ -1555,7 +1526,7 @@ public class DruidAdapterIT {
         + " EXTRACT( year from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'",
                 "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
@@ -1570,7 +1541,7 @@ public class DruidAdapterIT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.001Z/1997-01-20T00:00:00.000Z]], "
-            + "filter=[=($1, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
+            + "filter=[=(CAST($1):INTEGER, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
             + "EXTRACT(FLAG(YEAR), $0), $1]], groups=[{0, 1, 2, 3}], aggs=[[]])\n")
         .returnsUnordered("day=2; month=1; year=1997; product_id=1016",
             "day=10; month=1; year=1997; product_id=1016",
@@ -1589,7 +1560,7 @@ public class DruidAdapterIT {
         + " EXTRACT( year from \"timestamp\"), \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'", "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
                     + "'extractionFn':{'type':'timeFormat','format':'d',"
@@ -1603,7 +1574,7 @@ public class DruidAdapterIT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.001Z/1997-01-20T00:00:00.000Z]], "
-            + "filter=[=($1, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
+            + "filter=[=(CAST($1):INTEGER, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(MONTH), $0), "
             + "EXTRACT(FLAG(YEAR), $0), $1]], groups=[{0, 1, 2, 3}], aggs=[[]])\n")
         .returnsUnordered("EXPR$0=2; EXPR$1=1; EXPR$2=1997; product_id=1016",
             "EXPR$0=10; EXPR$1=1; EXPR$2=1997; product_id=1016",
@@ -1621,7 +1592,7 @@ public class DruidAdapterIT {
         + " \"product_id\" ";
     sql(sql)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 ",'granularity':'all'", "{'type':'extraction',"
                     + "'dimension':'__time','outputName':'extract_day',"
                     + "'extractionFn':{'type':'timeFormat','format':'d',"
@@ -1629,7 +1600,7 @@ public class DruidAdapterIT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.001Z/1997-01-20T00:00:00.000Z]], "
-            + "filter=[=($1, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), $1]], "
+            + "filter=[=(CAST($1):INTEGER, 1016)], projects=[[EXTRACT(FLAG(DAY), $0), $1]], "
             + "groups=[{0, 1}], aggs=[[]])\n")
         .returnsUnordered("EXPR$0=2; dayOfMonth=1016", "EXPR$0=10; dayOfMonth=1016",
             "EXPR$0=13; dayOfMonth=1016", "EXPR$0=16; dayOfMonth=1016");
@@ -1652,11 +1623,11 @@ public class DruidAdapterIT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1997-01-01T00:00:00.000Z/1998-01-01T00:00:00.000Z]], "
-            + "filter=[AND(>=(CAST($11):BIGINT, 8), <=(CAST($11):BIGINT, 10), "
-            + "<(CAST($10):BIGINT, 15))], groups=[{}], "
+            + "filter=[AND(>=(CAST($11):INTEGER, 8), <=(CAST($11):INTEGER, 10), "
+            + "<(CAST($10):INTEGER, 15))], groups=[{}], "
             + "aggs=[[SUM($90)]])\n")
         .returnsUnordered("EXPR$0=75364.1")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testPushOfFilterExtractionOnDayAndMonth() {
@@ -1681,7 +1652,7 @@ public class DruidAdapterIT {
         .returnsUnordered("product_id=1549; EXPR$1=30; EXPR$2=11; EXPR$3=1997",
             "product_id=1553; EXPR$1=30; EXPR$2=11; EXPR$3=1997")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
   }
 
   @Test public void testFilterExtractionOnMonthWithBetween() {
@@ -1692,7 +1663,7 @@ public class DruidAdapterIT {
     sql(sqlQuery)
         .returnsUnordered("product_id=1558; EXPR$1=10", "product_id=1558; EXPR$1=11",
             "product_id=1559; EXPR$1=11")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testFilterExtractionOnMonthWithIn() {
@@ -1703,7 +1674,7 @@ public class DruidAdapterIT {
         .returnsUnordered("product_id=1558; EXPR$1=10", "product_id=1558; EXPR$1=11",
             "product_id=1559; EXPR$1=11")
         .queryContains(
-            druidChecker("{'queryType':'groupBy',"
+            new DruidChecker("{'queryType':'groupBy',"
                 + "'dataSource':'foodmart','granularity':'all',"
                 + "'dimensions':[{'type':'default','dimension':'product_id','outputName':'product_id','outputType':'STRING'},"
                 + "{'type':'extraction','dimension':'__time','outputName':'extract_month',"
@@ -1729,7 +1700,7 @@ public class DruidAdapterIT {
         + " GROUP BY extract(month from \"timestamp\"), \"product_id\" order by m, s, "
         + "\"product_id\"";
     sql(sqlQuery).queryContains(
-        druidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
+        new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
             + "'granularity':'all','dimensions':[{'type':'extraction',"
             + "'dimension':'__time','outputName':'extract_month',"
             + "'extractionFn':{'type':'timeFormat','format':'M','timeZone':'UTC',"
@@ -1747,7 +1718,7 @@ public class DruidAdapterIT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-            + "filter=[>=(CAST($1):BIGINT, 1558)], projects=[[EXTRACT(FLAG(MONTH), $0), $1, $89]], "
+            + "filter=[>=(CAST($1):INTEGER, 1558)], projects=[[EXTRACT(FLAG(MONTH), $0), $1, $89]], "
             + "groups=[{0, 1}], aggs=[[SUM($2)]], sort0=[0], sort1=[2], sort2=[1], "
             + "dir0=[ASC], dir1=[ASC], dir2=[ASC])");
   }
@@ -1759,7 +1730,7 @@ public class DruidAdapterIT {
         + "group by floor(\"timestamp\" to MONTH)\n"
         + "order by \"month\" DESC";
     sql(sql)
-        .queryContains(druidChecker("'queryType':'timeseries'", "'descending':true"))
+        .queryContains(new DruidChecker("'queryType':'timeseries'", "'descending':true"))
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z"
             + "/2992-01-10T00:00:00.000Z]], projects=[[FLOOR($0, FLAG(MONTH))]], groups=[{0}], "
@@ -1782,7 +1753,7 @@ public class DruidAdapterIT {
         .explainContains(explain)
         .returnsOrdered("floorOfMonth=1997-12-01 00:00:00", "floorOfMonth=1997-11-01 00:00:00",
             "floorOfMonth=1997-10-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'", "'direction':'descending'"));
+        .queryContains(new DruidChecker("'queryType':'groupBy'", "'direction':'descending'"));
   }
 
   @Test public void testPushofOrderByYearWithYearMonthExtract() {
@@ -1795,7 +1766,7 @@ public class DruidAdapterIT {
     final String expectedPlan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[>=(CAST($1):BIGINT, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
+        + "filter=[>=(CAST($1):INTEGER, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
         + "EXTRACT(FLAG(MONTH), $0), $1, $89]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], sort0=[0], "
         + "sort1=[1], sort2=[3], sort3=[2], dir0=[DESC], "
         + "dir1=[ASC], dir2=[DESC], dir3=[ASC], fetch=[3])";
@@ -1818,7 +1789,7 @@ public class DruidAdapterIT {
         + "'ordering':'numeric'},'aggregations':[{'type':'longSum','name':'S',"
         + "'fieldName':'unit_sales'}],"
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
-    sql(sqlQuery).explainContains(expectedPlan).queryContains(druidChecker(expectedDruidQuery))
+    sql(sqlQuery).explainContains(expectedPlan).queryContains(new DruidChecker(expectedDruidQuery))
         .returnsOrdered("Y=1997; M=1; product_id=1558; S=6", "Y=1997; M=1; product_id=1559; S=6",
             "Y=1997; M=2; product_id=1558; S=24");
   }
@@ -1832,7 +1803,7 @@ public class DruidAdapterIT {
     final String expectedPlan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[>=(CAST($1):BIGINT, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
+        + "filter=[>=(CAST($1):INTEGER, 1558)], projects=[[EXTRACT(FLAG(YEAR), $0), "
         + "EXTRACT(FLAG(MONTH), $0), $1, $89]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], "
         + "sort0=[3], sort1=[1], sort2=[2], dir0=[DESC], dir1=[DESC], dir2=[ASC], fetch=[3])";
     final String expectedDruidQueryType = "'queryType':'groupBy'";
@@ -1840,7 +1811,7 @@ public class DruidAdapterIT {
         .returnsOrdered("Y=1997; M=12; product_id=1558; S=30", "Y=1997; M=3; product_id=1558; S=29",
             "Y=1997; M=5; product_id=1558; S=27")
         .explainContains(expectedPlan)
-        .queryContains(druidChecker(expectedDruidQueryType));
+        .queryContains(new DruidChecker(expectedDruidQueryType));
   }
 
   @Test public void testGroupByTimeSortOverMetrics() {
@@ -1860,7 +1831,7 @@ public class DruidAdapterIT {
         "C=6662; S=20388; EXPR$2=1997-09-01 00:00:00",
         "C=6588; S=20179; EXPR$2=1997-04-01 00:00:00",
         "C=6478; S=19958; EXPR$2=1997-10-01 00:00:00")
-        .queryContains(druidChecker("'queryType':'groupBy'"))
+        .queryContains(new DruidChecker("'queryType':'groupBy'"))
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[FLOOR($0, FLAG(MONTH)), $89]], groups=[{0}], "
@@ -1882,7 +1853,7 @@ public class DruidAdapterIT {
     sql(sqlQuery).returnsOrdered("timestamp=1997-12-30 00:00:00; C=22; S=36\ntimestamp=1997-12-29"
         + " 00:00:00; C=321; S=982\ntimestamp=1997-12-28 00:00:00; C=480; "
         + "S=1496\ntimestamp=1997-12-27 00:00:00; C=363; S=1156\ntimestamp=1997-12-26 00:00:00; "
-        + "C=144; S=420").queryContains(druidChecker(druidSubQuery));
+        + "C=144; S=420").queryContains(new DruidChecker(druidSubQuery));
 
   }
 
@@ -1900,7 +1871,7 @@ public class DruidAdapterIT {
         + "'dimensionOrder':'numeric'}]}";
     sql(sqlQuery).returnsOrdered("D=30; M=3; Y=1997; C=114; S=351\nD=30; M=5; Y=1997; "
         + "C=24; S=34\nD=30; M=6; Y=1997; C=73; S=183\nD=30; M=7; Y=1997; C=29; S=54\nD=30; M=8; "
-        + "Y=1997; C=137; S=422").queryContains(druidChecker(druidSubQuery));
+        + "Y=1997; C=137; S=422").queryContains(new DruidChecker(druidSubQuery));
 
   }
 
@@ -1913,7 +1884,7 @@ public class DruidAdapterIT {
         + "'dimensionOrder':'lexicographic'}]}";
     sql(sqlQuery).returnsOrdered("brand_name=Washington; C=576; S=1775\nbrand_name=Walrus; C=457;"
         + " S=1399\nbrand_name=Urban; C=299; S=924\nbrand_name=Tri-State; C=2339; "
-        + "S=7270\nbrand_name=Toucan; C=123; S=380").queryContains(druidChecker(druidSubQuery));
+        + "S=7270\nbrand_name=Toucan; C=123; S=380").queryContains(new DruidChecker(druidSubQuery));
 
   }
 
@@ -1939,7 +1910,7 @@ public class DruidAdapterIT {
         + "'timeZone':'UTC','locale':'en-US'}}]}]},"
         + "'aggregations':[],"
         + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z']}";
-    sql(sql).returnsOrdered("EXPR$0=10\nEXPR$0=11").queryContains(druidChecker(druidQuery));
+    sql(sql).returnsOrdered("EXPR$0=10\nEXPR$0=11").queryContains(new DruidChecker(druidQuery));
   }
 
   /** Test case for
@@ -1954,8 +1925,8 @@ public class DruidAdapterIT {
         + "    BindableProject(EXPR$0=[EXTRACT(FLAG(CENTURY), $0)])\n"
         + "      DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[=($1, 1558)], projects=[[$0]])\n";
-    sql(sql).explainContains(plan).queryContains(druidChecker("'queryType':'scan'"))
+        + "filter=[=(CAST($1):INTEGER, 1558)], projects=[[$0]])\n";
+    sql(sql).explainContains(plan).queryContains(new DruidChecker("'queryType':'scan'"))
         .returnsUnordered("EXPR$0=20");
   }
 
@@ -1988,7 +1959,7 @@ public class DruidAdapterIT {
   @Test public void testFalseFilterCaseConjectionWithTrue() {
     String sql = "Select count(*) as c from \"foodmart\" where "
         + "\"product_id\" = 1558 and (true or false)";
-    sql(sql).returnsUnordered("C=60").queryContains(druidChecker("'queryType':'timeseries'"));
+    sql(sql).returnsUnordered("C=60").queryContains(new DruidChecker("'queryType':'timeseries'"));
   }
 
   /** Test case for
@@ -2016,7 +1987,7 @@ public class DruidAdapterIT {
               .project(b.field("product_id"))
               .build();
         })
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testPushFieldEqualsLiteral() {
@@ -2035,7 +2006,7 @@ public class DruidAdapterIT {
         // Should return one row, "c=0"; logged
         // [CALCITE-1775] "GROUP BY ()" on empty relation should return 1 row
         .returnsUnordered("c=0")
-        .queryContains(druidChecker("'queryType':'timeseries'"));
+        .queryContains(new DruidChecker("'queryType':'timeseries'"));
   }
 
   @Test public void testPlusArithmeticOperation() {
@@ -2051,7 +2022,7 @@ public class DruidAdapterIT {
             "A=222698.26509999996; store_state=CA",
             "A=199049.57059999998; store_state=OR")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideArithmeticOperation() {
@@ -2067,7 +2038,7 @@ public class DruidAdapterIT {
             "store_state=CA; A=2.505379741272971",
             "store_state=WA; A=2.5045806163801996")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testMultiplyArithmeticOperation() {
@@ -2083,7 +2054,7 @@ public class DruidAdapterIT {
             "store_state=CA; A=1.0112000537448784E10",
             "store_state=OR; A=8.077425041941243E9")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testMinusArithmeticOperation() {
@@ -2100,7 +2071,7 @@ public class DruidAdapterIT {
             "store_state=CA; A=95637.41489999992",
             "store_state=OR; A=85504.56939999988")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testConstantPostAggregator() {
@@ -2116,7 +2087,7 @@ public class DruidAdapterIT {
             "store_state=CA; A=159267.83999999994",
             "store_state=OR; A=142377.06999999992")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testRecursiveArithmeticOperation() {
@@ -2136,7 +2107,7 @@ public class DruidAdapterIT {
             "store_state=CA; C=-74749.30433035882",
             "store_state=WA; C=-124367.29537914316")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   /**
@@ -2154,7 +2125,7 @@ public class DruidAdapterIT {
     foodmartApprox(sqlQuery)
         .runs()
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testExtractFilterWorkWithPostAggregations() {
@@ -2171,7 +2142,7 @@ public class DruidAdapterIT {
         .returnsOrdered("store_state=CA; brand_name=Bird Call; A=34.364599999999996",
             "store_state=OR; brand_name=Bird Call; A=39.16359999999999",
             "store_state=WA; brand_name=Bird Call; A=53.742500000000014")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testExtractFilterWorkWithPostAggregationsWithConstant() {
@@ -2191,7 +2162,7 @@ public class DruidAdapterIT {
             "store_state=OR; brand_name=Bird Call; A=39.16359999999999",
             "store_state=WA; brand_name=Bird Call; A=53.742500000000014")
         .explainContains(plan)
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testSingleAverageFunction() {
@@ -2208,7 +2179,7 @@ public class DruidAdapterIT {
             "store_state=CA; A=2.599338206292706",
             "store_state=WA; A=2.5828708592868717")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testPartiallyPostAggregation() {
@@ -2228,7 +2199,7 @@ public class DruidAdapterIT {
             "store_state=CA; A=2.505379741272971; B=74748.0",
             "store_state=WA; A=2.5045806163801996; B=124366.0")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDuplicateReferenceOnPostAggregation() {
@@ -2247,7 +2218,7 @@ public class DruidAdapterIT {
             "store_state=CA; A=159267.83999999994; C=95737.41489999992",
             "store_state=OR; A=142377.06999999992; C=85604.56939999988")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroDoubleTypeInfinity() {
@@ -2263,7 +2234,7 @@ public class DruidAdapterIT {
             "store_state=OR; A=Infinity",
             "store_state=WA; A=Infinity")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroDoubleTypeNegInfinity() {
@@ -2280,7 +2251,7 @@ public class DruidAdapterIT {
             "store_state=OR; A=-Infinity",
             "store_state=WA; A=-Infinity")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroDoubleTypeNaN() {
@@ -2297,7 +2268,7 @@ public class DruidAdapterIT {
             "store_state=OR; A=NaN",
             "store_state=WA; A=NaN")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testDivideByZeroIntegerType() {
@@ -2336,7 +2307,7 @@ public class DruidAdapterIT {
             "store_state=WA; brand_name=King; A=34.6104",
             "store_state=OR; brand_name=Toretti; A=36.3")
         .explainContains(plan)
-        .queryContains(druidChecker(postAggString));
+        .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testInterleaveBetweenAggregateAndGroupOrderByOnDimension() {
@@ -2357,7 +2328,7 @@ public class DruidAdapterIT {
             "store_state=CA; brand_name=Akron; A=250.349",
             "store_state=OR; brand_name=Akron; A=278.69720000000007")
             .explainContains(plan)
-            .queryContains(druidChecker(postAggString));
+            .queryContains(new DruidChecker(postAggString));
   }
 
   @Test public void testOrderByOnMetricsInSelectDruidQuery() {
@@ -2378,7 +2349,7 @@ public class DruidAdapterIT {
             "A=0.5; B=0.21; C=0.29000000000000004",
             "A=0.57; B=0.2793; C=0.29069999999999996")
         .explainContains(plan)
-        .queryContains(druidChecker(queryType));
+        .queryContains(new DruidChecker(queryType));
   }
 
   /**
@@ -2396,7 +2367,7 @@ public class DruidAdapterIT {
             + ":'EXPR$0','fieldName':'store_sales'}],'intervals':['1900-01-09T00:00:00.000Z/2992-01"
             + "-10T00:00:00.000Z'],'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2411,7 +2382,7 @@ public class DruidAdapterIT {
             + "'store_sales'}],'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2429,7 +2400,7 @@ public class DruidAdapterIT {
             + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2451,7 +2422,7 @@ public class DruidAdapterIT {
             + "['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2471,7 +2442,7 @@ public class DruidAdapterIT {
             + "['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2487,7 +2458,7 @@ public class DruidAdapterIT {
                 + "filter=[false], projects=[[$90, false]], groups=[{}], aggs=[[SUM($0)]])";
     sql(sql)
         .queryContains(
-            druidChecker("{\"queryType\":\"timeseries\","
+            new DruidChecker("{\"queryType\":\"timeseries\","
                 + "\"dataSource\":\"foodmart\",\"descending\":false,\"granularity\":\"all\","
                 + "\"filter\":{\"type\":\"expression\",\"expression\":\"1 == 2\"},"
                 + "\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"EXPR$0\","
@@ -2514,7 +2485,7 @@ public class DruidAdapterIT {
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"filter\":{\"type"
+            new DruidChecker("\"filter\":{\"type"
                 + "\":\"and\",\"fields\":[{\"type\":\"expression\",\"expression\":\"1 == 2\"},"
                 + "{\"type\":\"selector\",\"dimension\":\"store_city\",\"value\":\"Seattle\"}]}"));
   }
@@ -2535,7 +2506,7 @@ public class DruidAdapterIT {
             + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .returnsUnordered("EXPR$0=52644.07000000001");
   }
 
@@ -2553,7 +2524,7 @@ public class DruidAdapterIT {
             + ":'store_cost'}],'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2573,7 +2544,7 @@ public class DruidAdapterIT {
             + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
 
-    sql(sql).queryContains(druidChecker(expectedQuery));
+    sql(sql).queryContains(new DruidChecker(expectedQuery));
   }
 
   /**
@@ -2597,7 +2568,7 @@ public class DruidAdapterIT {
             + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .returnsUnordered("EXPR$0=159167.83999999994; EXPR$1=263793.2200000001");
   }
 
@@ -2623,7 +2594,7 @@ public class DruidAdapterIT {
             + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .returnsUnordered("EXPR$0=2600.01; EXPR$1=4486.4400000000005");
   }
 
@@ -2651,7 +2622,7 @@ public class DruidAdapterIT {
             + "'context':{'skipEmptyBuckets':false}}";
 
     sql(sql)
-        .queryContains(druidChecker(expectedQuery))
+        .queryContains(new DruidChecker(expectedQuery))
         .explainContains(expectedAggregateExplain)
         .returnsUnordered("EXPR$0=2600.01; EXPR$1=1013.162");
   }
@@ -2676,7 +2647,7 @@ public class DruidAdapterIT {
     String context = "'skipEmptyBuckets':false";
 
     sql(sql)
-        .queryContains(druidChecker(expectedFilter, context));
+        .queryContains(new DruidChecker(expectedFilter, context));
   }
 
   /**
@@ -2697,7 +2668,7 @@ public class DruidAdapterIT {
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"filter\":{\"type"
+            new DruidChecker("\"filter\":{\"type"
                 + "\":\"expression\",\"expression\":\"like(\\\"the_year\\\","));
   }
 
@@ -2713,7 +2684,7 @@ public class DruidAdapterIT {
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"", "\"filter\":{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"timeseries\"", "\"filter\":{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"10\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .returnsUnordered("EXPR$0=25.060000000000002");
@@ -2727,12 +2698,12 @@ public class DruidAdapterIT {
             + "  BindableProject(EXPR$0=[$1], product_id=[$0])\n"
             + "    DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], filter=[AND(>"
-            + "(CAST($1):BIGINT, 1553), >($91, 5))], groups=[{1}], aggs=[[SUM($90)]])";
+            + "(CAST($1):INTEGER, 1553), >($91, 5))], groups=[{1}], aggs=[[SUM($90)]])";
 
     sql(sql)
         .explainContains(expectedSubExplain)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"5\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .returnsUnordered("EXPR$0=10.16; product_id=1554\n"
@@ -2747,7 +2718,7 @@ public class DruidAdapterIT {
         + "group by floor(\"timestamp\" to DAY),\"product_id\"";
     sql(sql)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"5\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .returnsUnordered("EXPR$0=10.6; product_id=1556\n"
@@ -2776,8 +2747,8 @@ public class DruidAdapterIT {
             + "'name':'EXPR$0','fieldName':'store_sales'}]";
 
     sql(sql)
-            .queryContains(druidChecker(expectedFilterJson))
-            .queryContains(druidChecker(expectedAggregateJson))
+            .queryContains(new DruidChecker(expectedFilterJson))
+            .queryContains(new DruidChecker(expectedAggregateJson))
             .returnsUnordered("EXPR$0=301444.9099999999");
   }
 
@@ -2810,8 +2781,8 @@ public class DruidAdapterIT {
             + "'aggregator':{'type':'doubleSum','name':'EXPR$1','fieldName':'store_cost'}}]";
 
     sql(sql)
-            .queryContains(druidChecker(expectedFilterJson))
-            .queryContains(druidChecker(expectedAggregatesJson))
+            .queryContains(new DruidChecker(expectedFilterJson))
+            .queryContains(new DruidChecker(expectedAggregatesJson))
             .returnsUnordered("EXPR$0=13077.789999999992; EXPR$1=9830.7799");
   }
 
@@ -2849,7 +2820,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT count(\"countryName\") FROM (SELECT \"countryName\" FROM "
         + "\"wikipedia\" WHERE \"countryName\"  IS NOT NULL) as a";
     sql(sql, WIKI_AUTO2)
-        .queryContains(druidChecker("timeseries"))
+        .queryContains(new DruidChecker("timeseries"))
         .returnsUnordered("EXPR$0=3799");
   }
 
@@ -2858,7 +2829,7 @@ public class DruidAdapterIT {
     final String druidQuery = "{'queryType':'timeseries','dataSource':'foodmart'";
     sql(sql)
         .returnsUnordered("EXPR$0=86829")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   /**
@@ -2871,7 +2842,7 @@ public class DruidAdapterIT {
             + "'field':{'type':'selector','dimension':'the_month','value':'October'}}";
     // Check that the filter actually worked, and that druid was responsible for the filter
     sql(sql, FOODMART)
-            .queryContains(druidChecker(druidFilter))
+            .queryContains(new DruidChecker(druidFilter))
             .returnsOrdered("EXPR$0=11");
   }
 
@@ -2989,7 +2960,7 @@ public class DruidAdapterIT {
         .query(sql)
         .runs()
         .explainContains(expectedExplain)
-        .queryContains(druidChecker(expectedDruidQuery));
+        .queryContains(new DruidChecker(expectedDruidQuery));
   }
 
   /**
@@ -3004,7 +2975,7 @@ public class DruidAdapterIT {
             // customer_id gets transformed into it's actual underlying sketch column,
             // customer_id_ts. The thetaSketch aggregation is used to compute the count distinct.
             .queryContains(
-                    druidChecker("{'queryType':'timeseries','dataSource':"
+                    new DruidChecker("{'queryType':'timeseries','dataSource':"
                             + "'foodmart','descending':false,'granularity':'all','aggregations':[{'type':"
                             + "'thetaSketch','name':'EXPR$0','fieldName':'customer_id_ts'}],"
                             + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
@@ -3016,7 +2987,7 @@ public class DruidAdapterIT {
             + "from \"foodmart\" where \"the_month\" = 'October'")
             // Check that filtered aggregations work correctly
             .queryContains(
-                    druidChecker("{'type':'filtered','filter':"
+                    new DruidChecker("{'type':'filtered','filter':"
                             + "{'type':'selector','dimension':'store_state','value':'CA'},'aggregator':"
                             + "{'type':'thetaSketch','name':'EXPR$1','fieldName':'customer_id_ts'}}]"))
             .returnsUnordered("EXPR$0=42342.26999999995; EXPR$1=459");
@@ -3054,7 +3025,7 @@ public class DruidAdapterIT {
             + "(3 * count(distinct \"customer_id\")) "
             + "from \"foodmart\"")
             .queryContains(
-                    druidChecker("\"postAggregations\":[{\"type\":\"expression\","
+                    new DruidChecker("\"postAggregations\":[{\"type\":\"expression\","
                         + "\"name\":\"EXPR$0\",\"expression\":\"(((\\\"$f0\\\" * 2) + \\\"$f0\\\")"
                         + " - (3 * \\\"$f0\\\"))\"}]"))
             .returnsUnordered("EXPR$0=0");
@@ -3064,7 +3035,7 @@ public class DruidAdapterIT {
             + "sum(\"store_sales\") / count(distinct \"customer_id\") as \"avg$\" "
             + "from \"foodmart\" group by \"the_month\"")
             .queryContains(
-                    druidChecker("'postAggregations':[{'type':'expression',"
+                    new DruidChecker("'postAggregations':[{'type':'expression',"
                         + "'name':'avg$','expression':'(\\'$f1\\' / \\'$f2\\')'}]"))
             .returnsUnordered(
                     "month=January; avg$=32.62155444126063",
@@ -3085,7 +3056,7 @@ public class DruidAdapterIT {
     final String sql = "select (count(distinct \"user_id\") + 100) - "
         + "(count(distinct \"user_id\") * 2) from \"wiki\"";
     wikiApprox(sql)
-        .queryContains(druidChecker(druid))
+        .queryContains(new DruidChecker(druid))
         .returnsUnordered("EXPR$0=-10590");
 
     // Change COUNT(DISTINCT ...) to APPROX_COUNT_DISTINCT(...) and get
@@ -3093,7 +3064,7 @@ public class DruidAdapterIT {
     final String sql2 = "select (approx_count_distinct(\"user_id\") + 100) - "
         + "(approx_count_distinct(\"user_id\") * 2) from \"wiki\"";
     sql(sql2, WIKI)
-        .queryContains(druidChecker(druid))
+        .queryContains(new DruidChecker(druid))
         .returnsUnordered("EXPR$0=-10590");
   }
 
@@ -3109,7 +3080,7 @@ public class DruidAdapterIT {
     foodmartApprox("select count(distinct \"the_month\"), \"customer_id\" "
             + "from \"foodmart\" group by \"customer_id\"")
             .queryContains(
-                    druidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
+                    new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart',"
                         + "'granularity':'all','dimensions':[{'type':'default','dimension':"
                         + "'customer_id','outputName':'customer_id','outputType':'STRING'}],"
                         + "'limitSpec':{'type':'default'},'aggregations':[{"
@@ -3126,7 +3097,7 @@ public class DruidAdapterIT {
     sql(sql, WIKI)
         // make sure user_id column is not present
         .queryContains(
-            druidChecker("{'queryType':'scan','dataSource':'wikipedia','intervals':"
+            new DruidChecker("{'queryType':'scan','dataSource':'wikipedia','intervals':"
                 + "['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],'virtualColumns':"
                 + "[{'type':'expression','name':'vc','expression':'\\'__time\\'',"
                 + "'outputType':'LONG'}],'columns':['vc','channel','cityName','comment',"
@@ -3160,7 +3131,7 @@ public class DruidAdapterIT {
             + "'context':{'skipEmptyBuckets':false}}";
     sql(sqlQuery, FOODMART)
         .explainContains(plan)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("A=85.31639999999999");
 
     final String sqlQuery2 = "select sum(\"store_cost\") as a "
@@ -3187,7 +3158,7 @@ public class DruidAdapterIT {
     sql(sqlQuery, FOODMART)
         .explainContains(plan)
         .returnsUnordered("A=225541.91720000014")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
 
     final String sqlQuery2 = "select sum(\"store_cost\") as a "
         + "from \"foodmart\" "
@@ -3208,7 +3179,7 @@ public class DruidAdapterIT {
             + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
     sql(sql, FOODMART)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("C=0")
         .returnsCount(1);
   }
@@ -3224,7 +3195,7 @@ public class DruidAdapterIT {
             + "'intervals':['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],"
             + "'context':{'skipEmptyBuckets':false}}";
     sql(sql, FOODMART)
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsUnordered("C=86829");
   }
 
@@ -3241,7 +3212,7 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered("T=1997-01-01 00:00:00", "T=1997-01-01 00:00:00")
         .queryContains(
-            druidChecker(druidQuery));
+            new DruidChecker(druidQuery));
   }
 
   @Test
@@ -3268,7 +3239,7 @@ public class DruidAdapterIT {
         + "'lowerStrict':false,'ordering':'lexicographic','";
     sql(sql, FOODMART)
         .returnsOrdered("T=1997-05-01 00:00:00")
-        .queryContains(druidChecker(druidQuery));
+        .queryContains(new DruidChecker(druidQuery));
   }
 
   @Test public void testTimeWithFilterOnFloorOnTimeWithTimezone() {
@@ -3289,7 +3260,7 @@ public class DruidAdapterIT {
         .with(CalciteConnectionProperty.TIME_ZONE, "Asia/Kolkata")
         .query(sql)
         .runs()
-        .queryContains(druidChecker(druidQueryPart1, druidQueryPart2))
+        .queryContains(new DruidChecker(druidQueryPart1, druidQueryPart2))
         .returnsOrdered("T=2015-09-12 14:00:01");
   }
 
@@ -3311,7 +3282,7 @@ public class DruidAdapterIT {
         .with(CalciteConnectionProperty.TIME_ZONE.camelName(), "Asia/Kolkata")
         .query(sql)
         .runs()
-        .queryContains(druidChecker(druidQueryPart1, druidQueryPart2))
+        .queryContains(new DruidChecker(druidQueryPart1, druidQueryPart2))
         .returnsOrdered("T=2015-09-12 08:00:02; S=null; C=1",
             "T=2015-09-12 08:00:04; S=null; C=1",
             "T=2015-09-12 08:00:05; S=null; C=1",
@@ -3337,7 +3308,7 @@ public class DruidAdapterIT {
         .with(CalciteConnectionProperty.TIME_ZONE, "Asia/Kolkata")
         .query(sql)
         .runs()
-        .queryContains(druidChecker(druidQueryPart1, druidQueryPart2))
+        .queryContains(new DruidChecker(druidQueryPart1, druidQueryPart2))
         .returnsOrdered("T=2015-09-12 08:00:02; S=null; C=1",
             "T=2015-09-12 08:00:04; S=null; C=1",
             "T=2015-09-12 08:00:05; S=null; C=1",
@@ -3353,7 +3324,7 @@ public class DruidAdapterIT {
         + "EXTRACT(MONTH FROM \"timestamp\") = 01 AND EXTRACT(YEAR FROM \"timestamp\") = 1996 ";
     sql(sql, FOODMART)
         .runs()
-        .queryContains(druidChecker("{\"queryType\":\"timeseries\""));
+        .queryContains(new DruidChecker("{\"queryType\":\"timeseries\""));
   }
 
   @Test public void testFloorToDateRangeWithTimeZone() {
@@ -3370,7 +3341,7 @@ public class DruidAdapterIT {
         .with(CalciteConnectionProperty.TIME_ZONE.camelName(), "Asia/Kolkata")
         .query(sql)
         .runs()
-        .queryContains(druidChecker(druidQuery))
+        .queryContains(new DruidChecker(druidQuery))
         .returnsOrdered("T=1997-05-01 00:00:00");
   }
 
@@ -3379,7 +3350,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where ABS(-EXP(LN(SQRT"
         + "(\"store_sales\")))) = 1";
     sql(sql, FOODMART)
-        .queryContains(druidChecker("pow(\\\"store_sales\\\""))
+        .queryContains(new DruidChecker("pow(\\\"store_sales\\\""))
         .returnsUnordered("EXPR$0=32");
   }
 
@@ -3388,7 +3359,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where CAST(SQRT(ABS(-\"store_sales\"))"
         + " /2 as INTEGER) = 1";
     sql(sql, FOODMART)
-        .queryContains(druidChecker("(CAST((pow(abs((- \\\"store_sales\\\")),0.5) / 2),"))
+        .queryContains(new DruidChecker("(CAST((pow(abs((- \\\"store_sales\\\")),0.5) / 2),"))
         .returnsUnordered("EXPR$0=62449");
   }
 
@@ -3397,7 +3368,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where \"product_id\" LIKE '1%'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"like"))
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"like"))
         .returnsUnordered("EXPR$0=36839");
   }
 
@@ -3406,7 +3377,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where CHAR_LENGTH(\"product_id\") = 2";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"expression\":\"(strlen(\\\"product_id\\\") == 2"))
+            new DruidChecker("\"expression\":\"(strlen(\\\"product_id\\\") == 2"))
         .returnsUnordered("EXPR$0=4876");
   }
 
@@ -3416,7 +3387,7 @@ public class DruidAdapterIT {
         + "'SPOKANE'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
                 + "(lower(\\\"city\\\")) ==", "SPOKANE"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -3427,7 +3398,7 @@ public class DruidAdapterIT {
         + "'spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
                 + "(upper(\\\"city\\\")) ==", "spokane"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -3437,7 +3408,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where lower(\"city\") = 'Spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
                 + "(\\\"city\\\") ==", "Spokane"))
         .returnsUnordered("EXPR$0=0");
   }
@@ -3447,7 +3418,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where lower(\"city\") = 'spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(lower"
                 + "(\\\"city\\\") ==", "spokane"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -3457,7 +3428,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where upper(\"city\") = 'Spokane'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
                 + "(\\\"city\\\") ==", "Spokane"))
         .returnsUnordered("EXPR$0=0");
   }
@@ -3467,7 +3438,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where upper(\"city\") = 'SPOKANE'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\"(upper"
                 + "(\\\"city\\\") ==", "SPOKANE"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -3478,7 +3449,7 @@ public class DruidAdapterIT {
         + "'Spokane_extra'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
+            new DruidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
                 + "(\\\"city\\\",", "Spokane_extra"))
         .returnsUnordered("EXPR$0=7394");
   }
@@ -3488,7 +3459,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where (\"city\" || 'extra') IS NOT NULL";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
+            new DruidChecker("{\"type\":\"expression\",\"expression\":\"(concat"
                 + "(\\\"city\\\",", "!= null"))
         .returnsUnordered("EXPR$0=86829");
   }
@@ -3503,7 +3474,7 @@ public class DruidAdapterIT {
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "projects=[[0]], groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "{\"queryType\":\"timeseries\",\"dataSource\":\"foodmart\","
                     + "\"descending\":false,\"granularity\":\"all\","
                     + "\"aggregations\":[{\"type\":\"count\",\"name\":\"EXPR$0\"}],"
@@ -3517,7 +3488,8 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where (\"city\" || \"state_province\")"
         + " = 'SpokaneWA'";
     sql(sql, FOODMART)
-        .queryContains(druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==", "SpokaneWA"))
+        .queryContains(
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==", "SpokaneWA"))
         .returnsUnordered("EXPR$0=7394");
   }
 
@@ -3528,7 +3500,7 @@ public class DruidAdapterIT {
         + "AND \"state_province\" = 'WA'";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
                 "SpokaneWA",
                 "{\"type\":\"selector\",\"dimension\":\"state_province\",\"value\":\"WA\"}]}"))
         .returnsUnordered("EXPR$0=7394");
@@ -3541,7 +3513,7 @@ public class DruidAdapterIT {
         + "OR (\"state_province\" = 'CA' AND \"city\" IS NOT NULL)";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
                 "SpokaneWA", "{\"type\":\"and\",\"fields\":[{\"type\":\"selector\","
                     + "\"dimension\":\"state_province\",\"value\":\"CA\"},{\"type\":\"not\","
                     + "\"field\":{\"type\":\"selector\",\"dimension\":\"city\",\"value\":null}}]}"))
@@ -3553,7 +3525,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where \"city\" = \"state_province\"";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                 + "(\\\"city\\\" == \\\"state_province\\\")\"}"))
         .returnsUnordered("EXPR$0=0");
   }
@@ -3563,7 +3535,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT COUNT(*) FROM \"foodmart\"  where \"city\" <> \"state_province\"";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                 + "(\\\"city\\\" != \\\"state_province\\\")\"}"))
         .returnsUnordered("EXPR$0=86829");
   }
@@ -3580,7 +3552,7 @@ public class DruidAdapterIT {
             + "(||($29, $30), 'SpokaneWA'), =(||($29, '_extra'), 'Spokane_extra')), =($30, 'WA'))"
             + "], groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
+            new DruidChecker("(concat(\\\"city\\\",\\\"state_province\\\") ==",
                 "SpokaneWA", "{\"type\":\"selector\",\"dimension\":\"state_province\","
                     + "\"value\":\"WA\"}]}"))
         .returnsUnordered("EXPR$0=7394");
@@ -3592,7 +3564,7 @@ public class DruidAdapterIT {
         + ") / 3 + 1 AS INTEGER) > 1";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("(CAST((((pow(\\\"store_sales\\\",0.5) - 1) / 3) + 1)", "LONG"))
+            new DruidChecker("(CAST((((pow(\\\"store_sales\\\",0.5) - 1) / 3) + 1)", "LONG"))
         .returnsUnordered("EXPR$0=476");
   }
 
@@ -3607,7 +3579,7 @@ public class DruidAdapterIT {
             + "filter=[=(CAST(CAST($0):DATE NOT NULL):VARCHAR NOT NULL, '1997-01-01')], "
             + "groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker("{\"type\":\"expression\","
+            new DruidChecker("{\"type\":\"expression\","
                 + "\"expression\":\"(timestamp_format(timestamp_floor("))
         .returnsUnordered("EXPR$0=117");
   }
@@ -3618,7 +3590,7 @@ public class DruidAdapterIT {
         + "\"timestamp\") - 1 ) / 3 + 1 AS INTEGER) = 1";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker(",\"filter\":{\"type\":\"expression\",\"expression\":\"((("
+            new DruidChecker(",\"filter\":{\"type\":\"expression\",\"expression\":\"((("
                 + "(timestamp_extract(\\\"__time\\\"", "MONTH", ") - 1) / 3) + 1) == 1"))
         .returnsUnordered("EXPR$0=21587");
   }
@@ -3637,7 +3609,7 @@ public class DruidAdapterIT {
         .query(sql)
         .runs()
         .returnsOrdered("EXPR$0=86712")
-        .queryContains(druidChecker(filterPart1, filterTimezoneName));
+        .queryContains(new DruidChecker(filterPart1, filterTimezoneName));
   }
 
   @Test
@@ -3654,7 +3626,7 @@ public class DruidAdapterIT {
         .query(sql)
         .runs()
         .returnsOrdered("EXPR$0=7043")
-        .queryContains(druidChecker(filterPart1, filterTimezoneName, "MONTH", "== 2"));
+        .queryContains(new DruidChecker(filterPart1, filterTimezoneName, "MONTH", "== 2"));
   }
 
   @Test
@@ -3757,7 +3729,7 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=1997-01-01 00:00:00; EXPR$1=117")
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                     + "(timestamp_floor(timestamp_parse(concat(concat(",
                 "== timestamp_floor("));
   }
@@ -3770,7 +3742,7 @@ public class DruidAdapterIT {
         + "GROUP BY \"timestamp\"";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
+            new DruidChecker("\"filter\":{\"type\":\"expression\",\"expression\":\""
                     + "(timestamp_parse(concat(concat("))
         .returnsOrdered("EXPR$0=1997-01-01 00:00:00; EXPR$1=117");
   }
@@ -3785,7 +3757,7 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=2")
         .explainContains(plan)
-        .queryContains(druidChecker("\"queryType\":\"timeseries\""));
+        .queryContains(new DruidChecker("\"queryType\":\"timeseries\""));
   }
 
 
@@ -3798,7 +3770,7 @@ public class DruidAdapterIT {
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "filter=[=($1, $29)], groups=[{}], aggs=[[COUNT()]])")
         .queryContains(
-            druidChecker("\"filter\":{\"type\":\"expression\","
+            new DruidChecker("\"filter\":{\"type\":\"expression\","
                 + "\"expression\":\"(\\\"product_id\\\" == \\\"city\\\")\"}"))
         .returnsOrdered("EXPR$0=0");
   }
@@ -3810,7 +3782,7 @@ public class DruidAdapterIT {
         + "<= floor(\"store_sales\") * 25 + 2";
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "\"filter\":{\"type\":\"expression\",\"expression\":\"(((CAST(\\\"product_id\\\", ",
                 "LONG",
                 ") + (1 * \\\"store_sales\\\")) / (\\\"store_cost\\\" - 5))",
@@ -3832,7 +3804,7 @@ public class DruidAdapterIT {
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "filter=[<>($1, '1')], groups=[{}], aggs=[[COUNT()]])")
-        .queryContains(druidChecker("\"queryType\":\"timeseries\""))
+        .queryContains(new DruidChecker("\"queryType\":\"timeseries\""))
         .returnsOrdered("EXPR$0=86803");
   }
 
@@ -3884,7 +3856,7 @@ public class DruidAdapterIT {
         .returnsOrdered("EXPR$0=36")
         .explainContains(plan)
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 queryType, filterExp1, filterExpPart2, likeExpressionFilter, likeExpressionFilter2,
                 simpleBound, timeSimpleFilter, simpleExtractFilterMonth, simpleExtractFilterDay,
                 quarterAsExpressionFilter, quarterAsExpressionFilterTimeZone,
@@ -3931,7 +3903,7 @@ public class DruidAdapterIT {
         .returnsOrdered("C=60; EXPR$1=1227")
         .explainContains(plan)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "substring(\\\"product_id\\\"",
+            new DruidChecker("\"queryType\":\"groupBy\"", "substring(\\\"product_id\\\"",
                 "\"(strlen(\\\"product_id\\\")",
                 ",\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\","
                     + "\"expression\":\"substring(\\\"product_id\\\", 0, 4)\","
@@ -3947,7 +3919,7 @@ public class DruidAdapterIT {
 
     sql(sql, FOODMART).returnsOrdered("EXPR$0=10893")
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"", "like(substring(\\\"product_id\\\""))
+            new DruidChecker("\"queryType\":\"timeseries\"", "like(substring(\\\"product_id\\\""))
         .explainContains(
             "PLAN=EnumerableInterpreter\n  DruidQuery(table=[[foodmart, foodmart]], "
                 + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
@@ -3962,7 +3934,7 @@ public class DruidAdapterIT {
         + " WHERE SUBSTRING(\"product_id\" from CAST(\"store_cost\" as INT)/1000 + 1) like '1%'";
 
     sql(sql, FOODMART).returnsOrdered("EXPR$0=36839")
-        .queryContains(druidChecker("like(substring(\\\"product_id\\\""))
+        .queryContains(new DruidChecker("like(substring(\\\"product_id\\\""))
         .explainContains(
             "PLAN=EnumerableInterpreter\n  DruidQuery(table=[[foodmart, foodmart]], "
                 + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
@@ -3984,7 +3956,7 @@ public class DruidAdapterIT {
         + "group by floor(\"timestamp\" to DAY),\"product_id\"";
     sql(sql)
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
+            new DruidChecker("\"queryType\":\"groupBy\"", "{\"type\":\"bound\","
                 + "\"dimension\":\"store_cost\",\"lower\":\"5\",\"lowerStrict\":true,"
                 + "\"ordering\":\"numeric\"}"))
         .runs();
@@ -3996,12 +3968,16 @@ public class DruidAdapterIT {
   @Test
   public void testBetweenFilterWithCastOverNumeric() {
     final String sql = "SELECT COUNT(*) FROM " + FOODMART_TABLE + " WHERE \"product_id\" = 16.0";
+    // After CALCITE-2302 the Druid query changed a bit and the type of the
+    // filter became an expression (instead of a bound filter) but it still
+    // seems correct.
     sql(sql, FOODMART).runs().queryContains(
-        druidChecker(
-            "\"filter\":{\"type\":\"bound\",\"dimension\":\"product_id\",\"lower\":\"16.0\","
-                + "\"lowerStrict\":false,\"upper\":\"16.0\","
-                + "\"upperStrict\":false,\"ordering\":\"numeric\"}"));
-
+        new DruidChecker(
+            false,
+            "\"filter\":{"
+                + "\"type\":\"expression\","
+                + "\"expression\":\"(CAST(\\\"product_id\\\", \'DOUBLE\') == 16.0)\""
+                + "}"));
   }
 
   @Test
@@ -4028,7 +4004,7 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=117")
         .queryContains(
-            druidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
+            new DruidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
                     + "'descending':false,'granularity':'all','filter':{'type':'and','fields':"
                     + "[{'type':'bound','dimension':'__time','upper':'1997-01-02T00:00:00.000Z',"
                     + "'upperStrict':true,'ordering':'lexicographic',"
@@ -4049,7 +4025,7 @@ public class DruidAdapterIT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-            + "filter=[AND(IS NOT TRUE(=($1, 1020)), <>($1, 1020))],"
+            + "filter=[AND(IS NOT TRUE(=(CAST($1):INTEGER, 1020)), <>(CAST($1):INTEGER, 1020))],"
             + " groups=[{}], aggs=[[COUNT()]])");
     final String sql2 = "SELECT COUNT(*) FROM " + FOODMART_TABLE + "WHERE "
         + "\"product_id\" <> 1020";
@@ -4102,7 +4078,7 @@ public class DruidAdapterIT {
             + "[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "projects=[[EXTRACT(FLAG(YEAR), $0)]])")
         .queryContains(
-            druidChecker("\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\","
+            new DruidChecker("\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\","
                 + "\"expression\":\"timestamp_extract(\\\"__time\\\""));
   }
 
@@ -4116,7 +4092,7 @@ public class DruidAdapterIT {
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
             + "projects=[[+($90, 1)]], groups=[{}], aggs=[[SUM($0)]])")
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"",
+            new DruidChecker("\"queryType\":\"timeseries\"",
                 "\"doubleSum\",\"name\":\"EXPR$0\",\"expression\":\"(\\\"store_sales\\\" + 1)\""));
   }
 
@@ -4131,7 +4107,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$0, *(-($90), 2)]], groups=[{0}], "
             + "aggs=[[SUM($1)]], sort0=[1], dir0=[ASC], fetch=[2])")
         .queryContains(
-            druidChecker("'queryType':'groupBy'", "'granularity':'all'",
+            new DruidChecker("'queryType':'groupBy'", "'granularity':'all'",
                 "{'dimension':'S','direction':'ascending','dimensionOrder':'numeric'}",
                 "{'type':'doubleSum','name':'S','expression':'((- \\'store_sales\\') * 2)'}]"));
   }
@@ -4150,7 +4126,7 @@ public class DruidAdapterIT {
             + " groups=[{0}], aggs=[[SUM($1), MAX($2), MIN($3)]], post_projects=[[-($1, $2), $3]],"
             + " sort0=[0], dir0=[ASC], fetch=[2])")
         .queryContains(
-            druidChecker(",\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"$f1\","
+            new DruidChecker(",\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"$f1\","
                 + "\"expression\":\"((- \\\"store_sales\\\") * 2)\"},{\"type\":\"doubleMax\",\"name\""
                 + ":\"$f2\",\"expression\":\"(\\\"store_cost\\\" * \\\"store_cost\\\")\"},"
                 + "{\"type\":\"doubleMin\",\"name\":\"S2\",\"expression\":\"(\\\"store_sales\\\" "
@@ -4171,7 +4147,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], projects=[[||(||($1, '_'), $29), "
             + "+($90, CAST($53):DOUBLE)]], groups=[{0}], aggs=[[SUM($1)]], fetch=[2])")
         .queryContains(
-            druidChecker("'queryType':'groupBy'",
+            new DruidChecker("'queryType':'groupBy'",
                 "{'type':'doubleSum','name':'S','expression':'(\\'store_sales\\' + CAST(\\'cost\\'",
                 "'expression':'concat(concat(\\'product_id\\'",
                 "{'type':'default','dimension':'vc','outputName':'vc','outputType':'STRING'}],"
@@ -4189,7 +4165,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], filter=[=($30, 'CA')], projects=[[||(||($1, '_'), $29)]],"
             + " groups=[{}], aggs=[[COUNT($0)]])")
         .queryContains(
-            druidChecker("\"queryType\":\"timeseries\"",
+            new DruidChecker("\"queryType\":\"timeseries\"",
                 "\"aggregator\":{\"type\":\"count\",\"name\":\"EXPR$0\",\"expression\":"
                     + "\"concat(concat(\\\"product_id\\\"",
                 "\"aggregations\":[{\"type\":\"filtered\",\"filter\":{\"type\":\"not\",\"field\":"
@@ -4201,7 +4177,7 @@ public class DruidAdapterIT {
     final String sql = "SELECT SUM(cast(\"product_id\" AS INTEGER)) FROM " + FOODMART_TABLE;
     sql(sql, FOODMART)
         .queryContains(
-            druidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
+            new DruidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
                 + "'descending':false,'granularity':'all','aggregations':[{'type':'longSum',"
                 + "'name':'EXPR$0','expression':'CAST(\\'product_id\\'", "LONG"))
         .returnsOrdered("EXPR$0=68222919");
@@ -4213,7 +4189,7 @@ public class DruidAdapterIT {
     sql(sql, WIKI_AUTO2)
         .returnsOrdered("EXPR$0=353196")
         .queryContains(
-            druidChecker("{'queryType':'timeseries','dataSource':'wikipedia',"
+            new DruidChecker("{'queryType':'timeseries','dataSource':'wikipedia',"
                 + "'descending':false,'granularity':'all','aggregations':[{"
                 + "'type':'longSum','name':'EXPR$0','expression':'timestamp_extract(\\'__time\\'"));
   }
@@ -4224,7 +4200,7 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=12")
         .queryContains(
-            druidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
+            new DruidChecker("{'queryType':'timeseries','dataSource':'foodmart',"
                 + "'descending':false,'granularity':'all','aggregations':[{"
                 + "'type':'longMax','name':'EXPR$0','expression':'timestamp_extract(\\'__time\\'"));
   }
@@ -4246,7 +4222,7 @@ public class DruidAdapterIT {
 
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=24441; EXPR$1=86829")
-        .queryContains(druidChecker(query));
+        .queryContains(new DruidChecker(query));
   }
 
   @Test
@@ -4289,7 +4265,8 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered(
             "QR_TIMESTAMP_OK=1; SUM_STORE_SALES=139628.34999999971; YR_TIMESTAMP_OK=1997")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\"", extract_year, extract_expression))
+        .queryContains(
+            new DruidChecker("\"queryType\":\"groupBy\"", extract_year, extract_expression))
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  BindableProject(QR_TIMESTAMP_OK=[$0], SUM_STORE_SALES=[$2], YR_TIMESTAMP_OK=[$1])\n"
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
@@ -4313,7 +4290,7 @@ public class DruidAdapterIT {
         + "2992-01-10T00:00:00.000Z]], projects=[[+(+(*(EXTRACT(FLAG(YEAR), $0), 10000), "
         + "*(EXTRACT(FLAG(MONTH), $0), 100)), EXTRACT(FLAG(DAY), $0)), $90]], groups=[{0}], "
         + "aggs=[[SUM($1)]], fetch=[1])")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\""));
+        .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
   }
 
   @Test
@@ -4335,7 +4312,7 @@ public class DruidAdapterIT {
             + "NOT NULL):VARCHAR "
             + "NOT NULL, 12, 2)):INTEGER NOT NULL, EXTRACT(FLAG(MINUTE), $0), "
             + "EXTRACT(FLAG(HOUR), $0), $90]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], fetch=[1])")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\""));
+        .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
   }
 
   @Test
@@ -4351,7 +4328,7 @@ public class DruidAdapterIT {
             + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[EXTRACT(FLAG(SECOND), $0), "
             + "EXTRACT(FLAG(MINUTE), $0), $90]], groups=[{0, 1}], aggs=[[SUM($2)]], fetch=[1])")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\""));
+        .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
   }
 
   @Test
@@ -4374,7 +4351,7 @@ public class DruidAdapterIT {
             + "projects=[[EXTRACT(FLAG(WEEK), $0), EXTRACT(FLAG(DOW), $0), "
             + "EXTRACT(FLAG(DAY), $0), EXTRACT(FLAG(DOY), $0), EXTRACT(FLAG(QUARTER), $0), $1]], "
             + "groups=[{0, 1, 2, 3, 4}], aggs=[[SUM($5)]], fetch=[1])")
-        .queryContains(druidChecker("\"queryType\":\"groupBy\""));
+        .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
   }
 
   @Test
@@ -4402,7 +4379,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $90]], groups=[{0}], aggs=[[SUM($1)]], "
             + "filter=[>($1, 220)], sort0=[0], dir0=[ASC], fetch=[2])")
         .queryContains(
-            druidChecker("'having':{'type':'filter','filter':{'type':'bound',"
+            new DruidChecker("'having':{'type':'filter','filter':{'type':'bound',"
                 + "'dimension':'S','lower':'220','lowerStrict':true,'ordering':'numeric'}}"));
   }
 
@@ -4418,7 +4395,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], filter=[>($1, '10')], projects=[[$1, $90]], groups=[{0}],"
             + " aggs=[[SUM($1)]], filter=[>($1, 220)], sort0=[0], dir0=[ASC], fetch=[2])\n")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all'"));
   }
 
   @Test
@@ -4433,7 +4410,7 @@ public class DruidAdapterIT {
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $1, $90, $90]])")
         .queryContains(
-            druidChecker("{'queryType':'scan','dataSource':'foodmart','intervals':"
+            new DruidChecker("{'queryType':'scan','dataSource':'foodmart','intervals':"
                 + "['1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z'],'virtualColumns':["
                 + "{'type':'expression','name':'vc','expression':'\\'product_id\\'','outputType':"
                 + "'STRING'},{'type':'expression','name':'vc0','expression':'\\'store_sales\\'',"
@@ -4454,7 +4431,7 @@ public class DruidAdapterIT {
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $1, $90, $90]])")
         .queryContains(
-            druidChecker("{\"queryType\":\"scan\",\"dataSource\":\"foodmart\",\"intervals\":"
+            new DruidChecker("{\"queryType\":\"scan\",\"dataSource\":\"foodmart\",\"intervals\":"
                 + "[\"1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z\"],\"virtualColumns\":"
                 + "[{\"type\":\"expression\",\"name\":\"vc\",\"expression\":\"\\\"product_id\\\"\","
                 + "\"outputType\":\"STRING\"},{\"type\":\"expression\",\"name\":\"vc0\","
@@ -4475,7 +4452,7 @@ public class DruidAdapterIT {
             + "2992-01-10T00:00:00.000Z]], projects=[[$1, $90]], groups=[{0}], aggs=[[SUM($1)]], "
             + "sort0=[0], dir0=[ASC], fetch=[1])")
         .queryContains(
-            druidChecker("\"queryType\":\"groupBy\""))
+            new DruidChecker("\"queryType\":\"groupBy\""))
         .returnsOrdered("PROD_ID1=1; PROD_ID2=1; S1=236.55; S2=236.55");
   }
 
@@ -4486,7 +4463,7 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=565238.1299999986")
         .queryContains(
-            druidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
+            new DruidChecker("{'queryType':'groupBy','dataSource':'foodmart','granularity':'all',"
                 + "'dimensions':[{'type':'default','dimension':'vc','outputName':'vc','outputType':'LONG'}],"
                 + "'virtualColumns':[{'type':'expression','name':'vc','expression':'1','outputType':'LONG'}],"
                 + "'limitSpec':{'type':'default'},'aggregations':[{'type':'doubleSum','name':'EXPR$0',"
@@ -4503,7 +4480,7 @@ public class DruidAdapterIT {
         + " GROUP BY floor(\"timestamp\" TO quarter)";
 
     sql(sql, FOODMART).queryContains(
-        druidChecker(
+        new DruidChecker(
             "{\"queryType\":\"timeseries\",\"dataSource\":\"foodmart\",\"descending\":false,"
                 + "\"granularity\":{\"type\":\"period\",\"period\":\"P3M\",\"timeZone\":\"UTC\"},"
                 + "\"aggregations\":[{\"type\":\"doubleSum\",\"name\":\"EXPR$1\",\"fieldName\":\"store_sales\"}],"
@@ -4518,7 +4495,7 @@ public class DruidAdapterIT {
             + " GROUP BY floor(\"timestamp\" TO quarter), \"product_id\"";
 
     sql(sql, FOODMART).queryContains(
-        druidChecker(
+        new DruidChecker(
             "{\"queryType\":\"groupBy\",\"dataSource\":\"foodmart\",\"granularity\":\"all\",\"dimensions\":"
                 + "[{\"type\":\"extraction\",\"dimension\":\"__time\",\"outputName\":\"floor_quarter\",\"extractionFn\":{\"type\":\"timeFormat\"",
             "\"granularity\":{\"type\":\"period\",\"period\":\"P3M\",\"timeZone\":\"UTC\"},\"timeZone\":\"UTC\",\"locale\":\"und\"}},"
@@ -4541,7 +4518,7 @@ public class DruidAdapterIT {
         + "EXPR$0=3; product_id=1; EXPR$2=88.35\n"
         + "EXPR$0=4; product_id=1; EXPR$2=48.45")
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "{\"queryType\":\"groupBy\",\"dataSource\":\"foodmart\",\"granularity\":\"all\",\"dimensions\":"
                     + "[{\"type\":\"default\",\"dimension\":\"vc\",\"outputName\":\"vc\",\"outputType\":\"LONG\"},"
                     + "{\"type\":\"default\",\"dimension\":\"product_id\",\"outputName\":\"product_id\",\"outputType\":\"STRING\"}],"
@@ -4560,7 +4537,7 @@ public class DruidAdapterIT {
         + "EXPR$0=3; EXPR$1=140271.88999999964\n"
         + "EXPR$0=4; EXPR$1=152671.61999999985")
         .queryContains(
-            druidChecker(
+            new DruidChecker(
                 "{\"queryType\":\"groupBy\",\"dataSource\":\"foodmart\",\"granularity\":\"all\","
                     + "\"dimensions\":[{\"type\":\"default\",\"dimension\":\"vc\",\"outputName\":\"vc\",\"outputType\":\"LONG\"}],"
                     + "\"virtualColumns\":[{\"type\":\"expression\",\"name\":\"vc\",\"expression\":\"timestamp_extract(\\\"__time\\\",",
@@ -4576,7 +4553,7 @@ public class DruidAdapterIT {
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=86829; EXPR$1=565238.1299999986; EXPR$2=86829")
         .queryContains(
-            druidChecker("{'queryType':'timeseries'", "'context':{'skipEmptyBuckets':false}}"));
+            new DruidChecker("{'queryType':'timeseries'", "'context':{'skipEmptyBuckets':false}}"));
 
   }
 
@@ -4588,7 +4565,7 @@ public class DruidAdapterIT {
         .returnsOrdered("PID_CATEGORY=0; EXPR$1=55789",
                         "PID_CATEGORY=1; EXPR$1=31040")
         .queryContains(
-            druidChecker("{\"queryType\":\"groupBy\"",
+            new DruidChecker("{\"queryType\":\"groupBy\"",
                          "\"dimension\":\"vc\",\"outputName\":\"vc\",\"outputType\":\"LONG\"}]"));
 
   }

--- a/druid/src/test/java/org/apache/calcite/test/DruidChecker.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidChecker.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.apache.calcite.adapter.druid.DruidQuery;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * A consumer that checks that a particular Druid query is generated to implement a query.
+ */
+class DruidChecker implements Consumer<List> {
+  private final String[] lines;
+  private final boolean replaceSingleWithDoubleQuotes;
+
+  DruidChecker(String... lines) {
+    this(true, lines);
+  }
+
+  DruidChecker(boolean replaceSingleWithDoubleQuotes, String... lines) {
+    this.replaceSingleWithDoubleQuotes = replaceSingleWithDoubleQuotes;
+    this.lines = lines;
+  }
+
+  @Override public void accept(final List list) {
+    assertThat(list.size(), is(1));
+    DruidQuery.QuerySpec querySpec = (DruidQuery.QuerySpec) list.get(0);
+    for (String line : lines) {
+      final String s =
+          replaceSingleWithDoubleQuotes ? line.replace('\'', '"') : line;
+      assertThat(querySpec.getQueryString(null, -1), containsString(s));
+    }
+  }
+}
+
+// End DruidChecker.java


### PR DESCRIPTION
1. Update stale tests in DruidAdapterIT and DruidAdapter2IT following the implementation of implicit casts in CALCITE-2302.
2. Refactor common druidChecker code in DruidAdapterIT and DruidAdapter2IT in a separate class.

Co-authored-by: yuzhao.cyz <yuzhao.cyz@alibaba-inc.com>