### PR TITLE
[CALCITE-3364] Can't group table function result due to a type cast error if table function returns a row with a single value

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
@@ -251,15 +251,8 @@ public class PhysTypeImpl implements PhysType {
     // by the code that follows. If necessary the target format can be optimized before calling
     // this method.
     PhysType targetPhysType = PhysTypeImpl.of(typeFactory, rowType, targetFormat, false);
-    final Expression selector;
-    switch (targetPhysType.getFormat()) {
-    case SCALAR:
-      selector = Expressions.call(BuiltInMethod.IDENTITY_SELECTOR.method);
-      break;
-    default:
-      selector = Expressions.lambda(Function1.class,
-          targetPhysType.record(fieldReferences(o_, Util.range(fieldCount))), o_);
-    }
+    final Expression selector = Expressions.lambda(Function1.class,
+        targetPhysType.record(fieldReferences(o_, Util.range(fieldCount))), o_);
     return Expressions.call(exp, BuiltInMethod.SELECT.method, selector);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
@@ -441,6 +441,17 @@ public class TableFunctionTest {
     with().query(q).returnsUnordered("C=7");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3364">[CALCITE-3364]
+   * Can't group table function result due to a type cast error if table function
+   * returns a row with a single value</a>. */
+  @Test public void testUserDefinedTableFunction9() {
+    final String q = "select \"N\" + 1 as c\n"
+        + "from table(\"s\".\"fibonacci2\"(3))\n"
+        + "group by \"N\"";
+    with().query(q).returnsUnordered("C=2\nC=3\nC=4");
+  }
+
   @Test public void testCrossApply() {
     final String q1 = "select *\n"
         + "from (values 2, 5) as t (c)\n"


### PR DESCRIPTION
As described in [CALCITE-3364](https://issues.apache.org/jira/browse/CALCITE-3364), incorrect in row JavaRowFormat conversion causes the problem.

The issue is triggered in EnumerableAggregate [1]:
```
inputPhysType.convertTo(childExp, physType.getFormat())
```

[1] https://github.com/apache/calcite/blob/0af2a9777365e062bab7bf9170aead51ecd43384/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregate.java#L407
