### PR TITLE
[CALCITE-3707] Implement COSH function

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -95,6 +95,7 @@ import static org.apache.calcite.linq4j.tree.ExpressionType.OrElse;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Subtract;
 import static org.apache.calcite.linq4j.tree.ExpressionType.UnaryPlus;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CHR;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.COSH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DAYNAME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DIFFERENCE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.EXTRACT_VALUE;
@@ -395,6 +396,7 @@ public class RexImpTable {
     defineMethod(ATAN2, "atan2", NullPolicy.STRICT);
     defineMethod(CBRT, "cbrt", NullPolicy.STRICT);
     defineMethod(COS, "cos", NullPolicy.STRICT);
+    defineMethod(COSH, "cosh", NullPolicy.STRICT);
     defineMethod(COT, "cot", NullPolicy.STRICT);
     defineMethod(DEGREES, "degrees", NullPolicy.STRICT);
     defineMethod(RADIANS, "radians", NullPolicy.STRICT);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1406,6 +1406,17 @@ public class SqlFunctions {
     return Math.cos(b0);
   }
 
+  // COSH
+  /** SQL <code>COSH</code> operator applied to BigDecimal values. */
+  public static double cosh(BigDecimal b) {
+    return cosh(b.doubleValue());
+  }
+
+  /** SQL <code>COSH</code> operator applied to double values. */
+  public static double cosh(double b) {
+    return Math.cosh(b);
+  }
+
   // COT
   /** SQL <code>COT</code> operator applied to BigDecimal values. */
   public static double cot(BigDecimal b0) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -334,6 +334,15 @@ public abstract class SqlLibraryOperators {
           OperandTypes.INTEGER,
           SqlFunctionCategory.STRING);
 
+  @LibraryOperator(libraries = {ORACLE})
+  public static final SqlFunction COSH =
+      new SqlFunction("COSH",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.DOUBLE_NULLABLE,
+          null,
+          OperandTypes.NUMERIC,
+          SqlFunctionCategory.NUMERIC);
+
   @LibraryOperator(libraries = {MYSQL, POSTGRESQL})
   public static final SqlFunction MD5 =
       new SqlFunction("MD5",

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -373,6 +373,7 @@ public enum BuiltInMethod {
       long.class),
   FLOOR(SqlFunctions.class, "floor", int.class, int.class),
   CEIL(SqlFunctions.class, "ceil", int.class, int.class),
+  COSH(SqlFunctions.class, "cosh", long.class),
   OVERLAY(SqlFunctions.class, "overlay", String.class, String.class, int.class),
   OVERLAY3(SqlFunctions.class, "overlay", String.class, String.class, int.class,
       int.class),

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5694,6 +5694,31 @@ public abstract class SqlOperatorBaseTest {
     tester.checkNull("cos(cast(null as double))");
   }
 
+  @Test public void testCoshFunc() {
+    SqlTester tester = tester(SqlLibrary.ORACLE);
+    tester.checkType("cosh(1)", "DOUBLE NOT NULL");
+    tester.checkType("cosh(cast(1 as float))", "DOUBLE NOT NULL");
+    tester.checkType(
+        "cosh(case when false then 1 else null end)", "DOUBLE");
+    strictTester.checkFails(
+        "^cosh('abc')^",
+        "No match found for function signature COSH\\(<CHARACTER>\\)",
+        false);
+    tester.checkType("cosh('abc')", "DOUBLE NOT NULL");
+    tester.checkScalarApprox(
+        "cosh(1)",
+        "DOUBLE NOT NULL",
+        1.5430d,
+        0.0001d);
+    tester.checkScalarApprox(
+        "cosh(cast(1 as decimal(1, 0)))",
+        "DOUBLE NOT NULL",
+        1.5430d,
+        0.0001d);
+    tester.checkNull("cosh(cast(null as integer))");
+    tester.checkNull("cosh(cast(null as double))");
+  }
+
   @Test public void testCotFunc() {
     tester.setFor(
         SqlStdOperatorTable.COT);

--- a/core/src/test/resources/sql/functions.iq
+++ b/core/src/test/resources/sql/functions.iq
@@ -45,6 +45,17 @@ SELECT ExtractValue('<a>c</a>', '//a');
 
 !use oraclefunc
 
+# COSH
+select cosh(1);
++-------------------+
+| EXPR$0            |
++-------------------+
+| 1.543080634815244 |
++-------------------+
+(1 row)
+
+!ok
+
 SELECT XMLTRANSFORM(
                    '<?xml version="1.0"?>
                     <Article>

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2296,6 +2296,7 @@ semantics.
 | p | expr :: type                                   | Casts *expr* to *type*
 | o | CHR(integer) | Returns the character having the binary equivalent to *integer* as a CHAR value
 | m o p | CONCAT(string [, string ]*)                | Concatenates two or more strings
+| o | COSH(numeric)                                  | Returns the hyperbolic cosine of *numeric*
 | p | CONVERT_TIMEZONE(tz1, tz2, datetime)           | Converts the timezone of *datetime* from *tz1* to *tz2*
 | m | DAYNAME(datetime)                              | Returns the name, in the connection's locale, of the weekday in *datetime*; for example, it returns '星期日' for both DATE '2020-02-10' and TIMESTAMP '2020-02-10 10:10:10'
 | o | DECODE(value, value1, result1 [, valueN, resultN ]* [, default ]) | Compares *value* to each *valueN* value one by one; if *value* is equal to a *valueN*, returns the corresponding *resultN*, else returns *default*, or NULL if *default* is not specified

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2295,8 +2295,8 @@ semantics.
 |:- |:-----------------------------------------------|:-----------
 | p | expr :: type                                   | Casts *expr* to *type*
 | o | CHR(integer) | Returns the character having the binary equivalent to *integer* as a CHAR value
-| m o p | CONCAT(string [, string ]*)                | Concatenates two or more strings
 | o | COSH(numeric)                                  | Returns the hyperbolic cosine of *numeric*
+| m o p | CONCAT(string [, string ]*)                | Concatenates two or more strings
 | p | CONVERT_TIMEZONE(tz1, tz2, datetime)           | Converts the timezone of *datetime* from *tz1* to *tz2*
 | m | DAYNAME(datetime)                              | Returns the name, in the connection's locale, of the weekday in *datetime*; for example, it returns '星期日' for both DATE '2020-02-10' and TIMESTAMP '2020-02-10 10:10:10'
 | o | DECODE(value, value1, result1 [, valueN, resultN ]* [, default ]) | Compares *value* to each *valueN* value one by one; if *value* is equal to a *valueN*, returns the corresponding *resultN*, else returns *default*, or NULL if *default* is not specified


### PR DESCRIPTION
As illustrated in [CALCITE-3707](https://issues.apache.org/jira/browse/CALCITE-3707)
COSH   returns the hyperbolic cosine of a number.
select cosh(1);
+-------------------+
| EXPR$0            |
+-------------------+
| 1.543080634815244 |
+-------------------+
(1 row)

!ok