### PR TITLE
[CALCITE-3531] AggregateProjectPullUpConstantsRule should not remove …

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
@@ -49,7 +49,7 @@ import java.util.TreeMap;
  * {@link RelMetadataQuery#getPulledUpPredicates(RelNode)}; the input does not
  * need to be a {@link org.apache.calcite.rel.core.Project}.
  *
- * <p>This rules never removes the last column, because {@code Aggregate([])}
+ * <p>This rule never removes the last column, because {@code Aggregate([])}
  * returns 1 row even if its input is empty.
  *
  * <p>Since the transformed relational expression has to match the original

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -514,9 +514,13 @@ public class RexUtil {
     }
 
     public Boolean visitCall(RexCall call) {
-      // Constant if operator is deterministic and all operands are
-      // constant.
-      return call.getOperator().isDeterministic()
+      // Constant if operator meets the following conditions:
+      // 1. It is non-dynamic, e.g. it is safe to
+      //    cache query plans referencing this operator;
+      // 2. It is deterministic;
+      // 3. All its operands are constant.
+      return !call.getOperator().isDynamicFunction()
+          && call.getOperator().isDeterministic()
           && RexVisitorImpl.visitArrayAnd(this, call.getOperands());
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -908,7 +908,7 @@ public abstract class SqlOperator {
   }
 
   /**
-   * @return true iff a call to this operator is guaranteed to always return
+   * Returns whether a call to this operator is guaranteed to always return
    * the same result given the same operands; true is assumed by default
    */
   public boolean isDeterministic() {
@@ -916,7 +916,7 @@ public abstract class SqlOperator {
   }
 
   /**
-   * @return true iff it is unsafe to cache query plans referencing this
+   * Returns whether it is unsafe to cache query plans referencing this
    * operator; false is assumed by default
    */
   public boolean isDynamicFunction() {

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5257,6 +5257,20 @@ public class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Tests {@link AggregateProjectPullUpConstantsRule} where
+   * there are group keys of type
+   * {@link org.apache.calcite.sql.fun.SqlAbstractTimeFunction}
+   * that can not be removed. */
+  @Test public void testAggregateDynamicFunction() {
+    final String sql = "select hiredate\n"
+        + "from sales.emp\n"
+        + "where sal is null and hiredate = current_timestamp\n"
+        + "group by sal, hiredate\n"
+        + "having count(*) > 3";
+    sql(sql).withRule(AggregateProjectPullUpConstantsRule.INSTANCE2)
+        .checkUnchanged();
+  }
+
   @Test public void testReduceExpressionsNot() {
     final String sql = "select * from (values (false),(true)) as q (col1) where not(col1)";
     sql(sql).withRule(ReduceExpressionsRule.FILTER_INSTANCE)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -10652,6 +10652,35 @@ LogicalProject(JOB=[$1])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testAggregateDynamicFunction">
+        <Resource name="sql">
+            <![CDATA[select hiredate
+from sales.emp
+where sal is null and hiredate = current_timestamp
+group by sal, hiredate
+having count(*) > 3]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(HIREDATE=[$1])
+  LogicalFilter(condition=[>($2, 3)])
+    LogicalAggregate(group=[{0, 1}], agg#0=[COUNT()])
+      LogicalProject(SAL=[$5], HIREDATE=[$4])
+        LogicalFilter(condition=[AND(IS NULL($5), =($4, CURRENT_TIMESTAMP))])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(HIREDATE=[$1])
+  LogicalFilter(condition=[>($2, 3)])
+    LogicalAggregate(group=[{0, 1}], agg#0=[COUNT()])
+      LogicalProject(SAL=[$5], HIREDATE=[$4])
+        LogicalFilter(condition=[AND(IS NULL($5), =($4, CURRENT_TIMESTAMP))])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testExpandProjectInNullable">
         <Resource name="sql">
             <![CDATA[with e2 as (


### PR DESCRIPTION
…deterministic function group key if the function is dynamic

We can decide an operator is constant only if:
1. It is non-dynamic, e.g. it is safe to
   cache query plans referencing this operator;
2. It is deterministic;
3. All its operands are constant.