### PR TITLE
[CALCITE-3537] Add ProjectAggregateRule to normalize materialized view in SubstitutionVisitor

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.rules.FilterJoinRule;
 import org.apache.calcite.rel.rules.FilterMergeRule;
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
 import org.apache.calcite.rel.rules.FilterToCalcRule;
+import org.apache.calcite.rel.rules.ProjectAggregateTransposeRule;
 import org.apache.calcite.rel.rules.ProjectCalcMergeRule;
 import org.apache.calcite.rel.rules.ProjectJoinTransposeRule;
 import org.apache.calcite.rel.rules.ProjectMergeRule;
@@ -209,6 +210,7 @@ public abstract class RelOptMaterializations {
             .addRuleInstance(ProjectRemoveRule.INSTANCE)
             .addRuleInstance(ProjectJoinTransposeRule.INSTANCE)
             .addRuleInstance(ProjectSetOpTransposeRule.INSTANCE)
+            .addRuleInstance(ProjectAggregateTransposeRule.INSTANCE)
             .addRuleInstance(FilterToCalcRule.INSTANCE)
             .addRuleInstance(ProjectToCalcRule.INSTANCE)
             .addRuleInstance(FilterCalcMergeRule.INSTANCE)

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateTransposeRule.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.mapping.Mappings;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Planner rule that pushes a {@link org.apache.calcite.rel.core.Project}
+ * past a {@link org.apache.calcite.rel.core.Aggregate}.
+ */
+public class ProjectAggregateTransposeRule extends RelOptRule {
+
+  public static final ProjectAggregateTransposeRule INSTANCE =
+      new ProjectAggregateTransposeRule(Project.class,
+          Aggregate.class, RelFactories.LOGICAL_BUILDER);
+
+  /**
+   * Creates a ProjectAggregateTransposeRule.
+   */
+  private ProjectAggregateTransposeRule(Class<? extends Project> project,
+      Class<? extends Aggregate> aggregate, RelBuilderFactory relBuilderFactory) {
+    super(operand(project, operand(aggregate, any())),
+        relBuilderFactory, "ProjectAggregateTransposeRule");
+  }
+
+  public void onMatch(RelOptRuleCall call) {
+    final LogicalProject proRel = call.rel(0);
+    final LogicalAggregate aggRel = call.rel(1);
+
+    final Mappings.TargetMapping mapping =
+        Project.getMapping(aggRel.getRowType().getFieldCount(), proRel.getProjects());
+    if (mapping == null || Mappings.keepsOrdering(mapping)) {
+      // do nothing
+      return;
+    }
+    // Project              Aggregate
+    //    Aggregate  --->      Project
+    final List<Pair<Integer, Integer>> pairs = new ArrayList<>();
+    final List<Integer> groupings = aggRel.getGroupSet().toList();
+    RelBuilder relBuilder = call.builder();
+    final List<Integer> posList = new ArrayList<>();
+
+    for (int i = 0; i < groupings.size(); i++) {
+      pairs.add(Pair.of(mapping.getTarget(groupings.get(i)), i));
+    }
+    Collections.sort(pairs);
+    pairs.forEach(pair -> posList.add(pair.right));
+
+    for (int i = posList.size(); i < aggRel.getInput().getRowType().getFieldCount(); i++) {
+      posList.add(i);
+    }
+    List<RexNode> newProj = posList.stream().map(
+        pos -> RexInputRef.of(pos, aggRel.getInput().getRowType()))
+        .collect(Collectors.toList());
+    final RelNode project = relBuilder.push(aggRel.getInput()).project(newProj).build();
+
+    RelNode newAgg = relBuilder.push(project).aggregate(relBuilder.groupKey(aggRel.getGroupSet()),
+        aggRel.getAggCallList()).build();
+
+    if (!rowTypesAreEquivalent(proRel, newAgg)) {
+      return;
+    }
+
+    call.transformTo(newAgg);
+  }
+
+  private boolean rowTypesAreEquivalent(
+      RelNode rel0, RelNode rel1) {
+    if (rel0.getRowType().getFieldCount() != rel1.getRowType().getFieldCount()) {
+      return false;
+    }
+    for (Pair<RelDataTypeField, RelDataTypeField> pair
+        : Pair.zip(rel0.getRowType().getFieldList(), rel1.getRowType().getFieldList())) {
+      if (!pair.left.getType().equals(pair.right.getType())) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+// End ProjectAggregateTransposeRule.java

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateTransposeRule.java
@@ -18,13 +18,13 @@ package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalProject;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
@@ -90,25 +90,12 @@ public class ProjectAggregateTransposeRule extends RelOptRule {
     RelNode newAgg = relBuilder.push(project).aggregate(relBuilder.groupKey(aggRel.getGroupSet()),
         aggRel.getAggCallList()).build();
 
-    if (!rowTypesAreEquivalent(proRel, newAgg)) {
+    if (!RelOptUtil.areRowTypesEqual(proRel.getRowType(), newAgg.getRowType(), false)) {
       return;
     }
 
     call.transformTo(newAgg);
   }
 
-  private boolean rowTypesAreEquivalent(
-      RelNode rel0, RelNode rel1) {
-    if (rel0.getRowType().getFieldCount() != rel1.getRowType().getFieldCount()) {
-      return false;
-    }
-    for (Pair<RelDataTypeField, RelDataTypeField> pair
-        : Pair.zip(rel0.getRowType().getFieldList(), rel1.getRowType().getFieldList())) {
-      if (!pair.left.getType().equals(pair.right.getType())) {
-        return false;
-      }
-    }
-    return true;
-  }
 }
 // End ProjectAggregateTransposeRule.java

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateTransposeRule.java
@@ -98,4 +98,3 @@ public class ProjectAggregateTransposeRule extends RelOptRule {
   }
 
 }
-// End ProjectAggregateTransposeRule.java

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -3031,16 +3031,14 @@ class MaterializationTest {
     sql(mv, query).withOnlyBySubstitution(true).ok();
   }
 
-  @Test
-  public void testMvPredicate1() {
+  @Test public void testMvPredicate1() {
     checkMaterialize(
         "select \"deptno\", \"name\", \"empid\","
             + "count(*) from \"emps\" group by  \"name\", \"deptno\", \"empid\" ",
         "select \"name\", count(*) from \"emps\" where \"deptno\"= 10  group by \"name\" ", true);
   }
 
-  @Test
-  public void testMvPredicate2() {
+  @Test public void testMvPredicate2() {
     checkMaterialize(
         "select \"deptno\", \"name\", \"empid\", count(*) from "
             + "\"emps\" group by  \"name\", \"deptno\", \"empid\" ",
@@ -3048,8 +3046,7 @@ class MaterializationTest {
             + "\"name\"= 'Sebastian' OR \"name\"= 'Peter'  group by \"name\" ", true);
   }
 
-  @Test
-  public void testMvPredicate3() {
+  @Test public void testMvPredicate3() {
     checkMaterialize(
         "select \"deptno\", \"name\", \"empid\", count(*) from "
             + "\"emps\" group by  \"name\", \"deptno\", \"empid\" ",
@@ -3057,8 +3054,7 @@ class MaterializationTest {
             + "\"name\" = 'Sebastian' group by \"name\" ", true);
   }
 
-  @Test
-  public void testMvPredicate4() {
+  @Test public void testMvPredicate4() {
     checkMaterialize(
         "select \"name\", \"deptno\", \"empid\", "
             + "count(*) from \"emps\" group by \"name\", \"deptno\", \"empid\" ",

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -3031,6 +3031,41 @@ class MaterializationTest {
     sql(mv, query).withOnlyBySubstitution(true).ok();
   }
 
+  @Test
+  public void testMvPredicate1() {
+    checkMaterialize(
+        "select \"deptno\", \"name\", \"empid\","
+            + "count(*) from \"emps\" group by  \"name\", \"deptno\", \"empid\" ",
+        "select \"name\", count(*) from \"emps\" where \"deptno\"= 10  group by \"name\" ", true);
+  }
+
+  @Test
+  public void testMvPredicate2() {
+    checkMaterialize(
+        "select \"deptno\", \"name\", \"empid\", count(*) from "
+            + "\"emps\" group by  \"name\", \"deptno\", \"empid\" ",
+        "select \"name\", count(*) from \"emps\" where "
+            + "\"name\"= 'Sebastian' OR \"name\"= 'Peter'  group by \"name\" ", true);
+  }
+
+  @Test
+  public void testMvPredicate3() {
+    checkMaterialize(
+        "select \"deptno\", \"name\", \"empid\", count(*) from "
+            + "\"emps\" group by  \"name\", \"deptno\", \"empid\" ",
+        "select \"name\", count(*) from \"emps\" where "
+            + "\"name\" = 'Sebastian' group by \"name\" ", true);
+  }
+
+  @Test
+  public void testMvPredicate4() {
+    checkMaterialize(
+        "select \"name\", \"deptno\", \"empid\", "
+            + "count(*) from \"emps\" group by \"name\", \"deptno\", \"empid\" ",
+        "select \"name\", count(*) from \"emps\" where \"name\"= "
+            + "'Sebastian' group by \"name\" ", true);
+  }
+
   private static <E> List<List<List<E>>> list3(E[][][] as) {
     final ImmutableList.Builder<List<List<E>>> builder =
         ImmutableList.builder();


### PR DESCRIPTION
..this pr try to  fix some problems. 
And add ProjectAggregateTransposeRule, this rule is used for normalize materialized view. the top LogicalCalc is not taken into consideration by current implementation of SubstitutionVisitor;
a example such as:

query:
&ensp;Aggregate
&ensp;&ensp;Calc
&ensp;&ensp;&ensp;Scan
mv:
&ensp;Calc
&ensp;&ensp;Aggregate
&ensp;&ensp;&ensp;Calc
&ensp;&ensp;&ensp;&ensp;Scan

and transfer mv to :
&ensp;Aggregate
&ensp;&ensp;Calc
&ensp;&ensp;&ensp;Calc
&ensp;&ensp;&ensp;&ensp;Scan

final mv:
&ensp;Aggregate
&ensp;&ensp;Calc
&ensp;&ensp;&ensp;Scan

JIRA:https://issues.apache.org/jira/browse/CALCITE-3537