### PR TITLE
[CALCITE-3477] Decimal type should not be assigned from other types

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRules.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRules.java
@@ -131,12 +131,6 @@ public class SqlTypeAssignmentRules {
 
     // DECIMAL is assignable from...
     rule.clear();
-    rule.add(SqlTypeName.TINYINT);
-    rule.add(SqlTypeName.SMALLINT);
-    rule.add(SqlTypeName.INTEGER);
-    rule.add(SqlTypeName.BIGINT);
-    rule.add(SqlTypeName.REAL);
-    rule.add(SqlTypeName.DOUBLE);
     rule.add(SqlTypeName.DECIMAL);
     rules.add(SqlTypeName.DECIMAL, rule);
 

--- a/core/src/test/resources/sql/spatial.iq
+++ b/core/src/test/resources/sql/spatial.iq
@@ -283,6 +283,16 @@ EXPR$0
 {"x":-71.1043443253471,"y":42.3150676015829}
 !ok
 
+SELECT ST_MakePoint(1.0, 1);
+EXPR$0
+{"x":1,"y":1}
+!ok
+
+SELECT ST_MakePoint('-1.11', '2.2', 1.1);
+EXPR$0
+{"x":-1.11,"y":2.2,"z":1.1}
+!ok
+
 # Return point marked as WGS 84 long lat
 SELECT ST_SetSRID(ST_MakePoint(-71.1043443253471, 42.3150676015829),4326);
 EXPR$0


### PR DESCRIPTION
As illustrated in [CALCITE-3477](https://issues.apache.org/jira/browse/CALCITE-3477), it is not illegal to assign Decimal type from other types.