### PR TITLE
[CALCITE-3565] Explicitly cast assignable operand types to decimal fo udf

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/ReflectiveCallNotNullImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/ReflectiveCallNotNullImplementor.java
@@ -47,6 +47,8 @@ public class ReflectiveCallNotNullImplementor implements NotNullImplementor {
       RexCall call, List<Expression> translatedOperands) {
     translatedOperands =
         EnumUtils.fromInternal(method.getParameterTypes(), translatedOperands);
+    translatedOperands =
+        EnumUtils.convertAssignableTypes(method.getParameterTypes(), translatedOperands);
     final Expression callExpr;
     if ((method.getModifiers() & Modifier.STATIC) != 0) {
       callExpr = Expressions.call(method, translatedOperands);

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -6988,6 +6988,22 @@ public class JdbcTest {
         .returns("EXPR$0=[250, 500, 1000]\n");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3565">[CALCITE-3565]
+   * Explicitly cast assignable operand types to decimal for udf</a>. */
+  @Test public void testAssignableTypeCast() {
+    final String sql = "SELECT ST_MakePoint(1, 2.1)";
+    CalciteAssert.that()
+        .with(CalciteAssert.Config.GEO)
+        .query(sql)
+        .planContains("static final java.math.BigDecimal $L4J$C$new_java_math_BigDecimal_1_ = "
+            + "new java.math.BigDecimal(\n"
+            + "              1)")
+        .planContains("org.apache.calcite.runtime.GeoFunctions.ST_MakePoint("
+            + "$L4J$C$new_java_math_BigDecimal_1_, v)")
+        .returns("EXPR$0={\"x\":1,\"y\":2.1}\n");
+  }
+
   @Test public void testMatchSimple() {
     final String sql = "select *\n"
         + "from \"hr\".\"emps\" match_recognize (\n"


### PR DESCRIPTION
As illustrated in [CALCITE-3565](https://issues.apache.org/jira/browse/CALCITE-3565), one type can be assigned from another type conceptually, but in the runtime phase, explicite cast is still required.
This PR targets on `ReflectiveCallNotNullImplementor`, in which we can get exact arguments' types.