### PR TITLE
[CALCITE-3416] SQL Dialects DEFAULTs should be more extensible

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -61,6 +61,15 @@ import javax.annotation.Nullable;
  *
  * <p>It is used by classes such as {@link SqlWriter} and
  * {@link org.apache.calcite.sql.util.SqlBuilder}.
+ *
+ * <p>To add a new {@link SqlDialect} sub-class, extends this class to hold 2 public final
+ * static member:
+ * <ul>
+ *   <li>DEFAULT_CONTEXT: a default {@link Context} instance, which can be used to customize
+ *   or extending the dialect if the DEFAULT instance does not meet the requests</li>
+ *   <li>DEFAULT: the default {@link SqlDialect} instance with context properties defined with
+ *   <code>DEFAULT_CONTEXT</code></li>
+ * </ul>
  */
 public class SqlDialect {
   //~ Static fields/initializers ---------------------------------------------
@@ -235,8 +244,8 @@ public class SqlDialect {
 
   //~ Methods ----------------------------------------------------------------
 
-  /** Creates an empty context. Use {@link #EMPTY_CONTEXT} if possible. */
-  protected static Context emptyContext() {
+  /** Creates an empty context. Use {@link #EMPTY_CONTEXT} to reference the instance. */
+  private static Context emptyContext() {
     return new ContextImpl(DatabaseProduct.UNKNOWN, null, null, -1, -1,
         "'", "''", null,
         Casing.UNCHANGED, Casing.TO_UPPER, true, SqlConformanceEnum.DEFAULT,

--- a/core/src/main/java/org/apache/calcite/sql/dialect/AccessSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/AccessSqlDialect.java
@@ -22,10 +22,11 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Access database.
  */
 public class AccessSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new AccessSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.ACCESS)
-          .withIdentifierQuoteString("\""));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.ACCESS)
+      .withIdentifierQuoteString("\"");
+
+  public static final SqlDialect DEFAULT = new AccessSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an AccessSqlDialect. */
   public AccessSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/AnsiSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/AnsiSqlDialect.java
@@ -22,15 +22,17 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for an unknown ANSI compatible database.
  */
 public class AnsiSqlDialect extends SqlDialect {
+
+  public static final Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.UNKNOWN)
+      .withIdentifierQuoteString("`");
+
   /**
    * A dialect useful for generating generic SQL. If you need to do something
    * database-specific like quoting identifiers, don't rely on this dialect to
    * do what you want.
    */
-  public static final SqlDialect DEFAULT =
-      new AnsiSqlDialect(emptyContext()
-          .withDatabaseProduct(DatabaseProduct.UNKNOWN)
-          .withIdentifierQuoteString("`"));
+  public static final SqlDialect DEFAULT = new AnsiSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an AnsiSqlDialect. */
   public AnsiSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -45,17 +45,17 @@ import java.util.regex.Pattern;
  * dialect.
  */
 public class BigQuerySqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new BigQuerySqlDialect(
-          EMPTY_CONTEXT
-              .withDatabaseProduct(SqlDialect.DatabaseProduct.BIG_QUERY)
-              .withLiteralQuoteString("'")
-              .withLiteralEscapedQuoteString("\\'")
-              .withIdentifierQuoteString("`")
-              .withNullCollation(NullCollation.LOW)
-              .withUnquotedCasing(Casing.UNCHANGED)
-              .withQuotedCasing(Casing.UNCHANGED)
-              .withCaseSensitive(false));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.BIG_QUERY)
+      .withLiteralQuoteString("'")
+      .withLiteralEscapedQuoteString("\\'")
+      .withIdentifierQuoteString("`")
+      .withNullCollation(NullCollation.LOW)
+      .withUnquotedCasing(Casing.UNCHANGED)
+      .withQuotedCasing(Casing.UNCHANGED)
+      .withCaseSensitive(false);
+
+  public static final SqlDialect DEFAULT = new BigQuerySqlDialect(DEFAULT_CONTEXT);
 
   private static final List<String> RESERVED_KEYWORDS =
       ImmutableList.copyOf(

--- a/core/src/main/java/org/apache/calcite/sql/dialect/CalciteSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/CalciteSqlDialect.java
@@ -23,16 +23,17 @@ import org.apache.calcite.sql.SqlDialect;
  * by Apache Calcite.
  */
 public class CalciteSqlDialect extends SqlDialect {
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.CALCITE)
+      .withIdentifierQuoteString("\"");
+
   /**
    * A dialect useful for generating SQL which can be parsed by the Apache
    * Calcite parser, in particular quoting literals and identifiers. If you
    * want a dialect that knows the full capabilities of the database, create
    * one from a connection.
    */
-  public static final SqlDialect DEFAULT =
-      new CalciteSqlDialect(emptyContext()
-          .withDatabaseProduct(DatabaseProduct.CALCITE)
-          .withIdentifierQuoteString("\""));
+  public static final SqlDialect DEFAULT = new CalciteSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a CalciteSqlDialect. */
   public CalciteSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/Db2SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/Db2SqlDialect.java
@@ -26,9 +26,10 @@ import org.apache.calcite.sql.SqlWriter;
  * A <code>SqlDialect</code> implementation for the IBM DB2 database.
  */
 public class Db2SqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new Db2SqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.DB2));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.DB2);
