### PR TITLE
[CALCITE-3503] NPE at VolcanoPlanner#isValid when DEBUG is enabled

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -877,6 +877,10 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
    * Checks internal consistency.
    */
   protected boolean isValid(Litmus litmus) {
+    if (this.getRoot() == null) {
+      return true;
+    }
+
     RelMetadataQuery metaQuery = this.getRoot().getCluster().getMetadataQuerySupplier().get();
     for (RelSet set : allSets) {
       if (set.equivalentSet != null) {


### PR DESCRIPTION
When planner root is null, we should skip the validation since the memo is empty at that moment.