### PR TITLE
[CALCITE-3482] Equality of nested ROWs returns false for identical literal value

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -614,6 +614,12 @@ public class SqlFunctions {
     return b0.stripTrailingZeros().equals(b1.stripTrailingZeros());
   }
 
+  /** SQL <code>=</code> operator applied to Object[] values (neither may be
+   * null). */
+  public static boolean eq(Object[] b0, Object[] b1) {
+    return Arrays.deepEquals(b0, b1);
+  }
+
   /** SQL <code>=</code> operator applied to Object values (including String;
    * neither side may be null). */
   public static boolean eq(Object b0, Object b1) {

--- a/core/src/test/resources/sql/struct.iq
+++ b/core/src/test/resources/sql/struct.iq
@@ -47,4 +47,40 @@ select distinct * from (values
 
 !ok
 
+# [CALCITE-3482] Equality of nested ROWs returns false for identical literal value
+select * from
+(values
+    (1, ROW(1,2)),
+    (2, ROW(2,1)),
+    (3, ROW(1,2)),
+    (4, ROW(2,1))) as t(id,struct)
+where t.struct = ROW(2,1);
++----+--------+
+| ID | STRUCT |
++----+--------+
+|  2 | {2, 1} |
+|  4 | {2, 1} |
++----+--------+
+(2 rows)
+
+!ok
+
+# [CALCITE-3482] Equality of nested ROWs returns false for identical literal value
+select * from
+(values
+    (1, ROW(2, ROW(4,3))),
+    (2, ROW(2, ROW(3,4))),
+    (3, ROW(1, ROW(3,4))),
+    (4, ROW(2, ROW(3,4)))) as t(id,struct)
+where t.struct = ROW(2, ROW(3,4));
++----+-------------+
+| ID | STRUCT      |
++----+-------------+
+|  2 | {2, {3, 4}} |
+|  4 | {2, {3, 4}} |
++----+-------------+
+(2 rows)
+
+!ok
+
 # End struct.iq


### PR DESCRIPTION
Jira ticket: [CALCITE-3482](https://issues.apache.org/jira/browse/CALCITE-3482)