### PR TITLE
[CALCITE-3438] Validator should disallow use of the GROUPING function inside a FILTER clause 

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5276,9 +5276,11 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       }
     }
     if (filter != null) {
+      a.findGroupingFunctions(true);
       if (a.findAgg(filter) != null) {
         throw newValidationError(filter, RESOURCE.aggregateInFilterIllegal());
       }
+      a.findGroupingFunctions(false);
     }
     if (orderList != null) {
       for (SqlNode param : orderList) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7098,6 +7098,18 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("FILTER must not contain aggregate expression");
   }
 
+  @Test public void testAggregateFilterContainsGrouping() {
+    sql("select deptno, sum(sal) filter (where ^grouping(deptno) = 0^) "
+        + "from emp group by deptno")
+       .fails("FILTER must not contain aggregate expression");
+    sql("select deptno, sum(sal) filter (where ^grouping_id(deptno) = 0^) "
+        + "from emp group by deptno")
+        .fails("FILTER must not contain aggregate expression");
+    sql("select deptno, sum(sal) filter (where ^group_id() = 0^) "
+        + "from emp group by deptno")
+        .fails("FILTER must not contain aggregate expression");
+  }
+
   @Test public void testWithinGroup() {
     sql("select deptno,\n"
         + " collect(empno) within group(order by 1)\n"


### PR DESCRIPTION
`AggVisitor` ignores to find grouping functions in default. However, for some cases we need to consider these functions. This PR adds an interface to control its beheavior, and tries for fix the issue described in [CALCITE-3438](https://issues.apache.org/jira/browse/CALCITE-3438).