### PR TITLE
[CALCITE-3622] Update geode tests upgrade from junit4 to junit5

### DIFF
--- a/geode/src/test/java/org/apache/calcite/adapter/geode/rel/AbstractGeodeTest.java
+++ b/geode/src/test/java/org/apache/calcite/adapter/geode/rel/AbstractGeodeTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.calcite.adapter.geode.rel;
 
-import org.junit.ClassRule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Base class that allows sharing same geode instance across all tests.
@@ -26,7 +26,7 @@ import org.junit.ClassRule;
  */
 public abstract class AbstractGeodeTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final GeodeEmbeddedPolicy POLICY = GeodeEmbeddedPolicy.create().share();
 
 }

--- a/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeAllDataTypesTest.java
+++ b/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeAllDataTypesTest.java
@@ -26,8 +26,8 @@ import org.apache.geode.cache.Region;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.Date;
@@ -44,7 +44,7 @@ import java.util.Map;
  */
 public class GeodeAllDataTypesTest extends AbstractGeodeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     final Cache cache = POLICY.cache();
     final Region<?, ?> region =

--- a/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeBookstoreTest.java
+++ b/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeBookstoreTest.java
@@ -23,8 +23,8 @@ import org.apache.calcite.test.CalciteAssert;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -36,7 +36,7 @@ import java.util.Arrays;
  */
 public class GeodeBookstoreTest extends AbstractGeodeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Cache cache = POLICY.cache();
     Region<?, ?> bookMaster =  cache.<String, Object>createRegionFactory().create("BookMaster");

--- a/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeZipsTest.java
+++ b/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeZipsTest.java
@@ -29,9 +29,9 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.StructImpl;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  */
 public class GeodeZipsTest extends AbstractGeodeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Cache cache = POLICY.cache();
     Region<?, ?> region =  cache.<String, Object>createRegionFactory().create("zips");
@@ -92,7 +92,7 @@ public class GeodeZipsTest extends AbstractGeodeTest {
                 + "SUM(pop) AS EXPR$1 FROM /zips GROUP BY state"));
   }
 
-  @Test @Ignore("Currently fails")
+  @Test @Disabled("Currently fails")
   public void testGroupByViewWithAliases() {
     calciteAssert()
         .query("SELECT state as st, SUM(pop) po "
@@ -134,7 +134,7 @@ public class GeodeZipsTest extends AbstractGeodeTest {
         .queryContains(GeodeAssertions.query("SELECT MAX(pop) AS EXPR$0 FROM /zips"));
   }
 
-  @Test @Ignore("Currently fails")
+  @Test @Disabled("Currently fails")
   public void testJoin() {
     calciteAssert()
         .query("SELECT r._id FROM geode.zips AS v "
@@ -266,7 +266,7 @@ public class GeodeZipsTest extends AbstractGeodeTest {
             GeodeAssertions.query(expectedQuery));
   }
 
-  @Test @Ignore("Currently fails")
+  @Test @Disabled("Currently fails")
   public void testWhereWithOrWithEmptyResult() {
     String expectedQuery = "SELECT state AS state FROM /zips "
         + "WHERE state IN SET('', true, false, 123, 13.892)";


### PR DESCRIPTION
As illustrated in CALCITE-3622
Update `geode` tests upgrade from junit4 to junit5.