### PR TITLE
[CALCITE-3397] AssertionError for interpretering multiset value

### DIFF
--- a/core/src/main/java/org/apache/calcite/interpreter/CollectNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/CollectNode.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.interpreter;
+
+import org.apache.calcite.rel.core.Collect;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Interpreter node that implements a
+ * {@link org.apache.calcite.rel.core.Collect}.
+ */
+public class CollectNode extends AbstractSingleNode<Collect> {
+
+  public CollectNode(Compiler compiler, Collect rel) {
+    super(compiler, rel);
+  }
+
+  @Override public void run() throws InterruptedException {
+    Row row;
+    List<Object[]> values = new ArrayList<>();
+    while ((row = source.receive()) != null) {
+      values.add(row.getValues());
+    }
+    row = Row.of(ImmutableList.copyOf(values));
+    sink.send(row);
+  }
+}
+
+// End CollectNode.java

--- a/core/src/main/java/org/apache/calcite/interpreter/Nodes.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Nodes.java
@@ -18,6 +18,7 @@ package org.apache.calcite.interpreter;
 
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Collect;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Match;
@@ -88,6 +89,10 @@ public class Nodes {
 
     public void visit(Match match) {
       node = new MatchNode(this, match);
+    }
+
+    public void visit(Collect collect) {
+      node = new CollectNode(this, collect);
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
@@ -118,6 +118,16 @@ public class InterpreterTest {
     assertRows(interpreter, "[c]", "[b]", "[a]");
   }
 
+  @Test public void testInterpretMultiset() throws Exception {
+    final String sql = "select multiset['a', 'b', 'c']";
+    SqlNode parse = planner.parse(sql);
+    SqlNode validate = planner.validate(parse);
+    RelNode convert = planner.rel(validate).project();
+
+    final Interpreter interpreter = new Interpreter(dataContext, convert);
+    assertRows(interpreter, "[[a, b, c]]");
+  }
+
   private static void assertRows(Interpreter interpreter, String... rows) {
     assertRows(interpreter, false, rows);
   }


### PR DESCRIPTION
When interpretering sql  `select multiset['a', 'b', 'c']`, got AssertionError.
Please refer https://issues.apache.org/jira/browse/CALCITE-3397 for details.

This PR tries to add a `CollectNode` to run Collect Relnode.