### PR TITLE
Refine rules to avoid producing matches that are known to be no-op

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AbstractMaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AbstractMaterializedViewRule.java
@@ -157,6 +157,10 @@ public abstract class AbstractMaterializedViewRule extends RelOptRule {
     this.fastBailOut = fastBailOut;
   }
 
+  @Override public boolean matches(RelOptRuleCall call) {
+    return !call.getPlanner().getMaterializations().isEmpty();
+  }
+
   /**
    * Rewriting logic is based on "Optimizing Queries Using Materialized Views:
    * A Practical, Scalable Solution" by Goldstein and Larson.

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionMergeRule.java
@@ -70,6 +70,28 @@ public class UnionMergeRule extends RelOptRule {
 
   //~ Methods ----------------------------------------------------------------
 
+  @Override public boolean matches(RelOptRuleCall call) {
+    // It avoids adding the rule match to the match queue in case the rule is known to be a no-op
+    final SetOp topOp = call.rel(0);
+    @SuppressWarnings("unchecked") final Class<? extends SetOp> setOpClass =
+        (Class<? extends SetOp>) operands.get(0).getMatchedClass();
+    final SetOp bottomOp;
+    if (setOpClass.isInstance(call.rel(2))
+        && !Minus.class.isAssignableFrom(setOpClass)) {
+      bottomOp = call.rel(2);
+    } else if (setOpClass.isInstance(call.rel(1))) {
+      bottomOp = call.rel(1);
+    } else {
+      return false;
+    }
+
+    if (topOp.all && !bottomOp.all) {
+      return false;
+    }
+
+    return true;
+  }
+
   public void onMatch(RelOptRuleCall call) {
     final SetOp topOp = call.rel(0);
     @SuppressWarnings("unchecked") final Class<? extends SetOp> setOpClass =

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionPullUpConstantsRule.java
@@ -53,19 +53,17 @@ public class UnionPullUpConstantsRule extends RelOptRule {
   /** Creates a UnionPullUpConstantsRule. */
   public UnionPullUpConstantsRule(Class<? extends Union> unionClass,
       RelBuilderFactory relBuilderFactory) {
-    super(operand(unionClass, any()), relBuilderFactory, null);
+    // If field count is 1, then there's no room for
+    // optimization since we cannot create an empty Project
+    // operator. If we created a Project with one column, this rule would
+    // cycle.
+    super(
+        operandJ(unionClass, null, union -> union.getRowType().getFieldCount() > 1, any()),
+        relBuilderFactory, null);
   }
 
   @Override public void onMatch(RelOptRuleCall call) {
     final Union union = call.rel(0);
-
-    final int count = union.getRowType().getFieldCount();
-    if (count == 1) {
-      // No room for optimization since we cannot create an empty Project
-      // operator. If we created a Project with one column, this rule would
-      // cycle.
-      return;
-    }
 
     final RexBuilder rexBuilder = union.getCluster().getRexBuilder();
     final RelMetadataQuery mq = call.getMetadataQuery();

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionToDistinctRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionToDistinctRule.java
@@ -43,7 +43,9 @@ public class UnionToDistinctRule extends RelOptRule {
    */
   public UnionToDistinctRule(Class<? extends Union> unionClazz,
       RelBuilderFactory relBuilderFactory) {
-    super(operand(unionClazz, any()), relBuilderFactory, null);
+    super(
+        operandJ(unionClazz, null, union -> !union.all, any()),
+        relBuilderFactory, null);
   }
 
   @Deprecated // to be removed before 2.0
@@ -56,9 +58,6 @@ public class UnionToDistinctRule extends RelOptRule {
 
   public void onMatch(RelOptRuleCall call) {
     final Union union = call.rel(0);
-    if (union.all) {
-      return; // nothing to do
-    }
     final RelBuilder relBuilder = call.builder();
     relBuilder.pushAll(union.getInputs());
     relBuilder.union(true, union.getInputs().size());


### PR DESCRIPTION
UnionMergeRule produced lots of unrelated matches because it matched only the top operand as SetOp.
Bottom operand classes were compared in onMatch method only, so
it resulted in lots of false positives for the optimizer.

Not it does not get added to the optimizer queue at all.