### PR TITLE
[CALCITE-3360] SqlValidator throws NEP for unregistered function with…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
@@ -271,18 +271,20 @@ public class SqlFunction extends SqlOperator {
         return validator.deriveConstructorType(scope, call, this, function,
             argTypes);
       }
-      if (function == null && validator.isTypeCoercionEnabled()) {
-        // try again if implicit type coercion is allowed.
+      if (function == null) {
         boolean changed = false;
-        function = (SqlFunction) SqlUtil.lookupRoutine(validator.getOperatorTable(),
-            getNameAsId(), argTypes, argNames, getFunctionType(), SqlSyntax.FUNCTION, getKind(),
-            validator.getCatalogReader().nameMatcher(),
-            true);
-        // try to coerce the function arguments to the declared sql type name.
-        // if we succeed, the arguments would be wrapped with CAST operator.
-        if (function != null) {
-          TypeCoercion typeCoercion = validator.getTypeCoercion();
-          changed = typeCoercion.userDefinedFunctionCoercion(scope, call, function);
+        if (validator.isTypeCoercionEnabled()) {
+          // try again if implicit type coercion is allowed.
+          function = (SqlFunction) SqlUtil.lookupRoutine(validator.getOperatorTable(),
+              getNameAsId(), argTypes, argNames, getFunctionType(), SqlSyntax.FUNCTION, getKind(),
+              validator.getCatalogReader().nameMatcher(),
+              true);
+          // try to coerce the function arguments to the declared sql type name.
+          // if we succeed, the arguments would be wrapped with CAST operator.
+          if (function != null) {
+            TypeCoercion typeCoercion = validator.getTypeCoercion();
+            changed = typeCoercion.userDefinedFunctionCoercion(scope, call, function);
+          }
         }
         if (!changed) {
           throw validator.handleUnresolvedFunction(call, this, argTypes,

--- a/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
@@ -40,7 +40,7 @@ public abstract class SqlTypeNameSpec {
    * @param name Name of the type.
    * @param pos  Parser position, must not be null.
    */
-  SqlTypeNameSpec(SqlIdentifier name, SqlParserPos pos) {
+  public SqlTypeNameSpec(SqlIdentifier name, SqlParserPos pos) {
     this.typeName = name;
     this.pos = pos;
   }


### PR DESCRIPTION
…out implicit type coercion

SqlValidator should report the function signature for unregistered UDFs
when implicit type coercion is turned off.

We also change SqlTypeNameSpec constructor to public so that any other
engine can extend it and implement their custom data type.(Because it is
too small change, i just merge it into this one)