### PR TITLE
[CALCITE-3396] Materialization matching succeeds when query and view …

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
@@ -199,7 +199,8 @@ public class MaterializedViewSubstitutionVisitor extends SubstitutionVisitor {
       final MutableUnion target = (MutableUnion) call.target;
       List<MutableRel> queryInputs = query.getInputs();
       List<MutableRel> targetInputs = target.getInputs();
-      if (queryInputs.size() == targetInputs.size()) {
+      if (query.isAll() == target.isAll()
+          && queryInputs.size() == targetInputs.size()) {
         for (MutableRel rel: queryInputs) {
           int index = targetInputs.indexOf(rel);
           if (index == -1) {

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -2468,19 +2468,19 @@ public class MaterializationTest {
     checkMaterialize(sql, sql);
   }
 
-  @Test public void testUnionToUnion0() {
+  @Test public void testUnionAllToUnionAll() {
     String sql0 = "select * from \"emps\" where \"empid\" < 300";
     String sql1 = "select * from \"emps\" where \"empid\" > 200";
     checkMaterialize(sql0 + " union all " + sql1, sql1 + " union all " + sql0);
   }
 
-  @Test public void testUnionToUnion1() {
+  @Test public void testUnionDistinctToUnionDistinct() {
     String sql0 = "select * from \"emps\" where \"empid\" < 300";
     String sql1 = "select * from \"emps\" where \"empid\" > 200";
     checkMaterialize(sql0 + " union " + sql1, sql1 + " union " + sql0);
   }
 
-  @Test public void testUnionToUnion2() {
+  @Test public void testUnionDistinctToUnionAll() {
     String sql0 = "select * from \"emps\" where \"empid\" < 300";
     String sql1 = "select * from \"emps\" where \"empid\" > 200";
     checkNoMaterialize(sql0 + " union " + sql1, sql0 + " union all " + sql1,

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -2468,10 +2468,23 @@ public class MaterializationTest {
     checkMaterialize(sql, sql);
   }
 
-  @Test public void testUnionToUnion() {
+  @Test public void testUnionToUnion0() {
     String sql0 = "select * from \"emps\" where \"empid\" < 300";
     String sql1 = "select * from \"emps\" where \"empid\" > 200";
     checkMaterialize(sql0 + " union all " + sql1, sql1 + " union all " + sql0);
+  }
+
+  @Test public void testUnionToUnion1() {
+    String sql0 = "select * from \"emps\" where \"empid\" < 300";
+    String sql1 = "select * from \"emps\" where \"empid\" > 200";
+    checkMaterialize(sql0 + " union " + sql1, sql1 + " union " + sql0);
+  }
+
+  @Test public void testUnionToUnion2() {
+    String sql0 = "select * from \"emps\" where \"empid\" < 300";
+    String sql1 = "select * from \"emps\" where \"empid\" > 200";
+    checkNoMaterialize(sql0 + " union " + sql1, sql0 + " union all " + sql1,
+        HR_FKUK_MODEL);
   }
 
   private static <E> List<List<List<E>>> list3(E[][][] as) {


### PR DESCRIPTION
…are both of UNION but have different 'all' property (Jin Xing)

```
Materialized-View:
select * from emps where empid < 300
union
select * from emps where empid > 200

Query:
select * from emps where empid < 300
union all
select * from emps where empid > 200
```
Above MV and Query have different 'all' property in UNION but they succeed matching now. 
This PR proposes a check in `UnionToUnionUnifyRule`