### PR TITLE
[CALCITE-3494] Support decimal type aggregate in Interpreter

### DIFF
--- a/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
@@ -46,6 +46,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -122,6 +123,9 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
       case FLOAT:
         clazz = DoubleSum.class;
         break;
+      case DECIMAL:
+        clazz = BigDecimalSum.class;
+        break;
       case INTEGER:
         clazz = IntSum.class;
         break;
@@ -150,6 +154,9 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
       case REAL:
         clazz = MinDouble.class;
         break;
+      case DECIMAL:
+        clazz = MinBigDecimal.class;
+        break;
       case BOOLEAN:
         clazz = MinBoolean.class;
         break;
@@ -171,6 +178,9 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
       case DOUBLE:
       case REAL:
         clazz = MaxDouble.class;
+        break;
+      case DECIMAL:
+        clazz = MaxBigDecimal.class;
         break;
       default:
         clazz = MaxLong.class;
@@ -473,6 +483,29 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
     }
   }
 
+  /** Implementation of {@code SUM} over BigDecimal values as a user-defined
+   * aggregate. */
+  public static class BigDecimalSum {
+    public BigDecimalSum(){
+    }
+
+    public BigDecimal init() {
+      return new BigDecimal("0");
+    }
+
+    public BigDecimal add(BigDecimal accumulator, BigDecimal v) {
+      return accumulator.add(v);
+    }
+
+    public BigDecimal merge(BigDecimal accumulator0, BigDecimal accumulator01) {
+      return add(accumulator0, accumulator01);
+    }
+
+    public BigDecimal result(BigDecimal accumulator) {
+      return accumulator;
+    }
+  }
+
   /** Common implementation of comparison aggregate methods over numeric
    * values as a user-defined aggregate.
    * @param <T> The numeric type
@@ -540,6 +573,19 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
   }
 
   /** Implementation of {@code MIN} function to calculate the minimum of
+   * {@code BigDecimal} values as a user-defined aggregate.
+   */
+  public static class MinBigDecimal extends NumericComparison<BigDecimal> {
+    public MinBigDecimal() {
+      super(new BigDecimal(Double.MAX_VALUE), MinBigDecimal::min);
+    }
+
+    public static BigDecimal min(BigDecimal a, BigDecimal b) {
+      return a.min(b);
+    }
+  }
+
+  /** Implementation of {@code MIN} function to calculate the minimum of
    * {@code boolean} values as a user-defined aggregate.
    */
   public static class MinBoolean {
@@ -562,7 +608,7 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
     }
   }
 
-  /** Implementation of {@code MAX} function to calculate the minimum of
+  /** Implementation of {@code MAX} function to calculate the maximum of
    * {@code integer} values as a user-defined aggregate.
    */
   public static class MaxInt extends NumericComparison<Integer> {
@@ -571,7 +617,7 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
     }
   }
 
-  /** Implementation of {@code MAX} function to calculate the minimum of
+  /** Implementation of {@code MAX} function to calculate the maximum of
    * {@code long} values as a user-defined aggregate.
    */
   public static class MaxLong extends NumericComparison<Long> {
@@ -580,7 +626,7 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
     }
   }
 
-  /** Implementation of {@code MAX} function to calculate the minimum of
+  /** Implementation of {@code MAX} function to calculate the maximum of
    * {@code float} values as a user-defined aggregate.
    */
   public static class MaxFloat extends NumericComparison<Float> {
@@ -589,12 +635,25 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
     }
   }
 
-  /** Implementation of {@code MAX} function to calculate the minimum of
+  /** Implementation of {@code MAX} function to calculate the maximum of
    * {@code double} and {@code real} values as a user-defined aggregate.
    */
   public static class MaxDouble extends NumericComparison<Double> {
     public MaxDouble() {
       super(Double.MIN_VALUE, Math::max);
+    }
+  }
+
+  /** Implementation of {@code MAX} function to calculate the maximum of
+   * {@code BigDecimal} values as a user-defined aggregate.
+   */
+  public static class MaxBigDecimal extends NumericComparison<BigDecimal> {
+    public MaxBigDecimal() {
+      super(new BigDecimal(Double.MIN_VALUE), MaxBigDecimal::max);
+    }
+
+    public static BigDecimal max(BigDecimal a, BigDecimal b) {
+      return a.max(b);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/interpreter/Interpreter.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Interpreter.java
@@ -30,6 +30,7 @@ import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelVisitor;
+import org.apache.calcite.rel.rules.AggregateReduceFunctionsRule;
 import org.apache.calcite.rel.rules.CalcSplitRule;
 import org.apache.calcite.rel.rules.FilterTableScanRule;
 import org.apache.calcite.rel.rules.ProjectTableScanRule;
@@ -96,7 +97,9 @@ public class Interpreter extends AbstractEnumerable<Object[]>
         .addRuleInstance(FilterTableScanRule.INSTANCE)
         .addRuleInstance(FilterTableScanRule.INTERPRETER)
         .addRuleInstance(ProjectTableScanRule.INSTANCE)
-        .addRuleInstance(ProjectTableScanRule.INTERPRETER).build();
+        .addRuleInstance(ProjectTableScanRule.INTERPRETER)
+        .addRuleInstance(AggregateReduceFunctionsRule.INSTANCE)
+        .build();
     final HepPlanner planner = new HepPlanner(hepProgram);
     planner.setRoot(rootRel);
     rootRel = planner.findBestExp();

--- a/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
@@ -433,6 +433,13 @@ public class InterpreterTest {
         "[3, c, null, null]",
         "[null, null, 4, x]");
   }
+
+  @Test public void testInterpretDecimalAggregate() throws Exception {
+    final String sql = "select x, min(y), max(y), sum(y), avg(y)\n"
+        + "from (values ('a', -1.2), ('a', 2.3), ('a', 15)) as t(x, y)\n"
+        + "group by x";
+    sql(sql).returnsRows("[a, -1.2, 15.0, 16.1, 5.366666666666667]");
+  }
 }
 
 // End InterpreterTest.java


### PR DESCRIPTION
Using decimal type aggregate in Interpreter cause exception.
Please refer to [CALCITE-3494](https://issues.apache.org/jira/browse/CALCITE-3494) for details.

This PR tries to add support for decimal type aggregate in Interpreter.