### PR TITLE
[CALCITE-3791] HepPlanner does not clear metadata cache for the ancestors of discarded node when a transformation happens

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
@@ -943,9 +943,9 @@ public class RelMdUtil {
    * Removes cached metadata values for specified RelNode.
    *
    * @param rel RelNode whose cached metadata should be removed
+   * @return true if cache for the provided RelNode was not empty
    */
-  public static void clearCache(RelNode rel) {
-    rel.getCluster().getMetadataQuery().clearCache(rel);
+  public static boolean clearCache(RelNode rel) {
+    return rel.getCluster().getMetadataQuery().clearCache(rel);
   }
-
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQueryBase.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQueryBase.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Table;
 
 import java.lang.reflect.Proxy;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -98,8 +99,15 @@ public class RelMetadataQueryBase {
    * Removes cached metadata values for specified RelNode.
    *
    * @param rel RelNode whose cached metadata should be removed
+   * @return true if cache for the provided RelNode was not empty
    */
-  public void clearCache(RelNode rel) {
-    map.row(rel).clear();
+  public boolean clearCache(RelNode rel) {
+    Map<List, Object> row = map.row(rel);
+    if (row.isEmpty()) {
+      return false;
+    }
+
+    row.clear();
+    return true;
   }
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/CALCITE-3791.

