### PR TITLE
[CALCITE-3508] Strengthen outer Join to inner if it is under a Filter that discards null values

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3604,7 +3604,7 @@ public class RelOptRulesTest extends RelOptTestBase {
     final String sql = "select 1 from sales.emp d full outer join sales.emp e\n"
         + "on d.deptno = e.deptno  where d.deptno > 7 and e.deptno > 9";
     sql(sql).withPre(getTransitiveProgram())
-        .withRule(JoinPushTransitivePredicatesRule.INSTANCE).checkUnchanged();
+        .withRule(JoinPushTransitivePredicatesRule.INSTANCE).check();
   }
 
   @Test public void testTransitiveInferencePreventProjectPullUp()

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5397,22 +5397,25 @@ where d.deptno > 7 and e.deptno > 9]]>
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalFilter(condition=[>($16, 9)])
-    LogicalJoin(condition=[=($7, $16)], joinType=[left])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[CAST($9):INTEGER], ENAME0=[CAST($10):VARCHAR(20)], JOB0=[CAST($11):VARCHAR(10)], MGR0=[$12], HIREDATE0=[CAST($13):TIMESTAMP(0)], SAL0=[CAST($14):INTEGER], COMM0=[CAST($15):INTEGER], DEPTNO0=[CAST($16):INTEGER], SLACKER0=[CAST($17):BOOLEAN])
+    LogicalJoin(condition=[=($7, $16)], joinType=[inner])
       LogicalFilter(condition=[>($7, 7)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalFilter(condition=[>($7, 9)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalFilter(condition=[>($16, 9)])
-    LogicalJoin(condition=[=($7, $16)], joinType=[left])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[CAST($9):INTEGER], ENAME0=[CAST($10):VARCHAR(20)], JOB0=[CAST($11):VARCHAR(10)], MGR0=[$12], HIREDATE0=[CAST($13):TIMESTAMP(0)], SAL0=[CAST($14):INTEGER], COMM0=[CAST($15):INTEGER], DEPTNO0=[CAST($16):INTEGER], SLACKER0=[CAST($17):BOOLEAN])
+    LogicalJoin(condition=[=($7, $16)], joinType=[inner])
+      LogicalFilter(condition=[>($7, 9)])
+        LogicalFilter(condition=[>($7, 7)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalFilter(condition=[>($7, 7)])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalFilter(condition=[>($7, 7)])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalFilter(condition=[>($7, 9)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -5425,9 +5428,10 @@ where d.deptno > 7 and e.deptno > 9]]>
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalFilter(condition=[>($7, 7)])
-    LogicalJoin(condition=[=($7, $16)], joinType=[right])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(EMPNO=[CAST($0):INTEGER], ENAME=[CAST($1):VARCHAR(20)], JOB=[CAST($2):VARCHAR(10)], MGR=[$3], HIREDATE=[CAST($4):TIMESTAMP(0)], SAL=[CAST($5):INTEGER], COMM=[CAST($6):INTEGER], DEPTNO=[CAST($7):INTEGER], SLACKER=[CAST($8):BOOLEAN], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
+    LogicalJoin(condition=[=($7, $16)], joinType=[inner])
+      LogicalFilter(condition=[>($7, 7)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalFilter(condition=[>($7, 9)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -5435,12 +5439,14 @@ LogicalProject(EXPR$0=[1])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalFilter(condition=[>($7, 7)])
-    LogicalJoin(condition=[=($7, $16)], joinType=[right])
+  LogicalProject(EMPNO=[CAST($0):INTEGER], ENAME=[CAST($1):VARCHAR(20)], JOB=[CAST($2):VARCHAR(10)], MGR=[$3], HIREDATE=[CAST($4):TIMESTAMP(0)], SAL=[CAST($5):INTEGER], COMM=[CAST($6):INTEGER], DEPTNO=[CAST($7):INTEGER], SLACKER=[CAST($8):BOOLEAN], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
+    LogicalJoin(condition=[=($7, $16)], joinType=[inner])
       LogicalFilter(condition=[>($7, 9)])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalFilter(condition=[>($7, 9)])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalFilter(condition=[>($7, 7)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalFilter(condition=[>($7, 7)])
+        LogicalFilter(condition=[>($7, 9)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -5452,19 +5458,25 @@ on d.deptno = e.deptno  where d.deptno > 7 and e.deptno > 9]]>
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalFilter(condition=[AND(>($7, 7), >($16, 9))])
-    LogicalJoin(condition=[=($7, $16)], joinType=[full])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(EMPNO=[CAST($0):INTEGER], ENAME=[CAST($1):VARCHAR(20)], JOB=[CAST($2):VARCHAR(10)], MGR=[$3], HIREDATE=[CAST($4):TIMESTAMP(0)], SAL=[CAST($5):INTEGER], COMM=[CAST($6):INTEGER], DEPTNO=[CAST($7):INTEGER], SLACKER=[CAST($8):BOOLEAN], EMPNO0=[CAST($9):INTEGER], ENAME0=[CAST($10):VARCHAR(20)], JOB0=[CAST($11):VARCHAR(10)], MGR0=[$12], HIREDATE0=[CAST($13):TIMESTAMP(0)], SAL0=[CAST($14):INTEGER], COMM0=[CAST($15):INTEGER], DEPTNO0=[CAST($16):INTEGER], SLACKER0=[CAST($17):BOOLEAN])
+    LogicalJoin(condition=[=($7, $16)], joinType=[inner])
+      LogicalFilter(condition=[>($7, 7)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalFilter(condition=[>($7, 9)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EXPR$0=[1])
-  LogicalFilter(condition=[AND(>($7, 7), >($16, 9))])
-    LogicalJoin(condition=[=($7, $16)], joinType=[full])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(EMPNO=[CAST($0):INTEGER], ENAME=[CAST($1):VARCHAR(20)], JOB=[CAST($2):VARCHAR(10)], MGR=[$3], HIREDATE=[CAST($4):TIMESTAMP(0)], SAL=[CAST($5):INTEGER], COMM=[CAST($6):INTEGER], DEPTNO=[CAST($7):INTEGER], SLACKER=[CAST($8):BOOLEAN], EMPNO0=[CAST($9):INTEGER], ENAME0=[CAST($10):VARCHAR(20)], JOB0=[CAST($11):VARCHAR(10)], MGR0=[$12], HIREDATE0=[CAST($13):TIMESTAMP(0)], SAL0=[CAST($14):INTEGER], COMM0=[CAST($15):INTEGER], DEPTNO0=[CAST($16):INTEGER], SLACKER0=[CAST($17):BOOLEAN])
+    LogicalJoin(condition=[=($7, $16)], joinType=[inner])
+      LogicalFilter(condition=[>($7, 9)])
+        LogicalFilter(condition=[>($7, 7)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalFilter(condition=[>($7, 7)])
+        LogicalFilter(condition=[>($7, 9)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -11773,8 +11785,8 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[OR(AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0)))), AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0))), IS NOT TRUE(>($0, $9)), IS NOT TRUE(>($10, $11))))])
-    LogicalJoin(condition=[=($2, $13)], joinType=[left])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], m=[CAST($9):INTEGER], c=[CAST($10):BIGINT], d=[CAST($11):BIGINT], trueLiteral=[CAST($12):BOOLEAN], NAME=[CAST($13):VARCHAR(10)])
+    LogicalJoin(condition=[AND(=($2, $13), OR(AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0)))), AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0))), IS NOT TRUE(>($0, $9)), IS NOT TRUE(>($10, $11)))))], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalProject(m=[$1], c=[$2], d=[$3], trueLiteral=[true], NAME=[$0])
         LogicalAggregate(group=[{0}], m=[MIN($1)], c=[COUNT()], d=[COUNT($1)])

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -2068,12 +2068,12 @@ EnumerableAggregate(group=[{}], C=[COUNT()])
 select empno from "scott".emp as e
 where e.empno > ANY(
   select 2 from "scott".dept e2 where e2.deptno = e.deptno) ;
-EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t0, $t2)], expr#8=[IS NULL($t5)], expr#9=[0], expr#10=[=($t3, $t9)], expr#11=[OR($t8, $t10)], expr#12=[IS NOT TRUE($t11)], expr#13=[AND($t7, $t12)], expr#14=[IS NOT TRUE($t7)], expr#15=[>($t3, $t4)], expr#16=[IS NOT TRUE($t15)], expr#17=[AND($t7, $t12, $t14, $t16)], expr#18=[OR($t13, $t17)], EMPNO=[$t0], $condition=[$t18])
-  EnumerableHashJoin(condition=[=($1, $6)], joinType=[left])
-    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], DEPTNO=[$t7])
-      EnumerableTableScan(table=[[scott, EMP]])
+EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t5, $t0)], expr#8=[0], expr#9=[=($t1, $t8)], expr#10=[IS NOT TRUE($t9)], expr#11=[AND($t7, $t10)], expr#12=[IS NOT TRUE($t7)], expr#13=[>($t1, $t2)], expr#14=[IS NOT TRUE($t13)], expr#15=[AND($t7, $t10, $t12, $t14)], expr#16=[OR($t11, $t15)], EMPNO=[$t5], $condition=[$t16])
+  EnumerableHashJoin(condition=[=($4, $6)], joinType=[inner])
     EnumerableCalc(expr#0..2=[{inputs}], expr#3=[2], expr#4=[1:BIGINT], expr#5=[true], m=[$t3], c=[$t4], d=[$t4], trueLiteral=[$t5], DEPTNO=[$t0])
       EnumerableTableScan(table=[[scott, DEPT]])
+    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], DEPTNO=[$t7])
+      EnumerableTableScan(table=[[scott, EMP]])
 !plan
  EMPNO
 -------


### PR DESCRIPTION
This change expands upon `FilterJoinRule` ability to strengthen JOINs
by leveraging the filter clauses within the query. For a JOIN that is
nullable on either the left or the right, this change inspects the
Filter clauses of the query to determine if it is possible to
strengthen the JOIN.