### PR TITLE
[CALCITE-3781] HintStrategy can specify excluded rules for planner

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -300,6 +300,12 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
       return;
     }
 
+    if (ruleCall.isRuleExcluded()) {
+      LOGGER.debug("call#{}: Rule [{}] not fired due to exclusion hint",
+          ruleCall.id, ruleCall.getRule());
+      return;
+    }
+
     if (LOGGER.isDebugEnabled()) {
       // Leave this wrapped in a conditional to prevent unnecessarily calling Arrays.toString(...)
       LOGGER.debug("call#{}: Apply rule [{}] to {}",

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
@@ -18,6 +18,7 @@ package org.apache.calcite.plan;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.hint.Hintable;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.trace.CalciteTrace;
@@ -191,6 +192,21 @@ public abstract class RelOptRuleCall {
    */
   public RelOptPlanner getPlanner() {
     return planner;
+  }
+
+  /**
+   * Determines whether the rule is excluded by any root node hint.
+   *
+   * @return true iff rule should be excluded
+   */
+  public boolean isRuleExcluded() {
+    if (!(rels[0] instanceof Hintable)) {
+      return false;
+    }
+
+    return rels[0].getCluster()
+        .getHintStrategies()
+        .isRuleExcluded((Hintable) rels[0], rule);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -160,6 +160,11 @@ public class VolcanoRuleCall extends RelOptRuleCall {
         return;
       }
 
+      if (isRuleExcluded()) {
+        LOGGER.debug("Rule [{}] not fired due to exclusion hint", getRule());
+        return;
+      }
+
       for (int i = 0; i < rels.length; i++) {
         RelNode rel = rels[i];
         RelSubset subset = volcanoPlanner.getSubset(rel);

--- a/core/src/main/java/org/apache/calcite/rel/hint/HintStrategies.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/HintStrategies.java
@@ -51,7 +51,7 @@ public abstract class HintStrategies {
       new NodeTypeHintStrategy(NodeTypeHintStrategy.NodeType.CALC);
 
   /**
-   * Create a hint strategy from a specific matcher whose rules are totally customized.
+   * Creates a hint strategy from a specific matcher whose rules are totally customized.
    *
    * @param matcher The strategy matcher
    * @return A ExplicitHintStrategy instance.

--- a/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
@@ -258,4 +258,19 @@ LogicalJoin:[[USE_HASH_JOIN inheritPath:[0] options:[EMP, DEPT]]]
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testUseMergeJoin">
+        <Resource name="sql">
+            <![CDATA[select /*+ use_merge_join(emp, dept) */
+ename, job, sal, dept.name
+from emp join dept on emp.deptno = dept.deptno]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+EnumerableProject(ENAME=[$1], JOB=[$2], SAL=[$5], NAME=[$10])
+  EnumerableMergeJoin(condition=[=($7, $9)], joinType=[inner])
+    EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
+    EnumerableTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
It is efficient to support exclude rules explicitly for some hints, i.e.
USE_MERGE, NO_USE_HASH.