### PR TITLE
[CALCITE-3498] Unnest operation's ordinality should be deterministic

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -2747,6 +2747,14 @@ public class SqlFunctions {
       list = Arrays.asList(flatElements);
     }
 
+    @Override public boolean moveNext() {
+      boolean hasNext = super.moveNext();
+      if (hasNext && withOrdinality) {
+        ordinality++;
+      }
+      return hasNext;
+    }
+
     public FlatLists.ComparableList<E> current() {
       int i = 0;
       for (Object element : (Object[]) elements) {
@@ -2761,9 +2769,16 @@ public class SqlFunctions {
         i += a.length;
       }
       if (withOrdinality) {
-        flatElements[i] = (E) Integer.valueOf(++ordinality); // 1-based
+        flatElements[i] = (E) Integer.valueOf(ordinality);
       }
       return FlatLists.ofComparable(list);
+    }
+
+    @Override public void reset() {
+      super.reset();
+      if (withOrdinality) {
+        ordinality = 0;
+      }
     }
   }
 


### PR DESCRIPTION
As illustrated in [CALCITE-3498](https://issues.apache.org/jira/browse/CALCITE-3498), the ordinality's compution should be in `moveNext() `method rather than in `current()` method.