### PR TITLE
[CALCITE-3357] Trivial null checking in RelSet#addAbstractConverters

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -177,12 +177,12 @@ class RelSet {
         RelTraitDef traitDef = curOtherTrait.getTraitDef();
         RelTrait curRelTrait = subset.getTraitSet().getTrait(traitDef);
 
-        assert curRelTrait.getTraitDef() == traitDef;
-
         if (curRelTrait == null) {
           addAbstractConverter = false;
           break;
         }
+
+        assert curRelTrait.getTraitDef() == traitDef;
 
         boolean canConvert = false;
         boolean needConvert = false;

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -1833,7 +1833,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     // improve and the subset doesn't hear about it. You can end up with
     // a subset with a single rel of cost 99 which thinks its best cost is
     // 100. We think this happens because the back-links to parents are
-    // not established. So, give the subset another change to figure out
+    // not established. So, give the subset another chance to figure out
     // its cost.
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     subset.propagateCostImprovements(this, mq, rel, new HashSet<>());


### PR DESCRIPTION
In current code of `RelSet#addAbstractConverters`, null checking of `curRelTrait` happens after clause of assert `curRelTrait.getTraitDef() == traitDef`;

It makes more sense to adjust the order;
In my understanding, this issue was not found previously for two reasons:
1. `AbstractConverter` is not enabled by default (https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableConvention.java#L65)
2. It rarely happens that two algebra expression operators have identical semantics but different `RelTraitDef`

I found this issue when working on https://issues.apache.org/jira/browse/CALCITE-2970