### PR TITLE
[CALCITE-3697] Implement BITCOUNT function

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -94,6 +94,7 @@ import static org.apache.calcite.linq4j.tree.ExpressionType.NotEqual;
 import static org.apache.calcite.linq4j.tree.ExpressionType.OrElse;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Subtract;
 import static org.apache.calcite.linq4j.tree.ExpressionType.UnaryPlus;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.BITCOUNT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CHR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DAYNAME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DIFFERENCE;
@@ -405,6 +406,9 @@ public class RexImpTable {
     defineMethod(TRUNCATE, "struncate", NullPolicy.STRICT);
 
     map.put(PI, (translator, call, nullAs) -> Expressions.constant(Math.PI));
+
+    // bitwise
+    defineMethod(BITCOUNT, BuiltInMethod.BITCOUNT.method, NullPolicy.STRICT);
 
     // datetime
     defineImplementor(DATETIME_PLUS, NullPolicy.STRICT,

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1072,6 +1072,11 @@ public class SqlFunctions {
     return b0 & b1;
   }
 
+  /** Helper function for implementing <code>BITCOUNT</code> */
+  public static long bitCount(long b) {
+    return Long.bitCount(b);
+  }
+
   // |
   /** Helper function for implementing <code>BIT_OR</code> */
   public static long bitOr(long b0, long b1) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -255,6 +255,16 @@ public abstract class SqlLibraryOperators {
           OperandTypes.STRING_STRING,
           SqlFunctionCategory.STRING);
 
+  @LibraryOperator(libraries = {MYSQL})
+  public static final SqlFunction BITCOUNT =
+      new SqlFunction(
+          "BIT_COUNT",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.ARG0,
+          null,
+          OperandTypes.INTEGER,
+          SqlFunctionCategory.NUMERIC);
+
   /** The "CONCAT(arg, ...)" function that concatenates strings.
    * For example, "CONCAT('a', 'bc', 'd')" returns "abcd". */
   @LibraryOperator(libraries = {MYSQL, POSTGRESQL, ORACLE})

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -408,6 +408,7 @@ public enum BuiltInMethod {
   LESSER(SqlFunctions.class, "lesser", Comparable.class, Comparable.class),
   GREATER(SqlFunctions.class, "greater", Comparable.class, Comparable.class),
   BIT_AND(SqlFunctions.class, "bitAnd", long.class, long.class),
+  BITCOUNT(SqlFunctions.class, "bitCount", long.class),
   BIT_OR(SqlFunctions.class, "bitOr", long.class, long.class),
   BIT_XOR(SqlFunctions.class, "bitXor", long.class, long.class),
   MODIFIABLE_TABLE_GET_MODIFIABLE_COLLECTION(ModifiableTable.class,

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -8810,6 +8810,26 @@ public abstract class SqlOperatorBaseTest {
     tester.checkAgg("bit_and(x)", values, 2, 0);
   }
 
+  @Test public void testBitCountFunc() {
+    SqlTester tester = tester(SqlLibrary.MYSQL);
+    tester.checkFails("bit_count(^*^)", "Unknown identifier '\\*'", false);
+    tester.checkType("bit_count(1)", "INTEGER NOT NULL");
+    tester.checkType("bit_count(CAST(2 AS TINYINT))", "TINYINT NOT NULL");
+    tester.checkType("bit_count(CAST(2 AS SMALLINT))", "SMALLINT NOT NULL");
+    tester.checkFails("^bit_count(1.2)^",
+        "Cannot apply 'BIT_COUNT' to arguments of type 'BIT_COUNT\\(<DECIMAL\\(2, 1\\)>\\)'\\. Supported form\\(s\\): 'BIT_COUNT\\(<INTEGER>\\)'",
+        false);
+    tester.checkFails(
+        "^bit_count()^",
+        "Invalid number of arguments to function 'BIT_COUNT'. Was expecting 1 arguments",
+        false);
+    tester.checkFails(
+        "^bit_count(1, 2)^",
+        "Invalid number of arguments to function 'BIT_COUNT'. Was expecting 1 arguments",
+        false);
+    tester.checkScalar("bit_count(8)", "1", "INTEGER NOT NULL");
+  }
+
   @Test public void testBitOrFunc() {
     tester.setFor(SqlStdOperatorTable.BIT_OR, VM_FENNEL, VM_JAVA);
     tester.checkFails("bit_or(^*^)", "Unknown identifier '\\*'", false);

--- a/core/src/test/resources/sql/functions.iq
+++ b/core/src/test/resources/sql/functions.iq
@@ -18,6 +18,17 @@
 !use mysqlfunc
 !set outputformat mysql
 
+# BIT_COUNT
+select bit_count(8);
++--------+
+| EXPR$0 |
++--------+
+|      1 |
++--------+
+(1 row)
+
+!ok
+
 # MATH Functions
 
 # CBRT

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2294,6 +2294,7 @@ semantics.
 | C | Operator syntax                                | Description
 |:- |:-----------------------------------------------|:-----------
 | p | expr :: type                                   | Casts *expr* to *type*
+| m | BIT_COUNT(integer)                             | Returns the bitwise COUNT of non-null *integer*
 | o | CHR(integer) | Returns the character having the binary equivalent to *integer* as a CHAR value
 | m o p | CONCAT(string [, string ]*)                | Concatenates two or more strings
 | p | CONVERT_TIMEZONE(tz1, tz2, datetime)           | Converts the timezone of *datetime* from *tz1* to *tz2*


### PR DESCRIPTION
As illustrated in [CALCITE-3697](https://issues.apache.org/jira/browse/CALCITE-3697)
select bit_count(8);
+--------+
| EXPR$0 |
+--------+
|      1        |
+--------+
(1 row)

!ok