### PR TITLE
[CALCITE-3651] NPE when convert relational algebra that correlates TableFunctionScan 

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -872,9 +872,7 @@ public class RelToSqlConverter extends SqlImplementor
     SqlNode select = new SqlSelect(
         SqlParserPos.ZERO, null, null, tableCall,
         null, null, null, null, null, null, null, SqlNodeList.EMPTY);
-    Result x = new Result(select,
-        ImmutableList.of(Clause.SELECT), null, e.getRowType(), null);
-    return x;
+    return result(select, ImmutableList.of(Clause.SELECT), e, null);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3734,6 +3734,19 @@ public class RelToSqlConverterTest {
     sql(sql).ok(expected);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3651">[CALCITE-3651]
+   * NullPointerException when convert relational algebra that correlates TableFunctionScan</a>. */
+  @Test public void testLateralCorrelate() {
+    final String query = "select * from \"product\",\n"
+        + "lateral table(RAMP(\"product\".\"product_id\"))";
+    final String expected = "SELECT *\n"
+        + "FROM \"foodmart\".\"product\" AS \"$cor0\",\n"
+        + "LATERAL (SELECT *\n"
+        + "FROM TABLE(RAMP(\"$cor0\".\"product_id\"))) AS \"t\"";
+    sql(query).ok(expected);
+  }
+
   @Test public void testUncollectExplicitAlias() {
     final String sql = "select did + 1 \n"
         + "from unnest(select collect(\"department_id\") as deptid"


### PR DESCRIPTION
See full stack trace in jira[CALCITE-3651](https://issues.apache.org/jira/browse/CALCITE-3651)

The reason for NPE coms from the null value for `neededAlias` attribute when create Result object for TableFunctionScan.