### PR TITLE
Add caching for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,18 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/cache@v1
+      with:
+        path: '%USER_HOME%\.gradle\caches'
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**\*.gradle.*') }}-${{ hashFiles('**\gradle.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - uses: actions/cache@v1
+      with:
+        path: '%USER_HOME%\.gradle\wrapper'
+        key: ${{ runner.os }}-gradle-${{ hashFiles('gradle\wrapper\gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-wrapper-
     - name: 'Test'
       shell: cmd
       run: |
@@ -61,6 +73,18 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.*') }}-${{ hashFiles('**/gradle.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-wrapper-
     - name: 'Install Avatica to Maven Local repository'
       run: |
         git clone --branch master --depth 100 https://github.com/apache/calcite-avatica.git ../calcite-avatica
@@ -85,6 +109,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 13
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.*') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-wrapper-
       - name: 'Test'
         run: |
           ./gradlew --no-parallel --no-daemon build javadoc
@@ -103,6 +139,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.*') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-wrapper-
       - name: 'Test'
         run: |
           ./gradlew --no-parallel --no-daemon testSlow

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 {% endcomment %}
 -->
 [![Travis Build Status](https://travis-ci.org/apache/calcite.svg?branch=master)](https://travis-ci.org/apache/calcite)
-[![CI Status](https://github.com/apache/calcite/workflows/CI/badge.svg)](https://github.com/apache/calcite/actions)
+[![CI Status](https://github.com/apache/calcite/workflows/CI/badge.svg?branch=master)](https://github.com/apache/calcite/actions))
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/apache/calcite?svg=true&branch=master)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/calcite)
 
 # Apache Calcite


### PR DESCRIPTION
https://github.com/actions/cache#cache-limits

>A repository can have up to 2GB of caches. Once the 2GB limit is reached, older caches will be evicted based on when the cache was last accessed. Caches that are not accessed within the last week will also be evicted.

```
[warning]Cache size of ~2185 MB (2291234428 B) is over the 2GB limit, not saving cache.
```

:(