### PR TITLE
[CALCITE-3721] Filter of distinct aggregate call is lost after applyi…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
@@ -402,6 +402,8 @@ public final class AggregateExpandDistinctAggregatesRule extends RelOptRule {
         new TreeSet<>(ImmutableBitSet.ORDERING);
     // groupSet to distinct filter arg map,
     // filterArg will be -1 for groupSet of non-distinct agg.
+    // Using `Set` here because it's possible that two agg calls
+    // have different filterArgs but have same groupSet.
     final Map<ImmutableBitSet, Set<Integer>> distinctFilterArgMap = new HashMap<>();
     for (AggregateCall aggCall : aggregate.getAggCallList()) {
       ImmutableBitSet groupSet;
@@ -471,19 +473,19 @@ public final class AggregateExpandDistinctAggregatesRule extends RelOptRule {
         RexNode expr = relBuilder.equals(nodeZ, relBuilder.literal(v));
         if (distinctFilterArg > -1) {
           // merge the filter of the distinct aggregate call itself.
-          RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
           expr = relBuilder.and(expr,
-              rexBuilder.makeCall(SqlStdOperatorTable.IS_TRUE,
+              relBuilder.call(SqlStdOperatorTable.IS_TRUE,
                   relBuilder.field(distinctFilterArg)));
         }
         nodes.add(
             relBuilder.alias(expr,
-            "$g_" + v + (distinctFilterArg < 0 ? "" : "_" + distinctFilterArg)));
+            "$g_" + v + (distinctFilterArg < 0 ? "" : "_f_" + distinctFilterArg)));
       }
       relBuilder.project(nodes);
     }
 
     int x = groupCount;
