### PR TITLE
[CALCITE-3560] Additional calcite.util.Source implementation for generic text source (eg. CharSource)

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation("org.apache.calcite.avatica:avatica-server")
     implementation("org.apache.commons:commons-dbcp2")
     implementation("org.apache.commons:commons-lang3")
+    implementation("commons-io:commons-io")
     implementation("org.codehaus.janino:commons-compiler")
     implementation("org.codehaus.janino:janino")
     implementation("org.slf4j:slf4j-api")

--- a/core/src/test/java/org/apache/calcite/util/SourceTest.java
+++ b/core/src/test/java/org/apache/calcite/util/SourceTest.java
@@ -16,9 +16,17 @@
  */
 package org.apache.calcite.util;
 
+import com.google.common.io.CharSource;
+
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import static org.apache.calcite.util.Sources.file;
 import static org.apache.calcite.util.Sources.url;
@@ -26,6 +34,7 @@ import static org.apache.calcite.util.Sources.url;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests for {@link Source}.
@@ -41,6 +50,21 @@ public class SourceTest {
     }
     throw new IllegalStateException(
         "Unsupported operation system detected. Both / and c:/ produce relative paths");
+  }
+
+  /**
+   * Read lines from {@link CharSource}
+   */
+  @Test void charSource() throws IOException {
+    Source source = Sources.fromCharSource(CharSource.wrap("a\nb"));
+    for (Reader r: Arrays.asList(source.reader(),
+        new InputStreamReader(source.openStream(), StandardCharsets.UTF_8.name()))) {
+      try (BufferedReader reader = new BufferedReader(r)) {
+        assertEquals("a", reader.readLine());
+        assertEquals("b", reader.readLine());
+        assertNull(reader.readLine());
+      }
+    }
   }
 
   @Test public void testAppendWithSpaces() {

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvEnumerator.java
@@ -29,11 +29,11 @@ import org.apache.commons.lang3.time.FastDateFormat;
 import au.com.bytecode.opencsv.CSVReader;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -162,8 +162,8 @@ class CsvEnumerator<E> implements Enumerator<E> {
   }
 
   public static CSVReader openCsv(Source source) throws IOException {
-    final Reader fileReader = source.reader();
-    return new CSVReader(fileReader);
+    Objects.requireNonNull(source, "source");
+    return new CSVReader(source.reader());
   }
 
   public E current() {

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonEnumerator.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonEnumerator.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -67,21 +68,23 @@ public class JsonEnumerator implements Enumerator<Object[]> {
       objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
           .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
           .configure(JsonParser.Feature.ALLOW_COMMENTS, true);
-      if (source.file().exists() && source.file().length() > 0) {
-        if ("file".equals(source.protocol())) {
-          //noinspection unchecked
-          jsonObj = objectMapper.readValue(source.file(), Object.class);
-        } else {
-          //noinspection unchecked
-          jsonObj = objectMapper.readValue(source.url(), Object.class);
-        }
+
+      if ("file".equals(source.protocol()) && source.file().exists()) {
+        //noinspection unchecked
+        jsonObj = objectMapper.readValue(source.file(), Object.class);
+      } else if (Arrays.asList("http", "https", "ftp").contains(source.protocol())) {
+        //noinspection unchecked
+        jsonObj = objectMapper.readValue(source.url(), Object.class);
+      } else {
+        jsonObj = objectMapper.readValue(source.reader(), Object.class);
       }
+
     } catch (MismatchedInputException e) {
       if (!e.getMessage().contains("No content")) {
-        throw new RuntimeException(e);
+        throw new RuntimeException("Couldn't read " + source, e);
       }
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("Couldn't read " + source, e);
     }
 
     if (jsonObj == null) {


### PR DESCRIPTION
Currently calcite `calcite.util.Source` interface can be built only from File or URL. This forces data to be stored on disk or accessed remotely using URL api.

This proposal adds another Source implementation on the top of [CharSource](https://guava.dev/releases/23.0/api/docs/com/google/common/io/CharSource.html) so calcite adapters can operate on in-memory elements like String or generic text sources.