### PR TITLE
[CALCITE-3512] Query fails when comparing Time/TimeStamp types

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -25,10 +25,13 @@ import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.BlockStatement;
 import org.apache.calcite.linq4j.tree.ConstantUntypedNull;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.ExpressionType;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.MethodDeclaration;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
 import org.apache.calcite.linq4j.tree.Primitive;
+import org.apache.calcite.linq4j.tree.Types;
+import org.apache.calcite.linq4j.tree.UnaryExpression;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.type.RelDataType;
@@ -36,6 +39,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
@@ -45,6 +49,7 @@ import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
@@ -160,35 +165,83 @@ public class EnumUtils {
         parameters);
   }
 
+  /**
+   * In Calcite, {@code java.sql.Date} and {@code java.sql.Time} are
+   * stored as {@code Integer} type, {@code java.sql.Timestamp} is
+   * stored as {@code Long} type.
+   */
+  static Expression convertToInternalType(Expression operand, Type targetType) {
+    return convertToInternalType(operand, operand.getType(), targetType);
+  }
+
+  private static Expression convertToInternalType(Expression operand,
+      Type fromType, Type targetType) {
+    if (fromType == java.sql.Date.class) {
+      if (targetType == int.class) {
+        return Expressions.call(BuiltInMethod.DATE_TO_INT.method, operand);
+      } else if (targetType == Integer.class) {
+        return Expressions.call(BuiltInMethod.DATE_TO_INT_OPTIONAL.method, operand);
+      }
+    } else if (fromType == java.sql.Time.class) {
+      if (targetType == int.class) {
+        return Expressions.call(BuiltInMethod.TIME_TO_INT.method, operand);
+      } else if (targetType == Integer.class) {
+        return Expressions.call(BuiltInMethod.TIME_TO_INT_OPTIONAL.method, operand);
+      }
+    } else if (fromType == java.sql.Timestamp.class) {
+      if (targetType == long.class) {
+        return Expressions.call(BuiltInMethod.TIMESTAMP_TO_LONG.method, operand);
+      } else if (targetType == Long.class) {
+        return Expressions.call(BuiltInMethod.TIMESTAMP_TO_LONG_OPTIONAL.method, operand);
+      }
+    }
+    return operand;
+  }
+
   /** Converts from internal representation to JDBC representation used by
    * arguments of user-defined functions. For example, converts date values from
    * {@code int} to {@link java.sql.Date}. */
