### PR TITLE
[CALCITE-3769] Deprecate TableScanRule

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptAbstractTable.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptAbstractTable.java
@@ -113,7 +113,7 @@ public abstract class RelOptAbstractTable implements RelOptTable {
   }
 
   public Expression getExpression(Class clazz) {
-    throw new UnsupportedOperationException();
+    return null;
   }
 
   public RelOptTable extend(List<RelDataTypeField> extendedFields) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
@@ -65,7 +65,6 @@ import org.apache.calcite.rel.rules.SortProjectTransposeRule;
 import org.apache.calcite.rel.rules.SortRemoveConstantKeysRule;
 import org.apache.calcite.rel.rules.SortRemoveRule;
 import org.apache.calcite.rel.rules.SortUnionTransposeRule;
-import org.apache.calcite.rel.rules.TableScanRule;
 import org.apache.calcite.rel.rules.UnionMergeRule;
 import org.apache.calcite.rel.rules.UnionPullUpConstantsRule;
 import org.apache.calcite.rel.rules.UnionToDistinctRule;
@@ -113,7 +112,6 @@ public class RelOptRules {
   static final List<RelOptRule> BASE_RULES = ImmutableList.of(
       AggregateStarTableRule.INSTANCE,
       AggregateStarTableRule.INSTANCE2,
-      TableScanRule.INSTANCE,
       CalciteSystemProperty.COMMUTE.value()
           ? JoinAssociateRule.INSTANCE
           : ProjectMergeRule.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/plan/RelOptTable.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptTable.java
@@ -116,6 +116,8 @@ public interface RelOptTable extends Wrapper {
    * Generates code for this table.
    *
    * @param clazz The desired collection class; for example {@code Queryable}.
+   *
+   * @return the code for the table, or null if code generation is not supported
    */
   Expression getExpression(Class clazz);
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -2038,7 +2038,6 @@ public abstract class RelOptUtil {
         planner.addRule(rule);
       }
     }
-    planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE);
     planner.addRule(ProjectTableScanRule.INSTANCE);
     planner.addRule(ProjectTableScanRule.INTERPRETER);
 

--- a/core/src/main/java/org/apache/calcite/plan/ViewExpanders.java
+++ b/core/src/main/java/org/apache/calcite/plan/ViewExpanders.java
@@ -64,6 +64,13 @@ public abstract class ViewExpanders {
 
   /** Creates a simple {@code ToRelContext} that cannot expand views. */
   public static RelOptTable.ToRelContext simpleContext(RelOptCluster cluster) {
+    return simpleContext(cluster, ImmutableList.of());
+  }
+
+  /** Creates a simple {@code ToRelContext} that cannot expand views. */
+  public static RelOptTable.ToRelContext simpleContext(
+      RelOptCluster cluster,
+      List<RelHint> hints) {
     return new RelOptTable.ToRelContext() {
       public RelOptCluster getCluster() {
         return cluster;
@@ -75,7 +82,7 @@ public abstract class ViewExpanders {
       }
 
       public List<RelHint> getTableHints() {
-        return ImmutableList.of();
+        return hints;
       }
     };
   }

--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -16,12 +16,9 @@
  */
 package org.apache.calcite.prepare;
 
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
-import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.materialize.Lattice;
-import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelCollation;
@@ -36,7 +33,6 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.rel.type.RelRecordType;
-import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.schema.FilterableTable;
 import org.apache.calcite.schema.ModifiableTable;
@@ -288,30 +284,7 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
     if (table instanceof TranslatableTable) {
       return ((TranslatableTable) table).toRel(context, this);
     }
-    final RelOptCluster cluster = context.getCluster();
-    if (Hook.ENABLE_BINDABLE.get(false)) {
-      return LogicalTableScan.create(cluster, this, context.getTableHints());
-    }
-    if (CalciteSystemProperty.ENABLE_ENUMERABLE.value()
-        && table instanceof QueryableTable
-        && (expressionFunction != null
-        || EnumerableTableScan.canHandle(this))) {
-      return EnumerableTableScan.create(cluster, this);
-    }
-    if (table instanceof ScannableTable
-        || table instanceof FilterableTable
-        || table instanceof ProjectableFilterableTable) {
-      return LogicalTableScan.create(cluster, this, context.getTableHints());
-    }
-    // Some tests rely on the old behavior when tables were immediately converted to
-    // EnumerableTableScan
-    // Note: EnumerableTableScanRule can convert LogicalTableScan to EnumerableTableScan
-    if (CalciteSystemProperty.ENABLE_ENUMERABLE.value()
-        && ((table == null && expressionFunction != null)
-        || EnumerableTableScan.canHandle(this))) {
-      return EnumerableTableScan.create(cluster, this);
-    }
-    return LogicalTableScan.create(cluster, this, context.getTableHints());
+    return LogicalTableScan.create(context.getCluster(), this, context.getTableHints());
   }
 
   public List<RelCollation> getCollationList() {

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -530,7 +530,7 @@ public class RelFactories {
    */
   private static class TableScanFactoryImpl implements TableScanFactory {
     public RelNode createScan(RelOptCluster cluster, RelOptTable table, List<RelHint> hints) {
-      return LogicalTableScan.create(cluster, table, hints);
+      return table.toRel(ViewExpanders.simpleContext(cluster, hints));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/TableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/TableScanRule.java
@@ -29,7 +29,11 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * Planner rule that converts a
  * {@link org.apache.calcite.rel.logical.LogicalTableScan} to the result
  * of calling {@link RelOptTable#toRel}.
+ *
+ * @deprecated {@code org.apache.calcite.rel.core.RelFactories.TableScanFactoryImpl}
+ * has called {@link RelOptTable#toRel(RelOptTable.ToRelContext)}.
  */
+@Deprecated // to be removed before 2.0
 public class TableScanRule extends RelOptRule {
   //~ Static fields/initializers ---------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -55,7 +55,6 @@ import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.rel.rules.SemiJoinRule;
 import org.apache.calcite.rel.rules.SortProjectTransposeRule;
 import org.apache.calcite.rel.rules.SubQueryRemoveRule;
-import org.apache.calcite.rel.rules.TableScanRule;
 import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.apache.calcite.sql2rel.RelFieldTrimmer;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
@@ -85,6 +84,7 @@ public class Programs {
 
   public static final ImmutableSet<RelOptRule> RULE_SET =
       ImmutableSet.of(
+          EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
           EnumerableRules.ENUMERABLE_JOIN_RULE,
           EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE,
           EnumerableRules.ENUMERABLE_CORRELATE_RULE,
@@ -102,7 +102,6 @@ public class Programs {
           EnumerableRules.ENUMERABLE_MATCH_RULE,
           SemiJoinRule.PROJECT,
           SemiJoinRule.JOIN,
-          TableScanRule.INSTANCE,
           MatchRule.INSTANCE,
           CalciteSystemProperty.COMMUTE.value()
               ? JoinAssociateRule.INSTANCE

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -2852,9 +2852,9 @@ public class JdbcTest {
             + "  LogicalFilter(condition=[IN($0, {\n"
             + "LogicalProject(deptno=[$1])\n"
             + "  LogicalFilter(condition=[<($0, 150)])\n"
-            + "    EnumerableTableScan(table=[[hr, emps]])\n"
+            + "    LogicalTableScan(table=[[hr, emps]])\n"
             + "})])\n"
-            + "    EnumerableTableScan(table=[[hr, depts]])")
+            + "    LogicalTableScan(table=[[hr, depts]])")
         .explainContains(""
             + "EnumerableHashJoin(condition=[=($0, $5)], joinType=[semi])\n"
             + "  EnumerableTableScan(table=[[hr, depts]])\n"
@@ -3430,9 +3430,9 @@ public class JdbcTest {
           .convertContains("LogicalAggregate(group=[{}], C=[COUNT()])\n"
               + "  LogicalJoin(condition=[true], joinType=[inner])\n"
               + "    LogicalProject(DUMMY=[0])\n"
-              + "      EnumerableTableScan(table=[[hr, emps]])\n"
+              + "      LogicalTableScan(table=[[hr, emps]])\n"
               + "    LogicalProject(DUMMY=[0])\n"
-              + "      EnumerableTableScan(table=[[hr, depts]])");
+              + "      LogicalTableScan(table=[[hr, depts]])");
     }
   }
 
@@ -4386,7 +4386,7 @@ public class JdbcTest {
           .convertContains("LogicalProject(name=[$1], EXPR$1=[+($2, 1)])\n"
               + "  LogicalAggregate(group=[{0, 1}], agg#0=[COUNT($2)])\n"
               + "    LogicalProject(deptno=[$1], name=[$2], commission=[$4])\n"
-              + "      EnumerableTableScan(table=[[hr, emps]])\n");
+              + "      LogicalTableScan(table=[[hr, emps]])\n");
     }
   }
 
@@ -4404,7 +4404,7 @@ public class JdbcTest {
               + "LogicalProject(name=[$2], EXPR$1=[+(COUNT($3) OVER (PARTITION BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 1)])\n"
               + "  LogicalFilter(condition=[>($0, 10)])\n"
               + "    LogicalProject(empid=[$0], deptno=[$1], name=[$2], commission=[$4])\n"
-              + "      EnumerableTableScan(table=[[hr, emps]])\n");
+              + "      LogicalTableScan(table=[[hr, emps]])\n");
     }
   }
 
@@ -4761,9 +4761,9 @@ public class JdbcTest {
         + "LogicalProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
         + "  LogicalFilter(condition=[EXISTS({\n"
         + "LogicalFilter(condition=[=($cor0.deptno, $0)])\n"
-        + "  EnumerableTableScan(table=[[hr, depts]])\n"
+        + "  LogicalTableScan(table=[[hr, depts]])\n"
         + "})], variablesSet=[[$cor0]])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n";
+        + "    LogicalTableScan(table=[[hr, emps]])\n";
     CalciteAssert.hr().query(sql).convertContains(plan)
         .returnsUnordered(
             "empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000",
@@ -7147,7 +7147,7 @@ public class JdbcTest {
         + "isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], "
         + "patternDefinitions=[[=(CAST(PREV(UP.$0, 0)):INTEGER NOT NULL, 100)]], "
         + "inputFields=[[empid, deptno, name, salary, commission]])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n";
+        + "    LogicalTableScan(table=[[hr, emps]])\n";
     final String plan = "PLAN="
         + "EnumerableMatch(partition=[[]], order=[[0 DESC]], "
         + "outputFields=[[C, EMPID, TWO]], allRows=[false], "
@@ -7180,7 +7180,7 @@ public class JdbcTest {
         + "isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], "
         + "patternDefinitions=[[<(PREV(UP.$4, 0), PREV(UP.$4, 1))]], "
         + "inputFields=[[empid, deptno, name, salary, commission]])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n";
+        + "    LogicalTableScan(table=[[hr, emps]])\n";
     final String plan = "PLAN="
         + "EnumerableMatch(partition=[[]], order=[[0 DESC]], "
         + "outputFields=[[C, EMPID]], allRows=[false], "

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -122,7 +122,6 @@ import org.apache.calcite.rel.rules.SortProjectTransposeRule;
 import org.apache.calcite.rel.rules.SortRemoveConstantKeysRule;
 import org.apache.calcite.rel.rules.SortUnionTransposeRule;
 import org.apache.calcite.rel.rules.SubQueryRemoveRule;
-import org.apache.calcite.rel.rules.TableScanRule;
 import org.apache.calcite.rel.rules.UnionMergeRule;
 import org.apache.calcite.rel.rules.UnionPullUpConstantsRule;
 import org.apache.calcite.rel.rules.UnionToDistinctRule;
@@ -1968,7 +1967,6 @@ public class RelOptRulesTest extends RelOptTestBase {
 
   @Test public void testMergeFilterWithJoinCondition() throws Exception {
     HepProgram program = new HepProgramBuilder()
-        .addRuleInstance(TableScanRule.INSTANCE)
         .addRuleInstance(JoinExtractFilterRule.INSTANCE)
         .addRuleInstance(FilterToCalcRule.INSTANCE)
         .addRuleInstance(ProjectToCalcRule.INSTANCE)
@@ -2239,7 +2237,6 @@ public class RelOptRulesTest extends RelOptTestBase {
     // of the projections, transfer it to calc, for the other,
     // keep it unchanged.
     HepProgram program = new HepProgramBuilder()
-        .addRuleInstance(TableScanRule.INSTANCE)
         // Control the calc conversion.
         .addMatchLimit(1)
         .addRuleInstance(ProjectToCalcRule.INSTANCE)

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableJoinTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableJoinTest.java
@@ -209,12 +209,10 @@ public class EnumerableJoinTest {
             + "  EnumerableMergeJoin(condition=[=($0, $3)], joinType=[inner])\n"
             + "    EnumerableSort(sort0=[$0], dir0=[ASC])\n"
             + "      EnumerableCalc(expr#0..3=[{inputs}], proj#0..1=[{exprs}])\n"
-            + "        EnumerableInterpreter\n"
-            + "          BindableTableScan(table=[[s, depts]])\n"
+            + "        EnumerableTableScan(table=[[s, depts]])\n"
             + "    EnumerableSort(sort0=[$1], dir0=[ASC])\n"
             + "      EnumerableCalc(expr#0..4=[{inputs}], proj#0..2=[{exprs}])\n"
-            + "        EnumerableInterpreter\n"
-            + "          BindableTableScan(table=[[s, emps]])\n")
+            + "        EnumerableTableScan(table=[[s, emps]])\n")
         .returnsUnordered(""
             + "empid=110; name=Theodore; dept_name=Sales; e_deptno=10; d_deptno=10\n"
             + "empid=150; name=Sebastian; dept_name=Sales; e_deptno=10; d_deptno=10");

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
@@ -18,9 +18,12 @@ package org.apache.calcite.test.enumerable;
 
 import org.apache.calcite.adapter.enumerable.EnumerableRepeatUnion;
 import org.apache.calcite.adapter.java.ReflectiveSchema;
+import org.apache.calcite.interpreter.Bindables;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.HierarchySchema;
@@ -32,6 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -128,6 +132,8 @@ public class EnumerableRepeatUnionHierarchyTest {
     CalciteAssert.that()
         .withSchema("s", schema)
         .query("?")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(buildHierarchy(all, startIds, fromField, toField, maxDepth))
         .returnsOrdered(expected);
   }

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
@@ -17,12 +17,16 @@
 package org.apache.calcite.test.enumerable;
 
 import org.apache.calcite.adapter.enumerable.EnumerableRepeatUnion;
+import org.apache.calcite.interpreter.Bindables;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.test.CalciteAssert;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 /**
  * Unit tests for {@link EnumerableRepeatUnion}.
@@ -36,6 +40,8 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbers() {
     CalciteAssert.that()
         .query("?")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE delta(n) AS (
             //     VALUES (1)
@@ -62,6 +68,8 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbers2() {
     CalciteAssert.that()
         .query("?")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE aux(i) AS (
             //     VALUES (0)
@@ -90,6 +98,8 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbers3() {
     CalciteAssert.that()
         .query("?")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE aux(i, j) AS (
             //     VALUES (0, 0)
@@ -128,6 +138,8 @@ public class EnumerableRepeatUnionTest {
   @Test public void testFactorial() {
     CalciteAssert.that()
         .query("?")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE d(n, fact) AS (
             //     VALUES (0, 1)
@@ -168,6 +180,8 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbersNestedRecursion() {
     CalciteAssert.that()
         .query("?")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE t_out(n) AS (
             //     WITH RECURSIVE t_in(n) AS (

--- a/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
@@ -522,7 +522,7 @@ public class FrameworksTest {
 
     public Expression getExpression(SchemaPlus schema, String tableName,
         Class clazz) {
-      throw new UnsupportedOperationException();
+      return null;
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -135,7 +135,7 @@ public class PlannerTest {
 
         "LogicalProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
         + "  LogicalFilter(condition=[LIKE($2, '%e%')])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n");
+        + "    LogicalTableScan(table=[[hr, emps]])\n");
   }
 
   @Test public void testParseIdentiferMaxLengthWithDefault() {
@@ -167,7 +167,7 @@ public class PlannerTest {
 
         "LogicalSort(sort0=[$1], dir0=[ASC], offset=[10])\n"
         + "  LogicalProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
-        + "    EnumerableTableScan(table=[[hr, emps]])\n");
+        + "    LogicalTableScan(table=[[hr, emps]])\n");
   }
 
   private String toString(RelNode rel) {
@@ -390,6 +390,7 @@ public class PlannerTest {
     Program program =
         Programs.ofRules(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
     Planner planner = getPlanner(null, program);
@@ -552,6 +553,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             SortRemoveRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE,
             EnumerableRules.ENUMERABLE_SORT_RULE);
     Planner planner = getPlanner(null, Programs.of(ruleSet));
@@ -582,6 +584,7 @@ public class PlannerTest {
             SortRemoveRule.INSTANCE,
             SortJoinTransposeRule.INSTANCE,
             SortProjectTransposeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_LIMIT_RULE,
             EnumerableRules.ENUMERABLE_JOIN_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE,
@@ -686,6 +689,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             SortRemoveRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE,
             EnumerableRules.ENUMERABLE_WINDOW_RULE,
             EnumerableRules.ENUMERABLE_SORT_RULE,
@@ -711,6 +715,7 @@ public class PlannerTest {
   @Test public void testDuplicateSortPlanWORemoveSortRule() throws Exception {
     RuleSet ruleSet =
         RuleSets.ofList(
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE,
             EnumerableRules.ENUMERABLE_SORT_RULE);
     Planner planner = getPlanner(null, Programs.of(ruleSet));
@@ -754,6 +759,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
     final List<RelTraitDef> traitDefs = new ArrayList<>();
@@ -779,6 +785,7 @@ public class PlannerTest {
     RuleSet ruleSet =
         RuleSets.ofList(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
     Planner planner = getPlanner(null, Programs.of(ruleSet));
@@ -827,6 +834,7 @@ public class PlannerTest {
     RuleSet ruleSet1 =
         RuleSets.ofList(
             rule1,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
 
@@ -876,6 +884,7 @@ public class PlannerTest {
     Program program0 =
         Programs.ofRules(
             FilterMergeRule.INSTANCE,
+            EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
             EnumerableRules.ENUMERABLE_FILTER_RULE,
             EnumerableRules.ENUMERABLE_PROJECT_RULE);
 
@@ -1368,7 +1377,7 @@ public class PlannerTest {
     assertThat(plan,
         equalTo("LogicalSort(sort0=[$0], dir0=[ASC])\n"
         + "  LogicalProject(psPartkey=[$0])\n"
-        + "    EnumerableTableScan(table=[[tpch, partsupp]])\n"));
+        + "    LogicalTableScan(table=[[tpch, partsupp]])\n"));
   }
 
   /** Test case for

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
@@ -200,7 +200,7 @@ public class MatchTest {
     String builderExpected = ""
         + "LogicalFilter(condition=[CONTAINS($1, 'waltham')])\n"
         + "  LogicalProject(_MAP=[$0], city=[ITEM($0, 'city')])\n"
-        + "    LogicalTableScan(table=[[elastic, " + ZIPS + "]])\n";
+        + "    ElasticsearchTableScan(table=[[elastic, " + ZIPS + "]])\n";
 
     RelNode root = builder.build();
 


### PR DESCRIPTION
* Deprecate TableScanRule and always invoke RelOptTable#toRel for
RelBuilder#scan
* RelOptTableImpl#toRel does not translate to EnumerableTableScan
anymore, the EnumerableTableScan conversion logic has been moved to
EnumerableTableScan
* Remove the BindableTableScanRule from the default prepare ruleset, we
only add it where we really need that
* Fix the plan change