### PR TITLE
[CALCITE-3378] AssertionError for checking RexNode implify

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -1060,6 +1060,9 @@ public class RexLiteral extends RexNode {
       }
       break;
     }
+    if (clazz == String.class) {
+      return clazz.cast(value.toString());
+    }
     throw new AssertionError("cannot convert " + typeName
         + " literal to " + clazz);
   }


### PR DESCRIPTION
For RexLiteral with some value type, eg DECIMAL, getting value as string is not supported.
Sometimes when checking implify for RexNodes, we may need to do this, and then got AssertionError, see [CALCITE-3378](https://issues.apache.org/jira/browse/CALCITE-3378) for full stack trace.

This PR tries to add support for getting value as string for RexLiteral.