### PR TITLE
[CALCITE-3495] RelDecorrelator generate plan with different semantics when handle Aggregate

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5662,6 +5662,22 @@ public class RelOptRulesTest extends RelOptTestBase {
     checkSubQuery(sql).withLateDecorrelation(true).check();
   }
 
+  @Test public void testDecorrelateIn() throws Exception {
+    final String sql = "select deptno from (select deptno, empno from emp) p\n"
+        + "where empno in\n"
+        + "(select n from (select deptno, count(*) n from dept\n"
+        + " where p.deptno = dept.deptno group by deptno) t)";
+    checkSubQuery(sql).withLateDecorrelation(true).check();
+  }
+
+  @Test public void testDecorrelateIn2() throws Exception {
+    final String sql = "select deptno from (select deptno, empno from emp) p\n"
+        + "where empno in\n"
+        + "(select count(*) from dept\n"
+        + " where p.deptno = dept.deptno)";
+    checkSubQuery(sql).withLateDecorrelation(true).check();
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1511">[CALCITE-1511]
    * AssertionError while decorrelating query with two EXISTS

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -792,6 +792,106 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testDecorrelateIn">
+        <Resource name="sql">
+            <![CDATA[select deptno from (select deptno, empno from emp) p
+where empno in
+(select n from (select deptno, count(*) n from dept
+where p.deptno = dept.deptno group by deptno) t)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalFilter(condition=[IN($1, {
+LogicalProject(N=[$1])
+  LogicalAggregate(group=[{0}], N=[COUNT()])
+    LogicalProject(DEPTNO=[$0])
+      LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})], variablesSet=[[$cor0]])
+    LogicalProject(DEPTNO=[$7], EMPNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planMid">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalProject(DEPTNO=[$0], EMPNO=[$1])
+    LogicalFilter(condition=[=($1, $2)])
+      LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+        LogicalProject(DEPTNO=[$7], EMPNO=[$0])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalAggregate(group=[{0}])
+          LogicalProject(N=[$1])
+            LogicalAggregate(group=[{0}], N=[COUNT()])
+              LogicalProject(DEPTNO=[$0])
+                LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
+                  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalJoin(condition=[AND(=($0, $3), =($1, $2))], joinType=[inner])
+    LogicalProject(DEPTNO=[$7], EMPNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0, 1}])
+      LogicalProject(N=[$2], DEPTNO1=[$1])
+        LogicalAggregate(group=[{0, 1}], N=[COUNT()])
+          LogicalProject(DEPTNO=[$0], DEPTNO1=[$0])
+            LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDecorrelateIn2">
+        <Resource name="sql">
+            <![CDATA[select deptno from (select deptno, empno from emp) p
+where empno in
+(select count(*) from dept
+where p.deptno = dept.deptno)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalFilter(condition=[IN($1, {
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})], variablesSet=[[$cor0]])
+    LogicalProject(DEPTNO=[$7], EMPNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planMid">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalProject(DEPTNO=[$0], EMPNO=[$1])
+    LogicalFilter(condition=[=($1, $2)])
+      LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+        LogicalProject(DEPTNO=[$7], EMPNO=[$0])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+          LogicalProject($f0=[0])
+            LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
+              LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalProject(DEPTNO=[$0], EMPNO=[$1])
+    LogicalFilter(condition=[=($1, $2)])
+      LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+        LogicalProject(DEPTNO=[$7], EMPNO=[$0])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+          LogicalProject($f0=[0])
+            LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
+              LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testDecorrelateUncorrelatedInAndCorrelatedExists">
         <Resource name="sql">
             <![CDATA[select * from sales.emp
@@ -10006,12 +10106,13 @@ LogicalProject(EXPR$0=[CAST(OR(AND(IS TRUE(>($0, $9)), IS NOT TRUE(OR(IS NULL($1
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EXPR$0=[CAST(OR(AND(IS TRUE(>($0, $9)), IS NOT TRUE(OR(IS NULL($12), =($10, 0)))), AND(IS TRUE(>($10, $11)), null, IS NOT TRUE(OR(IS NULL($12), =($10, 0))), IS NOT TRUE(>($0, $9))), AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0))), IS NOT TRUE(>($0, $9)), IS NOT TRUE(>($10, $11))))):BOOLEAN NOT NULL])
-  LogicalJoin(condition=[=($2, $13)], joinType=[left])
+  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{2}])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalProject(m=[$1], c=[$2], d=[$3], trueLiteral=[true], NAME=[$0])
-      LogicalAggregate(group=[{0}], m=[MIN($1)], c=[COUNT()], d=[COUNT($1)])
-        LogicalProject(NAME=[$1], DEPTNO=[$0])
-          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalProject(m=[$0], c=[$1], d=[$2], trueLiteral=[true])
+      LogicalAggregate(group=[{}], m=[MIN($0)], c=[COUNT()], d=[COUNT($0)])
+        LogicalProject(DEPTNO=[$0])
+          LogicalFilter(condition=[=($cor0.JOB, $1)])
+            LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
     </TestCase>
@@ -11178,15 +11279,19 @@ LogicalProject(DEPTNO=[$0])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(SAL=[$5])
-  LogicalFilter(condition=[OR(=($10, 0), IS NOT TRUE(OR(IS NOT NULL($13), <($11, $10))))])
-    LogicalJoin(condition=[AND(=($0, $12), =($2, $14))], joinType=[left])
-      LogicalJoin(condition=[=($2, $9)], joinType=[left])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-        LogicalAggregate(group=[{0}], c=[COUNT()], ck=[COUNT($1)])
-          LogicalProject(NAME=[$1], DEPTNO=[$0])
-            LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-      LogicalProject(DEPTNO=[$0], i=[true], NAME=[$1])
-        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[OR(=($9, 0), IS NOT TRUE(OR(IS NOT NULL($12), <($10, $9))))])
+      LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{2}])
+        LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{2}])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+          LogicalAggregate(group=[{}], c=[COUNT()], ck=[COUNT($0)])
+            LogicalProject(DEPTNO=[$0])
+              LogicalFilter(condition=[=($cor0.JOB, $1)])
+                LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+        LogicalFilter(condition=[=($cor0.EMPNO, $0)])
+          LogicalProject(DEPTNO=[$0], i=[true])
+            LogicalFilter(condition=[=($cor0.JOB, $1)])
+              LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
         <Resource name="planMid">
@@ -11289,19 +11394,21 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[OR(=($10, 0), IS NOT TRUE(OR(IS NOT NULL($13), <($11, $10))))])
-    LogicalJoin(condition=[AND(=($0, $12), =($1, $14))], joinType=[left])
-      LogicalJoin(condition=[=($1, $9)], joinType=[left])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-        LogicalAggregate(group=[{0}], c=[COUNT()], ck=[COUNT($1)])
-          LogicalProject(ENAME=[$0], EMPNO=[$1])
-            LogicalFilter(condition=[>($2, 2)])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[OR(=($9, 0), IS NOT TRUE(OR(IS NOT NULL($12), <($10, $9))))])
+      LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1}])
+        LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1}])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+          LogicalAggregate(group=[{}], c=[COUNT()], ck=[COUNT($0)])
+            LogicalProject(EMPNO=[$1])
+              LogicalFilter(condition=[AND(>($2, 2), =($cor0.ENAME, $0))])
+                LogicalProject(ENAME=[$1], EMPNO=[$0], R=[$5])
+                  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalFilter(condition=[=($cor0.EMPNO, $0)])
+          LogicalProject(EMPNO=[$1], i=[true])
+            LogicalFilter(condition=[AND(>($2, 2), =($cor0.ENAME, $0))])
               LogicalProject(ENAME=[$1], EMPNO=[$0], R=[$5])
                 LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalProject(EMPNO=[$1], i=[true], ENAME=[$0])
