### PR TITLE
[CALCITE-3439] Support Intersect and Minus in RelMdPredicates

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -451,7 +451,7 @@ public class RelMdPredicates
   }
 
   /**
-   * Infers predicates for a Intersect.
+   * Infers predicates for a Minus.
    */
   public RelOptPredicateList getPredicates(Minus minus, RelMetadataQuery mq) {
     return mq.getPulledUpPredicates(minus.getInput(0));

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -21,6 +21,7 @@ import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RexImplicationChecker;
 import org.apache.calcite.plan.Strong;
 import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.plan.volcano.RelSubset;
@@ -28,8 +29,10 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Intersect;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Minus;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableScan;
@@ -37,6 +40,7 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexExecutor;
+import org.apache.calcite.rex.RexExecutorImpl;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -409,6 +413,50 @@ public class RelMdPredicates
     }
     return RelOptPredicateList.of(rexBuilder, predicates);
   }
+
+  /**
+   * Infers predicates for a Intersect.
+   */
+  public RelOptPredicateList getPredicates(Intersect intersect, RelMetadataQuery mq) {
+    final RexBuilder rexBuilder = intersect.getCluster().getRexBuilder();
+
+    final RexExecutorImpl rexImpl =
+        (RexExecutorImpl) (intersect.getCluster().getPlanner().getExecutor());
+    final RexImplicationChecker rexImplicationChecker =
+        new RexImplicationChecker(
+            intersect.getCluster().getRexBuilder(), rexImpl, intersect.getRowType());
+
+    Set<RexNode> finalPredicates = new HashSet<>();
+    RexNode composedFinalPredicates = null;
+    for (Ord<RelNode> input : Ord.zip(intersect.getInputs())) {
+      RelOptPredicateList info = mq.getPulledUpPredicates(input.e);
+      if (info.pulledUpPredicates.isEmpty()) {
+        return RelOptPredicateList.EMPTY;
+      }
+      final Set<RexNode> predicates = new HashSet<>();
+      for (RexNode pred : info.pulledUpPredicates) {
+        if (input.i == 0) {
+          predicates.add(pred);
+          continue;
+        } else if (rexImplicationChecker.implies(composedFinalPredicates, pred)) {
+          predicates.add(pred);
+        }
+      }
+      finalPredicates = predicates;
+      composedFinalPredicates = RexUtil.composeConjunction(
+          rexBuilder, finalPredicates);
+    }
+
+    return RelOptPredicateList.of(rexBuilder, finalPredicates);
+  }
+
+  /**
+   * Infers predicates for a Intersect.
+   */
+  public RelOptPredicateList getPredicates(Minus minus, RelMetadataQuery mq) {
+    return mq.getPulledUpPredicates(minus.getInput(0));
+  }
+
 
   /**
    * Infers predicates for a Sort.

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -424,8 +424,7 @@ public class RelMdPredicates
     final RexExecutorImpl rexImpl =
         (RexExecutorImpl) (intersect.getCluster().getPlanner().getExecutor());
     final RexImplicationChecker rexImplicationChecker =
-        new RexImplicationChecker(
-            intersect.getCluster().getRexBuilder(), rexImpl, intersect.getRowType());
+        new RexImplicationChecker(rexBuilder, rexImpl, intersect.getRowType());
 
     Set<RexNode> finalPredicates = new HashSet<>();
 

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1589,24 +1589,29 @@ public class RelMetadataTest extends SqlToRelTestBase {
         sortsAs("[IS NULL($0)]"));
   }
 
-  @Test public void testPullUpPredicatesFromUnion() {
+  @Test public void testPullUpPredicatesFromUnion0() {
     final RelMetadataQuery mq = RelMetadataQuery.instance();
-    RelNode rel = null;
-    rel = convertSql(""
+    final RelNode rel = convertSql(""
         + "select empno from emp where empno=1\n"
         + "union all\n"
         + "select empno from emp where empno=1");
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1)]"));
+  }
 
-    rel = convertSql(""
+  @Test public void testPullUpPredicatesFromUnion1() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelNode rel = convertSql(""
         + "select empno, deptno from emp where empno=1 or deptno=2\n"
         + "union all\n"
         + "select empno, deptno from emp where empno=3 or deptno=4");
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[OR(=($0, 1), =($1, 2), =($0, 3), =($1, 4))]"));
+  }
 
-    rel = convertSql(""
+  @Test public void testPullUpPredicatesFromUnion2() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelNode rel = convertSql(""
         + "select empno, comm, deptno from emp where empno=1 and comm=2 and deptno=3\n"
         + "union all\n"
         + "select empno, comm, deptno from emp where empno=1 and comm=4");
@@ -1615,34 +1620,52 @@ public class RelMetadataTest extends SqlToRelTestBase {
 
   }
 
-  @Test public void testPullUpPredicatesFromIntersect() {
+  @Test public void testPullUpPredicatesFromIntersect0() {
     final RelMetadataQuery mq = RelMetadataQuery.instance();
-    RelNode rel = null;
-    rel = convertSql(""
+    final RelNode rel = convertSql(""
         + "select empno from emp where empno=1\n"
         + "intersect all\n"
         + "select empno from emp where empno=1");
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1)]"));
 
-    rel = convertSql(""
-        + "select empno, deptno from emp where empno=1 and deptno=2\n"
-        + "intersect all\n"
-        + "select empno, deptno from emp where empno=1 and deptno=3");
-    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
-        sortsAs("[=($0, 1)]"));
+  }
 
-    rel = convertSql(""
-        + "select empno, deptno, comm from emp where 1=empno and deptno=2\n"
+  @Test public void testPullUpPredicatesFromIntersect1() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelNode rel = convertSql(""
+        + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
         + "intersect all\n"
         + "select empno, deptno, comm from emp where empno=1 and comm=3");
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
-        sortsAs("[=($0, 1)]"));
+        sortsAs("[=($0, 1), =($1, 2), =($2, 3)]"));
+
+  }
+
+  @Test public void testPullUpPredicatesFromIntersect2() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelNode rel = convertSql(""
+        + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
+        + "intersect all\n"
+        + "select empno, deptno, comm from emp where 1=empno and (deptno=2 or comm=3)");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[=($0, 1), =($1, 2)]"));
+
+  }
+
+  @Test public void testPullUpPredicatesFromIntersect3() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    final RelNode rel = convertSql(""
+        + "select empno, deptno, comm from emp where empno=1 or deptno=2\n"
+        + "intersect all\n"
+        + "select empno, deptno, comm from emp where deptno=2 or empno=1 or comm=3");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[OR(=($0, 1), =($1, 2))]"));
   }
 
   @Test public void testPullUpPredicatesFromMinus() {
     final RelMetadataQuery mq = RelMetadataQuery.instance();
-    RelNode rel = convertSql(""
+    final RelNode rel = convertSql(""
         + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
         + "except all\n"
         + "select empno, deptno, comm from emp where comm=3");

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1642,8 +1642,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
 
   @Test public void testPullUpPredicatesFromMinus() {
     final RelMetadataQuery mq = RelMetadataQuery.instance();
-    RelNode rel = null;
-    rel = convertSql(""
+    RelNode rel = convertSql(""
         + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
         + "except all\n"
         + "select empno, deptno, comm from emp where comm=3");

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1589,6 +1589,68 @@ public class RelMetadataTest extends SqlToRelTestBase {
         sortsAs("[IS NULL($0)]"));
   }
 
+  @Test public void testPullUpPredicatesFromUnion() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    RelNode rel = null;
+    rel = convertSql(""
+        + "select empno from emp where empno=1\n"
+        + "union all\n"
+        + "select empno from emp where empno=1");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[=($0, 1)]"));
+
+    rel = convertSql(""
+        + "select empno, deptno from emp where empno=1 or deptno=2\n"
+        + "union all\n"
+        + "select empno, deptno from emp where empno=3 or deptno=4");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[OR(=($0, 1), =($1, 2), =($0, 3), =($1, 4))]"));
+
+    rel = convertSql(""
+        + "select empno, comm, deptno from emp where empno=1 and comm=2 and deptno=3\n"
+        + "union all\n"
+        + "select empno, comm, deptno from emp where empno=1 and comm=4");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[=($0, 1), OR(AND(=($1, 2), =($2, 3)), =($1, 4))]"));
+
+  }
+
+  @Test public void testPullUpPredicatesFromIntersect() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    RelNode rel = null;
+    rel = convertSql(""
+        + "select empno from emp where empno=1\n"
+        + "intersect all\n"
+        + "select empno from emp where empno=1");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[=($0, 1)]"));
+
+    rel = convertSql(""
+        + "select empno, deptno from emp where empno=1 and deptno=2\n"
+        + "intersect all\n"
+        + "select empno, deptno from emp where empno=1 and deptno=3");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[=($0, 1)]"));
+
+    rel = convertSql(""
+        + "select empno, deptno, comm from emp where 1=empno and deptno=2\n"
+        + "intersect all\n"
+        + "select empno, deptno, comm from emp where empno=1 and comm=3");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[=($0, 1)]"));
+  }
+
+  @Test public void testPullUpPredicatesFromMinus() {
+    final RelMetadataQuery mq = RelMetadataQuery.instance();
+    RelNode rel = null;
+    rel = convertSql(""
+        + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
+        + "except all\n"
+        + "select empno, deptno, comm from emp where comm=3");
+    assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
+        sortsAs("[=($0, 1), =($1, 2)]"));
+  }
+
   @Test public void testDistributionSimple() {
     RelNode rel = convertSql("select * from emp where deptno = 10");
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();


### PR DESCRIPTION
Currently only Union is supported in RelMdPredicates. We might also support Intersect and Minus;
This issue was found when resolving CALCITE-3428

I also added a test for Union