### PR TITLE
[CALCITE-3598] EnumerableTableScan: wrong JavaRowFormat for elementType String

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
@@ -213,7 +213,8 @@ public class EnumerableTableScan
     }
     if (fieldCount == 1 && (Object.class == elementType
           || Primitive.is(elementType)
-          || Number.class.isAssignableFrom(elementType))) {
+          || Number.class.isAssignableFrom(elementType)
+          || String.class == elementType)) {
       return JavaRowFormat.SCALAR;
     }
     return JavaRowFormat.CUSTOM;

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -2280,10 +2280,7 @@ public class MaterializationTest {
                 + "      EnumerableTableScan(table=[[hr, dependents]])"));
   }
 
-  @Disabled
   @Test public void testJoinMaterialization8() {
-    // TODO: fails with java.lang.ClassCastException:
-    //  java.lang.String$CaseInsensitiveComparator cannot be cast to java.lang.String
     checkMaterialize(
         "select \"depts\".\"name\"\n"
             + "from \"emps\"\n"
@@ -2300,10 +2297,7 @@ public class MaterializationTest {
                 + "    EnumerableTableScan(table=[[hr, m0]])"));
   }
 
-  @Disabled
   @Test public void testJoinMaterialization9() {
-    // TODO: fails with java.lang.ClassCastException:
-    //  java.lang.String$CaseInsensitiveComparator cannot be cast to java.lang.String
     checkMaterialize(
         "select \"depts\".\"name\"\n"
             + "from \"emps\"\n"


### PR DESCRIPTION
Credits to @DonnyZone who pointed me in the right direction.
Jira ticket: [CALCITE-3598](https://issues.apache.org/jira/browse/CALCITE-3598)