### PR TITLE
[CALCITE-3764] AggregateCaseToFilterRule handles NULL values

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3537,6 +3537,12 @@ public class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(AggregateCaseToFilterRule.INSTANCE).check();
   }
 
+  @Test public void testAggregateCaseToFilterWhenCaseOperandsFlipped() {
+    final String sql = "select count(case when job = 'CLERK'\n"
+        + " then null else deptno end) from emp";
+    sql(sql).withRule(AggregateCaseToFilterRule.INSTANCE).check();
+  }
+
   @Test public void testPullAggregateThroughUnion() {
     HepProgram program = new HepProgramBuilder()
         .addRuleInstance(AggregateUnionAggregateRule.INSTANCE)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -46,6 +46,27 @@ LogicalProject(SUM_SAL=[$0], COUNT_DISTINCT_CLERK=[$1], SUM_SAL_D10=[$2], SUM_SA
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testAggregateCaseToFilterWhenCaseOperandsFlipped">
+        <Resource name="sql">
+            <![CDATA[
+select count(case when job = 'CLERK' then null else deptno end) from emp
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)])
+  LogicalProject($f0=[CASE(=($2, 'CLERK'), null:INTEGER, $7)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($1) FILTER $2])
+  LogicalProject($f0=[CASE(=($2, 'CLERK'), null:INTEGER, $7)], DEPTNO=[$7], $f2=[<>($2, 'CLERK')])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testAggregateExtractProjectRule">
         <Resource name="sql">
             <![CDATA[select sum(sal)


### PR DESCRIPTION
incorrectly.

Consider the following example:
    ```SELECT SUM(CASE col=10 THEN NULL ELSE 100) FROM t```;

When NULL appears in the column, ```NULL=10``` will be unknown
thus the result falls into ```ELSE```. condition ```IS_FALSE``` returns
false when condition is unknown, but condition ```IS_NOT_TRUE```
returns true. Thus the equivalent FILTER clause above should be:
    ```SELECT SUM(100) FILTER (WHERE col=10 IS NOT TRUE) FROM t;```