### PR TITLE
[CALCITE-3421] Reuse relMetadataQuery and fix doc in LogicalCalc

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
@@ -52,7 +52,7 @@ import java.util.Set;
  *
  * <ul>
  * <li>{@link FilterToCalcRule} creates this from a {@link LogicalFilter}
- * <li>{@link ProjectToCalcRule} creates this from a {@link LogicalFilter}
+ * <li>{@link ProjectToCalcRule} creates this from a {@link LogicalProject}
  * <li>{@link org.apache.calcite.rel.rules.FilterCalcMergeRule}
  *     merges this with a {@link LogicalFilter}
  * <li>{@link org.apache.calcite.rel.rules.ProjectCalcMergeRule}

--- a/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
@@ -110,7 +110,7 @@ public class TraitPropagationTest {
           RelOptUtil.dumpPlan("LOGICAL PLAN", planned, SqlExplainFormat.TEXT,
               SqlExplainLevel.ALL_ATTRIBUTES));
     }
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = planned.getCluster().getMetadataQuery();
     assertEquals("Sortedness was not propagated", 3,
         mq.getCumulativeCost(planned).getRows(), 0);
   }
@@ -323,7 +323,7 @@ public class TraitPropagationTest {
     public static PhysProj create(final RelNode input,
         final List<RexNode> projects, RelDataType rowType) {
       final RelOptCluster cluster = input.getCluster();
-      final RelMetadataQuery mq = RelMetadataQuery.instance();
+      final RelMetadataQuery mq = cluster.getMetadataQuery();
       final RelTraitSet traitSet =
           cluster.traitSet().replace(PHYSICAL)
               .replaceIfs(

--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTraitTest.java
@@ -264,12 +264,12 @@ public class VolcanoPlannerTraitTest {
     RelOptCluster cluster = newCluster(planner);
     NoneTinyLeafRel leaf = new NoneTinyLeafRel(cluster, "noneLeafRel");
     planner.setRoot(leaf);
-    RelOptCost cost = planner.getCost(leaf, RelMetadataQuery.instance());
+    RelOptCost cost = planner.getCost(leaf, cluster.getMetadataQuery());
 
     assertTrue(cost.isInfinite());
 
     planner.setNoneConventionHasInfiniteCost(false);
-    cost = planner.getCost(leaf, RelMetadataQuery.instance());
+    cost = planner.getCost(leaf, cluster.getMetadataQuery());
     assertTrue(!cost.isInfinite());
   }
 
@@ -342,7 +342,7 @@ public class VolcanoPlannerTraitTest {
       RelTrait fromTrait = rel.getTraitSet().getTrait(this);
 
       if (conversionMap.containsKey(fromTrait)) {
-        final RelMetadataQuery mq = RelMetadataQuery.instance();
+        final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
         for (Pair<RelTrait, ConverterRule> traitAndRule
             : conversionMap.get(fromTrait)) {
           RelTrait trait = traitAndRule.left;

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -284,7 +284,7 @@ public class PlannerTest {
     SqlNode parse = planner.parse(sql);
     SqlNode validate = planner.validate(parse);
     RelNode rel = planner.rel(validate).project();
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     final RelOptPredicateList predicates = mq.getPulledUpPredicates(rel);
     final String buf = predicates.pulledUpPredicates.toString();
     assertThat(buf, equalTo(expectedPredicates));


### PR DESCRIPTION
Reuse relMetadataQuery in TraitPropagationTest,VolcanoPlannerTraitTest,RelMetadataTest,PlannerTest