### PR TITLE
[CALCITE-3486] In JDBC adapter, when generating ROW value expression, generates the ROW keyword only if the dialect allows it (quxiucheng)

### DIFF
--- a/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
@@ -213,7 +213,7 @@ ORDER BY `A`, `B`]]>
   </TestCase>
   <TestCase name="testMultiset">
     <Resource name="formatted">
-      <![CDATA[VALUES ROW(MULTISET ((SELECT *
+      <![CDATA[VALUES(MULTISET ((SELECT *
             FROM `T`)))]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
MysqlSqlDialect unparse ROW keyword does not exist