### PR TITLE
[CALCITE-3540] FoodmartTest produces many warnings due to incorrect use of CalciteAssert.pooled()

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/FoodMartQuerySet.java
+++ b/core/src/test/java/org/apache/calcite/test/FoodMartQuerySet.java
@@ -73,6 +73,10 @@ public class FoodMartQuerySet {
   public static class FoodmartQuery {
     public int id;
     public String sql;
+
+    @Override public String toString() {
+      return "id=" + id;
+    }
   }
 }
 

--- a/core/src/test/java/org/apache/calcite/test/FoodmartTest.java
+++ b/core/src/test/java/org/apache/calcite/test/FoodmartTest.java
@@ -147,7 +147,7 @@ public class FoodmartTest {
     return list.stream();
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @MethodSource("queries")
   public void test(FoodMartQuerySet.FoodmartQuery query) {
     Assertions.assertTimeoutPreemptively(Duration.ofMinutes(2), () -> {
@@ -155,7 +155,7 @@ public class FoodmartTest {
     });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @Disabled
   @MethodSource("queries")
   public void testWithLattice(FoodMartQuerySet.FoodmartQuery query) {

--- a/core/src/test/java/org/apache/calcite/test/FoodmartTest.java
+++ b/core/src/test/java/org/apache/calcite/test/FoodmartTest.java
@@ -38,6 +38,13 @@ import java.util.stream.Stream;
 @Tag("slow")
 public class FoodmartTest {
 
+  private static final CalciteAssert.AssertThat ASSERT_FOODMART = CalciteAssert.that()
+      .with(CalciteAssert.Config.FOODMART_CLONE)
+      .pooled();
+  private static final CalciteAssert.AssertThat ASSERT_FOODMART_LATTICE = CalciteAssert.that()
+      .with(CalciteAssert.Config.JDBC_FOODMART_WITH_LATTICE)
+      .pooled();
+
   private static final int[] DISABLED_IDS = {
       58, 83, 202, 204, 205, 206, 207, 209, 211, 231, 247, 275, 309, 383, 384,
       385, 448, 449, 471, 494, 495, 496, 497, 499, 500, 501, 502, 503, 505, 506,
@@ -130,11 +137,7 @@ public class FoodmartTest {
   @MethodSource("queries")
   public void test(FoodMartQuerySet.FoodmartQuery query) {
     Assertions.assertTimeoutPreemptively(Duration.ofMinutes(2), () -> {
-      CalciteAssert.that()
-        .with(CalciteAssert.Config.FOODMART_CLONE)
-        .pooled()
-        .query(query.sql)
-        .runs();
+      ASSERT_FOODMART.query(query.sql).runs();
     });
   }
 
@@ -143,9 +146,7 @@ public class FoodmartTest {
   @MethodSource("queries")
   public void testWithLattice(FoodMartQuerySet.FoodmartQuery query) {
     Assertions.assertTimeoutPreemptively(Duration.ofMinutes(2), () -> {
-      CalciteAssert.that()
-        .with(CalciteAssert.Config.JDBC_FOODMART_WITH_LATTICE)
-        .pooled()
+      ASSERT_FOODMART_LATTICE
         .withDefaultSchema("foodmart")
         .query(query.sql)
         .enableMaterializations(true)


### PR DESCRIPTION
CalciteAssert.pooled() creates new AssertThat object (thus a new connection pool) in each call. To use the same pool for all FoodMart queries we have to keep and reuse the AssertThat object that was created after calling the pooled() method.