### PR TITLE
[CALCITE-3821] RelOptUtil::containsMultisetOrWindowedAgg doesn't real…

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalcRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalcRule.java
@@ -35,7 +35,7 @@ class EnumerableCalcRule extends ConverterRule {
     // The predicate ensures that if there's a multiset, FarragoMultisetSplitter
     // will work on it first.
     super(LogicalCalc.class,
-        (Predicate<Calc>) RelOptUtil::containsMultisetOrWindowedAgg,
+        (Predicate<Calc>) RelOptUtil::notContainsWindowedAgg,
         Convention.NONE, EnumerableConvention.INSTANCE,
         RelFactories.LOGICAL_BUILDER, "EnumerableCalcRule");
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilterRule.java
@@ -32,7 +32,7 @@ import java.util.function.Predicate;
 class EnumerableFilterRule extends ConverterRule {
   EnumerableFilterRule() {
     super(LogicalFilter.class,
-        (Predicate<LogicalFilter>) RelOptUtil::containsMultisetOrWindowedAgg,
+        (Predicate<LogicalFilter>) RelOptUtil::notContainsWindowedAgg,
         Convention.NONE, EnumerableConvention.INSTANCE,
         RelFactories.LOGICAL_BUILDER, "EnumerableFilterRule");
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProjectRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProjectRule.java
@@ -32,7 +32,7 @@ import java.util.function.Predicate;
 class EnumerableProjectRule extends ConverterRule {
   EnumerableProjectRule() {
     super(LogicalProject.class,
-        (Predicate<LogicalProject>) RelOptUtil::containsMultisetOrWindowedAgg,
+        (Predicate<LogicalProject>) RelOptUtil::notContainsWindowedAgg,
         Convention.NONE, EnumerableConvention.INSTANCE,
         RelFactories.LOGICAL_BUILDER, "EnumerableProjectRule");
   }

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -280,7 +280,7 @@ public class Bindables {
      */
     public BindableFilterRule(RelBuilderFactory relBuilderFactory) {
       super(LogicalFilter.class,
-          (Predicate<LogicalFilter>) RelOptUtil::containsMultisetOrWindowedAgg,
+          (Predicate<LogicalFilter>) RelOptUtil::notContainsWindowedAgg,
           Convention.NONE, BindableConvention.INSTANCE, relBuilderFactory,
           "BindableFilterRule");
     }
@@ -347,7 +347,7 @@ public class Bindables {
      */
     public BindableProjectRule(RelBuilderFactory relBuilderFactory) {
       super(LogicalProject.class,
-          (Predicate<LogicalProject>) RelOptUtil::containsMultisetOrWindowedAgg,
+          (Predicate<LogicalProject>) RelOptUtil::notContainsWindowedAgg,
           Convention.NONE, BindableConvention.INSTANCE, relBuilderFactory,
           "BindableProjectRule");
     }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -3415,20 +3415,17 @@ public abstract class RelOptUtil {
     return projectFactory.createProject(rel, ImmutableList.of(), exprList, outputNameList);
   }
 
-  /** Predicate for whether a {@link Calc} contains multisets or windowed
-   * aggregates. */
+  /** Predicate for if a {@link Calc} does not contain windowed aggregates. */
   public static boolean notContainsWindowedAgg(Calc calc) {
     return !calc.getProgram().containsAggs();
   }
 
-  /** Predicate for whether a {@link Filter} contains multisets or windowed
-   * aggregates. */
+  /** Predicate for if a {@link Filter} does not windowed aggregates. */
   public static boolean notContainsWindowedAgg(Filter filter) {
     return !RexOver.containsOver(filter.getCondition());
   }
 
-  /** Predicate for whether a {@link Project} contains multisets or windowed
-   * aggregates. */
+  /** Predicate for if a {@link Project} does not contain windowed aggregates. */
   public static boolean notContainsWindowedAgg(Project project) {
     return !RexOver.containsOver(project.getProjects(), null);
   }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -73,7 +73,6 @@ import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexLocalRef;
-import org.apache.calcite.rex.RexMultisetUtil;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.rex.RexProgram;
@@ -144,26 +143,24 @@ import javax.annotation.Nullable;
 public abstract class RelOptUtil {
   //~ Static fields/initializers ---------------------------------------------
 
-  static final boolean B = false;
-
   public static final double EPSILON = 1.0e-5;
 
   @SuppressWarnings("Guava")
   @Deprecated // to be removed before 2.0
   public static final com.google.common.base.Predicate<Filter>
       FILTER_PREDICATE =
-      RelOptUtil::containsMultisetOrWindowedAgg;
+      RelOptUtil::notContainsWindowedAgg;
 
   @SuppressWarnings("Guava")
   @Deprecated // to be removed before 2.0
   public static final com.google.common.base.Predicate<Project>
       PROJECT_PREDICATE =
-      RelOptUtil::containsMultisetOrWindowedAgg;
+      RelOptUtil::notContainsWindowedAgg;
 
   @SuppressWarnings("Guava")
   @Deprecated // to be removed before 2.0
   public static final com.google.common.base.Predicate<Calc> CALC_PREDICATE =
-      RelOptUtil::containsMultisetOrWindowedAgg;
+      RelOptUtil::notContainsWindowedAgg;
 
   //~ Methods ----------------------------------------------------------------
 
@@ -3420,26 +3417,20 @@ public abstract class RelOptUtil {
 
   /** Predicate for whether a {@link Calc} contains multisets or windowed
    * aggregates. */
-  public static boolean containsMultisetOrWindowedAgg(Calc calc) {
-    return !(B
-        && RexMultisetUtil.containsMultiset(calc.getProgram())
-        || calc.getProgram().containsAggs());
+  public static boolean notContainsWindowedAgg(Calc calc) {
+    return !calc.getProgram().containsAggs();
   }
 
   /** Predicate for whether a {@link Filter} contains multisets or windowed
    * aggregates. */
-  public static boolean containsMultisetOrWindowedAgg(Filter filter) {
-    return !(B
-        && RexMultisetUtil.containsMultiset(filter.getCondition(), true)
-        || RexOver.containsOver(filter.getCondition()));
+  public static boolean notContainsWindowedAgg(Filter filter) {
+    return !RexOver.containsOver(filter.getCondition());
   }
 
   /** Predicate for whether a {@link Project} contains multisets or windowed
    * aggregates. */
-  public static boolean containsMultisetOrWindowedAgg(Project project) {
-    return !(B
-        && RexMultisetUtil.containsMultiset(project.getProjects(), true)
-        || RexOver.containsOver(project.getProjects(), null));
+  public static boolean notContainsWindowedAgg(Project project) {
+    return !RexOver.containsOver(project.getProjects(), null);
   }
 
   /** Policies for handling two- and three-valued boolean logic. */


### PR DESCRIPTION
…ly check multiset

The check of containsMultiset() is shortcut by a "false" constant. Also what the function really does is to check rel node does not contain window aggs.