-        LogicalFilter(condition=[>($2, 2)])
-          LogicalProject(ENAME=[$1], EMPNO=[$0], R=[$5])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -11802,13 +11909,15 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[OR(AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0)))), AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0))), IS NOT TRUE(>($0, $9)), IS NOT TRUE(>($10, $11))))])
-    LogicalJoin(condition=[=($2, $13)], joinType=[left])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalProject(m=[$1], c=[$2], d=[$3], trueLiteral=[true], NAME=[$0])
-        LogicalAggregate(group=[{0}], m=[MIN($1)], c=[COUNT()], d=[COUNT($1)])
-          LogicalProject(NAME=[$1], DEPTNO=[$0])
-            LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[OR(AND(IS TRUE(>($0, $9)), IS NOT TRUE(OR(IS NULL($12), =($10, 0)))), AND(IS TRUE(>($10, $11)), null, IS NOT TRUE(OR(IS NULL($12), =($10, 0))), IS NOT TRUE(>($0, $9))), AND(>($0, $9), IS NOT TRUE(OR(IS NULL($12), =($10, 0))), IS NOT TRUE(>($0, $9)), IS NOT TRUE(>($10, $11))))])
+      LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{2}])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalProject(m=[$0], c=[$1], d=[$2], trueLiteral=[true])
+          LogicalAggregate(group=[{}], m=[MIN($0)], c=[COUNT()], d=[COUNT($0)])
+            LogicalProject(DEPTNO=[$0])
+              LogicalFilter(condition=[=($cor0.JOB, $1)])
+                LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
         </Resource>
     </TestCase>

