### PR TITLE
[CALCITE-3771] TRIM Support for HIVE/SPARK Dialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
+++ b/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlTrimFunction;
+
+/**
+ * The usage of this class is to put the common code that can be used by multiple dialect
+ * for RelToSql conversion.
+ */
+public class RelToSqlConverterUtil {
+
+  private RelToSqlConverterUtil(){}
+
+
+  /**
+   * This method will make regex pattern based on the TRIM flag
+   *
+   * @param call     SqlCall contains the values that needs to be trimmed
+   * @param trimFlag It will contain the trimFlag either BOTH,LEADING or TRAILING
+   * @return It will return the regex pattern of the character to be trimmed.
+   */
+  public static SqlCharStringLiteral makeRegexNodeFromCall(SqlNode call, SqlLiteral trimFlag) {
+    String regexPattern = ((SqlCharStringLiteral) call).toValue();
+    regexPattern = escapeSpecialChar(regexPattern);
+    switch (trimFlag.getValueAs(SqlTrimFunction.Flag.class)) {
+    case LEADING:
+      regexPattern = "^(".concat(regexPattern).concat(")*");
+      break;
+    case TRAILING:
+      regexPattern = "(".concat(regexPattern).concat(")*$");
+      break;
+    default:
+      regexPattern = "^(".concat(regexPattern).concat(")*|(")
+        .concat(regexPattern).concat(")*$");
+      break;
+    }
+    return SqlLiteral.createCharString(regexPattern,
+      call.getParserPosition());
+  }
+
+  /**
+   * This method will escpae the special character
+   *
+   * @param inputString String
+   * @return Escape character if any special character is present in the string
+   */
+  private static String escapeSpecialChar(String inputString) {
+    final String[] specialCharacters = {"\\", "^", "$", "{", "}", "[", "]", "(", ")", ".",
+        "*", "+", "?", "|", "<", ">", "-", "&", "%", "@"};
+
+    for (int i = 0; i < specialCharacters.length; i++) {
+      if (inputString.contains(specialCharacters[i])) {
+        inputString = inputString.replace(specialCharacters[i], "\\" + specialCharacters[i]);
+      }
+    }
+    return inputString;
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1011,7 +1011,11 @@ public class RelToSqlConverterTest {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3663">[CALCITE-3663]
    * Support for TRIM function in BigQuery dialect</a>. */
 
-  @Test public void testHiveAndBqTrim() {
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3771">[CALCITE-3771]
+   * Support of TRIM function for SPARK dialect and improvement in HIVE Dialect</a>. */
+
+  @Test public void testHiveSparkAndBqTrim() {
     final String query = "SELECT TRIM(' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM(' str ')\n"
@@ -1019,11 +1023,13 @@ public class RelToSqlConverterTest {
     sql(query)
       .withHive()
       .ok(expected)
+      .withSpark()
+      .ok(expected)
       .withBigQuery()
       .ok(expected);
   }
 
-  @Test public void testHiveAndBqTrimWithBoth() {
+  @Test public void testHiveSparkAndBqTrimWithBoth() {
     final String query = "SELECT TRIM(both ' ' from ' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM(' str ')\n"
@@ -1031,11 +1037,13 @@ public class RelToSqlConverterTest {
     sql(query)
       .withHive()
       .ok(expected)
+      .withSpark()
+      .ok(expected)
       .withBigQuery()
       .ok(expected);
   }
 
-  @Test public void testHiveAndBqTrimWithLeading() {
+  @Test public void testHiveSparkAndBqTrimWithLeading() {
     final String query = "SELECT TRIM(LEADING ' ' from ' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT LTRIM(' str ')\n"
@@ -1043,18 +1051,22 @@ public class RelToSqlConverterTest {
     sql(query)
       .withHive()
       .ok(expected)
+      .withSpark()
+      .ok(expected)
       .withBigQuery()
       .ok(expected);
   }
 
 
-  @Test public void testHiveAndBqTrimWithTailing() {
+  @Test public void testHiveSparkAndBqTrimWithTailing() {
     final String query = "SELECT TRIM(TRAILING ' ' from ' str ')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT RTRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
     sql(query)
       .withHive()
+      .ok(expected)
+      .withSpark()
       .ok(expected)
       .withBigQuery()
       .ok(expected);
@@ -1064,35 +1076,75 @@ public class RelToSqlConverterTest {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3663">[CALCITE-3663]
    * Support for TRIM function in Bigquery dialect</a>. */
 
-  @Test public void testBqTrimWithLeadingChar() {
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3771">[CALCITE-3771]
+   * Support of TRIM function for SPARK dialect and improvement in HIVE Dialect</a>. */
+
+  @Test public void testHiveSparkAndBqTrimWithLeadingChar() {
     final String query = "SELECT TRIM(LEADING 'a' from 'abcd')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT LTRIM('abcd', 'a')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedHS = "SELECT REGEXP_REPLACE('abcd', '^(a)*', '')\n"
+        + "FROM foodmart.reserve_employee";
     sql(query)
+      .withHive()
+      .ok(expectedHS)
+      .withSpark()
+      .ok(expectedHS)
       .withBigQuery()
       .ok(expected);
   }
 
-  @Test public void testBqTrimWithBothChar() {
+  @Test public void testHiveSparkAndBqTrimWithBothChar() {
     final String query = "SELECT TRIM(both 'a' from 'abcda')\n"
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM('abcda', 'a')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedHS = "SELECT REGEXP_REPLACE('abcda', '^(a)*|(a)*$', '')\n"
+        + "FROM foodmart.reserve_employee";
     sql(query)
+      .withHive()
+      .ok(expectedHS)
+      .withSpark()
+      .ok(expectedHS)
       .withBigQuery()
       .ok(expected);
   }
 
-  @Test public void testBqTrimWithTailingChar() {
+  @Test public void testHiveSparkAndBqTrimWithTailingChar() {
     final String query = "SELECT TRIM(TRAILING 'a' from 'abcd')\n"
-         + "from \"foodmart\".\"reserve_employee\"";
+        + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT RTRIM('abcd', 'a')\n"
-         + "FROM foodmart.reserve_employee";
+        + "FROM foodmart.reserve_employee";
+    final String expectedHS = "SELECT REGEXP_REPLACE('abcd', '(a)*$', '')\n"
+        + "FROM foodmart.reserve_employee";
     sql(query)
+      .withHive()
+      .ok(expectedHS)
+      .withSpark()
+      .ok(expectedHS)
       .withBigQuery()
       .ok(expected);
   }
+
+  @Test public void testHiveSparkAndBqTrimWithBothSpecialCharacter() {
+    final String query = "SELECT TRIM(BOTH '$@*A' from '$@*AABC$@*AADCAA$@*A')\n"
+        + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT TRIM('$@*AABC$@*AADCAA$@*A', '$@*A')\n"
+        + "FROM foodmart.reserve_employee";
+    final String expectedHS = "SELECT REGEXP_REPLACE('$@*AABC$@*AADCAA$@*A',"
+        + " '^(\\$\\@\\*A)*|(\\$\\@\\*A)*$', '')\n"
+        + "FROM foodmart.reserve_employee";
+    sql(query)
+      .withHive()
+      .ok(expectedHS)
+      .withSpark()
+      .ok(expectedHS)
+      .withBigQuery()
+      .ok(expected);
+  }
+
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2715">[CALCITE-2715]


### PR DESCRIPTION
In current Calcite implementation for query : SELECT TRIM('ABC') for SPARK Dialect it gets translated into SELECT TRIM(BOTH ' ' FROM 'ABC') .

But the proper query for SPARK is :: SELECT TRIM('ABC')

Unparse logic for the trim has been handled in Spark dialect to convert the source Trim query into valid SPARK query.



Also,In HIVE/SPARK dialect TRIM with two operand is not supported

Eg: SELECT TRIM(BOTH 'a' from 'ABC') So its equivalent is REGEXP_REPLACE which is handle in unparseTrim function.