### PR TITLE
[CALCITE-1824] GROUP_ID returns wrong result

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -58,7 +58,6 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlUserDefinedAggFunction;
 import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
 import org.apache.calcite.util.BuiltInMethod;
-import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
@@ -171,7 +170,6 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.GREATER_THAN;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.GREATER_THAN_OR_EQUAL;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.GROUPING;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.GROUPING_ID;
-import static org.apache.calcite.sql.fun.SqlStdOperatorTable.GROUP_ID;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.INITCAP;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.IS_A_SET;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.IS_EMPTY;
@@ -623,7 +621,6 @@ public class RexImpTable {
     final Supplier<GroupingImplementor> grouping =
         constructorSupplier(GroupingImplementor.class);
     aggMap.put(GROUPING, grouping);
-    aggMap.put(GROUP_ID, grouping);
     aggMap.put(GROUPING_ID, grouping);
     winAggMap.put(RANK, constructorSupplier(RankImplementor.class));
     winAggMap.put(DENSE_RANK, constructorSupplier(DenseRankImplementor.class));
@@ -1604,12 +1601,6 @@ public class RexImpTable {
       switch (info.aggregation().kind) {
       case GROUPING: // "GROUPING(e, ...)", also "GROUPING_ID(e, ...)"
         keys = result.call().getArgList();
-        break;
-      case GROUP_ID: // "GROUP_ID()"
-        // We don't implement GROUP_ID properly. In most circumstances, it
-        // returns 0, so we always return 0. Logged
-        // [CALCITE-1824] GROUP_ID returns wrong result
-        keys = ImmutableIntList.of();
         break;
       default:
         throw new AssertionError();

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupIdFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupIdFunction.java
@@ -24,11 +24,15 @@ import org.apache.calcite.sql.type.ReturnTypes;
 /**
  * The {@code GROUP_ID()} function.
  *
- * <p>Accepts no arguments. If the query has {@code GROUP BY x, y, z} then
- * {@code GROUP_ID()} is the same as {@code GROUPING(x, y, z)}.
+ * <p>Accepts no arguments. The {@code GROUP_ID()} function distinguishes duplicate groups
+ * resulting from a GROUP BY specification. It is useful in filtering out duplicate groupings
+ * from the query result.
  *
  * <p>This function is not defined in the SQL standard; our implementation is
  * consistent with Oracle.
+ *
+ * <p>If n duplicates exist for a particular grouping, then {@code GROUP_ID()} function returns
+ * numbers in the range 0 to n-1.
  *
  * <p>Some examples are in {@code agg.iq}.
  */

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
@@ -35,7 +35,7 @@ import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.SortedMap;
 import java.util.function.Supplier;
 
 import static org.apache.calcite.sql.SqlUtil.stripAs;
@@ -108,7 +108,7 @@ public class AggregatingSelectScope
       groupExprProjection = groupAnalyzer.groupExprProjection;
     }
 
-    final TreeMap<ImmutableBitSet, Integer> flatGroupSetCount =
+    final SortedMap<ImmutableBitSet, Integer> flatGroupSetCount =
         Maps.newTreeMap(ImmutableBitSet.COMPARATOR);
     for (List<ImmutableBitSet> groupSet : Linq4j.product(builder.build())) {
       final ImmutableBitSet set = ImmutableBitSet.union(groupSet);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -183,6 +183,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 import org.slf4j.Logger;
 
@@ -2960,12 +2961,12 @@ public class SqlToRelConverter {
             bb.scope.getMonotonicity(groupItem));
       }
 
-      // Add the aggregator
-      bb.setRoot(
-          createAggregate(bb, r.groupSet, r.groupSets,
-              aggConverter.getAggCalls()),
-          false);
+      final RelNode relNode = aggConverter.containsGroupId()
+          ? rewriteAggregateWithGroupId(bb, r, aggConverter)
+          : createAggregate(bb, r.groupSet, r.groupSets,
+              aggConverter.getAggCalls());
 
+      bb.setRoot(relNode, false);
       bb.mapRootRelToFieldProjection.put(bb.root, r.groupExprProjection);
 
       // Replace sub-queries in having here and modify having to use
@@ -3037,6 +3038,113 @@ public class SqlToRelConverter {
       bb.columnMonotonicities.add(
           bb.scope.getMonotonicity(selectItem));
     }
+  }
+
+  /**
+   * The {@code GROUP_ID()} function is used to distinguish duplicate groups.
+   * However, as Aggregate normalizes group sets (i.e., sorting, redundancy removal),
+   * this information is lost in RelNode. Therefore, it is impossible to
+   * implement the function in runtime.
+   *
+   * To fill this gap, an aggregation query that contains {@code GROUP_ID()} function
+   * will generally be rewritten into UNION when converting to RelNode.
+   *
+   * Also see the discussion in JIRA
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-1824">[CALCITE-1824]
+   * GROUP_ID returns wrong result</a>.
+   */
+  private RelNode rewriteAggregateWithGroupId(Blackboard bb,
+      AggregatingSelectScope.Resolved r, AggConverter converter) {
+    final List<AggregateCall> aggregateCalls = converter.getAggCalls();
+    final ImmutableBitSet groupSet = r.groupSet;
+    final Map<ImmutableBitSet, Integer> groupSetCount = r.groupSetCount;
+
+    final List<String> fieldNamesIfNoRewrite = createAggregate(bb, groupSet,
+        r.groupSets, aggregateCalls).getRowType().getFieldNames();
+
+    // For every GROUP_ID value, collect its group sets in map
+    // E.g., GROUPING SETS (a, a, b, c, c, c, c), the map will be
+    // {0 -> (a, b, c), 1 -> (a, c), 2 -> (c), 3 -> (c)},
+    // in which the max GROUP_ID() value is 3
+    final Map<Integer, Set<ImmutableBitSet>> groupIdToGroupSets = new HashMap<>();
+    int maxGroupId = 0;
+    for (Map.Entry<ImmutableBitSet, Integer> entry: groupSetCount.entrySet()) {
+      int groupId = entry.getValue() - 1;
+      if (groupId > maxGroupId) {
+        maxGroupId = groupId;
+      }
+      for (int i = 0; i <= groupId; i++) {
+        addGroupSet(i, entry.getKey(), groupIdToGroupSets);
+      }
+    }
+
+    // AggregateCalls without GROUP_ID
+    final List<AggregateCall> aggregateCallsWithoutGroupId = new ArrayList<>();
+    for (AggregateCall aggregateCall : aggregateCalls) {
+      if (aggregateCall.getAggregation().kind != SqlKind.GROUP_ID) {
+        aggregateCallsWithoutGroupId.add(aggregateCall);
+      }
+    }
+
+    final List<RelNode> projects = new ArrayList<>();
+    // For each group id, we first construct an Aggregate without GROUP_ID()
+    // function call, and then create a Project node on top of it.
+    // The Project adds literal value for group id in right position.
+    for (int groupId = 0; groupId <= maxGroupId; groupId++) {
+      // Create the Aggregate node without GROUP_ID() call
+      final ImmutableList<ImmutableBitSet> groupSets =
+          ImmutableList.copyOf(groupIdToGroupSets.get(groupId));
+      final RelNode aggregate = createAggregate(bb, groupSet,
+          groupSets, aggregateCallsWithoutGroupId);
+
+      // RexLiteral for each GROUP_ID, note the type should be BIGINT
+      final RelDataType groupIdType = typeFactory.createSqlType(SqlTypeName.BIGINT);
+      final RexNode groupIdLiteral = rexBuilder.makeExactLiteral(
+          BigDecimal.valueOf(groupId), groupIdType);
+
+      relBuilder.push(aggregate);
+      final List<String> aggregateFieldNames = aggregate.getRowType().getFieldNames();
+
+      final List<RexNode> selectList = new ArrayList<>();
+      final List<String> selectListNames = new ArrayList<>();
+      final int groupExprLength = r.groupExprList.size();
+      // Project fields from group by expressions
+      for (int i = 0; i < groupExprLength; i++) {
+        selectList.add(relBuilder.field(i));
+        selectListNames.add(aggregateFieldNames.get(i));
+      }
+      // Project fields from aggregate calls
+      int groupIdCount = 0;
+      for (int i = 0; i < aggregateCalls.size(); i++) {
+        if (aggregateCalls.get(i).getAggregation().kind == SqlKind.GROUP_ID) {
+          selectList.add(groupIdLiteral);
+          selectListNames.add(fieldNamesIfNoRewrite.get(groupExprLength + i));
+          groupIdCount++;
+        } else {
+          int ordinal = groupExprLength + i - groupIdCount;
+          selectList.add(relBuilder.field(ordinal));
+          selectListNames.add(aggregateFieldNames.get(ordinal));
+        }
+      }
+      final RelNode project = relBuilder.project(selectList)
+          .rename(selectListNames).build();
+      projects.add(project);
+    }
+    if (projects.size() == 1) {
+      return projects.get(0);
+    }
+    return LogicalUnion.create(projects, true);
+  }
+
+  /**
+   * Add a group set to the group sets of a specific group id
+   */
+  private void addGroupSet(int groupId, ImmutableBitSet groupSet,
+      final Map<Integer, Set<ImmutableBitSet>> groupIdToGroupSets) {
+    final Set<ImmutableBitSet> groupSets = groupIdToGroupSets.getOrDefault(
+        groupId, Sets.newTreeSet(ImmutableBitSet.COMPARATOR));
+    groupSets.add(groupSet);
+    groupIdToGroupSets.put(groupId, groupSets);
   }
 
   /**
@@ -5333,6 +5441,11 @@ public class SqlToRelConverter {
 
     public List<AggregateCall> getAggCalls() {
       return aggCalls;
+    }
+
+    boolean containsGroupId() {
+      return aggCalls.stream().anyMatch(
+          agg -> agg.getAggregation().kind == SqlKind.GROUP_ID);
     }
 
     public RelDataTypeFactory getTypeFactory() {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -4488,9 +4488,25 @@ public class JdbcTest {
             "empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000\n");
   }
 
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-1824">[CALCITE-1824]
-   * GROUP_ID returns wrong result</a>. */
+  /** Test case for rewriting queries that contain {@code GROUP_ID()} function.
+   * For instance, the query
+   * {@code
+   *    select deptno, group_id() as gid
+   *    from scott.emp
+   *    group by grouping sets(deptno, deptno, deptno, (), ())
+   * }
+   * will be converted into:
+   * {@code
+   *    select deptno, 0 as gid
+   *    from scott.emp group by grouping sets(deptno, ())
+   *    union all
+   *    select deptno, 1 as gid
+   *    from scott.emp group by grouping sets(deptno, ())
+   *    union all
+   *    select deptno, 2 as gid
+   *    from scott.emp group by grouping sets(deptno)
+   * }
+   */
   @Test public void testGroupId() {
     CalciteAssert.that()
         .with(CalciteAssert.Config.SCOTT)

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -856,9 +856,6 @@ group by rollup(1);
 
 !use scott
 
-# When
-#   [CALCITE-1824] GROUP_ID returns wrong result
-# is fixed, there will be an extra row (null, 1, 14).
 select deptno, group_id() as g, count(*) as c
 from "scott".emp
 group by grouping sets (deptno, (), ());
@@ -870,8 +867,9 @@ group by grouping sets (deptno, (), ());
 |     20 | 0 |  5 |
 |     30 | 0 |  6 |
 |        | 0 | 14 |
+|        | 1 | 14 |
 +--------+---+----+
-(4 rows)
+(5 rows)
 
 !ok
 
@@ -929,10 +927,6 @@ select deptno
 !ok
 
 # From http://rwijk.blogspot.com/2008/12/groupid.html
-# (replacing "to_char(...)" with "cast(... as varchar)")
-# The current results are incorrect. When
-#   [CALCITE-1824] GROUP_ID returns wrong result
-# is fixed, there will be 4 more rows.
 select deptno
        , job
        , empno
@@ -967,6 +961,7 @@ select deptno
 |     10 | PRESIDENT |  7839 | KING   |  5000.00 | grouped by deptno,job,empno,ename |
 |     10 | PRESIDENT |       |        |  5000.00 | grouped by deptno,job             |
 |     10 |           |       |        |  8750.00 | grouped by deptno, grouping set 3 |
+|     10 |           |       |        |  8750.00 | grouped by deptno, grouping set 4 |
 |     20 | ANALYST   |  7788 | SCOTT  |  3000.00 | grouped by deptno,job,empno,ename |
 |     20 | ANALYST   |  7902 | FORD   |  3000.00 | grouped by deptno,job,empno,ename |
 |     20 | ANALYST   |       |        |  6000.00 | grouped by deptno,job             |
@@ -976,6 +971,7 @@ select deptno
 |     20 | MANAGER   |  7566 | JONES  |  2975.00 | grouped by deptno,job,empno,ename |
 |     20 | MANAGER   |       |        |  2975.00 | grouped by deptno,job             |
 |     20 |           |       |        | 10875.00 | grouped by deptno, grouping set 3 |
+|     20 |           |       |        | 10875.00 | grouped by deptno, grouping set 4 |
 |     30 | CLERK     |  7900 | JAMES  |   950.00 | grouped by deptno,job,empno,ename |
 |     30 | CLERK     |       |        |   950.00 | grouped by deptno,job             |
 |     30 | MANAGER   |  7698 | BLAKE  |  2850.00 | grouped by deptno,job,empno,ename |
@@ -986,9 +982,11 @@ select deptno
 |     30 | SALESMAN  |  7844 | TURNER |  1500.00 | grouped by deptno,job,empno,ename |
 |     30 | SALESMAN  |       |        |  5600.00 | grouped by deptno,job             |
 |     30 |           |       |        |  9400.00 | grouped by deptno, grouping set 3 |
+|     30 |           |       |        |  9400.00 | grouped by deptno, grouping set 4 |
 |        |           |       |        | 29025.00 | grouped by (), grouping set 5     |
+|        |           |       |        | 29025.00 | grouped by (), grouping set 6     |
 +--------+-----------+-------+--------+----------+-----------------------------------+
-(27 rows)
+(31 rows)
 
 !ok
 


### PR DESCRIPTION
See the discussion in [CALCITE-1824](https://issues.apache.org/jira/browse/CALCITE-1824), we rewrite the query that contains `GROUP_ID` as `UNION-ALL`.