### PR TITLE
[CALCITE-3723] Following the change to add hints to RelNode, deprecat…

### DIFF
--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraProject.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraProject.java
@@ -28,6 +28,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +41,7 @@ import java.util.Map;
 public class CassandraProject extends Project implements CassandraRel {
   public CassandraProject(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, List<? extends RexNode> projects, RelDataType rowType) {
-    super(cluster, traitSet, input, projects, rowType);
+    super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     assert getConvention() == CassandraRel.CONVENTION;
     assert getConvention() == input.getConvention();
   }

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTableScan.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraTableScan.java
@@ -25,6 +25,8 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /**
@@ -45,7 +47,7 @@ public class CassandraTableScan extends TableScan implements CassandraRel {
    */
   protected CassandraTableScan(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table, CassandraTable cassandraTable, RelDataType projectRowType) {
-    super(cluster, traitSet, table);
+    super(cluster, traitSet, ImmutableList.of(), table);
     this.cassandraTable = cassandraTable;
     this.projectRowType = projectRowType;
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregate.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregate.java
@@ -66,7 +66,7 @@ public class EnumerableAggregate extends Aggregate implements EnumerableRel {
       List<ImmutableBitSet> groupSets,
       List<AggregateCall> aggCalls)
       throws InvalidRelException {
-    super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+    super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
     assert getConvention() instanceof EnumerableConvention;
 
     for (AggregateCall aggCall : aggCalls) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
@@ -60,7 +60,7 @@ public class EnumerableBatchNestedLoopJoin extends Join implements EnumerableRel
       Set<CorrelationId> variablesSet,
       ImmutableBitSet requiredColumns,
       JoinRelType joinType) {
-    super(cluster, traits, left, right, condition, variablesSet, joinType);
+    super(cluster, traits, ImmutableList.of(), left, right, condition, variablesSet, joinType);
     this.requiredColumns = requiredColumns;
   }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
@@ -71,7 +71,7 @@ public class EnumerableCalc extends Calc implements EnumerableRel {
       RelTraitSet traitSet,
       RelNode input,
       RexProgram program) {
-    super(cluster, traitSet, input, program);
+    super(cluster, traitSet, ImmutableList.of(), input, program);
     assert getConvention() instanceof EnumerableConvention;
     assert !program.containsAggs();
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableHashJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableHashJoin.java
@@ -60,6 +60,7 @@ public class EnumerableHashJoin extends Join implements EnumerableRel {
     super(
         cluster,
         traits,
+        ImmutableList.of(),
         left,
         right,
         condition,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -61,7 +61,7 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
       RexNode condition,
       Set<CorrelationId> variablesSet,
       JoinRelType joinType) {
-    super(cluster, traits, left, right, condition, variablesSet, joinType);
+    super(cluster, traits, ImmutableList.of(), left, right, condition, variablesSet, joinType);
     final List<RelCollation> collations =
         traits.getTraits(RelCollationTraitDef.INSTANCE);
     assert collations == null || RelCollations.contains(collations, joinInfo.leftKeys);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
@@ -47,7 +47,7 @@ public class EnumerableNestedLoopJoin extends Join implements EnumerableRel {
   protected EnumerableNestedLoopJoin(RelOptCluster cluster, RelTraitSet traits,
       RelNode left, RelNode right, RexNode condition,
       Set<CorrelationId> variablesSet, JoinRelType joinType) {
-    super(cluster, traits, left, right, condition, variablesSet, joinType);
+    super(cluster, traits, ImmutableList.of(), left, right, condition, variablesSet, joinType);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
@@ -27,6 +27,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Util;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Project} in
@@ -49,7 +51,7 @@ public class EnumerableProject extends Project implements EnumerableRel {
       RelNode input,
       List<? extends RexNode> projects,
       RelDataType rowType) {
-    super(cluster, traitSet, input, projects, rowType);
+    super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     assert getConvention() instanceof EnumerableConvention;
   }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
@@ -66,7 +66,7 @@ public class EnumerableTableScan
    * <p>Use {@link #create} unless you know what you are doing. */
   public EnumerableTableScan(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table, Class elementType) {
-    super(cluster, traitSet, table);
+    super(cluster, traitSet, ImmutableList.of(), table);
     assert getConvention() instanceof EnumerableConvention;
     this.elementType = elementType;
     assert canHandle(table)

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -376,7 +376,7 @@ public class JdbcRules {
         RelNode left, RelNode right, RexNode condition,
         Set<CorrelationId> variablesSet, JoinRelType joinType)
         throws InvalidRelException {
-      super(cluster, traitSet, left, right, condition, variablesSet, joinType);
+      super(cluster, traitSet, ImmutableList.of(), left, right, condition, variablesSet, joinType);
     }
 
     @Deprecated // to be removed before 2.0
@@ -557,7 +557,7 @@ public class JdbcRules {
         RelNode input,
         List<? extends RexNode> projects,
         RelDataType rowType) {
-      super(cluster, traitSet, input, projects, rowType);
+      super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
       assert getConvention() instanceof JdbcConvention;
     }
 
@@ -695,7 +695,7 @@ public class JdbcRules {
         List<ImmutableBitSet> groupSets,
         List<AggregateCall> aggCalls)
         throws InvalidRelException {
-      super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+      super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
       assert getConvention() instanceof JdbcConvention;
       assert this.groupSets.size() == 1 : "Grouping sets not supported";
       final SqlDialect dialect = ((JdbcConvention) getConvention()).dialect;

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTableScan.java
@@ -38,7 +38,7 @@ public class JdbcTableScan extends TableScan implements JdbcRel {
       RelOptTable table,
       JdbcTable jdbcTable,
       JdbcConvention jdbcConvention) {
-    super(cluster, cluster.traitSetOf(jdbcConvention), table);
+    super(cluster, cluster.traitSetOf(jdbcConvention), ImmutableList.of(), table);
     this.jdbcTable = Objects.requireNonNull(jdbcTable);
   }
 

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -181,7 +181,7 @@ public class Bindables {
     BindableTableScan(RelOptCluster cluster, RelTraitSet traitSet,
         RelOptTable table, ImmutableList<RexNode> filters,
         ImmutableIntList projects) {
-      super(cluster, traitSet, table);
+      super(cluster, traitSet, ImmutableList.of(), table);
       this.filters = Objects.requireNonNull(filters);
       this.projects = Objects.requireNonNull(projects);
       Preconditions.checkArgument(canHandle(table));
@@ -369,7 +369,7 @@ public class Bindables {
   public static class BindableProject extends Project implements BindableRel {
     public BindableProject(RelOptCluster cluster, RelTraitSet traitSet,
         RelNode input, List<? extends RexNode> projects, RelDataType rowType) {
-      super(cluster, traitSet, input, projects, rowType);
+      super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
       assert getConvention() instanceof BindableConvention;
     }
 
@@ -487,7 +487,8 @@ public class Bindables {
     protected BindableJoin(RelOptCluster cluster, RelTraitSet traitSet,
         RelNode left, RelNode right, RexNode condition,
         Set<CorrelationId> variablesSet, JoinRelType joinType) {
-      super(cluster, traitSet, left, right, condition, variablesSet, joinType);
+      super(cluster, traitSet, ImmutableList.of(), left, right,
+          condition, variablesSet, joinType);
     }
 
     @Deprecated // to be removed before 2.0
@@ -630,7 +631,7 @@ public class Bindables {
         List<ImmutableBitSet> groupSets,
         List<AggregateCall> aggCalls)
         throws InvalidRelException {
-      super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+      super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
       assert getConvention() instanceof BindableConvention;
 
       for (AggregateCall aggCall : aggCalls) {

--- a/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
@@ -171,16 +171,7 @@ public abstract class Aggregate extends SingleRel implements Hintable {
     }
   }
 
-  /**
-   * Create an Aggregate.
-   *
-   * @param cluster  Cluster
-   * @param traitSet Trait set
-   * @param input    Input relational expression
-   * @param groupSet Bit set of grouping fields
-   * @param groupSets List of all grouping sets; null for just {@code groupSet}
-   * @param aggCalls Collection of calls to aggregate functions
-   */
+  @Deprecated // to be removed before 2.0
   protected Aggregate(
       RelOptCluster cluster,
       RelTraitSet traitSet,
@@ -191,9 +182,6 @@ public abstract class Aggregate extends SingleRel implements Hintable {
     this(cluster, traitSet, new ArrayList<>(), input, groupSet, groupSets, aggCalls);
   }
 
-  /**
-   * Creates an Aggregate.
-   */
   @Deprecated // to be removed before 2.0
   protected Aggregate(
       RelOptCluster cluster,
@@ -203,7 +191,7 @@ public abstract class Aggregate extends SingleRel implements Hintable {
       ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets,
       List<AggregateCall> aggCalls) {
-    this(cluster, traits, new ArrayList<>(), child, groupSet, groupSets, aggCalls);
+    this(cluster, traits, ImmutableList.of(), child, groupSet, groupSets, aggCalls);
     checkIndicator(indicator);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Calc.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Calc.java
@@ -42,7 +42,6 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -79,20 +78,13 @@ public abstract class Calc extends SingleRel implements Hintable {
     assert isValid(Litmus.THROW, null);
   }
 
-  /**
-   * Creates a Calc.
-   *
-   * @param cluster Cluster
-   * @param traits Traits
-   * @param child Input relation
-   * @param program Calc program
-   */
+  @Deprecated // to be removed before 2.0
   protected Calc(
       RelOptCluster cluster,
       RelTraitSet traits,
       RelNode child,
       RexProgram program) {
-    this(cluster, traits, Collections.emptyList(), child, program);
+    this(cluster, traits, ImmutableList.of(), child, program);
   }
 
   @Deprecated // to be removed before 2.0
@@ -102,7 +94,7 @@ public abstract class Calc extends SingleRel implements Hintable {
       RelNode child,
       RexProgram program,
       List<RelCollation> collationList) {
-    this(cluster, traits, child, program);
+    this(cluster, traits, ImmutableList.of(), child, program);
     Util.discard(collationList);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/EquiJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/EquiJoin.java
@@ -22,6 +22,8 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ImmutableIntList;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.Objects;
 import java.util.Set;
 
@@ -52,7 +54,7 @@ public abstract class EquiJoin extends Join {
   public EquiJoin(RelOptCluster cluster, RelTraitSet traits, RelNode left,
       RelNode right, RexNode condition, Set<CorrelationId> variablesSet,
       JoinRelType joinType) {
-    super(cluster, traits, left, right, condition, variablesSet, joinType);
+    super(cluster, traits, ImmutableList.of(), left, right, condition, variablesSet, joinType);
     this.leftKeys = Objects.requireNonNull(joinInfo.leftKeys);
     this.rightKeys = Objects.requireNonNull(joinInfo.rightKeys);
     assert joinInfo.isEqui() : "Create EquiJoin with non-equi join condition.";
@@ -64,7 +66,7 @@ public abstract class EquiJoin extends Join {
       RelNode right, RexNode condition, ImmutableIntList leftKeys,
       ImmutableIntList rightKeys, Set<CorrelationId> variablesSet,
       JoinRelType joinType) {
-    super(cluster, traits, left, right, condition, variablesSet, joinType);
+    super(cluster, traits, ImmutableList.of(), left, right, condition, variablesSet, joinType);
     this.leftKeys = Objects.requireNonNull(leftKeys);
     this.rightKeys = Objects.requireNonNull(rightKeys);
   }

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -41,7 +41,6 @@ import org.apache.calcite.util.Util;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -116,32 +115,12 @@ public abstract class Join extends BiRel implements Hintable {
     this.hints = ImmutableList.copyOf(hints);
   }
 
-  /**
-   * Creates a Join.
-   *
-   * <p>Note: We plan to change the {@code variablesStopped} parameter to
-   * {@code Set&lt;CorrelationId&gt; variablesSet}
-   * {@link org.apache.calcite.util.Bug#upgrade(String) before version 2.0},
-   * because {@link #getVariablesSet()}
-   * is preferred over {@link #getVariablesStopped()}.
-   * This constructor is not deprecated, for now, because maintaining overloaded
-   * constructors in multiple sub-classes would be onerous.
-   *
-   * @param cluster          Cluster
-   * @param traitSet         Trait set
-   * @param left             Left input
-   * @param right            Right input
-   * @param condition        Join condition
-   * @param joinType         Join type
-   * @param variablesSet     Set variables that are set by the
-   *                         LHS and used by the RHS and are not available to
-   *                         nodes above this Join in the tree
-   */
+  @Deprecated // to be removed before 2.0
   protected Join(
       RelOptCluster cluster, RelTraitSet traitSet, RelNode left,
       RelNode right, RexNode condition, Set<CorrelationId> variablesSet,
       JoinRelType joinType) {
-    this(cluster, traitSet, new ArrayList<>(), left, right,
+    this(cluster, traitSet, ImmutableList.of(), left, right,
         condition, variablesSet, joinType);
   }
 
@@ -154,7 +133,7 @@ public abstract class Join extends BiRel implements Hintable {
       RexNode condition,
       JoinRelType joinType,
       Set<String> variablesStopped) {
-    this(cluster, traitSet, left, right, condition,
+    this(cluster, traitSet, ImmutableList.of(), left, right, condition,
         CorrelationId.setOf(variablesStopped), joinType);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Project.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Project.java
@@ -46,7 +46,6 @@ import org.apache.calcite.util.mapping.Mappings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -91,24 +90,16 @@ public abstract class Project extends SingleRel implements Hintable {
     assert isValid(Litmus.THROW, null);
   }
 
-  /**
-   * Creates a Project.
-   *
-   * @param cluster  Cluster that this relational expression belongs to
-   * @param traits   Traits of this relational expression
-   * @param input    Input relational expression
-   * @param projects List of expressions for the input columns
-   * @param rowType  Output row type
-   */
+  @Deprecated // to be removed before 2.0
   protected Project(RelOptCluster cluster, RelTraitSet traits,
       RelNode input, List<? extends RexNode> projects, RelDataType rowType) {
-    this(cluster, traits, new ArrayList<>(), input, projects, rowType);
+    this(cluster, traits, ImmutableList.of(), input, projects, rowType);
   }
 
   @Deprecated // to be removed before 2.0
   protected Project(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
       List<? extends RexNode> projects, RelDataType rowType, int flags) {
-    this(cluster, traitSet, input, projects, rowType);
+    this(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     Util.discard(flags);
   }
 
@@ -118,6 +109,7 @@ public abstract class Project extends SingleRel implements Hintable {
   protected Project(RelInput input) {
     this(input.getCluster(),
         input.getTraitSet(),
+        ImmutableList.of(),
         input.getInput(),
         input.getExpressionList("exprs"),
         input.getRowType("exprs", "fields"));

--- a/core/src/main/java/org/apache/calcite/rel/core/TableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/TableScan.java
@@ -73,16 +73,17 @@ public abstract class TableScan
     this.hints = ImmutableList.copyOf(hints);
   }
 
+  @Deprecated // to be removed before 2.0
   protected TableScan(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table) {
-    this(cluster, traitSet, new ArrayList<>(), table);
+    this(cluster, traitSet, ImmutableList.of(), table);
   }
 
   /**
    * Creates a TableScan by parsing serialized output.
    */
   protected TableScan(RelInput input) {
-    this(input.getCluster(), input.getTraitSet(), input.getTable("table"));
+    this(input.getCluster(), input.getTraitSet(), ImmutableList.of(), input.getTable("table"));
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/hint/Hintable.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/Hintable.java
@@ -28,17 +28,15 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Base class for relational expressions with {@link RelHint}s.
+ * {@link Hintable} is a kind of {@link RelNode} that can attach {@link RelHint}s.
  *
- * <p>Relational expressions that can attach hints should implement
- * this interface.
+ * <p>This interface is experimental, currently, {@link RelNode}s that implement it
+ * have a constructor parameter named "hints" used to construct relational expression
+ * with given attached hints.
  *
- * <p>This interface is experimental, currently, we make some {@link RelNode}s
- * implement this interface and add an argument named "hints" to construct these
- * relational expressions if hints are attached.
- *
- * <p>This design is not that elegant and mature, because we have to copy the hints whenever these
- * relational expressions are copied or used to derive new relational expressions.
+ * <p>Current design is not that elegant and mature, because we have to
+ * copy the hints whenever these relational expressions are copied or used to
+ * derive new relational expressions.
  * Even though we have implemented the mechanism to propagate the hints, for large queries,
  * there would be many cases where the hints are not copied to the right RelNode,
  * and the effort/memory is wasted if we are copying the hint to a RelNode
@@ -48,9 +46,9 @@ import java.util.Set;
 public interface Hintable {
 
   /**
-   * Attaches list of hints to this relational expression, should be overridden by
-   * every logical node that supports hint. This method is only for
-   * internal use during sql-to-rel conversion.
+   * Attaches list of hints to this relational expression.
+   *
+   * <p>This method is only for internal use during sql-to-rel conversion.
    *
    * <p>Sub-class should return a new copy of the relational expression.
    *
@@ -69,7 +67,7 @@ public interface Hintable {
   }
 
   /**
-   * Returns a new relation expression with the specified hints {@code hintList}.
+   * Returns a new relational expression with the specified hints {@code hintList}.
    *
    * <p>This method should be overridden by every logical node that supports hint.
    * It is only for internal use during decorrelation.

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
@@ -27,7 +27,8 @@ import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.util.ImmutableBitSet;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /**
@@ -69,19 +70,7 @@ public final class LogicalAggregate extends Aggregate {
     super(cluster, traitSet, hints, input, groupSet, groupSets, aggCalls);
   }
 
-
-  /**
-   * Creates a LogicalAggregate.
-   *
-   * <p>Use {@link #create} unless you know what you're doing.
-   *
-   * @param cluster    Cluster that this relational expression belongs to
-   * @param traitSet   Traits
-   * @param input      Input relational expression
-   * @param groupSet Bit set of grouping fields
-   * @param groupSets Grouping sets, or null to use just {@code groupSet}
-   * @param aggCalls Array of aggregates to compute, not null
-   */
+  @Deprecated // to be removed before 2.0
   public LogicalAggregate(
       RelOptCluster cluster,
       RelTraitSet traitSet,
@@ -89,14 +78,14 @@ public final class LogicalAggregate extends Aggregate {
       ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets,
       List<AggregateCall> aggCalls) {
-    this(cluster, traitSet, new ArrayList<>(), input, groupSet, groupSets, aggCalls);
+    this(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
   }
 
   @Deprecated // to be removed before 2.0
   public LogicalAggregate(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, boolean indicator, ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
-    super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+    super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
     checkIndicator(indicator);
   }
 
@@ -104,7 +93,7 @@ public final class LogicalAggregate extends Aggregate {
   public LogicalAggregate(RelOptCluster cluster,
       RelNode input, boolean indicator, ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
-    super(cluster, cluster.traitSetOf(Convention.NONE), input, groupSet,
+    super(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(), input, groupSet,
         groupSets, aggCalls);
     checkIndicator(indicator);
   }
@@ -139,7 +128,7 @@ public final class LogicalAggregate extends Aggregate {
       List<AggregateCall> aggCalls) {
     final RelOptCluster cluster = input.getCluster();
     final RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
-    return new LogicalAggregate(cluster, traitSet, input, groupSet,
+    return new LogicalAggregate(cluster, traitSet, ImmutableList.of(), input, groupSet,
         groupSets, aggCalls);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
@@ -39,7 +39,6 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -80,13 +79,13 @@ public final class LogicalCalc extends Calc {
     super(cluster, traitSet, hints, child, program);
   }
 
-  /** Creates a LogicalCalc. */
+  @Deprecated // to be removed before 2.0
   public LogicalCalc(
       RelOptCluster cluster,
       RelTraitSet traitSet,
       RelNode child,
       RexProgram program) {
-    this(cluster, traitSet, Collections.emptyList(), child, program);
+    this(cluster, traitSet, ImmutableList.of(), child, program);
   }
 
   /**
@@ -95,6 +94,7 @@ public final class LogicalCalc extends Calc {
   public LogicalCalc(RelInput input) {
     this(input.getCluster(),
         input.getTraitSet(),
+        ImmutableList.of(),
         input.getInput(),
         RexProgram.create(input));
   }
@@ -106,7 +106,7 @@ public final class LogicalCalc extends Calc {
       RelNode child,
       RexProgram program,
       List<RelCollation> collationList) {
-    this(cluster, traitSet, child, program);
+    this(cluster, traitSet, ImmutableList.of(), child, program);
     Util.discard(collationList);
   }
 
@@ -120,7 +120,7 @@ public final class LogicalCalc extends Calc {
             () -> RelMdCollation.calc(mq, input, program))
         .replaceIf(RelDistributionTraitDef.INSTANCE,
             () -> RelMdDistribution.calc(mq, input, program));
-    return new LogicalCalc(cluster, traitSet, input, program);
+    return new LogicalCalc(cluster, traitSet, ImmutableList.of(), input, program);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -109,7 +109,7 @@ public final class LogicalJoin extends Join {
       RelNode left, RelNode right, RexNode condition, Set<CorrelationId> variablesSet,
       JoinRelType joinType, boolean semiJoinDone,
       ImmutableList<RelDataTypeField> systemFieldList) {
-    this(cluster, traitSet, new ArrayList<>(), left, right, condition,
+    this(cluster, traitSet, ImmutableList.of(), left, right, condition,
         variablesSet, joinType, semiJoinDone, systemFieldList);
   }
 
@@ -118,7 +118,7 @@ public final class LogicalJoin extends Join {
       RelNode right, RexNode condition, JoinRelType joinType,
       Set<String> variablesStopped, boolean semiJoinDone,
       ImmutableList<RelDataTypeField> systemFieldList) {
-    this(cluster, traitSet, left, right, condition,
+    this(cluster, traitSet, ImmutableList.of(), left, right, condition,
         CorrelationId.setOf(variablesStopped), joinType, semiJoinDone,
         systemFieldList);
   }
@@ -126,18 +126,18 @@ public final class LogicalJoin extends Join {
   @Deprecated // to be removed before 2.0
   public LogicalJoin(RelOptCluster cluster, RelNode left, RelNode right,
       RexNode condition, JoinRelType joinType, Set<String> variablesStopped) {
-    this(cluster, cluster.traitSetOf(Convention.NONE), left, right, condition,
-        CorrelationId.setOf(variablesStopped), joinType, false,
-        ImmutableList.of());
+    this(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(),
+        left, right, condition, CorrelationId.setOf(variablesStopped),
+        joinType, false, ImmutableList.of());
   }
 
   @Deprecated // to be removed before 2.0
   public LogicalJoin(RelOptCluster cluster, RelNode left, RelNode right,
       RexNode condition, JoinRelType joinType, Set<String> variablesStopped,
       boolean semiJoinDone, ImmutableList<RelDataTypeField> systemFieldList) {
-    this(cluster, cluster.traitSetOf(Convention.NONE), left, right, condition,
-        CorrelationId.setOf(variablesStopped), joinType, semiJoinDone,
-        systemFieldList);
+    this(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(),
+        left, right, condition, CorrelationId.setOf(variablesStopped), joinType,
+        semiJoinDone, systemFieldList);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -34,7 +34,8 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.Util;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /**
@@ -67,27 +68,17 @@ public final class LogicalProject extends Project {
     assert traitSet.containsIfApplicable(Convention.NONE);
   }
 
-  /**
-   * Creates a LogicalProject.
-   *
-   * <p>Use {@link #create} unless you know what you're doing.
-   *
-   * @param cluster  Cluster this relational expression belongs to
-   * @param traitSet Traits of this relational expression
-   * @param input    Input relational expression
-   * @param projects List of expressions for the input columns
-   * @param rowType  Output row type
-   */
+  @Deprecated // to be removed before 2.0
   public LogicalProject(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, List<? extends RexNode> projects, RelDataType rowType) {
-    this(cluster, traitSet, new ArrayList<>(), input, projects, rowType);
+    this(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
   }
 
   @Deprecated // to be removed before 2.0
   public LogicalProject(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, List<? extends RexNode> projects, RelDataType rowType,
       int flags) {
-    this(cluster, traitSet, input, projects, rowType);
+    this(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     Util.discard(flags);
   }
 
@@ -95,7 +86,7 @@ public final class LogicalProject extends Project {
   public LogicalProject(RelOptCluster cluster, RelNode input,
       List<RexNode> projects, List<String> fieldNames, int flags) {
     this(cluster, cluster.traitSetOf(RelCollations.EMPTY),
-        input, projects,
+        ImmutableList.of(), input, projects,
         RexUtil.createStructType(cluster.getTypeFactory(), projects,
             fieldNames, null));
     Util.discard(flags);
@@ -129,7 +120,7 @@ public final class LogicalProject extends Project {
         cluster.traitSet().replace(Convention.NONE)
             .replaceIfs(RelCollationTraitDef.INSTANCE,
                 () -> RelMdCollation.project(mq, input, projects));
-    return new LogicalProject(cluster, traitSet, input, projects, rowType);
+    return new LogicalProject(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
   }
 
   @Override public LogicalProject copy(RelTraitSet traitSet, RelNode input,

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
@@ -71,19 +71,15 @@ public final class LogicalTableScan extends TableScan {
     super(cluster, traitSet, hints, table);
   }
 
-  /**
-   * Creates a LogicalTableScan.
-   *
-   * <p>Use {@link #create} unless you know what you're doing.
-   */
+  @Deprecated // to be removed before 2.0
   public LogicalTableScan(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table) {
-    this(cluster, traitSet, new ArrayList<>(), table);
+    this(cluster, traitSet, ImmutableList.of(), table);
   }
 
   @Deprecated // to be removed before 2.0
   public LogicalTableScan(RelOptCluster cluster, RelOptTable table) {
-    this(cluster, cluster.traitSetOf(Convention.NONE), table);
+    this(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(), table);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectWindowTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectWindowTransposeRule.java
@@ -36,6 +36,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.BitSets;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,7 +96,7 @@ public class ProjectWindowTransposeRule extends RelOptRule {
     }
 
     final LogicalProject projectBelowWindow =
-        new LogicalProject(cluster, window.getTraitSet(),
+        new LogicalProject(cluster, window.getTraitSet(), ImmutableList.of(),
             window.getInput(), exps, builder.build());
 
     // Create a new LogicalWindow with necessary inputs only

--- a/core/src/main/java/org/apache/calcite/schema/impl/StarTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/StarTable.java
@@ -127,7 +127,7 @@ public class StarTable extends AbstractTable implements TranslatableTable {
    */
   public static class StarTableScan extends TableScan {
     public StarTableScan(RelOptCluster cluster, RelOptTable relOptTable) {
-      super(cluster, cluster.traitSetOf(Convention.NONE), relOptTable);
+      super(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(), relOptTable);
     }
 
     @Override public RelOptCost computeSelfCost(RelOptPlanner planner,

--- a/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
@@ -168,7 +168,7 @@ public class TraitPropagationTest {
           false, false, false, Collections.singletonList(1), -1, RelCollations.EMPTY,
           sqlBigInt, "cnt");
       RelNode agg = new LogicalAggregate(cluster,
-          cluster.traitSetOf(Convention.NONE), project,
+          cluster.traitSetOf(Convention.NONE), ImmutableList.of(), project,
           ImmutableBitSet.of(0), null, Collections.singletonList(aggCall));
 
       final RelNode rootRel = agg;
@@ -297,7 +297,7 @@ public class TraitPropagationTest {
     PhysAgg(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
         ImmutableBitSet groupSet,
         List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
-      super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+      super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
     }
 
     public Aggregate copy(RelTraitSet traitSet, RelNode input,
@@ -317,7 +317,7 @@ public class TraitPropagationTest {
   private static class PhysProj extends Project implements Phys {
     PhysProj(RelOptCluster cluster, RelTraitSet traits, RelNode child,
         List<RexNode> exps, RelDataType rowType) {
-      super(cluster, traits, child, exps, rowType);
+      super(cluster, traits, ImmutableList.of(), child, exps, rowType);
     }
 
     public static PhysProj create(final RelNode input,

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -6199,7 +6199,7 @@ public class RelOptRulesTest extends RelOptTestBase {
         RelNode input,
         List<? extends RexNode> projects,
         RelDataType rowType) {
-      super(cluster, traitSet, input, projects, rowType);
+      super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     }
 
     public MyProject copy(RelTraitSet traitSet, RelNode input,

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -1243,7 +1243,7 @@ public class PlannerTest {
 
     MockJdbcTableScan(RelOptCluster cluster, RelOptTable table,
         JdbcConvention jdbcConvention) {
-      super(cluster, cluster.traitSetOf(jdbcConvention), table);
+      super(cluster, cluster.traitSetOf(jdbcConvention), ImmutableList.of(), table);
     }
 
     @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchAggregate.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchAggregate.java
@@ -33,6 +33,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -58,7 +59,7 @@ public class ElasticsearchAggregate extends Aggregate implements ElasticsearchRe
       ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets,
       List<AggregateCall> aggCalls) throws InvalidRelException  {
-    super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+    super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
 
     if (getConvention() != input.getConvention()) {
       String message = String.format(Locale.ROOT, "%s != %s", getConvention(),

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
@@ -28,6 +28,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,7 +41,7 @@ import java.util.stream.Collectors;
 public class ElasticsearchProject extends Project implements ElasticsearchRel {
   ElasticsearchProject(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
       List<? extends RexNode> projects, RelDataType rowType) {
-    super(cluster, traitSet, input, projects, rowType);
+    super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     assert getConvention() == ElasticsearchRel.CONVENTION;
     assert getConvention() == input.getConvention();
   }

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTableScan.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTableScan.java
@@ -28,6 +28,8 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.AggregateExpandDistinctAggregatesRule;
 import org.apache.calcite.rel.type.RelDataType;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -53,7 +55,7 @@ public class ElasticsearchTableScan extends TableScan implements ElasticsearchRe
   ElasticsearchTableScan(RelOptCluster cluster, RelTraitSet traitSet,
        RelOptTable table, ElasticsearchTable elasticsearchTable,
        RelDataType projectRowType) {
-    super(cluster, traitSet, table);
+    super(cluster, traitSet, ImmutableList.of(), table);
     this.elasticsearchTable = Objects.requireNonNull(elasticsearchTable, "elasticsearchTable");
     this.projectRowType = projectRowType;
 

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTableScan.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTableScan.java
@@ -37,6 +37,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /**
@@ -50,7 +52,7 @@ public class CsvTableScan extends TableScan implements EnumerableRel {
 
   protected CsvTableScan(RelOptCluster cluster, RelOptTable table,
       CsvTranslatableTable csvTable, int[] fields) {
-    super(cluster, cluster.traitSetOf(EnumerableConvention.INSTANCE), table);
+    super(cluster, cluster.traitSetOf(EnumerableConvention.INSTANCE), ImmutableList.of(), table);
     this.csvTable = csvTable;
     this.fields = fields;
 

--- a/file/src/main/java/org/apache/calcite/adapter/file/FileTableScan.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/FileTableScan.java
@@ -34,6 +34,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /**
@@ -49,7 +51,7 @@ class FileTableScan extends TableScan implements EnumerableRel {
 
   protected FileTableScan(RelOptCluster cluster, RelOptTable table,
       FileTable webTable, int[] fields) {
-    super(cluster, cluster.traitSetOf(EnumerableConvention.INSTANCE), table);
+    super(cluster, cluster.traitSetOf(EnumerableConvention.INSTANCE), ImmutableList.of(), table);
     this.webTable = webTable;
     this.fields = fields;
 

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeAggregate.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeAggregate.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 
@@ -49,7 +50,7 @@ public class GeodeAggregate extends Aggregate implements GeodeRel {
       ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets,
       List<AggregateCall> aggCalls) {
-    super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+    super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
 
     assert getConvention() == GeodeRel.CONVENTION;
     assert getConvention() == this.input.getConvention();

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeProject.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeProject.java
@@ -28,6 +28,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +43,7 @@ public class GeodeProject extends Project implements GeodeRel {
 
   GeodeProject(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, List<? extends RexNode> projects, RelDataType rowType) {
-    super(cluster, traitSet, input, projects, rowType);
+    super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     assert getConvention() == GeodeRel.CONVENTION;
     assert getConvention() == input.getConvention();
   }

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeTableScan.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeTableScan.java
@@ -25,6 +25,8 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /**
@@ -46,7 +48,7 @@ public class GeodeTableScan extends TableScan implements GeodeRel {
    */
   GeodeTableScan(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table, GeodeTable geodeTable, RelDataType projectRowType) {
-    super(cluster, traitSet, table);
+    super(cluster, traitSet, ImmutableList.of(), table);
     this.geodeTable = geodeTable;
     this.projectRowType = projectRowType;
 

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoAggregate.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoAggregate.java
@@ -29,6 +29,8 @@ import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +51,7 @@ public class MongoAggregate
       List<ImmutableBitSet> groupSets,
       List<AggregateCall> aggCalls)
       throws InvalidRelException {
-    super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+    super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
     assert getConvention() == MongoRel.CONVENTION;
     assert getConvention() == input.getConvention();
 

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoProject.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoProject.java
@@ -29,6 +29,8 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +41,7 @@ import java.util.List;
 public class MongoProject extends Project implements MongoRel {
   public MongoProject(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, List<? extends RexNode> projects, RelDataType rowType) {
-    super(cluster, traitSet, input, projects, rowType);
+    super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     assert getConvention() == MongoRel.CONVENTION;
     assert getConvention() == input.getConvention();
   }

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoTableScan.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoTableScan.java
@@ -27,6 +27,8 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /**
@@ -50,7 +52,7 @@ public class MongoTableScan extends TableScan implements MongoRel {
    */
   protected MongoTableScan(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table, MongoTable mongoTable, RelDataType projectRowType) {
-    super(cluster, traitSet, table);
+    super(cluster, traitSet, ImmutableList.of(), table);
     this.mongoTable = mongoTable;
     this.projectRowType = projectRowType;
 

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigAggregate.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigAggregate.java
@@ -27,6 +27,8 @@ import org.apache.calcite.util.ImmutableBitSet;
 
 import org.apache.pig.scripting.Pig;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +44,7 @@ public class PigAggregate extends Aggregate implements PigRel {
   public PigAggregate(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
-    super(cluster, traitSet, input, groupSet, groupSets, aggCalls);
+    super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
     assert getConvention() == PigRel.CONVENTION;
   }
 

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigJoin.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigJoin.java
@@ -27,8 +27,10 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Join} in
@@ -38,7 +40,8 @@ public class PigJoin extends Join implements PigRel {
   /** Creates a PigJoin. */
   public PigJoin(RelOptCluster cluster, RelTraitSet traitSet, RelNode left, RelNode right,
       RexNode condition, JoinRelType joinType) {
-    super(cluster, traitSet, left, right, condition, new HashSet<>(0), joinType);
+    super(cluster, traitSet, ImmutableList.of(), left, right, condition,
+        ImmutableSet.of(), joinType);
     assert getConvention() == PigRel.CONVENTION;
   }
 

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigProject.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigProject.java
@@ -24,6 +24,8 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Project} in
@@ -33,7 +35,7 @@ public class PigProject extends Project implements PigRel {
   /** Creates a PigProject. */
   public PigProject(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
       List<? extends RexNode> projects, RelDataType rowType) {
-    super(cluster, traitSet, input, projects, rowType);
+    super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     assert getConvention() == PigRel.CONVENTION;
   }
 

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigTableScan.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigTableScan.java
@@ -29,6 +29,8 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 
 import org.apache.pig.data.DataType;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +40,7 @@ public class PigTableScan extends TableScan implements PigRel {
 
   /** Creates a PigTableScan. */
   public PigTableScan(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table) {
-    super(cluster, traitSet, table);
+    super(cluster, traitSet, ImmutableList.of(), table);
     assert getConvention() == PigRel.CONVENTION;
   }
 

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -28,6 +28,14 @@ For a full list of releases, see
 Downloads are available on the
 [downloads page]({{ site.baseurl }}/downloads/).
 
+## 1.22.0 (un-released)
+
+#### Breaking Changes
+
+* Constructors for `Project`, `TableScan`, `Calc`, `Aggregate` and `Join` introduce new parameter named "hints";
+* `Project` names will not represent in `RelNode` digest anymore;
+* `RexCall`s are default to be normalized in the `RelNode` digest. 
+
 ## <a href="https://github.com/apache/calcite/releases/tag/calcite-1.21.0">1.21.0</a> / 2019-09-11
 {: #v1-21-0}
 

--- a/splunk/src/main/java/org/apache/calcite/adapter/splunk/SplunkTableScan.java
+++ b/splunk/src/main/java/org/apache/calcite/adapter/splunk/SplunkTableScan.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.Util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.lang.reflect.Method;
@@ -73,6 +74,7 @@ public class SplunkTableScan
     super(
         cluster,
         cluster.traitSetOf(EnumerableConvention.INSTANCE),
+        ImmutableList.of(),
         table);
     this.splunkTable = splunkTable;
     this.search = search;


### PR DESCRIPTION
…e the old constructors

Constructors for `Project`, `TableScan`, `Calc`, `Aggregate` and `Join`
introduce new parameter named "hints" which is a breaking change.