### PR TITLE
[CALCITE-3597] The conversion between java.sql.Timestamp and long is …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,10 @@ jobs:
     name: 'macOS (JDK 13)'
     runs-on: macos-latest
     steps:
+      - script:
+        title: time zone information
+        inputs:
+          - content: date -R
       - uses: actions/checkout@v2
         with:
           fetch-depth: 50

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,7 @@ before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
+before_install:
+  - date
+
 # End .travis.yml

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -2709,11 +2709,11 @@ public class SqlFunctions {
     final long millis0 =
         DateTimeUtils.floorMod(t0, DateTimeUtils.MILLIS_PER_DAY);
     final int d0 = (int) DateTimeUtils.floorDiv(t0 - millis0,
-      DateTimeUtils.MILLIS_PER_DAY);
+        DateTimeUtils.MILLIS_PER_DAY);
     final long millis1 =
         DateTimeUtils.floorMod(t1, DateTimeUtils.MILLIS_PER_DAY);
     final int d1 = (int) DateTimeUtils.floorDiv(t1 - millis1,
-      DateTimeUtils.MILLIS_PER_DAY);
+        DateTimeUtils.MILLIS_PER_DAY);
     int x = subtractMonths(d0, d1);
     final long d2 = addMonths(d1, x);
     if (d2 == d0 && millis0 < millis1) {

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -77,7 +77,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
-import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY;
 import static org.apache.calcite.util.Static.RESOURCE;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -1755,7 +1754,7 @@ public class SqlFunctions {
   }
 
   public static int toInt(java.util.Date v, TimeZone timeZone) {
-    return (int) (toLong(v, timeZone)  / MILLIS_PER_DAY);
+    return (int) (toLong(v, timeZone)  / DateTimeUtils.MILLIS_PER_DAY);
   }
 
   public static Integer toIntOptional(java.util.Date v) {
@@ -1777,7 +1776,7 @@ public class SqlFunctions {
    *
    * <p>Converse of {@link #internalToTime(int)}. */
   public static int toInt(java.sql.Time v) {
-    return (int) (toLong(v) % MILLIS_PER_DAY);
+    return (int) (toLong(v) % DateTimeUtils.MILLIS_PER_DAY);
   }
 
   public static Integer toIntOptional(java.sql.Time v) {
@@ -1813,7 +1812,7 @@ public class SqlFunctions {
     long epochDay = dateTime.toLocalDate().toEpochDay();
     long nanoOfDay = dateTime.toLocalTime().toNanoOfDay();
 
-    return epochDay * MILLIS_PER_DAY + nanoOfDay / 1_000_000;
+    return epochDay * DateTimeUtils.MILLIS_PER_DAY + nanoOfDay / 1_000_000;
   }
 
   // mainly intended for java.sql.Timestamp but works for other dates also
@@ -1908,7 +1907,7 @@ public class SqlFunctions {
   /** Converts the internal representation of a SQL DATE (int) to the Java
    * type used for UDF parameters ({@link java.sql.Date}). */
   public static java.sql.Date internalToDate(int v) {
-    final long t = v * MILLIS_PER_DAY;
+    final long t = v * DateTimeUtils.MILLIS_PER_DAY;
     return new java.sql.Date(t - LOCAL_TZ.getOffset(t));
   }
 
@@ -1974,11 +1973,11 @@ public class SqlFunctions {
   /** Converts the internal representation of a SQL TIMESTAMP (long) to the Java
    * type used for UDF parameters ({@link java.sql.Timestamp}). */
   public static java.sql.Timestamp internalToTimestamp(long v) {
-    int date = (int) (v / MILLIS_PER_DAY);
-    int time = (int) (v % MILLIS_PER_DAY);
+    int date = (int) (v / DateTimeUtils.MILLIS_PER_DAY);
+    int time = (int) (v % DateTimeUtils.MILLIS_PER_DAY);
     if (time < 0) {
       --date;
-      time += MILLIS_PER_DAY;
+      time += DateTimeUtils.MILLIS_PER_DAY;
     }
     long nanoOfDay = time * 1_000_000L;
     LocalDate localDate = LocalDate.ofEpochDay(date);
@@ -2178,7 +2177,7 @@ public class SqlFunctions {
    * @return milliseconds of the last day of the month since epoch
    */
   public static int lastDay(long timestamp) {
-    int date = (int) (timestamp / MILLIS_PER_DAY);
+    int date = (int) (timestamp / DateTimeUtils.MILLIS_PER_DAY);
     int y0 = (int) DateTimeUtils.unixDateExtract(TimeUnitRange.YEAR, date);
     int m0 = (int) DateTimeUtils.unixDateExtract(TimeUnitRange.MONTH, date);
     int last = lastDay(y0, m0);
@@ -2253,7 +2252,7 @@ public class SqlFunctions {
    * @return localDate
    */
   private static LocalDate timeStampToLocalDate(long timestamp) {
-    int date = (int) (timestamp / MILLIS_PER_DAY);
+    int date = (int) (timestamp / DateTimeUtils.MILLIS_PER_DAY);
     return dateToLocalDate(date);
   }
 
@@ -2267,9 +2266,9 @@ public class SqlFunctions {
   /** SQL {@code CURRENT_TIME} function. */
   @NonDeterministic
   public static int currentTime(DataContext root) {
-    int time = (int) (currentTimestamp(root) % MILLIS_PER_DAY);
+    int time = (int) (currentTimestamp(root) % DateTimeUtils.MILLIS_PER_DAY);
     if (time < 0) {
-      time += MILLIS_PER_DAY;
+      time += DateTimeUtils.MILLIS_PER_DAY;
     }
     return time;
   }
@@ -2278,8 +2277,8 @@ public class SqlFunctions {
   @NonDeterministic
   public static int currentDate(DataContext root) {
     final long timestamp = currentTimestamp(root);
-    int date = (int) (timestamp / MILLIS_PER_DAY);
-    final int time = (int) (timestamp % MILLIS_PER_DAY);
+    int date = (int) (timestamp / DateTimeUtils.MILLIS_PER_DAY);
+    final int time = (int) (timestamp % DateTimeUtils.MILLIS_PER_DAY);
     if (time < 0) {
       --date;
     }
@@ -2296,7 +2295,7 @@ public class SqlFunctions {
   /** SQL {@code LOCAL_TIME} function. */
   @NonDeterministic
   public static int localTime(DataContext root) {
-    return (int) (localTimestamp(root) % MILLIS_PER_DAY);
+    return (int) (localTimestamp(root) % DateTimeUtils.MILLIS_PER_DAY);
   }
 
   @NonDeterministic
@@ -2644,11 +2643,11 @@ public class SqlFunctions {
    * of milliseconds since the epoch. */
   public static long addMonths(long timestamp, int m) {
     final long millis =
-        DateTimeUtils.floorMod(timestamp, MILLIS_PER_DAY);
+        DateTimeUtils.floorMod(timestamp, DateTimeUtils.MILLIS_PER_DAY);
     timestamp -= millis;
     final long x =
-        addMonths((int) (timestamp / MILLIS_PER_DAY), m);
-    return x * MILLIS_PER_DAY + millis;
+        addMonths((int) (timestamp / DateTimeUtils.MILLIS_PER_DAY), m);
+    return x * DateTimeUtils.MILLIS_PER_DAY + millis;
   }
 
   /** Adds a given number of months to a date, represented as the number of
@@ -2708,13 +2707,13 @@ public class SqlFunctions {
 
   public static int subtractMonths(long t0, long t1) {
     final long millis0 =
-        DateTimeUtils.floorMod(t0, MILLIS_PER_DAY);
+        DateTimeUtils.floorMod(t0, DateTimeUtils.MILLIS_PER_DAY);
     final int d0 = (int) DateTimeUtils.floorDiv(t0 - millis0,
-        MILLIS_PER_DAY);
+      DateTimeUtils.MILLIS_PER_DAY);
     final long millis1 =
-        DateTimeUtils.floorMod(t1, MILLIS_PER_DAY);
+        DateTimeUtils.floorMod(t1, DateTimeUtils.MILLIS_PER_DAY);
     final int d1 = (int) DateTimeUtils.floorDiv(t1 - millis1,
-        MILLIS_PER_DAY);
+      DateTimeUtils.MILLIS_PER_DAY);
     int x = subtractMonths(d0, d1);
     final long d2 = addMonths(d1, x);
     if (d2 == d0 && millis0 < millis1) {

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -55,6 +55,8 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,6 +77,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
+import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY;
 import static org.apache.calcite.util.Static.RESOURCE;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -1752,7 +1755,7 @@ public class SqlFunctions {
   }
 
   public static int toInt(java.util.Date v, TimeZone timeZone) {
-    return (int) (toLong(v, timeZone)  / DateTimeUtils.MILLIS_PER_DAY);
+    return (int) (toLong(v, timeZone)  / MILLIS_PER_DAY);
   }
 
   public static Integer toIntOptional(java.util.Date v) {
@@ -1774,7 +1777,7 @@ public class SqlFunctions {
    *
    * <p>Converse of {@link #internalToTime(int)}. */
   public static int toInt(java.sql.Time v) {
-    return (int) (toLong(v) % DateTimeUtils.MILLIS_PER_DAY);
+    return (int) (toLong(v) % MILLIS_PER_DAY);
   }
 
   public static Integer toIntOptional(java.sql.Time v) {
@@ -1806,7 +1809,11 @@ public class SqlFunctions {
    *
    * <p>Converse of {@link #internalToTimestamp(long)}. */
   public static long toLong(Timestamp v) {
-    return toLong(v, LOCAL_TZ);
+    LocalDateTime dateTime = v.toLocalDateTime();
+    long epochDay = dateTime.toLocalDate().toEpochDay();
+    long nanoOfDay = dateTime.toLocalTime().toNanoOfDay();
+
+    return epochDay * MILLIS_PER_DAY + nanoOfDay / 1_000_000;
   }
 
   // mainly intended for java.sql.Timestamp but works for other dates also
@@ -1901,7 +1908,7 @@ public class SqlFunctions {
   /** Converts the internal representation of a SQL DATE (int) to the Java
    * type used for UDF parameters ({@link java.sql.Date}). */
   public static java.sql.Date internalToDate(int v) {
-    final long t = v * DateTimeUtils.MILLIS_PER_DAY;
+    final long t = v * MILLIS_PER_DAY;
     return new java.sql.Date(t - LOCAL_TZ.getOffset(t));
   }
 
@@ -1967,7 +1974,17 @@ public class SqlFunctions {
   /** Converts the internal representation of a SQL TIMESTAMP (long) to the Java
    * type used for UDF parameters ({@link java.sql.Timestamp}). */
   public static java.sql.Timestamp internalToTimestamp(long v) {
-    return new java.sql.Timestamp(v - LOCAL_TZ.getOffset(v));
+    int date = (int) (v / MILLIS_PER_DAY);
+    int time = (int) (v % MILLIS_PER_DAY);
+    if (time < 0) {
+      --date;
+      time += MILLIS_PER_DAY;
+    }
+    long nanoOfDay = time * 1_000_000L;
+    LocalDate localDate = LocalDate.ofEpochDay(date);
+    LocalTime localTime = LocalTime.ofNanoOfDay(nanoOfDay);
+
+    return java.sql.Timestamp.valueOf(LocalDateTime.of(localDate, localTime));
   }
 
   public static java.sql.Timestamp internalToTimestamp(Long v) {
@@ -2161,7 +2178,7 @@ public class SqlFunctions {
    * @return milliseconds of the last day of the month since epoch
    */
   public static int lastDay(long timestamp) {
-    int date = (int) (timestamp / DateTimeUtils.MILLIS_PER_DAY);
+    int date = (int) (timestamp / MILLIS_PER_DAY);
     int y0 = (int) DateTimeUtils.unixDateExtract(TimeUnitRange.YEAR, date);
     int m0 = (int) DateTimeUtils.unixDateExtract(TimeUnitRange.MONTH, date);
     int last = lastDay(y0, m0);
@@ -2236,7 +2253,7 @@ public class SqlFunctions {
    * @return localDate
    */
   private static LocalDate timeStampToLocalDate(long timestamp) {
-    int date = (int) (timestamp / DateTimeUtils.MILLIS_PER_DAY);
+    int date = (int) (timestamp / MILLIS_PER_DAY);
     return dateToLocalDate(date);
   }
 
@@ -2250,9 +2267,9 @@ public class SqlFunctions {
   /** SQL {@code CURRENT_TIME} function. */
   @NonDeterministic
   public static int currentTime(DataContext root) {
-    int time = (int) (currentTimestamp(root) % DateTimeUtils.MILLIS_PER_DAY);
+    int time = (int) (currentTimestamp(root) % MILLIS_PER_DAY);
     if (time < 0) {
-      time += DateTimeUtils.MILLIS_PER_DAY;
+      time += MILLIS_PER_DAY;
     }
     return time;
   }
@@ -2261,8 +2278,8 @@ public class SqlFunctions {
   @NonDeterministic
   public static int currentDate(DataContext root) {
     final long timestamp = currentTimestamp(root);
-    int date = (int) (timestamp / DateTimeUtils.MILLIS_PER_DAY);
-    final int time = (int) (timestamp % DateTimeUtils.MILLIS_PER_DAY);
+    int date = (int) (timestamp / MILLIS_PER_DAY);
+    final int time = (int) (timestamp % MILLIS_PER_DAY);
     if (time < 0) {
       --date;
     }
@@ -2279,7 +2296,7 @@ public class SqlFunctions {
   /** SQL {@code LOCAL_TIME} function. */
   @NonDeterministic
   public static int localTime(DataContext root) {
-    return (int) (localTimestamp(root) % DateTimeUtils.MILLIS_PER_DAY);
+    return (int) (localTimestamp(root) % MILLIS_PER_DAY);
   }
 
   @NonDeterministic
@@ -2627,11 +2644,11 @@ public class SqlFunctions {
    * of milliseconds since the epoch. */
   public static long addMonths(long timestamp, int m) {
     final long millis =
-        DateTimeUtils.floorMod(timestamp, DateTimeUtils.MILLIS_PER_DAY);
+        DateTimeUtils.floorMod(timestamp, MILLIS_PER_DAY);
     timestamp -= millis;
     final long x =
-        addMonths((int) (timestamp / DateTimeUtils.MILLIS_PER_DAY), m);
-    return x * DateTimeUtils.MILLIS_PER_DAY + millis;
+        addMonths((int) (timestamp / MILLIS_PER_DAY), m);
+    return x * MILLIS_PER_DAY + millis;
   }
 
   /** Adds a given number of months to a date, represented as the number of
@@ -2691,13 +2708,13 @@ public class SqlFunctions {
 
   public static int subtractMonths(long t0, long t1) {
     final long millis0 =
-        DateTimeUtils.floorMod(t0, DateTimeUtils.MILLIS_PER_DAY);
+        DateTimeUtils.floorMod(t0, MILLIS_PER_DAY);
     final int d0 = (int) DateTimeUtils.floorDiv(t0 - millis0,
-        DateTimeUtils.MILLIS_PER_DAY);
+        MILLIS_PER_DAY);
     final long millis1 =
-        DateTimeUtils.floorMod(t1, DateTimeUtils.MILLIS_PER_DAY);
+        DateTimeUtils.floorMod(t1, MILLIS_PER_DAY);
     final int d1 = (int) DateTimeUtils.floorDiv(t1 - millis1,
-        DateTimeUtils.MILLIS_PER_DAY);
+        MILLIS_PER_DAY);
     int x = subtractMonths(d0, d1);
     final long d2 = addMonths(d1, x);
     if (d2 == d0 && millis0 < millis1) {

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.TimeZone;
 
 import static org.apache.calcite.avatica.util.DateTimeUtils.ymdToUnixDate;
 import static org.apache.calcite.runtime.SqlFunctions.addMonths;
@@ -37,6 +38,7 @@ import static org.apache.calcite.runtime.SqlFunctions.concat;
 import static org.apache.calcite.runtime.SqlFunctions.fromBase64;
 import static org.apache.calcite.runtime.SqlFunctions.greater;
 import static org.apache.calcite.runtime.SqlFunctions.initcap;
+import static org.apache.calcite.runtime.SqlFunctions.internalToTimestamp;
 import static org.apache.calcite.runtime.SqlFunctions.lesser;
 import static org.apache.calcite.runtime.SqlFunctions.lower;
 import static org.apache.calcite.runtime.SqlFunctions.ltrim;
@@ -47,6 +49,7 @@ import static org.apache.calcite.runtime.SqlFunctions.rtrim;
 import static org.apache.calcite.runtime.SqlFunctions.sha1;
 import static org.apache.calcite.runtime.SqlFunctions.subtractMonths;
 import static org.apache.calcite.runtime.SqlFunctions.toBase64;
+import static org.apache.calcite.runtime.SqlFunctions.toLong;
 import static org.apache.calcite.runtime.SqlFunctions.trim;
 import static org.apache.calcite.runtime.SqlFunctions.upper;
 import static org.apache.calcite.test.Matchers.within;
@@ -942,5 +945,20 @@ public class SqlFunctionsTest {
     } catch (NullPointerException e) {
       // ok
     }
+  }
+
+  @Test public void testAsymmetricBetweenTimestampAndLong() {
+    TimeZone tz = TimeZone.getDefault();
+
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    java.sql.Timestamp dst2018Begin = java.sql.Timestamp.valueOf("2018-03-11 03:00:00");
+    assertThat(dst2018Begin, is(internalToTimestamp(toLong(dst2018Begin))));
+
+
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
+    java.sql.Timestamp ts = java.sql.Timestamp.valueOf("1900-01-01 00:00:00");
+    assertThat(ts, is(internalToTimestamp(toLong(ts))));
+
+    TimeZone.setDefault(tz);
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -46,8 +46,10 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -882,6 +884,20 @@ public class UdfTest {
         .returnsValue("86490000");
     with.query("values \"adhoc\".\"timestampFun\"(cast(null as timestamp))")
         .returnsValue("-1");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3597">[CALCITE-3597]
+   * User-defined function with Timestamp parameters and returns TIMESTAMP value</a>. */
+  @Test public void testTimestampReturnTimestamp() {
+    TimeZone tz = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
+
+    final CalciteAssert.AssertThat with = withUdf();
+    with.query("values \"adhoc\".\"timestampFunReturnsTimestamp\"(TIMESTAMP '1900-01-01 00:00:00')")
+      .returnsValue("1900-01-01 00:00:00");
+
+    TimeZone.setDefault(tz);
   }
 
   /** Test case for

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -46,7 +46,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;

--- a/core/src/test/java/org/apache/calcite/util/Smalls.java
+++ b/core/src/test/java/org/apache/calcite/util/Smalls.java
@@ -641,6 +641,9 @@ public class Smalls {
       return time == null ? 0 : SqlFunctions.toLong(time);
     }
 
+    public static Timestamp timestampFunReturnsTimestamp(Timestamp timestamp) {
+      return timestamp;
+    }
   }
 
   /** Example of a user-defined aggregate function (UDAF). */


### PR DESCRIPTION
…not asymmetric

In Calcite, we use SqlFunctions.toLong(Timestamp) and SqlFunctions.internalToTimestamp(long) to convert java.sql.Timestmap to internal long and vice versa. The main logical inside is +/- local time zone offset.But in the comments of TimeZone.getOffset(long date), the parameter represents in milliseconds since January 1, 1970 00:00:00 GMT. It means that there will one conversion above doesn't satisfy this hypothesis. This PR use LocalDateTime as intermediate of the conversion and solves the dissymmetry.