### PR TITLE
[CALCITE-3684] Implement CBRT function

### DIFF
--- a/babel/src/test/resources/sql/redshift.iq
+++ b/babel/src/test/resources/sql/redshift.iq
@@ -1479,8 +1479,9 @@ PI
 
 # CBRT
 select cbrt(-8);
-SELECT "CBRT"(-8)
-!explain-validated-on calcite
+EXPR$0
+-2.0
+!ok
 
 # CEILING (or CEIL)
 select ceiling(10.5);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -134,6 +134,7 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.BIT_XOR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CARDINALITY;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CASE;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CAST;
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CBRT;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CEIL;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CHARACTER_LENGTH;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CHAR_LENGTH;
@@ -391,6 +392,7 @@ public class RexImpTable {
     defineMethod(ASIN, "asin", NullPolicy.STRICT);
     defineMethod(ATAN, "atan", NullPolicy.STRICT);
     defineMethod(ATAN2, "atan2", NullPolicy.STRICT);
+    defineMethod(CBRT, "cbrt", NullPolicy.STRICT);
     defineMethod(COS, "cos", NullPolicy.STRICT);
     defineMethod(COT, "cot", NullPolicy.STRICT);
     defineMethod(DEGREES, "degrees", NullPolicy.STRICT);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1386,13 +1386,13 @@ public class SqlFunctions {
 
   // CBRT
   /** SQL <code>CBRT</code> operator applied to BigDecimal values. */
-  public static double cbrt(BigDecimal b0) {
-    return Math.cbrt(b0.doubleValue());
+  public static double cbrt(BigDecimal b) {
+    return cbrt(b.doubleValue());
   }
 
   /** SQL <code>CBRT</code> operator applied to double values. */
-  public static double cbrt(double b0) {
-    return Math.cbrt(b0);
+  public static double cbrt(double b) {
+    return Math.cbrt(b);
   }
 
   // COS

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1384,6 +1384,17 @@ public class SqlFunctions {
     return Math.atan2(b0, b1);
   }
 
+  // CBRT
+  /** SQL <code>CBRT</code> operator applied to BigDecimal values. */
+  public static double cbrt(BigDecimal b0) {
+    return Math.cbrt(b0.doubleValue());
+  }
+
+  /** SQL <code>CBRT</code> operator applied to double values. */
+  public static double cbrt(double b0) {
+    return Math.cbrt(b0);
+  }
+
   // COS
   /** SQL <code>COS</code> operator applied to BigDecimal values. */
   public static double cos(BigDecimal b0) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -107,6 +107,7 @@ public class SqlDialect {
           .add(SqlStdOperatorTable.CHARACTER_LENGTH)
           .add(SqlStdOperatorTable.COALESCE)
           .add(SqlStdOperatorTable.CONCAT)
+          .add(SqlStdOperatorTable.CBRT)
           .add(SqlStdOperatorTable.COS)
           .add(SqlStdOperatorTable.COT)
           .add(SqlStdOperatorTable.DIVIDE)

--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -74,6 +74,10 @@ import static org.apache.calcite.util.Static.RESOURCE;
  * <td>Arctangent, in radians, of float2 / float1</td>
  * </tr>
  * <tr>
+ * <td>CBRT(number)</td>
+ * <td>The cube root of number</td>
+ * </tr>
+ * <tr>
  * <td>CEILING(number)</td>
  * <td>Smallest integer &gt;= number</td>
  * </tr>
@@ -366,7 +370,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
 
   /** List of all numeric function names defined by JDBC. */
   private static final String NUMERIC_FUNCTIONS = constructFuncList(
-      "ABS", "ACOS", "ASIN", "ATAN", "ATAN2", "CEILING", "COS", "COT",
+      "ABS", "ACOS", "ASIN", "ATAN", "ATAN2", "CBRT", "CEILING", "COS", "COT",
       "DEGREES", "EXP", "FLOOR", "LOG", "LOG10", "MOD", "PI",
       "POWER", "RADIANS", "RAND", "ROUND", "SIGN", "SIN", "SQRT",
       "TAN", "TRUNCATE");
@@ -676,6 +680,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
       map.put("ASIN", simple(SqlStdOperatorTable.ASIN));
       map.put("ATAN", simple(SqlStdOperatorTable.ATAN));
       map.put("ATAN2", simple(SqlStdOperatorTable.ATAN2));
+      map.put("CBRT", simple(SqlStdOperatorTable.CBRT));
       map.put("CEILING", simple(SqlStdOperatorTable.CEIL));
       map.put("COS", simple(SqlStdOperatorTable.COS));
       map.put("COT", simple(SqlStdOperatorTable.COT));

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1632,6 +1632,15 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           OperandTypes.NUMERIC_NUMERIC,
           SqlFunctionCategory.NUMERIC);
 
+  public static final SqlFunction CBRT =
+      new SqlFunction(
+          "CBRT",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.DOUBLE_NULLABLE,
+          null,
+          OperandTypes.NUMERIC,
+          SqlFunctionCategory.NUMERIC);
+
   public static final SqlFunction COS =
       new SqlFunction(
           "COS",

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -1820,6 +1820,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkScalarApprox("{fn ASIN(0.2)}", "DOUBLE NOT NULL", 0.20135, 0.001);
     tester.checkScalarApprox("{fn ATAN(0.2)}", "DOUBLE NOT NULL", 0.19739, 0.001);
     tester.checkScalarApprox("{fn ATAN2(-2, 2)}", "DOUBLE NOT NULL", -0.78539, 0.001);
+    tester.checkScalar("{fn CBRT(8)}", 2.0, "DOUBLE NOT NULL");
     tester.checkScalar("{fn CEILING(-2.6)}", -2, "DECIMAL(2, 0) NOT NULL");
     tester.checkScalarApprox("{fn COS(0.2)}", "DOUBLE NOT NULL", 0.98007, 0.001);
     tester.checkScalarApprox("{fn COT(0.2)}", "DOUBLE NOT NULL", 4.93315, 0.001);
@@ -5602,6 +5603,34 @@ public abstract class SqlOperatorBaseTest {
         0.0001d);
     tester.checkNull("atan2(cast(null as integer), -1)");
     tester.checkNull("atan2(1, cast(null as double))");
+  }
+
+  @Test public void testCbrtFunc() {
+    tester.setFor(
+        SqlStdOperatorTable.CBRT);
+    tester.checkType("cbrt(1)", "DOUBLE NOT NULL");
+    tester.checkType("cbrt(cast(1 as float))", "DOUBLE NOT NULL");
+    tester.checkType(
+        "cbrt(case when false then 1 else null end)", "DOUBLE");
+    strictTester.checkFails(
+        "^cbrt('abc')^",
+        "Cannot apply 'CBRT' to arguments of type 'CBRT\\(<CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): 'CBRT\\(<NUMERIC>\\)'",
+        false);
+    tester.checkType("cbrt('abc')", "DOUBLE NOT NULL");
+    tester.checkScalar(
+        "cbrt(8)",
+        "2.0",
+        "DOUBLE NOT NULL");
+    tester.checkScalar(
+        "cbrt(-8)",
+        "-2.0",
+        "DOUBLE NOT NULL");
+    tester.checkScalar(
+        "cbrt(cast(1 as decimal(1, 0)))",
+        "1.0",
+        "DOUBLE NOT NULL");
+    tester.checkNull("cbrt(cast(null as integer))");
+    tester.checkNull("cbrt(cast(null as double))");
   }
 
   @Test public void testCosFunc() {

--- a/core/src/test/resources/sql/functions.iq
+++ b/core/src/test/resources/sql/functions.iq
@@ -18,6 +18,19 @@
 !use mysqlfunc
 !set outputformat mysql
 
+# MATH Functions
+
+# CBRT
+select cbrt(-8);
++--------+
+| EXPR$0 |
++--------+
+|   -2.0 |
++--------+
+(1 row)
+
+!ok
+
 # XML Functions
 
 SELECT ExtractValue('<a>c</a>', '//a');

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1230,6 +1230,7 @@ comp:
 | ASIN(numeric)             | Returns the arc sine of *numeric*
 | ATAN(numeric)             | Returns the arc tangent of *numeric*
 | ATAN2(numeric, numeric)   | Returns the arc tangent of the *numeric* coordinates
+| CBRT(numeric)             | Returns the cube root of *numeric*
 | COS(numeric)              | Returns the cosine of *numeric*
 | COT(numeric)              | Returns the cotangent of *numeric*
 | DEGREES(numeric)          | Converts *numeric* from radians to degrees
@@ -1633,6 +1634,7 @@ period:
 | {fn ASIN(numeric)}                | Returns the arc sine of *numeric*
 | {fn ATAN(numeric)}                | Returns the arc tangent of *numeric*
 | {fn ATAN2(numeric, numeric)}      | Returns the arc tangent of the *numeric* coordinates
+| {fn CBRT(numeric)}                | Returns the cube root of *numeric*
 | {fn CEILING(numeric)}             | Rounds *numeric* up, and returns the smallest number that is greater than or equal to *numeric*
 | {fn COS(numeric)}                 | Returns the cosine of *numeric*
 | {fn COT(numeric)}                 | Returns the cotangent of *numeric*


### PR DESCRIPTION
As illustrated in [CALCITE-3684](https://issues.apache.org/jira/browse/CALCITE-3684)
cbrt(x) → double Returns the cube root of x.
sql: `select cbrt(-8);`
result:
| EXPR$0 |
| ---- |
|  -2.0   |