### PR TITLE
[CALCITE-3798] Make RelBuilder view expander pluggable

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -187,7 +187,7 @@ public class JdbcRules {
       };
 
   public static final RelFactories.TableScanFactory TABLE_SCAN_FACTORY =
-      (cluster, table, hints) -> {
+      (toRelContext, table) -> {
         throw new UnsupportedOperationException();
       };
 

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -29,7 +29,6 @@ import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.Project;
-import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.core.Window;
@@ -3104,10 +3103,7 @@ public class RelBuilderTest {
           expandingConfig(connection);
       final RelOptTable.ViewExpander viewExpander =
           (RelOptTable.ViewExpander) Frameworks.getPlanner(configBuilder.build());
-      final RelFactories.TableScanFactory tableScanFactory =
-          RelFactories.expandingScanFactory(viewExpander,
-              RelFactories.DEFAULT_TABLE_SCAN_FACTORY);
-      configBuilder.context(Contexts.of(tableScanFactory));
+      configBuilder.context(Contexts.of(viewExpander));
       final RelBuilder builder = RelBuilder.create(configBuilder.build());
       RelNode node = builder.scan("MYVIEW").build();
 
@@ -3130,10 +3126,7 @@ public class RelBuilderTest {
           expandingConfig(connection);
       final RelOptTable.ViewExpander viewExpander =
           (RelOptTable.ViewExpander) Frameworks.getPlanner(configBuilder.build());
-      final RelFactories.TableScanFactory tableScanFactory =
-          RelFactories.expandingScanFactory(viewExpander,
-              RelFactories.DEFAULT_TABLE_SCAN_FACTORY);
-      configBuilder.context(Contexts.of(tableScanFactory));
+      configBuilder.context(Contexts.of(viewExpander));
       final RelBuilder builder = RelBuilder.create(configBuilder.build());
       RelNode node =
           builder.scan("MYVIEW")

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigRelFactories.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigRelFactories.java
@@ -60,9 +60,9 @@ public class PigRelFactories {
 
     public static final PigTableScanFactory INSTANCE = new PigTableScanFactory();
 
-    @Override public RelNode createScan(RelOptCluster cluster,
-        RelOptTable table, List<RelHint> hints) {
-      Util.discard(hints);
+    @Override public RelNode createScan(RelOptTable.ToRelContext toRelContext,
+        RelOptTable table) {
+      final RelOptCluster cluster = toRelContext.getCluster();
       return new PigTableScan(cluster, cluster.traitSetOf(PigRel.CONVENTION), table);
     }
   }

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelBuilder.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelBuilder.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.ViewExpanders;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.core.CorrelationId;
@@ -260,7 +261,8 @@ public class PigRelBuilder extends RelBuilder {
    * @return This builder
    */
   private RelBuilder scan(RelOptTable tableSchema) {
-    final RelNode scan = getScanFactory().createScan(cluster, tableSchema, ImmutableList.of());
+    final RelNode scan = getScanFactory().createScan(
+        ViewExpanders.simpleContext(cluster), tableSchema);
     push(scan);
     return this;
   }


### PR DESCRIPTION
User can config a view expander directly when constructing the
RelBuilder.

Deprecate RelFactories#expandingScanFactory, we already called
TranslatableTable#toRel in RelOptTable#toRel.