### PR TITLE
[CALCITE-3441] Remove SqlTypeExplicitPrecedenceList.COMPACT_NUMERIC_T…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeExplicitPrecedenceList.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeExplicitPrecedenceList.java
@@ -22,13 +22,11 @@ import org.apache.calcite.util.Glossary;
 import org.apache.calcite.util.ImmutableNullableList;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * SqlTypeExplicitPrecedenceList implements the
@@ -39,27 +37,16 @@ public class SqlTypeExplicitPrecedenceList
     implements RelDataTypePrecedenceList {
   //~ Static fields/initializers ---------------------------------------------
 
-  // NOTE jvs 25-Jan-2005:  the null entries delimit equivalence
-  // classes
   private static final List<SqlTypeName> NUMERIC_TYPES =
       ImmutableNullableList.of(
           SqlTypeName.TINYINT,
-          null,
           SqlTypeName.SMALLINT,
-          null,
           SqlTypeName.INTEGER,
-          null,
           SqlTypeName.BIGINT,
-          null,
           SqlTypeName.DECIMAL,
-          null,
           SqlTypeName.REAL,
-          null,
           SqlTypeName.FLOAT,
           SqlTypeName.DOUBLE);
-
-  private static final List<SqlTypeName> COMPACT_NUMERIC_TYPES =
-      ImmutableList.copyOf(Util.filter(NUMERIC_TYPES, Objects::nonNull));
 
   /**
    * Map from SqlTypeName to corresponding precedence list.
@@ -136,9 +123,9 @@ public class SqlTypeExplicitPrecedenceList
   }
 
   private static SqlTypeExplicitPrecedenceList numeric(SqlTypeName typeName) {
-    int i = getListPosition(typeName, COMPACT_NUMERIC_TYPES);
+    int i = getListPosition(typeName, NUMERIC_TYPES);
     return new SqlTypeExplicitPrecedenceList(
-        Util.skip(COMPACT_NUMERIC_TYPES, i));
+        Util.skip(NUMERIC_TYPES, i));
   }
 
   // implement RelDataTypePrecedenceList
@@ -166,13 +153,6 @@ public class SqlTypeExplicitPrecedenceList
   private static int getListPosition(SqlTypeName type, List<SqlTypeName> list) {
     int i = list.indexOf(type);
     assert i != -1;
-
-    // adjust for precedence equivalence classes
-    for (int j = i - 1; j >= 0; --j) {
-      if (list.get(j) == null) {
-        return j;
-      }
-    }
     return i;
   }
 


### PR DESCRIPTION
…YPES because the NULL delimiters are useless

We do not need the "null" value as delimiter for the equivalence class
because method Util.skip already did that.

This also tweak the "needToCast" check for implicit type coercion:
change the "canCast" check into an assert, that means, we should not
swallow the cast when the coercion is not allowed in the type coercion matrix.