### PR TITLE
[CALCITE-3779] Implement bitand scalar function

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -3495,7 +3495,7 @@ public class RexImpTable {
     }
   }
 
-  /** Implementor for bitwise  scalar function. */
+  /** Implementor for bitwise scalar function. */
   private static class BitWiseImplementor extends AbstractRexCallImplementor {
 
     protected final String methodName;

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -3505,12 +3505,11 @@ public class RexImpTable {
       this.methodName = methodName;
     }
 
-    @Override
-    String getVariableName() {
+    @Override String getVariableName() {
       return methodName;
     }
 
-    public Expression implementSafe(
+    @Override public Expression implementSafe(
         RexToLixTranslator translator,
         RexCall call,
         List<Expression> translatedOperands) {
@@ -3531,7 +3530,6 @@ public class RexImpTable {
           EnumUtils.call(SqlFunctions.class, methodName, operandsExps),
           returnType);
     }
-
   }
 
 }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1122,7 +1122,7 @@ public class SqlFunctions {
 
   /** Bitwise function <code>BIT_AND</code> applied to long and binary values. */
   public static ByteString bitAnd(long b0, ByteString b1) {
-    return binaryOperator(b0, b1, (x, y) -> (byte) (x & y));
+    return binaryOperator(b1, b0, (x, y) -> (byte) (x & y));
   }
 
   /** Bitwise function <code>BIT_AND</code> applied to binary and long values. */
@@ -1195,25 +1195,6 @@ public class SqlFunctions {
     final byte[] result = new byte[bytes0.length];
     for (int i = 0; i < bytes0.length; i++) {
       result[i] = bitOp.apply((byte) (b1 >> 8 * (bytes0.length - i - 1)), bytes0[i]);
-    }
-    return new ByteString(result);
-  }
-
-  /**
-   * Utility for bitwise function applied to long and byteString values.
-   *
-   * @param b0 The first long value operand of bitwise function.
-   * @param b1 The second byteString value operand of bitwise function.
-   * @param bitOp BitWise binary operator.
-   * @return ByteString after bitwise operation.
-   */
-  private static ByteString binaryOperator(
-      long b0, ByteString b1, BinaryOperator<Byte> bitOp) {
-    byte[] bytes1 = b1.getBytes();
-
-    final byte[] result = new byte[bytes1.length];
-    for (int i = 0; i < bytes1.length; i++) {
-      result[i] = bitOp.apply((byte) (b0 >> 8 * (bytes1.length - i - 1)), bytes1[i]);
     }
     return new ByteString(result);
   }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1126,7 +1126,7 @@ public class SqlFunctions {
   }
 
   /** Bitwise function <code>BIT_AND</code> applied to binary and long values. */
-  public static ByteString bitAnd(ByteString b0,  long b1) {
+  public static ByteString bitAnd(ByteString b0, long b1) {
     return binaryOperator(b0, b1, (x, y) -> (byte) (x & y));
   }
 
@@ -1190,7 +1190,7 @@ public class SqlFunctions {
    */
   private static ByteString binaryOperator(
       ByteString b0, long b1, BinaryOperator<Byte> bitOp) {
-    byte[] bytes0 = b0.getBytes();
+    final byte[] bytes0 = b0.getBytes();
 
     final byte[] result = new byte[bytes0.length];
     for (int i = 0; i < bytes0.length; i++) {

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -75,6 +75,7 @@ import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BinaryOperator;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 
 import static org.apache.calcite.util.Static.RESOURCE;
@@ -1120,6 +1121,16 @@ public class SqlFunctions {
     return binaryOperator(b0, b1, (x, y) -> (byte) (x & y));
   }
 
+  /** Bitwise function <code>BIT_AND</code> applied to long and binary values. */
+  public static ByteString bitAnd(long b0, ByteString b1) {
+    return binaryOperator(b0, b1, (x, y) -> (byte) (x & y));
+  }
+
+  /** SQL <code>BITAND</code> operator applied to ByteString and long values */
+  public static ByteString bitAnd(ByteString b0,  long b1) {
+    return binaryOperator(b0, b1, (x, y) -> (byte) (x & y));
+  }
+
   /** Bitwise function <code>BIT_OR</code> applied to integer values. */
   public static long bitOr(long b0, long b1) {
     return b0 | b1;
@@ -1167,6 +1178,44 @@ public class SqlFunctions {
       result[i] = bitOp.apply(b0.byteAt(i), b1.byteAt(i));
     }
 
+    return new ByteString(result);
+  }
+
+  /**
+   * Utility for bitwise function applied to byteString and long values.
+   *
+   * @param b0 The first byteString value operand of bitwise function.
+   * @param b1 The second long value operand of bitwise function.
+   * @param bitOp BitWise binary operator.
+   * @return ByteString after bitwise operation.
+   */
+  private static ByteString binaryOperator(
+      ByteString b0, long b1, BinaryOperator<Byte> bitOp) {
+    byte[] bytes0 = b0.getBytes();
+
+    final byte[] result = new byte[bytes0.length];
+    for (int i = 0; i < bytes0.length; i++) {
+      result[i] = bitOp.apply((byte) (b1 >> 8 * (bytes0.length - i - 1)), bytes0[i]);
+    }
+    return new ByteString(result);
+  }
+
+  /**
+   * Utility for bitwise function applied to long and byteString values.
+   *
+   * @param b0 The first long value operand of bitwise function.
+   * @param b1 The second byteString value operand of bitwise function.
+   * @param bitOp BitWise binary operator.
+   * @return ByteString after bitwise operation.
+   */
+  private static ByteString binaryOperator(
+      long b0, ByteString b1, BinaryOperator<Byte> bitOp) {
+    byte[] bytes1 = b1.getBytes();
+
+    final byte[] result = new byte[bytes1.length];
+    for (int i = 0; i < bytes1.length; i++) {
+      result[i] = bitOp.apply((byte) (b0 >> 8 * (bytes1.length - i - 1)), bytes1[i]);
+    }
     return new ByteString(result);
   }
 

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1192,11 +1192,10 @@ public class SqlFunctions {
       ByteString b0, long b1, BinaryOperator<Byte> bitOp) {
     final byte[] bytes0 = b0.getBytes();
 
-    final byte[] result = new byte[bytes0.length];
     for (int i = 0; i < bytes0.length; i++) {
-      result[i] = bitOp.apply((byte) (b1 >> 8 * (bytes0.length - i - 1)), bytes0[i]);
+      bytes0[i] = bitOp.apply((byte) (b1 >> 8 * (bytes0.length - i - 1)), bytes0[i]);
     }
-    return new ByteString(result);
+    return new ByteString(bytes0);
   }
 
   // EXP

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -75,7 +75,6 @@ import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BinaryOperator;
 import java.util.regex.Pattern;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 
 import static org.apache.calcite.util.Static.RESOURCE;
@@ -1126,7 +1125,7 @@ public class SqlFunctions {
     return binaryOperator(b0, b1, (x, y) -> (byte) (x & y));
   }
 
-  /** SQL <code>BITAND</code> operator applied to ByteString and long values */
+  /** Bitwise function <code>BIT_AND</code> applied to binary and long values. */
   public static ByteString bitAnd(ByteString b0,  long b1) {
     return binaryOperator(b0, b1, (x, y) -> (byte) (x & y));
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
@@ -54,7 +54,10 @@ public enum SqlLibrary {
   ORACLE("o", "oracle"),
   /** A collection of operators that are in PostgreSQL but not in standard
    * SQL. */
-  POSTGRESQL("p", "postgresql");
+  POSTGRESQL("p", "postgresql"),
+  /** A collection of operators that are in PostgreSQL but not in standard
+   * SQL. */
+  SNOWFLAKE("s", "snowflake");
 
   /** Abbreviation for the library used in SQL reference. */
   public final String abbrev;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
@@ -55,7 +55,7 @@ public enum SqlLibrary {
   /** A collection of operators that are in PostgreSQL but not in standard
    * SQL. */
   POSTGRESQL("p", "postgresql"),
-  /** A collection of operators that are in PostgreSQL but not in standard
+  /** A collection of operators that are in Snowflake but not in standard
    * SQL. */
   SNOWFLAKE("s", "snowflake");
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -37,6 +37,7 @@ import static org.apache.calcite.sql.fun.SqlLibrary.BIG_QUERY;
 import static org.apache.calcite.sql.fun.SqlLibrary.MYSQL;
 import static org.apache.calcite.sql.fun.SqlLibrary.ORACLE;
 import static org.apache.calcite.sql.fun.SqlLibrary.POSTGRESQL;
+import static org.apache.calcite.sql.fun.SqlLibrary.SNOWFLAKE;
 
 /**
  * Defines functions and operators that are not part of standard SQL but
@@ -476,5 +477,18 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = { POSTGRESQL })
   public static final SqlOperator INFIX_CAST =
       new SqlCastOperator();
+
+  @LibraryOperator(libraries = {SNOWFLAKE})
+  public static final SqlFunction BITAND =
+      new SqlFunction("BITAND",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.BITWISE_FUNCTION,
+          null,
+          OperandTypes.or(
+              OperandTypes.INTEGER_INTEGER,
+              OperandTypes.BINARY_BINARY,
+              OperandTypes.INTEGER_BINARY,
+              OperandTypes.BINARY_INTEGER),
+          SqlFunctionCategory.NUMERIC);
 
 }

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -239,6 +239,18 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker EXACT_NUMERIC_EXACT_NUMERIC =
       family(SqlTypeFamily.EXACT_NUMERIC, SqlTypeFamily.EXACT_NUMERIC);
 
+  public static final SqlSingleOperandTypeChecker INTEGER_INTEGER =
+      family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER);
+
+  public static final SqlSingleOperandTypeChecker BINARY_BINARY =
+      family(SqlTypeFamily.BINARY, SqlTypeFamily.BINARY);
+
+  public static final SqlSingleOperandTypeChecker INTEGER_BINARY =
+      family(SqlTypeFamily.INTEGER, SqlTypeFamily.BINARY);
+
+  public static final SqlSingleOperandTypeChecker BINARY_INTEGER =
+      family(SqlTypeFamily.BINARY, SqlTypeFamily.INTEGER);
+
   public static final SqlSingleOperandTypeChecker BINARY =
       family(SqlTypeFamily.BINARY);
 

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -442,7 +442,6 @@ public abstract class ReturnTypes {
   public static final SqlReturnTypeInference INTEGER_QUOTIENT_NULLABLE =
       ARG0_INTERVAL_NULLABLE.orElse(LEAST_RESTRICTIVE);
 
-
   /**
    * Type-inference strategy for a call where the first argument is a decimal.
    * The result type of a call is a decimal with a scale of 0, and the same

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -442,6 +442,7 @@ public abstract class ReturnTypes {
   public static final SqlReturnTypeInference INTEGER_QUOTIENT_NULLABLE =
       ARG0_INTERVAL_NULLABLE.orElse(LEAST_RESTRICTIVE);
 
+
   /**
    * Type-inference strategy for a call where the first argument is a decimal.
    * The result type of a call is a decimal with a scale of 0, and the same
@@ -906,4 +907,25 @@ public abstract class ReturnTypes {
       return relDataType;
     }
   };
+
+  /**
+   * Type-inference strategy that return binary first.
+   */
+  public static final SqlReturnTypeInference BINARY_FIRST =
+      opBinding -> {
+        RelDataType resultType = null;
+        for (RelDataType type : opBinding.collectOperandTypes()) {
+          if (SqlTypeUtil.isBinary(type)) {
+            resultType = type;
+            break;
+          }
+        }
+        return resultType;
+      };
+
+  /**
+   * Type-inference strategy that for bitwise operator.
+   */
+  public static final SqlReturnTypeInference BITWISE_FUNCTION =
+      chain(LEAST_RESTRICTIVE, BINARY_FIRST);
 }

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -9191,7 +9191,7 @@ public abstract class SqlOperatorBaseTest {
         "bitand(CAST(null AS TINYINT), 1)");
     tester1.checkFails(
         "bitand(CAST(x'03' AS BINARY(1)), CAST(x'ABCDEF12' AS BINARY(4)))",
-        "Invalid length for bitwise operator of input binary value",
+        "Different length for bitwise operands: the first: 1, the second: 4",
         true);
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -9135,7 +9135,67 @@ public abstract class SqlOperatorBaseTest {
         0d);
   }
 
-  @Test void testBitAndFunc() {
+  @Test public void testBitAndScalarFunc() {
+    final SqlTester tester1 = tester(SqlLibrary.SNOWFLAKE);
+    tester1.setFor(SqlLibraryOperators.BITAND);
+
+    tester1.checkFails(
+        "^bitand(1)^",
+        "Invalid number of arguments to function 'BITAND'. Was expecting 2 arguments",
+        false);
+    tester1.checkScalar(
+        "bitand(CAST(2 AS TINYINT), CAST(3 AS TINYINT))",
+        "2",
+        "TINYINT NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(3 AS SMALLINT), CAST(4 AS SMALLINT))",
+        "0",
+        "SMALLINT NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(-2 AS INTEGER), CAST(3 AS INTEGER))",
+        "2",
+        "INTEGER NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(-3 AS BIGINT), CAST(-4 AS BIGINT))",
+        "-4",
+        "BIGINT NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(-3 AS INTEGER), CAST(-4 AS BIGINT))",
+        "-4",
+        "BIGINT NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(x'03' AS BINARY(1)), CAST(x'12' AS BINARY(1)))",
+        "02",
+        "BINARY(1) NOT NULL");
+    tester1.checkScalar("bitand(CAST(x'ABCDEF12' AS BINARY(4)), CAST(x'123456AB' AS BINARY(4)))",
+        "02044602",
+        "BINARY(4) NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(x'ABCDEF12' AS VARBINARY(4)), CAST(x'123456AB' AS VARBINARY(4)))",
+        "02044602",
+        "VARBINARY(4) NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(x'ABCDEF12' AS VARBINARY), CAST(x'123456AB' AS VARBINARY))",
+        "02044602",
+        "VARBINARY NOT NULL");
+    tester1.checkScalar(
+        "bitand(CAST(1234 AS BIGINT), CAST(x'123456AB' AS VARBINARY))",
+        "00000482",
+        "VARBINARY NOT NULL");
+
+    tester1.checkScalar(
+        "bitand(CAST(x'123456AB' AS VARBINARY), CAST(1234 AS BIGINT))",
+        "00000482",
+        "VARBINARY NOT NULL");
+    tester1.checkNull(
+        "bitand(CAST(null AS TINYINT), 1)");
+    tester1.checkFails(
+        "bitand(CAST(x'03' AS BINARY(1)), CAST(x'ABCDEF12' AS BINARY(4)))",
+        "Invalid length for bitwise operator of input binary value",
+        true);
+  }
+
+  @Test public void testBitAndAggFunc() {
     tester.setFor(SqlStdOperatorTable.BIT_AND, VM_FENNEL, VM_JAVA);
     tester.checkFails("bit_and(^*^)", "Unknown identifier '\\*'", false);
     tester.checkType("bit_and(1)", "INTEGER");
@@ -9176,7 +9236,7 @@ public abstract class SqlOperatorBaseTest {
         true);
   }
 
-  @Test void testBitOrFunc() {
+  @Test public void testBitOrAggFunc() {
     tester.setFor(SqlStdOperatorTable.BIT_OR, VM_FENNEL, VM_JAVA);
     tester.checkFails("bit_or(^*^)", "Unknown identifier '\\*'", false);
     tester.checkType("bit_or(1)", "INTEGER");
@@ -9207,7 +9267,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkAgg("bit_or(x)", new String[]{"CAST(x'02' AS BINARY)"}, "02", 0);
   }
 
-  @Test void testBitXorFunc() {
+  @Test public void testBitXorAggFunc() {
     tester.setFor(SqlStdOperatorTable.BIT_XOR, VM_FENNEL, VM_JAVA);
     tester.checkFails("bit_xor(^*^)", "Unknown identifier '\\*'", false);
     tester.checkType("bit_xor(1)", "INTEGER");

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2458,7 +2458,6 @@ semantics.
 | b | UNIX_SECONDS(timestamp)                        | Returns the number of seconds since 1970-01-01 00:00:00
 | b | UNIX_DATE(date)                                | Returns the number of days since 1970-01-01
 | o | XMLTRANSFORM(xml, xslt)                        | Returns a string after applying xslt to supplied XML
-| o | XMLTRANSFORM(xml, xslt)                        | Returns a string after applying xslt to supplied xml.
 | s | BITAND(value0, value1)                         | Returns bitwise and of input values
 
 Note:

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2397,6 +2397,7 @@ The 'C' (compatibility) column contains value
 'm' for MySQL ('fun=mysql' in the connect string),
 'o' for Oracle ('fun=oracle' in the connect string),
 'p' for PostgreSQL ('fun=postgresql' in the connect string).
+'s' for Snowflake ('fun=snowflake' in the connect string).
 
 One operator name may correspond to multiple SQL dialects, but with different
 semantics.
@@ -2457,6 +2458,8 @@ semantics.
 | b | UNIX_SECONDS(timestamp)                        | Returns the number of seconds since 1970-01-01 00:00:00
 | b | UNIX_DATE(date)                                | Returns the number of days since 1970-01-01
 | o | XMLTRANSFORM(xml, xslt)                        | Returns a string after applying xslt to supplied XML
+| o | XMLTRANSFORM(xml, xslt)                        | Returns a string after applying xslt to supplied xml.
+| s | BITAND(value0, value1)                         | Returns bitwise and of input values
 
 Note:
 


### PR DESCRIPTION
Implement bitand scalar function which support tinyint, smallint, int, bigint, binary and varbinary type.
Related issue: [CALCITE-3779](https://issues.apache.org/jira/browse/CALCITE-3779)
Parent issue: [CALCITE-3732](https://issues.apache.org/jira/browse/CALCITE-3732)