### PR TITLE
[CALCITE-3715] Add an interface to pass the table hints to RelOptTable

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptTable.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptTable.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelReferentialConstraint;
 import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -150,5 +151,29 @@ public interface RelOptTable extends Wrapper {
    * expression. */
   interface ToRelContext extends ViewExpander {
     RelOptCluster getCluster();
+
+    /**
+     * Returns the table hints of the table to convert,
+     * usually you can use the hints to pass along some dynamic params.
+     *
+     * @return the hints attached to the table, never null
+     */
+    List<RelHint> getTableHints();
+  }
+
+  /** Interface to customize the {@link ToRelContext}. **/
+  interface ToRelContextSupplier {
+    /**
+     * Returns a {@link ToRelContext} instance.
+     *
+     * @param viewExpander The view expander
+     * @param cluster      The cluster
+     * @param hints        The hints attached to the table,
+     *                     empty if the table does not have any hints
+     *
+     * @return A new {@link ToRelContext} instance.
+     */
+    ToRelContext get(RelOptTable.ViewExpander viewExpander,
+        RelOptCluster cluster, List<RelHint> hints);
   }
 }

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteMaterializer.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteMaterializer.java
@@ -100,7 +100,7 @@ class CalciteMaterializer extends CalcitePrepareImpl.CalcitePreparingStmt {
 
     RelOptTable table =
         this.catalogReader.getTable(materialization.materializedTable.path());
-    materialization.tableRel = sqlToRelConverter2.toRel(table, null);
+    materialization.tableRel = sqlToRelConverter2.toRel(table, ImmutableList.of());
   }
 
   /** Converts a relational expression to use a

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -470,7 +470,7 @@ public class SqlToRelConverter {
       boolean restructure) {
     RelStructuredTypeFlattener typeFlattener =
         new RelStructuredTypeFlattener(relBuilder,
-            rexBuilder, createToRelContext(), restructure);
+            rexBuilder, createToRelContext(ImmutableList.of()), restructure);
     return typeFlattener.rewrite(rootRel);
   }
 
@@ -2439,7 +2439,7 @@ public class SqlToRelConverter {
       final RelDataType rowType = table.getRowType(typeFactory);
       RelOptTable relOptTable = RelOptTableImpl.create(null, rowType, table,
           udf.getNameAsId().names);
-      RelNode converted = toRel(relOptTable, null);
+      RelNode converted = toRel(relOptTable, ImmutableList.of());
       bb.setRoot(converted, true);
       return;
     }
@@ -3377,13 +3377,13 @@ public class SqlToRelConverter {
         .build();
   }
 
-  private RelOptTable.ToRelContext createToRelContext() {
-    return ViewExpanders.toRelContext(viewExpander, cluster);
+  private RelOptTable.ToRelContext createToRelContext(List<RelHint> hints) {
+    return ViewExpanders.toRelContext(viewExpander, cluster, hints);
   }
 
-  public RelNode toRel(final RelOptTable table, final List<RelHint> hints) {
-    final RelNode rel = table.toRel(createToRelContext());
-    final RelNode scan = rel instanceof Hintable && hints != null && hints.size() > 0
+  public RelNode toRel(final RelOptTable table, @Nonnull final List<RelHint> hints) {
+    final RelNode rel = table.toRel(createToRelContext(hints));
+    final RelNode scan = rel instanceof Hintable && hints.size() > 0
         ? SqlUtil.attachRelHint(hintStrategies, hints, (Hintable) rel)
         : rel;
 


### PR DESCRIPTION
* In RelOptTable, add an interface ToRelContextSupplier to allow
customize the ToRelContext
* Add ToRelContext#getTableHints to fetch hints when translating table
to relational node
* Add a new method ViewExpanders#toRelContext(ViewExpander,
RelOptCluster, List<RelHint>) to allow passing the hints to the ToRelContext
* Remove the old `viewExpander instanceOf ToRelContext` logic because it
is never used in Calcite, and we should not cast a superclass to child
class