### PR TITLE
[CALCITE-3801] Deprecate SqlToRelConverter.Config#isConvertTableAccess

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -57,8 +57,6 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
-import org.apache.calcite.plan.hep.HepPlanner;
-import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
@@ -214,14 +212,12 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     final Convention resultConvention =
         enableBindable ? BindableConvention.INSTANCE
             : EnumerableConvention.INSTANCE;
-    final HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+    // Use the Volcano because it can handle the traits.
+    final VolcanoPlanner planner = new VolcanoPlanner();
     planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
 
     final SqlToRelConverter.ConfigBuilder configBuilder =
         SqlToRelConverter.configBuilder().withTrimUnusedFields(true);
-    if (analyze) {
-      configBuilder.withConvertTableAccess(false);
-    }
 
     final CalcitePreparingStmt preparingStmt =
         new CalcitePreparingStmt(this, context, catalogReader, typeFactory,

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -247,7 +247,6 @@ public class PlannerImpl implements Planner, ViewExpander {
     final SqlToRelConverter.Config config = SqlToRelConverter.configBuilder()
         .withConfig(sqlToRelConverterConfig)
         .withTrimUnusedFields(false)
-        .withConvertTableAccess(false)
         .build();
     final SqlToRelConverter sqlToRelConverter =
         new SqlToRelConverter(this, validator,
@@ -300,7 +299,6 @@ public class PlannerImpl implements Planner, ViewExpander {
         .configBuilder()
         .withConfig(sqlToRelConverterConfig)
         .withTrimUnusedFields(false)
-        .withConvertTableAccess(false)
         .build();
     final SqlToRelConverter sqlToRelConverter =
         new SqlToRelConverter(this, validator,

--- a/core/src/test/java/org/apache/calcite/rel/logical/ToLogicalConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/logical/ToLogicalConverterTest.java
@@ -78,7 +78,6 @@ public class ToLogicalConverterTest {
   private static final SqlToRelConverter.Config DEFAULT_REL_CONFIG =
       SqlToRelConverter.configBuilder()
           .withTrimUnusedFields(false)
-          .withConvertTableAccess(false)
           .build();
 
   private static FrameworkConfig frameworkConfig() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -94,13 +94,11 @@ public class RelToSqlConverterTest {
   static final SqlToRelConverter.Config DEFAULT_REL_CONFIG =
       SqlToRelConverter.configBuilder()
           .withTrimUnusedFields(false)
-          .withConvertTableAccess(false)
           .build();
 
   static final SqlToRelConverter.Config NO_EXPAND_CONFIG =
       SqlToRelConverter.configBuilder()
           .withTrimUnusedFields(false)
-          .withConvertTableAccess(false)
           .withExpand(false)
           .build();
 


### PR DESCRIPTION
Because of CALCITE-3769, this config option is actually useless now,
we always return logical rel with method RelOptTable#toRel.