### PR TITLE
[CALCITE-3799] Following CALCITE-3769, fix the slow tests

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScanRule.java
@@ -62,9 +62,7 @@ public class EnumerableTableScanRule extends ConverterRule {
     final Table table = relOptTable.unwrap(Table.class);
     final Expression expression = relOptTable.getExpression(Object.class);
 
-    if (table instanceof QueryableTable
-        && (expression != null
-            || EnumerableTableScan.canHandle(relOptTable))) {
+    if (table instanceof QueryableTable) {
       return EnumerableTableScan.create(scan.getCluster(), relOptTable);
     }
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
@@ -23,7 +23,6 @@ import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalJoin;
-import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
 import org.apache.calcite.rel.rules.AggregateFilterTransposeRule;
 import org.apache.calcite.rel.rules.AggregateProjectMergeRule;
@@ -156,7 +155,7 @@ public class RelOptMaterialization {
                           Mappings.offsetSource(rightMapping, offset),
                           leftMapping.getTargetCount()));
               final RelNode project = RelOptUtil.createProject(
-                  LogicalTableScan.create(cluster, leftRelOptTable, ImmutableList.of()),
+                  leftRelOptTable.toRel(ViewExpanders.simpleContext(cluster)),
                   Mappings.asList(mapping.inverse()));
               final List<RexNode> conditions = new ArrayList<>();
               if (left.condition != null) {
@@ -180,7 +179,7 @@ public class RelOptMaterialization {
                       Mappings.offsetSource(leftMapping, offset),
                       Mappings.offsetTarget(rightMapping, leftCount));
               final RelNode project = RelOptUtil.createProject(
-                  LogicalTableScan.create(cluster, rightRelOptTable, ImmutableList.of()),
+                  rightRelOptTable.toRel(ViewExpanders.simpleContext(cluster)),
                   Mappings.asList(mapping.inverse()));
               final List<RexNode> conditions = new ArrayList<>();
               if (left.condition != null) {

--- a/core/src/test/java/org/apache/calcite/test/LatticeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LatticeTest.java
@@ -339,7 +339,7 @@ public class LatticeTest {
                   counter));
     } catch (Throwable e) {
       assertThat(Throwables.getStackTraceAsString(e),
-          containsString("CannotPlanException"));
+          containsString("java.lang.AssertionError"));
     }
     assertThat(counter.get(), equalTo(1));
   }
@@ -356,7 +356,7 @@ public class LatticeTest {
             CalciteAssert.checkRel(
                 "LogicalProject(unit_sales=[$7], brand_name=[$10])\n"
                     + "  LogicalProject(product_id=[$0], time_id=[$1], customer_id=[$2], promotion_id=[$3], store_id=[$4], store_sales=[$5], store_cost=[$6], unit_sales=[$7], product_class_id=[$8], product_id0=[$9], brand_name=[$10], product_name=[$11], SKU=[$12], SRP=[$13], gross_weight=[$14], net_weight=[$15], recyclable_package=[$16], low_fat=[$17], units_per_case=[$18], cases_per_pallet=[$19], shelf_width=[$20], shelf_height=[$21], shelf_depth=[$22])\n"
-                    + "    LogicalTableScan(table=[[adhoc, star]])\n",
+                    + "    StarTableScan(table=[[adhoc, star]])\n",
                 counter));
     assertThat(counter.intValue(), equalTo(1));
   }
@@ -376,11 +376,11 @@ public class LatticeTest {
               anyOf(
                   containsStringLinux(
                       "LogicalProject(brand_name=[$1], customer_id=[$0])\n"
-                      + "  LogicalAggregate(group=[{2, 10}])\n"
-                      + "    LogicalTableScan(table=[[adhoc, star]])\n"),
+                          + "  LogicalAggregate(group=[{2, 10}])\n"
+                          + "    StarTableScan(table=[[adhoc, star]])\n"),
                   containsStringLinux(
                       "LogicalAggregate(group=[{2, 10}])\n"
-                      + "  LogicalTableScan(table=[[adhoc, star]])\n")));
+                          + "  StarTableScan(table=[[adhoc, star]])\n")));
           return null;
         });
     assertThat(counter.intValue(), equalTo(2));
@@ -819,7 +819,7 @@ public class LatticeTest {
             CalciteAssert.checkRel(
                 "LogicalProject(unit_sales=[$7], brand_name=[$10])\n"
                     + "  LogicalProject(product_id=[$0], time_id=[$1], customer_id=[$2], promotion_id=[$3], store_id=[$4], store_sales=[$5], store_cost=[$6], unit_sales=[$7], product_class_id=[$8], product_id0=[$9], brand_name=[$10], product_name=[$11], SKU=[$12], SRP=[$13], gross_weight=[$14], net_weight=[$15], recyclable_package=[$16], low_fat=[$17], units_per_case=[$18], cases_per_pallet=[$19], shelf_width=[$20], shelf_height=[$21], shelf_depth=[$22])\n"
-                    + "    LogicalTableScan(table=[[adhoc, star]])\n",
+                    + "    StarTableScan(table=[[adhoc, star]])\n",
                 counter));
     if (enabled) {
       assertThat(counter.intValue(), is(1));
@@ -877,7 +877,7 @@ public class LatticeTest {
         .enableMaterializations(true)
         .substitutionMatches(
             CalciteAssert.checkRel(
-                "EnumerableTableScan(table=[[mat, m0]])\n",
+                "LogicalTableScan(table=[[mat, m0]])\n",
                 counter));
     assertThat(counter.intValue(), equalTo(1));
   }


### PR DESCRIPTION
* Fix the RelOptMaterialization to always expand the StartTable
* Simplify the logic in EnumerableTableScanRule
* Also fix the plan diff introduced by other patches