### PR TITLE
[CALCITE-3595] Test infrastructure overwrites reference log with wrong results

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/DiffRepository.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffRepository.java
@@ -762,10 +762,10 @@ public class DiffRepository {
     DiffRepository diffRepository = MAP_CLASS_TO_REPOSITORY.get(clazz);
     if (diffRepository == null) {
       final URL refFile = findFile(clazz, ".xml");
+      final String refFilePath = Sources.of(refFile).file().getAbsolutePath();
       final File logFile =
-          new File(
-              Sources.of(refFile).file().getAbsolutePath()
-                  .replace("test-classes", "surefire"));
+          new File(refFilePath.replace(".xml", "_actual.xml"));
+      assert !refFilePath.equals(logFile.getAbsolutePath());
       diffRepository =
           new DiffRepository(refFile, logFile, baseRepository, filter);
       MAP_CLASS_TO_REPOSITORY.put(clazz, diffRepository);


### PR DESCRIPTION
See jira [CALCIT-3595](https://issues.apache.org/jira/browse/CALCITE-3595)