### PR TITLE
[CALCITE-3479] Stack overflow error thrown when running join query

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -354,23 +354,10 @@ public class RelSubset extends AbstractRelNode {
     }
     try {
       RelOptCost cost = planner.getCost(rel, mq);
-      boolean updateBest = cost.isLt(bestCost);
-
-      // Best rel's cost is increased, we need to search for new best rel
-      if (rel == best && bestCost.isLt(cost)) {
-        updateBest = true;
-        for (RelNode node : getRels()) {
-          RelOptCost relCost = planner.getCost(node, mq);
-          if (relCost.isLt(cost)) {
-            cost = relCost;
-            rel = node;
-          }
-        }
-      }
 
       // Update subset best cost when we find a cheaper rel or the current
       // best's cost is changed
-      if (updateBest) {
+      if (cost.isLt(bestCost)) {
         LOGGER.trace("Subset cost changed: subset [{}] cost was {} now {}",
             this, bestCost, cost);
 

--- a/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
@@ -38,6 +38,7 @@ import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.test.CalciteAssert.ConnectionPostProcessor;
+import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -84,7 +85,7 @@ public class ScannableTableTest {
   /** A table with one column. */
   @Test public void testSimple() throws Exception {
     CalciteAssert.that()
-        .with(newSchema("s", "simple", new SimpleTable()))
+        .with(newSchema("s", Pair.of("simple", new SimpleTable())))
         .query("select * from \"s\".\"simple\"")
         .returnsUnordered("i=0", "i=10", "i=20", "i=30");
   }
@@ -92,7 +93,7 @@ public class ScannableTableTest {
   /** A table with two columns. */
   @Test public void testSimple2() throws Exception {
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", new BeatlesTable()))
+        .with(newSchema("s", Pair.of("beatles", new BeatlesTable())))
         .query("select * from \"s\".\"beatles\"")
         .returnsUnordered("i=4; j=John",
             "i=4; j=Paul",
@@ -108,7 +109,7 @@ public class ScannableTableTest {
         + "EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles]], filters=[[=($0, 4)]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query("select * from \"s\".\"beatles\" where \"i\" = 4")
         .explainContains(explain)
         .returnsUnordered("i=4; j=John; k=1940",
@@ -126,7 +127,7 @@ public class ScannableTableTest {
         + "EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles2]], filters=[[=($0, 4)]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles2", table))
+        .with(newSchema("s", Pair.of("beatles2", table)))
         .query("select * from \"s\".\"beatles2\" where \"i\" = 4")
         .explainContains(explain)
         .returnsUnordered("i=4; j=John; k=1940",
@@ -143,7 +144,7 @@ public class ScannableTableTest {
         + "EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles]], filters=[[=($0, 4)]], projects=[[1]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query("select \"j\" from \"s\".\"beatles\" where \"i\" = 4")
         .explainContains(explain)
         .returnsUnordered("j=John",
@@ -160,7 +161,7 @@ public class ScannableTableTest {
         + "EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles2]], filters=[[=($0, 4)]], projects=[[1]]";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles2", table))
+        .with(newSchema("s", Pair.of("beatles2", table)))
         .query("select \"j\" from \"s\".\"beatles2\" where \"i\" = 4")
         .explainContains(explain)
         .returnsUnordered("j=John",
@@ -177,7 +178,7 @@ public class ScannableTableTest {
         + "EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles]], filters=[[=($0, 4)]], projects=[[2, 1]]";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query("select \"k\",\"j\" from \"s\".\"beatles\" where \"i\" = 4")
         .explainContains(explain)
         .returnsUnordered("k=1940; j=John",
@@ -197,7 +198,7 @@ public class ScannableTableTest {
         + "  BindableTableScan(table=[[s, beatles]], filters=[[>($2, 1941)]], "
         + "projects=[[0, 2]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query("select \"i\",\"k\" from \"s\".\"beatles\" where \"k\" > 1941")
         .explainContains(explain)
         .returnsUnordered("i=4; k=1942",
@@ -216,7 +217,7 @@ public class ScannableTableTest {
     final String explain = "PLAN=EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles2]], filters=[[=($0, 4)]], projects=[[2]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles2", table))
+        .with(newSchema("s", Pair.of("beatles2", table)))
         .query("select \"k\" from \"s\".\"beatles2\" where \"i\" = 4")
         .explainContains(explain)
         .returnsUnordered("k=1940",
@@ -232,7 +233,7 @@ public class ScannableTableTest {
         + "  EnumerableInterpreter\n"
         + "    BindableTableScan(table=[[s, beatles]], filters=[[>($0, 1)]], projects=[[2]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query("select max(\"k\") as m from \"s\".\"beatles\" where \"i\" > 1")
         .explainContains(explain)
         .returnsUnordered("M=1943");
@@ -251,7 +252,7 @@ public class ScannableTableTest {
         + "    BindableTableScan(table=[[s, beatles]], filters=[[>($2, 1900)]], "
         + "projects=[[0]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query(sql)
         .explainContains(explain)
         .returnsUnordered("i=4; C=2",
@@ -274,7 +275,7 @@ public class ScannableTableTest {
         + "      BindableTableScan(table=[[s, beatles]], "
         + "filters=[[=($2, 1940)]], projects=[[2, 0]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query(sql)
         .explainContains(explain)
         .returnsUnordered("k=1940; C=2");
@@ -310,7 +311,7 @@ public class ScannableTableTest {
         + "EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles2]], filters=[[>($2, 1941)]], projects=[[2]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles2", table))
+        .with(newSchema("s", Pair.of("beatles2", table)))
         .query("select \"k\" from \"s\".\"beatles2\" where \"k\" > 1941")
         .explainContains(explain)
         .returnsUnordered("k=1942",
@@ -330,7 +331,7 @@ public class ScannableTableTest {
         + "  EnumerableInterpreter\n"
         + "    BindableTableScan(table=[[s, beatles]], projects=[[2, 0]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query("select \"k\", \"i\", \"k\", \"i\"+\"i\" \"ii\", 3 from \"s\".\"beatles\"")
         .explainContains(explain)
         .returnsUnordered(
@@ -352,7 +353,7 @@ public class ScannableTableTest {
         + "EnumerableInterpreter\n"
         + "  BindableTableScan(table=[[s, beatles]], projects=[[2, 0]])";
     CalciteAssert.that()
-        .with(newSchema("s", "beatles", table))
+        .with(newSchema("s", Pair.of("beatles", table)))
         .query("select \"k\", \"i\" from \"s\".\"beatles\"")
         .explainContains(explain)
         .returnsUnordered(
@@ -378,9 +379,9 @@ public class ScannableTableTest {
         + "    BindableTableScan(table=[[s, b2]], filters=[[=($0, 10)]])";
     CalciteAssert.that()
             .with(
-              newSchema("s", "b1",
-                new BeatlesProjectableFilterableTable(buf, true), "b2",
-                new BeatlesProjectableFilterableTable(buf, true)))
+              newSchema("s",
+                  Pair.of("b1", new BeatlesProjectableFilterableTable(buf, true)),
+                  Pair.of("b2", new BeatlesProjectableFilterableTable(buf, true))))
             .query("select * from \"s\".\"b1\", \"s\".\"b2\" "
                     + "where \"s\".\"b1\".\"i\" = 10 and \"s\".\"b2\".\"i\" = 10 "
                     + "and \"s\".\"b1\".\"i\" = \"s\".\"b2\".\"i\"")
@@ -458,26 +459,14 @@ public class ScannableTableTest {
   }
 
   protected ConnectionPostProcessor newSchema(final String schemaName,
-      final String tableName, final Table table) {
+      Pair<String, Table>... tables) {
     return connection -> {
       CalciteConnection con = connection.unwrap(CalciteConnection.class);
       SchemaPlus rootSchema = con.getRootSchema();
       SchemaPlus schema = rootSchema.add(schemaName, new AbstractSchema());
-      schema.add(tableName, table);
-      connection.setSchema(schemaName);
-      return connection;
-    };
-  }
-
-  protected ConnectionPostProcessor newSchema(final String schemaName,
-                                                     final String tableName1, final Table table1,
-                                                     final String tableName2, final Table table2) {
-    return connection -> {
-      CalciteConnection con = connection.unwrap(CalciteConnection.class);
-      SchemaPlus rootSchema = con.getRootSchema();
-      SchemaPlus schema = rootSchema.add(schemaName, new AbstractSchema());
-      schema.add(tableName1, table1);
-      schema.add(tableName2, table2);
+      for (Pair<String, Table> t : tables) {
+        schema.add(t.left, t.right);
+      }
       connection.setSchema(schemaName);
       return connection;
     };


### PR DESCRIPTION
With fix of CALCITE-2166, we recalculate the RelNode cost within a subset when its best cost is increased, in order to find the new best RelNode. But this could lead to cyclic reference between best RelNodes and then fail to generate a plan.

In this change, we remove the recalcuation part to mitigate this problem.

JIRA - https://issues.apache.org/jira/browse/CALCITE-3479