### PR TITLE
[CALCITE-3321] BigQuery does not have correct casing rules

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql.dialect;
 
+import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
@@ -45,7 +46,10 @@ public class BigQuerySqlDialect extends SqlDialect {
               .withLiteralQuoteString("'")
               .withLiteralEscapedQuoteString("\\'")
               .withIdentifierQuoteString("`")
-              .withNullCollation(NullCollation.LOW));
+              .withNullCollation(NullCollation.LOW)
+              .withUnquotedCasing(Casing.UNCHANGED)
+              .withQuotedCasing(Casing.UNCHANGED)
+              .withCaseSensitive(false));
 
   private static final List<String> RESERVED_KEYWORDS =
       ImmutableList.copyOf(

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8885,6 +8885,11 @@ public class SqlParserTest {
         "select unquotedColumn from \"doubleQuotedTable\"",
         is("SELECT \"unquotedcolumn\"\n"
             + "FROM \"doublequotedtable\""));
+    // BigQuery leaves quoted and unquoted identifers unchanged
+    checkDialect(SqlDialect.DatabaseProduct.BIG_QUERY.getDialect(),
+        "select unquotedColumn from `doubleQuotedTable`",
+        is("SELECT unquotedColumn\n"
+            + "FROM doubleQuotedTable"));
   }
 
   @Test public void testParenthesizedSubQueries() {


### PR DESCRIPTION
Here's the rules for reference:

https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#case_sensitivity

So I think leaving casing unchanged and treating it as case insensitive gets us the results we want.

I couldn't find anywhere that seemed obvious to put a test for this, so let me know if there is a place or not!