### PR TITLE
[CALCITE-3399] Field-pruning for set operators (except UNION ALL) changes query semantics

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3578,6 +3578,60 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test public void testTrimUnionAll() {
+    final String sql = ""
+        + "select deptno from\n"
+        + "(select ename, deptno from emp\n"
+        + "union all\n"
+        + "select name, deptno from dept)";
+    sql(sql).trim(true).ok();
+  }
+
+  @Test public void testTrimUnionDistinct() {
+    final String sql = ""
+        + "select deptno from\n"
+        + "(select ename, deptno from emp\n"
+        + "union\n"
+        + "select name, deptno from dept)";
+    sql(sql).trim(true).ok();
+  }
+
+  @Test public void testTrimIntersectAll() {
+    final String sql = ""
+        + "select deptno from\n"
+        + "(select ename, deptno from emp\n"
+        + "intersect all\n"
+        + "select name, deptno from dept)";
+    sql(sql).trim(true).ok();
+  }
+
+  @Test public void testTrimIntersectDistinct() {
+    final String sql = ""
+        + "select deptno from\n"
+        + "(select ename, deptno from emp\n"
+        + "intersect\n"
+        + "select name, deptno from dept)";
+    sql(sql).trim(true).ok();
+  }
+
+  @Test public void testTrimExceptAll() {
+    final String sql = ""
+        + "select deptno from\n"
+        + "(select ename, deptno from emp\n"
+        + "except all\n"
+        + "select name, deptno from dept)";
+    sql(sql).trim(true).ok();
+  }
+
+  @Test public void testTrimExceptDistinct() {
+    final String sql = ""
+        + "select deptno from\n"
+        + "(select ename, deptno from emp\n"
+        + "except\n"
+        + "select name, deptno from dept)";
+    sql(sql).trim(true).ok();
+  }
+
   /**
    * Visitor that checks that every {@link RelNode} in a tree is valid.
    *

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6348,6 +6348,125 @@ LogicalProject(EXPR$0=[IGNORE NULLS(LEAD($5, 4))], EXPR$1=[LEAD($5, 4) OVER (ORD
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testTrimUnionAll">
+        <Resource name="sql">
+            <![CDATA[
+select deptno from
+(select ename, deptno from emp
+union all
+select name, deptno from dept)
+]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalUnion(all=[true])
+  LogicalProject(DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(DEPTNO=[$0])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testTrimUnionDistinct">
+        <Resource name="sql">
+            <![CDATA[
+select deptno from
+(select ename, deptno from emp
+union
+select name, deptno from dept)
+]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$1])
+  LogicalUnion(all=[false])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(NAME=[$1], DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testTrimIntersectAll">
+        <Resource name="sql">
+            <![CDATA[
+select deptno from
+(select ename, deptno from emp
+intersect all
+select name, deptno from dept)
+]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$1])
+  LogicalIntersect(all=[true])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(NAME=[$1], DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testTrimIntersectDistinct">
+        <Resource name="sql">
+            <![CDATA[
+select deptno from
+(select ename, deptno from emp
+intersect
+select name, deptno from dept)
+]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$1])
+  LogicalIntersect(all=[false])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(NAME=[$1], DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testTrimExceptAll">
+        <Resource name="sql">
+            <![CDATA[
+select deptno from
+(select ename, deptno from emp
+except all
+select name, deptno from dept)
+]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$1])
+  LogicalMinus(all=[true])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(NAME=[$1], DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testTrimExceptDistinct">
+        <Resource name="sql">
+            <![CDATA[
+select deptno from
+(select ename, deptno from emp
+except
+select name, deptno from dept)
+]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(DEPTNO=[$1])
+  LogicalMinus(all=[false])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(NAME=[$1], DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testAggregateWithSameDigestInSubQueries">
         <Resource name="sql">
             <![CDATA[select


### PR DESCRIPTION
`RelFieldTrimmer#trimFields` provides functionality to trim fields for  `UNION, UNION ALL, INTERSECT, INTERSECT ALL, EXCEPT, EXCEPT ALL`;

But `UNION ALL, INTERSECT, INTERSECT ALL, EXCEPT, EXCEPT ALL` works by checking duplication. Column pruning on inputs of `SetOp` might lead to different semantics.

Take below example for illustration
```
emp0:
name, deptno
 "A",       0
 "B",       1

emp1:
name, deptno
 "C",      0
 "D",      2

select deptno from
(select name, deptno from emp0
intersect
select name, deptno from emp1)
```

Run above Sql on `emp0` and `emp1`, result is not empty if trim fields on inputs of `INTERSECT`, but result is empty if DO NOT trim fields on inputs of `INTERSECT`

This PR proposes to trim fields only for `UNION ALL`