### PR TITLE
[CALCITE-3675] SQL to Rel conversion is broken for coalesce on nullable field

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexCallBinding.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCallBinding.java
@@ -122,6 +122,10 @@ public class RexCallBinding extends SqlOperatorBinding {
     return RexUtil.isLiteral(operands.get(ordinal), allowCast);
   }
 
+  public List<RexNode> operands() {
+    return operands;
+  }
+
   // implement SqlOperatorBinding
   public int getOperandCount() {
     return operands.size();

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3270,6 +3270,21 @@ public class JdbcTest {
             "deptno=20; C=1; S=8000.0");
   }
 
+  @Test public void testCaseWhenOnNullableField() {
+    CalciteAssert.hr()
+        .query("select case when \"commission\" is not null "
+            + "then \"commission\" else 100 end\n"
+            + "from \"hr\".\"emps\"\n")
+        .explainContains("PLAN=EnumerableCalc(expr#0..4=[{inputs}],"
+            + " expr#5=[IS NOT NULL($t4)], expr#6=[CAST($t4):INTEGER NOT NULL],"
+            + " expr#7=[100], expr#8=[CASE($t5, $t6, $t7)], EXPR$0=[$t8])\n"
+            + "  EnumerableTableScan(table=[[hr, emps]])")
+        .returns("EXPR$0=1000\n"
+            + "EXPR$0=500\n"
+            + "EXPR$0=100\n"
+            + "EXPR$0=250\n");
+  }
+
   @Test public void testSelectDistinct() {
     CalciteAssert.hr()
         .query("select distinct \"deptno\"\n"

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3645,6 +3645,11 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test public void testCoalesceOnNullableField() {
+    final String sql = "select coalesce(mgr, 0) from emp";
+    sql(sql).ok();
+  }
+
   /**
    * Visitor that checks that every {@link RelNode} in a tree is valid.
    *

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8196,7 +8196,7 @@ where coalesce(e1.mgr, -1) = coalesce(e2.mgr, -1)]]>
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
-  LogicalFilter(condition=[=(CASE(IS NOT NULL($3), $3, -1), CASE(IS NOT NULL($12), $12, -1))])
+  LogicalFilter(condition=[=(CASE(IS NOT NULL($3), CAST($3):INTEGER NOT NULL, -1), CASE(IS NOT NULL($12), CAST($12):INTEGER NOT NULL, -1))])
     LogicalJoin(condition=[true], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -8205,7 +8205,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
-  LogicalJoin(condition=[=(CASE(IS NOT NULL($3), $3, -1), CASE(IS NOT NULL($12), $12, -1))], joinType=[inner])
+  LogicalJoin(condition=[=(CASE(IS NOT NULL($3), CAST($3):INTEGER NOT NULL, -1), CASE(IS NOT NULL($12), CAST($12):INTEGER NOT NULL, -1))], joinType=[inner])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6474,4 +6474,15 @@ LogicalProject(EMPNO=[$0], DEPTNO=[$1], DEPTNO0=[$3], NAME=[$4])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testCoalesceOnNullableField">
+        <Resource name="sql">
+            <![CDATA[select coalesce(mgr, 0) from emp]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[CASE(IS NOT NULL($3), CAST($3):INTEGER NOT NULL, 0)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
The issue is introduced by [CALCITE-3355](https://issues.apache.org/jira/browse/CALCITE-3355), in which type deducing is only conducted in validation phase. 

However, when converting to RexNode, a new `SqlOperatorBinding` (i.e., `RexCallBinding`) is used. Consequently, it fails type preservation check.

This PR tries to fill the gap.