--- a/core/src/test/resources/sql/blank.iq
+++ b/core/src/test/resources/sql/blank.iq
@@ -73,16 +73,16 @@ insert into table2 values (NULL, 1), (2, 1);
 # Checked on Oracle
 !set lateDecorrelate true
 select i, j from table1 where table1.j NOT IN (select i from table2 where table1.i=table2.j);
-EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[=($t3, $t8)], expr#10=[IS NULL($t1)], expr#11=[IS NOT NULL($t7)], expr#12=[<($t4, $t3)], expr#13=[OR($t10, $t11, $t12)], expr#14=[IS NOT TRUE($t13)], expr#15=[OR($t9, $t14)], proj#0..1=[{exprs}], $condition=[$t15])
-  EnumerableHashJoin(condition=[AND(=($0, $6), =($1, $5))], joinType=[left])
-    EnumerableHashJoin(condition=[=($0, $2)], joinType=[left])
+EnumerableCalc(expr#0..5=[{inputs}], expr#6=[0], expr#7=[=($t2, $t6)], expr#8=[IS NULL($t1)], expr#9=[IS NOT NULL($t5)], expr#10=[<($t3, $t2)], expr#11=[OR($t8, $t9, $t10)], expr#12=[IS NOT TRUE($t11)], expr#13=[OR($t7, $t12)], proj#0..1=[{exprs}], $condition=[$t13])
+  EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
+    EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
       EnumerableTableScan(table=[[BLANK, TABLE1]])
-      EnumerableAggregate(group=[{1}], c=[COUNT()], ck=[COUNT($0)])
-        EnumerableCalc(expr#0..1=[{inputs}], expr#2=[IS NOT NULL($t1)], proj#0..1=[{exprs}], $condition=[$t2])
+      EnumerableAggregate(group=[{}], c=[COUNT()], ck=[COUNT($0)])
+        EnumerableCalc(expr#0..1=[{inputs}], expr#2=[$cor0], expr#3=[$t2.I], expr#4=[=($t3, $t1)], proj#0..1=[{exprs}], $condition=[$t4])
           EnumerableTableScan(table=[[BLANK, TABLE2]])
-    EnumerableCalc(expr#0..1=[{inputs}], expr#2=[true], proj#0..2=[{exprs}])
+    EnumerableCalc(expr#0..1=[{inputs}], expr#2=[$cor0], expr#3=[$t2.J], expr#4=[=($t3, $t0)], proj#0..1=[{exprs}], $condition=[$t4])
       EnumerableAggregate(group=[{0, 1}])
-        EnumerableCalc(expr#0..1=[{inputs}], expr#2=[IS NOT NULL($t1)], expr#3=[IS NOT NULL($t0)], expr#4=[AND($t2, $t3)], proj#0..1=[{exprs}], $condition=[$t4])
+        EnumerableCalc(expr#0..1=[{inputs}], expr#2=[true], expr#3=[$cor0], expr#4=[$t3.I], expr#5=[=($t4, $t1)], I=[$t0], i=[$t2], $condition=[$t5])
           EnumerableTableScan(table=[[BLANK, TABLE2]])
 !plan
 +---+---+

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -2048,30 +2048,30 @@ where sal + 100 not in (
 
 !ok
 EnumerableAggregate(group=[{}], C=[COUNT()])
-  EnumerableCalc(expr#0..9=[{inputs}], expr#10=[0], expr#11=[=($t4, $t10)], expr#12=[IS NULL($t2)], expr#13=[IS NOT NULL($t7)], expr#14=[<($t5, $t4)], expr#15=[OR($t12, $t13, $t14)], expr#16=[IS NOT TRUE($t15)], expr#17=[OR($t11, $t16)], proj#0..9=[{exprs}], $condition=[$t17])
-    EnumerableHashJoin(condition=[AND(=($1, $8), =($2, $9))], joinType=[left])
-      EnumerableHashJoin(condition=[=($1, $3)], joinType=[left])
+  EnumerableCalc(expr#0..6=[{inputs}], expr#7=[0], expr#8=[=($t3, $t7)], expr#9=[IS NULL($t2)], expr#10=[IS NOT NULL($t6)], expr#11=[<($t4, $t3)], expr#12=[OR($t9, $t10, $t11)], expr#13=[IS NOT TRUE($t12)], expr#14=[OR($t8, $t13)], proj#0..6=[{exprs}], $condition=[$t14])
+    EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1}])
+      EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1}])
         EnumerableCalc(expr#0..7=[{inputs}], proj#0..1=[{exprs}], SAL=[$t5])
           EnumerableTableScan(table=[[scott, EMP]])
-        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[1:BIGINT], expr#4=[IS NOT NULL($t1)], DNAME=[$t1], $f1=[$t3], $f2=[$t3], $condition=[$t4])
-          EnumerableTableScan(table=[[scott, DEPT]])
-      EnumerableNestedLoopJoin(condition=[=(+($3, 100), $0)], joinType=[inner])
-        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[IS NOT NULL($t1)], DEPTNO=[$t0], i=[$t3], DNAME=[$t1], $condition=[$t4])
-          EnumerableTableScan(table=[[scott, DEPT]])
-        EnumerableAggregate(group=[{5}])
-          EnumerableTableScan(table=[[scott, EMP]])
+        EnumerableAggregate(group=[{}], c=[COUNT()], ck=[COUNT($0)])
+          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[$cor0], expr#4=[$t3.ENAME], expr#5=[CAST($t4):VARCHAR(14)], expr#6=[=($t1, $t5)], proj#0..2=[{exprs}], $condition=[$t6])
+            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[$cor0], expr#5=[$t4.ENAME], expr#6=[CAST($t5):VARCHAR(14)], expr#7=[=($t1, $t6)], expr#8=[$cor0], expr#9=[$t8.SAL], expr#10=[100], expr#11=[+($t9, $t10)], expr#12=[=($t11, $t0)], expr#13=[AND($t7, $t12)], DEPTNO=[$t0], i=[$t3], $condition=[$t13])
+        EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Correlated ANY sub-query
 select empno from "scott".emp as e
 where e.empno > ANY(
   select 2 from "scott".dept e2 where e2.deptno = e.deptno) ;
-EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t0, $t2)], expr#8=[IS NULL($t5)], expr#9=[0], expr#10=[=($t3, $t9)], expr#11=[OR($t8, $t10)], expr#12=[IS NOT TRUE($t11)], expr#13=[AND($t7, $t12)], expr#14=[IS NOT TRUE($t7)], expr#15=[>($t3, $t4)], expr#16=[IS NOT TRUE($t15)], expr#17=[AND($t7, $t12, $t14, $t16)], expr#18=[OR($t13, $t17)], EMPNO=[$t0], $condition=[$t18])
-  EnumerableHashJoin(condition=[=($1, $6)], joinType=[left])
+EnumerableCalc(expr#0..5=[{inputs}], expr#6=[>($t0, $t2)], expr#7=[IS NULL($t5)], expr#8=[0], expr#9=[=($t3, $t8)], expr#10=[OR($t7, $t9)], expr#11=[IS NOT TRUE($t10)], expr#12=[AND($t6, $t11)], expr#13=[IS NOT TRUE($t6)], expr#14=[>($t3, $t4)], expr#15=[IS NOT TRUE($t14)], expr#16=[AND($t6, $t11, $t13, $t15)], expr#17=[OR($t12, $t16)], EMPNO=[$t0], $condition=[$t17])
+  EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1}])
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], DEPTNO=[$t7])
       EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableCalc(expr#0..2=[{inputs}], expr#3=[2], expr#4=[1:BIGINT], expr#5=[true], m=[$t3], c=[$t4], d=[$t4], trueLiteral=[$t5], DEPTNO=[$t0])
-      EnumerableTableScan(table=[[scott, DEPT]])
+    EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], proj#0..3=[{exprs}])
+      EnumerableAggregate(group=[{}], m=[MIN($0)], c=[COUNT()], d=[COUNT($0)])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[2], expr#4=[$cor0], expr#5=[$t4.DEPTNO], expr#6=[=($t0, $t5)], EXPR$0=[$t3], $condition=[$t6])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
  EMPNO
 -------