-  static Expression fromInternal(Expression e, Class<?> targetType) {
-    if (e == ConstantUntypedNull.INSTANCE) {
-      return e;
+  private static Expression fromInternalType(Expression operand, Type targetType) {
+    return fromInternalType(operand, operand.getType(), targetType);
+  }
+
+  private static Expression fromInternalType(Expression operand,
+      Type fromType, Type targetType) {
+    if (operand == ConstantUntypedNull.INSTANCE) {
+      return operand;
     }
-    if (!(e.getType() instanceof Class)) {
-      return e;
+    if (!(operand.getType() instanceof Class)) {
+      return operand;
     }
-    if (targetType.isAssignableFrom((Class) e.getType())) {
-      return e;
+    if (Types.isAssignableFrom(targetType, fromType)) {
+      return operand;
     }
     if (targetType == java.sql.Date.class) {
-      return Expressions.call(BuiltInMethod.INTERNAL_TO_DATE.method, e);
+      // E.g. from "int" or "Integer" to "java.sql.Date",
+      // generate "SqlFunctions.internalToDate".
+      if (isA(fromType, Primitive.INT)) {
+        return Expressions.call(BuiltInMethod.INTERNAL_TO_DATE.method, operand);
+      }
+    } else if (targetType == java.sql.Time.class) {
+      // E.g. from "int" or "Integer" to "java.sql.Time",
+      // generate "SqlFunctions.internalToTime".
+      if (isA(fromType, Primitive.INT)) {
+        return Expressions.call(BuiltInMethod.INTERNAL_TO_TIME.method, operand);
+      }
+    } else if (targetType == java.sql.Timestamp.class) {
+      // E.g. from "long" or "Long" to "java.sql.Timestamp",
+      // generate "SqlFunctions.internalToTimestamp".
+      if (isA(fromType, Primitive.LONG)) {
+        return Expressions.call(BuiltInMethod.INTERNAL_TO_TIMESTAMP.method, operand);
+      }
     }
-    if (targetType == java.sql.Time.class) {
-      return Expressions.call(BuiltInMethod.INTERNAL_TO_TIME.method, e);
-    }
-    if (targetType == java.sql.Timestamp.class) {
-      return Expressions.call(BuiltInMethod.INTERNAL_TO_TIMESTAMP.method, e);
-    }
-    if (Primitive.is(e.type)
+    if (Primitive.is(operand.type)
         && Primitive.isBox(targetType)) {
-      // E.g. e is "int", target is "Long", generate "(long) e".
-      return Expressions.convert_(e,
+      // E.g. operand is "int", target is "Long", generate "(long) operand".
+      return Expressions.convert_(operand,
           Primitive.ofBox(targetType).primitiveClass);
     }
-    return e;
+    return operand;
   }
 
   static List<Expression> fromInternal(Class<?>[] targetTypes,
@@ -196,7 +249,7 @@ public class EnumUtils {
     final List<Expression> list = new ArrayList<>();
     if (targetTypes.length == expressions.size()) {
       for (int i = 0; i < expressions.size(); i++) {
-        list.add(fromInternal(expressions.get(i), targetTypes[i]));
+        list.add(fromInternalType(expressions.get(i), targetTypes[i]));
       }
     } else {
       int j = 0;
@@ -208,7 +261,7 @@ public class EnumUtils {
         } else {
           type = targetTypes[j].getComponentType();
         }
-        list.add(fromInternal(expressions.get(i), type));
+        list.add(fromInternalType(expressions.get(i), type));
       }
     }
     return list;
@@ -224,7 +277,7 @@ public class EnumUtils {
     return type;
   }
 
-  static Type toInternal(RelDataType type) {
+  private static Type toInternal(RelDataType type) {
     switch (type.getSqlTypeName()) {
     case DATE:
     case TIME:
@@ -238,6 +291,225 @@ public class EnumUtils {
 
   static List<Type> internalTypes(List<? extends RexNode> operandList) {
     return Util.transform(operandList, node -> toInternal(node.getType()));
+  }
+
+  public static Expression convert(Expression operand, Type toType) {
+    final Type fromType = operand.getType();
+    return EnumUtils.convert(operand, fromType, toType);
+  }
+
+  public static Expression convert(Expression operand, Type fromType,
+      Type toType) {
+    if (!Types.needTypeCast(fromType, toType)) {
+      return operand;
+    }
+    // E.g. from "Short" to "int".
+    // Generate "x.intValue()".
+    final Primitive toPrimitive = Primitive.of(toType);
+    final Primitive toBox = Primitive.ofBox(toType);
+    final Primitive fromBox = Primitive.ofBox(fromType);
+    final Primitive fromPrimitive = Primitive.of(fromType);
+    final boolean fromNumber = fromType instanceof Class
+        && Number.class.isAssignableFrom((Class) fromType);
+    if (fromType == String.class) {
+      if (toPrimitive != null) {
+        switch (toPrimitive) {
+        case CHAR:
+        case SHORT:
+        case INT:
+        case LONG:
+        case FLOAT:
+        case DOUBLE:
+          // Generate "SqlFunctions.toShort(x)".
+          return Expressions.call(
+              SqlFunctions.class,
+              "to" + SqlFunctions.initcap(toPrimitive.primitiveName),
+              operand);
+        default:
+          // Generate "Short.parseShort(x)".
+          return Expressions.call(
+              toPrimitive.boxClass,
+              "parse" + SqlFunctions.initcap(toPrimitive.primitiveName),
+              operand);
+        }
+      }
+      if (toBox != null) {
+        switch (toBox) {
+        case CHAR:
+          // Generate "SqlFunctions.toCharBoxed(x)".
+          return Expressions.call(
+              SqlFunctions.class,
+              "to" + SqlFunctions.initcap(toBox.primitiveName) + "Boxed",
+              operand);
+        default:
+          // Generate "Short.valueOf(x)".
+          return Expressions.call(
+              toBox.boxClass,
+              "valueOf",
+              operand);
+        }
+      }
+    }
+    if (toPrimitive != null) {
+      if (fromPrimitive != null) {
+        // E.g. from "float" to "double"
+        return Expressions.convert_(
+            operand, toPrimitive.primitiveClass);
+      }
+      if (fromNumber || fromBox == Primitive.CHAR) {
+        // Generate "x.shortValue()".
+        return Expressions.unbox(operand, toPrimitive);
+      } else {
+        // E.g. from "Object" to "short".
+        // Generate "SqlFunctions.toShort(x)"
+        return Expressions.call(
+            SqlFunctions.class,
+            "to" + SqlFunctions.initcap(toPrimitive.primitiveName),
+            operand);
+      }
+    } else if (fromNumber && toBox != null) {
+      // E.g. from "Short" to "Integer"
+      // Generate "x == null ? null : Integer.valueOf(x.intValue())"
+      return Expressions.condition(
+          Expressions.equal(operand, RexImpTable.NULL_EXPR),
+          RexImpTable.NULL_EXPR,
+          Expressions.box(
+              Expressions.unbox(operand, toBox),
+              toBox));
+    } else if (fromPrimitive != null && toBox != null) {
+      // E.g. from "int" to "Long".
+      // Generate Long.valueOf(x)
+      // Eliminate primitive casts like Long.valueOf((long) x)
+      if (operand instanceof UnaryExpression) {
+        UnaryExpression una = (UnaryExpression) operand;
+        if (una.nodeType == ExpressionType.Convert
+            || Primitive.of(una.getType()) == toBox) {
+          return Expressions.box(una.expression, toBox);
+        }
+      }
+      if (fromType == toBox.primitiveClass) {
+        return Expressions.box(operand, toBox);
+      }
+      // E.g., from "int" to "Byte".
+      // Convert it first and generate "Byte.valueOf((byte)x)"
+      // Because there is no method "Byte.valueOf(int)" in Byte
+      return Expressions.box(
+          Expressions.convert_(operand, toBox.primitiveClass),
+          toBox);
+    }
+    // Convert datetime types to internal storage type:
+    // 1. java.sql.Date -> int or Integer
+    // 2. java.sql.Time -> int or Integer
+    // 3. java.sql.Timestamp -> long or Long
+    if (representAsInternalType(fromType)) {
+      final Expression internalTypedOperand =
+          convertToInternalType(operand, fromType, toType);
+      if (operand != internalTypedOperand) {
+        return internalTypedOperand;
+      }
+    }
+    // Convert internal storage type to datetime types:
+    // 1. int or Integer -> java.sql.Date
+    // 2. int or Integer -> java.sql.Time
+    // 3. long or Long -> java.sql.Timestamp
+    if (representAsInternalType(toType)) {
+      final Expression originTypedOperand =
+          fromInternalType(operand, fromType, toType);
+      if (operand != originTypedOperand) {
+        return originTypedOperand;
+      }
+    }
+    if (toType == BigDecimal.class) {
+      if (fromBox != null) {
+        // E.g. from "Integer" to "BigDecimal".
+        // Generate "x == null ? null : new BigDecimal(x.intValue())"
+        return Expressions.condition(
+            Expressions.equal(operand, RexImpTable.NULL_EXPR),
+            RexImpTable.NULL_EXPR,
+            Expressions.new_(
+                BigDecimal.class,
+                Expressions.unbox(operand, fromBox)));
+      }
+      if (fromPrimitive != null) {
+        // E.g. from "int" to "BigDecimal".
+        // Generate "new BigDecimal(x)"
+        // Fix CALCITE-2325, we should decide null here for int type.
+        return Expressions.condition(
+            Expressions.equal(operand, RexImpTable.NULL_EXPR),
+            RexImpTable.NULL_EXPR,
+            Expressions.new_(
+                BigDecimal.class,
+                operand));
+      }
+      // E.g. from "Object" to "BigDecimal".
+      // Generate "x == null ? null : SqlFunctions.toBigDecimal(x)"
+      return Expressions.condition(
+          Expressions.equal(operand, RexImpTable.NULL_EXPR),
+          RexImpTable.NULL_EXPR,
+          Expressions.call(
+              SqlFunctions.class,
+              "toBigDecimal",
+              operand));
+    } else if (toType == String.class) {
+      if (fromPrimitive != null) {
+        switch (fromPrimitive) {
+        case DOUBLE:
+        case FLOAT:
+          // E.g. from "double" to "String"
+          // Generate "SqlFunctions.toString(x)"
+          return Expressions.call(
+              SqlFunctions.class,
+              "toString",
+              operand);
+        default:
+          // E.g. from "int" to "String"
+          // Generate "Integer.toString(x)"
+          return Expressions.call(
+              fromPrimitive.boxClass,
+              "toString",
+              operand);
+        }
+      } else if (fromType == BigDecimal.class) {
+        // E.g. from "BigDecimal" to "String"
+        // Generate "SqlFunctions.toString(x)"
+        return Expressions.condition(
+            Expressions.equal(operand, RexImpTable.NULL_EXPR),
+            RexImpTable.NULL_EXPR,
+            Expressions.call(
+                SqlFunctions.class,
+                "toString",
+                operand));
+      } else {
+        Expression result;
+        try {
+          // Try to call "toString()" method
+          // E.g. from "Integer" to "String"
+          // Generate "x == null ? null : x.toString()"
+          result = Expressions.condition(
+              Expressions.equal(operand, RexImpTable.NULL_EXPR),
+              RexImpTable.NULL_EXPR,
+              Expressions.call(operand, "toString"));
+        } catch (RuntimeException e) {
+          // For some special cases, e.g., "BuiltInMethod.LESSER",
+          // its return type is generic ("Comparable"), which contains
+          // no "toString()" method. We fall through to "(String)x".
+          return Expressions.convert_(operand, toType);
+        }
+        return result;
+      }
+    }
+    return Expressions.convert_(operand, toType);
+  }
+
+  private static boolean isA(Type fromType, Primitive primitive) {
+    return Primitive.of(fromType) == primitive
+        || Primitive.ofBox(fromType) == primitive;
+  }
+
+  private static boolean representAsInternalType(Type type) {
+    return type == java.sql.Date.class
+        || type == java.sql.Time.class
+        || type == java.sql.Timestamp.class;
   }
 
   /** Transforms a JoinRelType to Linq4j JoinType. **/

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -240,35 +240,6 @@ public class EnumUtils {
     return Util.transform(operandList, node -> toInternal(node.getType()));
   }
 
-  static Expression enforce(final Type storageType,
-      final Expression e) {
-    if (storageType != null && e.type != storageType) {
-      if (e.type == java.sql.Date.class) {
-        if (storageType == int.class) {
-          return Expressions.call(BuiltInMethod.DATE_TO_INT.method, e);
-        }
-        if (storageType == Integer.class) {
-          return Expressions.call(BuiltInMethod.DATE_TO_INT_OPTIONAL.method, e);
-        }
-      } else if (e.type == java.sql.Time.class) {
-        if (storageType == int.class) {
-          return Expressions.call(BuiltInMethod.TIME_TO_INT.method, e);
-        }
-        if (storageType == Integer.class) {
-          return Expressions.call(BuiltInMethod.TIME_TO_INT_OPTIONAL.method, e);
-        }
-      } else if (e.type == java.sql.Timestamp.class) {
-        if (storageType == long.class) {
-          return Expressions.call(BuiltInMethod.TIMESTAMP_TO_LONG.method, e);
-        }
-        if (storageType == Long.class) {
-          return Expressions.call(BuiltInMethod.TIMESTAMP_TO_LONG_OPTIONAL.method, e);
-        }
-      }
-    }
-    return e;
-  }
-
   /** Transforms a JoinRelType to Linq4j JoinType. **/
   static JoinType toLinq4jJoinType(JoinRelType joinRelType) {
     switch (joinRelType) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
@@ -136,7 +136,7 @@ public class EnumerableCalc extends Calc implements EnumerableRel {
                 Enumerator.class, inputJavaType),
             "inputEnumerator");
     Expression input =
-        RexToLixTranslator.convert(
+        EnumUtils.convert(
             Expressions.call(
                 inputEnumerator,
                 BuiltInMethod.ENUMERATOR_CURRENT.method),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMatch.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMatch.java
@@ -176,7 +176,7 @@ public class EnumerableMatch extends Match implements EnumerableRel {
     // Add loop variable initialization
     builder2.add(
         Expressions.declare(0, row_,
-            RexToLixTranslator.convert(
+            EnumUtils.convert(
                 Expressions.call(rows_, BuiltInMethod.LIST_GET.method, i_),
                 inputPhysType.getJavaRowType())));
 
@@ -476,7 +476,7 @@ public class EnumerableMatch extends Match implements EnumerableRel {
       return Expressions.condition(
           Expressions.greaterThanOrEqual(this.index, Expressions.constant(0)),
           generator.apply(
-              RexToLixTranslator.convert(
+              EnumUtils.convert(
                   Expressions.call(this.passedRows,
                       BuiltInMethod.LIST_GET.method, this.index),
                   physType.getJavaRowType()))

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -145,10 +145,10 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
                   right.getRowType().getFieldList().get(pair.right).getType()));
       final Type keyClass = typeFactory.getJavaClass(keyType);
       leftExpressions.add(
-          RexToLixTranslator.convert(
+          EnumUtils.convert(
               leftResult.physType.fieldReference(left_, pair.left), keyClass));
       rightExpressions.add(
-          RexToLixTranslator.convert(
+          EnumUtils.convert(
               rightResult.physType.fieldReference(right_, pair.right), keyClass));
     }
     final PhysType leftKeyPhysType =

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java
@@ -266,7 +266,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
       final Expression row_ =
           builder4.append(
               "row",
-              RexToLixTranslator.convert(
+              EnumUtils.convert(
                   Expressions.arrayIndex(rows_, i_),
                   inputPhysType.getJavaRowType()));
 
@@ -600,7 +600,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
       public Expression getRow(Expression rowIndex) {
         return block.append(
             "jRow",
-            RexToLixTranslator.convert(
+            EnumUtils.convert(
                 Expressions.arrayIndex(rows_, rowIndex),
                 inputPhysType.getJavaRowType()));
       }
@@ -891,7 +891,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
           });
       // Several count(a) and count(b) might share the result
       Expression aggRes = builder.append("a" + agg.aggIdx + "res",
-          RexToLixTranslator.convert(res, agg.result.getType()));
+          EnumUtils.convert(res, agg.result.getType()));
       builder.add(
           Expressions.statement(Expressions.assign(agg.result, aggRes)));
     }
@@ -916,7 +916,7 @@ public class EnumerableWindow extends Window implements EnumerableRel {
       Expression offs = translator.translate(node);
       // Floating offset does not make sense since we refer to array index.
       // Nulls do not make sense as well.
-      offs = RexToLixTranslator.convert(offs, int.class);
+      offs = EnumUtils.convert(offs, int.class);
 
       Expression b = i_;
       if (bound.isFollowing()) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/JavaRowFormat.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/JavaRowFormat.java
@@ -184,7 +184,7 @@ public enum JavaRowFormat {
       if (fromType == null) {
         fromType = e.getType();
       }
-      return RexToLixTranslator.convert(e, fromType, fieldType);
+      return EnumUtils.convert(e, fromType, fieldType);
     }
   },
 
@@ -213,7 +213,7 @@ public enum JavaRowFormat {
       if (fromType == null) {
         fromType = e.getType();
       }
-      return RexToLixTranslator.convert(e, fromType, fieldType);
+      return EnumUtils.convert(e, fromType, fieldType);
     }
   },
 
@@ -244,7 +244,7 @@ public enum JavaRowFormat {
       if (fromType == null) {
         fromType = e.getType();
       }
-      return RexToLixTranslator.convert(e, fromType, fieldType);
+      return EnumUtils.convert(e, fromType, fieldType);
     }
   };
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
@@ -658,7 +658,9 @@ public class PhysTypeImpl implements PhysType {
       fieldType = null;
     } else {
       fieldType = fieldClass(field);
-      if (fieldType != java.sql.Date.class) {
+      if (fieldType != java.sql.Date.class
+          && fieldType != java.sql.Time.class
+          && fieldType != java.sql.Timestamp.class) {
         fieldType = null;
       }
     }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
@@ -219,7 +219,7 @@ public class PhysTypeImpl implements PhysType {
     final List<Expression> expressions = new ArrayList<>();
     for (int field : argList) {
       expressions.add(
-          RexToLixTranslator.convert(
+          EnumUtils.convert(
               fieldReference(v1, field),
               fieldClass(field)));
     }
@@ -308,8 +308,8 @@ public class PhysTypeImpl implements PhysType {
       Expression arg1 = fieldReference(parameterV1, index);
       switch (Primitive.flavor(fieldClass(index))) {
       case OBJECT:
-        arg0 = RexToLixTranslator.convert(arg0, Comparable.class);
-        arg1 = RexToLixTranslator.convert(arg1, Comparable.class);
+        arg0 = EnumUtils.convert(arg0, Comparable.class);
+        arg1 = EnumUtils.convert(arg1, Comparable.class);
       }
       final boolean nullsFirst =
           collation.nullDirection
@@ -407,8 +407,8 @@ public class PhysTypeImpl implements PhysType {
       Expression arg1 = fieldReference(parameterV1, index);
       switch (Primitive.flavor(fieldClass(index))) {
       case OBJECT:
-        arg0 = RexToLixTranslator.convert(arg0, Comparable.class);
-        arg1 = RexToLixTranslator.convert(arg1, Comparable.class);
+        arg0 = EnumUtils.convert(arg0, Comparable.class);
+        arg1 = EnumUtils.convert(arg1, Comparable.class);
       }
       final boolean nullsFirst =
           fieldCollation.nullDirection
@@ -566,7 +566,7 @@ public class PhysTypeImpl implements PhysType {
       // }
       Class returnType = fieldClasses.get(field0);
       Expression fieldReference =
-          RexToLixTranslator.convert(
+          EnumUtils.convert(
               fieldReference(v1, field0),
               returnType);
       return Expressions.lambda(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -1096,7 +1096,7 @@ public class RexImpTable {
       final Expression ifTrue;
       switch (nullAs) {
       case NULL:
-        ifTrue = RexToLixTranslator.convert(NULL_EXPR, box.getType());
+        ifTrue = EnumUtils.convert(NULL_EXPR, box.getType());
         break;
       case IS_NULL:
         ifTrue = TRUE_EXPR;
@@ -1246,7 +1246,7 @@ public class RexImpTable {
       case BOX:
         switch (this) {
         case NOT_POSSIBLE:
-          return RexToLixTranslator.convert(
+          return EnumUtils.convert(
               x,
               Primitive.ofBox(x.getType()).primitiveClass);
         }
@@ -1379,7 +1379,7 @@ public class RexImpTable {
         next = Expressions.call(acc, "add", add.arguments().get(0));
       } else {
         next = Expressions.add(acc,
-            RexToLixTranslator.convert(add.arguments().get(0), acc.type));
+            EnumUtils.convert(add.arguments().get(0), acc.type));
       }
       accAdvance(add, acc, next);
     }
@@ -1457,7 +1457,7 @@ public class RexImpTable {
 
     public Expression implementResult(AggContext info,
         AggResultContext result) {
-      return RexToLixTranslator.convert(result.accumulator().get(1),
+      return EnumUtils.convert(result.accumulator().get(1),
           info.returnType());
     }
   }
@@ -2199,8 +2199,8 @@ public class RexImpTable {
     private Expression call(Expression operand, Type type,
         TimeUnit timeUnit) {
       return Expressions.call(SqlFunctions.class, methodName,
-          RexToLixTranslator.convert(operand, type),
-          RexToLixTranslator.convert(
+          EnumUtils.convert(operand, type),
+          EnumUtils.convert(
               Expressions.constant(timeUnit.multiplier), type));
     }
   }
@@ -2227,7 +2227,7 @@ public class RexImpTable {
 
       final Type returnType =
           translator.typeFactory.getJavaClass(call.getType());
-      return RexToLixTranslator.convert(expression, returnType);
+      return EnumUtils.convert(expression, returnType);
     }
   }
 
@@ -2339,7 +2339,7 @@ public class RexImpTable {
 
       final Type returnType =
           translator.typeFactory.getJavaClass(call.getType());
-      return RexToLixTranslator.convert(
+      return EnumUtils.convert(
           Expressions.makeBinary(expressionType, expressions.get(0),
               expressions.get(1)),
           returnType);
@@ -2956,7 +2956,7 @@ public class RexImpTable {
     @Override public Expression implement(RexToLixTranslator translator, RexCall call,
         ParameterExpression row, ParameterExpression rows,
         ParameterExpression symbols, ParameterExpression i) {
-      return RexToLixTranslator.convert(
+      return EnumUtils.convert(
           Expressions.call(symbols, BuiltInMethod.LIST_GET.method, i),
           String.class);
     }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/StrictAggImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/StrictAggImplementor.java
@@ -54,7 +54,7 @@ public abstract class StrictAggImplementor implements AggImplementor {
       Expression next) {
     add.currentBlock().add(
         Expressions.statement(
-            Expressions.assign(acc, RexToLixTranslator.convert(next, acc.type))));
+            Expressions.assign(acc, EnumUtils.convert(next, acc.type))));
   }
 
   public final List<Type> getStateType(AggContext info) {
@@ -166,7 +166,7 @@ public abstract class StrictAggImplementor implements AggImplementor {
   public final Expression implementResult(AggContext info,
       final AggResultContext result) {
     if (!needTrackEmptySet) {
-      return RexToLixTranslator.convert(
+      return EnumUtils.convert(
           implementNotNullResult(info, result), info.returnType());
     }
     String tmpName = result.accumulator().isEmpty()
@@ -177,7 +177,7 @@ public abstract class StrictAggImplementor implements AggImplementor {
 
     List<Expression> acc = result.accumulator();
     final BlockBuilder thenBlock = result.nestBlock();
-    Expression nonNull = RexToLixTranslator.convert(
+    Expression nonNull = EnumUtils.convert(
         implementNotNullResult(info, result), info.returnType());
     result.exitBlock();
     thenBlock.add(Expressions.statement(Expressions.assign(res, nonNull)));

--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -17,7 +17,7 @@
 package org.apache.calcite.adapter.java;
 
 import org.apache.calcite.DataContext;
-import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.adapter.enumerable.EnumUtils;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Enumerator;
 import org.apache.calcite.linq4j.Linq4j;
@@ -167,7 +167,7 @@ public class ReflectiveSchema
   /** Returns an expression for the object wrapped by this schema (not the
    * schema itself). */
   Expression getTargetExpression(SchemaPlus parentSchema, String name) {
-    return RexToLixTranslator.convert(
+    return EnumUtils.convert(
         Expressions.call(
             Schemas.unwrap(
                 getExpression(parentSchema, name),

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutorImpl.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rex;
 
 import org.apache.calcite.DataContext;
+import org.apache.calcite.adapter.enumerable.EnumUtils;
 import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
 import org.apache.calcite.adapter.enumerable.RexToLixTranslator.InputGetter;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
@@ -151,7 +152,7 @@ public class RexExecutorImpl implements RexExecutor {
           BuiltInMethod.DATA_CONTEXT_GET.method,
           Expressions.constant("inputRecord"));
       Expression recFromCtxCasted =
-          RexToLixTranslator.convert(recFromCtx, Object[].class);
+          EnumUtils.convert(recFromCtx, Object[].class);
       IndexExpression recordAccess = Expressions.arrayIndex(recFromCtxCasted,
           Expressions.constant(index));
       if (storageType == null) {
@@ -159,7 +160,7 @@ public class RexExecutorImpl implements RexExecutor {
             rowType.getFieldList().get(index).getType();
         storageType = ((JavaTypeFactory) typeFactory).getJavaClass(fieldType);
       }
-      return RexToLixTranslator.convert(recordAccess, storageType);
+      return EnumUtils.convert(recordAccess, storageType);
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1797,6 +1797,10 @@ public class SqlFunctions {
         : (Integer) cannotConvert(o, int.class);
   }
 
+  public static Integer toIntOptional(Object o) {
+    return o == null ? null : toInt(o);
+  }
+
   /** Converts the Java type used for UDF parameters of SQL TIMESTAMP type
    * ({@link java.sql.Timestamp}) to internal representation (long).
    *
@@ -1838,7 +1842,12 @@ public class SqlFunctions {
     return o instanceof Long ? (Long) o
         : o instanceof Number ? toLong((Number) o)
         : o instanceof String ? toLong((String) o)
+        : o instanceof java.util.Date ? toLong((java.util.Date) o)
         : (Long) cannotConvert(o, long.class);
+  }
+
+  public static Long toLongOptional(Object o) {
+    return o == null ? null : toLong(o);
   }
 
   public static float toFloat(String s) {

--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -17,7 +17,7 @@
 package org.apache.calcite.schema;
 
 import org.apache.calcite.DataContext;
-import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.adapter.enumerable.EnumUtils;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
@@ -176,7 +176,7 @@ public final class Schemas {
           Expressions.constant(elementType),
           Expressions.constant(tableName));
     }
-    return RexToLixTranslator.convert(expression, clazz);
+    return EnumUtils.convert(expression, clazz);
   }
 
   public static DataContext createDataContext(

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
@@ -16,7 +16,7 @@
  */
 package org.apache.calcite.sql.validate;
 
-import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.adapter.enumerable.EnumUtils;
 import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
@@ -186,7 +186,7 @@ public class SqlUserDefinedTableMacro extends SqlFunction {
     // expressions.
     BlockBuilder bb = new BlockBuilder();
     final Expression expr =
-        RexToLixTranslator.convert(Expressions.constant(o), clazz);
+        EnumUtils.convert(Expressions.constant(o), clazz);
     bb.add(Expressions.return_(null, expr));
     final FunctionExpression convert =
         Expressions.lambda(bb.toBlock(), Collections.emptyList());

--- a/core/src/test/java/org/apache/calcite/adapter/enumerable/EnumUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/adapter/enumerable/EnumUtilsTest.java
@@ -26,18 +26,18 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
- * Tests for {@link RexToLixTranslator}.
+ * Tests for {@link EnumUtils}.
  */
-public final class RexToLixTranslatorTest {
+public final class EnumUtilsTest {
 
   @Test public void testDateTypeToInnerTypeConvert() {
     // java.sql.Date x;
     final ParameterExpression date =
         Expressions.parameter(0, java.sql.Date.class, "x");
     final Expression dateToInt =
-        RexToLixTranslator.convert(date, int.class);
+        EnumUtils.convert(date, int.class);
     final Expression dateToInteger =
-        RexToLixTranslator.convert(date, Integer.class);
+        EnumUtils.convert(date, Integer.class);
     assertThat(Expressions.toString(dateToInt),
         is("org.apache.calcite.runtime.SqlFunctions.toInt(x)"));
     assertThat(Expressions.toString(dateToInteger),
@@ -47,9 +47,9 @@ public final class RexToLixTranslatorTest {
     final ParameterExpression time =
         Expressions.parameter(0, java.sql.Time.class, "x");
     final Expression timeToInt =
-        RexToLixTranslator.convert(time, int.class);
+        EnumUtils.convert(time, int.class);
     final Expression timeToInteger =
-        RexToLixTranslator.convert(time, Integer.class);
+        EnumUtils.convert(time, Integer.class);
     assertThat(Expressions.toString(timeToInt),
         is("org.apache.calcite.runtime.SqlFunctions.toInt(x)"));
     assertThat(Expressions.toString(timeToInteger),
@@ -59,9 +59,9 @@ public final class RexToLixTranslatorTest {
     final ParameterExpression timestamp =
         Expressions.parameter(0, java.sql.Timestamp.class, "x");
     final Expression timeStampToLongPrimitive =
-        RexToLixTranslator.convert(timestamp, long.class);
+        EnumUtils.convert(timestamp, long.class);
     final Expression timeStampToLong =
-        RexToLixTranslator.convert(timestamp, Long.class);
+        EnumUtils.convert(timestamp, Long.class);
     assertThat(Expressions.toString(timeStampToLongPrimitive),
         is("org.apache.calcite.runtime.SqlFunctions.toLong(x)"));
     assertThat(Expressions.toString(timeStampToLong),
@@ -69,4 +69,4 @@ public final class RexToLixTranslatorTest {
   }
 }
 
-// End RexToLixTranslatorTest.java
+// End EnumUtilsTest.java

--- a/core/src/test/java/org/apache/calcite/adapter/enumerable/RexToLixTranslatorTest.java
+++ b/core/src/test/java/org/apache/calcite/adapter/enumerable/RexToLixTranslatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.enumerable;
+
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.ParameterExpression;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link RexToLixTranslator}.
+ */
+public final class RexToLixTranslatorTest {
+
+  @Test public void testDateTypeToInnerTypeConvert() {
+    // java.sql.Date x;
+    final ParameterExpression date =
+        Expressions.parameter(0, java.sql.Date.class, "x");
+    final Expression dateToInt =
+        RexToLixTranslator.convert(date, int.class);
+    final Expression dateToInteger =
+        RexToLixTranslator.convert(date, Integer.class);
+    assertThat(Expressions.toString(dateToInt),
+        is("org.apache.calcite.runtime.SqlFunctions.toInt(x)"));
+    assertThat(Expressions.toString(dateToInteger),
+        is("org.apache.calcite.runtime.SqlFunctions.toIntOptional(x)"));
+
+    // java.sql.Time x;
+    final ParameterExpression time =
+        Expressions.parameter(0, java.sql.Time.class, "x");
+    final Expression timeToInt =
+        RexToLixTranslator.convert(time, int.class);
+    final Expression timeToInteger =
+        RexToLixTranslator.convert(time, Integer.class);
+    assertThat(Expressions.toString(timeToInt),
+        is("org.apache.calcite.runtime.SqlFunctions.toInt(x)"));
+    assertThat(Expressions.toString(timeToInteger),
+        is("org.apache.calcite.runtime.SqlFunctions.toIntOptional(x)"));
+
+    // java.sql.TimeStamp x;
+    final ParameterExpression timestamp =
+        Expressions.parameter(0, java.sql.Timestamp.class, "x");
+    final Expression timeStampToLongPrimitive =
+        RexToLixTranslator.convert(timestamp, long.class);
+    final Expression timeStampToLong =
+        RexToLixTranslator.convert(timestamp, Long.class);
+    assertThat(Expressions.toString(timeStampToLongPrimitive),
+        is("org.apache.calcite.runtime.SqlFunctions.toLong(x)"));
+    assertThat(Expressions.toString(timeStampToLong),
+        is("org.apache.calcite.runtime.SqlFunctions.toLongOptional(x)"));
+  }
+}
+
+// End RexToLixTranslatorTest.java

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -807,6 +807,41 @@ public class ReflectiveSchemaTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3512">[CALCITE-3512]
+   * Query fails when comparing Time/TimeStamp types</a>. */
+  @Test public void testTimeCanCompare() {
+    final String sql = "select a.v\n"
+        + "from (select \"sqlTime\" v\n"
+        + "  from \"s\".\"everyTypes\" "
+        + "  group by \"sqlTime\") a,"
+        + "    (select \"sqlTime\" v\n"
+        + "  from \"s\".\"everyTypes\"\n"
+        + "  group by \"sqlTime\") b\n"
+        + "where a.v >= b.v\n"
+        + "group by a.v";
+    CalciteAssert.that()
+        .withSchema("s", CATCHALL)
+        .query(sql)
+        .returnsUnordered("V=00:00:00");
+  }
+
+  @Test public void testTimestampCanCompare() {
+    final String sql = "select a.v\n"
+        + "from (select \"sqlTimestamp\" v\n"
+        + "  from \"s\".\"everyTypes\" "
+        + "  group by \"sqlTimestamp\") a,"
+        + "    (select \"sqlTimestamp\" v\n"
+        + "  from \"s\".\"everyTypes\"\n"
+        + "  group by \"sqlTimestamp\") b\n"
+        + "where a.v >= b.v\n"
+        + "group by a.v";
+    CalciteAssert.that()
+        .withSchema("s", CATCHALL)
+        .query(sql)
+        .returnsUnordered("V=1970-01-01 00:00:00");
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-281">[CALCITE-1919]
    * NPE when target in ReflectiveSchema belongs to the unnamed package</a>. */
   @Test public void testReflectiveSchemaInUnnamedPackage() throws Exception {


### PR DESCRIPTION
As described in [CALCITE-3512](https://issues.apache.org/jira/browse/CALCITE-3512), we need to support type cast from `Time/TimeStamp` to `Integer/Long`.