### PR TITLE
[CALCITE-3677] Add assertion to EnumerableTableScan constructor to validate if the table is suitable for enumerable scan

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScanRule.java
@@ -23,7 +23,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalTableScan;
-import org.apache.calcite.schema.Table;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 import java.util.function.Predicate;
@@ -45,7 +44,8 @@ public class EnumerableTableScanRule extends ConverterRule {
    * @param relBuilderFactory Builder for relational expressions
    */
   public EnumerableTableScanRule(RelBuilderFactory relBuilderFactory) {
-    super(LogicalTableScan.class, (Predicate<RelNode>) r -> true,
+    super(LogicalTableScan.class,
+        (Predicate<LogicalTableScan>) r -> EnumerableTableScan.canHandle(r.getTable()),
         Convention.NONE, EnumerableConvention.INSTANCE, relBuilderFactory,
         "EnumerableTableScanRule");
   }
@@ -53,10 +53,6 @@ public class EnumerableTableScanRule extends ConverterRule {
   @Override public RelNode convert(RelNode rel) {
     LogicalTableScan scan = (LogicalTableScan) rel;
     final RelOptTable relOptTable = scan.getTable();
-    final Table table = relOptTable.unwrap(Table.class);
-    if (!EnumerableTableScan.canHandle(table)) {
-      return null;
-    }
     final Expression expression = relOptTable.getExpression(Object.class);
     if (expression == null) {
       return null;

--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -79,6 +79,18 @@ public final class CalciteSystemProperty<T> {
   public static final CalciteSystemProperty<Boolean> ENABLE_ENUMERABLE =
       booleanProperty("calcite.enable.enumerable", true);
 
+  /** Whether the EnumerableTableScan should support ARRAY fields. */
+  public static final CalciteSystemProperty<Boolean> ENUMERABLE_ENABLE_TABLESCAN_ARRAY =
+      booleanProperty("calcite.enable.enumerable.tablescan.array", false);
+
+  /** Whether the EnumerableTableScan should support MAP fields. */
+  public static final CalciteSystemProperty<Boolean> ENUMERABLE_ENABLE_TABLESCAN_MAP =
+      booleanProperty("calcite.enable.enumerable.tablescan.map", false);
+
+  /** Whether the EnumerableTableScan should support MULTISET fields. */
+  public static final CalciteSystemProperty<Boolean> ENUMERABLE_ENABLE_TABLESCAN_MULTISET =
+      booleanProperty("calcite.enable.enumerable.tablescan.multiset", false);
+
   /** Whether streaming is enabled in the default planner configuration. */
   public static final CalciteSystemProperty<Boolean> ENABLE_STREAM =
       booleanProperty("calcite.enable.stream", true);

--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -147,6 +147,15 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
         this.expressionFunction, this.rowCount);
   }
 
+  @Override public String toString() {
+    return "RelOptTableImpl{"
+        + "schema=" + schema
+        + ", names= " + names
+        + ", table=" + table
+        + ", rowType=" + rowType
+        + '}';
+  }
+
   private static Function<Class, Expression> getClassExpressionFunction(
       CalciteSchema.TableEntry tableEntry, Table table) {
     return getClassExpressionFunction(tableEntry.schema.plus(), tableEntry.name,
@@ -284,7 +293,9 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
       return LogicalTableScan.create(cluster, this);
     }
     if (CalciteSystemProperty.ENABLE_ENUMERABLE.value()
-        && table instanceof QueryableTable) {
+        && table instanceof QueryableTable
+        && (expressionFunction != null
+        || EnumerableTableScan.canHandle(this))) {
       return EnumerableTableScan.create(cluster, this);
     }
     if (table instanceof ScannableTable
@@ -292,10 +303,15 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
         || table instanceof ProjectableFilterableTable) {
       return LogicalTableScan.create(cluster, this);
     }
-    if (CalciteSystemProperty.ENABLE_ENUMERABLE.value()) {
+    // Some tests rely on the old behavior when tables were immediately converted to
+    // EnumerableTableScan
+    // Note: EnumerableTableScanRule can convert LogicalTableScan to EnumerableTableScan
+    if (CalciteSystemProperty.ENABLE_ENUMERABLE.value()
+        && ((table == null && expressionFunction != null)
+        || EnumerableTableScan.canHandle(this))) {
       return EnumerableTableScan.create(cluster, this);
     }
-    throw new AssertionError();
+    return LogicalTableScan.create(cluster, this);
   }
 
   public List<RelCollation> getCollationList() {

--- a/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.plan.volcano;
 
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.jdbc.CalcitePrepare;
@@ -48,6 +47,7 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.SortRemoveRule;
@@ -153,7 +153,7 @@ public class TraitPropagationTest {
         }
       };
 
-      final RelNode rt1 = EnumerableTableScan.create(cluster, t1);
+      final RelNode rt1 = LogicalTableScan.create(cluster, t1);
 
       // project s column
       RelNode project = LogicalProject.create(rt1,
@@ -279,11 +279,11 @@ public class TraitPropagationTest {
     static final PhysTableRule INSTANCE = new PhysTableRule();
 
     private PhysTableRule() {
-      super(anyChild(EnumerableTableScan.class), "PhysScan");
+      super(anyChild(LogicalTableScan.class), "PhysScan");
     }
 
     public void onMatch(RelOptRuleCall call) {
-      EnumerableTableScan rel = call.rel(0);
+      LogicalTableScan rel = call.rel(0);
       call.transformTo(new PhysTable(rel.getCluster()));
     }
   }

--- a/core/src/test/java/org/apache/calcite/sql/validate/LexEscapeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/validate/LexEscapeTest.java
@@ -16,12 +16,10 @@
  */
 package org.apache.calcite.sql.validate;
 
-import org.apache.calcite.adapter.enumerable.EnumerableConvention;
-import org.apache.calcite.adapter.enumerable.EnumerableProject;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.plan.RelTraitDef;
-import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -84,11 +82,8 @@ public class LexEscapeTest {
     SqlNode parse = planner.parse(sql);
     SqlNode validate = planner.validate(parse);
     RelNode convert = planner.rel(validate).rel;
-    RelTraitSet traitSet =
-        planner.getEmptyTraitSet().replace(EnumerableConvention.INSTANCE);
-    RelNode transform = planner.transform(0, traitSet, convert);
-    assertThat(transform, instanceOf(EnumerableProject.class));
-    List<RelDataTypeField> fields = transform.getRowType().getFieldList();
+    assertThat(convert, instanceOf(LogicalProject.class));
+    List<RelDataTypeField> fields = convert.getRowType().getFieldList();
     // Get field type from sql text and validate we parsed it after validation.
     assertThat(fields.size(), is(4));
     assertThat(fields.get(0).getType().getSqlTypeName(), is(SqlTypeName.VARCHAR));

--- a/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
@@ -268,11 +268,10 @@ public class ScannableTableTest {
         + "group by \"k\"";
     final Table table = new BeatlesProjectableFilterableTable(buf, false);
     final String explain = "PLAN="
-        + "EnumerableAggregate(group=[{0}], C=[COUNT()])\n"
+        + "EnumerableAggregate(group=[{1}], C=[COUNT()])\n"
         + "  EnumerableAggregate(group=[{0, 1}])\n"
         + "    EnumerableInterpreter\n"
-        + "      BindableTableScan(table=[[s, beatles]], "
-        + "filters=[[=($2, 1940)]], projects=[[2, 0]])";
+        + "      BindableTableScan(table=[[s, beatles]], filters=[[=($2, 1940)]], projects=[[0, 2]])";
     CalciteAssert.that()
         .with(newSchema("s", Pair.of("beatles", table)))
         .query(sql)


### PR DESCRIPTION
This is a workaround for CALCITE-3673.
TransientTable can only be implemented with interpreter,
so EnumerableTableScan should not be created for those tables.