### PR TITLE
[CALCITE-3627] Incorrect null semantic for ROW function

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/NullPolicy.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/NullPolicy.java
@@ -31,6 +31,8 @@ public enum NullPolicy {
   SEMI_STRICT,
   /** If any of the arguments are null, return null. */
   ANY,
+  /** If all of the arguments are null, return null. */
+  ALL,
   /** If the first argument is null, return null. */
   ARG0,
   /** If any of the arguments are false, result is false; else if any


### PR DESCRIPTION
As illustrated in [CALCITE-3627](https://issues.apache.org/jira/browse/CALCITE-3627)
This PR:
(1) allows `ROW` function's return type can be nullable;
(2) introduces a new NullPolicy (`ALL`) to implements the special semantic.