+
+  public static final SqlDialect DEFAULT = new Db2SqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a Db2SqlDialect. */
   public Db2SqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/DerbySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/DerbySqlDialect.java
@@ -22,9 +22,10 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Apache Derby database.
  */
 public class DerbySqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new DerbySqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.DERBY));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.DERBY);
+
+  public static final SqlDialect DEFAULT = new DerbySqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a DerbySqlDialect. */
   public DerbySqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/FirebirdSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/FirebirdSqlDialect.java
@@ -22,9 +22,10 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Firebird database.
  */
 public class FirebirdSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new FirebirdSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.FIREBIRD));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.FIREBIRD);
+
+  public static final SqlDialect DEFAULT = new FirebirdSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a FirebirdSqlDialect. */
   public FirebirdSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/H2SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/H2SqlDialect.java
@@ -22,10 +22,11 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the H2 database.
  */
 public class H2SqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new H2SqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.H2)
-          .withIdentifierQuoteString("\""));
+  public static final Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.H2)
+      .withIdentifierQuoteString("\"");
+
+  public static final SqlDialect DEFAULT = new H2SqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an H2SqlDialect. */
   public H2SqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
@@ -38,10 +38,11 @@ import org.apache.calcite.sql.type.BasicSqlType;
  * A <code>SqlDialect</code> implementation for the Apache Hive database.
  */
 public class HiveSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new HiveSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.HIVE)
-          .withNullCollation(NullCollation.LOW));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.HIVE)
+      .withNullCollation(NullCollation.LOW);
+
+  public static final SqlDialect DEFAULT = new HiveSqlDialect(DEFAULT_CONTEXT);
 
   private final boolean emulateNullDirection;
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/HsqldbSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HsqldbSqlDialect.java
@@ -33,9 +33,10 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  * A <code>SqlDialect</code> implementation for the Hsqldb database.
  */
 public class HsqldbSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new HsqldbSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.HSQLDB));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.HSQLDB);
+
+  public static final SqlDialect DEFAULT = new HsqldbSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an HsqldbSqlDialect. */
   public HsqldbSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/InfobrightSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/InfobrightSqlDialect.java
@@ -22,10 +22,11 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Infobright database.
  */
 public class InfobrightSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new InfobrightSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.INFOBRIGHT)
-          .withIdentifierQuoteString("`"));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.INFOBRIGHT)
+      .withIdentifierQuoteString("`");
+
+  public static final SqlDialect DEFAULT = new InfobrightSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an InfobrightSqlDialect. */
   public InfobrightSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/InformixSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/InformixSqlDialect.java
@@ -22,9 +22,10 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Informix database.
  */
 public class InformixSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new InformixSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.INFORMIX));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.INFORMIX);
