### PR TITLE
[CALCITE-3695] Implement TANH function

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -117,6 +117,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.RIGHT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SHA1;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SOUNDEX;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPACE;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.TANH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TO_BASE64;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TRANSLATE3;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.XML_TRANSFORM;
@@ -402,6 +403,7 @@ public class RexImpTable {
     defineMethod(SIGN, "sign", NullPolicy.STRICT);
     defineMethod(SIN, "sin", NullPolicy.STRICT);
     defineMethod(TAN, "tan", NullPolicy.STRICT);
+    defineMethod(TANH, "tanh", NullPolicy.STRICT);
     defineMethod(TRUNCATE, "struncate", NullPolicy.STRICT);
 
     map.put(PI, (translator, call, nullAs) -> Expressions.constant(Math.PI));

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1562,6 +1562,17 @@ public class SqlFunctions {
     return Math.tan(b0);
   }
 
+  // TANH
+  /** SQL <code>TANH</code> operator applied to BigDecimal values. */
+  public static double tanh(BigDecimal b) {
+    return tanh(b.doubleValue());
+  }
+
+  /** SQL <code>TANH</code> operator applied to double values. */
+  public static double tanh(double b) {
+    return Math.tanh(b);
+  }
+
   // Helpers
 
   /** Helper for implementing MIN. Somewhat similar to LEAST operator. */

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -334,6 +334,15 @@ public abstract class SqlLibraryOperators {
           OperandTypes.INTEGER,
           SqlFunctionCategory.STRING);
 
+  @LibraryOperator(libraries = {ORACLE})
+  public static final SqlFunction TANH =
+      new SqlFunction("TANH",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.DOUBLE_NULLABLE,
+          null,
+          OperandTypes.NUMERIC,
+          SqlFunctionCategory.NUMERIC);
+
   @LibraryOperator(libraries = {MYSQL, POSTGRESQL})
   public static final SqlFunction MD5 =
       new SqlFunction("MD5",

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -382,6 +382,7 @@ public enum BuiltInMethod {
   RAND_INTEGER(RandomFunction.class, "randInteger", int.class),
   RAND_INTEGER_SEED(RandomFunction.class, "randIntegerSeed", int.class,
       int.class),
+  TANH(SqlFunctions.class, "tanh", long.class),
   TRUNCATE(SqlFunctions.class, "truncate", String.class, int.class),
   TRUNCATE_OR_PAD(SqlFunctions.class, "truncateOrPad", String.class, int.class),
   TRIM(SqlFunctions.class, "trim", boolean.class, boolean.class, String.class,

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5906,6 +5906,31 @@ public abstract class SqlOperatorBaseTest {
     tester.checkNull("tan(cast(null as double))");
   }
 
+  @Test public void testTanhFunc() {
+    SqlTester tester = tester(SqlLibrary.ORACLE);
+    tester.checkType("tanh(1)", "DOUBLE NOT NULL");
+    tester.checkType("tanh(cast(1 as float))", "DOUBLE NOT NULL");
+    tester.checkType(
+        "tanh(case when false then 1 else null end)", "DOUBLE");
+    strictTester.checkFails(
+        "^tanh('abc')^",
+        "No match found for function signature TANH\\(<CHARACTER>\\)",
+        false);
+    tester.checkType("tanh('abc')", "DOUBLE NOT NULL");
+    tester.checkScalarApprox(
+        "tanh(1)",
+        "DOUBLE NOT NULL",
+        0.7615d,
+        0.0001d);
+    tester.checkScalarApprox(
+        "tanh(cast(1 as decimal(1, 0)))",
+        "DOUBLE NOT NULL",
+        0.7615d,
+        0.0001d);
+    tester.checkNull("tanh(cast(null as integer))");
+    tester.checkNull("tanh(cast(null as double))");
+  }
+
   @Test public void testTruncateFunc() {
     tester.setFor(
         SqlStdOperatorTable.TRUNCATE);

--- a/core/src/test/resources/sql/functions.iq
+++ b/core/src/test/resources/sql/functions.iq
@@ -45,6 +45,17 @@ SELECT ExtractValue('<a>c</a>', '//a');
 
 !use oraclefunc
 
+# TANH
+select tanh(1);
++--------------------+
+| EXPR$0             |
++--------------------+
+| 0.7615941559557649 |
++--------------------+
+(1 row)
+
+!ok
+
 SELECT XMLTRANSFORM(
                    '<?xml version="1.0"?>
                     <Article>

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2327,6 +2327,7 @@ semantics.
 | m o p | SOUNDEX(string)                            | Returns the phonetic representation of *string*; throws if *string* is encoded with multi-byte encoding such as UTF-8
 | m | SPACE(integer)                                 | Returns a string of *integer* spaces; returns an empty string if *integer* is less than 1
 | o | SUBSTR(string, position [, substringLength ]) | Returns a portion of *string*, beginning at character *position*, *substringLength* characters long. SUBSTR calculates lengths using characters as defined by the input character set
+| o | TANH(numeric)                                  | Returns the hyperbolic tangent of *numeric*
 | o p | TO_DATE(string, format)                      | Converts *string* to a date using the format *format*
 | o p | TO_TIMESTAMP(string, format)                 | Converts *string* to a timestamp using the format *format*
 | o p | TRANSLATE(expr, fromString, toString)        | Returns *expr* with all occurrences of each character in *fromString* replaced by its corresponding character in *toString*. Characters in *expr* that are not in *fromString* are not replaced


### PR DESCRIPTION
As illustrated in [CALCITE-3695](https://issues.apache.org/jira/browse/CALCITE-3695)
TANH   returns the hyperbolic cosine of a number.
select tanh(1);
+--------------------+
| EXPR$0             |
+--------------------+
| 0.7615941559557649 |
+--------------------+
(1 row)

!ok