### PR TITLE
[CALCITE-3519] Fix problem in `inheritPath` of `RelHint`.

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/hint/RelHint.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/RelHint.java
@@ -17,7 +17,7 @@
 
 package org.apache.calcite.rel.hint;
 
-import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.ImmutableIntList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 public class RelHint {
   //~ Instance fields --------------------------------------------------------
 
-  public final ImmutableBitSet inheritPath;
+  public final ImmutableIntList inheritPath;
   public final String hintName;
   public final List<String> listOptions;
   public final Map<String, String> kvOptions;
@@ -55,7 +55,7 @@ public class RelHint {
       @Nullable Map<String, String> kvOptions) {
     Objects.requireNonNull(inheritPath);
     Objects.requireNonNull(hintName);
-    this.inheritPath = ImmutableBitSet.of(inheritPath);
+    this.inheritPath = ImmutableIntList.copyOf(inheritPath);
     this.hintName = hintName;
     this.listOptions = listOption == null ? ImmutableList.of() : ImmutableList.copyOf(listOption);
     this.kvOptions = kvOptions == null ? ImmutableMap.of() : ImmutableMap.copyOf(kvOptions);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -5745,8 +5745,10 @@ public class SqlToRelConverter {
 
     private static List<RelHint> copyWithInheritPath(List<RelHint> hints,
         Deque<Integer> inheritPath) {
+      List<Integer> path = Arrays.asList(inheritPath.toArray(new Integer[]{}));
+      Collections.reverse(path);
       return hints.stream()
-          .map(hint -> hint.copy(Arrays.asList(inheritPath.toArray(new Integer[]{}))))
+          .map(hint -> hint.copy(path))
           .collect(Collectors.toList());
     }
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
@@ -108,17 +108,17 @@ public class SqlHintsConverterTest extends SqlToRelTestBase {
         + "inner join dept d1 on e1.deptno = d1.deptno\n"
         + "inner join emp e2 on e1.ename = e2.job");
     final List<String> expectedHints = Arrays.asList(
-        "Project:[[PROPERTIES inheritPath:{} options:{K1=v1, K2=v2}], "
-            + "[INDEX inheritPath:{} options:[ENAME]], "
-            + "[NO_HASH_JOIN inheritPath:{}]]",
-        "LogicalJoin:[[NO_HASH_JOIN inheritPath:{0}]]",
-        "LogicalJoin:[[NO_HASH_JOIN inheritPath:{0}]]",
-        "TableScan:[[PROPERTIES inheritPath:{0} options:{K1=v1, K2=v2}], "
-            + "[INDEX inheritPath:{0} options:[ENAME]]]",
-        "TableScan:[[PROPERTIES inheritPath:{0, 1} options:{K1=v1, K2=v2}], "
-            + "[INDEX inheritPath:{0, 1} options:[ENAME]]]",
-        "TableScan:[[PROPERTIES inheritPath:{0, 1} options:{K1=v1, K2=v2}], "
-            + "[INDEX inheritPath:{0, 1} options:[ENAME]]]");
+        "Project:[[PROPERTIES inheritPath:[] options:{K1=v1, K2=v2}], "
+            + "[INDEX inheritPath:[] options:[ENAME]], "
+            + "[NO_HASH_JOIN inheritPath:[]]]",
+        "LogicalJoin:[[NO_HASH_JOIN inheritPath:[0]]]",
+        "LogicalJoin:[[NO_HASH_JOIN inheritPath:[0, 0]]]",
+        "TableScan:[[PROPERTIES inheritPath:[0, 0, 0] options:{K1=v1, K2=v2}], "
+            + "[INDEX inheritPath:[0, 0, 0] options:[ENAME]]]",
+        "TableScan:[[PROPERTIES inheritPath:[0, 0, 1] options:{K1=v1, K2=v2}], "
+            + "[INDEX inheritPath:[0, 0, 1] options:[ENAME]]]",
+        "TableScan:[[PROPERTIES inheritPath:[0, 1, 0] options:{K1=v1, K2=v2}], "
+            + "[INDEX inheritPath:[0, 1, 0] options:[ENAME]]]");
     sql(sql).ok(expectedHints);
   }
 


### PR DESCRIPTION
As illustrated in [Jira 3519](https://issues.apache.org/jira/browse/CALCITE-3519),  
`ImmutableBitSet` is not suitable for representing `inheritPath`. Details are shown in the link.