### PR TITLE
[CALCITE-3476] ParameterScope should override resolveColumn interface

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/ParameterScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/ParameterScope.java
@@ -19,6 +19,7 @@ package org.apache.calcite.sql.validate;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
 
 import java.util.Map;
 
@@ -56,6 +57,10 @@ public class ParameterScope extends EmptyScope {
     return this;
   }
 
+  @Override
+  public RelDataType resolveColumn(String name, SqlNode ctx) {
+    return nameToTypeMap.get(name);
+  }
 }
 
 // End ParameterScope.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/ParameterScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/ParameterScope.java
@@ -57,8 +57,7 @@ public class ParameterScope extends EmptyScope {
     return this;
   }
 
-  @Override
-  public RelDataType resolveColumn(String name, SqlNode ctx) {
+  @Override public RelDataType resolveColumn(String name, SqlNode ctx) {
     return nameToTypeMap.get(name);
   }
 }


### PR DESCRIPTION
`ParameterScope` accepts namedToTypeMap but never use it. We should fix this by overriding resolveColumn and lookup in the map. Otherwise, `SqlValidator.validateParameterizedExpression` doesn't work.