### PR TITLE
[CALCITE-3729] Filters failed to be pushed down when it's identical to join condition (Jin Xing)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterJoinRule.java
@@ -185,7 +185,8 @@ public abstract class FilterJoinRule extends RelOptRule {
     // If no filter got pushed after validate, reset filterPushed flag
     if (leftFilters.isEmpty()
         && rightFilters.isEmpty()
-        && joinFilters.size() == origJoinFilters.size()) {
+        && joinFilters.size() == origJoinFilters.size()
+        && aboveFilters.size() == origAboveFilters.size()) {
       if (Sets.newHashSet(joinFilters)
           .equals(Sets.newHashSet(origJoinFilters))) {
         filterPushed = false;

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -573,6 +573,14 @@ public class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(FilterJoinRule.FILTER_ON_JOIN).check();
   }
 
+  @Test public void testPushAboveFiltersIntoInnerJoinCondition() {
+    final String sql = ""
+        + "select * from sales.dept d inner join sales.emp e\n"
+        + "on d.deptno = e.deptno and d.deptno > e.mgr\n"
+        + "where d.deptno > e.mgr";
+    sql(sql).withRule(FilterJoinRule.FILTER_ON_JOIN).check();
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3225">[CALCITE-3225]
    * JoinToMultiJoinRule should not match SEMI/ANTI LogicalJoin</a>. */

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1418,6 +1418,32 @@ LogicalProject(EXPR$0=[1])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testPushAboveFiltersIntoInnerJoinCondition">
+        <Resource name="sql">
+            <![CDATA[
+select * from sales.dept d inner join sales.emp e
+on d.deptno = e.deptno and d.deptno > e.mgr
+where d.deptno > e.mgr
+]]>
+        </Resource>
+    <Resource name="planBefore">
+        <![CDATA[
+LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$2], ENAME=[$3], JOB=[$4], MGR=[$5], HIREDATE=[$6], SAL=[$7], COMM=[$8], DEPTNO0=[$9], SLACKER=[$10])
+  LogicalFilter(condition=[>($0, $5)])
+    LogicalJoin(condition=[AND(=($0, $9), >($0, $5))], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+        <![CDATA[
+LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$2], ENAME=[$3], JOB=[$4], MGR=[$5], HIREDATE=[$6], SAL=[$7], COMM=[$8], DEPTNO0=[$9], SLACKER=[$10])
+  LogicalJoin(condition=[AND(=($0, $9), >($0, $5))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    </TestCase>
     <TestCase name="testPushFilterThroughSemiJoin">
         <Resource name="sql">
             <![CDATA[select * from (


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-3727
We need to check if `aboveFilters` gets changed from `origAboveFilters` in `FilterJoinRule#perform`