### PR TITLE
[CALCITE-3520] Type cast from primitive to box is not correct

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -25,13 +25,11 @@ import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.BlockStatement;
 import org.apache.calcite.linq4j.tree.ConstantUntypedNull;
 import org.apache.calcite.linq4j.tree.Expression;
-import org.apache.calcite.linq4j.tree.ExpressionType;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.MethodDeclaration;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
 import org.apache.calcite.linq4j.tree.Primitive;
 import org.apache.calcite.linq4j.tree.Types;
-import org.apache.calcite.linq4j.tree.UnaryExpression;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.type.RelDataType;
@@ -394,16 +392,6 @@ public class EnumUtils {
               Expressions.unbox(operand, toBox),
               toBox));
     } else if (fromPrimitive != null && toBox != null) {
-      // E.g. from "int" to "Long".
-      // Generate Long.valueOf(x)
-      // Eliminate primitive casts like Long.valueOf((long) x)
-      if (operand instanceof UnaryExpression) {
-        UnaryExpression una = (UnaryExpression) operand;
-        if (una.nodeType == ExpressionType.Convert
-            || Primitive.of(una.getType()) == toBox) {
-          return Expressions.box(una.expression, toBox);
-        }
-      }
       if (fromType == toBox.primitiveClass) {
         return Expressions.box(operand, toBox);
       }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -25,11 +25,13 @@ import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.BlockStatement;
 import org.apache.calcite.linq4j.tree.ConstantUntypedNull;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.ExpressionType;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.MethodDeclaration;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
 import org.apache.calcite.linq4j.tree.Primitive;
 import org.apache.calcite.linq4j.tree.Types;
+import org.apache.calcite.linq4j.tree.UnaryExpression;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.type.RelDataType;
@@ -392,6 +394,19 @@ public class EnumUtils {
               Expressions.unbox(operand, toBox),
               toBox));
     } else if (fromPrimitive != null && toBox != null) {
+      // E.g. from "int" to "Long".
+      // Generate Long.valueOf(x)
+      // Eliminate primitive casts like Long.valueOf((long) x)
+      if (operand instanceof UnaryExpression) {
+        UnaryExpression una = (UnaryExpression) operand;
+        if (una.nodeType == ExpressionType.Convert
+            && Primitive.of(una.getType()) == toBox) {
+          Primitive origin = Primitive.of(una.expression.type);
+          if (origin != null && toBox.assignableFrom(origin)) {
+            return Expressions.box(una.expression, toBox);
+          }
+        }
+      }
       if (fromType == toBox.primitiveClass) {
         return Expressions.box(operand, toBox);
       }

--- a/core/src/test/java/org/apache/calcite/adapter/enumerable/EnumUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/adapter/enumerable/EnumUtilsTest.java
@@ -68,10 +68,11 @@ public final class EnumUtilsTest {
         is("org.apache.calcite.runtime.SqlFunctions.toLongOptional(x)"));
   }
 
