### PR TITLE
[CALCITE-3836] The hash codes of RelNodes are unreliable

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -402,7 +402,7 @@ public abstract class AbstractRelNode implements RelNode {
    * (e.g. visitors, planner) can define the identity as meets their needs.
    */
   @Override public final int hashCode() {
-    return super.hashCode();
+    return this.id ^ (this.id << 16);
   }
 
   /**

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/RelNodeBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/RelNodeBenchmark.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.benchmarks;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for {@link org.apache.calcite.rel.RelNode}s.
+ */
+public class RelNodeBenchmark {
+
+  static class TestRelNode extends SingleRel {
+    TestRelNode(RelOptCluster cluster, RelTraitSet traits, RelNode input) {
+      super(cluster, traits, input);
+    }
+  }
+
+  /**
+   * State object for the hash code benchmarks.
+   */
+  @State(Scope.Benchmark)
+  public static class HashCodeState {
+
+    private TestRelNode node;
+
+    public HashCodeState() {
+      createNode();
+    }
+
+    @Setup(Level.Invocation)
+    public void createNode() {
+      VolcanoPlanner planner = new VolcanoPlanner();
+      planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+
+      final RelDataTypeFactory typeFactory =
+          new SqlTypeFactoryImpl(org.apache.calcite.rel.type.RelDataTypeSystem.DEFAULT);
+      RelOptCluster cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory));
+
+      node = new TestRelNode(cluster, cluster.traitSetOf(Convention.NONE), null);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public int getOutwardEdgesBenchmark(HashCodeState state) {
+    return state.node.hashCode();
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(RelNodeBenchmark.class.getName())
+        .forks(1)
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
For all sub-classes of AbstractRelNode, the hashCode methods depend on AbstractRelNode#hashCode, because it is declared as final.

AbstractRelNode#hashCode depends on Object#hashCode, which is called identify hash code. The details of identity hash code depends on the specific JVM implementation. For many JVMs, the implementation is based on the object address in the memory. The problem is that, the address of an object may change in a JVM, due to GC, memory contraction, etc. So the hash code of an object may change, even if the content of the object is not changed (This can be confirmed from the JavaDoc of Object#hashCode).

This problem may cause severe issues that are hard to diagnose and debug, like an object is in the hash table, but cannot be retrieved; duplicate objects in the hash map, etc.

To solve the problem, we compute a hash code solely from the node id. This is consistent with the previous semantics, and solves the above problem.