+
+  public static final SqlDialect DEFAULT = new InformixSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an InformixSqlDialect. */
   public InformixSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/IngresSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/IngresSqlDialect.java
@@ -22,9 +22,10 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Ingres database.
  */
 public class IngresSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new IngresSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.INGRES));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.INGRES);
+
+  public static final SqlDialect DEFAULT = new IngresSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an IngresSqlDialect. */
   public IngresSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/InterbaseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/InterbaseSqlDialect.java
@@ -22,9 +22,10 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Interbase database.
  */
 public class InterbaseSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new InterbaseSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.INTERBASE));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.INTERBASE);
+
+  public static final SqlDialect DEFAULT = new InterbaseSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an InterbaseSqlDialect. */
   public InterbaseSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/LucidDbSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/LucidDbSqlDialect.java
@@ -22,10 +22,11 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the LucidDB database.
  */
 public class LucidDbSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new LucidDbSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.LUCIDDB)
-          .withIdentifierQuoteString("\""));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.LUCIDDB)
+      .withIdentifierQuoteString("\"");
+
+  public static final SqlDialect DEFAULT = new LucidDbSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a LucidDbSqlDialect. */
   public LucidDbSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -41,12 +41,13 @@ import org.apache.calcite.sql.type.ReturnTypes;
  * database.
  */
 public class MssqlSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new MssqlSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.MSSQL)
-          .withIdentifierQuoteString("[")
-          .withCaseSensitive(false)
-          .withNullCollation(NullCollation.LOW));
+  public static final Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.MSSQL)
+      .withIdentifierQuoteString("[")
+      .withCaseSensitive(false)
+      .withNullCollation(NullCollation.LOW);
+
+  public static final SqlDialect DEFAULT = new MssqlSqlDialect(DEFAULT_CONTEXT);
 
   private static final SqlFunction MSSQL_SUBSTRING =
       new SqlFunction("SUBSTRING", SqlKind.OTHER_FUNCTION,

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -49,12 +49,13 @@ import org.apache.calcite.sql.type.SqlTypeName;
  * A <code>SqlDialect</code> implementation for the MySQL database.
  */
 public class MysqlSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new MysqlSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.MYSQL)
-          .withIdentifierQuoteString("`")
-          .withUnquotedCasing(Casing.UNCHANGED)
-          .withNullCollation(NullCollation.LOW));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.MYSQL)
+      .withIdentifierQuoteString("`")
+      .withUnquotedCasing(Casing.UNCHANGED)
+      .withNullCollation(NullCollation.LOW);
+
+  public static final SqlDialect DEFAULT = new MysqlSqlDialect(DEFAULT_CONTEXT);
 
   /** MySQL specific function. */
   public static final SqlFunction ISNULL_FUNCTION =

--- a/core/src/main/java/org/apache/calcite/sql/dialect/NeoviewSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/NeoviewSqlDialect.java
@@ -22,9 +22,10 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Neoview database.
  */
 public class NeoviewSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new NeoviewSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.NEOVIEW));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.NEOVIEW);
+
+  public static final SqlDialect DEFAULT = new NeoviewSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a NeoviewSqlDialect. */
   public NeoviewSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/NetezzaSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/NetezzaSqlDialect.java
@@ -22,10 +22,11 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Netezza database.
  */
 public class NetezzaSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new NetezzaSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.NETEZZA)
-          .withIdentifierQuoteString("\""));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.NETEZZA)
+      .withIdentifierQuoteString("\"");
+
+  public static final SqlDialect DEFAULT = new NetezzaSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a NetezzaSqlDialect. */
   public NetezzaSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -46,7 +46,6 @@ import java.util.List;
  * A <code>SqlDialect</code> implementation for the Oracle database.
  */
 public class OracleSqlDialect extends SqlDialect {
-
   /** OracleDB type system. */
   private static final RelDataTypeSystem ORACLE_TYPE_SYSTEM =
       new RelDataTypeSystemImpl() {
@@ -61,11 +60,12 @@ public class OracleSqlDialect extends SqlDialect {
         }
       };
 
-  public static final SqlDialect DEFAULT =
-      new OracleSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.ORACLE)
-          .withIdentifierQuoteString("\"")
-          .withDataTypeSystem(ORACLE_TYPE_SYSTEM));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.ORACLE)
+      .withIdentifierQuoteString("\"")
+      .withDataTypeSystem(ORACLE_TYPE_SYSTEM);
+
+  public static final SqlDialect DEFAULT = new OracleSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates an OracleSqlDialect. */
   public OracleSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/ParaccelSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ParaccelSqlDialect.java
