### PR TITLE
[CALCITE-3819] Prune parent RelNode when merging child RelSet with parent RelSet

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.Converter;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.util.trace.CalciteTrace;
@@ -105,6 +106,25 @@ class RelSet {
    */
   public List<RelNode> getParentRels() {
     return parents;
+  }
+
+  /**
+   * Returns the child Relset for current set
+   */
+  public Set<RelSet> getChildSets(VolcanoPlanner planner) {
+    Set<RelSet> childSets = new HashSet<>();
+    for (RelNode node : this.rels) {
+      if (node instanceof Converter) {
+        continue;
+      }
+      for (RelNode child : node.getInputs()) {
+        RelSet childSet = planner.equivRoot(((RelSubset) child).getSet());
+        if (childSet.id != this.id) {
+          childSets.add(childSet);
+        }
+      }
+    }
+    return childSets;
   }
 
   /**
@@ -326,7 +346,29 @@ class RelSet {
       if (otherSubset.bestCost.isLt(subset.bestCost)) {
         changedSubsets.put(subset, otherSubset.best);
       }
-      for (RelNode otherRel : otherSubset.getRels()) {
+    }
+
+    Set<RelNode> parentRels = new HashSet<>(parents);
+    for (RelNode otherRel : otherSet.rels) {
+      Double importance = planner.getImportance(otherRel);
+      if (importance != null && importance == 0d) {
+        continue;
+      }
+
+      boolean pruned = false;
+      if (parentRels.contains(otherRel)) {
+        // if otherRel is a enforcing operator e.g.
+        // Sort, Exchange, do not prune it.
+        if (otherRel.getInputs().size() != 1
+            || otherRel.getInput(0).getTraitSet()
+                .satisfies(otherRel.getTraitSet())) {
+          pruned = true;
+        }
+      }
+
+      if (pruned) {
+        planner.setImportance(otherRel, 0d);
+      } else {
         planner.reregister(this, otherRel);
       }
     }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -123,6 +123,22 @@ public class VolcanoRuleCall extends RelOptRuleCall {
         volcanoPlanner.listener.ruleProductionSucceeded(event);
       }
 
+      for (int i = 0; i < rels.length; i++) {
+        if (rel == rels[i]) {
+          if (i == 0) {
+            return;
+          }
+          volcanoPlanner.setImportance(rels[0], 0d);
+          break;
+        }
+
+        final RelNode relCopy = rel;
+        if (rels[i].getInputs().stream().anyMatch(n -> n == relCopy)) {
+          volcanoPlanner.setImportance(rels[0], 0d);
+          break;
+        }
+      }
+
       // Registering the root relational expression implicitly registers
       // its descendants. Register any explicit equivalences first, so we
       // don't register twice and cause churn.


### PR DESCRIPTION
Suppose we have 2 RelSets:
RelSet A: rel1
RelSet B: rel2

 rel1 is the parent of rel2.

If there is a transformation rule that transform rel1 to rel2, we will merge
RelSet A and B. During merge process, we can safely prune rel1 to avoid further
rule apply on rel1 and reduce search space, more importantly, avoid cyclic
reference.