### PR TITLE
[CALCITE-3633] Update Cassandra tests upgrade from junit4 to junit5

### DIFF
--- a/cassandra/gradle.properties
+++ b/cassandra/gradle.properties
@@ -16,5 +16,3 @@
 #
 description=A library designed to abstract away any required dependency on a metrics library
 artifact.name=Apache Calcite Avatica Metrics
-# JUnit4 use is allowed until the rest of the tests are migrated to JUnit5
-junit4=true

--- a/cassandra/src/test/java/org/apache/calcite/test/BaseCassandraUnit.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/BaseCassandraUnit.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import com.datastax.driver.core.SocketOptions;
+
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Base class for CassandraCQLUnit.
+ */
+public abstract class BaseCassandraUnit implements BeforeAllCallback, AfterAllCallback {
+
+  protected String configurationFileName;
+  protected long startupTimeoutMillis;
+  protected int readTimeoutMillis = 12000;
+
+  public BaseCassandraUnit() {
+    this(EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT);
+  }
+
+  public BaseCassandraUnit(long startupTimeoutMillis) {
+    this.startupTimeoutMillis = startupTimeoutMillis;
+  }
+
+  @Override public void beforeAll(ExtensionContext context) throws Exception {
+    /* start an embedded Cassandra */
+    if (configurationFileName != null) {
+      EmbeddedCassandraServerHelper.startEmbeddedCassandra(configurationFileName,
+          startupTimeoutMillis);
+    } else {
+      EmbeddedCassandraServerHelper.startEmbeddedCassandra(startupTimeoutMillis);
+    }
+
+    /* create structure and load data */
+    load();
+  }
+
+  @Override public void afterAll(ExtensionContext context) throws Exception {
+    if (EmbeddedCassandraServerHelper.getCluster() != null) {
+      EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+    }
+  }
+
+  protected abstract void load();
+
+  /**
+   * Gets a base SocketOptions with an overridden readTimeoutMillis.
+   */
+  protected SocketOptions getSocketOptions() {
+    SocketOptions socketOptions = new SocketOptions();
+    socketOptions.setReadTimeoutMillis(this.readTimeoutMillis);
+    return socketOptions;
+  }
+}

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
@@ -16,29 +16,14 @@
  */
 package org.apache.calcite.test;
 
-import org.apache.calcite.config.CalciteSystemProperty;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.Sources;
-import org.apache.calcite.util.TestUtil;
-
-import org.apache.cassandra.config.DatabaseDescriptor;
 
 import com.google.common.collect.ImmutableMap;
 