@@ -22,10 +22,11 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Paraccel database.
  */
 public class ParaccelSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new ParaccelSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.PARACCEL)
-          .withIdentifierQuoteString("\""));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.PARACCEL)
+      .withIdentifierQuoteString("\"");
+
+  public static final SqlDialect DEFAULT = new ParaccelSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a ParaccelSqlDialect. */
   public ParaccelSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PhoenixSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PhoenixSqlDialect.java
@@ -22,10 +22,11 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Apache Phoenix database.
  */
 public class PhoenixSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new PhoenixSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.PHOENIX)
-          .withIdentifierQuoteString("\""));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.PHOENIX)
+      .withIdentifierQuoteString("\"");
+
+  public static final SqlDialect DEFAULT = new PhoenixSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a PhoenixSqlDialect. */
   public PhoenixSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
@@ -36,7 +36,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
  * A <code>SqlDialect</code> implementation for the PostgreSQL database.
  */
 public class PostgresqlSqlDialect extends SqlDialect {
-
   /** PostgreSQL type system. */
   private static final RelDataTypeSystem POSTGRESQL_TYPE_SYSTEM =
       new RelDataTypeSystemImpl() {
@@ -56,12 +55,13 @@ public class PostgresqlSqlDialect extends SqlDialect {
         }
       };
 
-  public static final SqlDialect DEFAULT =
-      new PostgresqlSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.POSTGRESQL)
-          .withIdentifierQuoteString("\"")
-          .withUnquotedCasing(Casing.TO_LOWER)
-          .withDataTypeSystem(POSTGRESQL_TYPE_SYSTEM));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.POSTGRESQL)
+      .withIdentifierQuoteString("\"")
+      .withUnquotedCasing(Casing.TO_LOWER)
+      .withDataTypeSystem(POSTGRESQL_TYPE_SYSTEM);
+
+  public static final SqlDialect DEFAULT = new PostgresqlSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a PostgresqlSqlDialect. */
   public PostgresqlSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/RedshiftSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/RedshiftSqlDialect.java
@@ -25,13 +25,14 @@ import org.apache.calcite.sql.SqlWriter;
  * A <code>SqlDialect</code> implementation for the Redshift database.
  */
 public class RedshiftSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new RedshiftSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.REDSHIFT)
-          .withIdentifierQuoteString("\"")
-          .withQuotedCasing(Casing.TO_LOWER)
-          .withUnquotedCasing(Casing.TO_LOWER)
-          .withCaseSensitive(false));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.REDSHIFT)
+      .withIdentifierQuoteString("\"")
+      .withQuotedCasing(Casing.TO_LOWER)
+      .withUnquotedCasing(Casing.TO_LOWER)
+      .withCaseSensitive(false);
+
+  public static final SqlDialect DEFAULT = new RedshiftSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a RedshiftSqlDialect. */
   public RedshiftSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SnowflakeSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SnowflakeSqlDialect.java
@@ -23,11 +23,13 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Snowflake database.
  */
 public class SnowflakeSqlDialect extends SqlDialect {
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.SNOWFLAKE)
+      .withIdentifierQuoteString("\"")
+      .withUnquotedCasing(Casing.TO_UPPER);
+
   public static final SqlDialect DEFAULT =
