### PR TITLE
[CALCITE-3374] Error format check result for explain plan as json

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlExplain.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlExplain.java
@@ -172,7 +172,7 @@ public class SqlExplain extends SqlCall {
    * Returns whether result is to be in JSON format.
    */
   public boolean isJson() {
-    return getFormat() == SqlExplainFormat.XML;
+    return getFormat() == SqlExplainFormat.JSON;
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -20,6 +20,7 @@ import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.avatica.util.Quoting;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlExplain;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
@@ -3533,6 +3534,13 @@ public class SqlParserTest {
     sql("explain plan with type for (values (true))")
         .ok("EXPLAIN PLAN INCLUDING ATTRIBUTES WITH TYPE FOR\n"
             + "(VALUES (ROW(TRUE)))");
+  }
+
+  @Test public void testExplainJsonFormat() {
+    final String sql = "explain plan as json for select * from emps";
+    TesterImpl tester = (TesterImpl) getTester();
+    SqlExplain sqlExplain = (SqlExplain) tester.parseStmtsAndHandleEx(sql).get(0);
+    assertEquals(sqlExplain.isJson(), true);
   }
 
   @Test public void testDescribeSchema() {


### PR DESCRIPTION
The format check result of explain plan as json is incorrect.
This PR tries to fix it.