### PR TITLE
[hotfix]Remove the useless JdbcConvention out in descriptionPrefix for JdbcToEnumerableConverterRule.

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverterRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverterRule.java
@@ -35,7 +35,7 @@ public class JdbcToEnumerableConverterRule extends ConverterRule {
       RelBuilderFactory relBuilderFactory) {
     super(RelNode.class, (Predicate<RelNode>) r -> true, out,
         EnumerableConvention.INSTANCE, relBuilderFactory,
-        "JdbcToEnumerableConverterRule:" + out);
+        "JdbcToEnumerableConverterRule");
   }
 
   @Override public RelNode convert(RelNode rel) {


### PR DESCRIPTION
CALCITE-3115 has merged into master, But it not modify the descriptionPrefix of JdbcToEnumerableConverterRule.