### PR TITLE
[CALCITE-3668] VolcanoPlanner does not match all the RelSubSet in matchRecursive

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * <code>VolcanoRuleCall</code> implements the {@link RelOptRuleCall} interface
@@ -317,8 +318,10 @@ public class VolcanoRuleCall extends RelOptRuleCall {
           final RelSubset subset =
               (RelSubset) inputs.get(operand.ordinalInParent);
           if (operand.getMatchedClass() == RelSubset.class) {
-            // If the rule wants the whole subset, we just provide it
-            successors = ImmutableList.of(subset);
+            // Find all the sibling subsets that satisfy the traitSet of current subset.
+            successors = subset.set.subsets.stream()
+                .filter(s -> s.getTraitSet().satisfies(subset.getTraitSet()))
+                .collect(Collectors.toList());
           } else {
             successors = subset.getRelList();
           }

--- a/core/src/test/java/org/apache/calcite/plan/volcano/PlannerTests.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/PlannerTests.java
@@ -125,7 +125,7 @@ class PlannerTests {
     }
 
     @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-      assert traitSet.comprises(Convention.NONE);
+      assert traitSet.contains(Convention.NONE);
       return new NoneSingleRel(getCluster(), sole(inputs));
     }
   }
@@ -203,7 +203,7 @@ class PlannerTests {
     }
 
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-      assert traitSet.comprises(PHYS_CALLING_CONVENTION);
+      assert traitSet.contains(PHYS_CALLING_CONVENTION);
       return new PhysSingleRel(getCluster(), sole(inputs));
     }
   }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/CALCITE-3668

The change was introduced by https://github.com/apache/calcite/pull/784, which I think is wrong.