### PR TITLE
[CALCITE-3435] Enable decimal modulus operation to allow numeric with non-zero scale

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
@@ -18,6 +18,7 @@ package org.apache.calcite.rel.type;
 
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 
 /** Default implementation of
  * {@link org.apache.calcite.rel.type.RelDataTypeSystem},
@@ -250,6 +251,69 @@ public abstract class RelDataTypeSystemImpl implements RelDataTypeSystem {
 
   public boolean allowExtendedTrim() {
     return false;
+  }
+
+  /**
+   * Infers the return type of a decimal modulus operation. Decimal modulus
+   * involves at least one decimal operand.
+   *
+   * <p>Rules:
+   *
+   * <ul>
+   * <li>Let p1, s1 be the precision and scale of the first operand</li>
+   * <li>Let p2, s2 be the precision and scale of the second operand</li>
+   * <li>Let p, s be the precision and scale of the result</li>
+   * <li>Let d be the number of whole digits in the result</li>
+   * <li>Then the result type is a decimal with:
+   *   <ul>
+   *   <li>s = max(s1, s2)</li>
+   *   <li>p = min(p1 - s1, p2 - s2) + max(s1, s2)</li>
+   *   </ul>
+   * </li>
+   * <li>p and s are capped at their maximum values</li>
+   * </ul>
+   *
+   * @param typeFactory typeFactory used to create output type
+   * @param type1 type of the first operand
+   * @param type2 type of the second operand
+   * @return the result type for a decimal modulus, or null if decimal
+   * modulus should not be applied to the operands.
+   */
+  @Override public RelDataType deriveDecimalModType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    if (SqlTypeUtil.isExactNumeric(type1)
+        && SqlTypeUtil.isExactNumeric(type2)) {
+      if (SqlTypeUtil.isDecimal(type1)
+          || SqlTypeUtil.isDecimal(type2)) {
+        // Java numeric will always have invalid precision/scale,
+        // use its default decimal precision/scale instead.
+        type1 = RelDataTypeFactoryImpl.isJavaType(type1)
+            ? typeFactory.decimalOf(type1)
+            : type1;
+        type2 = RelDataTypeFactoryImpl.isJavaType(type2)
+            ? typeFactory.decimalOf(type2)
+            : type2;
+        int p1 = type1.getPrecision();
+        int p2 = type2.getPrecision();
+        int s1 = type1.getScale();
+        int s2 = type2.getScale();
+        // keep consistency with SQL standard
+        if (s1 == 0 && s2 == 0) {
+          return type2;
+        }
+
+        int scale = Math.max(s1, s2);
+        assert scale <= getMaxNumericScale();
+
+        int precision = Math.min(p1 - s1, p2 - s2) + Math.max(s1, s2);
+        precision = Math.min(precision, getMaxNumericPrecision());
+        assert precision > 0;
+
+        return typeFactory.createSqlType(SqlTypeName.DECIMAL,
+                precision, scale);
+      }
+    }
+    return null;
   }
 
 }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1156,8 +1156,8 @@ public class SqlFunctions {
   }
 
   // temporary
-  public static int mod(int b0, BigDecimal b1) {
-    return mod(b0, b1.intValue());
+  public static BigDecimal mod(int b0, BigDecimal b1) {
+    return mod(BigDecimal.valueOf(b0), b1);
   }
 
   public static BigDecimal mod(BigDecimal b0, BigDecimal b1) {

--- a/core/src/test/java/org/apache/calcite/sql/type/RelDataTypeSystemTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/RelDataTypeSystemTest.java
@@ -137,7 +137,7 @@ public class RelDataTypeSystemTest {
 
     RelDataType dataType = SqlStdOperatorTable.MOD.inferReturnType(TYPE_FACTORY, Lists
             .newArrayList(operand1, operand2));
-    Assert.assertEquals(19, dataType.getPrecision());
+    Assert.assertEquals(11, dataType.getPrecision());
     Assert.assertEquals(2, dataType.getScale());
   }
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -1539,6 +1539,19 @@ public class JdbcTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3435">[CALCITE-3435]
+   * Enable decimal modulus operation to allow numeric with non-zero scale</a>. */
+  @Test public void testModOperation() {
+    CalciteAssert.that()
+        .query("select mod(33.5, 7) as c0, floor(mod(33.5, 7)) as c1, "
+            + "mod(11, 3.2) as c2, floor(mod(11, 3.2)) as c3,"
+            + "mod(12, 3) as c4, floor(mod(12, 3)) as c5")
+        .typeIs("[C0 DECIMAL NOT NULL, C1 DECIMAL NOT NULL, C2 DECIMAL NOT NULL, "
+            + "C3 DECIMAL NOT NULL, C4 INTEGER NOT NULL, C5 INTEGER NOT NULL]")
+        .returns("C0=5.5; C1=5; C2=1.4; C3=1; C4=0; C5=0\n");
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-387">[CALCITE-387]
    * CompileException when cast TRUE to nullable boolean</a>. */
   @Test public void testTrue() {


### PR DESCRIPTION
As discussed in [CALCITE-3435](https://issues.apache.org/jira/browse/CALCITE-3477), this PR extends to allow non-zero scale numeric in modulus operation.