### PR TITLE
Use concurrent test execution by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -533,6 +533,7 @@ allprojects {
                 }
                 passProperty("java.awt.headless")
                 passProperty("junit.jupiter.execution.parallel.enabled", "true")
+                passProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
                 passProperty("junit.jupiter.execution.timeout.default", "5 m")
                 passProperty("user.language", "TR")
                 passProperty("user.country", "tr")

--- a/cassandra/build.gradle.kts
+++ b/cassandra/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     implementation("org.slf4j:slf4j-api")
 
     testImplementation(project(":core", "testClasses"))
-    testImplementation("com.github.stephenc.jcip:jcip-annotations")
     testImplementation("org.apache.cassandra:cassandra-all") {
         exclude("org.slf4j", "log4j-over-slf4j")
             .because("log4j is already present in the classpath")

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
@@ -25,13 +25,13 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 
 import com.google.common.collect.ImmutableMap;
 
-import net.jcip.annotations.NotThreadSafe;
-
 import org.cassandraunit.CassandraCQLUnit;
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -55,7 +55,7 @@ import static org.junit.Assume.assumeTrue;
 // force tests to run sequentially (maven surefire and failsafe are running them in parallel)
 // seems like some of our code is sharing static variables (like Hooks) which causes tests
 // to fail non-deterministically (flaky tests).
-@NotThreadSafe
+@Execution(ExecutionMode.SAME_THREAD)
 public class CassandraAdapterTest {
 
   @ClassRule

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -66,7 +66,6 @@ dependencies {
     testOracle("com.oracle.ojdbc:ojdbc8")
     testPostgresql("org.postgresql:postgresql")
 
-    testImplementation("com.github.stephenc.jcip:jcip-annotations")
     testImplementation("net.hydromatic:foodmart-data-hsqldb")
     testImplementation("net.hydromatic:foodmart-queries")
     testImplementation("net.hydromatic:quidem")

--- a/core/src/main/java/org/apache/calcite/runtime/Hook.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Hook.java
@@ -118,7 +118,12 @@ public enum Hook {
    *         closeable.close();
    *     }</pre>
    * </blockquote>
+   * @deprecated this installs a global hook (cross-thread), so it might have greater impact
+   *     than expected. Use with caution. Prefer thread-local hooks.
+   * @see #addThread(Consumer)
    */
+  @API(status = API.Status.MAINTAINED)
+  @Deprecated
   public <T> Closeable add(final Consumer<T> handler) {
     //noinspection unchecked
     handlers.add((Consumer<Object>) handler);

--- a/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
@@ -34,12 +34,12 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 
-import net.jcip.annotations.NotThreadSafe;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -88,7 +88,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Technically speaking, the test is thread safe, however Caclite/Avatica have thread-safety issues
  * see https://issues.apache.org/jira/browse/CALCITE-2853.
  */
-@NotThreadSafe
+@Execution(ExecutionMode.SAME_THREAD)
 public class CalciteRemoteDriverTest {
   public static final String LJS = Factory2.class.getName();
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3157,9 +3157,9 @@ public class RelOptRulesTest extends RelOptTestBase {
         + "when 1 IS NOT NULL then 2\n"
         + "else null end as qx "
         + "from emp";
-    try (Hook.Closeable a = Hook.REL_BUILDER_SIMPLIFY.add(Hook.propertyJ(false))) {
-      sql(sql).with(program).check();
-    }
+    sql(sql)
+        .withProperty(Hook.REL_BUILDER_SIMPLIFY, false)
+        .with(program).check();
   }
 
   @Test public void testReduceCastsNullable() throws Exception {

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
@@ -26,8 +26,6 @@ import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.HierarchySchema;
 import org.apache.calcite.tools.RelBuilder;
 
-import net.jcip.annotations.NotThreadSafe;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -42,7 +40,6 @@ import java.util.function.Function;
  * <a href="https://issues.apache.org/jira/browse/CALCITE-2812">[CALCITE-2812]
  * Add algebraic operators to allow expressing recursive queries</a>.
  */
-@NotThreadSafe
 public class EnumerableRepeatUnionHierarchyTest {
 
   // Tests for the following hierarchy:

--- a/redis/src/test/java/org/apache/calcite/adapter/redis/RedisCaseBase.java
+++ b/redis/src/test/java/org/apache/calcite/adapter/redis/RedisCaseBase.java
@@ -18,6 +18,8 @@ package org.apache.calcite.adapter.redis;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -27,6 +29,7 @@ import redis.embedded.RedisServer;
 /**
  * RedisITCaseBase.
  */
+@Execution(ExecutionMode.SAME_THREAD)
 public abstract class RedisCaseBase {
 
   public static final int PORT = getAvailablePort();


### PR DESCRIPTION
This switches test execution to the concurrent mode by default. In other words, both test classes and test methods could be executed concurrently.

Note: `Hook#add` should not be used in test code as it adds global hooks
which become shared across threads.

Use `Hook#addThread` if you need to add a hook.