### PR TITLE
[CALCITE-3459] AssertionError for using Timestamp/Time/Date in user defined table function

### DIFF
--- a/core/src/test/java/org/apache/calcite/util/Smalls.java
+++ b/core/src/test/java/org/apache/calcite/util/Smalls.java
@@ -74,6 +74,12 @@ public class Smalls {
       Types.lookupMethod(Smalls.class, "generateStrings", Integer.class);
   public static final Method GENERATE_STRINGS_OF_INPUT_SIZE_METHOD =
       Types.lookupMethod(Smalls.class, "generateStringsOfInputSize", List.class);
+  public static final Method TIMESTAMP_STRING_LENGTH =
+      Types.lookupMethod(Smalls.class, "timestampStringLength", Timestamp.class);
+  public static final Method TIME_STRING_LENGTH =
+      Types.lookupMethod(Smalls.class, "timeStringLength", Time.class);
+  public static final Method DATE_STRING_LENGTH =
+      Types.lookupMethod(Smalls.class, "dateStringLength", Date.class);
   public static final Method MAZE_METHOD =
       Types.lookupMethod(MazeTable.class, "generate", int.class, int.class,
           int.class);
@@ -186,6 +192,18 @@ public class Smalls {
 
   public static QueryableTable generateStringsOfInputSize(final List<Integer> list) {
     return generateStrings(list.size());
+  }
+
+  public static QueryableTable timestampStringLength(final Timestamp timestamp) {
+    return generateStrings(timestamp.toString().length());
+  }
+
+  public static QueryableTable timeStringLength(final Time time) {
+    return generateStrings(time.toString().length());
+  }
+
+  public static QueryableTable dateStringLength(final Date date) {
+    return generateStrings(date.toString().length());
   }
 
   /** A function that generates multiplication table of {@code ncol} columns x

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
@@ -33,6 +33,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -577,9 +580,14 @@ public abstract class Expressions {
         String stringValue = String.valueOf(value);
         if (type == BigDecimal.class) {
           value = new BigDecimal(stringValue);
-        }
-        if (type == BigInteger.class) {
+        } else if (type == BigInteger.class) {
           value = new BigInteger(stringValue);
+        } else if (type == Timestamp.class) {
+          value = Timestamp.valueOf(stringValue);
+        } else if (type == Date.class) {
+          value = Date.valueOf(stringValue);
+        } else if (type == Time.class) {
+          value = Time.valueOf(stringValue);
         }
         if (primitive != null) {
           value = primitive.parse(stringValue);

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.linq4j.tree;
 
+import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.linq4j.Extensions;
 import org.apache.calcite.linq4j.function.Function;
 import org.apache.calcite.linq4j.function.Function0;
@@ -42,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.TimeZone;
 import java.util.UUID;
 
 /**
@@ -582,12 +584,8 @@ public abstract class Expressions {
           value = new BigDecimal(stringValue);
         } else if (type == BigInteger.class) {
           value = new BigInteger(stringValue);
-        } else if (type == Timestamp.class) {
-          value = Timestamp.valueOf(stringValue);
-        } else if (type == Date.class) {
-          value = Date.valueOf(stringValue);
-        } else if (type == Time.class) {
-          value = Time.valueOf(stringValue);
+        } else if (type == Timestamp.class || type == Date.class || type == Time.class) {
+          value = parseUTCString(stringValue, type);
         }
         if (primitive != null) {
           value = primitive.parse(stringValue);
@@ -595,6 +593,21 @@ public abstract class Expressions {
       }
     }
     return new ConstantExpression(type, value);
+  }
+
+  private static Object parseUTCString(String value, Type type) {
+    TimeZone currentTimeZone = DateTimeUtils.DEFAULT_ZONE;
+    TimeZone.setDefault(DateTimeUtils.UTC_ZONE);
+    Object result = null;
+    if (type == Timestamp.class) {
+      result = Timestamp.valueOf(value);
+    } else if (type == Date.class) {
+      result = Date.valueOf(value);
+    } else if (type == Time.class) {
+      result = Time.valueOf(value);
+    }
+    TimeZone.setDefault(currentTimeZone);
+    return result;
   }
 
   /**

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
@@ -44,6 +44,9 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1273,6 +1276,23 @@ public class ExpressionTest {
         Expressions.toString(Expressions.constant(199999999999999L, BigDecimal.class)));
     assertEquals("java.math.BigDecimal.valueOf(1234L, 2)",
         Expressions.toString(Expressions.constant(12.34, BigDecimal.class)));
+  }
+
+  @Test public void testTimeRelatedConstantExpression() {
+    assertThat(
+        Expressions.toString(
+            Expressions.constant("2019-10-12 19:00:35", Timestamp.class)),
+        is("2019-10-12 19:00:35.0"));
+
+    assertThat(
+        Expressions.toString(
+            Expressions.constant("2019-10-12", Date.class)),
+        is("2019-10-12"));
+
+    assertThat(
+        Expressions.toString(
+            Expressions.constant("19:00:35", Time.class)),
+        is("19:00:35"));
   }
 
   @Test public void testClassDecl() {

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
@@ -58,6 +58,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeSet;
 
 import static org.apache.calcite.linq4j.test.BlockBuilderBase.ONE;
@@ -1279,6 +1280,8 @@ public class ExpressionTest {
   }
 
   @Test public void testTimeRelatedConstantExpression() {
+    TimeZone currentTimeZone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     assertThat(
         Expressions.toString(
             Expressions.constant("2019-10-12 19:00:35", Timestamp.class)),
@@ -1293,6 +1296,7 @@ public class ExpressionTest {
         Expressions.toString(
             Expressions.constant("19:00:35", Time.class)),
         is("19:00:35"));
+    TimeZone.setDefault(currentTimeZone);
   }
 
   @Test public void testClassDecl() {


### PR DESCRIPTION
Currently, creating a constant expression of Timestamp/Time/Date type from string will cause exception, please refer to [CALCITE-3459](https://issues.apache.org/jira/browse/CALCITE-3459) for the full exception stack trace.

This PR tries to convert String value to Timestamp/Time/Date object when value type is Timestamp/Time/Date.