### PR TITLE
[CALCITE-3820] EnumerableDefaults#orderBy should be lazily computed + support enumerator re-initialization

### DIFF
--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -2407,13 +2407,17 @@ public abstract class EnumerableDefaults {
   public static <TSource, TKey> Enumerable<TSource> orderBy(
       Enumerable<TSource> source, Function1<TSource, TKey> keySelector,
       Comparator<TKey> comparator) {
-    // NOTE: TreeMap allows null comparator. But the caller of this method
-    // must supply a comparator if the key does not extend Comparable.
-    // Otherwise there will be a ClassCastException while retrieving.
-    final Map<TKey, List<TSource>> map = new TreeMap<>(comparator);
-    LookupImpl<TKey, TSource> lookup = toLookup_(map, source, keySelector,
-        Functions.identitySelector());
-    return lookup.valuesEnumerable();
+    return new AbstractEnumerable<TSource>() {
+      @Override public Enumerator<TSource> enumerator() {
+        // NOTE: TreeMap allows null comparator. But the caller of this method
+        // must supply a comparator if the key does not extend Comparable.
+        // Otherwise there will be a ClassCastException while retrieving.
+        final Map<TKey, List<TSource>> map = new TreeMap<>(comparator);
+        final LookupImpl<TKey, TSource> lookup = toLookup_(map, source, keySelector,
+            Functions.identitySelector());
+        return lookup.valuesEnumerable().enumerator();
+      }
+    };
   }
 
   /**


### PR DESCRIPTION
Jira ticket: [CALCITE-3820](https://issues.apache.org/jira/browse/CALCITE-3820)

The current implementation of EnumerableDefaults#orderBy has the following disadvantages:

1) The TreeMap that performs the actual sorting is eagerly computed. This operation can be quite heavy if we have a very big source. The fact that it is eagerly computed might lead to bad performance in situations where the sort is executed, but it is actually not needed. For example, in a NestedLoopJoin, if the outer enumerator returns no results, the inner one is not even accessed. If we had a huge orderBy as inner, today it would be computed in that scenario, even though it is not actually required. For this reason, in terms of performance it seems clearly preferable to delay the sort operation as much as possible.

2) The Enumerable / Enumerator returned by EnumerableDefaults#orderBy cannot be re-evaluated. Since the map, and the subsequent LookupImpl, the Enumerable relies on is eagerly computed, every called to enumerator will return the same values, even if the source Enumerable has changed. This is a corner case, but we can see it if, for example, we have a MergeJoin, with EnumerableSort (i.e. using EnumerableDefaults#orderBy) inside a RepeatUnion (a.k.a. recursive union). In this situation, the RepeatUnion re-evaluates its right child, so that the output of the iteration N-1 is used as input for the iteration N. In this scenario, the EnumerableDefaults#orderBy will not work as expected, since it will not be actually re-computed (see EnumerableMethods#repeatUnion).