### PR TITLE
[CALCITE-3593] RelToSqlConverter fails to wrap a new SqlSelect for HAVING clause when isHavingAlias is true 

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -1227,6 +1228,11 @@ public abstract class SqlImplementor {
       if (rel instanceof Aggregate
           && !dialect.supportsNestedAggregations()
           && hasNestedAggregations((Aggregate) rel)) {
+        needNew = true;
+      }
+
+      if (rel instanceof Project && this.clauses.contains(Clause.HAVING)
+          && dialect.getConformance().isHavingAlias()) {
         needNew = true;
       }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -39,6 +39,8 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.validate.SqlAbstractConformance;
+import org.apache.calcite.sql.validate.SqlConformance;
 
 import com.google.common.collect.ImmutableList;
 
@@ -190,6 +192,14 @@ public class BigQuerySqlDialect extends SqlDialect {
     } else {
       throw new RuntimeException("Range time unit is not supported for BigQuery.");
     }
+  }
+
+  @Override public SqlConformance getConformance() {
+    return new SqlAbstractConformance() {
+      @Override public boolean isHavingAlias() {
+        return true;
+      }
+    };
   }
 
   private TimeUnit validate(TimeUnit timeUnit) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
@@ -34,6 +34,7 @@ import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 
@@ -180,8 +181,8 @@ public class RelToSqlConverterStructsTest {
 
   private RelToSqlConverterTest.Sql sql(String sql) {
     return new RelToSqlConverterTest.Sql(ROOT_SCHEMA, sql,
-        CalciteSqlDialect.DEFAULT, RelToSqlConverterTest.DEFAULT_REL_CONFIG,
-        ImmutableList.of());
+        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT,
+        RelToSqlConverterTest.DEFAULT_REL_CONFIG, ImmutableList.of());
   }
 
   @Test public void testNestedSchemaSelectStar() {


### PR DESCRIPTION
Currently below plan 
```
LogicalProject(DEPTNO=[-($0, 10)])
  LogicalFilter(condition=[>($0, 0)])
    LogicalAggregate(group=[{0}])
      LogicalProject(DEPTNO=[$7])
        JdbcTableScan(table=[[JDBC_SCOTT, EMP]])
```
is converted as 
```
SELECT DEPTNO - 10 AS DEPTNO
FROM SCOTT.EMP
GROUP BY DEPTNO
HAVING DEPTNO > 0
```
However semantics is not correct for BigQuery -- "HAVING DEPTNO > 0" refers to the alias.
This PR proposes to wrap a new SqlSelect when isHavingAlias is true for HAVING clause.