### PR TITLE
[CALCITE-3725] RelMetadataTest fails with NPE due to unsafe RelMetada…

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1019,8 +1019,8 @@ public class RelMetadataTest extends SqlToRelTestBase {
   }
 
   private void checkColumnUniquenessForFilterWithConstantColumns(String sql) {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(sql);
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(rel.getRowType().getFieldNames().toString(),
         is("[DEPTNO, SAL]"));
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0, 1)), is(true));
@@ -1029,19 +1029,18 @@ public class RelMetadataTest extends SqlToRelTestBase {
   }
 
   @Test public void testColumnUniquenessForUnionWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final String sql = ""
         + "select deptno, sal from emp where sal=1000\n"
         + "union\n"
         + "select deptno, sal from emp where sal=1000\n";
     final RelNode rel = convertSql(sql);
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(rel.getRowType().getFieldNames().toString(),
         is("[DEPTNO, SAL]"));
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0)), is(true));
   }
 
   @Test public void testColumnUniquenessForIntersectWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final String sql = ""
         + "select deptno, sal\n"
         + "from (select distinct deptno, sal from emp)\n"
@@ -1049,13 +1048,13 @@ public class RelMetadataTest extends SqlToRelTestBase {
         + "intersect all\n"
         + "select deptno, sal from emp\n";
     final RelNode rel = convertSql(sql);
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(rel.getRowType().getFieldNames().toString(),
         is("[DEPTNO, SAL]"));
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0, 1)), is(true));
   }
 
   @Test public void testColumnUniquenessForMinusWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final String sql = ""
         + "select deptno, sal\n"
         + "from (select distinct deptno, sal from emp)\n"
@@ -1063,6 +1062,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
         + "except all\n"
         + "select deptno, sal from emp\n";
     final RelNode rel = convertSql(sql);
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(rel.getRowType().getFieldNames().toString(),
         is("[DEPTNO, SAL]"));
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0)), is(true));
@@ -1070,20 +1070,19 @@ public class RelMetadataTest extends SqlToRelTestBase {
   }
 
   @Test public void testColumnUniquenessForSortWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final String sql = ""
         + "select *\n"
         + "from (select distinct deptno, sal from emp)\n"
         + "where sal=1000\n"
         + "order by deptno";
     final RelNode rel = convertSql(sql);
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(rel.getRowType().getFieldNames().toString(),
         is("[DEPTNO, SAL]"));
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0, 1)), is(true));
   }
 
   @Test public void testColumnUniquenessForJoinWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final String sql = ""
         + "select *\n"
         + "from (select distinct deptno, sal from emp) A\n"
@@ -1092,6 +1091,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     final RelNode rel = convertSql(sql);
     assertThat(rel.getRowType().getFieldNames().toString(),
         is("[DEPTNO, SAL, DEPTNO0, SAL0]"));
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0, 2)), is(true));
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0, 1, 2)), is(true));
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(0, 2, 3)), is(true));
@@ -1099,18 +1099,17 @@ public class RelMetadataTest extends SqlToRelTestBase {
   }
 
   @Test public void testColumnUniquenessForAggregateWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final String sql = ""
         + "select deptno, ename, sum(sal)\n"
         + "from emp\n"
         + "where deptno=1010\n"
         + "group by deptno, ename";
     final RelNode rel = convertSql(sql);
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.areColumnsUnique(rel, ImmutableBitSet.of(1)), is(true));
   }
 
   @Test public void testColumnUniquenessForExchangeWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final FrameworkConfig config = RelBuilderTest.config().build();
     final RelBuilder builder = RelBuilder.create(config);
     RelNode exchange = builder.scan("EMP")
@@ -1119,11 +1118,11 @@ public class RelMetadataTest extends SqlToRelTestBase {
         .filter(builder.equals(builder.field("SAL"), builder.literal(1)))
         .exchange(RelDistributions.hash(ImmutableList.of(1)))
         .build();
+    final RelMetadataQuery mq = exchange.getCluster().getMetadataQuery();
     assertThat(mq.areColumnsUnique(exchange, ImmutableBitSet.of(0)), is(true));
   }
 
   @Test public void testColumnUniquenessForCorrelateWithConstantColumns() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final FrameworkConfig config = RelBuilderTest.config().build();
     final RelBuilder builder = RelBuilder.create(config);
     RelNode rel0 = builder.scan("EMP")
@@ -1143,6 +1142,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
         .push(rel1)
         .correlate(JoinRelType.SEMI, v.get().id, builder.field(2, 0, "DEPTNO"))
         .build();
+    final RelMetadataQuery mq = correl.getCluster().getMetadataQuery();
     assertThat(mq.areColumnsUnique(correl, ImmutableBitSet.of(0)), is(true));
   }
 
@@ -1966,85 +1966,85 @@ public class RelMetadataTest extends SqlToRelTestBase {
   }
 
   @Test public void testPullUpPredicatesFromUnion0() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno from emp where empno=1\n"
         + "union all\n"
         + "select empno from emp where empno=1");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1)]"));
   }
 
   @Test public void testPullUpPredicatesFromUnion1() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno, deptno from emp where empno=1 or deptno=2\n"
         + "union all\n"
         + "select empno, deptno from emp where empno=3 or deptno=4");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[OR(=($0, 1), =($1, 2), =($0, 3), =($1, 4))]"));
   }
 
   @Test public void testPullUpPredicatesFromUnion2() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno, comm, deptno from emp where empno=1 and comm=2 and deptno=3\n"
         + "union all\n"
         + "select empno, comm, deptno from emp where empno=1 and comm=4");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1), OR(AND(=($1, 2), =($2, 3)), =($1, 4))]"));
 
   }
 
   @Test public void testPullUpPredicatesFromIntersect0() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno from emp where empno=1\n"
         + "intersect all\n"
         + "select empno from emp where empno=1");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1)]"));
 
   }
 
   @Test public void testPullUpPredicatesFromIntersect1() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
         + "intersect all\n"
         + "select empno, deptno, comm from emp where empno=1 and comm=3");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1), =($1, 2), =($2, 3)]"));
 
   }
 
   @Test public void testPullUpPredicatesFromIntersect2() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
         + "intersect all\n"
         + "select empno, deptno, comm from emp where 1=empno and (deptno=2 or comm=3)");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1), =($1, 2)]"));
 
   }
 
   @Test public void testPullUpPredicatesFromIntersect3() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno, deptno, comm from emp where empno=1 or deptno=2\n"
         + "intersect all\n"
         + "select empno, deptno, comm from emp where deptno=2 or empno=1 or comm=3");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[OR(=($0, 1), =($1, 2))]"));
   }
 
   @Test public void testPullUpPredicatesFromMinus() {
-    final RelMetadataQuery mq = RelMetadataQuery.instance();
     final RelNode rel = convertSql(""
         + "select empno, deptno, comm from emp where empno=1 and deptno=2\n"
         + "except all\n"
         + "select empno, deptno, comm from emp where comm=3");
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     assertThat(mq.getPulledUpPredicates(rel).pulledUpPredicates,
         sortsAs("[=($0, 1), =($1, 2)]"));
   }


### PR DESCRIPTION
…taQuery.instance call (Jin Xing)

Follow the approach from 
https://issues.apache.org/jira/browse/CALCITE-3403
https://issues.apache.org/jira/browse/CALCITE-3421

Reuse RelMetadataQuery.