### PR TITLE
[CALCITE-3442] In ElasticSearch adapter, set `stored_fields = _none_` to prohibit FetchPhase get involved 

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
@@ -186,9 +186,10 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
     query.put("_source", false);
     query.put("size", 0);
     query.remove("script_fields");
-    // Set _source = false and size = 0, `FetchPhase` would still be executed against the Elasticsearch Cluster
-    // and visit the Lucene stored_fields, which would lead to performance declined dramatically.
-    // We can set `stored_fields = _none` prohibit this such behavior
+    // set _source = false and size = 0, `FetchPhase` would still be executed
+    // to fetch the metadata fields and visit the Lucene stored_fields,
+    // which would lead to performance declined dramatically.
+    // `stored_fields = _none` can prohibit such behavior entirely
     query.put("stored_fields", "_none_");
 
     // allows to detect aggregation for count(*)

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
@@ -186,6 +186,10 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
     query.put("_source", false);
     query.put("size", 0);
     query.remove("script_fields");
+    // Set _source = false and size = 0, `FetchPhase` would still be executed against the Elasticsearch Cluster
+    // and visit the Lucene stored_fields, which would lead to performance declined dramatically.
+    // We can set `stored_fields = _none` prohibit this such behavior
+    query.put("stored_fields", "_none_");
 
     // allows to detect aggregation for count(*)
     final Predicate<Map.Entry<String, String>> isCountStar = e -> e.getValue()

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
@@ -117,7 +117,7 @@ public class AggregationTest {
         .query("select count(*) from view")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker(
-                "_source:false, 'stored_fields': '_none_', size:0,  track_total_hits:true"))
+                "_source:false, 'stored_fields': '_none_', size:0, track_total_hits:true"))
         .returns("EXPR$0=3\n");
 
     CalciteAssert.that()
@@ -368,7 +368,7 @@ public class AggregationTest {
                 + "min(cast(_MAP['val2'] as integer)) as v2 from elastic.%s", NAME))
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker(
-            "_source:false, 'stored_fields': '_none_', size:0, track_total_hits:true", "'stored_fields': '_none_'",
+            "_source:false, 'stored_fields': '_none_', size:0, track_total_hits:true",
             "aggregations:{'v1.max.field': 'val1'",
             "'v2.min.field': 'val2'}"))
         .returnsUnordered("v1=7; v2=5");

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
@@ -117,7 +117,7 @@ public class AggregationTest {
         .query("select count(*) from view")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker(
-                "_source:false, size:0, track_total_hits:true"))
+                "_source:false, 'stored_fields': '_none_', size:0,  track_total_hits:true"))
         .returns("EXPR$0=3\n");
 
     CalciteAssert.that()
@@ -138,7 +138,7 @@ public class AggregationTest {
         .query("select count(*), sum(val1), sum(val2) from view")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker(
-                "_source:false, size:0, track_total_hits:true",
+                "_source:false, size:0, track_total_hits:true", "'stored_fields': '_none_'",
                 "aggregations:{'EXPR$0.value_count.field': '_id'",
                     "'EXPR$1.sum.field': 'val1'",
                     "'EXPR$2.sum.field': 'val2'}"))
@@ -149,7 +149,7 @@ public class AggregationTest {
         .query("select min(val1), max(val2), count(*) from view")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker(
-                "_source:false, size:0, track_total_hits:true",
+                "_source:false, 'stored_fields': '_none_', size:0, track_total_hits:true",
                 "aggregations:{'EXPR$0.min.field': 'val1'",
                 "'EXPR$1.max.field': 'val2'",
                 "'EXPR$2.value_count.field': '_id'}"))
@@ -368,7 +368,7 @@ public class AggregationTest {
                 + "min(cast(_MAP['val2'] as integer)) as v2 from elastic.%s", NAME))
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker(
-            "_source:false, size:0, track_total_hits:true",
+            "_source:false, 'stored_fields': '_none_', size:0, track_total_hits:true", "'stored_fields': '_none_'",
             "aggregations:{'v1.max.field': 'val1'",
             "'v2.min.field': 'val2'}"))
         .returnsUnordered("v1=7; v2=5");

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -514,7 +514,7 @@ public class ElasticSearchAdapterTest {
         .query("select count(*) from zips")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
-            "size:0", "track_total_hits:true"))
+            "size:0", "'stored_fields': '_none_'", "track_total_hits:true"))
         .returns("EXPR$0=149\n");
 
     // check with limit (should still return correct result).
