### PR TITLE
[CALCITE-3563] When resolving method call in calcite runtime, add type check and match mechanism for input arguments

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -23,10 +23,12 @@ import org.apache.calcite.linq4j.function.Function2;
 import org.apache.calcite.linq4j.function.Predicate2;
 import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.BlockStatement;
+import org.apache.calcite.linq4j.tree.ConstantExpression;
 import org.apache.calcite.linq4j.tree.ConstantUntypedNull;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.ExpressionType;
 import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.MethodCallExpression;
 import org.apache.calcite.linq4j.tree.MethodDeclaration;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
 import org.apache.calcite.linq4j.tree.Primitive;
@@ -52,6 +54,7 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -453,13 +456,7 @@ public class EnumUtils {
       if (fromPrimitive != null) {
         // E.g. from "int" to "BigDecimal".
         // Generate "new BigDecimal(x)"
-        // Fix CALCITE-2325, we should decide null here for int type.
-        return Expressions.condition(
-            Expressions.equal(operand, RexImpTable.NULL_EXPR),
-            RexImpTable.NULL_EXPR,
-            Expressions.new_(
-                BigDecimal.class,
-                operand));
+        return Expressions.new_(BigDecimal.class, operand);
       }
       // E.g. from "Object" to "BigDecimal".
       // Generate "x == null ? null : SqlFunctions.toBigDecimal(x)"
@@ -502,6 +499,14 @@ public class EnumUtils {
       } else {
         Expression result;
         try {
+          // Avoid to generate code like:
+          // "null.toString()"/"(xxx) null.toString()"
+          if (operand instanceof ConstantExpression) {
+            ConstantExpression ce = (ConstantExpression) operand;
+            if (ce.value == null) {
+              return Expressions.convert_(operand, toType);
+            }
+          }
           // Try to call "toString()" method
           // E.g. from "Integer" to "String"
           // Generate "x == null ? null : x.toString()"
@@ -576,11 +581,111 @@ public class EnumUtils {
    * Handle decimal type specifically with explicit type conversion
    */
   private static Expression convertAssignableType(
-      Expression argument,  Type targetType) {
+      Expression argument, Type targetType) {
     if (targetType != BigDecimal.class) {
       return argument;
     }
     return convert(argument, targetType);
+  }
+
+  public static MethodCallExpression call(Class clazz, String methodName,
+      List<? extends Expression> arguments) {
+    return call(clazz, methodName, arguments, null);
+  }
+
+  /**
+   * The powerful version of {@code org.apache.calcite.linq4j.tree.Expressions#call(
+   * Type, String, Iterable<? extends Expression>)}. Try best effort to convert the
+   * accepted arguments to match parameter type.
+   *
+   * @param clazz Class against which method is invoked
+   * @param methodName Name of method
+   * @param arguments argument expressions
+   * @param targetExpression target expression
+   *
+   * @return MethodCallExpression that call the given name method
+   * @throws RuntimeException if no suitable method found
+   */
+  public static MethodCallExpression call(Class clazz, String methodName,
+       List<? extends Expression> arguments, Expression targetExpression) {
+    Class[] argumentTypes = Types.toClassArray(arguments);
+    try {
+      Method candidate = clazz.getMethod(methodName, argumentTypes);
+      return Expressions.call(targetExpression, candidate, arguments);
+    } catch (NoSuchMethodException e) {
+      for (Method method : clazz.getMethods()) {
+        if (method.getName().equals(methodName)) {
+          final boolean varArgs = method.isVarArgs();
+          final Class[] parameterTypes = method.getParameterTypes();
+          if (Types.allAssignable(varArgs, parameterTypes, argumentTypes)) {
+            return Expressions.call(targetExpression, method, arguments);
+          }
+          // fall through
+          final List<? extends Expression> typeMatchedArguments =
+              matchMethodParameterTypes(varArgs, parameterTypes, arguments);
+          if (typeMatchedArguments != null) {
+            return Expressions.call(targetExpression, method, typeMatchedArguments);
+          }
+        }
+      }
+      throw new RuntimeException("while resolving method '" + methodName
+          + Arrays.toString(argumentTypes) + "' in class " + clazz, e);
+    }
+  }
+
+  private static List<? extends Expression> matchMethodParameterTypes(boolean varArgs,
+      Class[] parameterTypes, List<? extends Expression> arguments) {
+    if ((varArgs  && arguments.size() < parameterTypes.length - 1)
+        || (!varArgs && arguments.size() != parameterTypes.length)) {
+      return null;
+    }
+    final List<Expression> typeMatchedArguments = new ArrayList<>();
+    for (int i = 0; i < arguments.size(); i++) {
+      Class parameterType =
+          !varArgs || i < parameterTypes.length - 1
+              ? parameterTypes[i]
+              : Object.class;
+      final Expression typeMatchedArgument =
+          matchMethodParameterType(arguments.get(i), parameterType);
+      if (typeMatchedArgument == null) {
+        return null;
+      }
+      typeMatchedArguments.add(typeMatchedArgument);
+    }
+    return typeMatchedArguments;
+  }
+
+  /**
+   * Match an argument expression to method parameter type with best effort
+   * @param argument Argument Expression
+   * @param parameter Parameter type
+   * @return Converted argument expression that matches the parameter type.
+   *         Returns null if it is impossible to match.
+   */
+  private static Expression matchMethodParameterType(
+      Expression argument, Class parameter) {
+    Type argumentType = argument.getType();
+    if (Types.isAssignableFrom(parameter, argumentType)) {
+      return argument;
+    }
+    // Object.class is not assignable from primitive types,
+    // but the method with Object parameters can accept primitive types.
+    // E.g., "array(Object... args)" in SqlFunctions
+    if (parameter == Object.class
+        && Primitive.of(argumentType) != null) {
+      return argument;
+    }
+    // Convert argument with Object.class type to parameter explicitly
+    if (argumentType == Object.class
+        && Primitive.of(argumentType) == null) {
+      return convert(argument, parameter);
+    }
+    // assignable types that can be accepted with explicit conversion
+    if (parameter == BigDecimal.class
+        && Primitive.ofBoxOr(argumentType) != null) {
+      return convert(argument, parameter);
+    }
+    return null;
   }
 
   /** Transforms a JoinRelType to Linq4j JoinType. **/

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -2222,11 +2222,12 @@ public class RexImpTable {
         RexCall call,
         List<Expression> translatedOperands) {
       final Expression expression;
+      Class clazz = method.getDeclaringClass();
       if (Modifier.isStatic(method.getModifiers())) {
-        expression = Expressions.call(method, translatedOperands);
+        expression = EnumUtils.call(clazz, method.getName(), translatedOperands);
       } else {
-        expression = Expressions.call(translatedOperands.get(0), method,
-            Util.skip(translatedOperands, 1));
+        expression = EnumUtils.call(clazz, method.getName(),
+            Util.skip(translatedOperands, 1), translatedOperands.get(0));
       }
 
       final Type returnType =
@@ -2250,7 +2251,7 @@ public class RexImpTable {
         RexToLixTranslator translator,
         RexCall call,
         List<Expression> translatedOperands) {
-      return Expressions.call(
+      return EnumUtils.call(
           SqlFunctions.class,
           methodName,
           translatedOperands);

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -4246,6 +4246,20 @@ public class JdbcTest {
             "empid=110; commission=250; M=2");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3563">[CALCITE-3563]
+   * When resolving method call in calcite runtime, add type check and match
+   * mechanism for input arguments</a>. */
+  @Test public void testMethodParameterTypeMatch() {
+    CalciteAssert.that()
+        .query("SELECT mod(12.5, cast(3 as bigint))")
+        .planContains("final java.math.BigDecimal v = "
+            + "$L4J$C$new_java_math_BigDecimal_12_5_")
+        .planContains("org.apache.calcite.runtime.SqlFunctions.mod(v, "
+            + "$L4J$C$new_java_math_BigDecimal_3L_)")
+        .returns("EXPR$0=0.5\n");
+  }
+
   /** Tests UNBOUNDED PRECEDING clause. */
   @Test public void testSumOverUnboundedPreceding() {
     CalciteAssert.that()

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
@@ -156,7 +156,7 @@ public abstract class Types {
     return classes.toArray(new Class[0]);
   }
 
-  static Class[] toClassArray(Iterable<? extends Expression> arguments) {
+  public static Class[] toClassArray(Iterable<? extends Expression> arguments) {
     List<Class> classes = new ArrayList<>();
     for (Expression argument : arguments) {
       classes.add(toClass(argument.getType()));
@@ -255,7 +255,7 @@ public abstract class Types {
     return field(toClass(clazz).getFields()[ordinal]);
   }
 
-  static boolean allAssignable(boolean varArgs, Class[] parameterTypes,
+  public static boolean allAssignable(boolean varArgs, Class[] parameterTypes,
       Class[] argumentTypes) {
     if (varArgs) {
       if (argumentTypes.length < parameterTypes.length - 1) {


### PR DESCRIPTION
Current now, Calcite's runtime for method call is not efficient and "intelligent" enough. For some cases, a query run successfully just "by chance".

In general, there are mainly two approaches to implement a method call, `MethodImplementor` and `MethodNameImplementor`. `MethodImplementor` relies user-specified method with fixed parameter types, while `MethodNameImplementor` looks up an appropriate method according to method name and argument types dynamically. 

**Problems:**
(1) `MethodImplementor` skips to check argument types in runtime. Sometimes, the method called may be different with the one defined in BuiltInMethod. What's more, even the arguments are illegal, we can only get the exception in the compilation time after codegen. It is too late.

(2) `MethodNameImplementor` fails to find the suitable method in some cases. 
For example, the following test fails with exception
> java.lang.RuntimeException: while resolving method 'mod[class java.math.BigDecimal, long]' in class class org.apache.calcite.runtime.SqlFunctions

```
  @Test public void tes() {
    CalciteAssert.that()
        .query("SELECT mod(12.5, cast(3 as bigint))")
        .returns("EXPR$0=0.5\n");
  }
```
However, there is already a method `mod(decimal, decimal)` in SqlFunctions that can accept long typed argument. As we discussed in CALCITE-3565, though decimal type is assignable from other types, we need to make cast explicitly.

**This PR makes changes on:**
(1) A stronger interface for method call expression in Calcite core.
(2) Both `MethodImplementor` and `MethodNameImplementor` use this interface.
(3) Fix some trivial issues exposed during the implementation. 