### PR TITLE
[CALCITE-3436] CalciteConnectionConfigImpl.set obliterates previous property values

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
@@ -41,7 +41,9 @@ public class CalciteConnectionConfigImpl extends ConnectionConfigImpl
   public CalciteConnectionConfigImpl set(CalciteConnectionProperty property,
       String value) {
     final Properties properties1 = (Properties) this.properties.clone();
-    properties1.setProperty(property.camelName(), value);
+    if (properties1.getProperty(property.camelName()) == null) {
+      properties1.setProperty(property.camelName(), value);
+    }
     return new CalciteConnectionConfigImpl(properties1);
   }
 

--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
@@ -40,13 +40,8 @@ public class CalciteConnectionConfigImpl extends ConnectionConfigImpl
   /** Returns a copy of this configuration with one property changed. */
   public CalciteConnectionConfigImpl set(CalciteConnectionProperty property,
       String value) {
-    final Properties properties1 = new Properties();
-    this.properties.forEach((connectionProp, connectionValue) -> {
-      properties1.setProperty((String) connectionProp, (String) connectionValue);
-    });
-    if (properties1.getProperty(property.camelName(), null) == null) {
-      properties1.setProperty(property.camelName(), value);
-    }
+    final Properties properties1 = (Properties) this.properties.clone();
+    properties1.setProperty(property.camelName(), value);
     return new CalciteConnectionConfigImpl(properties1);
   }
 

--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
@@ -40,8 +40,13 @@ public class CalciteConnectionConfigImpl extends ConnectionConfigImpl
   /** Returns a copy of this configuration with one property changed. */
   public CalciteConnectionConfigImpl set(CalciteConnectionProperty property,
       String value) {
-    final Properties properties1 = new Properties(properties);
-    properties1.setProperty(property.camelName(), value);
+    final Properties properties1 = new Properties();
+    this.properties.forEach((connectionProp, connectionValue) -> {
+      properties1.setProperty((String) connectionProp, (String) connectionValue);
+    });
+    if (properties1.getProperty(property.camelName(), null) == null) {
+      properties1.setProperty(property.camelName(), value);
+    }
     return new CalciteConnectionConfigImpl(properties1);
   }
 

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -117,25 +117,17 @@ public class PlannerImpl implements Planner, ViewExpander {
     reset();
   }
 
+  /** Gets a user defined config and appends default connection values */
   private CalciteConnectionConfig connConfig() {
-    CalciteConnectionConfig unwrapped = context.unwrap(CalciteConnectionConfig.class);
-    if (unwrapped != null) {
-      // may actually be overriding case_sensitive and/or conformance
-      // should look into how to check for if case_sensitive/conformance have been set
-      unwrapped = ((CalciteConnectionConfigImpl) unwrapped).set(
-              CalciteConnectionProperty.CASE_SENSITIVE,
-              String.valueOf(parserConfig.caseSensitive()));
-      unwrapped = ((CalciteConnectionConfigImpl) unwrapped).set(
-              CalciteConnectionProperty.CONFORMANCE,
-              String.valueOf(parserConfig.conformance()));
-      return unwrapped;
+    CalciteConnectionConfig config = context.unwrap(CalciteConnectionConfig.class);
+    if (config == null) {
+      config = new CalciteConnectionConfigImpl(new Properties());
     }
-    Properties properties = new Properties();
-    properties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(),
-        String.valueOf(parserConfig.caseSensitive()));
-    properties.setProperty(CalciteConnectionProperty.CONFORMANCE.camelName(),
-        String.valueOf(parserConfig.conformance()));
-    return new CalciteConnectionConfigImpl(properties);
+    return ((CalciteConnectionConfigImpl) config)
+        .set(CalciteConnectionProperty.CASE_SENSITIVE,
+            String.valueOf(parserConfig.caseSensitive()))
+        .set(CalciteConnectionProperty.CONFORMANCE,
+            String.valueOf(parserConfig.conformance()));
   }
 
   /** Makes sure that the state is at least the given state. */

--- a/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
@@ -252,11 +252,12 @@ public class FrameworksTest {
   /** Test for {@link CalciteConnectionConfigImpl#set} returns back a full
    * copy of {@link CalciteConnectionConfig} */
   @Test public void testConnectionConfigSetsFullCopy() {
-    CalciteConnectionConfig calciteConnectionConfig = new CalciteConnectionConfigImpl(new Properties())
+    CalciteConnectionConfig calciteConnectionConfig = new CalciteConnectionConfigImpl(
+        new Properties())
             .set(CalciteConnectionProperty.LENIENT_OPERATOR_LOOKUP,
-                    Boolean.toString(true))
+                Boolean.toString(true))
             .set(CalciteConnectionProperty.CASE_SENSITIVE,
-                    Boolean.toString(true));
+                Boolean.toString(true));
 
     assertThat(calciteConnectionConfig.lenientOperatorLookup(), is(true));
     assertThat(calciteConnectionConfig.caseSensitive(), is(true));
@@ -264,8 +265,8 @@ public class FrameworksTest {
     assertNull(calciteConnectionConfig.schema());
   }
 
-  /** Test for {@link CalciteConnectionConfigImpl#set} overrides previously
-   * stored values */
+  /** Test for {@link CalciteConnectionConfigImpl#set} does not overrides
+   * previously stored values */
   @Test public void testConnectionConfigOverride() {
     Properties prop = new Properties();
     prop.setProperty(CalciteConnectionProperty.FORCE_DECORRELATE.camelName(),
@@ -281,7 +282,7 @@ public class FrameworksTest {
         .set(CalciteConnectionProperty.CASE_SENSITIVE,
             Boolean.toString(true));
 
-    assertThat(calciteConnectionConfig.lenientOperatorLookup(), is(true));
+    assertThat(calciteConnectionConfig.lenientOperatorLookup(), is(false));
     assertThat(calciteConnectionConfig.caseSensitive(), is(true));
     assertThat(calciteConnectionConfig.forceDecorrelate(), is(false));
     // retrieves default value despite not being set


### PR DESCRIPTION
Resolved issue where if context was passed a CalciteConnectionConfig, it would not set the default CalciteConnectionConfig settings.

I introduced a few tests that checks for if the values will get obliterated upon calling CalciteConnectionConfigImpl.set(). Upon further inspection, when creating a new Properties object with properties argument, these will be stored in a defaults field. To return a copy of the config without having it set in the defaults field I cloned the properties field instead. 

Lastly, refactored the `frameworkConfig.getCostFactory()` method into the field `costFactory`