### PR TITLE
[CALCITE-3429] AssertionError for user-defined table function with map argument

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
@@ -255,19 +255,33 @@ public class JavaTypeFactoryImpl
       SqlTypeName sqlTypeName = type.getSqlTypeName();
       final RelDataType relDataType;
       if (SqlTypeUtil.isArray(type)) {
-        final RelDataType elementType = type.getComponentType() == null
-                // type.getJavaClass() is collection with erased generic type
-                ? typeFactory.createSqlType(SqlTypeName.ANY)
-                // elementType returned by JavaType is also of JavaType,
-                // and needs conversion using typeFactory
-                : toSql(typeFactory, type.getComponentType());
+        // Transform to sql type, take care for two cases:
+        // 1. type.getJavaClass() is collection with erased generic type
+        // 2. ElementType returned by JavaType is also of JavaType,
+        // and needs conversion using typeFactory
+        final RelDataType elementType = toSqlTypeWithNullToAny(
+            typeFactory, type.getComponentType());
         relDataType = typeFactory.createArrayType(elementType, -1);
+      } else if (SqlTypeUtil.isMap(type)) {
+        final RelDataType keyType = toSqlTypeWithNullToAny(
+            typeFactory, type.getKeyType());
+        final RelDataType valueType = toSqlTypeWithNullToAny(
+            typeFactory, type.getValueType());
+        relDataType = typeFactory.createMapType(keyType, valueType);
       } else {
         relDataType = typeFactory.createSqlType(sqlTypeName);
       }
       return typeFactory.createTypeWithNullability(relDataType, type.isNullable());
     }
     return type;
+  }
+
+  private static RelDataType toSqlTypeWithNullToAny(
+      final RelDataTypeFactory typeFactory, RelDataType type) {
+    if (type == null) {
+      return typeFactory.createSqlType(SqlTypeName.ANY);
+    }
+    return toSql(typeFactory, type);
   }
 
   public Type createSyntheticType(List<Type> types) {

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -605,6 +605,32 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
       }
     }
 
+    /**
+     * For {@link JavaType} created with {@link Map} class,
+     * cannot get the type of key and value.
+     * Using ANY type as key type.
+     */
+    @Override public RelDataType getKeyType() {
+      if (Map.class.isAssignableFrom(clazz)) {
+        return createSqlType(SqlTypeName.ANY);
+      } else {
+        return null;
+      }
+    }
+
+    /**
+     * For {@link JavaType} created with {@link Map} class,
+     * cannot get the type of key and value.
+     * Using ANY type as value type.
+     */
+    @Override public RelDataType getValueType() {
+      if (Map.class.isAssignableFrom(clazz)) {
+        return createSqlType(SqlTypeName.ANY);
+      } else {
+        return null;
+      }
+    }
+
     public Charset getCharset() {
       return this.charset;
     }

--- a/core/src/main/java/org/apache/calcite/sql/type/JavaToSqlTypeConversionRules.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/JavaToSqlTypeConversionRules.java
@@ -77,6 +77,7 @@ public class JavaToSqlTypeConversionRules {
           .put(ColumnList.class, SqlTypeName.COLUMN_LIST)
           .put(ArrayImpl.class, SqlTypeName.ARRAY)
           .put(List.class, SqlTypeName.ARRAY)
+          .put(Map.class, SqlTypeName.MAP)
           .put(Void.class, SqlTypeName.NULL)
           .build();
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRules.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRules.java
@@ -193,6 +193,9 @@ public class SqlTypeAssignmentRules {
     // ARRAY is assignable from ...
     rules.add(SqlTypeName.ARRAY, EnumSet.of(SqlTypeName.ARRAY));
 
+    // Map is assignable from ...
+    rules.add(SqlTypeName.MAP, EnumSet.of(SqlTypeName.MAP));
+
     // ANY is assignable from ...
     rule.clear();
     rule.add(SqlTypeName.TINYINT);

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -220,6 +220,8 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
         : "use createMultisetType() instead";
     assert typeName != SqlTypeName.ARRAY
         : "use createArrayType() instead";
+    assert typeName != SqlTypeName.MAP
+        : "use createMapType() instead";
     assert typeName != SqlTypeName.ROW
         : "use createStructType() instead";
     assert !SqlTypeName.INTERVAL_TYPES.contains(typeName)

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
@@ -151,6 +152,23 @@ public class SqlTypeFactoryTest {
     final RelDataType copyRecordType = typeFactory.createTypeWithNullability(recordType, true);
     assertFalse(recordType.isNullable());
     assertTrue(copyRecordType.isNullable());
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3429">[CALCITE-3429]
+   * AssertionError thrown for user-defined table function with map argument</a>. */
+  @Test public void testCreateTypeWithJavaMapType() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType relDataType = f.typeFactory.createJavaType(Map.class);
+    assertThat(relDataType.getSqlTypeName(), is(SqlTypeName.MAP));
+    assertThat(relDataType.getKeyType().getSqlTypeName(), is(SqlTypeName.ANY));
+
+    try {
+      f.typeFactory.createSqlType(SqlTypeName.MAP);
+      fail();
+    } catch (AssertionError e) {
+      assertThat(e.getMessage(), is("use createMapType() instead"));
+    }
   }
 
 }

--- a/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
@@ -123,6 +123,24 @@ public class TableFunctionTest {
     }
   }
 
