### PR TITLE
[CALCITE-3577] Unparse to correct BigQuery interval syntax: "INTERVAL…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -17,14 +17,18 @@
 package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlAlienSystemTypeNameSpec;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlIntervalLiteral;
+import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -151,6 +155,49 @@ public class BigQuerySqlDialect extends SqlDialect {
       break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
+    }
+  }
+
+  /** BigQuery interval syntax: INTERVAL int64 time_unit. */
+  @Override public void unparseSqlIntervalLiteral(
+          SqlWriter writer, SqlIntervalLiteral literal, int leftPrec, int rightPrec) {
+    SqlIntervalLiteral.IntervalValue interval =
+            (SqlIntervalLiteral.IntervalValue) literal.getValue();
+    writer.keyword("INTERVAL");
+    if (interval.getSign() == -1) {
+      writer.print("-");
+    }
+    writer.literal(literal.getValue().toString());
+    unparseSqlIntervalQualifier(writer, interval.getIntervalQualifier(),
+            RelDataTypeSystem.DEFAULT);
+  }
+
+  @Override public void unparseSqlIntervalQualifier(
+          SqlWriter writer, SqlIntervalQualifier qualifier, RelDataTypeSystem typeSystem) {
+    final String start = validate(qualifier.timeUnitRange.startUnit).name();
+    if (qualifier.timeUnitRange.endUnit == null) {
+      writer.keyword(start);
+    } else {
+      throw new RuntimeException("Range time unit is not supported.");
+    }
+  }
+
+  private TimeUnit validate(TimeUnit timeUnit) {
+    switch (timeUnit) {
+    case MICROSECOND:
+    case MILLISECOND:
+    case SECOND:
+    case MINUTE:
+    case HOUR:
+    case DAY:
+    case WEEK:
+    case MONTH:
+    case QUARTER:
+    case YEAR:
+    case ISOYEAR:
+      return timeUnit;
+    default:
+      throw new RuntimeException(" Time unit " + timeUnit + "is not supported now.");
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -178,7 +178,7 @@ public class BigQuerySqlDialect extends SqlDialect {
     if (qualifier.timeUnitRange.endUnit == null) {
       writer.keyword(start);
     } else {
-      throw new RuntimeException("Range time unit is not supported.");
+      throw new RuntimeException("Range time unit is not supported for BigQuery.");
     }
   }
 
@@ -197,7 +197,7 @@ public class BigQuerySqlDialect extends SqlDialect {
     case ISOYEAR:
       return timeUnit;
     default:
-      throw new RuntimeException(" Time unit " + timeUnit + "is not supported now.");
+      throw new RuntimeException("Time unit " + timeUnit + " is not supported for BigQuery.");
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -167,7 +167,13 @@ public class BigQuerySqlDialect extends SqlDialect {
     if (interval.getSign() == -1) {
       writer.print("-");
     }
-    writer.literal(literal.getValue().toString());
+    Long intervalValueInLong;
+    try {
+      intervalValueInLong = Long.parseLong(literal.getValue().toString());
+    } catch (NumberFormatException e) {
+      throw new RuntimeException("Only INT64 is supported as the interval value for BigQuery.");
+    }
+    writer.literal(intervalValueInLong.toString());
     unparseSqlIntervalQualifier(writer, interval.getIntervalQualifier(),
             RelDataTypeSystem.DEFAULT);
   }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2311,11 +2311,7 @@ public class RelToSqlConverterTest {
 
     final String sql2 = "select  * from \"employee\" where  \"hire_date\" + "
             + "INTERVAL '1 2:34:56.78' DAY TO SECOND > TIMESTAMP '2005-10-17 00:00:00' ";
-    sql(sql2).withBigQuery().throws_("Range time unit is not supported in BigQuery.");
-
-    final String sql3 = "select  * from \"employee\" where  \"hire_date\" + "
-            + "INTERVAL '10' NANOSECOND > TIMESTAMP '2005-10-17 00:00:00' ";
-    sql(sql3).withBigQuery().throws_("Time unit NANOSECOND is not supported for BigQuery.");
+    sql(sql2).withBigQuery().throws_("Only INT64 is supported as the interval value for BigQuery.");
   }
 
   @Test public void testFloorMysqlWeek() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2311,7 +2311,11 @@ public class RelToSqlConverterTest {
 
     final String sql2 = "select  * from \"employee\" where  \"hire_date\" + "
             + "INTERVAL '1 2:34:56.78' DAY TO SECOND > TIMESTAMP '2005-10-17 00:00:00' ";
-    sql(sql2).withBigQuery().throws_("Range time unit is not supported.");
+    sql(sql2).withBigQuery().throws_("Range time unit is not supported in BigQuery.");
+
+    final String sql3 = "select  * from \"employee\" where  \"hire_date\" + "
+            + "INTERVAL '10' NANOSECOND > TIMESTAMP '2005-10-17 00:00:00' ";
+    sql(sql3).withBigQuery().throws_("Time unit NANOSECOND is not supported for BigQuery.");
   }
 
   @Test public void testFloorMysqlWeek() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2292,6 +2292,28 @@ public class RelToSqlConverterTest {
         .ok(expectedDateMinusNegate);
   }
 
+  @Test public void testUnparseSqlIntervalQualifierBigQuery() {
+    final String sql0 = "select  * from \"employee\" where  \"hire_date\" - "
+            + "INTERVAL '19800' SECOND(5) > TIMESTAMP '2005-10-17 00:00:00' ";
+    final String expect0 = "SELECT *\n"
+            + "FROM foodmart.employee\n"
+            + "WHERE (hire_date - INTERVAL 19800 SECOND)"
+            + " > TIMESTAMP '2005-10-17 00:00:00'";
+    sql(sql0).withBigQuery().ok(expect0);
+
+    final String sql1 = "select  * from \"employee\" where  \"hire_date\" + "
+            + "INTERVAL '10' HOUR > TIMESTAMP '2005-10-17 00:00:00' ";
+    final String expect1 = "SELECT *\n"
+            + "FROM foodmart.employee\n"
+            + "WHERE (hire_date + INTERVAL 10 HOUR)"
+            + " > TIMESTAMP '2005-10-17 00:00:00'";
+    sql(sql1).withBigQuery().ok(expect1);
+
+    final String sql2 = "select  * from \"employee\" where  \"hire_date\" + "
+            + "INTERVAL '1 2:34:56.78' DAY TO SECOND > TIMESTAMP '2005-10-17 00:00:00' ";
+    sql(sql2).withBigQuery().throws_("Range time unit is not supported.");
+  }
+
   @Test public void testFloorMysqlWeek() {
     String query = "SELECT floor(\"hire_date\" TO WEEK) FROM \"employee\"";
     String expected = "SELECT STR_TO_DATE(DATE_FORMAT(`hire_date` , '%x%v-1'), '%x%v-%w')\n"


### PR DESCRIPTION
… int64 time_unit". Range time unit is not supported yet by BigQuery.