### PR TITLE
[CALCITE-3513] Unify TableFunction implementor's NullPolicy and its behavior

### DIFF
--- a/core/src/main/java/org/apache/calcite/schema/impl/ReflectiveFunctionBase.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ReflectiveFunctionBase.java
@@ -16,6 +16,9 @@
  */
 package org.apache.calcite.schema.impl;
 
+import org.apache.calcite.adapter.enumerable.NullPolicy;
+import org.apache.calcite.linq4j.function.SemiStrict;
+import org.apache.calcite.linq4j.function.Strict;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.Function;
@@ -87,6 +90,20 @@ public abstract class ReflectiveFunctionBase implements Function {
       }
     }
     return null;
+  }
+
+  static NullPolicy getNullPolicy(Method m) {
+    if (m.getAnnotation(Strict.class) != null) {
+      return NullPolicy.STRICT;
+    } else if (m.getAnnotation(SemiStrict.class) != null) {
+      return NullPolicy.SEMI_STRICT;
+    } else if (m.getDeclaringClass().getAnnotation(Strict.class) != null) {
+      return NullPolicy.STRICT;
+    } else if (m.getDeclaringClass().getAnnotation(SemiStrict.class) != null) {
+      return NullPolicy.SEMI_STRICT;
+    } else {
+      return NullPolicy.NONE;
+    }
   }
 
   /** Creates a ParameterListBuilder. */

--- a/core/src/main/java/org/apache/calcite/schema/impl/ScalarFunctionImpl.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ScalarFunctionImpl.java
@@ -20,8 +20,6 @@ import org.apache.calcite.adapter.enumerable.CallImplementor;
 import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.adapter.enumerable.ReflectiveCallNotNullImplementor;
 import org.apache.calcite.adapter.enumerable.RexImpTable;
-import org.apache.calcite.linq4j.function.SemiStrict;
-import org.apache.calcite.linq4j.function.Strict;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.ImplementableFunction;
@@ -132,20 +130,6 @@ public class ScalarFunctionImpl extends ReflectiveFunctionBase
     final NullPolicy nullPolicy = getNullPolicy(method);
     return RexImpTable.createImplementor(
         new ReflectiveCallNotNullImplementor(method), nullPolicy, false);
-  }
-
-  private static NullPolicy getNullPolicy(Method m) {
-    if (m.getAnnotation(Strict.class) != null) {
-      return NullPolicy.STRICT;
-    } else if (m.getAnnotation(SemiStrict.class) != null) {
-      return NullPolicy.SEMI_STRICT;
-    } else if (m.getDeclaringClass().getAnnotation(Strict.class) != null) {
-      return NullPolicy.STRICT;
-    } else if (m.getDeclaringClass().getAnnotation(SemiStrict.class) != null) {
-      return NullPolicy.SEMI_STRICT;
-    } else {
-      return NullPolicy.NONE;
-    }
   }
 
   public RelDataType getReturnType(RelDataTypeFactory typeFactory,

--- a/core/src/main/java/org/apache/calcite/schema/impl/TableFunctionImpl.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/TableFunctionImpl.java
@@ -18,7 +18,6 @@ package org.apache.calcite.schema.impl;
 
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.enumerable.CallImplementor;
-import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.adapter.enumerable.ReflectiveCallNotNullImplementor;
 import org.apache.calcite.adapter.enumerable.RexImpTable;
 import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
@@ -137,7 +136,7 @@ public class TableFunctionImpl extends ReflectiveFunctionBase implements
             }
             return expr;
           }
-        }, NullPolicy.ANY, false);
+        }, getNullPolicy(method), false);
   }
 
   private Table apply(List<Object> arguments) {

--- a/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
@@ -487,6 +487,47 @@ public class TableFunctionTest {
       assertThat(CalciteAssert.toString(resultSet), equalTo(expected));
     }
   }
