### PR TITLE
[CALCITE-3584] Support SQL hints propagation for decorrelation

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/hint/Hintable.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/Hintable.java
@@ -51,40 +51,47 @@ import java.util.Set;
 public interface Hintable {
 
   /**
-   * Attach list of hints to this relational expression, should be overridden by
+   * Attaches list of hints to this relational expression, should be overridden by
    * every logical node that supports hint. This method is only for
    * internal use during sql-to-rel conversion.
    *
-   * <p>The sub-class should return a new copy of the relational expression. We make
-   * the default implementation return the relational expression directly only
-   * because not every kind of relational expression supports hints.
+   * <p>The sub-class should return a new copy of the relational expression.
+   *
+   * <p>The default implementation merges the given hints with existing ones,
+   * put them in one list and eliminate the duplicates; then
+   * returns a new copy of this relational expression with the merged hints.
    *
    * @param hintList The hints to attach to this relational expression
    * @return Relational expression with the hints {@code hintList} attached
    */
   default RelNode attachHints(List<RelHint> hintList) {
+    Objects.requireNonNull(hintList);
+    final Set<RelHint> hints = new LinkedHashSet<>(getHints());
+    hints.addAll(hintList);
+    return withHints(new ArrayList<>(hints));
+  }
+
+  /**
+   * Returns a new relation expression with the specified hints {@code hintList}.
+   *
+   * <p>This method should be overridden by every logical node that supports hint.
+   * It is only for internal use during decorrelation.
+   *
+   * <p>The sub-class should return a new copy of the relational expression.
+   *
+   * <p>We make the default implementation return the relational expression directly
+   * only because not every kind of relational expression supports hints.
+   *
+   * @return Relational expression with set up hints
+   */
+  default RelNode withHints(List<RelHint> hintList) {
     return (RelNode) this;
   }
 
   /**
-   * @return The hints list of this relational expressions
+   * Returns the hints of this relational expressions as a list.
    */
   ImmutableList<RelHint> getHints();
-
-  /**
-   * Merge this relation expression's hints with the given hint list.
-   *
-   * <p>The default behavior is to put them in one list and eliminate the duplicates.
-   *
-   * @param hintList Hints to be merged
-   * @return A merged hint list
-   */
-  default List<RelHint> mergeHints(List<RelHint> hintList) {
-    Objects.requireNonNull(hintList);
-    final Set<RelHint> hints = new LinkedHashSet<>(getHints());
-    hints.addAll(hintList);
-    return new ArrayList<>(hints);
-  }
 }
 
 // End Hintable.java

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -214,8 +214,8 @@ public final class LogicalJoin extends Join {
     return systemFieldList;
   }
 