-  @Test public void testTypeFromPrimitiveToBox() {
+  @Test public void testTypeConvertFromPrimitiveToBox() {
     final Expression intVariable =
         Expressions.parameter(0, int.class, "intV");
 
+    // (byte)(int) -> Byte: Byte.valueOf((byte) intV)
     final Expression bytePrimitiveConverted =
         Expressions.convert_(intVariable, byte.class);
     final Expression converted0 =
@@ -79,12 +80,45 @@ public final class EnumUtilsTest {
     assertThat(Expressions.toString(converted0),
         is("Byte.valueOf((byte) intV)"));
 
+    // (char)(int) -> Character: Character.valueOf((char) intV)
     final Expression characterPrimitiveConverted =
         Expressions.convert_(intVariable, char.class);
     final Expression converted1 =
         EnumUtils.convert(characterPrimitiveConverted, Character.class);
     assertThat(Expressions.toString(converted1),
         is("Character.valueOf((char) intV)"));
+
+    // (short)(int) -> Short: Short.valueOf((short) intV)
+    final Expression shortPrimitiveConverted =
+        Expressions.convert_(intVariable, short.class);
+    final Expression converted2 =
+        EnumUtils.convert(shortPrimitiveConverted, Short.class);
+    assertThat(Expressions.toString(converted2),
+        is("Short.valueOf((short) intV)"));
+
+    // (long)(int) -> Long: Long.valueOf(intV)
+    final Expression longPrimitiveConverted =
+        Expressions.convert_(intVariable, long.class);
+    final Expression converted3 =
+        EnumUtils.convert(longPrimitiveConverted, Long.class);
+    assertThat(Expressions.toString(converted3),
+        is("Long.valueOf(intV)"));
+
+    // (float)(int) -> Float: Float.valueOf(intV)
+    final Expression floatPrimitiveConverted =
+        Expressions.convert_(intVariable, float.class);
+    final Expression converted4 =
+        EnumUtils.convert(floatPrimitiveConverted, Float.class);
+    assertThat(Expressions.toString(converted4),
+        is("Float.valueOf(intV)"));
+
+    // (double)(int) -> Double: Double.valueOf(intV)
+    final Expression doublePrimitiveConverted =
+        Expressions.convert_(intVariable, double.class);
+    final Expression converted5 =
+        EnumUtils.convert(doublePrimitiveConverted, Double.class);
+    assertThat(Expressions.toString(converted5),
+        is("Double.valueOf(intV)"));
 
     final Expression byteConverted =
         EnumUtils.convert(intVariable, Byte.class);

--- a/core/src/test/java/org/apache/calcite/adapter/enumerable/EnumUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/adapter/enumerable/EnumUtilsTest.java
@@ -67,6 +67,55 @@ public final class EnumUtilsTest {
     assertThat(Expressions.toString(timeStampToLong),
         is("org.apache.calcite.runtime.SqlFunctions.toLongOptional(x)"));
   }
+
+  @Test public void testTypeFromPrimitiveToBox() {
+    final Expression intVariable =
+        Expressions.parameter(0, int.class, "intV");
+
+    final Expression bytePrimitiveConverted =
+        Expressions.convert_(intVariable, byte.class);
+    final Expression converted0 =
+        EnumUtils.convert(bytePrimitiveConverted, Byte.class);
+    assertThat(Expressions.toString(converted0),
+        is("Byte.valueOf((byte) intV)"));
+
+    final Expression characterPrimitiveConverted =
+        Expressions.convert_(intVariable, char.class);
+    final Expression converted1 =
+        EnumUtils.convert(characterPrimitiveConverted, Character.class);
+    assertThat(Expressions.toString(converted1),
+        is("Character.valueOf((char) intV)"));
+
+    final Expression byteConverted =
+        EnumUtils.convert(intVariable, Byte.class);
+    assertThat(Expressions.toString(byteConverted),
+        is("Byte.valueOf((byte) intV)"));
+
+    final Expression shortConverted =
+        EnumUtils.convert(intVariable, Short.class);
+    assertThat(Expressions.toString(shortConverted),
+        is("Short.valueOf((short) intV)"));
+
+    final Expression integerConverted =
+        EnumUtils.convert(intVariable, Integer.class);
+    assertThat(Expressions.toString(integerConverted),
+        is("Integer.valueOf(intV)"));
+
+    final Expression longConverted =
+        EnumUtils.convert(intVariable, Long.class);
+    assertThat(Expressions.toString(longConverted),
+        is("Long.valueOf((long) intV)"));
+
+    final Expression floatConverted =
+        EnumUtils.convert(intVariable, Float.class);
+    assertThat(Expressions.toString(floatConverted),
+        is("Float.valueOf((float) intV)"));
+
+    final Expression doubleConverted =
+        EnumUtils.convert(intVariable, Double.class);
+    assertThat(Expressions.toString(doubleConverted),
+        is("Double.valueOf((double) intV)"));
+  }
 }
 
 // End EnumUtilsTest.java


### PR DESCRIPTION
Current optimization:
```
int x;
Long.valueOf((long) x) -> Long.valueOf(x)
```
However, it is not always safe to eliminate primitive cast when converting from primitive to box.
 ```
boolean a = false;
byte b = 0;
char c = 'c';
short d = 1;
int e = 0;
long f = 0L;
float g = 1.1f;
double h = 2.2D;

Correct Statement:
==============================================================
Boolean.valueOf(a);
Byte.valueOf(b);
Character.valueOf(c);
Short.valueOf(b); Short.valueOf(d);
Integer.valueOf(b); Integer.valueOf(c); Integer.valueOf(d); Integer.valueOf(e);
Long.valueOf(b); Long.valueOf(c); Long.valueOf(d); Long.valueOf(e); Long.valueOf(f);
Float.valueOf(b); Float.valueOf(c); Float.valueOf(d); Float.valueOf(e); Float.valueOf(f); Float.valueOf(g);
Double.valueOf(b); Double.valueOf(c); Double.valueOf(d); Double.valueOf(e); Double.valueOf(f); Double.valueOf(g); Double.valueOf(h);
```

If the case is:
```
int x;
Byte.valueOf((byte) x) -> Byte.valueOf(x)
```
We will get the exception below.
```
java.lang.RuntimeException: while resolving method 'valueOf[int]' in class class java.lang.Byte
	at org.apache.calcite.linq4j.tree.Types.lookupMethod(Types.java:323)
	at org.apache.calcite.linq4j.tree.Expressions.call(Expressions.java:445)
	at org.apache.calcite.linq4j.tree.Expressions.call(Expressions.java:457)
	at org.apache.calcite.linq4j.tree.Expressions.box(Expressions.java:1437)
	at org.apache.calcite.adapter.enumerable.EnumUtils.convert(EnumUtils.java:404)
	at org.apache.calcite.adapter.enumerable.EnumUtils.convert(EnumUtils.java:306)
	......
Caused by: java.lang.NoSuchMethodException: java.lang.Byte.valueOf(int)
	at java.base/java.lang.Class.getMethod(Class.java:2108)
	at org.apache.calcite.linq4j.tree.Types.lookupMethod(Types.java:314)
	... 72 more
```
Moreover, we cannot figure out queries to hit this code path. Because the codegen framework will conduct unbox operation when necessary.