### PR TITLE
[CALCITE-3773] Wrong parameter in EnumerableMergeJoin::create method

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -35,7 +35,6 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableIntList;
@@ -85,7 +84,7 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
   }
 
   public static EnumerableMergeJoin create(RelNode left, RelNode right,
-      RexLiteral condition, ImmutableIntList leftKeys,
+      RexNode condition, ImmutableIntList leftKeys,
       ImmutableIntList rightKeys, JoinRelType joinType) {
     final RelOptCluster cluster = right.getCluster();
     RelTraitSet traitSet = cluster.traitSet();
@@ -96,7 +95,7 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
       traitSet = traitSet.replace(collations);
     }
     return new EnumerableMergeJoin(cluster, traitSet, left, right, condition,
-        leftKeys, rightKeys, ImmutableSet.of(), joinType);
+        ImmutableSet.of(), joinType);
   }
 
   @Override public EnumerableMergeJoin copy(RelTraitSet traitSet,


### PR DESCRIPTION
Minor change.
Jira ticket: [CALCITE-3773](https://issues.apache.org/jira/browse/CALCITE-3773)

The public EnumerableMergeJoin::create method takes a RexLiteral condition as parameter. However, in the actual (package-private) constructor (and in the parent Join class), the condition is defined as a RexNode. Therefore, the create method parameter must be fixed.

Also, this EnumerableMergeJoin::create method calls a deprecated constructor, it should call the non-deprecated one.