### PR TITLE
[WIP][CALCITE-3409] Add an interface in MaterializedViewSubstitutionVisito…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.plan;
 
+import org.apache.calcite.plan.SubstitutionVisitor.UnifyRule;
 import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
@@ -192,6 +193,10 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
 
   public RelOptPlanner chooseDelegate() {
     return this;
+  }
+
+  public void registerMaterializationRules(List<UnifyRule> rules) {
+    // ignore - this planner does not support materializations
   }
 
   public void addMaterialization(RelOptMaterialization materialization) {

--- a/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
@@ -46,12 +46,23 @@ public class MaterializedViewSubstitutionVisitor extends SubstitutionVisitor {
           .build();
 
   public MaterializedViewSubstitutionVisitor(RelNode target_, RelNode query_) {
-    super(target_, query_, EXTENDED_RULES);
+    this(target_, query_, ImmutableList.of());
   }
 
   public MaterializedViewSubstitutionVisitor(RelNode target_, RelNode query_,
-      RelBuilderFactory relBuilderFactory) {
-    super(target_, query_, EXTENDED_RULES, relBuilderFactory);
+      List<SubstitutionVisitor.UnifyRule> additionalRules) {
+    super(target_, query_,
+        ImmutableList.<SubstitutionVisitor.UnifyRule>builder()
+            .addAll(EXTENDED_RULES).addAll(additionalRules).build());
+  }
+
+  public MaterializedViewSubstitutionVisitor(RelNode target_, RelNode query_,
+      RelBuilderFactory relBuilderFactory,
+      List<SubstitutionVisitor.UnifyRule> additionalRules) {
+    super(target_, query_,
+        ImmutableList.<SubstitutionVisitor.UnifyRule>builder()
+            .addAll(EXTENDED_RULES).addAll(additionalRules).build(),
+        relBuilderFactory);
   }
 
   public List<RelNode> go(RelNode replacement_) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.plan;
 
+import org.apache.calcite.plan.SubstitutionVisitor.UnifyRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.CachingRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
@@ -156,6 +157,16 @@ public interface RelOptPlanner {
    * knowledge. Right now, the local planner retains control.
    */
   RelOptPlanner chooseDelegate();
+
+  /**
+   * In addition to the internal defined materialization matching rules in
+   * {@link org.apache.calcite.plan.MaterializedViewSubstitutionVisitor}
+   * and {@link org.apache.calcite.plan.SubstitutionVisitor}, this method
+   * allows user to SET self defined {@link SubstitutionVisitor.UnifyRule}s,
+   * thus to extend the ability of substitution based materialization
+   * matching in different scenarios.
+   */
+  void registerMaterializationRules(List<UnifyRule> rules);
 
   /**
    * Defines a pair of relational expressions that are equivalent.

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -801,7 +801,7 @@ public class SubstitutionVisitor {
    * <p>The rule declares the query and target types; this allows the
    * engine to fire only a few rules in a given context.</p>
    */
-  protected abstract static class UnifyRule {
+  public abstract static class UnifyRule {
     protected final int slotCount;
     protected final Operand queryOperand;
     protected final Operand targetOperand;
@@ -868,7 +868,7 @@ public class SubstitutionVisitor {
   /**
    * Arguments to an application of a {@link UnifyRule}.
    */
-  protected class UnifyRuleCall {
+  public class UnifyRuleCall {
     protected final UnifyRule rule;
     public final MutableRel query;
     public final MutableRel target;
@@ -918,7 +918,7 @@ public class SubstitutionVisitor {
    * generated a {@code result} that is equivalent to {@code query} and
    * contains {@code target}.
    */
-  protected static class UnifyResult {
+  public static class UnifyResult {
     private final UnifyRuleCall call;
     // equivalent to "query", contains "result"
     private final MutableRel result;
@@ -932,7 +932,7 @@ public class SubstitutionVisitor {
   }
 
   /** Abstract base class for implementing {@link UnifyRule}. */
-  protected abstract static class AbstractUnifyRule extends UnifyRule {
+  public abstract static class AbstractUnifyRule extends UnifyRule {
     public AbstractUnifyRule(Operand queryOperand, Operand targetOperand,
         int slotCount) {
       super(slotCount, queryOperand, targetOperand);
@@ -1474,7 +1474,7 @@ public class SubstitutionVisitor {
   }
 
   /** Operand to a {@link UnifyRule}. */
-  protected abstract static class Operand {
+  public abstract static class Operand {
     protected final Class<? extends MutableRel> clazz;
 
     protected Operand(Class<? extends MutableRel> clazz) {


### PR DESCRIPTION
…r to allow registering UnifyRule (Jin Xing)

In current code of MaterializedViewSubstitutionVisitor, all matching rules are internal defined. The existing rules support the most popular scenarios. But my customers sometimes ask for the ability to self define some matching rules, thus to support some special scenarios.

I take below example as an illustration:
```
Query:
select * from table
where from_unixtime(_EVENT_TIME_, "yyyymmdd hh") >= "20190909 00"
and from_unixtime(_EVENT_TIME_, "yyyymmdd hh") <= "20190909 23" ;

Materialized View:
select * from table 
where from_unixtime(_EVENT_TIME_, "yyyymmdd") = "20190909";
```
It's hard to enumerate the matching pattern for different functions in internal matching rules. We can expose a method to register new UnifyRules and allow user to extend the ability of MV matching