### PR TITLE
[CALCITE-3601] Update elasticsearch tests upgrade from junit4 to junit5

### DIFF
--- a/elasticsearch/gradle.properties
+++ b/elasticsearch/gradle.properties
@@ -16,5 +16,3 @@
 #
 description=Elasticsearch adapter for Calcite
 artifact.name=Calcite Elasticsearch
-# JUnit4 use is allowed until the rest of the tests are migrated to JUnit5
-junit4=true

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
@@ -28,9 +28,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -47,14 +47,13 @@ import java.util.Map;
  */
 public class AggregationTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
 
   private static final String NAME = "aggs";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupInstance() throws Exception {
-
     final Map<String, String> mappings = ImmutableMap.<String, String>builder()
         .put("cat1", "keyword")
         .put("cat2", "keyword")

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
@@ -25,9 +25,9 @@ import org.apache.calcite.test.CalciteAssert;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -42,7 +42,7 @@ import java.util.Map;
  */
 public class BooleanLogicTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
 
   private static final String NAME = "docs";
@@ -51,7 +51,7 @@ public class BooleanLogicTest {
    * Used to create {@code zips} index and insert some data
    * @throws Exception when ES node setup failed
    */
-  @BeforeClass
+  @BeforeAll
   public static void setupInstance() throws Exception {
 
     final Map<String, String> mapping = ImmutableMap.of("a", "keyword", "b", "keyword",

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -30,9 +30,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -55,7 +55,7 @@ import java.util.function.Consumer;
  */
 public class ElasticSearchAdapterTest {
 
-  @ClassRule //init once for all tests
+  @RegisterExtension //init once for all tests
   public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
 
   /** Default index/type name */
@@ -66,7 +66,7 @@ public class ElasticSearchAdapterTest {
    * Used to create {@code zips} index and insert zip data in bulk.
    * @throws Exception when instance setup failed
    */
-  @BeforeClass
+  @BeforeAll
   public static void setupInstance() throws Exception {
     final Map<String, String> mapping = ImmutableMap.of("city", "keyword", "state",
         "keyword", "pop", "long");

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
@@ -81,6 +81,10 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
     node.start();
   }
 
+  @Override public void afterAll(ExtensionContext context) throws Exception {
+    node.close();
+  }
+
   /**
    * Factory method to create this rule.
    * @return managed resource to be used in unit tests
@@ -211,9 +215,5 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
    */
   private TransportAddress httpAddress() {
     return node.httpAddress();
-  }
-
-  @Override public void afterAll(ExtensionContext context) throws Exception {
-    node.close();
   }
 }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
@@ -77,6 +77,10 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
     closer.add(node);
   }
 
+  @Override public void beforeAll(ExtensionContext context) {
+    node.start();
+  }
+
   /**
    * Factory method to create this rule.
    * @return managed resource to be used in unit tests
@@ -211,9 +215,5 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
 
   @Override public void afterAll(ExtensionContext context) throws Exception {
     node.close();
-  }
-
-  @Override public void beforeAll(ExtensionContext context) {
-    node.start();
   }
 }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
@@ -79,7 +79,6 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
 
   /**
    * Factory method to create this rule.
-   *
    * @return managed resource to be used in unit tests
    */
   public static EmbeddedElasticsearchPolicy create() {
@@ -98,7 +97,7 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
    *  }
    * </pre>
    *
-   * @param index   index of the index
+   * @param index index of the index
    * @param mapping field and field type mapping
    * @throws IOException if there is an error
    */
@@ -109,7 +108,7 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
     ObjectNode mappings = mapper().createObjectNode();
 
     ObjectNode properties = mappings.with("mappings").with("properties");
-    for (Map.Entry<String, String> entry : mapping.entrySet()) {
+    for (Map.Entry<String, String> entry: mapping.entrySet()) {
       applyMapping(properties, entry.getKey(), entry.getValue());
     }
 
@@ -125,13 +124,13 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
    * Creates nested mappings for an index. This function is called recursively for each level.
    *
    * @param parent current parent
-   * @param key    field name
-   * @param type   ES mapping type ({@code keyword}, {@code long} etc.)
+   * @param key field name
+   * @param type ES mapping type ({@code keyword}, {@code long} etc.)
    */
   private static void applyMapping(ObjectNode parent, String key, String type) {
     final int index = key.indexOf('.');
     if (index > -1) {
-      String prefix = key.substring(0, index);
+      String prefix  = key.substring(0, index);
       String suffix = key.substring(index + 1, key.length());
       applyMapping(parent.with(prefix).with("properties"), suffix, type);
     } else {
@@ -143,7 +142,7 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
     Objects.requireNonNull(index, "index");
     Objects.requireNonNull(document, "document");
     String uri = String.format(Locale.ROOT,
-        "/%s/_doc?refresh", index);
+          "/%s/_doc?refresh", index);
     StringEntity entity = new StringEntity(mapper().writeValueAsString(document),
         ContentType.APPLICATION_JSON);
     final Request r = new Request("POST", uri);
@@ -161,7 +160,7 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
     }
 
     List<String> bulk = new ArrayList<>(documents.size() * 2);
-    for (ObjectNode doc : documents) {
+    for (ObjectNode doc: documents) {
       bulk.add(String.format(Locale.ROOT, "{\"index\": {\"_index\":\"%s\"}}", index));
       bulk.add(mapper().writeValueAsString(doc));
     }
@@ -176,7 +175,6 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
 
   /**
    * Exposes Jackson API to be used to parse search results.
-   *
    * @return existing instance of ObjectMapper
    */
   ObjectMapper mapper() {
@@ -185,7 +183,6 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
 
   /**
    * Low-level http rest client connected to current embedded elastic search instance.
-   *
    * @return http client connected to ES cluster
    */
   RestClient restClient() {
@@ -206,7 +203,6 @@ class EmbeddedElasticsearchPolicy implements BeforeAllCallback, AfterAllCallback
 
   /**
    * HTTP address for rest clients (can be ES native or any other).
-   *
    * @return http address to connect to
    */
   private TransportAddress httpAddress() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
@@ -44,9 +44,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -63,13 +63,14 @@ import java.util.Map;
 import static org.apache.calcite.test.Matchers.hasTree;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Testing Elasticsearch match query.
  */
 public class MatchTest {
 
-  @ClassRule //init once for all tests
+  @RegisterExtension //init once for all tests
   public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
 
   /** Default index/type name */
@@ -80,7 +81,7 @@ public class MatchTest {
    * Used to create {@code zips} index and insert zip data in bulk.
    * @throws Exception when instance setup failed
    */
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     final Map<String, String> mapping = ImmutableMap.of("city", "text", "state",
         "keyword", "pop", "long");

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
@@ -27,9 +27,9 @@ import org.apache.calcite.util.TestUtil;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -42,20 +42,21 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.PatternSyntaxException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 
 /**
  * Checks renaming of fields (also upper, lower cases) during projections
  */
 public class Projection2Test {
 
-  @ClassRule
+  @RegisterExtension
   public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
 
   private static final String NAME = "nested";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupInstance() throws Exception {
 
     final Map<String, String> mappings = ImmutableMap.of("a", "long",

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ProjectionTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ProjectionTest.java
@@ -25,9 +25,9 @@ import org.apache.calcite.test.CalciteAssert;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -42,12 +42,12 @@ import java.util.Map;
  */
 public class ProjectionTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
 
   private static final String NAME = "docs";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupInstance() throws Exception {
 
     final Map<String, String> mappings = ImmutableMap.of("A", "keyword",

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ScrollingTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ScrollingTest.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,13 +47,13 @@ import java.util.stream.IntStream;
  */
 public class ScrollingTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
 
   private static final String NAME = "scroll";
   private static final int SIZE = 10;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupInstance() throws Exception {
     NODE.createIndex(NAME, Collections.singletonMap("value", "long"));
     final List<ObjectNode> docs = new ArrayList<>();


### PR DESCRIPTION
As illustrated in CALCITE-3601
Update `elasticsearch` tests upgrade from junit4 to junit5.