-import org.cassandraunit.CassandraCQLUnit;
-import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.rules.ExternalResource;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Tests for the {@code org.apache.calcite.adapter.cassandra} package.
@@ -58,8 +43,8 @@ import static org.junit.Assume.assumeTrue;
 @Execution(ExecutionMode.SAME_THREAD)
 public class CassandraAdapterTest {
 
-  @ClassRule
-  public static final ExternalResource RULE = initCassandraIfEnabled();
+  @RegisterExtension
+  public static final CassandraCQLUnit RULE = new CassandraCQLUnit().initCassandraIfEnabled();
 
   /** Connection factory based on the "mongo-zips" model. */
   private static final ImmutableMap<String, String> TWISSANDRA =
@@ -67,64 +52,6 @@ public class CassandraAdapterTest {
           Sources.of(
               CassandraAdapterTest.class.getResource("/model.json"))
               .file().getAbsolutePath());
-
-  /**
-   * Whether to run this test.
-   * <p>Enabled by default, unless explicitly disabled
-   * from command line ({@code -Dcalcite.test.cassandra=false}) or running on incompatible JDK
-   * version (see below).
-   *
-   * <p>As of this wiring Cassandra 4.x is not yet released and we're using 3.x
-   * (which fails on JDK11+). All cassandra tests will be skipped if
-   * running on JDK11+.
-   *
-   * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-9608">CASSANDRA-9608</a>
-   * @return {@code true} if test is compatible with current environment,
-   *         {@code false} otherwise
-   */
-  private static boolean enabled() {
-    final boolean enabled = CalciteSystemProperty.TEST_CASSANDRA.value();
-    Bug.upgrade("remove JDK version check once current adapter supports Cassandra 4.x");
-    final boolean compatibleJdk = TestUtil.getJavaMajorVersion() < 11;
-    return enabled && compatibleJdk;
-  }
-
-  private static ExternalResource initCassandraIfEnabled() {
-    if (!enabled()) {
-      // Return NOP resource (to avoid nulls)
-      return new ExternalResource() {
-        @Override public Statement apply(final Statement base, final Description description) {
-          return super.apply(base, description);
-        }
-      };
-    }
-
-    String configurationFileName = null; // use default one
-    // Apache Jenkins often fails with
-    // CassandraAdapterTest Cassandra daemon did not start within timeout (20 sec by default)
-    long startUpTimeoutMillis = TimeUnit.SECONDS.toMillis(60);
-
-    CassandraCQLUnit rule = new CassandraCQLUnit(
-        new ClassPathCQLDataSet("twissandra.cql"),
-        configurationFileName,
-        startUpTimeoutMillis);
-
-    // This static init is necessary otherwise tests fail with CassandraUnit in IntelliJ (jdk10)
-    // should be called right after constructor
-    // NullPointerException for DatabaseDescriptor.getDiskFailurePolicy
-    // for more info see
-    // https://github.com/jsevellec/cassandra-unit/issues/249
-    // https://github.com/jsevellec/cassandra-unit/issues/221
-    DatabaseDescriptor.daemonInitialization();
-
-    return rule;
-  }
-
-  @BeforeClass
-  public static void setUp() {
-    // run tests only if explicitly enabled
-    assumeTrue("test explicitly disabled", enabled());
-  }
 
   @Test public void testSelect() {
     CalciteAssert.that()

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraCQLUnit.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraCQLUnit.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.apache.calcite.config.CalciteSystemProperty;
+import org.apache.calcite.util.Bug;
+import org.apache.calcite.util.TestUtil;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+
+import org.cassandraunit.CQLDataLoader;
+import org.cassandraunit.dataset.CQLDataSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * CassandraCQLUnit for start embedded cassandra cluster.
+ */
+public class CassandraCQLUnit extends BaseCassandraUnit {
+  private CQLDataSet dataSet = null;
+  public Session session;
+  public Cluster cluster;
+
+  public CassandraCQLUnit() {
+  }
+
+  public CassandraCQLUnit(CQLDataSet dataSet) {
+    this.dataSet = dataSet;
+  }
+
+  public CassandraCQLUnit(CQLDataSet dataSet, int readTimeoutMillis) {
+    this.dataSet = dataSet;
+    this.readTimeoutMillis = readTimeoutMillis;
+  }
+
+  public CassandraCQLUnit(CQLDataSet dataSet, String configurationFileName) {
+    this(dataSet);
+    this.configurationFileName = configurationFileName;
+  }
+
+  public CassandraCQLUnit(CQLDataSet dataSet, String configurationFileName, int readTimeoutMillis) {
+    this(dataSet);
+    this.configurationFileName = configurationFileName;
+    this.readTimeoutMillis = readTimeoutMillis;
+  }
+
+  // The former constructors with hostip and port have been removed. Now host+port is directly
+  //read out of the provided
+  // configurationFile(Name). You may also use EmbeddedCassandraServerHelper
+  //.CASSANDRA_RNDPORT_YML_FILE to select
+  // random (free) ports for EmbeddedCassandra, such that you can start multiple embedded
+  //cassandras on the same host
+  // (but not in the same JVM).
+  public CassandraCQLUnit(CQLDataSet dataSet, String configurationFileName,
+      long startUpTimeoutMillis) {
+    super(startUpTimeoutMillis);
+    this.dataSet = dataSet;
+    this.configurationFileName = configurationFileName;
+  }
+
+  public CassandraCQLUnit(CQLDataSet dataSet, String configurationFileName,
+      long startUpTimeoutMillis, int readTimeoutMillis) {
+    super(startUpTimeoutMillis);
+    this.dataSet = dataSet;
+    this.configurationFileName = configurationFileName;
+    this.readTimeoutMillis = readTimeoutMillis;
+  }
+
+  @Override public void beforeAll(ExtensionContext context) throws Exception {
+    // run tests only if explicitly enabled
+    assumeTrue("test explicitly disabled", isEnabled());
+    super.beforeAll(context);
+  }
+
+  @Override public void afterAll(ExtensionContext context) throws Exception {
+    // run tests only if explicitly enabled
+    assumeTrue("test explicitly disabled", isEnabled());
+    super.afterAll(context);
+  }
+
+  @Override protected void load() {
+    cluster = EmbeddedCassandraServerHelper.getCluster();
+    session = EmbeddedCassandraServerHelper.getSession();
+    CQLDataLoader dataLoader = new CQLDataLoader(session);
+    dataLoader.load(dataSet);
+    session = dataLoader.getSession();
+  }
+
+  /**
+   * Whether to run this test.
+   * <p>Enabled by default, unless explicitly disabled
+   * from command line ({@code -Dcalcite.test.cassandra=false}) or running on incompatible JDK
+   * version (see below).
+   *
+   * <p>As of this wiring Cassandra 4.x is not yet released and we're using 3.x
+   * (which fails on JDK11+). All cassandra tests will be skipped if
+   * running on JDK11+.
+   *
+   * @return {@code true} if test is compatible with current environment,
+   * {@code false} otherwise
+   * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-9608">CASSANDRA-9608</a>
+   */
+  private static boolean enabled() {
+    final boolean enabled = CalciteSystemProperty.TEST_CASSANDRA.value();
+    Bug.upgrade("remove JDK version check once current adapter supports Cassandra 4.x");
+    final boolean compatibleJdk = TestUtil.getJavaMajorVersion() < 11;
+    return enabled && compatibleJdk;
+  }
+
+  // Getters for those who do not like to directly access fields
+  public Session getSession() {
+    return session;
+  }
+
+  public Cluster getCluster() {
+    return cluster;
+  }
+
+  public boolean isEnabled() {
+    return enabled() && dataSet != null;
+  }
+
+  CassandraCQLUnit initCassandraIfEnabled() {
+    try {
+      if (!enabled()) {
+        // Return NOP resource (to avoid nulls)
+        return new CassandraCQLUnit();
+      }
+      String configurationFileName = null; // use default one
+      // Apache Jenkins often fails with
+      // CassandraAdapterTest Cassandra daemon did not start within timeout (20 sec by default)
+      long startUpTimeoutMillis = TimeUnit.SECONDS.toMillis(60);
+
+      CassandraCQLUnit rule = new CassandraCQLUnit(
+          new ClassPathCQLDataSet("twissandra.cql"),
+          configurationFileName,
+          startUpTimeoutMillis);
+
+      // This static init is necessary otherwise tests fail with CassandraUnit in IntelliJ (jdk10)
+      // should be called right after constructor
+      // NullPointerException for DatabaseDescriptor.getDiskFailurePolicy
+      // for more info see
+      // https://github.com/jsevellec/cassandra-unit/issues/249
+      // https://github.com/jsevellec/cassandra-unit/issues/221
+      DatabaseDescriptor.daemonInitialization();
+      return rule;
+    } catch (Exception ignored) {
+    }
+    return new CassandraCQLUnit();
+  }
+}


### PR DESCRIPTION
As illustrated in [CALCITE-3633](https://issues.apache.org/jira/browse/CALCITE-3633)
Update `Cassandra` tests upgrade from junit4 to junit5.