### PR TITLE
Following [CALCITE-3763] Fix slow test failure

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/LatticeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LatticeTest.java
@@ -334,12 +334,11 @@ public class LatticeTest {
           .convertMatches(
               CalciteAssert.checkRel(""
                   + "LogicalAggregate(group=[{}], EXPR$0=[COUNT()])\n"
-                  + "  LogicalProject(DUMMY=[0])\n"
-                  + "    StarTableScan(table=[[adhoc, star]])\n",
+                  + "  StarTableScan(table=[[adhoc, star]])\n",
                   counter));
     } catch (Throwable e) {
       assertThat(Throwables.getStackTraceAsString(e),
-          containsString("java.lang.AssertionError"));
+          containsString("CannotPlanException"));
     }
     assertThat(counter.get(), equalTo(1));
   }


### PR DESCRIPTION
Fix the test failure introduced by CALCITE-3763. Could you help to confirm it? @julianhyde 