### PR TITLE
[CALCITE-3423] Support using CAST operation and BOOLEAN type value in table macro

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -458,7 +458,8 @@ public class RexLiteral extends RexNode {
     if (o == null
         || o instanceof BigDecimal
         || o instanceof NlsString
-        || o instanceof ByteString) {
+        || o instanceof ByteString
+        || o instanceof Boolean) {
       return litmus.succeed();
     } else if (o instanceof List) {
       List list = (List) o;

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
@@ -147,6 +147,8 @@ public class SqlUserDefinedTableMacro extends SqlFunction {
         builder2.put(getValue(key), getValue(value));
       }
       return builder2.build();
+    case CAST:
+      return getValue(((SqlCall) right).operand(0));
     default:
       if (SqlUtil.isNullLiteral(right, true)) {
         return null;
@@ -175,8 +177,8 @@ public class SqlUserDefinedTableMacro extends SqlFunction {
     if (clazz.isAssignableFrom(o.getClass())) {
       return o;
     }
-    if (clazz == String.class && o instanceof NlsString) {
-      return ((NlsString) o).getValue();
+    if (o instanceof NlsString) {
+      return coerce(((NlsString) o).getValue(), type);
     }
     // We need optimization here for constant folding.
     // Not all the expressions can be interpreted (e.g. ternary), so

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
@@ -32,7 +32,6 @@ import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeUtil;
-import org.apache.calcite.sql.validate.SqlUserDefinedTableMacro;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Util;
@@ -562,11 +561,6 @@ public class TypeCoercionImpl extends AbstractTypeCoercion {
     final List<RelDataType> paramTypes = function.getParamTypes();
     assert paramTypes != null;
     boolean coerced = false;
-    // User defined table macro only allows literals.
-    // we should support this in the future.
-    if (function instanceof SqlUserDefinedTableMacro) {
-      return false;
-    }
     for (int i = 0; i < call.operandCount(); i++) {
       SqlNode operand = call.operand(i);
       if (operand.getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -410,7 +410,8 @@ public class JdbcTest {
   }
 
   /**
-   * Adds table macro for connection.
+   * Adds table macro for connection, with catalog named "s"
+   * and the method reflection name as the name of the macro.
    */
   private void addTableMacro(Connection connection, Method method) throws SQLException {
     CalciteConnection calciteConnection =

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -498,6 +498,15 @@ public class JdbcTest {
     assertThat(CalciteAssert.toString(resultSet),
         equalTo("N={'a'=1, 'baz'=2}     \n"
             + "N='2019-10-18 10:35:23'\n"));
+
+    // check for implicit type coercion
+    addTableMacro(connection, Smalls.VIEW_METHOD);
+    resultSet = connection.createStatement().executeQuery(
+        "select * from table(\"s\".\"view\"(5)) as t(n)");
+    assertThat(CalciteAssert.toString(resultSet),
+        equalTo("N=1\n"
+            + "N=3\n"
+            + "N=5\n"));
     connection.close();
   }
 
@@ -522,13 +531,13 @@ public class JdbcTest {
         .returns(expected2);
     with.query("select * from table(\"adhoc\".\"View\"(t=>'5', t=>'6'))")
         .throws_("Duplicate argument name 'T'");
-    with.query("select * from table(\"adhoc\".\"View\"(t=>'5', s=>'6'))")
-        .throws_(
-            "No match found for function signature View(T => <CHARACTER>, S => <CHARACTER>)");
     final String expected3 = "c=1\n"
         + "c=3\n"
         + "c=6\n"
         + "c=5\n";
+    // implicit type coercion
+    with.query("select * from table(\"adhoc\".\"View\"(t=>'5', s=>'6'))")
+        .returns(expected3);
     with.query("select * from table(\"adhoc\".\"View\"(t=>5, s=>'6'))")
         .returns(expected3);
   }

--- a/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
@@ -359,16 +359,10 @@ public class TableFunctionTest {
   }
 
   @Test public void testUserDefinedTableFunction4() {
-    final String q = "select *\n"
+    final String q = "select \"c1\"\n"
         + "from table(\"s\".\"multiplication\"('2', 3, 100))\n"
-        + "where c1 + 2 < c2";
-    // With type coercion, a cast node with null as argument would be
-    // passed to the function to infer the table row type, we use
-    // SqlUserDefinedTableMacro#convertArguments to decide the type.
-    // For this table function: multiplication,
-    // it will just throw IllegalArgumentException.
-    final String e = "java.lang.IllegalArgumentException";
-    with().query(q).throws_(e);
+        + "where \"c1\" + 2 < \"c2\"";
+    with().query(q).returnsUnordered("c1=103");
   }
 
   @Test public void testUserDefinedTableFunction5() {


### PR DESCRIPTION
Currently, exception happens when using bool type or cast operation in table macro.

This PR tries to add support for using CAST operation and bool type value in table macro.