@@ -2098,13 +2098,12 @@ select empno,
 e.deptno > ANY(
   select 2 from "scott".dept e2 where e2.deptno = e.empno) from "scott".emp as e;
 
-EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t1, $t2)], expr#8=[IS TRUE($t7)], expr#9=[IS NULL($t5)], expr#10=[0], expr#11=[=($t3, $t10)], expr#12=[OR($t9, $t11)], expr#13=[IS NOT TRUE($t12)], expr#14=[AND($t8, $t13)], expr#15=[>($t3, $t4)], expr#16=[IS TRUE($t15)], expr#17=[null:BOOLEAN], expr#18=[IS NOT TRUE($t7)], expr#19=[AND($t16, $t17, $t13, $t18)], expr#20=[IS NOT TRUE($t15)], expr#21=[AND($t7, $t13, $t18, $t20)], expr#22=[OR($t14, $t19, $t21)], EMPNO=[$t0], EXPR$1=[$t22])
-  EnumerableHashJoin(condition=[=($0, $6)], joinType=[left])
-    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], DEPTNO=[$t7])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableCalc(expr#0..3=[{inputs}], expr#4=[true], m=[$t1], c=[$t2], d=[$t3], trueLiteral=[$t4], DEPTNO0=[$t0])
-      EnumerableAggregate(group=[{0}], m=[MIN($1)], c=[COUNT()], d=[COUNT($1)])
-        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[CAST($t0):SMALLINT NOT NULL], expr#4=[2], DEPTNO0=[$t3], EXPR$0=[$t4])
+EnumerableCalc(expr#0..11=[{inputs}], expr#12=[>($t7, $t8)], expr#13=[IS TRUE($t12)], expr#14=[IS NULL($t11)], expr#15=[0], expr#16=[=($t9, $t15)], expr#17=[OR($t14, $t16)], expr#18=[IS NOT TRUE($t17)], expr#19=[AND($t13, $t18)], expr#20=[>($t9, $t10)], expr#21=[IS TRUE($t20)], expr#22=[null:BOOLEAN], expr#23=[IS NOT TRUE($t12)], expr#24=[AND($t21, $t22, $t18, $t23)], expr#25=[IS NOT TRUE($t20)], expr#26=[AND($t12, $t18, $t23, $t25)], expr#27=[OR($t19, $t24, $t26)], EMPNO=[$t0], EXPR$1=[$t27])
+  EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
+    EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], proj#0..3=[{exprs}])
+      EnumerableAggregate(group=[{}], m=[MIN($0)], c=[COUNT()], d=[COUNT($0)])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[2], expr#4=[CAST($t0):SMALLINT NOT NULL], expr#5=[$cor0], expr#6=[$t5.EMPNO], expr#7=[=($t4, $t6)], EXPR$0=[$t3], $condition=[$t7])
           EnumerableTableScan(table=[[scott, DEPT]])
 !plan
  EMPNO | EXPR$1


### PR DESCRIPTION
In some case, the semantics of sql is changed after decorrelated, see [CALCIT-3495](https://issues.apache.org/jira/browse/CALCITE-3495) for detail.

This PR tries to fail  the decorrelation for this kind of sql.