### PR TITLE
[CALCITE-3246] NullPointerException while deserializing udf operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -454,13 +454,15 @@ public class RelJson {
       final Map<String, Object> opMap = (Map) map.get("op");
       final RelDataTypeFactory typeFactory = cluster.getTypeFactory();
       if (opMap != null) {
-        final String op = (String) opMap.get("name");
+        if (map.containsKey("class")) {
+          opMap.put("class", map.get("class"));
+        }
         final List operands = (List) map.get("operands");
         final List<RexNode> rexOperands = toRexList(relInput, operands);
         final Object jsonType = map.get("type");
         final Map window = (Map) map.get("window");
         if (window != null) {
-          final SqlAggFunction operator = toAggregation(relInput, op, opMap);
+          final SqlAggFunction operator = toAggregation(opMap);
           final RelDataType type = toType(typeFactory, jsonType);
           List<RexNode> partitionKeys = new ArrayList<>();
           if (window.containsKey("partition")) {
@@ -492,7 +494,7 @@ public class RelJson {
               ImmutableList.copyOf(orderKeys), lowerBound, upperBound, physical,
               true, false, distinct, false);
         } else {
-          final SqlOperator operator = toOp(relInput, opMap);
+          final SqlOperator operator = toOp(opMap);
           final RelDataType type;
           if (jsonType != null) {
             type = toType(typeFactory, jsonType);
@@ -632,7 +634,7 @@ public class RelJson {
     return list;
   }
 
-  SqlOperator toOp(RelInput relInput, Map<String, Object> map) {
+  SqlOperator toOp(Map<String, Object> map) {
     // in case different operator has the same kind, check with both name and kind.
     String name = map.get("name").toString();
     String kind = map.get("kind").toString();
@@ -658,8 +660,8 @@ public class RelJson {
     return null;
   }
 
-  SqlAggFunction toAggregation(RelInput relInput, String agg, Map<String, Object> map) {
-    return (SqlAggFunction) toOp(relInput, map);
+  SqlAggFunction toAggregation(Map<String, Object> map) {
+    return (SqlAggFunction) toOp(map);
   }
 
   private Map toJson(SqlOperator operator) {

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
@@ -275,7 +275,7 @@ public class RelJsonReader {
   private AggregateCall toAggCall(RelInput relInput, Map<String, Object> jsonAggCall) {
     final Map<String, Object> aggMap = (Map) jsonAggCall.get("agg");
     final SqlAggFunction aggregation =
-        relJson.toAggregation(relInput, (String) aggMap.get("name"), aggMap);
+        relJson.toAggregation(aggMap);
     final Boolean distinct = (Boolean) jsonAggCall.get("distinct");
     @SuppressWarnings("unchecked")
     final List<Integer> operands = (List<Integer>) jsonAggCall.get("operands");


### PR DESCRIPTION
The class of udf was lost in the pr [CALCITE-3177](https://github.com/apache/calcite/pull/1305), causing an NullPointerException when deserializing of udf operator. In this pr, add class info to the map parameter for deserializing operator, and remove unused function parameter.

This is a re-create PR of https://github.com/apache/calcite/pull/1372,  and please see more discussion in jira [CALCITE-3246](https://issues.apache.org/jira/browse/CALCITE-3246)