### PR TITLE
[CALCITE-963] Variable Hoisting for EnumerableRel

### DIFF
--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraToEnumerableConverter.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraToEnumerableConverter.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
@@ -69,7 +70,8 @@ public class CassandraToEnumerableConverter
     return super.computeSelfCost(planner, mq).multiplyBy(.1);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // Generates a call to "query" with the appropriate fields and predicates
     final BlockBuilder list = new BlockBuilder();
     final CassandraRel.Implementor cassandraImplementor = new CassandraRel.Implementor();

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregate.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregate.java
@@ -41,6 +41,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -105,11 +106,12 @@ public class EnumerableAggregate extends Aggregate implements EnumerableRel {
     }
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final JavaTypeFactory typeFactory = implementor.getTypeFactory();
     final BlockBuilder builder = new BlockBuilder();
     final EnumerableRel child = (EnumerableRel) getInput();
-    final Result result = implementor.visitChild(this, 0, child, pref);
+    final Result result = implementor.visitChild(this, 0, child, pref, variables);
     Expression childExp =
         builder.append(
             "child",

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 
@@ -122,10 +123,11 @@ public class EnumerableBatchNestedLoopJoin extends Join implements EnumerableRel
     return pw.item("batchSize", variablesSet.size());
   }
 
-  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final Result leftResult =
-        implementor.visitChild(this, 0, (EnumerableRel) left, pref);
+        implementor.visitChild(this, 0, (EnumerableRel) left, pref, variables);
     final Expression leftExpression =
         builder.append(
             "left", leftResult.block);
@@ -182,7 +184,7 @@ public class EnumerableBatchNestedLoopJoin extends Join implements EnumerableRel
       }
     }
     final Result rightResult =
-        implementor.visitChild(this, 1, (EnumerableRel) right, pref);
+        implementor.visitChild(this, 1, (EnumerableRel) right, pref, variables);
 
     corrBlock.add(rightResult.block);
     for (String c : corrVar) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
@@ -42,6 +42,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexSimplify;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.util.BuiltInMethod;
@@ -107,13 +108,14 @@ public class EnumerableCalc extends Calc implements EnumerableRel {
     return new EnumerableCalc(getCluster(), traitSet, child, program);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final JavaTypeFactory typeFactory = implementor.getTypeFactory();
     final BlockBuilder builder = new BlockBuilder();
     final EnumerableRel child = (EnumerableRel) getInput();
 
     final Result result =
-        implementor.visitChild(this, 0, child, pref);
+        implementor.visitChild(this, 0, child, pref, variables);
 
     final PhysType physType =
         PhysTypeImpl.of(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCollect.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCollect.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Collect;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Collect} in
@@ -40,12 +41,13 @@ public class EnumerableCollect extends Collect implements EnumerableRel {
     return new EnumerableCollect(getCluster(), traitSet, newInput, fieldName);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final EnumerableRel child = (EnumerableRel) getInput();
     // REVIEW zabetak January 7, 2019: Even if we ask the implementor to provide a result
     // where records are represented as arrays (Prefer.ARRAY) this may not be respected.
-    final Result result = implementor.visitChild(this, 0, child, Prefer.ARRAY);
+    final Result result = implementor.visitChild(this, 0, child, Prefer.ARRAY, variables);
     final PhysType physType =
         PhysTypeImpl.of(
             implementor.getTypeFactory(),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelate.java
@@ -30,6 +30,7 @@ import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 
@@ -81,11 +82,11 @@ public class EnumerableCorrelate extends Correlate
         traitSet, left, right, correlationId, requiredColumns, joinType);
   }
 
-  public Result implement(EnumerableRelImplementor implementor,
-      Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final Result leftResult =
-        implementor.visitChild(this, 0, (EnumerableRel) left, pref);
+        implementor.visitChild(this, 0, (EnumerableRel) left, pref, variables);
     Expression leftExpression =
         builder.append(
             "left", leftResult.block);
@@ -111,7 +112,7 @@ public class EnumerableCorrelate extends Correlate
         corrBlock, leftResult.physType);
 
     final Result rightResult =
-        implementor.visitChild(this, 1, (EnumerableRel) right, pref);
+        implementor.visitChild(this, 1, (EnumerableRel) right, pref, variables);
 
     implementor.clearCorrelVariable(getCorrelVariable());
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilter.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilter.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMdDistribution;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Filter} in
  * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention enumerable calling convention}. */
