### PR TITLE
[CALCITE-2450] Normalize RexCall predicates when computing digest

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -96,6 +96,13 @@ public final class CalciteSystemProperty<T> {
       booleanProperty("calcite.enable.stream", true);
 
   /**
+   * Whether RexNode digest should be normalized (e.g. call operands ordered).
+   * <p>Normalization helps to treat $0=$1 and $1=$0 expressions equal, thus it saves efforts
+   * on planning.</p> */
+  public static final CalciteSystemProperty<Boolean> ENABLE_REX_DIGEST_NORMALIZE =
+      booleanProperty("calcite.enable.rexnode.digest.normalize", true);
+
+  /**
    *  Whether to follow the SQL standard strictly.
    */
   public static final CalciteSystemProperty<Boolean> STRICT =

--- a/core/src/main/java/org/apache/calcite/rel/RelWriter.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelWriter.java
@@ -16,8 +16,11 @@
  */
 package org.apache.calcite.rel;
 
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.util.Pair;
+
+import org.apiguardian.api.API;
 
 import java.util.List;
 
@@ -84,5 +87,17 @@ public interface RelWriter {
    */
   default boolean nest() {
     return false;
+  }
+
+  /**
+   * Activates {@link RexNode} normalization if {@link SqlExplainLevel#DIGEST_ATTRIBUTES} is used.
+   * Note: the returned value must be closed, and the API is designed to be used with a
+   * try-with-resources.
+   * @return a handle that should be closed to revert normalization state
+   */
+  @API(since = "1.22", status = API.Status.EXPERIMENTAL)
+  default RexNode.Closeable withRexNormalize() {
+    boolean needNormalize = getDetailLevel() == SqlExplainLevel.DIGEST_ATTRIBUTES;
+    return RexNode.withNormalize(needNormalize);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonWriter.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonWriter.java
@@ -18,6 +18,7 @@ package org.apache.calcite.rel.externalize;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.util.JsonBuilder;
 import org.apache.calcite.util.Pair;
@@ -140,6 +141,8 @@ public class RelJsonWriter implements RelWriter {
   public String asString() {
     final Map<String, Object> map = jsonBuilder.map();
     map.put("rels", relList);
-    return jsonBuilder.toJsonString(map);
+    try (RexNode.Closeable ignored = withRexNormalize()) {
+      return jsonBuilder.toJsonString(map);
+    }
   }
 }

--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -28,6 +28,8 @@ import org.apache.calcite.util.Litmus;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
@@ -51,6 +53,13 @@ import javax.annotation.Nonnull;
  * no one is going to be generating source code from this tree.)</p>
  */
 public class RexCall extends RexNode {
+  /**
+   * Sort shorter digests first, then order by string representation.
+   * The result is designed for consistent output and better readability.
+   */
+  private static final Comparator<String> OPERAND_READABILITY_COMPARATOR =
+      Comparator.comparing(String::length).thenComparing(Comparator.naturalOrder());
+
   //~ Instance fields --------------------------------------------------------
 
   public final SqlOperator op;
@@ -100,13 +109,14 @@ public class RexCall extends RexNode {
    * @return original StringBuilder for fluent API
    */
   protected final StringBuilder appendOperands(StringBuilder sb) {
+    if (operands.isEmpty()) {
+      return sb;
+    }
+    List<String> operandDigests = new ArrayList<>(operands.size());
     for (int i = 0; i < operands.size(); i++) {
-      if (i > 0) {
-        sb.append(", ");
-      }
       RexNode operand = operands.get(i);
       if (!(operand instanceof RexLiteral)) {
-        sb.append(operand);
+        operandDigests.add(operand.toString());
         continue;
       }
       // Type information might be omitted in certain cases to improve readability
@@ -127,9 +137,87 @@ public class RexCall extends RexNode {
           includeType = RexDigestIncludeType.NO_TYPE;
         }
       }
-      sb.append(((RexLiteral) operand).computeDigest(includeType));
+      operandDigests.add(((RexLiteral) operand).computeDigest(includeType));
+    }
+    int totalLength = (operandDigests.size() - 1) * 2; // commas
+    for (String s : operandDigests) {
+      totalLength += s.length();
+    }
+    sb.ensureCapacity(sb.length() + totalLength);
+    sortOperandsIfNeeded(sb, operands, operandDigests);
+    for (int i = 0; i < operandDigests.size(); i++) {
+      String op = operandDigests.get(i);
+      if (i != 0) {
+        sb.append(", ");
+      }
+      sb.append(op);
     }
     return sb;
+  }
+
+  private void sortOperandsIfNeeded(StringBuilder sb,
+      List<RexNode> operands, List<String> operandDigests) {
+    if (operands.isEmpty() || !needNormalize()) {
+      return;
+    }
+    final SqlKind kind = op.getKind();
+    if (SqlKind.SYMMETRICAL_SAME_ARG_TYPE.contains(kind)) {
+      final RelDataType firstType = operands.get(0).getType();
+      for (int i = 1; i < operands.size(); i++) {
+        if (!equalSansNullability(firstType, operands.get(i).getType())) {
+          // Arguments have different type, thus they must not be sorted
+          return;
+        }
+      }
+      // fall through: order arguments below
+    } else if (!SqlKind.SYMMETRICAL.contains(kind)
+        && (kind == kind.reverse()
+        || !op.getName().equals(kind.sql)
+        || sb.length() < kind.sql.length() + 1
+        || sb.charAt(sb.length() - 1) != '(')) {
+      // The operations have to be either symmetrical or reversible
+      // Nothing matched => we skip argument sorting
+      // Note: RexCall digest uses op.getName() that might be different from kind.sql
+      // for certain calls. So we skip normalizing the calls that have customized op.getName()
+      // We ensure the current string contains enough room for preceding kind.sql otherwise
+      // we won't have an option to replace the operator to reverse it in case the operands are
+      // reordered.
+      return;
+    }
+    // $0=$1 is the same as $1=$0, so we make sure the digest is the same for them
+    String oldFirstArg = operandDigests.get(0);
+    operandDigests.sort(OPERAND_READABILITY_COMPARATOR);
+
+    // When $1 > $0 is normalized, the operation needs to be flipped
+    // So we sort arguments first, then flip the sign
+    if (kind != kind.reverse()) {
+      assert operands.size() == 2
+          : "Compare operation must have 2 arguments: " + this
+          + ". Actual arguments are " + operandDigests;
+      int operatorEnd = sb.length() - 1 /* ( */;
+      int operatorStart = operatorEnd - op.getName().length();
+      assert op.getName().contentEquals(sb.subSequence(operatorStart, operatorEnd))
+          : "Operation name must precede opening brace like in <=(x, y). Actual content is "
+          + sb.subSequence(operatorStart, operatorEnd)
+          + " at position " + operatorStart + " in " + sb;
+
+      SqlKind newKind = kind.reverse();
+
+      // If arguments are the same, then we normalize < vs >
+      // '<' == 60, '>' == 62, so we prefer <
+      if (operandDigests.get(0).equals(operandDigests.get(1))) {
+        if (newKind.compareTo(kind) > 0) {
+          // If reverse kind is greater, then skip reversing
+          return;
+        }
+      } else if (oldFirstArg.equals(operandDigests.get(0))) {
+        // The sorting did not shuffle the operands, so we do not need to update operation name
+        // in the digest
+        return;
+      }
+      // Replace operator name in the digest
+      sb.replace(operatorStart, operatorEnd, newKind.sql);
+    }
   }
 
   /**
@@ -177,14 +265,21 @@ public class RexCall extends RexNode {
   }
 
   @Override public final @Nonnull String toString() {
+    if (!needNormalize()) {
+      // Non-normalize describe is requested
+      return computeDigest(digestWithType());
+    }
     // This data race is intentional
     String localDigest = digest;
     if (localDigest == null) {
-      localDigest = computeDigest(
-          isA(SqlKind.CAST) || isA(SqlKind.NEW_SPECIFICATION));
+      localDigest = computeDigest(digestWithType());
       digest = Objects.requireNonNull(localDigest);
     }
     return localDigest;
+  }
+
+  private boolean digestWithType() {
+    return isA(SqlKind.CAST) || isA(SqlKind.NEW_SPECIFICATION);
   }
 
   public <R> R accept(RexVisitor<R> visitor) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.sql;
 
+import org.apiguardian.api.API;
+
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Locale;
@@ -1339,6 +1341,29 @@ public enum SqlKind {
           GREATER_THAN, GREATER_THAN_OR_EQUAL,
           LESS_THAN, LESS_THAN_OR_EQUAL,
           IS_DISTINCT_FROM, IS_NOT_DISTINCT_FROM);
+
+  /**
+   * Category of operators that do not depend on the argument order.
+   *
+   * <p>For instance: {@link #AND}, {@link #OR}, {@link #EQUALS}, {@link #LEAST}</p>
+   * <p>Note: {@link #PLUS} does depend on the argument oder if argument types are different</p>
+   */
+  @API(since = "1.22", status = API.Status.EXPERIMENTAL)
+  public static final Set<SqlKind> SYMMETRICAL =
+      EnumSet.of(
+          AND, OR, EQUALS, NOT_EQUALS,
+          IS_DISTINCT_FROM, IS_NOT_DISTINCT_FROM,
+          GREATEST, LEAST);
+
+  /**
+   * Category of operators that do not depend on the argument order if argument types are equal.
+   *
+   * <p>For instance: {@link #PLUS}, {@link #TIMES}</p>
+   */
+  @API(since = "1.22", status = API.Status.EXPERIMENTAL)
+  public static final Set<SqlKind> SYMMETRICAL_SAME_ARG_TYPE =
+      EnumSet.of(
+          PLUS, TIMES);
 
   /** Lower-case name. */
   public final String lowerName = name().toLowerCase(Locale.ROOT);

--- a/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
@@ -668,12 +668,12 @@ public class LatticeSuggesterTest {
     t.addQuery(q0);
     assertThat(t.s.latticeMap.size(), is(1));
     assertThat(t.s.latticeMap.keySet().iterator().next(),
-        is("sales_fact_1997 (customer:+($2, 2)):[MIN(customer.fname)]"));
+        is("sales_fact_1997 (customer:+(2, $2)):[MIN(customer.fname)]"));
     assertThat(t.s.space.g.toString(),
         is("graph(vertices: [[foodmart, customer],"
             + " [foodmart, sales_fact_1997]], "
             + "edges: [Step([foodmart, sales_fact_1997],"
-            + " [foodmart, customer], +($2, 2):+($0, 1))])"));
+            + " [foodmart, customer], +(2, $2):+(1, $0))])"));
   }
 
   /** Tests that we can run the suggester against non-JDBC schemas.

--- a/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
@@ -700,9 +700,9 @@ public class DateRangeRulesTest {
   private void checkDateRange(Fixture f, RexNode e, String timeZone,
       Matcher<String> matcher, Matcher<String> simplifyMatcher) {
     e = DateRangeRules.replaceTimeUnits(f.rexBuilder, e, timeZone);
-    assertThat(e.toString(), matcher);
+    assertThat(e.toStringRaw(), matcher);
     final RexNode e2 = f.simplify.simplify(e);
-    assertThat(e2.toString(), simplifyMatcher);
+    assertThat(e2.toStringRaw(), simplifyMatcher);
   }
 
   /** Common expressions across tests. */