@@ -526,6 +526,7 @@ public class ElasticSearchAdapterTest {
         .query("select count(*) as cnt from zips")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
+            "'stored_fields': '_none_'",
             "size:0", "track_total_hits:true"))
         .returns("cnt=149\n");
 
@@ -535,6 +536,7 @@ public class ElasticSearchAdapterTest {
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
             "size:0",
             "track_total_hits:true",
+            "'stored_fields': '_none_'",
             "aggregations:{'EXPR$0':{min:{field:'pop'}},'EXPR$1':{max:"
                 + "{field:'pop'}}}"))
         .returns("EXPR$0=21; EXPR$1=112047\n");
@@ -557,7 +559,7 @@ public class ElasticSearchAdapterTest {
             + "limit 6")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("_source:false",
-                "size:0",
+                "size:0", "'stored_fields': '_none_'",
                 "aggregations:{'g_state':{'terms':{'field':'state','missing':'__MISSING__', 'size' : 6}}}"))
         .returnsOrdered("state=AK",
             "state=AL",
@@ -574,7 +576,7 @@ public class ElasticSearchAdapterTest {
             + "order by city limit 10")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
-                "size:0",
+                "size:0", "'stored_fields': '_none_'",
                 "aggregations:{'g_city':{'terms':{'field':'city','missing':'__MISSING__','size':10,'order':{'_key':'asc'}}",
                 "aggregations:{'g_state':{'terms':{'field':'state','missing':'__MISSING__','size':10}}}}}}"))
         .returnsOrdered("state=SD; city=ABERDEEN",
@@ -596,7 +598,7 @@ public class ElasticSearchAdapterTest {
             + "order by state limit 3")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
-                "size:0",
+                "size:0", "'stored_fields': '_none_'",
                 "aggregations:{'g_state':{terms:{field:'state',missing:'__MISSING__',size:3,"
                     + " order:{'_key':'asc'}}",
                 "aggregations:{'EXPR$0':{min:{field:'pop'}},'EXPR$1':{max:{field:'pop'}}}}}"))
@@ -613,6 +615,7 @@ public class ElasticSearchAdapterTest {
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
                 "size:0",
+                "'stored_fields': '_none_'",
                 "aggregations:{'g_state':{terms:{field:'state',missing:'__MISSING__',"
                     + "size:3, order:{'_key':'asc'}}",
                 "aggregations:{'EXPR$0':{min:{field:'pop'}} }}}"))
@@ -629,6 +632,7 @@ public class ElasticSearchAdapterTest {
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
                 "size:0",
+                "'stored_fields': '_none_'",
                 "aggregations:{'g_state':{terms:{field:'state',missing:'__MISSING__',"
                     + " size:3, order:{'_key':'asc'}}",
                 "aggregations:{'EXPR$0':{'value_count':{field:'city'}} }}}"))
@@ -645,6 +649,7 @@ public class ElasticSearchAdapterTest {
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
                 "size:0",
+                "'stored_fields': '_none_'",
                 "aggregations:{'g_state':{terms:{field:'state',missing:'__MISSING__',"
                     + "size:3, order:{'_key':'desc'}}",
                 "aggregations:{'EXPR$0':{min:{field:'pop'}},'EXPR$1':"
@@ -695,7 +700,7 @@ public class ElasticSearchAdapterTest {
             + " group by state order by state limit 3")
         .queryContains(
             ElasticsearchChecker.elasticsearchChecker("'_source':false",
-            "size:0",
+            "size:0", "'stored_fields': '_none_'",
             "aggregations:{'g_state':{terms:{field:'state', missing:'__MISSING__', size:3, "
                 + "order:{'_key':'asc'}}",
             "aggregations:{'EXPR$1':{cardinality:{field:'city'}}",


### PR DESCRIPTION
Set `stored_fields = _none` to prohibit `FetchPhase` get be involved and improve performance at some agg scenario for elasticsearch-adapter
