### PR TITLE
[CALCITE-3338] Error with executeBatch and preparedStatement when usi…

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -279,18 +279,25 @@ abstract class CalciteConnectionImpl
       CalciteStatement statement = (CalciteStatement) createStatement();
       CalcitePrepare.CalciteSignature<T> signature =
           statement.prepare(queryable);
-      return enumerable(statement.handle, signature).enumerator();
+      return enumerable(statement.handle, signature, null).enumerator();
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
   public <T> Enumerable<T> enumerable(Meta.StatementHandle handle,
-      CalcitePrepare.CalciteSignature<T> signature) throws SQLException {
+      CalcitePrepare.CalciteSignature<T> signature,
+      List<TypedValue> parameterValues0) throws SQLException {
     Map<String, Object> map = new LinkedHashMap<>();
     AvaticaStatement statement = lookupStatement(handle);
-    final List<TypedValue> parameterValues =
-        TROJAN.getParameterValues(statement);
+
+    final List<TypedValue> parameterValues;
+    if (parameterValues0 == null || parameterValues0.isEmpty()) {
+      parameterValues =
+          TROJAN.getParameterValues(statement);
+    } else {
+      parameterValues = parameterValues0;
+    }
 
     if (MetaImpl.checkParameterValueHasNull(parameterValues)) {
       throw new SQLException("exception while executing query: unbound parameter");

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -503,7 +503,7 @@ public class CalciteMetaImpl extends MetaImpl {
       //noinspection unchecked
       final CalcitePrepare.CalciteSignature<Object> calciteSignature =
           (CalcitePrepare.CalciteSignature<Object>) signature;
-      return getConnection().enumerable(handle, calciteSignature);
+      return getConnection().enumerable(handle, calciteSignature, parameterValues);
     } catch (SQLException e) {
       throw new RuntimeException(e.getMessage());
     }

--- a/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
@@ -881,6 +881,40 @@ public class CalciteRemoteDriverTest {
    */
   @Test public void testRemotePreparedStatementInsert2() throws Exception {
   }
+
+  @Test public void testInsertBatchWithPreparedStatement() throws Exception {
+    final Connection connection = DriverManager.getConnection(
+        "jdbc:avatica:remote:factory="
+            + LocalServiceModifiableFactory.class.getName());
+    assertThat(connection.getMetaData().supportsBatchUpdates(), is(true));
+    assertThat(connection.isClosed(), is(false));
+
+    PreparedStatement pst = connection.prepareStatement(
+        "insert into \"foo\".\"bar\" values (?, ?, ?, ?, ?)");
+    pst.setInt(1, 1);
+    pst.setInt(2, 1);
+    pst.setString(3, "second");
+    pst.setInt(4, 1);
+    pst.setInt(5, 1);
+    pst.addBatch();
+    pst.addBatch();
+
+    int[] updateCounts = pst.executeBatch();
+    assertThat(updateCounts.length, is(2));
+    assertThat(updateCounts[0], is(1));
+    assertThat(updateCounts[1], is(1));
+    ResultSet resultSet = pst.getResultSet();
+    assertThat(resultSet, nullValue());
+
+    // Now empty batch
+    pst.clearBatch();
+    updateCounts = pst.executeBatch();
+    assertThat(updateCounts.length, is(0));
+    resultSet = pst.getResultSet();
+    assertThat(resultSet, nullValue());
+
+    connection.close();
+  }
 }
 
 // End CalciteRemoteDriverTest.java


### PR DESCRIPTION
…ng RemoteMeta

Parameter values are not passed into `CalciteConnectionImpl#enumerable` when using `RemoteMeta`. 
Referring to `org.apache.calcite.avatica.jdbc.JdbcMeta`, `parameterValues` are copied into `preparedStatement` when `JdbcMeta#execute`. But there's no similar logic in `CalciteMetaImpl`.

In current impl of `CalciteConnectionImpl#enumerable`, it depends on calling `lookupStatement` and then get params from `AvaticaStatement`. But when it's a remote request,  `lookupStatement` will create a new `AvaticaStatement`. Thus params are lost.

https://github.com/apache/calcite-avatica/blob/master/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java#L706