### PR TITLE
[CALCITE-3332] Query failed with AssertionError: cannot cast null as class java.math.BigDecima

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlBinaryOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBinaryOperator.java
@@ -181,7 +181,24 @@ public class SqlBinaryOperator extends SqlOperator {
     return type;
   }
 
+  protected boolean hasNullOperand(final SqlOperatorBinding call) {
+    for (int i = 0; i < call.getOperandCount(); i++) {
+      if (call.isOperandNull(i, true)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
+    // specially handle cases with null operands
+    if (hasNullOperand(call)) {
+      switch (this.kind) {
+      case DIVIDE:
+        return SqlMonotonicity.CONSTANT;
+      }
+    }
+
     if (getName().equals("/")) {
       final SqlMonotonicity mono0 = call.getOperandMonotonicity(0);
       final SqlMonotonicity mono1 = call.getOperandMonotonicity(1);

--- a/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -257,7 +257,7 @@ public class SqlLiteral extends SqlNode {
   }
 
   public <T> T getValueAs(Class<T> clazz) {
-    if (clazz.isInstance(value)) {
+    if (value == null || clazz.isInstance(value)) {
       return clazz.cast(value);
     }
     switch (typeName) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
@@ -195,10 +195,14 @@ public class SqlSubstringFunction extends SqlFunction {
       final SqlMonotonicity mono0 = call.getOperandMonotonicity(0);
       if ((mono0 != SqlMonotonicity.NOT_MONOTONIC)
           && call.getOperandMonotonicity(1) == SqlMonotonicity.CONSTANT
-          && call.getOperandLiteralValue(1, BigDecimal.class)
-              .equals(BigDecimal.ZERO)
           && call.getOperandMonotonicity(2) == SqlMonotonicity.CONSTANT) {
-        return mono0.unstrict();
+        if (call.isOperandNull(1, true)) {
+          return SqlMonotonicity.CONSTANT;
+        }
+        if (call.getOperandLiteralValue(1, BigDecimal.class)
+            .equals(BigDecimal.ZERO)) {
+          return mono0.unstrict();
+        }
       }
     }
     return super.getMonotonicity(call);

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -641,6 +641,25 @@ public class ReflectiveSchemaTest {
     }
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3332">[CALCITE-3332]
+   * Query failed with AssertionError: cannot cast null as class java.math.BigDecimal</a>. */
+  @Test public void testNullLiteral() {
+    final CalciteAssert.AssertThat with =
+        CalciteAssert.that().withSchema("s", CATCHALL);
+    with.query("select \"wrapperLong\" * null as c\n"
+        + " from \"s\".\"everyTypes\"")
+        .returns("C=null\n"
+            + "C=null\n");
+    with.query("select \"wrapperLong\" / null as c\n"
+        + " from \"s\".\"everyTypes\"")
+        .returns("C=null\n"
+            + "C=null\n");
+    with.query("select substring('abcdef' from "
+        + "cast(null as int) for 4) as c\n")
+        .returns("C=null\n");
+  }
+
   @Test public void testCastFromString() {
     CalciteAssert.that().withSchema("s", CATCHALL)
         .query("select cast(\"string\" as int) as c from \"s\".\"everyTypes\"")

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10289,6 +10289,39 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .monotonic(SqlMonotonicity.INCREASING);
   }
 
+  /** Tests that various expressions with null operands are monotonic. */
+  @Test public void testNullOperandMonotonic() {
+    // SqlBinaryOperator
+    sql("select deptno / null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null / deptno from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null / null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    // SqlMonotonicBinaryOperator
+    sql("select deptno + null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null + deptno from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null + null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select deptno - null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null - deptno from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null - null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select deptno * null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null * deptno from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    sql("select null * null from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+    // SqlFunction
+    sql("select substring('abcdef' from cast(null as int) for 4) from emp")
+        .monotonic(SqlMonotonicity.CONSTANT);
+  }
+
   @Test public void testStreamUnionAll() {
     sql("select orderId\n"
         + "from ^orders^\n"


### PR DESCRIPTION
Calcite runtime can process null semantic. However, the null literal is not properly handled when figuring out SqlMonotonicity, as demonstrated in [CALCITE-3332](https://issues.apache.org/jira/browse/CALCITE-3332). 