### PR TITLE
[CALCITE-3792] Remove the generic type declaration of method

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
@@ -154,7 +154,7 @@ public class RelOptCluster {
   }
 
   /**
-   * Set up the customized {@link RelMetadataQuery} instance supplier that to
+   * Sets up the customized {@link RelMetadataQuery} instance supplier that to
    * use during rule planning.
    *
    * <p>Note that the {@code mqSupplier} should return
@@ -166,22 +166,22 @@ public class RelOptCluster {
     this.mqSupplier = mqSupplier;
   }
 
-  /** Returns the current RelMetadataQuery.
+  /**
+   * Returns the current RelMetadataQuery.
    *
    * <p>This method might be changed or moved in future.
    * If you have a {@link RelOptRuleCall} available,
    * for example if you are in a {@link RelOptRule#onMatch(RelOptRuleCall)}
    * method, then use {@link RelOptRuleCall#getMetadataQuery()} instead. */
-  public <M extends RelMetadataQuery> M getMetadataQuery() {
+  public RelMetadataQuery getMetadataQuery() {
     if (mq == null) {
       mq = this.mqSupplier.get();
     }
-    //noinspection unchecked
-    return (M) mq;
+    return mq;
   }
 
   /**
-   * @return The supplier of RelMetadataQuery
+   * Returns the supplier of RelMetadataQuery.
    */
   public Supplier<RelMetadataQuery> getMetadataQuerySupplier() {
     return this.mqSupplier;
@@ -196,7 +196,7 @@ public class RelOptCluster {
   }
 
   /**
-   * Setup the hint propagation strategies to be used during rule planning.
+   * Sets up the hint propagation strategies to be used during rule planning.
    *
    * <p>Use <code>RelOptNode.getCluster().getHintStrategies()</code> to fetch
    * the hint strategies.
@@ -207,10 +207,9 @@ public class RelOptCluster {
    *
    * @param hintStrategies The specified hint strategies to override the default one(empty)
    */
-  public RelOptCluster withHintStrategies(HintStrategyTable hintStrategies) {
+  public void setHintStrategies(HintStrategyTable hintStrategies) {
     Objects.requireNonNull(hintStrategies);
     this.hintStrategies = hintStrategies;
-    return this;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRuleCall.java
@@ -210,11 +210,11 @@ public abstract class RelOptRuleCall {
   }
 
   /**
-   * Returns the current RelMetadataQuery or its sub-class,
+   * Returns the current RelMetadataQuery
    * to be used for instance by
    * {@link RelOptRule#onMatch(RelOptRuleCall)}.
    */
-  public <M extends RelMetadataQuery> M getMetadataQuery() {
+  public RelMetadataQuery getMetadataQuery() {
     return rel(0).getCluster().getMetadataQuery();
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -331,8 +331,9 @@ public class SqlToRelConverter {
     this.config = new ConfigBuilder().withConfig(config).build();
     this.relBuilder = config.getRelBuilderFactory().create(cluster, null);
     this.hintStrategies = config.getHintStrategyTable();
-    this.cluster = Objects.requireNonNull(cluster)
-        .withHintStrategies(this.hintStrategies);
+
+    cluster.setHintStrategies(this.hintStrategies);
+    this.cluster = Objects.requireNonNull(cluster);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1305,7 +1305,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     final RelNode rel = root.rel;
     assertThat(rel, instanceOf(LogicalFilter.class));
     assertThat(rel.getCluster().getMetadataQuery(), instanceOf(MyRelMetadataQuery.class));
-    final MyRelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final MyRelMetadataQuery mq = (MyRelMetadataQuery) rel.getCluster().getMetadataQuery();
 
     try {
       assertThat(colType(mq, rel, 0), equalTo("DEPTNO-rel"));
@@ -1416,7 +1416,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     // Top node is a filter. Its metadata uses getColType(RelNode, int).
     assertThat(rel, instanceOf(LogicalFilter.class));
     assertThat(rel.getCluster().getMetadataQuery(), instanceOf(MyRelMetadataQuery.class));
-    final MyRelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final MyRelMetadataQuery mq = (MyRelMetadataQuery) rel.getCluster().getMetadataQuery();
     assertThat(colType(mq, rel, 0), equalTo("DEPTNO-rel"));
     assertThat(colType(mq, rel, 1), equalTo("EXPR$1-rel"));
 
@@ -1444,11 +1444,13 @@ public class RelMetadataTest extends SqlToRelTestBase {
     // Invalidate the metadata query triggers clearing of all the metadata.
     rel.getCluster().invalidateMetadataQuery();
     assertThat(rel.getCluster().getMetadataQuery(), instanceOf(MyRelMetadataQuery.class));
-    final MyRelMetadataQuery mq1 = rel.getCluster().getMetadataQuery();
+    final MyRelMetadataQuery mq1 = (MyRelMetadataQuery) rel.getCluster().getMetadataQuery();
     assertThat(colType(mq1, input, 0), equalTo("DEPTNO-agg"));
     assertThat(buf.size(), equalTo(5));
     assertThat(colType(mq1, input, 0), equalTo("DEPTNO-agg"));
     assertThat(buf.size(), equalTo(5));
+    // Resets the RelMetadataQuery to default.
+    rel.getCluster().setMetadataQuerySupplier(RelMetadataQuery::instance);
   }
 
   /** Unit test for


### PR DESCRIPTION
* The type inference of Scala code 'val mq = cluster.getMetadataQuery'
is failed if we have that generic type declaration for the Java method
* After this change, we need a explicit cast for RelMetadataQuery
sub-class
* Fix the RelMetadataTest to reset the RelMetadataQuery instance as
default after a test
* Also rename RelOptCluster#withHintStrategies to setHintStrategies
because it does not really return a new copy