### PR TITLE
[CALCITE-3448] AggregateOnCalcToAggregateUnifyRule ignores Project…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -132,7 +132,7 @@ public class SubstitutionVisitor {
           JoinOnRightCalcToJoinUnifyRule.INSTANCE,
           JoinOnCalcsToJoinUnifyRule.INSTANCE,
           AggregateToAggregateUnifyRule.INSTANCE,
-          AggregateOnCalcToAggUnifyRule.INSTANCE,
+          AggregateOnCalcToAggregateUnifyRule.INSTANCE,
           UnionToUnionUnifyRule.INSTANCE,
           UnionOnCalcsToUnionUnifyRule.INSTANCE);
 
@@ -1412,12 +1412,12 @@ public class SubstitutionVisitor {
    * We try to pull up the {@link MutableCalc} to top of {@link MutableAggregate},
    * then match the {@link MutableAggregate} in query to {@link MutableAggregate} in target.
    */
-  private static class AggregateOnCalcToAggUnifyRule extends AbstractUnifyRule {
+  private static class AggregateOnCalcToAggregateUnifyRule extends AbstractUnifyRule {
 
-    public static final AggregateOnCalcToAggUnifyRule INSTANCE =
-        new AggregateOnCalcToAggUnifyRule();
+    public static final AggregateOnCalcToAggregateUnifyRule INSTANCE =
+        new AggregateOnCalcToAggregateUnifyRule();
 
-    private AggregateOnCalcToAggUnifyRule() {
+    private AggregateOnCalcToAggregateUnifyRule() {
       super(operand(MutableAggregate.class, operand(MutableCalc.class, query(0))),
           operand(MutableAggregate.class, target(0)), 1);
     }

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -74,6 +74,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1475,11 +1476,13 @@ public class SubstitutionVisitor {
       if (!Mappings.keepsOrdering(mapping)) {
         final List<Integer> posList = new ArrayList<>();
         final int fieldCount = aggregate2.rowType.getFieldCount();
-        for (int group: aggregate2.groupSet) {
-          if (inverseMapping.getTargetOpt(group) != -1) {
-            posList.add(inverseMapping.getTarget(group));
-          }
+        final List<Pair<Integer, Integer>> pairs = new ArrayList<>();
+        final List<Integer> groupings = aggregate2.groupSet.toList();
+        for (int i = 0; i < groupings.size(); i++) {
+          pairs.add(Pair.of(mapping.getTarget(groupings.get(i)), i));
         }
+        Collections.sort(pairs);
+        pairs.forEach(pair -> posList.add(pair.right));
         for (int i = posList.size(); i < fieldCount; i++) {
           posList.add(i);
         }

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -431,10 +431,10 @@ public abstract class Mappings {
     int prevTarget = -1;
     for (int i = 0; i < mapping.getSourceCount(); i++) {
       int target = mapping.getTargetOpt(i);
-      if (target != -1 && target < prevTarget) {
-        return false;
-      }
       if (target != -1) {
+        if (target < prevTarget) {
+          return false;
+        }
         prevTarget = target;
       }
     }

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -434,7 +434,9 @@ public abstract class Mappings {
       if (target != -1 && target < prevTarget) {
         return false;
       }
-      prevTarget = target;
+      if (target != -1) {
+        prevTarget = target;
+      }
     }
     return true;
   }

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -866,7 +866,7 @@ public class MaterializationTest {
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3448">[CALCITE-3448]
-   * AggregateOnProjectToAggregateUnifyRule ignores Project incorrectly when
+   * AggregateOnCalcToAggregateUnifyRule ignores Project incorrectly when
    * there's missing grouping or mapping breaks ordering</a>. */
   @Test public void testAggregateOnProject5() {
     checkMaterialize(

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -864,6 +864,22 @@ public class MaterializationTest {
                 + "    EnumerableTableScan(table=[[hr, m0]])"));
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3448">[CALCITE-3448]
+   * AggregateOnProjectToAggregateUnifyRule ignores Project incorrectly when
+   * there's missing grouping or mapping breaks ordering</a>. */
+  @Test public void testAggregateOnProject5() {
+    checkMaterialize(
+        "select \"empid\", \"deptno\", \"name\", count(*) from \"emps\"\n"
+            + "group by \"empid\", \"deptno\", \"name\"",
+        "select \"name\", \"empid\", count(*) from \"emps\" group by \"name\", \"empid\"",
+        HR_FKUK_MODEL,
+        CalciteAssert.checkResultContains(""
+            + "EnumerableCalc(expr#0..2=[{inputs}], name=[$t1], empid=[$t0], EXPR$2=[$t2])\n"
+            + "  EnumerableAggregate(group=[{0, 2}], EXPR$2=[$SUM0($3)])\n"
+            + "    EnumerableTableScan(table=[[hr, m0]])"));
+  }
+
   @Test public void testAggregateOnProjectAndFilter() {
     String mv = ""
         + "select \"deptno\", sum(\"salary\"), count(1)\n"


### PR DESCRIPTION
… incorrectly when there's missing grouping or mapping breaks ordering (Jin Xing)

CALCITE-3087 fixed AggregateOnProjectToAggregateUnifyRule when mapping under Aggregate breaks ordering. But it fails when there's missing grouping in query compared with target.
Below matching fails:
```
        MV:
        select empid, deptno, name, count(*) from emps
        group by empid, deptno, name

        Query:
        select name, empid, count(*) from emps group by name, empid
```
Note that -- comparing groupings in MV `(empid, deptno, name)` and groupings in query `(name, empid)`, `deptno` is missed and ordering is broken 