### PR TITLE
[CALCITE-3347] IndexOutOfBoundsException in FixNullabilityShuttle when using FilterIntoJoinRule

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterJoinRule.java
@@ -329,7 +329,8 @@ public abstract class FilterJoinRule extends RelOptRule {
     final Iterator<RexNode> filterIter = joinFilters.iterator();
     while (filterIter.hasNext()) {
       RexNode exp = filterIter.next();
-      if (!predicate.apply(join, joinType, exp)) {
+      // Do not pull up filter conditions for semi/anti join.
+      if (!predicate.apply(join, joinType, exp) && joinType.projectsRight()) {
         aboveFilters.add(exp);
         filterIter.remove();
       }

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -7081,6 +7081,21 @@ public class JdbcTest {
     }
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3347">[CALCITE-3347]
+   * IndexOutOfBoundsException in FixNullabilityShuttle when using FilterIntoJoinRule</a>.
+   */
+  @Test public void testSemiJoin() {
+    CalciteAssert.that()
+        .with(CalciteAssert.Config.JDBC_FOODMART)
+        .query("select *\n"
+            + " from \"foodmart\".\"employee\""
+            + " where \"employee_id\" = 1 and \"last_name\" in"
+            + " (select \"last_name\" from \"foodmart\".\"employee\" where \"employee_id\" = 2)")
+        .runs();
+  }
+
   private static String sums(int n, boolean c) {
     final StringBuilder b = new StringBuilder();
     for (int i = 0; i < n; i++) {


### PR DESCRIPTION
Exception may occur when using semi-join, please refer to [CALCITE-3347](https://issues.apache.org/jira/browse/CALCITE-3347) for more details.

This PR use the test case contributed by @LiShuMing 