+
+  /**
+   * Test of a table function that produces null.
+   */
+  @Test public void testNullContentTableFunction() throws SQLException {
+    try (Connection connection = DriverManager.getConnection("jdbc:calcite:")) {
+      CalciteConnection calciteConnection =
+          connection.unwrap(CalciteConnection.class);
+      SchemaPlus rootSchema = calciteConnection.getRootSchema();
+      SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
+      final TableFunction table =
+          TableFunctionImpl.create(Smalls.NULL_PRODUCED_METHOD);
+      schema.add("generate", table);
+
+      final String sql1 = "select *\n"
+          + "from table(\"s\".\"generate\"(1, 2))";
+      ResultSet resultSet = connection.createStatement().executeQuery(sql1);
+      final String expected1 = "S=abcde\n"
+          + "S=xyz\n"
+          + "S=generate(x=1, y=2)\n";
+      assertThat(CalciteAssert.toString(resultSet), equalTo(expected1));
+
+      final String sql2 = "select *\n"
+          + "from table(\"s\".\"generate\"(1, 1))";
+      resultSet = connection.createStatement().executeQuery(sql2);
+      final String expected2 =  "S=abcde\n"
+          + "S=xyz\n"
+          + "S=null\n";
+      assertThat(CalciteAssert.toString(resultSet), equalTo(expected2));
+
+      final String sql3 = "select *\n"
+          + "from table(\"s\".\"generate\"(1, cast(null as integer)))";
+      try {
+        connection.createStatement().executeQuery(sql3);
+      } catch (Exception e) {
+        // org.apache.calcite.runtime.Enumerables.slice0(null)
+        assertThat(e.getCause().toString(),
+            containsString("java.lang.NullPointerException"));
+      }
+    }
+  }
 }
 
 // End TableFunctionTest.java

--- a/core/src/test/java/org/apache/calcite/util/Smalls.java
+++ b/core/src/test/java/org/apache/calcite/util/Smalls.java
@@ -29,6 +29,7 @@ import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.function.Deterministic;
 import org.apache.calcite.linq4j.function.Parameter;
 import org.apache.calcite.linq4j.function.SemiStrict;
+import org.apache.calcite.linq4j.function.Strict;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -102,6 +103,9 @@ public class Smalls {
   public static final Method PROCESS_CURSORS_METHOD =
       Types.lookupMethod(Smalls.class, "processCursors",
           int.class, Enumerable.class, Enumerable.class);
+  public static final Method NULL_PRODUCED_METHOD =
+      Types.lookupMethod(NullContentTable.class, "generate",
+          Integer.class, Integer.class);
 
   private Smalls() {}
 
@@ -898,6 +902,41 @@ public class Smalls {
     }
 
     public Enumerable<Object[]> scan(DataContext root) {
+      Object[][] rows = {{"abcde"}, {"xyz"}, {content}};
+      return Linq4j.asEnumerable(rows);
+    }
+  }
+
+  /** This is table that may produce null content. */
+  public static class NullContentTable extends AbstractTable
+      implements ScannableTable {
+
+    private final Integer x;
+    private final Integer y;
+
+    private NullContentTable(Integer x, Integer y) {
+      this.x = x;
+      this.y = y;
+    }
+
+    @Strict public static ScannableTable generate(Integer x, Integer y) {
+      return new NullContentTable(x, y);
+    }
+
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+      RelDataType recordType = typeFactory.builder()
+          .add("S", SqlTypeName.VARCHAR, 12)
+          .nullable(true)
+          .build();
+      return typeFactory.createTypeWithNullability(recordType, true);
+    }
+
+    public Enumerable<Object[]> scan(DataContext root) {
+      String content = null;
+      if (x.intValue() != y.intValue()) {
+        content = String.format(
+            Locale.ROOT, "generate(x=%d, y=%d)", x, y);
+      }
       Object[][] rows = {{"abcde"}, {"xyz"}, {content}};
       return Linq4j.asEnumerable(rows);
     }


### PR DESCRIPTION
Details are illustrated in [CALCITE-3513](https://issues.apache.org/jira/browse/CALCITE-3513), Table function's implementation should be `NullPolicy.NONE`.