--- a/core/src/test/java/org/apache/calcite/rex/RexCallNormalizationTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexCallNormalizationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rex;
+
+import org.junit.jupiter.api.Test;
+
+public class RexCallNormalizationTest extends RexProgramTestBase {
+  @Test public void digestIsNormalized() {
+    final RexNode node = and(or(vBool(1), vBool()), vBool());
+    checkDigest(node, "AND(?0.bool0, OR(?0.bool0, ?0.bool1))");
+    checkRaw(node, "AND(OR(?0.bool1, ?0.bool0), ?0.bool0)");
+
+    checkDigest(eq(vVarchar(), literal("0123456789012345")),
+        "=(?0.varchar0, '0123456789012345')");
+    checkDigest(eq(vVarchar(), literal("01")), "=('01', ?0.varchar0)");
+  }
+
+  @Test public void skipNormalizationWorks() {
+    final RexNode node = and(or(vBool(1), vBool()), vBool());
+    try (RexNode.Closeable ignored = RexNode.skipNormalize()) {
+      checkDigest(node, "AND(OR(?0.bool1, ?0.bool0), ?0.bool0)");
+      checkRaw(node, "AND(OR(?0.bool1, ?0.bool0), ?0.bool0)");
+    }
+  }
+
+  @Test public void skipNormalizeWorks() {
+    checkDigest(and(or(vBool(1), vBool()), vBool()),
+        "AND(?0.bool0, OR(?0.bool0, ?0.bool1))");
+  }
+
+  @Test public void reversibleSameArgOpsNormalizedToLess() {
+    checkDigest(lt(vBool(), vBool()), "<(?0.bool0, ?0.bool0)");
+    checkDigest(gt(vBool(), vBool()), "<(?0.bool0, ?0.bool0)");
+    checkDigest(le(vBool(), vBool()), "<=(?0.bool0, ?0.bool0)");
+    checkDigest(ge(vBool(), vBool()), "<=(?0.bool0, ?0.bool0)");
+  }
+
+  @Test public void reversibleDifferentArgTypesShouldNotBeShuffled() {
+    checkDigest(plus(vSmallInt(), vInt()), "+(?0.smallint0, ?0.int0)");
+    checkDigest(plus(vInt(), vSmallInt()), "+(?0.int0, ?0.smallint0)");
+    checkDigest(mul(vSmallInt(), vInt()), "*(?0.smallint0, ?0.int0)");
+    checkDigest(mul(vInt(), vSmallInt()), "*(?0.int0, ?0.smallint0)");
+  }
+
+  @Test public void reversibleDifferentNullabilityArgsAreNormalized() {
+    checkDigest(plus(vIntNotNull(), vInt()), "+(?0.int0, ?0.notNullInt0)");
+    checkDigest(plus(vInt(), vIntNotNull()), "+(?0.int0, ?0.notNullInt0)");
+    checkDigest(mul(vIntNotNull(), vInt()), "*(?0.int0, ?0.notNullInt0)");
+    checkDigest(mul(vInt(), vIntNotNull()), "*(?0.int0, ?0.notNullInt0)");
+  }
+
+  @Test public void symmetricalDifferentArgOps() {
+    for (int i = 0; i < 2; i++) {
+      int j = 1 - i;
+      checkDigest(eq(vBool(i), vBool(j)), "=(?0.bool0, ?0.bool1)");
+      checkDigest(ne(vBool(i), vBool(j)), "<>(?0.bool0, ?0.bool1)");
+    }
+  }
+
+  @Test public void reversibleDifferentArgOps() {
+    for (int i = 0; i < 2; i++) {
+      int j = 1 - i;
+      checkDigest(
+          lt(vBool(i), vBool(j)),
+          i < j
+              ? "<(?0.bool0, ?0.bool1)"
+              : ">(?0.bool0, ?0.bool1)");
+      checkDigest(
+          le(vBool(i), vBool(j)),
+          i < j
+              ? "<=(?0.bool0, ?0.bool1)"
+              : ">=(?0.bool0, ?0.bool1)");
+      checkDigest(
+          gt(vBool(i), vBool(j)),
+          i < j
+              ? ">(?0.bool0, ?0.bool1)"
+              : "<(?0.bool0, ?0.bool1)");
+      checkDigest(
+          ge(vBool(i), vBool(j)),
+          i < j
+              ? ">=(?0.bool0, ?0.bool1)"
+              : "<=(?0.bool0, ?0.bool1)");
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramBuilderBase.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramBuilderBase.java
@@ -58,10 +58,14 @@ public abstract class RexProgramBuilderBase {
   protected RexLiteral falseLiteral;
   protected RexLiteral nullBool;
   protected RexLiteral nullInt;
+  protected RexLiteral nullSmallInt;
   protected RexLiteral nullVarchar;
 
   private RelDataType nullableBool;
   private RelDataType nonNullableBool;
+
+  private RelDataType nullableSmallInt;
+  private RelDataType nonNullableSmallInt;
 
   private RelDataType nullableInt;
   private RelDataType nonNullableInt;
@@ -118,6 +122,10 @@ public abstract class RexProgramBuilderBase {
     nonNullableInt = typeFactory.createSqlType(SqlTypeName.INTEGER);
     nullableInt = typeFactory.createTypeWithNullability(nonNullableInt, true);
     nullInt = rexBuilder.makeNullLiteral(nullableInt);
+
+    nonNullableSmallInt = typeFactory.createSqlType(SqlTypeName.SMALLINT);
+    nullableSmallInt = typeFactory.createTypeWithNullability(nonNullableSmallInt, true);
+    nullSmallInt = rexBuilder.makeNullLiteral(nullableSmallInt);
 
     nonNullableBool = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
     nullableBool = typeFactory.createTypeWithNullability(nonNullableBool, true);
@@ -386,6 +394,14 @@ public abstract class RexProgramBuilderBase {
     return nullable ? nullableInt : nonNullableInt;
   }
 
+  protected RelDataType tSmallInt() {
+    return nonNullableSmallInt;
+  }
+
+  protected RelDataType tSmallInt(boolean nullable) {
+    return nullable ? nullableSmallInt : nonNullableSmallInt;
+  }
+
   protected RelDataType tBigInt() {
     return tBigInt(false);
   }
@@ -559,6 +575,50 @@ public abstract class RexProgramBuilderBase {
    */
   protected RexNode vIntNotNull(int arg) {
     return vParamNotNull("int", arg, nonNullableInt);
+  }
+
+  /**
+   * Creates {@code nullable int variable} with index of 0.
+   * If you need several distinct variables, use {@link #vSmallInt(int)}.
+   * The resulting node would look like {@code ?0.notNullSmallInt0}
+   *
+   * @return nullable int variable with index of 0
+   */
+  protected RexNode vSmallInt() {
+    return vSmallInt(0);
+  }
+
+  /**
+   * Creates {@code nullable int variable} with index of {@code arg} (0-based).
+   * The resulting node would look like {@code ?0.int3} if {@code arg} is {@code 3}.
+   *
+   * @param arg argument index (0-based)
+   * @return nullable int variable with given index (0-based)
+   */
+  protected RexNode vSmallInt(int arg) {
+    return vParam("smallint", arg, nonNullableSmallInt);
+  }
+
+  /**
+   * Creates {@code non-nullable int variable} with index of 0.
+   * If you need several distinct variables, use {@link #vSmallIntNotNull(int)}.
+   * The resulting node would look like {@code ?0.notNullSmallInt0}
+   *
+   * @return non-nullable int variable with index of 0
+   */
+  protected RexNode vSmallIntNotNull() {
+    return vSmallIntNotNull(0);
+  }
+
+  /**
+   * Creates {@code non-nullable int variable} with index of {@code arg} (0-based).
+   * The resulting node would look like {@code ?0.notNullSmallInt3} if {@code arg} is {@code 3}.
+   *
+   * @param arg argument index (0-based)
+   * @return non-nullable int variable with given index (0-based)
+   */
+  protected RexNode vSmallIntNotNull(int arg) {
+    return vParamNotNull("smallint", arg, nonNullableSmallInt);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -741,7 +741,7 @@ public class RexProgramTest extends RexProgramTestBase {
     final int nodeCount = nodeCount(cnf);
     assertThat((n + 1) * (int) Math.pow(2, n) + 1, equalTo(nodeCount));
     if (n == 3) {
-      assertThat(cnf.toString(),
+      assertThat(cnf.toStringRaw(),
           equalTo("AND(OR(?0.x0, ?0.x1, ?0.x2), OR(?0.x0, ?0.x1, ?0.y2),"
               + " OR(?0.x0, ?0.y1, ?0.x2), OR(?0.x0, ?0.y1, ?0.y2),"
               + " OR(?0.y0, ?0.x1, ?0.x2), OR(?0.y0, ?0.x1, ?0.y2),"
@@ -1104,7 +1104,7 @@ public class RexProgramTest extends RexProgramTestBase {
     // as previous, using simplifyFilterPredicates
     assertThat(simplify
             .simplifyFilterPredicates(args)
-            .toString(),
+            .toStringRaw(),
         equalTo("AND(=(?0.a, 1), =(?0.b, 1))"));
 
     // "a = 1 and a = 10" is always false
@@ -1410,7 +1410,7 @@ public class RexProgramTest extends RexProgramTestBase {
     // TODO: "b is not unknown" would be the best simplification.
     final RexNode simplified =
         this.simplify.simplifyUnknownAs(neOrEq, RexUnknownAs.UNKNOWN);
-    assertThat(simplified.toString(),
+    assertThat(simplified.toStringRaw(),
         equalTo("OR(<>(?0.b, 1), =(?0.b, 1))"));
 
     // "a is null or a is not null" ==> "true"
@@ -2171,7 +2171,7 @@ public class RexProgramTest extends RexProgramTestBase {
 
   private void assertTypeAndToString(
       RexNode rexNode, String representation, String type) {
-    assertEquals(representation, rexNode.toString());
+    assertEquals(representation, rexNode.toStringRaw());
     assertEquals(type, rexNode.getType().toString()
         + (rexNode.getType().isNullable() ? "" : " NOT NULL"), "type of " + rexNode);
   }

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
@@ -29,24 +29,33 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RexProgramTestBase extends RexProgramBuilderBase {
 
+  protected void checkDigest(RexNode node, String expected) {
+    assertEquals(expected, node.toString(), () -> "Digest of " + node.toStringRaw());
+  }
+
+  protected void checkRaw(RexNode node, String expected) {
+    assertEquals(expected, node.toStringRaw(),
+        () -> "Raw representation of node with digest " + node);
+  }
+
   protected void checkCnf(RexNode node, String expected) {
     assertThat("RexUtil.toCnf(rexBuilder, " + node + ")",
-        RexUtil.toCnf(rexBuilder, node).toString(), equalTo(expected));
+        RexUtil.toCnf(rexBuilder, node).toStringRaw(), equalTo(expected));
   }
 
   protected void checkThresholdCnf(RexNode node, int threshold, String expected) {
     assertThat("RexUtil.toCnf(rexBuilder, threshold=" + threshold + " , " + node + ")",
-        RexUtil.toCnf(rexBuilder, threshold, node).toString(),
+        RexUtil.toCnf(rexBuilder, threshold, node).toStringRaw(),
         equalTo(expected));
   }
 
   protected void checkPullFactorsUnchanged(RexNode node) {
-    checkPullFactors(node, node.toString());
+    checkPullFactors(node, node.toStringRaw());
   }
 
   protected void checkPullFactors(RexNode node, String expected) {
     assertThat("RexUtil.pullFactors(rexBuilder, " + node + ")",
-        RexUtil.pullFactors(rexBuilder, node).toString(),
+        RexUtil.pullFactors(rexBuilder, node).toStringRaw(),
         equalTo(expected));
   }
 
@@ -60,7 +69,7 @@ public class RexProgramTestBase extends RexProgramBuilderBase {
     String actual;
     if (node.isA(SqlKind.CAST) || node.isA(SqlKind.NEW_SPECIFICATION)) {
       // toString contains type (see RexCall.toString)
-      actual = node.toString();
+      actual = node.toStringRaw();
     } else {
       actual = node + ":" + node.getType() + (node.getType().isNullable() ? "" : " NOT NULL");
     }
@@ -69,17 +78,17 @@ public class RexProgramTestBase extends RexProgramBuilderBase {
 
   /** Simplifies an expression and checks that the result is as expected. */
   protected void checkSimplify(RexNode node, String expected) {
-    final String nodeString = node.toString();
+    final String nodeString = node.toStringRaw();
     checkSimplify3_(node, expected, expected, expected);
     if (expected.equals(nodeString)) {
-      throw new AssertionError("expected == node.toString(); "
+      throw new AssertionError("expected == node.toStringRaw(); "
           + "use checkSimplifyUnchanged");
     }
   }
 
   /** Simplifies an expression and checks that the result is unchanged. */
   protected void checkSimplifyUnchanged(RexNode node) {
-    final String expected = node.toString();
+    final String expected = node.toStringRaw();
     checkSimplify3_(node, expected, expected, expected);
   }
 
@@ -117,16 +126,16 @@ public class RexProgramTestBase extends RexProgramBuilderBase {
     final RexNode simplified =
         simplify.simplifyUnknownAs(node, RexUnknownAs.UNKNOWN);
     assertThat("simplify(unknown as unknown): " + node,
-        simplified.toString(), equalTo(expected));
+        simplified.toStringRaw(), equalTo(expected));
     if (node.getType().getSqlTypeName() == SqlTypeName.BOOLEAN) {
       final RexNode simplified2 =
           simplify.simplifyUnknownAs(node, RexUnknownAs.FALSE);
       assertThat("simplify(unknown as false): " + node,
-          simplified2.toString(), equalTo(expectedFalse));
+          simplified2.toStringRaw(), equalTo(expectedFalse));
       final RexNode simplified3 =
           simplify.simplifyUnknownAs(node, RexUnknownAs.TRUE);
       assertThat("simplify(unknown as true): " + node,
-          simplified3.toString(), equalTo(expectedTrue));
+          simplified3.toStringRaw(), equalTo(expectedTrue));
     } else {
       assertThat("node type is not BOOLEAN, so <<expectedFalse>> should match <<expected>>",
           expectedFalse, is(expected));
@@ -138,7 +147,7 @@ public class RexProgramTestBase extends RexProgramBuilderBase {
   protected void checkSimplifyFilter(RexNode node, String expected) {
     final RexNode simplified =
         this.simplify.simplifyUnknownAs(node, RexUnknownAs.FALSE);
-    assertThat(simplified.toString(), equalTo(expected));
+    assertThat(simplified.toStringRaw(), equalTo(expected));
   }
 
   protected void checkSimplifyFilter(RexNode node, RelOptPredicateList predicates,
@@ -146,16 +155,19 @@ public class RexProgramTestBase extends RexProgramBuilderBase {
     final RexNode simplified =
         simplify.withPredicates(predicates)
             .simplifyUnknownAs(node, RexUnknownAs.FALSE);
-    assertThat(simplified.toString(), equalTo(expected));
+    assertThat(simplified.toStringRaw(), equalTo(expected));
   }
 
   /** Checks that {@link RexNode#isAlwaysTrue()},
    * {@link RexNode#isAlwaysTrue()} and {@link RexSimplify} agree that
    * an expression reduces to true or false. */
   protected void checkIs(RexNode e, boolean expected) {
-    assertThat("isAlwaysTrue() of expression: " + e.toString(), e.isAlwaysTrue(), is(expected));
-    assertThat("isAlwaysFalse() of expression: " + e.toString(), e.isAlwaysFalse(), is(!expected));
-    assertThat("Simplification is not using isAlwaysX informations", simplify(e).toString(),
+    assertThat(
+        "isAlwaysTrue() of expression: " + e.toStringRaw(), e.isAlwaysTrue(), is(expected));
+    assertThat(
+        "isAlwaysFalse() of expression: " + e.toStringRaw(), e.isAlwaysFalse(), is(!expected));
+    assertThat(
+        "Simplification is not using isAlwaysX informations", simplify(e).toStringRaw(),
         is(expected ? "true" : "false"));
   }
 

--- a/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializationTest.java
@@ -1274,7 +1274,7 @@ public class MaterializationTest {
   private void checkSatisfiable(RexNode e, String s) {
     assertTrue(SubstitutionVisitor.mayBeSatisfiable(e));
     final RexNode simple = simplify.simplifyUnknownAsFalse(e);
-    assertEquals(s, simple.toString());
+    assertEquals(s, simple.toStringRaw());
   }
 
   @Test public void testSplitFilter() {
@@ -1318,7 +1318,7 @@ public class MaterializationTest {
     newFilter = SubstitutionVisitor.splitFilter(simplify,
         x_eq_1,
         rexBuilder.makeCall(SqlStdOperatorTable.OR, x_eq_1, z_eq_3));
-    assertThat(newFilter.toString(), equalTo("=($0, 1)"));
+    assertThat(newFilter.toStringRaw(), equalTo("=($0, 1)"));
 
     // 2b.
     //   condition: x = 1 or y = 2
@@ -1328,7 +1328,7 @@ public class MaterializationTest {
     newFilter = SubstitutionVisitor.splitFilter(simplify,
         rexBuilder.makeCall(SqlStdOperatorTable.OR, x_eq_1, y_eq_2),
         rexBuilder.makeCall(SqlStdOperatorTable.OR, x_eq_1, y_eq_2, z_eq_3));
-    assertThat(newFilter.toString(), equalTo("OR(=($0, 1), =($1, 2))"));
+    assertThat(newFilter.toStringRaw(), equalTo("OR(=($0, 1), =($1, 2))"));
 
     // 2c.
     //   condition: x = 1
@@ -1338,7 +1338,7 @@ public class MaterializationTest {
     newFilter = SubstitutionVisitor.splitFilter(simplify,
         x_eq_1,
         rexBuilder.makeCall(SqlStdOperatorTable.OR, x_eq_1, y_eq_2, z_eq_3));
-    assertThat(newFilter.toString(),
+    assertThat(newFilter.toStringRaw(),
         equalTo("=($0, 1)"));
 
     // 2d.
@@ -1386,7 +1386,7 @@ public class MaterializationTest {
     newFilter = SubstitutionVisitor.splitFilter(simplify,
         rexBuilder.makeCall(SqlStdOperatorTable.AND, x_eq_1, y_eq_2),
         y_eq_2);
-    assertThat(newFilter.toString(), equalTo("=($0, 1)"));
+    assertThat(newFilter.toStringRaw(), equalTo("=($0, 1)"));
 
     // Example 5.
     //   condition: x = 1

--- a/core/src/test/java/org/apache/calcite/test/RexTransformerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RexTransformerTest.java
@@ -114,7 +114,7 @@ public class RexTransformerTest {
 
     RexTransformer transformer = new RexTransformer(root, rexBuilder);
     RexNode result = transformer.transformNullSemantics();
-    String actual = result.toString();
+    String actual = result.toStringRaw();
     if (!actual.equals(expected)) {
       String msg =
           "\nExpected=<" + expected + ">\n  Actual=<" + actual + ">";
@@ -374,7 +374,7 @@ public class RexTransformerTest {
         null,
         null);
 
-    assertThat(remaining.toString(), is("<>(CAST($0):INTEGER NOT NULL, $9)"));
+    assertThat(remaining.toStringRaw(), is("<>(CAST($0):INTEGER NOT NULL, $9)"));
     assertThat(leftJoinKeys.isEmpty(), is(true));
     assertThat(rightJoinKeys.isEmpty(), is(true));
   }

--- a/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
@@ -144,7 +144,7 @@ public class FrameworksTest {
         });
     String s =
         RelOptUtil.dumpPlan("", x, SqlExplainFormat.TEXT,
-            SqlExplainLevel.DIGEST_ATTRIBUTES);
+            SqlExplainLevel.EXPPLAN_ATTRIBUTES);
     assertThat(Util.toLinux(s),
         equalTo("EnumerableFilter(condition=[>($1, 1)])\n"
             + "  EnumerableTableScan(table=[[myTable]])\n"));

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -99,6 +99,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.calcite.plan.RelOptRule.operand;
+import static org.apache.calcite.test.RelMetadataTest.sortsAs;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -312,8 +313,7 @@ public class PlannerTest {
     RelNode rel = planner.rel(validate).project();
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     final RelOptPredicateList predicates = mq.getPulledUpPredicates(rel);
-    final String buf = predicates.pulledUpPredicates.toString();
-    assertThat(buf, equalTo(expectedPredicates));
+    assertThat(predicates.pulledUpPredicates, sortsAs(expectedPredicates));
   }
 
   /** Tests predicates that can be pulled-up from a UNION. */
@@ -1428,7 +1428,7 @@ public class PlannerTest {
             + "  EnumerableUnion(all=[true])\n"
             + "    EnumerableTableScan(table=[[scott, EMP]])\n"
             + "    EnumerableTableScan(table=[[scott, EMP]])\n"
-            + "  EnumerableFilter(condition=[=($cor0.DEPTNO, $0)])\n"
+            + "  EnumerableFilter(condition=[=($0, $cor0.DEPTNO)])\n"
             + "    EnumerableUnion(all=[true])\n"
             + "      EnumerableTableScan(table=[[scott, EMP]])\n"
             + "      EnumerableTableScan(table=[[scott, EMP]])\n"));


### PR DESCRIPTION
`$0=$1` and `$1=$0` have the same semantics, so it is worth normalizing them to reduce the planning time.

See https://issues.apache.org/jira/browse/CALCITE-2450