### PR TITLE
[CALCITE-3377] HSQLDB is case insensitive

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/HsqldbSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HsqldbSqlDialect.java
@@ -35,7 +35,8 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 public class HsqldbSqlDialect extends SqlDialect {
   public static final SqlDialect DEFAULT =
       new HsqldbSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.HSQLDB));
+          .withDatabaseProduct(DatabaseProduct.HSQLDB)
+          .withCaseSensitive(false));
 
   /** Creates an HsqldbSqlDialect. */
   public HsqldbSqlDialect(Context context) {


### PR DESCRIPTION
This is necessary so the validator doesn't error on case mismatches for unquoted identifiers.

cc @julianhyde 

I'm not sure the best place to add a test for this either, perhaps somewhere in `SqlValidatorTest.java`?