-      new SnowflakeSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.SNOWFLAKE)
-          .withIdentifierQuoteString("\"")
-          .withUnquotedCasing(Casing.TO_UPPER));
+      new SnowflakeSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a SnowflakeSqlDialect. */
   public SnowflakeSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -36,10 +36,11 @@ import org.apache.calcite.sql.type.ReturnTypes;
  * A <code>SqlDialect</code> implementation for the APACHE SPARK database.
  */
 public class SparkSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new SparkSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.SPARK)
-          .withNullCollation(NullCollation.LOW));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.SPARK)
+      .withNullCollation(NullCollation.LOW);
+
+  public static final SqlDialect DEFAULT = new SparkSqlDialect(DEFAULT_CONTEXT);
 
   private static final SqlFunction SPARKSQL_SUBSTRING =
       new SqlFunction("SUBSTRING", SqlKind.OTHER_FUNCTION,

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SybaseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SybaseSqlDialect.java
@@ -24,9 +24,10 @@ import org.apache.calcite.sql.SqlWriter;
  * A <code>SqlDialect</code> implementation for the Sybase database.
  */
 public class SybaseSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new SybaseSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.SYBASE));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.SYBASE);
+
+  public static final SqlDialect DEFAULT = new SybaseSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a SybaseSqlDialect. */
   public SybaseSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/TeradataSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/TeradataSqlDialect.java
@@ -22,10 +22,12 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Teradata database.
  */
 public class TeradataSqlDialect extends SqlDialect {
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.TERADATA)
+      .withIdentifierQuoteString("\"");
+
   public static final SqlDialect DEFAULT =
