### PR TITLE
[Calcite 3663] Support for TRIM function in BigQuery dialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -30,11 +30,13 @@ import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSetOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -157,6 +159,9 @@ public class BigQuerySqlDialect extends SqlDialect {
       SqlSyntax.BINARY.unparse(writer, INTERSECT_DISTINCT, call, leftPrec,
           rightPrec);
       break;
+    case TRIM:
+      unparseTrim(writer, call, leftPrec, rightPrec);
+      break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }
@@ -190,6 +195,42 @@ public class BigQuerySqlDialect extends SqlDialect {
     } else {
       throw new RuntimeException("Range time unit is not supported for BigQuery.");
     }
+  }
+
+  /**
+   * For usage of TRIM, LTRIM and RTRIM in BQ see
+   * <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#trim">
+   *  BQ Trim Function</a>.
+   */
+  private void unparseTrim(SqlWriter writer, SqlCall call, int leftPrec,
+      int rightPrec) {
+    final String operatorName;
+    SqlLiteral trimFlag = call.operand(0);
+    SqlLiteral valueToTrim = call.operand(1);
+    switch (trimFlag.getValueAs(SqlTrimFunction.Flag.class)) {
+    case LEADING:
+      operatorName = "LTRIM";
+      break;
+    case TRAILING:
+      operatorName = "RTRIM";
+      break;
+    default:
+      operatorName = call.getOperator().getName();
+      break;
+    }
+    final SqlWriter.Frame trimFrame = writer.startFunCall(operatorName);
+    call.operand(2).unparse(writer, leftPrec, rightPrec);
+
+    /**
+     * If the trimmed character is non space character then add it to the target sql.
+     * eg: TRIM(BOTH 'A' from 'ABCD'
+     * Output Query: TRIM('ABC', 'A')
+     * */
+    if (!valueToTrim.toValue().matches("\\s+")) {
+      writer.literal(",");
+      call.operand(1).unparse(writer, leftPrec, rightPrec);
+    }
+    writer.endFunCall(trimFrame);
   }
 
   private TimeUnit validate(TimeUnit timeUnit) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -958,36 +958,92 @@ public class RelToSqlConverterTest {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3220">[CALCITE-3220]
    * HiveSqlDialect should transform the SQL-standard TRIM function to TRIM,
    * LTRIM or RTRIM</a>. */
-  @Test public void testHiveTrim() {
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3663">[CALCITE-3663]
+   * Support for TRIM function in Bigquery dialect</a>. */
+
+  @Test public void testHiveAndBqTrim() {
     final String query = "SELECT TRIM(' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
-    sql(query).withHive().ok(expected);
+    sql(query)
+      .withHive()
+      .ok(expected)
+      .withBigQuery()
+      .ok(expected);
   }
 
-  @Test public void testHiveTrimWithBoth() {
+  @Test public void testHiveAndBqTrimWithBoth() {
     final String query = "SELECT TRIM(both ' ' from ' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
-    sql(query).withHive().ok(expected);
+    sql(query)
+      .withHive()
+      .ok(expected)
+      .withBigQuery()
+      .ok(expected);
   }
 
-  @Test public void testHiveTrimWithLeading() {
+  @Test public void testHiveAndBqTrimWithLeading() {
     final String query = "SELECT TRIM(LEADING ' ' from ' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT LTRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
-    sql(query).withHive().ok(expected);
+    sql(query)
+      .withHive()
+      .ok(expected)
+      .withBigQuery()
+      .ok(expected);
   }
 
-  @Test public void testHiveTrimWithTailing() {
+
+  @Test public void testHiveAndBqTrimWithTailing() {
     final String query = "SELECT TRIM(TRAILING ' ' from ' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT RTRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
-    sql(query).withHive().ok(expected);
+    sql(query)
+      .withHive()
+      .ok(expected)
+      .withBigQuery()
+      .ok(expected);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3663">[CALCITE-3663]
+   * Support for TRIM function in Bigquery dialect</a>. */
+
+  @Test public void testBqTrimWithLeadingChar() {
+    final String query = "SELECT TRIM(LEADING 'a' from 'abcd')\n"
+        + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT LTRIM('abcd', 'a')\n"
+        + "FROM foodmart.reserve_employee";
+    sql(query)
+      .withBigQuery()
+      .ok(expected);
+  }
+
+  @Test public void testBqTrimWithBothChar() {
+    final String query = "SELECT TRIM(both 'a' from 'abcda')\n"
+        + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT TRIM('abcda', 'a')\n"
+        + "FROM foodmart.reserve_employee";
+    sql(query)
+      .withBigQuery()
+      .ok(expected);
+  }
+
+  @Test public void testBqTrimWithTailingChar() {
+    final String query = "SELECT TRIM(TRAILING 'a' from 'abcd')\n"
+         + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT RTRIM('abcd', 'a')\n"
+         + "FROM foodmart.reserve_employee";
+    sql(query)
+      .withBigQuery()
+      .ok(expected);
   }
 
   /** Test case for


### PR DESCRIPTION
In current Calcite implementation for query : SELECT TRIM('ABC') for  big-query Dialect it translated into SELECT TRIM(BOTH ' ' FROM 'ABC') .
But the appropriate query for BigQuery is  :: SELECT TRIM('ABC')
Similarly below query
SELECT TRIM(BOTH 'a' from 'ABC') 
SELECT TRIM(LEADING ' ' from 'ABC') 
SELECT TRIM(TRAILING ' ' from 'ABC') are translated into invalid BigQuery query.

Unparse logic for the trim has been handle in BigQuery dialect to convert the source Trim query into valid bigQuery query.