+    final ImmutableBitSet groupSet = aggregate.getGroupSet();
     final List<AggregateCall> newCalls = new ArrayList<>();
     for (AggregateCall aggCall : aggregate.getAggCallList()) {
       final int newFilterArg;
@@ -492,14 +494,14 @@ public final class AggregateExpandDistinctAggregatesRule extends RelOptRule {
       if (!aggCall.isDistinct()) {
         aggregation = SqlStdOperatorTable.MIN;
         newArgList = ImmutableIntList.of(x++);
-        newFilterArg = filters.get(Pair.of(aggregate.getGroupSet(), -1));
+        newFilterArg = filters.get(Pair.of(groupSet, -1));
       } else {
         aggregation = aggCall.getAggregation();
         newArgList = remap(fullGroupSet, aggCall.getArgList());
-        final ImmutableBitSet groupSet = ImmutableBitSet.of(aggCall.getArgList())
+        final ImmutableBitSet newGroupSet = ImmutableBitSet.of(aggCall.getArgList())
             .setIf(aggCall.filterArg, aggCall.filterArg >= 0)
-            .union(aggregate.getGroupSet());
-        newFilterArg = filters.get(Pair.of(groupSet, aggCall.filterArg));
+            .union(groupSet);
+        newFilterArg = filters.get(Pair.of(newGroupSet, aggCall.filterArg));
       }
       final AggregateCall newCall =
           AggregateCall.create(aggregation, false,
@@ -511,7 +513,7 @@ public final class AggregateExpandDistinctAggregatesRule extends RelOptRule {
 
     relBuilder.aggregate(
         relBuilder.groupKey(
-            remap(fullGroupSet, aggregate.getGroupSet()),
+            remap(fullGroupSet, groupSet),
             remap(fullGroupSet, aggregate.getGroupSets())),
         newCalls);
     relBuilder.convert(aggregate.getRowType(), true);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
@@ -402,14 +402,17 @@ public final class AggregateExpandDistinctAggregatesRule extends RelOptRule {
       Aggregate aggregate) {
     final Set<ImmutableBitSet> groupSetTreeSet =
         new TreeSet<>(ImmutableBitSet.ORDERING);
+    final Map<ImmutableBitSet, Integer> groupSetToDistinctAggCallFilterArg = new HashMap<>();
     for (AggregateCall aggCall : aggregate.getAggCallList()) {
       if (!aggCall.isDistinct()) {
         groupSetTreeSet.add(aggregate.getGroupSet());
       } else {
-        groupSetTreeSet.add(
+        ImmutableBitSet groupSet =
             ImmutableBitSet.of(aggCall.getArgList())
                 .setIf(aggCall.filterArg, aggCall.filterArg >= 0)
-                .union(aggregate.getGroupSet()));
+                .union(aggregate.getGroupSet());
+        groupSetTreeSet.add(groupSet);
+        groupSetToDistinctAggCallFilterArg.put(groupSet, aggCall.filterArg);
       }
     }
 
@@ -453,10 +456,17 @@ public final class AggregateExpandDistinctAggregatesRule extends RelOptRule {
       final RexNode nodeZ = nodes.remove(nodes.size() - 1);
       for (Map.Entry<ImmutableBitSet, Integer> entry : filters.entrySet()) {
         final long v = groupValue(fullGroupSet, entry.getKey());
-        nodes.add(
-            relBuilder.alias(
-                relBuilder.equals(nodeZ, relBuilder.literal(v)),
-                "$g_" + v));
+        int distinctAggCallFilterArg = remap(fullGroupSet,
+            groupSetToDistinctAggCallFilterArg.getOrDefault(entry.getKey(), -1));
+        RexNode expr = relBuilder.equals(nodeZ, relBuilder.literal(v));
+        if (distinctAggCallFilterArg > -1) {
+          // merge the filter of the distinct aggregate call itself.
+          RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
+          expr = relBuilder.and(expr,
+              rexBuilder.makeCall(SqlStdOperatorTable.IS_TRUE,
+                  relBuilder.field(distinctAggCallFilterArg)));
+        }
+        nodes.add(relBuilder.alias(expr, "$g_" + v));
       }
       relBuilder.project(nodes);
     }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1483,6 +1483,16 @@ public class RelOptRulesTest extends RelOptTestBase {
     sql(sql).with(program).check();
   }
 
+  @Test public void testDistinctWithDiffFiltersAndSameGroupSet() {
+    final String sql = "SELECT COUNT(DISTINCT c) FILTER (WHERE d),\n"
+        + "COUNT(DISTINCT d) FILTER (WHERE c)\n"
+        + "FROM (select sal > 1000 is true as c, sal < 500 is true as d, comm from emp)";
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(AggregateExpandDistinctAggregatesRule.INSTANCE)
+        .build();
+    sql(sql).with(program).check();
+  }
+
   @Test public void testDistinctWithFilterAndGroupBy() {
     final String sql = "SELECT deptno, SUM(comm), COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)\n"
         + "FROM emp\n"

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1474,6 +1474,27 @@ public class RelOptRulesTest extends RelOptTestBase {
     sql(sql).with(program).check();
   }
 
+  @Test public void testDistinctWithFilterWithoutGroupBy() {
+    final String sql = "SELECT SUM(comm), COUNT(DISTINCT comm),\n"
+        + "COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)\n"
+        + "FROM emp";
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(AggregateExpandDistinctAggregatesRule.INSTANCE)
+        .build();
+    sql(sql).with(program).check();
+  }
+
+  @Test public void testDistinctWithFilterAndGroupBy() {
+    final String sql = "SELECT deptno, SUM(comm), COUNT(DISTINCT comm),\n"
+        + "COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)\n"
+        + "FROM emp\n"
+        + "GROUP BY deptno";
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(AggregateExpandDistinctAggregatesRule.INSTANCE)
+        .build();
+    sql(sql).with(program).check();
+  }
+
   @Test public void testPushProjectPastFilter() {
     final String sql = "select empno + deptno from emp where sal = 10 * comm\n"
         + "and upper(ename) = 'FOO'";

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1475,8 +1475,7 @@ public class RelOptRulesTest extends RelOptTestBase {
   }
 
   @Test public void testDistinctWithFilterWithoutGroupBy() {
-    final String sql = "SELECT SUM(comm), COUNT(DISTINCT comm),\n"
-        + "COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)\n"
+    final String sql = "SELECT SUM(comm), COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)\n"
         + "FROM emp";
     HepProgram program = new HepProgramBuilder()
         .addRuleInstance(AggregateExpandDistinctAggregatesRule.INSTANCE)
@@ -1485,8 +1484,7 @@ public class RelOptRulesTest extends RelOptTestBase {
   }
 
   @Test public void testDistinctWithFilterAndGroupBy() {
-    final String sql = "SELECT deptno, SUM(comm), COUNT(DISTINCT comm),\n"
-        + "COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)\n"
+    final String sql = "SELECT deptno, SUM(comm), COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)\n"
         + "FROM emp\n"
         + "GROUP BY deptno";
     HepProgram program = new HepProgramBuilder()

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1168,7 +1168,7 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT(DISTINCT $1) FILTER
         <Resource name="planAfter">
             <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[MIN($2) FILTER $4], EXPR$1=[COUNT($0) FILTER $3])
-  LogicalProject(SAL=[$0], $f2=[$1], EXPR$0=[$2], $g_0_1=[AND(=($3, 0), IS TRUE($1))], $g_3=[=($3, 3)])
+  LogicalProject(SAL=[$0], $f2=[$1], EXPR$0=[$2], $g_0_f_1=[AND(=($3, 0), IS TRUE($1))], $g_3=[=($3, 3)])
     LogicalAggregate(group=[{1, 2}], groups=[[{1, 2}, {}]], EXPR$0=[SUM($0)], $g=[GROUPING($1, $2)])
       LogicalProject(COMM=[$6], SAL=[$5], $f2=[>($5, 1000)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -1191,7 +1191,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT(DISTINCT $0) FILTER $1], EXPR$1=[COUN
         <Resource name="planAfter">
             <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[COUNT($0) FILTER $3], EXPR$1=[COUNT($1) FILTER $2])
-  LogicalProject(C=[$0], D=[$1], $g_0_0=[AND(=($2, 0), $0)], $g_0_1=[AND(=($2, 0), $1)])
+  LogicalProject(C=[$0], D=[$1], $g_0_f_0=[AND(=($2, 0), $0)], $g_0_f_1=[AND(=($2, 0), $1)])
     LogicalAggregate(group=[{0, 1}], $g=[GROUPING($0, $1)])
       LogicalProject(C=[>($5, 1000)], D=[<($5, 500)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -1215,7 +1215,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT(DISTINCT $2) FILTE
             <![CDATA[
 LogicalProject(DEPTNO=[$0], EXPR$1=[CAST($1):INTEGER NOT NULL], EXPR$2=[$2])
   LogicalAggregate(group=[{0}], EXPR$1=[MIN($3) FILTER $5], EXPR$2=[COUNT($1) FILTER $4])
-    LogicalProject(DEPTNO=[$0], SAL=[$1], $f3=[$2], EXPR$1=[$3], $g_0_2=[AND(=($4, 0), IS TRUE($2))], $g_3=[=($4, 3)])
+    LogicalProject(DEPTNO=[$0], SAL=[$1], $f3=[$2], EXPR$1=[$3], $g_0_f_2=[AND(=($4, 0), IS TRUE($2))], $g_3=[=($4, 3)])
       LogicalAggregate(group=[{0, 2, 3}], groups=[[{0, 2, 3}, {0}]], EXPR$1=[SUM($1)], $g=[GROUPING($0, $2, $3)])
         LogicalProject(DEPTNO=[$7], COMM=[$6], SAL=[$5], $f3=[>($5, 1000)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1155,22 +1155,21 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM($3)], EXPR$2=[MIN($4)], EXPR$3=[COUNT(
     </TestCase>
     <TestCase name="testDistinctWithFilterWithoutGroupBy">
         <Resource name="sql">
-            <![CDATA[SELECT SUM(comm), COUNT(DISTINCT comm),
-COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)
+            <![CDATA[SELECT SUM(comm), COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)
 FROM emp]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT(DISTINCT $0)], EXPR$2=[COUNT(DISTINCT $1) FILTER $2])
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT(DISTINCT $1) FILTER $2])
   LogicalProject(COMM=[$6], SAL=[$5], $f2=[>($5, 1000)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalAggregate(group=[{}], EXPR$0=[MIN($3) FILTER $6], EXPR$1=[COUNT($0) FILTER $4], EXPR$2=[COUNT($1) FILTER $5])
-  LogicalProject(COMM=[$0], SAL=[$1], $f2=[$2], EXPR$0=[$3], $g_3=[=($4, 3)], $g_4=[AND(=($4, 4), IS TRUE($2))], $g_7=[=($4, 7)])
-    LogicalAggregate(group=[{0, 1, 2}], groups=[[{0}, {1, 2}, {}]], EXPR$0=[SUM($0)], $g=[GROUPING($0, $1, $2)])
+LogicalAggregate(group=[{}], EXPR$0=[MIN($1) FILTER $3], EXPR$1=[COUNT($0) FILTER $2])
+  LogicalProject(SAL=[$0], EXPR$0=[$2], $g_0=[AND(=($3, 0), IS TRUE($1))], $g_3=[=($3, 3)])
+    LogicalAggregate(group=[{1, 2}], groups=[[{1, 2}, {}]], EXPR$0=[SUM($0)], $g=[GROUPING($1, $2)])
       LogicalProject(COMM=[$6], SAL=[$5], $f2=[>($5, 1000)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -1178,24 +1177,23 @@ LogicalAggregate(group=[{}], EXPR$0=[MIN($3) FILTER $6], EXPR$1=[COUNT($0) FILTE
     </TestCase>
     <TestCase name="testDistinctWithFilterAndGroupBy">
         <Resource name="sql">
-            <![CDATA[SELECT deptno, SUM(comm), COUNT(DISTINCT comm),
-COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)
+            <![CDATA[SELECT deptno, SUM(comm), COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)
 FROM emp
 GROUP BY deptno]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
-LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT(DISTINCT $1)], EXPR$3=[COUNT(DISTINCT $2) FILTER $3])
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT(DISTINCT $2) FILTER $3])
   LogicalProject(DEPTNO=[$7], COMM=[$6], SAL=[$5], $f3=[>($5, 1000)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalProject(DEPTNO=[$0], EXPR$1=[CAST($1):INTEGER NOT NULL], EXPR$2=[$2], EXPR$3=[$3])
-  LogicalAggregate(group=[{0}], EXPR$1=[MIN($4) FILTER $7], EXPR$2=[COUNT($1) FILTER $5], EXPR$3=[COUNT($2) FILTER $6])
-    LogicalProject(DEPTNO=[$0], COMM=[$1], SAL=[$2], $f3=[$3], EXPR$1=[$4], $g_3=[=($5, 3)], $g_4=[AND(=($5, 4), IS TRUE($3))], $g_7=[=($5, 7)])
-      LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1}, {0, 2, 3}, {0}]], EXPR$1=[SUM($1)], $g=[GROUPING($0, $1, $2, $3)])
+LogicalProject(DEPTNO=[$0], EXPR$1=[CAST($1):INTEGER NOT NULL], EXPR$2=[$2])
+  LogicalAggregate(group=[{0}], EXPR$1=[MIN($2) FILTER $4], EXPR$2=[COUNT($1) FILTER $3])
+    LogicalProject(DEPTNO=[$0], SAL=[$1], EXPR$1=[$3], $g_0=[AND(=($4, 0), IS TRUE($2))], $g_3=[=($4, 3)])
+      LogicalAggregate(group=[{0, 2, 3}], groups=[[{0, 2, 3}, {0}]], EXPR$1=[SUM($1)], $g=[GROUPING($0, $2, $3)])
         LogicalProject(DEPTNO=[$7], COMM=[$6], SAL=[$5], $f3=[>($5, 1000)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1167,10 +1167,33 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT(DISTINCT $1) FILTER
         </Resource>
         <Resource name="planAfter">
             <![CDATA[
-LogicalAggregate(group=[{}], EXPR$0=[MIN($1) FILTER $3], EXPR$1=[COUNT($0) FILTER $2])
-  LogicalProject(SAL=[$0], EXPR$0=[$2], $g_0=[AND(=($3, 0), IS TRUE($1))], $g_3=[=($3, 3)])
+LogicalAggregate(group=[{}], EXPR$0=[MIN($2) FILTER $4], EXPR$1=[COUNT($0) FILTER $3])
+  LogicalProject(SAL=[$0], $f2=[$1], EXPR$0=[$2], $g_0_1=[AND(=($3, 0), IS TRUE($1))], $g_3=[=($3, 3)])
     LogicalAggregate(group=[{1, 2}], groups=[[{1, 2}, {}]], EXPR$0=[SUM($0)], $g=[GROUPING($1, $2)])
       LogicalProject(COMM=[$6], SAL=[$5], $f2=[>($5, 1000)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDistinctWithDiffFiltersAndSameGroupSet">
+        <Resource name="sql">
+            <![CDATA[SELECT COUNT(DISTINCT c) FILTER (WHERE d),
+COUNT(DISTINCT d) FILTER (WHERE c)
+FROM (select sal > 1000 is true as c, sal < 500 is true as d from emp)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT(DISTINCT $0) FILTER $1], EXPR$1=[COUNT(DISTINCT $1) FILTER $0])
+  LogicalProject(C=[>($5, 1000)], D=[<($5, 500)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0) FILTER $3], EXPR$1=[COUNT($1) FILTER $2])
+  LogicalProject(C=[$0], D=[$1], $g_0_0=[AND(=($2, 0), $0)], $g_0_1=[AND(=($2, 0), $1)])
+    LogicalAggregate(group=[{0, 1}], $g=[GROUPING($0, $1)])
+      LogicalProject(C=[>($5, 1000)], D=[<($5, 500)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
@@ -1191,8 +1214,8 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT(DISTINCT $2) FILTE
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(DEPTNO=[$0], EXPR$1=[CAST($1):INTEGER NOT NULL], EXPR$2=[$2])
-  LogicalAggregate(group=[{0}], EXPR$1=[MIN($2) FILTER $4], EXPR$2=[COUNT($1) FILTER $3])
-    LogicalProject(DEPTNO=[$0], SAL=[$1], EXPR$1=[$3], $g_0=[AND(=($4, 0), IS TRUE($2))], $g_3=[=($4, 3)])
+  LogicalAggregate(group=[{0}], EXPR$1=[MIN($3) FILTER $5], EXPR$2=[COUNT($1) FILTER $4])
+    LogicalProject(DEPTNO=[$0], SAL=[$1], $f3=[$2], EXPR$1=[$3], $g_0_2=[AND(=($4, 0), IS TRUE($2))], $g_3=[=($4, 3)])
       LogicalAggregate(group=[{0, 2, 3}], groups=[[{0, 2, 3}, {0}]], EXPR$1=[SUM($1)], $g=[GROUPING($0, $2, $3)])
         LogicalProject(DEPTNO=[$7], COMM=[$6], SAL=[$5], $f3=[>($5, 1000)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1153,6 +1153,54 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM($3)], EXPR$2=[MIN($4)], EXPR$3=[COUNT(
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testDistinctWithFilterWithoutGroupBy">
+        <Resource name="sql">
+            <![CDATA[SELECT SUM(comm), COUNT(DISTINCT comm),
+COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)
+FROM emp]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT(DISTINCT $0)], EXPR$2=[COUNT(DISTINCT $1) FILTER $2])
+  LogicalProject(COMM=[$6], SAL=[$5], $f2=[>($5, 1000)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($3) FILTER $6], EXPR$1=[COUNT($0) FILTER $4], EXPR$2=[COUNT($1) FILTER $5])
+  LogicalProject(COMM=[$0], SAL=[$1], $f2=[$2], EXPR$0=[$3], $g_3=[=($4, 3)], $g_4=[AND(=($4, 4), IS TRUE($2))], $g_7=[=($4, 7)])
+    LogicalAggregate(group=[{0, 1, 2}], groups=[[{0}, {1, 2}, {}]], EXPR$0=[SUM($0)], $g=[GROUPING($0, $1, $2)])
+      LogicalProject(COMM=[$6], SAL=[$5], $f2=[>($5, 1000)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testDistinctWithFilterAndGroupBy">
+        <Resource name="sql">
+            <![CDATA[SELECT deptno, SUM(comm), COUNT(DISTINCT comm),
+COUNT(DISTINCT sal) FILTER (WHERE sal > 1000)
+FROM emp
+GROUP BY deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[COUNT(DISTINCT $1)], EXPR$3=[COUNT(DISTINCT $2) FILTER $3])
+  LogicalProject(DEPTNO=[$7], COMM=[$6], SAL=[$5], $f3=[>($5, 1000)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(DEPTNO=[$0], EXPR$1=[CAST($1):INTEGER NOT NULL], EXPR$2=[$2], EXPR$3=[$3])
+  LogicalAggregate(group=[{0}], EXPR$1=[MIN($4) FILTER $7], EXPR$2=[COUNT($1) FILTER $5], EXPR$3=[COUNT($2) FILTER $6])
+    LogicalProject(DEPTNO=[$0], COMM=[$1], SAL=[$2], $f3=[$3], EXPR$1=[$4], $g_3=[=($5, 3)], $g_4=[AND(=($5, 4), IS TRUE($3))], $g_7=[=($5, 7)])
+      LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1}, {0, 2, 3}, {0}]], EXPR$1=[SUM($1)], $g=[GROUPING($0, $1, $2, $3)])
+        LogicalProject(DEPTNO=[$7], COMM=[$6], SAL=[$5], $f3=[>($5, 1000)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testEmptyAggregate">
         <Resource name="sql">
             <![CDATA[select sum(empno) from emp where false group by deptno]]>


### PR DESCRIPTION
…ng `AggregateExpandDistinctAggregatesRule`

In `AggregateExpandDistinctAggregatesRule`, when the distinct aggregate call is rewritten using 
groupingSets, the filter of the distinct aggregate call itself is lost unexpected.