### PR TITLE
[CALCITE-3379] Support expand STRING column expression of table durin…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -1202,7 +1202,7 @@ public class SqlValidatorUtil {
         false,
         false,
         "",
-        new ExplicitTablesSchema(tableMap));
+        new ExplicitTableSchema(tableMap));
 
     return new CalciteCatalogReader(
         schema,
@@ -1329,10 +1329,10 @@ public class SqlValidatorUtil {
   /**
    * A {@link AbstractSchema} that can specify the table map explicitly.
    */
-  private static class ExplicitTablesSchema extends AbstractSchema {
+  private static class ExplicitTableSchema extends AbstractSchema {
     private final Map<String, Table> tableMap;
 
-    ExplicitTablesSchema(Map<String, Table> tableMap) {
+    ExplicitTableSchema(Map<String, Table> tableMap) {
       this.tableMap = Objects.requireNonNull(tableMap);
     }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/InitializerContext.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/InitializerContext.java
@@ -20,6 +20,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
 
 /**
  * Provides context for {@link InitializerExpressionFactory} methods.
@@ -27,9 +29,60 @@ import org.apache.calcite.sql.SqlNode;
 public interface InitializerContext {
   RexBuilder getRexBuilder();
 
+  /**
+   * Parse a column computation expression for a table. Usually this expression is declared
+   * in the create table statement, i.e.
+   * <pre>
+   *   create table t(
+   *     a int not null,
+   *     b varchar(5) as (my_udf(a)) virtual,
+   *     c int not null as (a + 1)
+   *   );
+   * </pre>
+   *
+   * You can use the string format expression "my_udf(a)" and "a + 1"
+   * as the initializer expression of column b and c.
+   *
+   * <p>Calcite doesn't really need this now because the DDL nodes
+   * can be executed directly from {@code SqlNode}s, but we still provide the way
+   * to initialize from a SQL-like string, because a string can be used to persist easily and
+   * the column expressions are important part of the table metadata.
+   *
+   * @param config parse config
+   * @param expr   the SQL-style column expression
+   * @return a {@code SqlNode} instance
+   */
+  default SqlNode parseExpression(SqlParser.Config config, String expr) {
+    SqlParser parser = SqlParser.create(expr, config);
+    try {
+      return parser.parseExpression();
+    } catch (SqlParseException e) {
+      throw new RuntimeException("Failed to parse expression " + expr, e);
+    }
+  }
+
+  /**
+   * Validate the expression with a base table row type. The expression may reference the fields
+   * of the row type defines.
+   *
+   * @param rowType the table row type
+   * @param expr    the expression
+   * @return a validated {@code SqlNode}, usually it transforms
+   * from a {@code SqlUnresolvedFunction} to a resolved one
+   */
   SqlNode validateExpression(RelDataType rowType, SqlNode expr);
 
-  RexNode convertExpression(SqlNode e);
+  /**
+   * Converts a {@code SqlNode} to {@code RexNode}.
+   *
+   * <p>Caution that the {@code SqlNode} must be validated,
+   * you can use {@link #validateExpression} to validate if the {@code SqlNode}
+   * is un-validated.
+   *
+   * @param expr the expression of sql node to convert
+   * @return a converted {@code RexNode} instance
+   */
+  RexNode convertExpression(SqlNode expr);
 }
 
 // End InitializerContext.java

--- a/core/src/main/java/org/apache/calcite/sql2rel/InitializerExpressionFactory.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/InitializerExpressionFactory.java
@@ -17,12 +17,14 @@
 package org.apache.calcite.sql2rel;
 
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.sql.SqlFunction;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 /**
  * InitializerExpressionFactory supplies default values for INSERT, UPDATE, and NEW.
@@ -76,6 +78,18 @@ public interface InitializerExpressionFactory {
       RelOptTable table,
       int iColumn,
       InitializerContext context);
+
+  /**
+   * Creates a hook function to customize the relational expression right after the column
+   * expressions are converted. Usually the relational expression is a projection
+   * above a table scan.
+   *
+   * @return a hook function to transform the relational expression
+   * right after the column expression conversion to a customized one
+   *
+   * @see #newColumnDefaultValue(RelOptTable, int, InitializerContext)
+   */
+  BiFunction<InitializerContext, RelNode, RelNode> postExpressionConversionHook();
 
   /**
    * Creates an expression which evaluates to the initializer expression for a

--- a/core/src/main/java/org/apache/calcite/sql2rel/NullInitializerExpressionFactory.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/NullInitializerExpressionFactory.java
@@ -17,12 +17,14 @@
 package org.apache.calcite.sql2rel;
 
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.sql.SqlFunction;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 /**
  * An implementation of {@link InitializerExpressionFactory} that always supplies NULL.
@@ -57,6 +59,10 @@ public class NullInitializerExpressionFactory implements InitializerExpressionFa
     final RelDataType fieldType =
         table.getRowType().getFieldList().get(iColumn).getType();
     return context.getRexBuilder().makeNullLiteral(fieldType);
+  }
+
+  public BiFunction<InitializerContext, RelNode, RelNode> postExpressionConversionHook() {
+    return null;
   }
 
   public RexNode newAttributeInitializer(RelDataType type,

--- a/server/src/test/java/org/apache/calcite/test/ServerTest.java
+++ b/server/src/test/java/org/apache/calcite/test/ServerTest.java
@@ -428,7 +428,7 @@ public class ServerTest {
           + " h varchar(3) not null,\n"
           + " i varchar(3),\n"
           + " j int not null as (char_length(h)) virtual,\n"
-          + " k varchar(3) null as (trim(i)) virtual)";
+          + " k varchar(3) null as (rtrim(i)) virtual)";
       boolean b = s.execute(create);
       assertThat(b, is(false));
 
@@ -448,7 +448,8 @@ public class ServerTest {
 
       final String plan = ""
           + "EnumerableCalc(expr#0..1=[{inputs}], expr#2=[CHAR_LENGTH($t0)], "
-          + "expr#3=[FLAG(BOTH)], expr#4=[' '], expr#5=[TRIM($t3, $t4, $t1)], proj#0..2=[{exprs}], K=[$t5])\n"
+          + "expr#3=[FLAG(TRAILING)], expr#4=[' '], "
+          + "expr#5=[TRIM($t3, $t4, $t1)], proj#0..2=[{exprs}], K=[$t5])\n"
           + "  EnumerableTableScan(table=[[T1]])\n";
       try (ResultSet r = s.executeQuery("explain plan for " + select)) {
         assertThat(r.next(), is(true));


### PR DESCRIPTION
…g sql-to-rel conversion

* Add a default implementation in InitializerContext to support parsing
string column expression
* Add a hook function interface in InitializerExpressionFactory to
let user customized the node transformation right after the column
expression conversion
* In SqlToRelConverter#toRel, remove the lazy initialization logic for
Blackboard instance because the Java8 Supplier does not have memorization