### PR TITLE
[CALCITE-3393] RelStructuredTypeFlattener: improve support for functions with struct input

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2834,6 +2834,35 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   @Test
+  public void testFunctionWithStructInput() {
+    final String sql =
+        "select json_type(skill) from sales.dept_nested";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testAggregateFunctionForStructInput() {
+    final String sql = "select "
+        + "collect(skill) as collect_skill, count(skill) as count_skill, count(*) as count_star, "
+        + "approx_count_distinct(skill) as approx_count_distinct_skill, "
+        + "max(skill) as max_skill, min(skill) as min_skill, "
+        + "any_value(skill) as any_value_skill "
+        + "from sales.dept_nested";
+    sql(sql).ok();
+  }
+
+  @Test
+  public void testAggregateFunctionForStructInputByName() {
+    final String sql = "select "
+        + "collect(skill) as collect_skill, count(skill) as count_skill, count(*) as count_star, "
+        + "approx_count_distinct(skill) as approx_count_distinct_skill, "
+        + "max(skill) as max_skill, min(skill) as min_skill, "
+        + "any_value(skill) as any_value_skill "
+        + "from sales.dept_nested group by name";
+    sql(sql).ok();
+  }
+
+  @Test
   public void testNestedPrimitiveFieldAccess() {
     final String sql =
         "select dn.skill['desc'] from sales.dept_nested dn";

--- a/core/src/test/java/org/apache/calcite/test/catalog/Fixture.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/Fixture.java
@@ -19,7 +19,6 @@ package org.apache.calcite.test.catalog;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeComparability;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.StructKind;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -28,183 +27,141 @@ import org.apache.calcite.sql.type.ObjectSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 /** Types used during initialization. */
-final class Fixture {
-  final RelDataType intType;
-  final RelDataType intTypeNull;
-  final RelDataType bigintType;
-  final RelDataType bigintTypeNull;
-  final RelDataType decimalType;
-  final RelDataType varcharType;
-  final RelDataType varchar5Type;
-  final RelDataType varchar10Type;
-  final RelDataType varchar10TypeNull;
-  final RelDataType varchar20Type;
-  final RelDataType varchar20TypeNull;
-  final RelDataType timestampType;
-  final RelDataType timestampTypeNull;
-  final RelDataType dateType;
-  final RelDataType booleanType;
-  final RelDataType booleanTypeNull;
-  final RelDataType rectilinearCoordType;
-  final RelDataType rectilinearPeekCoordType;
-  final RelDataType rectilinearPeekNoExpandCoordType;
-  final RelDataType abRecordType;
-  final RelDataType skillRecordType;
-  final RelDataType empRecordType;
-  final RelDataType empListType;
-  final ObjectSqlType addressType;
+final class Fixture extends AbstractFixture {
+  final RelDataType intType = required(SqlTypeName.INTEGER);
+  final RelDataType intTypeNull = nullable(intType);
+  final RelDataType bigintType = required(SqlTypeName.BIGINT);
+  final RelDataType decimalType = required(SqlTypeName.DECIMAL);
+  final RelDataType varcharType = required(SqlTypeName.VARCHAR);
+  final RelDataType varcharTypeNull = required(SqlTypeName.VARCHAR);
+  final RelDataType varchar5Type = required(SqlTypeName.VARCHAR, 5);
+  final RelDataType varchar10Type = required(SqlTypeName.VARCHAR, 10);
+  final RelDataType varchar10TypeNull = nullable(varchar10Type);
+  final RelDataType varchar20Type = required(SqlTypeName.VARCHAR, 20);
+  final RelDataType varchar20TypeNull = nullable(varchar20Type);
+  final RelDataType timestampType = required(SqlTypeName.TIMESTAMP);
+  final RelDataType timestampTypeNull = nullable(timestampType);
+  final RelDataType dateType = required(SqlTypeName.DATE);
+  final RelDataType booleanType = required(SqlTypeName.BOOLEAN);
+  final RelDataType booleanTypeNull = nullable(booleanType);
+  final RelDataType rectilinearCoordType = typeFactory.builder()
+      .add("X", intType)
+      .add("Y", intType)
+      .build();
+  final RelDataType rectilinearPeekCoordType = typeFactory.builder()
+      .add("X", intType)
+      .add("Y", intType)
+      .add("unit", varchar20Type)
+      .kind(StructKind.PEEK_FIELDS)
+      .build();
+  final RelDataType rectilinearPeekNoExpandCoordType = typeFactory.builder()
+      .add("M", intType)
+      .add("SUB",
+          typeFactory.builder()
+              .add("A", intType)
+              .add("B", intType)
+              .kind(StructKind.PEEK_FIELDS_NO_EXPAND)
+              .build())
+      .kind(StructKind.PEEK_FIELDS_NO_EXPAND)
+      .build();
+  final RelDataType abRecordType = typeFactory.builder()
+      .add("A", varchar10Type)
+      .add("B", varchar10Type)
+      .build();;
+  final RelDataType skillRecordType = typeFactory.builder()
+      .add("TYPE", varchar10Type)
+      .add("DESC", varchar20Type)
+      .add("OTHERS", abRecordType)
+      .build();
+  final RelDataType empRecordType = typeFactory.builder()
+      .add("EMPNO", intType)
+      .add("ENAME", varchar10Type)
+      .add("DETAIL", typeFactory.builder()
+          .add("SKILLS", array(skillRecordType)).build())
+      .build();
+  final RelDataType empListType = array(empRecordType);
+  final ObjectSqlType addressType = new ObjectSqlType(SqlTypeName.STRUCTURED,
+      new SqlIdentifier("ADDRESS", SqlParserPos.ZERO),
+      false,
+      Arrays.asList(
+          new RelDataTypeFieldImpl("STREET", 0, varchar20Type),
+          new RelDataTypeFieldImpl("CITY", 1, varchar20Type),
+          new RelDataTypeFieldImpl("ZIP", 2, intType),
+          new RelDataTypeFieldImpl("STATE", 3, varchar20Type)),
+      RelDataTypeComparability.NONE);
   // Row(f0 int, f1 varchar)
-  final RelDataType recordType1;
+  final RelDataType recordType1 = typeFactory.createStructType(
+      Arrays.asList(intType, varcharType),
+      Arrays.asList("f0", "f1"));
   // Row(f0 int not null, f1 varchar null)
-  final RelDataType recordType2;
+  final RelDataType recordType2 = typeFactory.createStructType(
+      Arrays.asList(intType, nullable(varcharType)),
+      Arrays.asList("f0", "f1"));
   // Row(f0 Row(ff0 int not null, ff1 varchar null) null, f1 timestamp not null)
-  final RelDataType recordType3;
+  final RelDataType recordType3 = typeFactory.createStructType(
+      Arrays.asList(
+          nullable(
+              typeFactory.createStructType(Arrays.asList(intType, varcharTypeNull),
+          Arrays.asList("ff0", "ff1"))), timestampType), Arrays.asList("f0", "f1"));
   // Row(f0 bigint not null, f1 decimal null) array
-  final RelDataType recordType4;
+  final RelDataType recordType4 = array(
+      typeFactory.createStructType(
+      Arrays.asList(bigintType, nullable(decimalType)),
+      Arrays.asList("f0", "f1")));
   // Row(f0 varchar not null, f1 timestamp null) multiset
-  final RelDataType recordType5;
-  final RelDataType intArrayType;
-  final RelDataType varchar5ArrayType;
-  final RelDataType intArrayArrayType;
-  final RelDataType varchar5ArrayArrayType;
-  final RelDataType intMultisetType;
-  final RelDataType varchar5MultisetType;
-  final RelDataType intMultisetArrayType;
-  final RelDataType varchar5MultisetArrayType;
-  final RelDataType intArrayMultisetType;
+  final RelDataType recordType5 = typeFactory.createMultisetType(
+      typeFactory.createStructType(
+          Arrays.asList(varcharType, timestampTypeNull),
+          Arrays.asList("f0", "f1")),
+      -1);
+  final RelDataType intArrayType = array(intType);
+  final RelDataType varchar5ArrayType = array(varchar5Type);
+  final RelDataType intArrayArrayType = array(intArrayType);
+  final RelDataType varchar5ArrayArrayType = array(varchar5ArrayType);
+  final RelDataType intMultisetType = typeFactory.createMultisetType(intType, -1);
+  final RelDataType varchar5MultisetType = typeFactory.createMultisetType(varchar5Type, -1);
+  final RelDataType intMultisetArrayType = array(intMultisetType);
+  final RelDataType varchar5MultisetArrayType = array(varchar5MultisetType);
+  final RelDataType intArrayMultisetType = typeFactory.createMultisetType(intArrayType, -1);
   // Row(f0 int array multiset, f1 varchar(5) array) array multiset
-  final RelDataType rowArrayMultisetType;
+  final RelDataType rowArrayMultisetType = typeFactory.createMultisetType(
+      array(
+          typeFactory.createStructType(
+          Arrays.asList(intArrayMultisetType, varchar5ArrayType),
+          Arrays.asList("f0", "f1"))),
+      -1);
 
   Fixture(RelDataTypeFactory typeFactory) {
-    intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
-    intTypeNull = typeFactory.createTypeWithNullability(intType, true);
-    bigintType = typeFactory.createSqlType(SqlTypeName.BIGINT);
-    bigintTypeNull = typeFactory.createTypeWithNullability(bigintType, true);
-    decimalType = typeFactory.createSqlType(SqlTypeName.DECIMAL);
-    varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
-    varchar5Type = typeFactory.createSqlType(SqlTypeName.VARCHAR, 5);
-    varchar10Type = typeFactory.createSqlType(SqlTypeName.VARCHAR, 10);
-    varchar10TypeNull = typeFactory.createTypeWithNullability(varchar10Type, true);
-    varchar20Type = typeFactory.createSqlType(SqlTypeName.VARCHAR, 20);
-    varchar20TypeNull = typeFactory.createTypeWithNullability(varchar20Type, true);
-    timestampType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
-    timestampTypeNull =
-        typeFactory.createTypeWithNullability(timestampType, true);
-    dateType =
-        typeFactory.createSqlType(SqlTypeName.DATE);
-    booleanType =
-        typeFactory.createSqlType(SqlTypeName.BOOLEAN);
-    booleanTypeNull =
-        typeFactory.createTypeWithNullability(booleanType, true);
-    rectilinearCoordType =
-        typeFactory.builder()
-            .add("X", intType)
-            .add("Y", intType)
-            .build();
-    rectilinearPeekCoordType =
-        typeFactory.builder()
-            .add("X", intType)
-            .add("Y", intType)
-            .add("unit", varchar20Type)
-            .kind(StructKind.PEEK_FIELDS)
-            .build();
-    rectilinearPeekNoExpandCoordType =
-        typeFactory.builder()
-            .add("M", intType)
-            .add("SUB",
-                typeFactory.builder()
-                    .add("A", intType)
-                    .add("B", intType)
-                    .kind(StructKind.PEEK_FIELDS_NO_EXPAND)
-                    .build())
-            .kind(StructKind.PEEK_FIELDS_NO_EXPAND)
-            .build();
-    abRecordType =
-        typeFactory.builder()
-            .add("A", varchar10Type)
-            .add("B", varchar10Type)
-            .build();
-    skillRecordType =
-        typeFactory.builder()
-            .add("TYPE", varchar10Type)
-            .add("DESC", varchar20Type)
-            .add("OTHERS", abRecordType)
-            .build();
-    empRecordType =
-        typeFactory.builder()
-            .add("EMPNO", intType)
-            .add("ENAME", varchar10Type)
-            .add("DETAIL",
-                typeFactory.builder().add("SKILLS",
-                    typeFactory.createArrayType(skillRecordType, -1)).build())
-            .build();
-    empListType =
-        typeFactory.createArrayType(empRecordType, -1);
-    addressType =
-        new ObjectSqlType(SqlTypeName.STRUCTURED,
-            new SqlIdentifier("ADDRESS", SqlParserPos.ZERO),
-            false,
-            Arrays.asList(
-                new RelDataTypeFieldImpl("STREET", 0, varchar20Type),
-                new RelDataTypeFieldImpl("CITY", 1, varchar20Type),
-                new RelDataTypeFieldImpl("ZIP", 2, intType),
-                new RelDataTypeFieldImpl("STATE", 3, varchar20Type)),
-            RelDataTypeComparability.NONE);
-    // Row(f0 int, f1 varchar)
-    recordType1 = typeFactory.createStructType(
-        Arrays.asList(intType, varcharType),
-        Arrays.asList("f0", "f1"));
-    // Row(f0 int not null, f1 varchar null)
-    recordType2 = typeFactory.createStructType(
-        Arrays.asList(intType,
-            nullable(typeFactory, varcharType)),
-        Arrays.asList("f0", "f1"));
-    // Row(f0 Row(ff0 int not null, ff1 varchar null) null, f1 timestamp not null)
-    recordType3 = typeFactory.createStructType(
-        Arrays.asList(
-            nullable(typeFactory,
-                typeFactory.createStructType(
-                    recordType2.getFieldList().stream()
-                        .map(RelDataTypeField::getType).collect(Collectors.toList()),
-                    Arrays.asList("ff0", "ff1"))), timestampType),
-        Arrays.asList("f0", "f1"));
-    // Row(f0 bigint not null, f1 decimal null) array
-    recordType4 = typeFactory.createArrayType(
-        typeFactory.createStructType(
-            Arrays.asList(bigintType, nullable(typeFactory, decimalType)),
-            Arrays.asList("f0", "f1")),
-        -1);
-    // Row(f0 varchar not null, f1 timestamp null) multiset
-    recordType5 = typeFactory.createMultisetType(
-        typeFactory.createStructType(
-            Arrays.asList(varcharType, nullable(typeFactory, timestampType)),
-            Arrays.asList("f0", "f1")),
-        -1);
-    intArrayType = typeFactory.createArrayType(intType, -1);
-    varchar5ArrayType = typeFactory.createArrayType(varchar5Type, -1);
-    intArrayArrayType = typeFactory.createArrayType(intArrayType, -1);
-    varchar5ArrayArrayType = typeFactory.createArrayType(varchar5ArrayType, -1);
-    intMultisetType = typeFactory.createMultisetType(intType, -1);
-    varchar5MultisetType = typeFactory.createMultisetType(varchar5Type, -1);
-    intMultisetArrayType = typeFactory.createArrayType(intMultisetType, -1);
-    varchar5MultisetArrayType = typeFactory.createArrayType(varchar5MultisetType, -1);
-    intArrayMultisetType = typeFactory.createMultisetType(intArrayType, -1);
-    // Row(f0 int array multiset, f1 varchar(5) array) array multiset
-    rowArrayMultisetType = typeFactory.createMultisetType(
-        typeFactory.createArrayType(
-            typeFactory.createStructType(
-                Arrays.asList(intArrayMultisetType, varchar5ArrayType),
-                Arrays.asList("f0", "f1")),
-            -1),
-        -1);
+    super(typeFactory);
+    // todo: try to release typeFactory
   }
 
-  private static RelDataType nullable(RelDataTypeFactory typeFactory, RelDataType type) {
+  private RelDataType nullable(RelDataType type) {
     return typeFactory.createTypeWithNullability(type, true);
+  }
+
+  private RelDataType required(SqlTypeName typeName, int... args) {
+    assert args.length < 3 : "unknown size of additional int args";
+    return args.length == 2 ? typeFactory.createSqlType(typeName, args[0], args[1])
+        : args.length == 1 ? typeFactory.createSqlType(typeName, args[0])
+        : typeFactory.createSqlType(typeName);
+  }
+
+  private RelDataType array(RelDataType type) {
+    return typeFactory.createArrayType(type, -1);
   }
 }
 
+/**
+ * Just a little trick to store factory ref before field init in fixture
+ */
+abstract class AbstractFixture {
+  final RelDataTypeFactory typeFactory;
+
+  AbstractFixture(RelDataTypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+  }
+}
 // End Fixture.java

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6272,4 +6272,51 @@ LogicalProject(EXPR$0=[IGNORE NULLS(LEAD($5, 4))], EXPR$1=[LEAD($5, 4) OVER (ORD
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testFunctionWithStructInput">
+        <Resource name="sql">
+            <![CDATA[select json_type(skill) from sales.dept_nested]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[JSON_TYPE(ROW($2.TYPE, $2.DESC, ROW($2.OTHERS.A, $2.OTHERS.B)))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testAggregateFunctionForStructInput">
+        <Resource name="sql">
+            <![CDATA[select
+         collect(skill) as collect_skill, count(skill) as count_skill, count(*) as count_star, 
+         approx_count_distinct(skill) as approx_count_distinct_skill, 
+         max(skill) as max_skill, min(skill) as min_skill, 
+         any_value(skill) as any_value_skill 
+         from sales.dept_nested]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(COLLECT_SKILL=[$0], COUNT_SKILL=[$1], COUNT_STAR=[$1], APPROX_COUNT_DISTINCT_SKILL=[$2], MAX_SKILL=[ROW($3.TYPE, $3.DESC, ROW($3.OTHERS.A, $3.OTHERS.B))], MIN_SKILL=[ROW($4.TYPE, $4.DESC, ROW($4.OTHERS.A, $4.OTHERS.B))], ANY_VALUE_SKILL=[ROW($5.TYPE, $5.DESC, ROW($5.OTHERS.A, $5.OTHERS.B))])
+  LogicalAggregate(group=[{}], COLLECT_SKILL=[COLLECT($0)], COUNT_SKILL=[COUNT()], APPROX_COUNT_DISTINCT_SKILL=[COUNT(DISTINCT $0)], MAX_SKILL=[MAX($0)], MIN_SKILL=[MIN($0)], ANY_VALUE_SKILL=[ANY_VALUE($0)])
+    LogicalProject(SKILL=[ROW($2.TYPE, $2.DESC, ROW($2.OTHERS.A, $2.OTHERS.B))])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testAggregateFunctionForStructInputByName">
+        <Resource name="sql">
+            <![CDATA[select 
+         collect(skill) as collect_skill, count(skill) as count_skill, count(*) as count_star,
+         approx_count_distinct(skill) as approx_count_distinct_skill,
+         max(skill) as max_skill, min(skill) as min_skill,
+         any_value(skill) as any_value_skill 
+         from sales.dept_nested group by name]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(COLLECT_SKILL=[$1], COUNT_SKILL=[$2], COUNT_STAR=[$2], APPROX_COUNT_DISTINCT_SKILL=[$3], MAX_SKILL=[ROW($4.TYPE, $4.DESC, ROW($4.OTHERS.A, $4.OTHERS.B))], MIN_SKILL=[ROW($5.TYPE, $5.DESC, ROW($5.OTHERS.A, $5.OTHERS.B))], ANY_VALUE_SKILL=[ROW($6.TYPE, $6.DESC, ROW($6.OTHERS.A, $6.OTHERS.B))])
+  LogicalAggregate(group=[{0}], COLLECT_SKILL=[COLLECT($1)], COUNT_SKILL=[COUNT()], APPROX_COUNT_DISTINCT_SKILL=[COUNT(DISTINCT $1)], MAX_SKILL=[MAX($1)], MIN_SKILL=[MIN($1)], ANY_VALUE_SKILL=[ANY_VALUE($1)])
+    LogicalProject(NAME=[$1], SKILL=[ROW($2.TYPE, $2.DESC, ROW($2.OTHERS.A, $2.OTHERS.B))])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
1. Implemented flattening for LogicalAggregate rel nodes.
2. Fixed functions which accept struct column as input.
3. Improved usability of test Fixture, now there is no need to search type field initialization indside constructor after jumping to type field.

Jira - [CALCITE-3393](https://issues.apache.org/jira/browse/CALCITE-3393).