### PR TITLE
[CALCITE-3365] Don't require use of JdbcSchema in QuerySqlStatisticProvider

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -100,6 +100,16 @@ public class JdbcTable extends AbstractQueryableTable
     return jdbcTableType;
   }
 
+  @Override public <C> C unwrap(Class<C> aClass) {
+    if (aClass.isInstance(jdbcSchema.getDataSource())) {
+      return aClass.cast(jdbcSchema.getDataSource());
+    } else if (aClass.isInstance(jdbcSchema.dialect)) {
+      return aClass.cast(jdbcSchema.dialect);
+    } else {
+      return super.unwrap(aClass);
+    }
+  }
+
   public RelDataType getRowType(RelDataTypeFactory typeFactory) {
     if (protoRowType == null) {
       try {

--- a/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
@@ -271,18 +271,20 @@ public class SqlFunction extends SqlOperator {
         return validator.deriveConstructorType(scope, call, this, function,
             argTypes);
       }
-      if (function == null && validator.isTypeCoercionEnabled()) {
-        // try again if implicit type coercion is allowed.
+      if (function == null) {
         boolean changed = false;
-        function = (SqlFunction) SqlUtil.lookupRoutine(validator.getOperatorTable(),
-            getNameAsId(), argTypes, argNames, getFunctionType(), SqlSyntax.FUNCTION, getKind(),
-            validator.getCatalogReader().nameMatcher(),
-            true);
-        // try to coerce the function arguments to the declared sql type name.
-        // if we succeed, the arguments would be wrapped with CAST operator.
-        if (function != null) {
-          TypeCoercion typeCoercion = validator.getTypeCoercion();
-          changed = typeCoercion.userDefinedFunctionCoercion(scope, call, function);
+        if (validator.isTypeCoercionEnabled()) {
+          // try again if implicit type coercion is allowed.
+          function = (SqlFunction) SqlUtil.lookupRoutine(validator.getOperatorTable(),
+              getNameAsId(), argTypes, argNames, getFunctionType(), SqlSyntax.FUNCTION, getKind(),
+              validator.getCatalogReader().nameMatcher(),
+              true);
+          // try to coerce the function arguments to the declared sql type name.
+          // if we succeed, the arguments would be wrapped with CAST operator.
+          if (function != null) {
+            TypeCoercion typeCoercion = validator.getTypeCoercion();
+            changed = typeCoercion.userDefinedFunctionCoercion(scope, call, function);
+          }
         }
         if (!changed) {
           throw validator.handleUnresolvedFunction(call, this, argTypes,

--- a/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
@@ -40,7 +40,7 @@ public abstract class SqlTypeNameSpec {
    * @param name Name of the type.
    * @param pos  Parser position, must not be null.
    */
-  SqlTypeNameSpec(SqlIdentifier name, SqlParserPos pos) {
+  public SqlTypeNameSpec(SqlIdentifier name, SqlParserPos pos) {
     this.typeName = name;
     this.pos = pos;
   }

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -160,7 +160,7 @@ public class RelBuilder {
   private final RexSimplify simplifier;
   private final Config config;
 
-  protected RelBuilder(Context context, RelOptCluster cluster,
+  public RelBuilder(Context context, RelOptCluster cluster,
       RelOptSchema relOptSchema) {
     this.cluster = cluster;
     this.relOptSchema = relOptSchema;


### PR DESCRIPTION
We're trying to pass in schema data manually to process queries for BigQuery, but that caused problems in the `QuerySqlStatisticProvider`, since we do not have a `JdbcSchema` to pass in. So, this refactors `QuerySqlStatisticProvider` to grab the `dialect` and `dataSource` using `unwrap` instead, so that any schema that implements `unwrap` methods for these types will work with `QuerySqlStatisticProvider`.

I had to make the constructor public in `RelBuilder` to make this work, but @julianhyde said he would take a look so we don't need to do that!