@@ -64,7 +65,8 @@ public class EnumerableFilter
     return new EnumerableFilter(getCluster(), traitSet, input, condition);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // EnumerableCalc is always better
     throw new UnsupportedOperationException();
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableInterpreter.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableInterpreter.java
@@ -28,6 +28,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 
 import java.util.List;
@@ -83,7 +84,8 @@ public class EnumerableInterpreter extends SingleRel
         factor);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final JavaTypeFactory typeFactory = implementor.getTypeFactory();
     final BlockBuilder builder = new BlockBuilder();
     final PhysType physType =

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableIntersect.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableIntersect.java
@@ -24,6 +24,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Intersect;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 
 import java.util.List;
@@ -42,12 +43,13 @@ public class EnumerableIntersect extends Intersect implements EnumerableRel {
     return new EnumerableIntersect(getCluster(), traitSet, inputs, all);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     Expression intersectExp = null;
     for (Ord<RelNode> ord : Ord.zip(inputs)) {
       EnumerableRel input = (EnumerableRel) ord.e;
-      final Result result = implementor.visitChild(this, ord.i, input, pref);
+      final Result result = implementor.visitChild(this, ord.i, input, pref, variables);
       Expression childExp =
           builder.append(
               "child" + ord.i,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMatch.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMatch.java
@@ -41,6 +41,7 @@ import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.runtime.Enumerables;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.sql.SqlMatchFunction;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -103,10 +104,11 @@ public class EnumerableMatch extends Match implements EnumerableRel {
   }
 
   public EnumerableRel.Result implement(EnumerableRelImplementor implementor,
-      EnumerableRel.Prefer pref) {
+      EnumerableRel.Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final EnumerableRel input = (EnumerableRel) getInput();
-    final Result result = implementor.visitChild(this, 0, input, pref);
+    final Result result = implementor.visitChild(this, 0, input, pref, variables);
     final PhysType physType =
         PhysTypeImpl.of(implementor.getTypeFactory(), input.getRowType(),
             result.format);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -38,6 +38,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Pair;
@@ -119,16 +120,17 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
     return planner.getCostFactory().makeCost(d, 0, 0);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     BlockBuilder builder = new BlockBuilder();
     final Result leftResult =
-        implementor.visitChild(this, 0, (EnumerableRel) left, pref);
+        implementor.visitChild(this, 0, (EnumerableRel) left, pref, variables);
     final Expression leftExpression =
         builder.append("left", leftResult.block);
     final ParameterExpression left_ =
         Expressions.parameter(leftResult.physType.getJavaRowType(), "left");
     final Result rightResult =
-        implementor.visitChild(this, 1, (EnumerableRel) right, pref);
+        implementor.visitChild(this, 1, (EnumerableRel) right, pref, variables);
     final Expression rightExpression =
         builder.append("right", rightResult.block);
     final ParameterExpression right_ =

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMinus.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMinus.java
@@ -24,6 +24,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Minus;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 
 import java.util.List;
@@ -42,12 +43,13 @@ public class EnumerableMinus extends Minus implements EnumerableRel {
     return new EnumerableMinus(getCluster(), traitSet, inputs, all);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     Expression minusExp = null;
     for (Ord<RelNode> ord : Ord.zip(inputs)) {
       EnumerableRel input = (EnumerableRel) ord.e;
-      final Result result = implementor.visitChild(this, ord.i, input, pref);
+      final Result result = implementor.visitChild(this, ord.i, input, pref, variables);
       Expression childExp =
           builder.append(
               "child" + ord.i,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
@@ -32,6 +32,7 @@ import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 
 import com.google.common.collect.ImmutableList;
@@ -109,14 +110,15 @@ public class EnumerableNestedLoopJoin extends Join implements EnumerableRel {
     return planner.getCostFactory().makeCost(rowCount, 0, 0);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final Result leftResult =
-        implementor.visitChild(this, 0, (EnumerableRel) left, pref);
+        implementor.visitChild(this, 0, (EnumerableRel) left, pref, variables);
     Expression leftExpression =
         builder.append("left", leftResult.block);
     final Result rightResult =
-        implementor.visitChild(this, 1, (EnumerableRel) right, pref);
+        implementor.visitChild(this, 1, (EnumerableRel) right, pref, variables);
     Expression rightExpression =
         builder.append("right", rightResult.block);
     final PhysType physType =

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.Util;
 
@@ -91,7 +92,8 @@ public class EnumerableProject extends Project implements EnumerableRel {
         projects, rowType);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // EnumerableCalcRel is always better
     throw new UnsupportedOperationException();
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.java
@@ -43,6 +43,7 @@ import org.apache.calcite.linq4j.tree.UnaryExpression;
 import org.apache.calcite.linq4j.tree.VisitorImpl;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.runtime.Bindable;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.util.BuiltInMethod;
@@ -92,16 +93,17 @@ public class EnumerableRelImplementor extends JavaRelImplementor {
       EnumerableRel parent,
       int ordinal,
       EnumerableRel child,
-      EnumerableRel.Prefer prefer) {
+      EnumerableRel.Prefer prefer,
+      HoistedVariables variables) {
     if (parent != null) {
       assert child == parent.getInputs().get(ordinal);
     }
-    return child.implement(this, prefer);
+    return child.implement(this, prefer, variables);
   }
 
   public ClassDeclaration implementRoot(EnumerableRel rootRel,
-      EnumerableRel.Prefer prefer) {
-    EnumerableRel.Result result = rootRel.implement(this, prefer);
+      EnumerableRel.Prefer prefer, HoistedVariables variables) {
+    EnumerableRel.Result result = rootRel.implement(this, prefer, variables);
     switch (prefer) {
     case ARRAY:
       if (result.physType.getFormat() == JavaRowFormat.ARRAY
@@ -149,7 +151,7 @@ public class EnumerableRelImplementor extends JavaRelImplementor {
             Modifier.PUBLIC,
             Enumerable.class,
             BuiltInMethod.BINDABLE_BIND.method.getName(),
-            Expressions.list(DataContext.ROOT),
+            Expressions.list(DataContext.ROOT, HoistedVariables.VARIABLES),
             block));
     memberDeclarations.add(
         Expressions.methodDecl(Modifier.PUBLIC, Class.class,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnion.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnion.java
@@ -24,6 +24,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.RepeatUnion;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 
 import java.util.List;
@@ -52,7 +53,8 @@ public class EnumerableRepeatUnion extends RepeatUnion implements EnumerableRel 
         inputs.get(0), inputs.get(1), all, iterationLimit);
   }
 
-  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     if (!all) {
       throw new UnsupportedOperationException(
           "Only EnumerableRepeatUnion ALL is supported");
@@ -64,8 +66,9 @@ public class EnumerableRepeatUnion extends RepeatUnion implements EnumerableRel 
     RelNode seed = getSeedRel();
     RelNode iteration = getIterativeRel();
 
-    Result seedResult = implementor.visitChild(this, 0, (EnumerableRel) seed, pref);
-    Result iterationResult = implementor.visitChild(this, 1, (EnumerableRel) iteration, pref);
+    Result seedResult = implementor.visitChild(this, 0, (EnumerableRel) seed, pref, variables);
+    Result iterationResult = implementor.visitChild(this, 1, (EnumerableRel) iteration, pref,
+        variables);
 
     Expression seedExp = builder.append("seed", seedResult.block);
     Expression iterativeExp = builder.append("iteration", iterationResult.block);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSort.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSort.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
 
@@ -64,10 +65,12 @@ public class EnumerableSort extends Sort implements EnumerableRel {
         offset, fetch);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final EnumerableRel child = (EnumerableRel) getInput();
-    final Result result = implementor.visitChild(this, 0, child, pref);
+    final Result result = implementor.visitChild(this, 0, child, pref,
+        variables);
     final PhysType physType =
         PhysTypeImpl.of(
             implementor.getTypeFactory(),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableFunctionScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableFunctionScan.java
@@ -27,6 +27,7 @@ import org.apache.calcite.rel.metadata.RelColumnMapping;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.schema.QueryableTable;
 import org.apache.calcite.schema.impl.TableFunctionImpl;
 import org.apache.calcite.sql.validate.SqlUserDefinedTableFunction;
@@ -60,7 +61,8 @@ public class EnumerableTableFunctionScan extends TableFunctionScan
         elementType, rowType, rexCall, columnMappings);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     BlockBuilder bb = new BlockBuilder();
      // Non-array user-specified types are not supported yet
     final JavaRowFormat format;

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModify.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModify.java
@@ -29,6 +29,7 @@ import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.schema.ModifiableTable;
 import org.apache.calcite.util.BuiltInMethod;
 
@@ -70,10 +71,11 @@ public class EnumerableTableModify extends TableModify
         isFlattened());
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final Result result = implementor.visitChild(
-        this, 0, (EnumerableRel) getInput(), pref);
+        this, 0, (EnumerableRel) getInput(), pref, variables);
     Expression childExp =
         builder.append(
             "child", result.block);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.schema.FilterableTable;
 import org.apache.calcite.schema.ProjectableFilterableTable;
 import org.apache.calcite.schema.QueryableTable;
@@ -234,7 +235,8 @@ public class EnumerableTableScan
     return new EnumerableTableScan(getCluster(), traitSet, table, elementType);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // Note that representation is ARRAY. This assumes that the table
     // returns a Object[] for each record. Actually a Table<T> can
     // return any type T. And, if it is a JdbcTable, we'd like to be

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableSpool.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableSpool.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Spool;
 import org.apache.calcite.rel.core.TableSpool;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.schema.ModifiableTable;
 import org.apache.calcite.util.BuiltInMethod;
 
@@ -62,7 +63,8 @@ public class EnumerableTableSpool extends TableSpool implements EnumerableRel {
     return new EnumerableTableSpool(cluster, traitSet, input, readType, writeType, table);
   }
 
-  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // TODO for the moment only LAZY read & write is supported
     if (readType != Type.LAZY || writeType != Type.LAZY) {
       throw new UnsupportedOperationException(
@@ -75,7 +77,7 @@ public class EnumerableTableSpool extends TableSpool implements EnumerableRel {
     BlockBuilder builder = new BlockBuilder();
 
     RelNode input = getInput();
-    Result inputResult = implementor.visitChild(this, 0, (EnumerableRel) input, pref);
+    Result inputResult = implementor.visitChild(this, 0, (EnumerableRel) input, pref, variables);
 
     String tableName = table.getQualifiedName().get(table.getQualifiedName().size() - 1);
     Expression tableExp = Expressions.convert_(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUncollect.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUncollect.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Uncollect;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.SqlFunctions.FlatProductInputType;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.util.BuiltInMethod;
@@ -75,10 +76,11 @@ public class EnumerableUncollect extends Uncollect implements EnumerableRel {
         withOrdinality);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     final EnumerableRel child = (EnumerableRel) getInput();
-    final Result result = implementor.visitChild(this, 0, child, pref);
+    final Result result = implementor.visitChild(this, 0, child, pref, variables);
     final PhysType physType =
         PhysTypeImpl.of(
             implementor.getTypeFactory(),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnion.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnion.java
@@ -24,6 +24,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 
 import java.util.List;
@@ -41,12 +42,13 @@ public class EnumerableUnion extends Union implements EnumerableRel {
     return new EnumerableUnion(getCluster(), traitSet, inputs, all);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder builder = new BlockBuilder();
     Expression unionExp = null;
     for (Ord<RelNode> ord : Ord.zip(inputs)) {
       EnumerableRel input = (EnumerableRel) ord.e;
-      final Result result = implementor.visitChild(this, ord.i, input, pref);
+      final Result result = implementor.visitChild(this, ord.i, input, pref, variables);
       Expression childExp =
           builder.append(
               "child" + ord.i,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableValues.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableValues.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
 
@@ -70,7 +71,8 @@ public class EnumerableValues extends Values implements EnumerableRel {
     return create(getCluster(), rowType, tuples);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
 /*
           return Linq4j.asEnumerable(
               new Object[][] {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
@@ -46,6 +46,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexWindowBound;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.SortedMultiMap;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.validate.SqlConformance;
@@ -159,11 +160,12 @@ public class EnumerableWindow extends Window implements EnumerableRel {
     // source = Linq4j.asEnumerable(list);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final JavaTypeFactory typeFactory = implementor.getTypeFactory();
     final EnumerableRel child = (EnumerableRel) getInput();
     final BlockBuilder builder = new BlockBuilder();
-    final Result result = implementor.visitChild(this, 0, child, pref);
+    final Result result = implementor.visitChild(this, 0, child, pref, variables);
     Expression source_ = builder.append("source", result.block);
 
     final List<Expression> translatedConstants =

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverter.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverter.java
@@ -40,6 +40,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.schema.Schemas;
@@ -82,7 +83,8 @@ public class JdbcToEnumerableConverter
     return super.computeSelfCost(planner, mq).multiplyBy(.1);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // Generate:
     //   ResultSetEnumerable.of(schema.getDataSource(), "select ...")
     final BlockBuilder builder0 = new BlockBuilder(false);

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -65,6 +65,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.schema.FilterableTable;
 import org.apache.calcite.schema.ProjectableFilterableTable;
 import org.apache.calcite.schema.ScannableTable;
@@ -254,7 +255,7 @@ public class Bindables {
           || table.unwrap(ProjectableFilterableTable.class) != null;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       if (table.unwrap(ProjectableFilterableTable.class) != null) {
         return table.unwrap(ProjectableFilterableTable.class).scan(dataContext,
                 filters, projects.toIntArray());
@@ -325,7 +326,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -383,7 +384,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -439,7 +440,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -509,7 +510,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -561,7 +562,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -587,7 +588,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -673,7 +674,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -735,7 +736,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 
@@ -800,7 +801,7 @@ public class Bindables {
       return Object[].class;
     }
 
-    public Enumerable<Object[]> bind(DataContext dataContext) {
+    public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
       return help(dataContext, this);
     }
 

--- a/core/src/main/java/org/apache/calcite/interpreter/InterpretableConverter.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/InterpretableConverter.java
@@ -24,6 +24,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.runtime.ArrayBindable;
+import org.apache.calcite.runtime.HoistedVariables;
 
 import java.util.List;
 
@@ -47,7 +48,7 @@ public class InterpretableConverter extends ConverterImpl
     return Object[].class;
   }
 
-  public Enumerable<Object[]> bind(DataContext dataContext) {
+  public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
     return new Interpreter(dataContext, getInput());
   }
 }

--- a/core/src/main/java/org/apache/calcite/interpreter/Interpreters.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Interpreters.java
@@ -20,6 +20,7 @@ import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.runtime.ArrayBindable;
+import org.apache.calcite.runtime.HoistedVariables;
 
 /**
  * Utilities relating to {@link org.apache.calcite.interpreter.Interpreter}
@@ -36,7 +37,7 @@ public class Interpreters {
       return (ArrayBindable) rel;
     }
     return new ArrayBindable() {
-      public Enumerable<Object[]> bind(DataContext dataContext) {
+      public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables v) {
         return new Interpreter(dataContext, rel);
       }
 

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -41,6 +41,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.runtime.FlatLists;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
@@ -202,7 +203,7 @@ public class CalciteMetaImpl extends MetaImpl {
           new CalcitePrepare.CalciteSignature<Object>("",
               ImmutableList.of(), internalParameters, null,
               columns, cursorFactory, null, ImmutableList.of(), -1,
-              null, Meta.StatementType.SELECT) {
+              null, Meta.StatementType.SELECT, new HoistedVariables()) {
             @Override public Enumerable<Object> enumerable(
                 DataContext dataContext) {
               return Linq4j.asEnumerable(firstFrame.rows);

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteResultSet.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteResultSet.java
@@ -26,6 +26,7 @@ import org.apache.calcite.avatica.util.Cursor;
 import org.apache.calcite.linq4j.Enumerator;
 import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.runtime.ArrayEnumeratorCursor;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.ObjectEnumeratorCursor;
 
 import com.google.common.collect.ImmutableList;
@@ -81,7 +82,8 @@ public class CalciteResultSet extends AvaticaResultSet {
             signature.parameters, signature.internalParameters,
             signature.rowType, columnMetaDataList, Meta.CursorFactory.ARRAY,
             signature.rootSchema, ImmutableList.of(), -1, null,
-            statement.getStatementType());
+            // @TODO wrong variables.
+            statement.getStatementType(), new HoistedVariables());
     ResultSetMetaData subResultSetMetaData =
         new AvaticaResultSetMetaData(statement, null, newSignature);
     final CalciteResultSet resultSet =

--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -42,6 +42,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexExecutorImpl;
 import org.apache.calcite.runtime.Bindable;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.runtime.Typed;
 import org.apache.calcite.schema.ColumnStrategy;
@@ -572,6 +573,13 @@ public abstract class Prepare {
      * @return producer of rows resulting from execution
      */
     Bindable getBindable(Meta.CursorFactory cursorFactory);
+
+    /**
+     * Returns the variables to used on {@link Bindable#bind(DataContext, HoistedVariables) bind}
+     */
+    default HoistedVariables getVariables() {
+      return new HoistedVariables();
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/runtime/Bindable.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Bindable.java
@@ -20,7 +20,8 @@ import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.Enumerable;
 
 /**
- * Statement that can be bound to a {@link DataContext} and then executed.
+ * Statement that can be bound to a {@link DataContext} and a set of {@link HoistedVariables} and
+ * then executed.
  *
  * @param <T> Element type of the resulting enumerable
  */
@@ -31,9 +32,10 @@ public interface Bindable<T> {
    * environment (usually schemas).
    *
    * @param dataContext Environment that provides tables
+   * @param hoisted The variables hoisted from the EnumerableRels
    * @return Enumerable over rows
    */
-  Enumerable<T> bind(DataContext dataContext);
+  Enumerable<T> bind(DataContext dataContext, HoistedVariables hoisted);
 }
 
 // End Bindable.java

--- a/core/src/main/java/org/apache/calcite/runtime/HoistedVariables.java
+++ b/core/src/main/java/org/apache/calcite/runtime/HoistedVariables.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.runtime;
+
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.ParameterExpression;
+
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * HoistedVariables is a container for runtime variables populated by
+ * {@link org.apache.calcite.adapter.enumerable.EnumerableRel} implementations.
+ */
+public class HoistedVariables {
+  private final List<VariableSlot> indexedVariables = new ArrayList<>();
+
+  public static final ParameterExpression VARIABLES = Expressions.parameter(Modifier.FINAL,
+      HoistedVariables.class, "variables");
+
+  /**
+   * Acquires an unbound {@link VariableSlot} that can be later referenced in generated code.
+   *
+   * @param variableName  a variable name used only for debugging -- it is not required to be unique
+   *
+   * @return reserved position in the collection of variables
+   */
+  public Integer registerVariable(final String variableName) {
+    indexedVariables.add(new VariableSlot(variableName));
+    return Integer.valueOf(indexedVariables.size());
+  }
+
+  /**
+   * Bounds the variable at variableIndex to the provided value.
+   *
+   * @param variableIndex the reserved position acquired from {@link #registeredVariable(String)}
+   * @param value the value to store. Can be any Object and can be null
+   *
+   * @throws {@link IllegalArgumentException} when variableIndex hasn't been reserved.
+   */
+  public void setVariable(Integer variableIndex, Object value) {
+    if (variableIndex > indexedVariables.size()) {
+      throw new IllegalArgumentException(
+          String.format(
+              Locale.ENGLISH,
+              "No variable at index %d", variableIndex));
+    }
+    indexedVariables.get(variableIndex - 1)
+      .setVariable(value);
+  }
+
+  /**
+   * Fetches the bound variable at the provided variableIndex slot.
+   *
+   * @param variableIndex the reserved position returned from {@link #registeredVariable(String)}
+   *
+   * @return the bound variable for this slot that was set by {@link #setVariable}.
+   * @throws {@link IllegalArgumentException} when variableIndex has not been reserved
+   * @throws {@link IllegalArgumentException} when the variable at variableIndex hasn't been set.
+   */
+  public Object getVariable(Integer variableIndex) {
+    if (variableIndex > indexedVariables.size()) {
+      throw new IllegalArgumentException(
+          String.format(
+              Locale.ENGLISH,
+              "No variable at index %d", variableIndex));
+    }
+    return indexedVariables.get(variableIndex - 1)
+      .getVariable();
+  }
+
+  /**
+   * Runtime check to ensure all the variables that have been registered have also been set. A
+   * A variable is reserved by calling {@link #registerVariable(String)} and a variable is later set
+   * by calling {@link #setVariable(Integer, Object)}.
+   *
+   * @return returns true when all reserved variables have been set
+   */
+  public boolean allVariablesBound() {
+    return this.indexedVariables
+      .stream()
+      .allMatch(VariableSlot::isSet);
+  }
+
+  /**
+   * A reserved slot in the variable pool that is expected to be filled at bind time.
+   */
+  private static class VariableSlot {
+    private Object value;
+    private boolean variableSet;
+    private String variableName;
+
+    VariableSlot(final String variableName) {
+      this.value = null;
+      this.variableName = variableName;
+    }
+
+    public void setVariable(final Object v) {
+      // @TODO: if is already variableSet true, throw an error.
+      this.value = v;
+      variableSet = true;
+    }
+
+    public boolean isSet() {
+      return variableSet;
+    }
+
+    public Object getVariable() {
+      if (!variableSet) {
+        throw new IllegalArgumentException(
+            String.format(
+                Locale.ENGLISH, "%s was declared but never set", variableName));
+      }
+      return value;
+    }
+  }
+}
+// End HoistedVariables.java

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -81,6 +81,7 @@ import org.apache.calcite.runtime.BinarySearch;
 import org.apache.calcite.runtime.Bindable;
 import org.apache.calcite.runtime.Enumerables;
 import org.apache.calcite.runtime.FlatLists;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.JsonFunctions;
 import org.apache.calcite.runtime.Matcher;
 import org.apache.calcite.runtime.Pattern;
@@ -269,7 +270,7 @@ public enum BuiltInMethod {
   BI_PREDICATE_TEST(BiPredicate.class, "test", Object.class, Object.class),
   CONSUMER_ACCEPT(Consumer.class, "accept", Object.class),
   TYPED_GET_ELEMENT_TYPE(ArrayBindable.class, "getElementType"),
-  BINDABLE_BIND(Bindable.class, "bind", DataContext.class),
+  BINDABLE_BIND(Bindable.class, "bind", DataContext.class, HoistedVariables.class),
   RESULT_SET_GET_DATE2(ResultSet.class, "getDate", int.class, Calendar.class),
   RESULT_SET_GET_TIME2(ResultSet.class, "getTime", int.class, Calendar.class),
   RESULT_SET_GET_TIMESTAMP2(ResultSet.class, "getTimestamp", int.class,
@@ -577,7 +578,8 @@ public enum BuiltInMethod {
   AGG_LAMBDA_FACTORY_ACC_RESULT_SELECTOR(AggregateLambdaFactory.class,
       "resultSelector", Function2.class),
   AGG_LAMBDA_FACTORY_ACC_SINGLE_GROUP_RESULT_SELECTOR(AggregateLambdaFactory.class,
-      "singleGroupResultSelector", Function1.class);
+      "singleGroupResultSelector", Function1.class),
+  HOISTED_VARIABLE_GET(HoistedVariables.class, "getVariable", Integer.class);
 
   public final Method method;
   public final Constructor constructor;

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
@@ -39,6 +39,7 @@ import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.HashMultimap;
@@ -542,7 +543,7 @@ public class VolcanoPlannerTraitTest {
     }
 
     @Override public Result implement(EnumerableRelImplementor implementor,
-        Prefer pref) {
+        Prefer pref, HoistedVariables variables) {
       return null;
     }
   }
@@ -786,7 +787,7 @@ public class VolcanoPlannerTraitTest {
     }
 
     @Override public Result implement(EnumerableRelImplementor implementor,
-        Prefer pref) {
+        Prefer pref, HoistedVariables variables) {
       return null;
     }
   }

--- a/core/src/test/java/org/apache/calcite/runtime/HoistedVariablesTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/HoistedVariablesTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.runtime;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class to ensure the the behavior of {@link HoistedVariables}
+ */
+public class HoistedVariablesTest {
+  @Test
+  public void registerAndSetSingleVariable() {
+    HoistedVariables v = new HoistedVariables();
+
+    // Register the variable when generating the java code.
+    // This should happen in EnumerableRel's implement() method.
+    final Integer variableSlot = v.registerVariable("testVariable");
+
+    assertFalse("testVariable isn't bound yet, allVariablesBound should return false",
+        v.allVariablesBound());
+
+    // Set the variable after the code is generated but prior to it being run.
+    // This should happen in EnumerableRel's hoistedVariables() method.
+    final String variableValue = "testing value";
+    v.setVariable(variableSlot, variableValue);
+    assertTrue("testVariable is now bound, allVariablesBound should be true",
+        v.allVariablesBound());
+
+    // Finally, get the variable emulating what the compiled code does at runtime.
+    // This should happen while executing Bindable's bind() method.
+    assertEquals("Fetching variable out of hoistedVariables should return what was bound",
+        variableValue, v.getVariable(variableSlot));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void fetchVariableThatIsntRegistered() {
+    HoistedVariables v = new HoistedVariables();
+
+    final Integer variableSlot = v.registerVariable("testVariable");
+    final String variableValue = "testing value";
+    v.setVariable(variableSlot, variableValue);
+
+    v.getVariable(Integer.valueOf(178));
+  }
+}
+// End HoistedVariablesTest.java

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -52,6 +52,7 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.sql.SqlKind;
@@ -622,7 +623,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
     return Object[].class;
   }
 
-  @Override public Enumerable<Object[]> bind(DataContext dataContext) {
+  @Override public Enumerable<Object[]> bind(DataContext dataContext, HoistedVariables variables) {
     return table.unwrap(ScannableTable.class).scan(dataContext);
   }
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverter.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchToEnumerableConverter.java
@@ -34,6 +34,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
 
@@ -58,7 +59,8 @@ public class ElasticsearchToEnumerableConverter extends ConverterImpl implements
     return super.computeSelfCost(planner, mq).multiplyBy(.1);
   }
 
-  @Override public Result implement(EnumerableRelImplementor relImplementor, Prefer prefer) {
+  @Override public Result implement(EnumerableRelImplementor relImplementor, Prefer prefer,
+      HoistedVariables variables) {
     final BlockBuilder block = new BlockBuilder();
     final ElasticsearchRel.Implementor implementor = new ElasticsearchRel.Implementor();
     implementor.visitChild(0, getInput());

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTableScan.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTableScan.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.runtime.HoistedVariables;
 
 import java.util.List;
 
@@ -95,7 +96,8 @@ public class CsvTableScan extends TableScan implements EnumerableRel {
             / ((double) table.getRowType().getFieldCount() + 2D));
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     PhysType physType =
         PhysTypeImpl.of(
             implementor.getTypeFactory(),

--- a/file/src/main/java/org/apache/calcite/adapter/file/FileTableScan.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/FileTableScan.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.runtime.HoistedVariables;
 
 import java.util.List;
 
@@ -76,7 +77,8 @@ class FileTableScan extends TableScan implements EnumerableRel {
     return builder.build();
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     PhysType physType =
         PhysTypeImpl.of(
             implementor.getTypeFactory(),

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeToEnumerableConverter.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeToEnumerableConverter.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
 
@@ -83,7 +84,8 @@ public class GeodeToEnumerableConverter extends ConverterImpl implements Enumera
    *
    * @param implementor GeodeImplementContext
    */
-  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  @Override public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
 
     // travers all relations form this to the scan leaf
     final GeodeImplementContext geodeImplementContext = new GeodeImplementContext();

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoToEnumerableConverter.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoToEnumerableConverter.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
@@ -67,7 +68,8 @@ public class MongoToEnumerableConverter
     return super.computeSelfCost(planner, mq).multiplyBy(.1);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // Generates a call to "find" or "aggregate", depending upon whether
     // an aggregate is present.
     //

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigToEnumerableConverter.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigToEnumerableConverter.java
@@ -28,6 +28,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.BuiltInMethod;
 
@@ -65,7 +66,8 @@ public class PigToEnumerableConverter
    * store results in a predefined file so they can be read here and returned as
    * a {@code Result} object.
    */
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     final BlockBuilder list = new BlockBuilder();
     final PhysType physType =
         PhysTypeImpl.of(implementor.getTypeFactory(), rowType,

--- a/spark/src/main/java/org/apache/calcite/adapter/spark/SparkToEnumerableConverter.java
+++ b/spark/src/main/java/org/apache/calcite/adapter/spark/SparkToEnumerableConverter.java
@@ -34,6 +34,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.sql.validate.SqlConformance;
 
 import java.util.List;
@@ -66,7 +67,8 @@ public class SparkToEnumerableConverter
     return super.computeSelfCost(planner, mq).multiplyBy(.01);
   }
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     // Generate:
     //   RDD rdd = ...;
     //   return SparkRuntime.asEnumerable(rdd);

--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/SplunkTableScan.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/SplunkTableScan.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.Util;
 
@@ -118,7 +119,8 @@ public class SplunkTableScan
           String.class,
           List.class);
 
-  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref,
+      HoistedVariables variables) {
     Map map = ImmutableMap.builder()
         .put("search", search)
         .put("earliest", Util.first(earliest, ""))

--- a/ubenchmark/src/main/java/org/apache/calcite/adapter/enumerable/CodeGenerationBenchmark.java
+++ b/ubenchmark/src/main/java/org/apache/calcite/adapter/enumerable/CodeGenerationBenchmark.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.ArrayBindable;
 import org.apache.calcite.runtime.Bindable;
+import org.apache.calcite.runtime.HoistedVariables;
 import org.apache.calcite.runtime.Typed;
 import org.apache.calcite.runtime.Utilities;
 import org.apache.calcite.tools.RelBuilder;
@@ -180,7 +181,8 @@ public class CodeGenerationBenchmark {
 
         EnumerableRelImplementor relImplementor =
             new EnumerableRelImplementor(plan.getCluster().getRexBuilder(), new HashMap<>());
-        info.classExpr = relImplementor.implementRoot(plan, EnumerableRel.Prefer.ARRAY);
+        info.classExpr = relImplementor.implementRoot(plan, EnumerableRel.Prefer.ARRAY,
+            new HoistedVariables());
         info.javaCode =
             Expressions.toString(info.classExpr.memberDeclarations, "\n", false);
 


### PR DESCRIPTION
Summary:
Increase `BINDABLE_CACHE` hit rate by hoisted variables into the
compiled class and late binding variables -- at runtime. Allowing for
similar queries to leverage existing compiled classes.