### PR TITLE
[CALCITE-3389] Test can fail if HashSet iterates in a different order

### DIFF
--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
@@ -1536,7 +1536,7 @@ public class ExpressionTest {
   }
 
   @Test public void testTenElementsSetLiteral() throws Exception {
-    Set set = new HashSet(); // for consistent output
+    Set set = new LinkedHashSet(); // for consistent output
     for (int i = 0; i < 10; i++) {
       set.add(i);
     }


### PR DESCRIPTION
Tests can fail if the iteration order of HashSet changes. 

This PR proposes to modify HashSet to LinkedHashMap for a deterministic order (insertion order, which is also what test expects)