### PR TITLE
[CALCITE-3583] Support serialized to json and deserialized from json for Exchange relation operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
@@ -82,7 +82,7 @@ public class RelDistributions {
 
   /** Creates a distribution. */
   public static RelDistribution distribution(
-      RelDistribution.Type type, List<Number> keys) {
+      RelDistribution.Type type, Collection<? extends Number> keys) {
     ImmutableIntList list = ImmutableIntList.copyOf(keys);
     RelDistributionImpl trait =
         new RelDistributionImpl(type, list);

--- a/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
@@ -80,6 +80,15 @@ public class RelDistributions {
     return RelDistributionTraitDef.INSTANCE.canonize(trait);
   }
 
+  /** Creates a distribution. */
+  public static RelDistribution distribution(
+      RelDistribution.Type type, List<Number> keys) {
+    ImmutableIntList list = ImmutableIntList.copyOf(keys);
+    RelDistributionImpl trait =
+        new RelDistributionImpl(type, list);
+    return RelDistributionTraitDef.INSTANCE.canonize(trait);
+  }
+
   /** Implementation of {@link org.apache.calcite.rel.RelDistribution}. */
   private static class RelDistributionImpl implements RelDistribution {
     private static final Ordering<Iterable<Integer>> ORDERING =

--- a/core/src/main/java/org/apache/calcite/rel/core/Exchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Exchange.java
@@ -68,8 +68,7 @@ public abstract class Exchange extends SingleRel {
    * Creates an Exchange by parsing serialized output.
    */
   public Exchange(RelInput input) {
-    this(input.getCluster(), input.getTraitSet().plus(input.getCollation()),
-        input.getInput(),
+    this(input.getCluster(), input.getTraitSet(), input.getInput(),
         RelDistributionTraitDef.INSTANCE.canonize(input.getDistribution()));
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelEnumTypes.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelEnumTypes.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.externalize;
 
 import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.sql.JoinConditionType;
 import org.apache.calcite.sql.JoinType;
 import org.apache.calcite.sql.SqlExplain;
@@ -69,6 +70,7 @@ public abstract class RelEnumTypes {
     register(enumByName, SqlSelectKeyword.class);
     register(enumByName, SqlTrimFunction.Flag.class);
     register(enumByName, TimeUnitRange.class);
+    register(enumByName, RelDistribution.Type.class);
     ENUM_BY_NAME = enumByName.build();
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -191,7 +191,10 @@ public class RelJson {
   }
 
   public RelDistribution toDistribution(Object o) {
-    return RelDistributions.ANY; // TODO:
+    final Map map = (Map) o;
+    final RelDistribution.Type type = RelEnumTypes.toEnum((String) map.get("type"));
+    final List<Number> keys = (List) map.get("keys");
+    return RelDistributions.distribution(type, keys);
   }
 
   public RelDataType toType(RelDataTypeFactory typeFactory, Object o) {
@@ -285,6 +288,8 @@ public class RelJson {
       return toJson((RelDataType) value);
     } else if (value instanceof RelDataTypeField) {
       return toJson((RelDataTypeField) value);
+    } else if (value instanceof RelDistribution) {
+      return toJson((RelDistribution) value);
     } else {
       throw new UnsupportedOperationException("type not serializable: "
           + value + " (type " + value.getClass().getCanonicalName() + ")");
@@ -441,6 +446,13 @@ public class RelJson {
       map.put("type", windowBound.isPreceding() ? "PRECEDING" : "FOLLOWING");
       map.put("offset", toJson(windowBound.getOffset()));
     }
+    return map;
+  }
+
+  private Object toJson(RelDistribution distribution) {
+    final Map<String, Object> map = jsonBuilder.map();
+    map.put("type", RelEnumTypes.fromEnum(distribution.getType()));
+    map.put("keys", distribution.getKeys());
     return map;
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -190,6 +190,10 @@ public class RelJson {
     return new RelFieldCollation(field, direction, nullDirection);
   }
 
+  /**
+   * When serialized to json string, a {@link RelDistribution} object will serialized to
+   * a map, see {@link #toJson(RelDistribution)}
+   */
   public RelDistribution toDistribution(Object o) {
     final Map map = (Map) o;
     final RelDistribution.Type type = RelEnumTypes.toEnum((String) map.get("type"));

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -769,7 +769,7 @@ public class RelWriterTest {
         .scan("EMP")
         .exchange(RelDistributions.hash(ImmutableList.of(0, 1)))
         .build();
-    String relJson = RelOptUtil.dumpPlan("", rel,
+    final String relJson = RelOptUtil.dumpPlan("", rel,
         SqlExplainFormat.JSON, SqlExplainLevel.EXPPLAN_ATTRIBUTES);
     String s = deserializeAndDumpToTextFormat(getSchema(rel), relJson);
     final String expected = ""

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -19,6 +19,7 @@ package org.apache.calcite.plan;
 import org.apache.calcite.adapter.java.ReflectiveSchema;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.AggregateCall;
@@ -757,6 +758,22 @@ public class RelWriterTest {
     String s = deserializeAndDumpToTextFormat(getSchema(rel), relJson);
     final String expected = ""
         + "LogicalProject($f0=[MYFUN($0)])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(s, isLinux(expected));
+  }
+
+  @Test public void testExchange() {
+    final FrameworkConfig config = RelBuilderTest.config().build();
+    final RelBuilder builder = RelBuilder.create(config);
+    final RelNode rel = builder
+        .scan("EMP")
+        .exchange(RelDistributions.hash(ImmutableList.of(0, 1)))
+        .build();
+    String relJson = RelOptUtil.dumpPlan("", rel,
+        SqlExplainFormat.JSON, SqlExplainLevel.EXPPLAN_ATTRIBUTES);
+    String s = deserializeAndDumpToTextFormat(getSchema(rel), relJson);
+    final String expected = ""
+        + "LogicalExchange(distribution=[hash[0, 1]])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(s, isLinux(expected));
   }


### PR DESCRIPTION
Currently, serialize Exchange relnode to json will cause exception, please refer to jira: [CALCITE-3583](https://issues.apache.org/jira/browse/CALCITE-3583) for more details.

This pr tries to support serialized to json and deserialized from json for Exchange relnode.