### PR TITLE
[WIP] [CALCITE-3549] Lex config for view expanding is not supported

### DIFF
--- a/core/src/main/java/org/apache/calcite/model/ModelHandler.java
+++ b/core/src/main/java/org/apache/calcite/model/ModelHandler.java
@@ -456,7 +456,7 @@ public class ModelHandler {
           .add(jsonView.name).build();
       schema.add(jsonView.name,
           ViewTable.viewMacro(schema, jsonView.getSql(), path, viewPath,
-              jsonView.modifiable));
+              jsonView.modifiable, connection.getProperties()));
     } catch (Exception e) {
       throw new RuntimeException("Error instantiating " + jsonView, e);
     }

--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -55,6 +55,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 
 import static org.apache.calcite.jdbc.CalciteSchema.LatticeEntry;
 
@@ -299,12 +300,14 @@ public final class Schemas {
   public static CalcitePrepare.AnalyzeViewResult analyzeView(
       final CalciteConnection connection, final CalciteSchema schema,
       final List<String> schemaPath, final String viewSql,
-      List<String> viewPath, boolean fail) {
+      List<String> viewPath, boolean fail, Properties parseProperties) {
     final CalcitePrepare prepare = CalcitePrepare.DEFAULT_FACTORY.apply();
-    final ImmutableMap<CalciteConnectionProperty, String> propValues =
-        ImmutableMap.of();
+    CalciteConnectionConfig connConfig =
+        new CalciteConnectionConfigImpl(parseProperties);
     final CalcitePrepare.Context context =
-        makeContext(connection, schema, schemaPath, viewPath, propValues);
+        makeContext(connConfig, connection.getTypeFactory(),
+            createDataContext(connection, schema.root().plus()),
+            schema, schemaPath, viewPath);
     CalcitePrepare.Dummy.push(context);
     try {
       return prepare.analyzeView(context, viewSql, fail);

--- a/core/src/main/java/org/apache/calcite/schema/impl/ViewTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ViewTable.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Properties;
 
 /**
  * Table whose contents are defined using an SQL statement.
@@ -83,6 +84,21 @@ public class ViewTable
       List<String> schemaPath, List<String> viewPath, Boolean modifiable) {
     return new ViewTableMacro(CalciteSchema.from(schema), viewSql, schemaPath,
         viewPath, modifiable);
+  }
+
+  /** Table macro that returns a view.
+   *
+   * @param schema Schema the view will belong to
+   * @param viewSql SQL query
+   * @param schemaPath Path of schema
+   * @param modifiable Whether view is modifiable, or null to deduce it
+   * @param parseProperties Properties used to parse {@code viewSql}
+   */
+  public static ViewTableMacro viewMacro(
+      SchemaPlus schema, String viewSql, List<String> schemaPath,
+      List<String> viewPath, Boolean modifiable, Properties parseProperties) {
+    return new ViewTableMacro(CalciteSchema.from(schema), viewSql, schemaPath,
+        viewPath, modifiable, parseProperties);
   }
 
   /** Returns the view's SQL definition. */

--- a/core/src/main/java/org/apache/calcite/schema/impl/ViewTableMacro.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ViewTableMacro.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 /** Table function that implements a view. It returns the operator
  * tree of the view's SQL query. */
@@ -42,6 +43,7 @@ public class ViewTableMacro implements TableMacro {
    * context for validating {@code viewSql}. */
   protected final List<String> schemaPath;
   protected final List<String> viewPath;
+  protected final Properties parseProperties;
 
   /**
    * Creates a ViewTableMacro.
@@ -55,12 +57,32 @@ public class ViewTableMacro implements TableMacro {
    */
   public ViewTableMacro(CalciteSchema schema, String viewSql,
       List<String> schemaPath, List<String> viewPath, Boolean modifiable) {
+    this(schema, viewSql, schemaPath, viewPath, modifiable, new Properties());
+  }
+
+  /**
+   * Creates a ViewTableMacro.
+   *
+   * @param schema     Root schema
+   * @param viewSql    SQL defining the view
+   * @param schemaPath Schema path relative to the root schema
+   * @param viewPath   View path relative to the schema path
+   * @param modifiable Request that a view is modifiable (dependent on analysis
+   *                   of {@code viewSql})
+   * @param modifiable Request that a view is modifiable (dependent on analysis
+   *                   of {@code viewSql})
+   * @param parseProperties Properties used to parse the {@code viewSql}
+   */
+  public ViewTableMacro(
+      CalciteSchema schema, String viewSql, List<String> schemaPath,
+      List<String> viewPath, Boolean modifiable, Properties parseProperties) {
     this.viewSql = viewSql;
     this.schema = schema;
     this.viewPath = viewPath == null ? null : ImmutableList.copyOf(viewPath);
     this.modifiable = modifiable;
     this.schemaPath =
         schemaPath == null ? null : ImmutableList.copyOf(schemaPath);
+    this.parseProperties = parseProperties;
   }
 
   public List<FunctionParameter> getParameters() {
@@ -72,7 +94,7 @@ public class ViewTableMacro implements TableMacro {
         MaterializedViewTable.MATERIALIZATION_CONNECTION;
     CalcitePrepare.AnalyzeViewResult parsed =
         Schemas.analyzeView(connection, schema, schemaPath, viewSql, viewPath,
-            modifiable != null && modifiable);
+            modifiable != null && modifiable, parseProperties);
     final List<String> schemaPath1 =
         schemaPath != null ? schemaPath : schema.path(null);
     if ((modifiable == null || modifiable)

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -5607,6 +5607,19 @@ public class JdbcTest {
             + "whose definition is cyclic");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3549">[CALCITE-3549]
+   * Lex config for view expanding is not supported</a>. */
+  @Test public void testLexConfigForView() {
+    modelWithView("select * from EMPLOYEES where deptno = 10", null)
+        .with(Lex.JAVA)
+        .query("select * from adhoc.V order by name desc")
+        .returns(""
+            + "empid=110; deptno=10; name=Theodore; salary=11500.0; commission=250\n"
+            + "empid=150; deptno=10; name=Sebastian; salary=7000.0; commission=null\n"
+            + "empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000\n");
+  }
+
   /** Tests saving query results into temporary tables, per
    * {@link org.apache.calcite.avatica.Handler.ResultSink}. */
   @Test public void testAutomaticTemporaryTable() throws Exception {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-3549

Two things done in this PR:
1. Store parser properties in `ViewTableMacro` when create view;
2. Use the properties from first step when analyze view and expand view