### PR TITLE
[CALCITE-3564] Unify function's operands type check in validation and runtime

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1166,6 +1166,14 @@ public class SqlFunctions {
     return mod(BigDecimal.valueOf(b0), b1);
   }
 
+  public static BigDecimal mod(long b0, BigDecimal b1) {
+    return mod(BigDecimal.valueOf(b0), b1);
+  }
+
+  public static BigDecimal mod(BigDecimal b0, long b1) {
+    return mod(b0, BigDecimal.valueOf(b1));
+  }
+
   public static BigDecimal mod(BigDecimal b0, BigDecimal b1) {
     final BigDecimal[] bigDecimals = b0.divideAndRemainder(b1);
     return bigDecimals[1];

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlRandFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlRandFunction.java
@@ -40,7 +40,7 @@ public class SqlRandFunction extends SqlFunction {
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.DOUBLE,
         null,
-        OperandTypes.or(OperandTypes.NILADIC, OperandTypes.NUMERIC),
+        OperandTypes.or(OperandTypes.NILADIC, OperandTypes.INTEGER),
         SqlFunctionCategory.NUMERIC);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlRandIntegerFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlRandIntegerFunction.java
@@ -40,7 +40,7 @@ public class SqlRandIntegerFunction extends SqlFunction {
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.INTEGER,
         null,
-        OperandTypes.or(OperandTypes.NUMERIC, OperandTypes.NUMERIC_NUMERIC),
+        OperandTypes.or(OperandTypes.INTEGER, OperandTypes.INTEGER_INTEGER),
         SqlFunctionCategory.NUMERIC);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -210,6 +210,9 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker NUMERIC_INTEGER =
       family(SqlTypeFamily.NUMERIC, SqlTypeFamily.INTEGER);
 
+  public static final SqlSingleOperandTypeChecker INTEGER_INTEGER =
+      family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER);
+
   public static final SqlSingleOperandTypeChecker NUMERIC_NUMERIC =
       family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC);
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3587,6 +3587,15 @@ public class JdbcTest {
             + "empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000\n");
   }
 
+  @Test public void testFunctionImplementations() {
+    CalciteAssert.that()
+        .query("SELECT mod(12.5, cast(3 as bigint))")
+        .returns("EXPR$0=0.5\n");
+    CalciteAssert.that()
+        .query("SELECT mod(cast(5 as bigint), 1.2)")
+        .returns("EXPR$0=0.2\n");
+  }
+
   /** Tests windowed aggregation. */
   @Test public void testWinAgg() {
     CalciteAssert.hr()

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7920,6 +7920,24 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("Object 'NONEXISTENT' not found");
   }
 
+  @Test public void testRandFunction() {
+    sql("select ^rand(1.5)^")
+        .fails("Cannot apply 'RAND' to arguments of type "
+            + "'RAND\\(<DECIMAL\\(2, 1\\)>\\)'\\. "
+            + "Supported form\\(s\\): 'RAND\\(\\)'\n"
+            + "'RAND\\(<INTEGER>\\)'");
+    sql("select ^rand_integer(1.5)^")
+        .fails("Cannot apply 'RAND_INTEGER' to arguments of type "
+            + "'RAND_INTEGER\\(<DECIMAL\\(2, 1\\)>\\)'\\. "
+            + "Supported form\\(s\\): 'RAND_INTEGER\\(<INTEGER>\\)'\n"
+            + "'RAND_INTEGER\\(<INTEGER>, <INTEGER>\\)'");
+    sql("select ^rand_integer(1, 1.5)^")
+        .fails("Cannot apply 'RAND_INTEGER' to arguments of type "
+            + "'RAND_INTEGER\\(<INTEGER>, <DECIMAL\\(2, 1\\)>\\)'\\. "
+            + "Supported form\\(s\\): 'RAND_INTEGER\\(<INTEGER>\\)'\n"
+            + "'RAND_INTEGER\\(<INTEGER>, <INTEGER>\\)'");
+  }
+
   @Test public void testCollectionTable() {
     sql("select * from table(ramp(3))")
         .type("RecordType(INTEGER NOT NULL I) NOT NULL");


### PR DESCRIPTION
SqlFunction(MOD) allows `OperandTypes.EXACT_NUMERIC_EXACT_NUMERIC`, but it does not implement interfaces for `(long, decimal)`. It is straightforward to fix the issue in runtime layer.
While `RAND/RAND_INTEGER` accept integer arguments, it is reasonable to throw exception in validation phase.