### PR TITLE
[CALCITE-3503] (Follow up) NPE at VolcanoPlanner#isValid when DEBUG i…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -880,7 +880,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
       return true;
     }
 
-    RelMetadataQuery metaQuery = this.getRoot().getCluster().getMetadataQuerySupplier().get();
+    RelMetadataQuery metaQuery = null;
     for (RelSet set : allSets) {
       if (set.equivalentSet != null) {
         return litmus.fail("set [{}] has been merged: it should not be in the list", set);
@@ -899,6 +899,10 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
                     subset, subset.best);
           }
 
+          if (metaQuery == null) {
+            metaQuery = subset.best.getCluster().getMetadataQuerySupplier().get();
+          }
+
           // Make sure bestCost is up-to-date
           try {
             RelOptCost bestCost = getCost(subset.best, metaQuery);
@@ -913,6 +917,10 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
         }
 
         for (RelNode rel : subset.getRels()) {
+          if (metaQuery == null) {
+            metaQuery = rel.getCluster().getMetadataQuerySupplier().get();
+          }
+
           try {
             RelOptCost relCost = getCost(rel, metaQuery);
             if (relCost.isLt(subset.bestCost)) {


### PR DESCRIPTION
…s enabled

Still conducts isValid() check even if planner.root is not set