### PR TITLE
[CALCITE-3514] LatticeTest fails when JdbcSchema re-computes JdbcTables

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
@@ -41,6 +41,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -78,6 +79,9 @@ public class JdbcSchema implements Schema {
   final JdbcConvention convention;
   private ImmutableMap<String, JdbcTable> tableMap;
   private final boolean snapshot;
+
+  @VisibleForTesting
+  public static boolean forceTableComputation = false;
 
   @Experimental
   public static final ThreadLocal<Foo> THREAD_METADATA = new ThreadLocal<>();
@@ -342,7 +346,7 @@ public class JdbcSchema implements Schema {
   }
 
   public Table getTable(String name) {
-    return getTableMap(false).get(name);
+    return getTableMap(forceTableComputation).get(name);
   }
 
   private synchronized ImmutableMap<String, JdbcTable> getTableMap(

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -200,6 +200,24 @@ public class JdbcTable extends AbstractQueryableTable
         sourceExpressionList, flattened);
   }
 
+  @Override public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof JdbcTable)) {
+      return false;
+    }
+    JdbcTable other = (JdbcTable) obj;
+    return Objects.equals(other.jdbcTableName, this.jdbcTableName)
+        && Objects.equals(other.jdbcCatalogName, this.jdbcCatalogName)
+        && Objects.equals(other.jdbcSchemaName, this.jdbcSchemaName);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(jdbcSchema, jdbcCatalogName,
+        jdbcSchemaName, jdbcTableName, jdbcTableType);
+  }
+
   /** Enumerable that returns the contents of a {@link JdbcTable} by connecting
    * to the JDBC data source.
    *

--- a/core/src/main/java/org/apache/calcite/schema/impl/StarTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/StarTable.java
@@ -112,7 +112,7 @@ public class StarTable extends AbstractTable implements TranslatableTable {
   public int columnOffset(Table table) {
     int n = 0;
     for (Pair<Table, Integer> pair : Pair.zip(tables, fieldCounts)) {
-      if (pair.left == table) {
+      if (pair.left.equals(table)) {
         return n;
       }
       n += pair.right;

--- a/core/src/test/java/org/apache/calcite/test/LatticeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LatticeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.materialize.Lattice;
 import org.apache.calcite.materialize.Lattices;
@@ -483,10 +484,12 @@ public class LatticeTest {
   @Test public void testTileAlgorithm2() {
     // Different explain than above, but note that it still selects columns
     // (27, 31).
+    JdbcSchema.forceTableComputation = true;
     final String explain = "EnumerableAggregate(group=[{4, 5}])\n"
         + "  EnumerableTableScan(table=[[adhoc, m{16, 17, 27, 31, 32, 36, 37}]";
     checkTileAlgorithm(Lattices.class.getCanonicalName() + "#CACHED_SQL",
         explain);
+    JdbcSchema.forceTableComputation = false;
   }
 
   /** As {@link #testTileAlgorithm()}, but uses the


### PR DESCRIPTION
As illustrated in [CALCITE-3514](https://issues.apache.org/jira/browse/CALCITE-3514), we need to implement `JdbcTable`'s `equals()` and `hashCode() `methods.