### PR TITLE
[CALCITE-3502] Upgrade Geode dependency 1.6.0 -> 1.9.2

### DIFF
--- a/geode/src/main/java/org/apache/calcite/adapter/geode/util/GeodeUtils.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/util/GeodeUtils.java
@@ -103,7 +103,6 @@ public class GeodeUtils {
         .addPoolLocator(locatorHost, locatorPort)
         .setPdxSerializer(new ReflectionBasedAutoSerializer(autoSerializerPackagePath))
         .setPdxReadSerialized(readSerialized)
-        .setPdxPersistent(false)
         .create();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@ limitations under the License.
     <foodmart-queries.version>0.4.1</foodmart-queries.version>
     <forbiddenapis.version>2.6</forbiddenapis.version>
     <freemarker.version>2.3.28</freemarker.version>
-    <geode.version>1.6.0</geode.version>
+    <geode.version>1.9.2</geode.version>
     <git-commit-id-plugin.version>2.1.9</git-commit-id-plugin.version>
     <!-- We support (and test against) Guava versions between
          19.0 and 27.1. Default is 19.0 due to Cassandra adapter. -->


### PR DESCRIPTION
Remove `ClientCacheFactory.setPdxPersistent` which is deprecated for client caches.

Release notes: https://cwiki.apache.org/confluence/display/GEODE/Release+Notes