### PR TITLE
[CALCITE-3418] Grouped Window Function TUMBLE should return "$TUMBLE"…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupedWindowFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupedWindowFunction.java
@@ -128,13 +128,6 @@ public class SqlGroupedWindowFunction extends SqlFunction {
     // make the method abstract.
     return call.getOperandMonotonicity(0).unstrict();
   }
-
-  @Override public String getName() {
-    // Always rename the name of the SqlKind. The tumble operator is called
-    // "$TUMBLE", so that it does not clash with a user-defined table function
-    // "TUMBLE", but we want the name to be "TUMBLE".
-    return getKind().name();
-  }
 }
 
 // End SqlGroupedWindowFunction.java

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10081,7 +10081,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select stream ^tumble(rowtime, interval '2' hour)^ as rowtime\n"
         + "from orders\n"
         + "group by tumble(rowtime, interval '2' hour), productId")
-        .fails("Group function 'TUMBLE' can only appear in GROUP BY clause");
+        .fails("Group function '\\$TUMBLE' can only appear in GROUP BY clause");
     // TUMBLE with align argument
     sql("select stream\n"
         + "  tumble_end(rowtime, interval '2' hour, time '00:12:00') as rowtime\n"
@@ -10093,14 +10093,14 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "from orders\n"
         + "group by floor(rowtime to hour)")
         .fails("Call to auxiliary group function 'TUMBLE_END' must have "
-            + "matching call to group function 'TUMBLE' in GROUP BY clause");
+            + "matching call to group function '\\$TUMBLE' in GROUP BY clause");
     // Arguments to TUMBLE_END are slightly different to arguments to TUMBLE
     sql("select stream\n"
         + "  ^tumble_start(rowtime, interval '2' hour, time '00:13:00')^ as rowtime\n"
         + "from orders\n"
         + "group by tumble(rowtime, interval '2' hour, time '00:12:00')")
         .fails("Call to auxiliary group function 'TUMBLE_START' must have "
-            + "matching call to group function 'TUMBLE' in GROUP BY clause");
+            + "matching call to group function '\\$TUMBLE' in GROUP BY clause");
     // Even though align defaults to TIME '00:00:00', we need structural
     // equivalence, not semantic equivalence.
     sql("select stream\n"
@@ -10108,7 +10108,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "from orders\n"
         + "group by tumble(rowtime, interval '2' hour)")
         .fails("Call to auxiliary group function 'TUMBLE_END' must have "
-            + "matching call to group function 'TUMBLE' in GROUP BY clause");
+            + "matching call to group function '\\$TUMBLE' in GROUP BY clause");
     // TUMBLE query produces no monotonic column - OK
     sql("select stream productId\n"
         + "from orders\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -3326,7 +3326,7 @@ group by tumble(rowtime, interval '2' hour), productId]]>
 LogicalDelta
   LogicalProject(ROWTIME=[+($0, 7200000:INTERVAL HOUR)], PRODUCTID=[$1])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject($f0=[TUMBLE($0, 7200000:INTERVAL HOUR)], PRODUCTID=[$1])
+      LogicalProject($f0=[$TUMBLE($0, 7200000:INTERVAL HOUR)], PRODUCTID=[$1])
         LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
 ]]>
         </Resource>
@@ -4619,7 +4619,7 @@ GROUP BY TUMBLE(rowtime, INTERVAL '1' MINUTE)]]>
 LogicalDelta
   LogicalProject(S=[$0], E=[+($0, 60000:INTERVAL MINUTE)])
     LogicalAggregate(group=[{0}])
-      LogicalProject($f0=[TUMBLE($1, 60000:INTERVAL MINUTE)])
+      LogicalProject($f0=[$TUMBLE($1, 60000:INTERVAL MINUTE)])
         LogicalTableScan(table=[[CATALOG, SALES, SHIPMENTS]])
 ]]>
         </Resource>
@@ -4636,7 +4636,7 @@ group by tumble(rowtime, interval '2' hour), orderId]]>
 LogicalDelta
   LogicalProject(ROWTIME=[+($0, 7200000:INTERVAL HOUR)], ORDERID=[$1])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject($f0=[TUMBLE($1, 7200000:INTERVAL HOUR)], ORDERID=[$0])
+      LogicalProject($f0=[$TUMBLE($1, 7200000:INTERVAL HOUR)], ORDERID=[$0])
         LogicalTableScan(table=[[CATALOG, SALES, SHIPMENTS]])
 ]]>
         </Resource>


### PR DESCRIPTION
… as its operator name. By doing so, we will avoid function overloading in SqlFunction.deriveType.