+  @Test public void testTableFunctionWithMapParameter() throws SQLException {
+    try (Connection connection = DriverManager.getConnection("jdbc:calcite:")) {
+      CalciteConnection calciteConnection =
+          connection.unwrap(CalciteConnection.class);
+      SchemaPlus rootSchema = calciteConnection.getRootSchema();
+      SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
+      final TableFunction table =
+          TableFunctionImpl.create(Smalls.GENERATE_STRINGS_OF_INPUT_MAP_SIZE_METHOD);
+      schema.add("GenerateStringsOfInputMapSize", table);
+      final String sql = "select *\n"
+          + "from table(\"s\".\"GenerateStringsOfInputMapSize\"(Map[5,4,3,1])) as t(n, c)\n"
+          + "where char_length(c) > 0";
+      ResultSet resultSet = connection.createStatement().executeQuery(sql);
+      assertThat(CalciteAssert.toString(resultSet),
+          equalTo("N=1; C=a\n"));
+    }
+  }
+
   /**
    * Tests a table function that implements {@link ScannableTable} and returns
    * a single column.

--- a/core/src/test/java/org/apache/calcite/util/Smalls.java
+++ b/core/src/test/java/org/apache/calcite/util/Smalls.java
@@ -60,6 +60,7 @@ import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -74,6 +75,8 @@ public class Smalls {
       Types.lookupMethod(Smalls.class, "generateStrings", Integer.class);
   public static final Method GENERATE_STRINGS_OF_INPUT_SIZE_METHOD =
       Types.lookupMethod(Smalls.class, "generateStringsOfInputSize", List.class);
+  public static final Method GENERATE_STRINGS_OF_INPUT_MAP_SIZE_METHOD =
+      Types.lookupMethod(Smalls.class, "generateStringsOfInputMapSize", Map.class);
   public static final Method MAZE_METHOD =
       Types.lookupMethod(MazeTable.class, "generate", int.class, int.class,
           int.class);
@@ -186,6 +189,9 @@ public class Smalls {
 
   public static QueryableTable generateStringsOfInputSize(final List<Integer> list) {
     return generateStrings(list.size());
+  }
+  public static QueryableTable generateStringsOfInputMapSize(final Map<Integer, Integer> map) {
+    return generateStrings(map.size());
   }
 
   /** A function that generates multiplication table of {@code ncol} columns x

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeTable.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeTable.java
@@ -108,6 +108,9 @@ public class GeodeTable extends AbstractQueryableTable implements TranslatableTa
         type = typeFactory.createMultisetType(
             typeFactory.createSqlType(SqlTypeName.ANY),
             -1);
+      } else if (typeName == SqlTypeName.MAP) {
+        RelDataType anyType = typeFactory.createSqlType(SqlTypeName.ANY);
+        type = typeFactory.createMapType(anyType, anyType);
       } else {
         type = typeFactory.createSqlType(typeName);
       }


### PR DESCRIPTION
Similar to https://github.com/apache/calcite/pull/1519, using map in table function may cause exception.
Please refer to jira [CALCITE-3429](https://issues.apache.org/jira/browse/CALCITE-3429) for full stack trace.

To fix it, this PR make the follow changes:
1. Add map info from Java Map class to SqlTypeName.Map
2. SqlTypeName.Map is not a basic type, should not be used in factory method `createSqlType`, just like SqlTypeName.Array
3. Add coerce rule for SqlTypeName.MAP