### PR TITLE
[CALCITE-3620] Remove implicit lateral operator for temporal table join

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2023,10 +2023,7 @@ SqlNode TableRef2(boolean lateral) :
             }
         }
         [
-            snapshot = Snapshot(tableRef) {
-                tableRef = SqlStdOperatorTable.LATERAL.createCall(
-                    getPos(), snapshot);
-            }
+            tableRef = Snapshot(tableRef)
         ]
         [
             tableRef = MatchRecognize(tableRef)
@@ -2695,7 +2692,16 @@ SqlSnapshot Snapshot(SqlNode tableRef) :
     final SqlNode e;
 }
 {
-    <FOR> { s = span(); } <SYSTEM_TIME> <AS> <OF>
+    { s = span(); } <FOR> <SYSTEM_TIME> <AS> <OF>
+    // Syntax for temporal table in
+    // standard SQL 2011 IWD 9075-2:201?(E) 7.6 <table reference>
+    // supports grammar as following:
+    // 1. datetime literal
+    // 2. datetime value function, i.e. CURRENT_TIMESTAMP
+    // 3. datetime term in 1 or 2 +(or -) interval term
+
+    // We extend to support column reference, use Expression
+    // to simplify the parsing code.
     e = Expression(ExprContext.ACCEPT_NON_QUERY) {
         return new SqlSnapshot(s.end(this), tableRef, e);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlLateralOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLateralOperator.java
@@ -40,16 +40,12 @@ public class SqlLateralOperator extends SqlSpecialOperator {
       int rightPrec) {
     final Set<SqlKind> specialOperandKinds = ImmutableSet.of(
         SqlKind.COLLECTION_TABLE,
-        SqlKind.SNAPSHOT,
         SqlKind.SELECT,
         SqlKind.AS);
     if (call.operandCount() == 1
         && specialOperandKinds.contains(call.operand(0).getKind())) {
-      if (call.operand(0).getKind() != SqlKind.SNAPSHOT) {
-        // 1. Do not create ( ) around the following TABLE clause.
-        // 2. Do not print LATERAL keyword for snapshot table.
-        writer.keyword(getName());
-      }
+      // Do not create ( ) around the following TABLE clause.
+      writer.keyword(getName());
       call.operand(0).unparse(writer, 0, 0);
     } else {
       SqlUtil.unparseFunctionSyntax(this, writer, call);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2103,7 +2103,7 @@ public class SqlToRelConverter {
       return;
 
     case SNAPSHOT:
-      snapshotTemporalTable(bb, (SqlCall) from);
+      convertTemporalTable(bb, (SqlCall) from);
       return;
 
     case JOIN:
@@ -2474,7 +2474,7 @@ public class SqlToRelConverter {
       LogicalTableFunctionScan callRel) {
   }
 
-  private void snapshotTemporalTable(Blackboard bb, SqlCall call) {
+  private void convertTemporalTable(Blackboard bb, SqlCall call) {
     final SqlSnapshot snapshot = (SqlSnapshot) call;
     final RexNode period = bb.convertExpression(snapshot.getPeriod());
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -3488,8 +3488,8 @@ public class SqlParserTest {
     // Can not use explicit LATERAL keyword.
     final String sql1 = "select stream * from orders, LATERAL ^products_temporal^\n"
         + "for system_time as of TIMESTAMP '2011-01-02 00:00:00'";
-    final String expected1 = "(?s)Encountered \"products_temporal\" at line .*";
-    sql(sql1).fails(expected1);
+    final String error = "(?s)Encountered \"products_temporal\" at line .*";
+    sql(sql1).fails(error);
 
     // Inner join with a specific timestamp
     final String sql2 = "select stream * from orders join products_temporal\n"
@@ -3502,7 +3502,7 @@ public class SqlParserTest {
         + "ON (`ORDERS`.`PRODUCTID` = `PRODUCTS_TEMPORAL`.`PRODUCTID`)";
     sql(sql2).ok(expected2);
 
-    // Left join with a timestamp expression
+    // Left join with a timestamp field
     final String sql3 = "select stream * from orders left join products_temporal\n"
         + "for system_time as of orders.rowtime "
         + "on orders.productid = products_temporal.productid";
@@ -3512,6 +3512,17 @@ public class SqlParserTest {
         + "FOR SYSTEM_TIME AS OF `ORDERS`.`ROWTIME` "
         + "ON (`ORDERS`.`PRODUCTID` = `PRODUCTS_TEMPORAL`.`PRODUCTID`)";
     sql(sql3).ok(expected3);
+
+    // Left join with a timestamp expression
+    final String sql4 = "select stream * from orders left join products_temporal\n"
+        + "for system_time as of orders.rowtime - INTERVAL '3' DAY "
+        + "on orders.productid = products_temporal.productid";
+    final String expected4 = "SELECT STREAM *\n"
+        + "FROM `ORDERS`\n"
+        + "LEFT JOIN `PRODUCTS_TEMPORAL` "
+        + "FOR SYSTEM_TIME AS OF (`ORDERS`.`ROWTIME` - INTERVAL '3' DAY) "
+        + "ON (`ORDERS`.`PRODUCTID` = `PRODUCTS_TEMPORAL`.`PRODUCTID`)";
+    sql(sql4).ok(expected4);
   }
 
   @Test public void testCollectionTableWithLateral() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7994,9 +7994,19 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "for system_time as of timestamp '2011-01-02 00:00:00' "
         + "on orders.productid = products_temporal.productid").ok();
 
-    // verify left join with a timestamp expression
+    // verify left join with a timestamp field
     sql("select stream * from orders left join products_temporal "
         + "for system_time as of orders.rowtime "
+        + "on orders.productid = products_temporal.productid").ok();
+
+    // verify left join with a timestamp expression
+    sql("select stream * from orders left join products_temporal\n"
+        + "for system_time as of orders.rowtime - INTERVAL '3' DAY\n"
+        + "on orders.productid = products_temporal.productid").ok();
+
+    // verify left join with a datetime value function
+    sql("select stream * from orders left join products_temporal\n"
+        + "for system_time as of CURRENT_TIMESTAMP\n"
         + "on orders.productid = products_temporal.productid").ok();
   }
 


### PR DESCRIPTION
* Remove the SqlLateralOperator instantiation for temporal table join;
* Remove SNAPSHOT node match for SqlLateralOperator;
* In SqlValidatorImpl, fix the scope of SNAPSHOT node.