### PR TITLE
[CALCITE-3625] Update mongo tests upgrade from junit4 to junit5

### DIFF
--- a/mongodb/gradle.properties
+++ b/mongodb/gradle.properties
@@ -16,5 +16,3 @@
 #
 description=MongoDB adapter for Calcite
 artifact.name=Calcite MongoDB
-# JUnit4 use is allowed until the rest of the tests are migrated to JUnit5
-junit4=true

--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -38,10 +38,10 @@ import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.json.JsonWriterSettings;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -81,12 +81,12 @@ public class MongoAdapterTest implements SchemaFactory {
   /** Number of records in local file */
   protected static final int ZIPS_SIZE = 149;
 
-  @ClassRule
+  @RegisterExtension
   public static final MongoDatabasePolicy POLICY = MongoDatabasePolicy.create();
 
   private static MongoSchema schema;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     MongoDatabase database = POLICY.database();
 
@@ -207,7 +207,7 @@ public class MongoAdapterTest implements SchemaFactory {
                 "{$project: {STATE: '$state', ID: '$_id'}}"));
   }
 
-  @Ignore
+  @Disabled
   @Test public void testFilterSort() {
     // LONGITUDE and LATITUDE are null because of CALCITE-194.
     Util.discard(Bug.CALCITE_194_FIXED);
@@ -253,7 +253,7 @@ public class MongoAdapterTest implements SchemaFactory {
             "CITY=LAWTON; LONGITUDE=null; LATITUDE=null; POP=45542; STATE=OK; ID=73505");
   }
 
-  @Ignore("broken; [CALCITE-2115] is logged to fix it")
+  @Disabled("broken; [CALCITE-2115] is logged to fix it")
   @Test public void testUnionPlan() {
     assertModel(MODEL)
         .query("select * from \"sales_fact_1997\"\n"
@@ -272,7 +272,7 @@ public class MongoAdapterTest implements SchemaFactory {
                 "product_id=337", "product_id=1512"));
   }
 
-  @Ignore(
+  @Disabled(
       "java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Double")
   @Test public void testFilterUnionPlan() {
     assertModel(MODEL)
@@ -501,7 +501,7 @@ public class MongoAdapterTest implements SchemaFactory {
                 "{$sort: {STATE: 1}}"));
   }
 
-  @Ignore("https://issues.apache.org/jira/browse/CALCITE-270")
+  @Disabled("https://issues.apache.org/jira/browse/CALCITE-270")
   @Test public void testGroupByHaving2() {
     assertModel(MODEL)
         .query("select state, count(*) as c from zips\n"
@@ -560,7 +560,7 @@ public class MongoAdapterTest implements SchemaFactory {
                 "{$project: {C: 1, STATE: 1, CITY: 1}}"));
   }
 
-  @Ignore("broken; [CALCITE-2115] is logged to fix it")
+  @Disabled("broken; [CALCITE-2115] is logged to fix it")
   @Test public void testDistinctCount() {
     assertModel(MODEL)
         .query("select state, count(distinct city) as cdc from zips\n"
@@ -612,7 +612,7 @@ public class MongoAdapterTest implements SchemaFactory {
                 "{$limit: 5}"));
   }
 
-  @Ignore("broken; [CALCITE-2115] is logged to fix it")
+  @Disabled("broken; [CALCITE-2115] is logged to fix it")
   @Test public void testProject() {
     assertModel(MODEL)
         .query("select state, city, 0 as zero from zips order by state, city")

--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoDatabasePolicy.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoDatabasePolicy.java
@@ -22,7 +22,8 @@ import org.apache.calcite.util.Closer;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.Closeable;
 import java.net.InetSocketAddress;
@@ -42,7 +43,7 @@ import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
  * {@code $ mvn -Pit install}) this rule will connect to an existing (external)
  * Mongo instance ({@code localhost}).
  */
-class MongoDatabasePolicy extends ExternalResource {
+class MongoDatabasePolicy implements AfterAllCallback {
 
   private static final String DB_NAME = "test";
 
@@ -55,6 +56,10 @@ class MongoDatabasePolicy extends ExternalResource {
     this.database = client.getDatabase(DB_NAME);
     this.closer = Objects.requireNonNull(closer, "closer");
     closer.add(client::close);
+  }
+
+  @Override public void afterAll(ExtensionContext context) {
+    closer.close();
   }
 
   /**
@@ -81,13 +86,7 @@ class MongoDatabasePolicy extends ExternalResource {
     return new MongoDatabasePolicy(client, closer);
   }
 
-
   MongoDatabase database() {
     return database;
   }
-
-  @Override protected void after() {
-    closer.close();
-  }
-
 }

--- a/mongodb/src/test/java/org/apache/calcite/test/MongoAssertions.java
+++ b/mongodb/src/test/java/org/apache/calcite/test/MongoAssertions.java
@@ -31,7 +31,8 @@ import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 
 /**
  * Util class which needs to be in the same package as {@link CalciteAssert}
@@ -102,6 +103,6 @@ public class MongoAssertions {
    * @see <a href="https://github.com/fakemongo/fongo/issues/152">Aggregation with $cond (172)</a>
    */
   public static void assumeRealMongoInstance() {
-    assumeTrue("Expect mongo instance", useMongo());
+    assumeTrue(useMongo(), "Expect mongo instance");
   }
 }


### PR DESCRIPTION
As illustrated in CALCITE-3625
Update `mongo` tests upgrade from junit4 to junit5.