### PR TITLE
[CALCITE-3567] Unnest support Map wrapped with RecordType

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -515,63 +515,79 @@ public abstract class OperandTypes {
    *
    * @see #COLLECTION */
   public static final SqlSingleOperandTypeChecker RECORD_COLLECTION =
-      new SqlSingleOperandTypeChecker() {
-        public boolean checkSingleOperandType(
-            SqlCallBinding callBinding,
-            SqlNode node,
-            int iFormalOperand,
-            boolean throwOnFailure) {
-          assert 0 == iFormalOperand;
-          RelDataType type =
-              callBinding.getValidator().deriveType(
-                  callBinding.getScope(),
-                  node);
-          boolean validationError = false;
-          if (!type.isStruct()) {
-            validationError = true;
-          } else if (type.getFieldList().size() != 1) {
-            validationError = true;
-          } else {
-            SqlTypeName typeName =
-                type.getFieldList().get(0).getType().getSqlTypeName();
-            if (typeName != SqlTypeName.MULTISET
-                && typeName != SqlTypeName.ARRAY) {
-              validationError = true;
-            }
-          }
+      new RecordTypeWithOneFieldChecker(
+          sqlTypeName ->
+              sqlTypeName != SqlTypeName.ARRAY && sqlTypeName != SqlTypeName.MULTISET) {
 
-          if (validationError && throwOnFailure) {
-            throw callBinding.newValidationSignatureError();
-          }
-          return !validationError;
-        }
-
-        public boolean checkOperandTypes(
-            SqlCallBinding callBinding,
-            boolean throwOnFailure) {
-          return checkSingleOperandType(
-              callBinding,
-              callBinding.operand(0),
-              0,
-              throwOnFailure);
-        }
-
-        public SqlOperandCountRange getOperandCountRange() {
-          return SqlOperandCountRanges.of(1);
-        }
-
-        public String getAllowedSignatures(SqlOperator op, String opName) {
+        @Override public String getAllowedSignatures(SqlOperator op, String opName) {
           return "UNNEST(<MULTISET>)";
         }
-
-        public boolean isOptional(int i) {
-          return false;
-        }
-
-        public Consistency getConsistency() {
-          return Consistency.NONE;
-        }
       };
+
+
+  /**
+   * Checker for record just has one field.
+   */
+  private abstract static class RecordTypeWithOneFieldChecker
+      implements SqlSingleOperandTypeChecker {
+
+    private final Predicate<SqlTypeName> typeNamePredicate;
+
+    private RecordTypeWithOneFieldChecker(Predicate<SqlTypeName> predicate) {
+      this.typeNamePredicate = predicate;
+    }
+
+    public boolean checkSingleOperandType(
+        SqlCallBinding callBinding,
+        SqlNode node,
+        int iFormalOperand,
+        boolean throwOnFailure) {
+      assert 0 == iFormalOperand;
+      RelDataType type =
+          callBinding.getValidator().deriveType(
+              callBinding.getScope(),
+              node);
+      boolean validationError = false;
+      if (!type.isStruct()) {
+        validationError = true;
+      } else if (type.getFieldList().size() != 1) {
+        validationError = true;
+      } else {
+        SqlTypeName typeName =
+            type.getFieldList().get(0).getType().getSqlTypeName();
+        if (typeNamePredicate.test(typeName)) {
+          validationError = true;
+        }
+      }
+
+      if (validationError && throwOnFailure) {
+        throw callBinding.newValidationSignatureError();
+      }
+      return !validationError;
+    }
+
+    public boolean checkOperandTypes(
+        SqlCallBinding callBinding,
+        boolean throwOnFailure) {
+      return checkSingleOperandType(
+          callBinding,
+          callBinding.operand(0),
+          0,
+          throwOnFailure);
+    }
+
+    public SqlOperandCountRange getOperandCountRange() {
+      return SqlOperandCountRanges.of(1);
+    }
+
+    public boolean isOptional(int i) {
+      return false;
+    }
+
+    public Consistency getConsistency() {
+      return Consistency.NONE;
+    }
+  }
 
   /** Checker that returns whether a value is a collection (multiset or array)
    * of scalar or record values. */
@@ -579,7 +595,17 @@ public abstract class OperandTypes {
       OperandTypes.or(COLLECTION, RECORD_COLLECTION);
 
   public static final SqlSingleOperandTypeChecker SCALAR_OR_RECORD_COLLECTION_OR_MAP =
-      OperandTypes.or(COLLECTION_OR_MAP, RECORD_COLLECTION);
+      OperandTypes.or(COLLECTION_OR_MAP,
+          new RecordTypeWithOneFieldChecker(
+              sqlTypeName ->
+                  sqlTypeName != SqlTypeName.MULTISET
+                      && sqlTypeName != SqlTypeName.ARRAY
+                      && sqlTypeName != SqlTypeName.MAP) {
+
+          @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+            return "UNNEST(<MULTISET>)\nUNNEST(<ARRAY>)\nUNNEST(<MAP>)";
+          }
+        });
 
   public static final SqlOperandTypeChecker MULTISET_MULTISET =
       new MultisetOperandTypeChecker();

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -2067,6 +2067,33 @@ public class JdbcTest {
             "I=20; O=2");
   }
 
+  @Test public void testUnnestRecordType() {
+    // unnest(RecordType(Array))
+    CalciteAssert.that()
+        .query("select * from unnest\n"
+            + "(select t.x from (values array[10, 20], array[30, 40]) as t(x))\n"
+            + " with ordinality as t(a, o)")
+        .returnsUnordered("A=10; O=1", "A=20; O=2",
+            "A=30; O=1", "A=40; O=2");
+
+    // unnest(RecordType(Multiset))
+    CalciteAssert.that()
+        .query("select * from unnest\n"
+            + "(select t.x from (values multiset[10, 20], array[30, 40]) as t(x))\n"
+            + " with ordinality as t(a, o)")
+        .returnsUnordered("A=10; O=1", "A=20; O=2",
+            "A=30; O=1", "A=40; O=2");
+
+    // unnest(RecordType(Map))
+    CalciteAssert.that()
+        .query("select * from unnest\n"
+            + "(select t.x from (values map['a', 20], map['b', 30], map['c', 40]) as t(x))\n"
+            + " with ordinality as t(a, b, o)")
+        .returnsUnordered("A=a; B=20; O=1",
+            "A=b; B=30; O=1",
+            "A=c; B=40; O=1");
+  }
+
   @Test public void testUnnestMultiset() {
     CalciteAssert.that()
         .with(CalciteAssert.Config.REGULAR)


### PR DESCRIPTION
JIRA: [CALCITE-3567](https://issues.apache.org/jira/browse/CALCITE-3567)

Currently, UNNEST(RECORDTYPE(ARRAY)) and UNNEST(RECORDTYPE(MULTISET)) works well, but UNNEST(RECORDTYPE(MAP)) is not supported.
Because `SqlUnnestOperator` use [SCALAR_OR_RECORD_COLLECTION_OR_MAP](https://github.com/apache/calcite/blob/master/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java#L581), and it just checks `MULTISET` and `ARRAY` in `RecordType`.

This PR tries to add check for `MAP` in `RecordType` for `SqlUnnestOperator` too.