### PR TITLE
[CALCITE-3785] HepPlanner.belongToDag() doesn't have to use mapDigest…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -498,16 +498,11 @@ public class HepPlanner extends AbstractRelOptPlanner {
     }
   }
 
-  /** Returns whether the vertex is valid. */
-  private boolean belongsToDag(HepRelVertex vertex) {
-    return graph.vertexSet().contains(vertex);
-  }
-
   private HepRelVertex applyRule(
       RelOptRule rule,
       HepRelVertex vertex,
       boolean forceConversions) {
-    if (!belongsToDag(vertex)) {
+    if (!graph.vertexSet().contains(vertex)) {
       return null;
     }
     RelTrait parentTrait = null;
@@ -627,6 +622,13 @@ public class HepPlanner extends AbstractRelOptPlanner {
       Map<RelNode, List<RelNode>> nodeChildren) {
     if (!operand.matches(rel)) {
       return false;
+    }
+    for (RelNode input : rel.getInputs()) {
+      if (!(input instanceof HepRelVertex)) {
+        // The graph could be partially optimized for materialized view. In that
+        // case, the input would be a RelNode and shouldn't be matched again here.
+        return false;
+      }
     }
     bindings.add(rel);
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -500,8 +500,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
 
   /** Returns whether the vertex is valid. */
   private boolean belongsToDag(HepRelVertex vertex) {
-    Pair<String, List<RelDataType>> key = key(vertex.getCurrentRel());
-    return mapDigestToVertex.get(key) != null;
+    return graph.vertexSet().contains(vertex);
   }
 
   private HepRelVertex applyRule(


### PR DESCRIPTION
…ToVertex

To test whether or not a vertex belongs to DAG, we can simply do graph.vertexSet().contains(vertex). There's no need to look up in mapDigestToVertex map, which incurs overhead of creating the map key. This problem was amplified by CALCITE-3713.