### PR TITLE
hint should appear in setOperand

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
@@ -127,6 +127,9 @@ public class SqlSelect extends SqlCall {
     case 9:
       fetch = operand;
       break;
+    case 10:
+      hints = (SqlNodeList) operand;
+      break;
     default:
       throw new AssertionError(i);
     }


### PR DESCRIPTION
Because the hint already appera in getOperandList , so it also should be in setOperand.