### PR TITLE
[CALCITE-3587] RexBuilder may lose decimal fraction for creating literal with DECIMAL type

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -60,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -1517,6 +1518,11 @@ public class RexBuilder {
       if (o instanceof BigDecimal) {
         return o;
       }
+      assert !(o instanceof Float || o instanceof Double)
+          : String.format(Locale.ROOT,
+              "%s is not compatible with %s, try to use makeExactLiteral",
+              o.getClass().getCanonicalName(),
+              type.getSqlTypeName());
       return new BigDecimal(((Number) o).longValue());
     case FLOAT:
       if (o instanceof BigDecimal) {

--- a/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
@@ -414,6 +414,24 @@ public class RexBuilderTest {
     assertThat(literal.getValue3(), nullValue());
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3587">[CALCITE-3587]
+   * RexBuilder may lose decimal fraction for creating literal with DECIMAL type</a>.
+   */
+  @Test public void testDecimal() {
+    final RelDataTypeFactory typeFactory =
+        new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    final RelDataType type = typeFactory.createSqlType(SqlTypeName.DECIMAL, 4, 2);
+    final RexBuilder builder = new RexBuilder(typeFactory);
+    try {
+      builder.makeLiteral(12.3, type, false);
+      fail();
+    } catch (AssertionError e) {
+      assertThat(e.getMessage(),
+          is("java.lang.Double is not compatible with DECIMAL, try to use makeExactLiteral"));
+    }
+  }
+
   /** Tests {@link DateString} year range. */
   @Test public void testDateStringYearError() {
     try {


### PR DESCRIPTION
DECIMAL is fixed point type, when creating RexLiteral with DECIMAL type,
should not only use the integer part, need the decimal fraction part as well