-  @Override public RelNode attachHints(List<RelHint> hintList) {
-    return new LogicalJoin(getCluster(), traitSet, mergeHints(hintList),
+  @Override public RelNode withHints(List<RelHint> hintList) {
+    return new LogicalJoin(getCluster(), traitSet, hintList,
         left, right, condition, variablesSet, joinType, semiJoinDone, systemFieldList);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -141,8 +141,8 @@ public final class LogicalProject extends Project {
     return shuttle.visit(this);
   }
 
-  @Override public RelNode attachHints(List<RelHint> hintList) {
-    return new LogicalProject(getCluster(), traitSet, mergeHints(hintList),
+  @Override public RelNode withHints(List<RelHint> hintList) {
+    return new LogicalProject(getCluster(), traitSet, hintList,
         input, getProjects(), rowType);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
@@ -129,8 +129,8 @@ public final class LogicalTableScan extends TableScan {
     return create(cluster, relOptTable, new ArrayList<>());
   }
 
-  @Override public RelNode attachHints(List<RelHint> hintList) {
-    return new LogicalTableScan(getCluster(), traitSet, mergeHints(hintList), table);
+  @Override public RelNode withHints(List<RelHint> hintList) {
+    return new LogicalTableScan(getCluster(), traitSet, hintList, table);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -216,6 +216,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
       RelNode restructured = relBuilder.push(flattened)
           .projectNamed(structuringExps, resultFieldNames, true)
           .build();
+      restructured = RelOptUtil.copyRelHints(flattened, restructured);
       // REVIEW jvs 23-Mar-2005:  How do we make sure that this
       // implementation stays in Java?  Fennel can't handle
       // structured types.
@@ -731,8 +732,9 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
     RelNode newRel = rel.getTable().toRel(toRelContext);
     if (!SqlTypeUtil.isFlat(rel.getRowType())) {
       newRel = coverNewRelByFlatteningProjection(rel, newRel);
+    } else {
+      newRel = RelOptUtil.copyRelHints(rel, newRel);
     }
-    newRel = RelOptUtil.copyRelHints(rel, newRel);
     setNewForOldRel(rel, newRel);
   }
 
@@ -747,6 +749,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
     newRel = relBuilder.push(newRel)
         .projectNamed(projects, fieldNames, true)
         .build();
+    newRel = RelOptUtil.copyRelHints(rel, newRel);
     return newRel;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -194,12 +194,10 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -598,7 +596,7 @@ public class SqlToRelConverter {
       }
     }
     // propagate the hints.
-    result = result.accept(new RelHintPropagateShuttle(this.hintStrategies));
+    result = RelOptUtil.propagateRelHints(result, false);
     return RelRoot.of(result, validatedRowType, query.getKind())
         .withCollation(collation)
         .withHints(hints);
@@ -5637,126 +5635,6 @@ public class SqlToRelConverter {
       this.id = id;
       this.requiredColumns = requiredColumns;
       this.r = r;
-    }
-  }
-
-  /**
-   * A {@code RelShuttle} which propagates all the hints of relational expression to
-   * their children nodes.
-   *
-   * <p>Given a plan:
-   *
-   * <blockquote><pre>
-   *            Filter (Hint1)
-   *                |
-   *               Join
-   *              /    \
-   *            Scan  Project (Hint2)
-   *                     |
-   *                    Scan2
-   * </pre></blockquote>
-   *
-   * <p>Every hint has a {@code inheritPath} (integers list) which records its propagate path,
-   * number `0` represents the hint is propagated from the first(left) child,
-   * number `1` represents the hint is propagated from the second(right) child,
-   * so the plan would have hints path as follows
-   * (assumes each hint can be propagated to all child nodes):
-   *
-   * <ul>
-   *   <li>Filter would have hints {Hint1[]}</li>
-   *   <li>Join would have hints {Hint1[0]}</li>
-   *   <li>Scan would have hints {Hint1[0, 0]}</li>
-   *   <li>Project would have hints {Hint1[0,1], Hint2[]}</li>
-   *   <li>Scan2 would have hints {[Hint1[0, 1, 0], Hint2[0]}</li>
-   * </ul>
-   */
-  private static class RelHintPropagateShuttle extends RelShuttleImpl {
-    /**
-     * Stack recording the hints and its current inheritPath.
-     */
-    private final Deque<Pair<List<RelHint>, Deque<Integer>>> inheritPaths =
-        new ArrayDeque<>();
-
-    /**
-     * The hint strategies to decide if a hint should be attached to
-     * a relational expression.
-     */
-    private final HintStrategyTable hintStrategies;
-
-    RelHintPropagateShuttle(HintStrategyTable hintStrategies) {
-      this.hintStrategies = hintStrategies;
-    }
-
-    /**
-     * Visits a particular child of a parent.
-     */
-    protected RelNode visitChild(RelNode parent, int i, RelNode child) {
-      inheritPaths.forEach(inheritPath -> inheritPath.right.push(i));
-      try {
-        RelNode child2 = child.accept(this);
-        if (child2 != child) {
-          final List<RelNode> newInputs = new ArrayList<>(parent.getInputs());
-          newInputs.set(i, child2);
-          return parent.copy(parent.getTraitSet(), newInputs);
-        }
-        return parent;
-      } finally {
-        inheritPaths.forEach(inheritPath -> inheritPath.right.pop());
-      }
-    }
-
-    public RelNode visit(LogicalJoin join) {
-      final LogicalJoin join1 = (LogicalJoin) super.visit(join);
-      return attachHints(join1);
-    }
-
-    public RelNode visit(LogicalProject project) {
-      final List<RelHint> topHints = project.getHints();
-      final boolean hasHints = topHints != null && topHints.size() > 0;
-      if (hasHints) {
-        inheritPaths.push(Pair.of(topHints, new ArrayDeque<>()));
-      }
-      final RelNode project1 = super.visit(project);
-      if (hasHints) {
-        inheritPaths.pop();
-      }
-      return attachHints(project1);
-    }
-
-    public RelNode visit(TableScan scan) {
-      TableScan scan1 = (TableScan) super.visit(scan);
-      return attachHints(scan1);
-    }
-
-    private RelNode attachHints(RelNode original) {
-      assert original instanceof Hintable;
-      if (inheritPaths.size() > 0) {
-        final List<RelHint> hints = inheritPaths.stream()
-            .sorted(Comparator.comparingInt(o -> o.right.size()))
-            .map(path -> copyWithInheritPath(path.left, path.right))
-            .reduce(new ArrayList<>(), (acc, hints1) -> {
-              acc.addAll(hints1);
-              return acc;
-            });
-        final List<RelHint> filteredHints = hintStrategies.apply(hints, original);
-        if (filteredHints.size() > 0) {
-          return ((Hintable) original).attachHints(filteredHints);
-        }
-      }
-      return original;
-    }
-
-    private static List<RelHint> copyWithInheritPath(List<RelHint> hints,
-        Deque<Integer> inheritPath) {
-      // Copy the Dequeue in reverse order.
-      final List<Integer> path = new ArrayList<>();
-      final Iterator<Integer> iterator = inheritPath.descendingIterator();
-      while (iterator.hasNext()) {
-        path.add(iterator.next());
-      }
-      return hints.stream()
-          .map(hint -> hint.copy(path))
-          .collect(Collectors.toList());
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
@@ -133,6 +133,30 @@ public class SqlHintsConverterTest extends SqlToRelTestBase {
     sql(sql).withTester(t -> t.withDecorrelation(true)).ok();
   }
 
+  @Test public void testHintsInSubQueryWithDecorrelation2() {
+    final String sql = "select /*+ properties(k1='v1', k2='v2'), index(ename), no_hash_join */\n"
+        + "sum(e1.empno) from emp e1, dept d1\n"
+        + "where e1.deptno = d1.deptno\n"
+        + "and e1.sal> (\n"
+        + "select /*+ properties(k1='v1', k2='v2'), index(ename), no_hash_join */\n"
+        + "  avg(e2.sal)\n"
+        + "  from emp e2\n"
+        + "  where e2.deptno = d1.deptno)";
+    sql(sql).withTester(t -> t.withDecorrelation(true)).ok();
+  }
+
+  @Test public void testHintsInSubQueryWithDecorrelation3() {
+    final String sql = "select /*+ resource(parallelism='3'), index(ename), no_hash_join */\n"
+        + "sum(e1.empno) from emp e1, dept d1\n"
+        + "where e1.deptno = d1.deptno\n"
+        + "and e1.sal> (\n"
+        + "select /*+ resource(cpu='2'), index(ename), no_hash_join */\n"
+        + "  avg(e2.sal)\n"
+        + "  from emp e2\n"
+        + "  where e2.deptno = d1.deptno)";
+    sql(sql).withTester(t -> t.withDecorrelation(true)).ok();
+  }
+
   @Test public void testHintsInSubQueryWithoutDecorrelation() {
     final String sql = "select /*+ resource(parallelism='3') */\n"
         + "sum(e1.empno) from emp e1, dept d1\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
@@ -55,6 +55,56 @@ select /*+ resource(cpu='2') */ avg(e2.sal) from emp e2 where e2.deptno = d1.dep
         </Resource>
         <Resource name="hints">
             <![CDATA[
+Project:[[RESOURCE inheritPath:[] options:{PARALLELISM=3}]]
+Project:[[RESOURCE inheritPath:[0] options:{PARALLELISM=3}]]
+Project:[[RESOURCE inheritPath:[] options:{CPU=2}], [RESOURCE inheritPath:[0, 0, 1, 0] options:{PARALLELISM=3}]]
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testHintsInSubQueryWithDecorrelation2">
+        <Resource name="sql">
+            <![CDATA[select /*+ properties(k1='v1', k2='v2'), index(ename), no_hash_join */
+sum(e1.empno) from emp e1, dept d1
+where e1.deptno = d1.deptno
+and e1.sal> (
+select /*+ properties(k1='v1', k2='v2'), index(ename), no_hash_join */
+  avg(e2.sal)
+  from emp e2
+  where e2.deptno = d1.deptno)]]>
+        </Resource>
+        <Resource name="hints">
+            <![CDATA[
+Project:[[PROPERTIES inheritPath:[] options:{K1=v1, K2=v2}], [INDEX inheritPath:[] options:[ENAME]], [NO_HASH_JOIN inheritPath:[]]]
+LogicalJoin:[[NO_HASH_JOIN inheritPath:[0, 0]]]
+LogicalJoin:[[NO_HASH_JOIN inheritPath:[0, 0, 0]]]
+TableScan:[[PROPERTIES inheritPath:[0, 0, 0, 0] options:{K1=v1, K2=v2}], [INDEX inheritPath:[0, 0, 0, 0] options:[ENAME]]]
+TableScan:[[PROPERTIES inheritPath:[0, 0, 0, 1] options:{K1=v1, K2=v2}], [INDEX inheritPath:[0, 0, 0, 1] options:[ENAME]]]
+Project:[[PROPERTIES inheritPath:[] options:{K1=v1, K2=v2}], [INDEX inheritPath:[] options:[ENAME]], [NO_HASH_JOIN inheritPath:[]]]
+TableScan:[[PROPERTIES inheritPath:[0] options:{K1=v1, K2=v2}], [INDEX inheritPath:[0] options:[ENAME]], [PROPERTIES inheritPath:[0, 0, 1, 0, 0] options:{K1=v1, K2=v2}], [INDEX inheritPath:[0, 0, 1, 0, 0] options:[ENAME]]]
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testHintsInSubQueryWithDecorrelation3">
+        <Resource name="sql">
+            <![CDATA[select /*+ resource(parallelism='3'), index(ename), no_hash_join */
+sum(e1.empno) from emp e1, dept d1
+where e1.deptno = d1.deptno
+and e1.sal> (
+select /*+ resource(cpu='2'), index(ename), no_hash_join */
+  avg(e2.sal)
+  from emp e2
+  where e2.deptno = d1.deptno)]]>
+        </Resource>
+        <Resource name="hints">
+            <![CDATA[
+Project:[[RESOURCE inheritPath:[] options:{PARALLELISM=3}], [INDEX inheritPath:[] options:[ENAME]], [NO_HASH_JOIN inheritPath:[]]]
+Project:[[RESOURCE inheritPath:[0] options:{PARALLELISM=3}]]
+LogicalJoin:[[NO_HASH_JOIN inheritPath:[0, 0]]]
+LogicalJoin:[[NO_HASH_JOIN inheritPath:[0, 0, 0]]]
+TableScan:[[INDEX inheritPath:[0, 0, 0, 0] options:[ENAME]]]
+TableScan:[[INDEX inheritPath:[0, 0, 0, 1] options:[ENAME]]]
+Project:[[RESOURCE inheritPath:[] options:{CPU=2}], [INDEX inheritPath:[] options:[ENAME]], [NO_HASH_JOIN inheritPath:[]], [RESOURCE inheritPath:[0, 0, 1, 0] options:{PARALLELISM=3}]]
+TableScan:[[INDEX inheritPath:[0] options:[ENAME]], [INDEX inheritPath:[0, 0, 1, 0, 0] options:[ENAME]]]
 ]]>
         </Resource>
     </TestCase>


### PR DESCRIPTION
* Add a new interface Hintable#setHints(List) to set up the rel node
hists;
* Move RelHintPropagateShuttle from SqlToRelConverter to RelOptUtils;
* Add a new method RelOptUtil#propagateRelHints(RelNode, boolean) to
support hints for sql-to-rel conversion and decorrelation;
* Copy the hints for flattened projection in RelStructuredTypeFlattener;
* Add test cases for hints propagation with decorrelation.