-      new TeradataSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.TERADATA)
-          .withIdentifierQuoteString("\""));
+      new TeradataSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a TeradataSqlDialect. */
   public TeradataSqlDialect(Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
@@ -23,11 +23,12 @@ import org.apache.calcite.sql.SqlDialect;
  * A <code>SqlDialect</code> implementation for the Vertica database.
  */
 public class VerticaSqlDialect extends SqlDialect {
-  public static final SqlDialect DEFAULT =
-      new VerticaSqlDialect(EMPTY_CONTEXT
-          .withDatabaseProduct(DatabaseProduct.VERTICA)
-          .withIdentifierQuoteString("\"")
-          .withUnquotedCasing(Casing.UNCHANGED));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(SqlDialect.DatabaseProduct.VERTICA)
+      .withIdentifierQuoteString("\"")
+      .withUnquotedCasing(Casing.UNCHANGED);
+
+  public static final SqlDialect DEFAULT = new VerticaSqlDialect(DEFAULT_CONTEXT);
 
   /** Creates a VerticaSqlDialect. */
   public VerticaSqlDialect(Context context) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -135,9 +135,7 @@ public class RelToSqlConverterTest {
   }
 
   private static MysqlSqlDialect mySqlDialect(NullCollation nullCollation) {
-    return new MysqlSqlDialect(SqlDialect.EMPTY_CONTEXT
-        .withDatabaseProduct(SqlDialect.DatabaseProduct.MYSQL)
-        .withIdentifierQuoteString("`")
+    return new MysqlSqlDialect(MysqlSqlDialect.DEFAULT_CONTEXT
         .withNullCollation(nullCollation));
   }
 
@@ -1169,13 +1167,13 @@ public class RelToSqlConverterTest {
 
   @Test public void testHiveSelectQueryWithOrderByDescAndHighNullsWithVersionGreaterThanOrEq21() {
     final HiveSqlDialect hive2_1Dialect =
-        new HiveSqlDialect(SqlDialect.EMPTY_CONTEXT
+        new HiveSqlDialect(HiveSqlDialect.DEFAULT_CONTEXT
             .withDatabaseMajorVersion(2)
             .withDatabaseMinorVersion(1)
             .withNullCollation(NullCollation.LOW));
 
     final HiveSqlDialect hive2_2_Dialect =
-        new HiveSqlDialect(SqlDialect.EMPTY_CONTEXT
+        new HiveSqlDialect(HiveSqlDialect.DEFAULT_CONTEXT
             .withDatabaseMajorVersion(2)
             .withDatabaseMinorVersion(2)
             .withNullCollation(NullCollation.LOW));
@@ -1191,7 +1189,7 @@ public class RelToSqlConverterTest {
 
   @Test public void testHiveSelectQueryWithOrderByDescAndHighNullsWithVersion20() {
     final HiveSqlDialect hive2_1_0_Dialect =
-        new HiveSqlDialect(SqlDialect.EMPTY_CONTEXT
+        new HiveSqlDialect(HiveSqlDialect.DEFAULT_CONTEXT
             .withDatabaseMajorVersion(2)
             .withDatabaseMinorVersion(0)
             .withNullCollation(NullCollation.LOW));
@@ -4044,8 +4042,7 @@ public class RelToSqlConverterTest {
     Sql withMssql(int majorVersion) {
       final SqlDialect mssqlDialect = DatabaseProduct.MSSQL.getDialect();
       return dialect(
-          new MssqlSqlDialect(SqlDialect.EMPTY_CONTEXT
-              .withDatabaseProduct(DatabaseProduct.MSSQL)
+          new MssqlSqlDialect(MssqlSqlDialect.DEFAULT_CONTEXT
               .withDatabaseMajorVersion(majorVersion)
               .withIdentifierQuoteString(mssqlDialect.quoteIdentifier("")
                   .substring(0, 1))
@@ -4059,8 +4056,7 @@ public class RelToSqlConverterTest {
     Sql withMysql8() {
       final SqlDialect mysqlDialect = DatabaseProduct.MYSQL.getDialect();
       return dialect(
-          new SqlDialect(SqlDialect.EMPTY_CONTEXT
-              .withDatabaseProduct(DatabaseProduct.MYSQL)
+          new SqlDialect(MysqlSqlDialect.DEFAULT_CONTEXT
               .withDatabaseMajorVersion(8)
               .withIdentifierQuoteString(mysqlDialect.quoteIdentifier("")
                   .substring(0, 1))
@@ -4102,9 +4098,7 @@ public class RelToSqlConverterTest {
     Sql withPostgresqlModifiedTypeSystem() {
       // Postgresql dialect with max length for varchar set to 256
       final PostgresqlSqlDialect postgresqlSqlDialect =
-          new PostgresqlSqlDialect(SqlDialect.EMPTY_CONTEXT
-              .withDatabaseProduct(DatabaseProduct.POSTGRESQL)
-              .withIdentifierQuoteString("\"")
+          new PostgresqlSqlDialect(PostgresqlSqlDialect.DEFAULT_CONTEXT
               .withDataTypeSystem(new RelDataTypeSystemImpl() {
                 @Override public int getMaxPrecision(SqlTypeName typeName) {
                   switch (typeName) {
@@ -4121,9 +4115,7 @@ public class RelToSqlConverterTest {
     Sql withOracleModifiedTypeSystem() {
       // Oracle dialect with max length for varchar set to 512
       final OracleSqlDialect oracleSqlDialect =
-          new OracleSqlDialect(SqlDialect.EMPTY_CONTEXT
-              .withDatabaseProduct(DatabaseProduct.ORACLE)
-              .withIdentifierQuoteString("\"")
+          new OracleSqlDialect(OracleSqlDialect.DEFAULT_CONTEXT
               .withDataTypeSystem(new RelDataTypeSystemImpl() {
                 @Override public int getMaxPrecision(SqlTypeName typeName) {
                   switch (typeName) {

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -49,7 +49,7 @@ public class PigRelOpTest extends PigRelTestBase {
    */
   private static class PigRelSqlDialect extends SqlDialect {
     static final SqlDialect DEFAULT =
-        new CalciteSqlDialect(emptyContext()
+        new CalciteSqlDialect(SqlDialect.EMPTY_CONTEXT
             .withDatabaseProduct(DatabaseProduct.CALCITE));
 
     private PigRelSqlDialect(Context context) {


### PR DESCRIPTION
* In each SqlDialect sub-class, add a new public static final member
named DEFAULT_CONTEXT used to extend the dialect
* Make SqlDialect.emptyContext private, we should now always use
SqlDialect.EMPTY_CONTEXT instead