### PR TITLE
[CALCITE-3547] SqlValidatorException because Planner cannot find UDFs added to schema

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -300,8 +300,10 @@ public class PlannerImpl implements Planner, ViewExpander {
     final SqlConformance conformance = conformance();
     final CalciteCatalogReader catalogReader =
         createCatalogReader().withSchemaPath(schemaPath);
+    final SqlOperatorTable opTab =
+        ChainedSqlOperatorTable.of(operatorTable, catalogReader);
     final SqlValidator validator =
-        new CalciteSqlValidator(operatorTable, catalogReader, typeFactory,
+        new CalciteSqlValidator(opTab, catalogReader, typeFactory,
             conformance);
     validator.setIdentifierExpansion(true);
 

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -47,6 +47,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.RelDecorrelator;
@@ -213,8 +214,10 @@ public class PlannerImpl implements Planner, ViewExpander {
     ensure(State.STATE_3_PARSED);
     final SqlConformance conformance = conformance();
     final CalciteCatalogReader catalogReader = createCatalogReader();
+    final SqlOperatorTable opTab =
+        ChainedSqlOperatorTable.of(operatorTable, catalogReader);
     this.validator =
-        new CalciteSqlValidator(operatorTable, catalogReader, typeFactory,
+        new CalciteSqlValidator(opTab, catalogReader, typeFactory,
             conformance);
     this.validator.setIdentifierExpansion(true);
     try {

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -248,6 +248,9 @@ public class PlannerTest {
     }
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3547">[CALCITE-3547]
+   * SqlValidatorException because Planner cannot find UDFs added to schema</a>. */
   @Test public void testValidateUserDefinedFunctionInSchema() throws Exception {
     SchemaPlus rootSchema = Frameworks.createRootSchema(true);
     rootSchema.add("my_plus",


### PR DESCRIPTION
`CalciteSqlValidator` inside `PlannerImpl` only looks for UDFs in `SqlStdOperatorTable`. When an UDF is added to schema, it is not available for searching by the validator. This PR aims to let UDFs in schema available to the validator just like what `CalcitePrepareImpl` does.

* Add `SqlStdOperatorTable` and `CalciteCatalogReader` to `ChainedSqlOperatorTable`, which then available to `CalciteSqlValidator`
* Add a test case in `PlannerTest` (`testValidateUserDefinedFunctionInSchema`)
