### PR TITLE
[CALCITE-3460] Poor performance in RexReplacer for large queries

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
@@ -77,6 +77,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -833,7 +834,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
   protected static class RexReplacer extends RexShuttle {
     private final RexSimplify simplify;
     private final RexUnknownAs unknownAs;
-    private final List<RexNode> reducibleExps;
+    private final Map<RexNode, Integer> reducibleExpsMap;
     private final List<RexNode> reducedValues;
     private final List<Boolean> addCasts;
 
@@ -845,9 +846,12 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
         List<Boolean> addCasts) {
       this.simplify = simplify;
       this.unknownAs = unknownAs;
-      this.reducibleExps = reducibleExps;
+      this.reducibleExpsMap = new HashMap<>();
       this.reducedValues = reducedValues;
       this.addCasts = addCasts;
+      for (int i = 0; i < reducibleExps.size(); i++) {
+        reducibleExpsMap.put(reducibleExps.get(i), i);
+      }
     }
 
     @Override public RexNode visitInputRef(RexInputRef inputRef) {
@@ -868,8 +872,8 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
     }
 
     private RexNode visit(final RexNode call) {
-      int i = reducibleExps.indexOf(call);
-      if (i == -1) {
+      Integer i = reducibleExpsMap.get(call);
+      if (i == null) {
         return null;
       }
       RexNode replacement = reducedValues.get(i);

--- a/core/src/main/java/org/apache/calcite/rex/RexShuttle.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexShuttle.java
@@ -145,7 +145,8 @@ public class RexShuttle implements RexVisitor<RexNode> {
   protected List<RexNode> visitList(
       List<? extends RexNode> exprs, boolean[] update) {
     ImmutableList.Builder<RexNode> clonedOperands = ImmutableList.builder();
-    for (RexNode operand : exprs) {
+    for (int i = 0; i < exprs.size(); i++) {
+      RexNode operand = exprs.get(i);
       RexNode clonedOperand = operand.accept(this);
       if ((clonedOperand != operand) && (update != null)) {
         update[0] = true;
@@ -160,8 +161,8 @@ public class RexShuttle implements RexVisitor<RexNode> {
    */
   public void visitList(
       List<? extends RexNode> exprs, List<RexNode> outExprs) {
-    for (RexNode expr : exprs) {
-      outExprs.add(expr.accept(this));
+    for (int i = 0; i < exprs.size(); i++) {
+      outExprs.add(exprs.get(i).accept(this));
     }
   }
 


### PR DESCRIPTION
We have queries that have tens of thousands of RexCalls.
reducibleExps.indexOf(call) is an (O) operation, which takes 50% of the running
time, causing the query runs for ever until timed out.  In RexShuttle,
ImmutableList iterator creation in visitList takes another 5~7% of running
time, and it is creating millions of temporary iterator object, not only time
consuming, but also memory consuming.