### PR TITLE
[CALCITE-3285] EnumerableMergeJoin should support non-equi join conditions

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -187,7 +187,7 @@ public enum BuiltInMethod {
   EMITTER_EMIT(Enumerables.Emitter.class, "emit", List.class, List.class,
       List.class, int.class, Consumer.class),
   MERGE_JOIN(EnumerableDefaults.class, "mergeJoin", Enumerable.class,
-      Enumerable.class, Function1.class, Function1.class, Function2.class,
+      Enumerable.class, Function1.class, Function1.class, Predicate2.class, Function2.class,
       boolean.class, boolean.class),
   SLICE0(Enumerables.class, "slice0", Enumerable.class),
   SEMI_JOIN(EnumerableDefaults.class, "semiJoin", Enumerable.class,

--- a/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
@@ -220,6 +220,83 @@ public class EnumerablesTest {
         matcher);
   }
 
+  @Test public void testMergeJoinWithPredicate() {
+    final List<Emp> listEmp1 = Arrays.asList(
+        new Emp(1, "Fred"),
+        new Emp(2, "Fred"),
+        new Emp(3, "Joe"),
+        new Emp(4, "Joe"),
+        new Emp(5, "Peter"));
+    final List<Emp> listEmp2 = Arrays.asList(
+        new Emp(2, "Fred"),
+        new Emp(3, "Fred"),
+        new Emp(3, "Joe"),
+        new Emp(5, "Joe"),
+        new Emp(6, "Peter"));
+
+    assertThat(
+        EnumerableDefaults.mergeJoin(
+            Linq4j.asEnumerable(listEmp1),
+            Linq4j.asEnumerable(listEmp2),
+            e1 -> e1.name,
+            e2 -> e2.name,
+            (e1, e2) -> e1.deptno < e2.deptno,
+            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+        equalTo("["
+            + "Emp(1, Fred)-Emp(2, Fred), "
+            + "Emp(1, Fred)-Emp(3, Fred), "
+            + "Emp(2, Fred)-Emp(3, Fred), "
+            + "Emp(3, Joe)-Emp(5, Joe), "
+            + "Emp(4, Joe)-Emp(5, Joe), "
+            + "Emp(5, Peter)-Emp(6, Peter)]"));
+
+    assertThat(
+        EnumerableDefaults.mergeJoin(
+            Linq4j.asEnumerable(listEmp2),
+            Linq4j.asEnumerable(listEmp1),
+            e2 -> e2.name,
+            e1 -> e1.name,
+            (e2, e1) -> e2.deptno > e1.deptno,
+            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+        equalTo("["
+            + "Emp(2, Fred)-Emp(1, Fred), "
+            + "Emp(3, Fred)-Emp(1, Fred), "
+            + "Emp(3, Fred)-Emp(2, Fred), "
+            + "Emp(5, Joe)-Emp(3, Joe), "
+            + "Emp(5, Joe)-Emp(4, Joe), "
+            + "Emp(6, Peter)-Emp(5, Peter)]"));
+
+    assertThat(
+        EnumerableDefaults.mergeJoin(
+            Linq4j.asEnumerable(listEmp1),
+            Linq4j.asEnumerable(listEmp2),
+            e1 -> e1.name,
+            e2 -> e2.name,
+            (e1, e2) -> e1.deptno == e2.deptno * 2,
+            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+        equalTo("[]"));
+
+    assertThat(
+        EnumerableDefaults.mergeJoin(
+            Linq4j.asEnumerable(listEmp2),
+            Linq4j.asEnumerable(listEmp1),
+            e2 -> e2.name,
+            e1 -> e1.name,
+            (e2, e1) -> e2.deptno == e1.deptno * 2,
+            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+        equalTo("[Emp(2, Fred)-Emp(1, Fred)]"));
+
+    assertThat(
+        EnumerableDefaults.mergeJoin(
+            Linq4j.asEnumerable(listEmp2),
+            Linq4j.asEnumerable(listEmp1),
+            e2 -> e2.name,
+            e1 -> e1.name,
+            (e2, e1) -> e2.deptno == e1.deptno + 2,
+            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+        equalTo("[Emp(3, Fred)-Emp(1, Fred), Emp(5, Joe)-Emp(3, Joe)]"));
+  }
+
   private static <T extends Comparable<T>> Enumerable<T> intersect(
       List<T> list0, List<T> list1) {
     return EnumerableDefaults.mergeJoin(

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableJoinTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableJoinTest.java
@@ -207,8 +207,8 @@ public class EnumerableJoinTest {
                 builder.alias(builder.field(1, "depts", "deptno"), "d_deptno"))
             .build())
         .explainHookMatches("" // It is important that we have MergeJoin in the plan
-            + "EnumerableCalc(expr#0..4=[{inputs}], expr#5=[10], expr#6=[*($t5, $t3)], expr#7=[>($t0, $t6)], empid=[$t0], name=[$t2], dept_name=[$t4], e_deptno=[$t1], d_deptno=[$t3], $condition=[$t7])\n"
-            + "  EnumerableMergeJoin(condition=[=($1, $3)], joinType=[inner])\n"
+            + "EnumerableCalc(expr#0..4=[{inputs}], empid=[$t0], name=[$t2], dept_name=[$t4], e_deptno=[$t1], d_deptno=[$t3])\n"
+            + "  EnumerableMergeJoin(condition=[AND(=($1, $3), >($0, *(10, $3)))], joinType=[inner])\n"
             + "    EnumerableSort(sort0=[$1], dir0=[ASC])\n"
             + "      EnumerableCalc(expr#0..4=[{inputs}], proj#0..2=[{exprs}])\n"
             + "        EnumerableTableScan(table=[[s, emps]])\n"

--- a/linq4j/build.gradle.kts
+++ b/linq4j/build.gradle.kts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 dependencies {
+    api("org.apiguardian:apiguardian-api")
+
     implementation("com.google.guava:guava")
     implementation("org.apache.calcite.avatica:avatica-core")
 }


### PR DESCRIPTION
Jira ticket: [CALCITE-3285](https://issues.apache.org/jira/browse/CALCITE-3285).
Added an extra predicate for non-equi condition in EnumerableDefaults#MergeJoinEnumerator (it will be null in case of equi-joins).