### PR TITLE
Following CALCITE-3769: Add BindableTableScanRule into the default ru…

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScan.java
@@ -238,18 +238,23 @@ public class EnumerableTableScan
     switch (relFieldType.getSqlTypeName()) {
     case ARRAY:
     case MULTISET:
-      // We can't represent a multiset or array as a List<Employee>, because
-      // the consumer does not know the element type.
-      // The standard element type is List.
-      // We need to convert to a List<List>.
-      final JavaTypeFactory typeFactory =
-          (JavaTypeFactory) getCluster().getTypeFactory();
-      final PhysType elementPhysType = PhysTypeImpl.of(
-          typeFactory, relFieldType.getComponentType(), JavaRowFormat.CUSTOM);
-      final MethodCallExpression e2 =
-          Expressions.call(BuiltInMethod.AS_ENUMERABLE2.method, e);
-      final Expression e3 = elementPhysType.convertTo(e2, JavaRowFormat.LIST);
-      return Expressions.call(e3, BuiltInMethod.ENUMERABLE_TO_LIST.method);
+      final RelDataType fieldType = relFieldType.getComponentType();
+      if (fieldType.isStruct()) {
+        // We can't represent a multiset or array as a List<Employee>, because
+        // the consumer does not know the element type.
+        // The standard element type is List.
+        // We need to convert to a List<List>.
+        final JavaTypeFactory typeFactory =
+                (JavaTypeFactory) getCluster().getTypeFactory();
+        final PhysType elementPhysType = PhysTypeImpl.of(
+                typeFactory, fieldType, JavaRowFormat.CUSTOM);
+        final MethodCallExpression e2 =
+                Expressions.call(BuiltInMethod.AS_ENUMERABLE2.method, e);
+        final Expression e3 = elementPhysType.convertTo(e2, JavaRowFormat.LIST);
+        return Expressions.call(e3, BuiltInMethod.ENUMERABLE_TO_LIST.method);
+      } else {
+        return e;
+      }
     default:
       return e;
     }

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -234,6 +234,11 @@ public class Bindables {
 
     @Override public RelOptCost computeSelfCost(RelOptPlanner planner,
         RelMetadataQuery mq) {
+      boolean noPushing = filters.isEmpty()
+              && projects.size() == table.getRowType().getFieldCount();
+      if (noPushing) {
+        return super.computeSelfCost(planner, mq);
+      }
       // Cost factor for pushing filters
       double f = filters.isEmpty() ? 1d : 0.5d;
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -2038,6 +2038,21 @@ public abstract class RelOptUtil {
         planner.addRule(rule);
       }
     }
+    // Registers this rule for default ENUMERABLE convention
+    // because:
+    // 1. ScannableTable can bind data directly;
+    // 2. Only BindableTable supports project push down now.
+
+    // EnumerableInterpreterRule.INSTANCE would then transform
+    // the BindableTableScan to
+    // EnumerableInterpreter + BindableTableScan.
+
+    // Note: the cost of EnumerableInterpreter + BindableTableScan
+    // is always bigger that EnumerableTableScan because of the additional
+    // EnumerableInterpreter node, but if there are pushing projects or filter,
+    // we prefer BindableTableScan instead,
+    // see BindableTableScan#computeSelfCost.
+    planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE);
     planner.addRule(ProjectTableScanRule.INSTANCE);
     planner.addRule(ProjectTableScanRule.INTERPRETER);
 

--- a/core/src/test/java/org/apache/calcite/test/StreamTest.java
+++ b/core/src/test/java/org/apache/calcite/test/StreamTest.java
@@ -290,8 +290,7 @@ public class StreamTest {
             + "    EnumerableCalc(expr#0..3=[{inputs}], expr#4=[CAST($t2):VARCHAR(32) NOT NULL], proj#0..4=[{exprs}])\n"
             + "      EnumerableInterpreter\n"
             + "        BindableTableScan(table=[[STREAM_JOINS, ORDERS, (STREAM)]])\n"
-            + "    EnumerableInterpreter\n"
-            + "      BindableTableScan(table=[[STREAM_JOINS, PRODUCTS]])")
+            + "    EnumerableTableScan(table=[[STREAM_JOINS, PRODUCTS]])")
         .returns(
             startsWith("ROWTIME=2015-02-15 10:15:00; ORDERID=1; SUPPLIERID=1",
                 "ROWTIME=2015-02-15 10:24:15; ORDERID=2; SUPPLIERID=0",

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionHierarchyTest.java
@@ -18,12 +18,9 @@ package org.apache.calcite.test.enumerable;
 
 import org.apache.calcite.adapter.enumerable.EnumerableRepeatUnion;
 import org.apache.calcite.adapter.java.ReflectiveSchema;
-import org.apache.calcite.interpreter.Bindables;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.HierarchySchema;
@@ -35,7 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -132,8 +128,6 @@ public class EnumerableRepeatUnionHierarchyTest {
     CalciteAssert.that()
         .withSchema("s", schema)
         .query("?")
-        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
-            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(buildHierarchy(all, startIds, fromField, toField, maxDepth))
         .returnsOrdered(expected);
   }

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
@@ -17,16 +17,12 @@
 package org.apache.calcite.test.enumerable;
 
 import org.apache.calcite.adapter.enumerable.EnumerableRepeatUnion;
-import org.apache.calcite.interpreter.Bindables;
-import org.apache.calcite.plan.RelOptPlanner;
-import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.test.CalciteAssert;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.function.Consumer;
 
 /**
  * Unit tests for {@link EnumerableRepeatUnion}.
@@ -40,8 +36,6 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbers() {
     CalciteAssert.that()
         .query("?")
-        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
-            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE delta(n) AS (
             //     VALUES (1)
@@ -68,8 +62,6 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbers2() {
     CalciteAssert.that()
         .query("?")
-        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
-            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE aux(i) AS (
             //     VALUES (0)
@@ -98,8 +90,6 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbers3() {
     CalciteAssert.that()
         .query("?")
-        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
-            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE aux(i, j) AS (
             //     VALUES (0, 0)
@@ -138,8 +128,6 @@ public class EnumerableRepeatUnionTest {
   @Test public void testFactorial() {
     CalciteAssert.that()
         .query("?")
-        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
-            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE d(n, fact) AS (
             //     VALUES (0, 1)
@@ -180,8 +168,6 @@ public class EnumerableRepeatUnionTest {
   @Test public void testGenerateNumbersNestedRecursion() {
     CalciteAssert.that()
         .query("?")
-        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
-            planner.addRule(Bindables.BINDABLE_TABLE_SCAN_RULE))
         .withRel(
             //   WITH RECURSIVE t_out(n) AS (
             //     WITH RECURSIVE t_in(n) AS (

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvFilterableTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvFilterableTable.java
@@ -50,6 +50,7 @@ public class CsvFilterableTable extends CsvTable
   }
 
   public Enumerable<Object[]> scan(DataContext root, List<RexNode> filters) {
+    final List<CsvFieldType> fieldTypes = getFieldTypes(root.getTypeFactory());
     final String[] filterValues = new String[fieldTypes.size()];
     filters.removeIf(filter -> addFilter(filter, filterValues));
     final int[] fields = CsvEnumerator.identityList(fieldTypes.size());

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvScannableTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvScannableTable.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.util.Source;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -44,6 +45,7 @@ public class CsvScannableTable extends CsvTable
   }
 
   public Enumerable<Object[]> scan(DataContext root) {
+    final List<CsvFieldType> fieldTypes = getFieldTypes(root.getTypeFactory());
     final int[] fields = CsvEnumerator.identityList(fieldTypes.size());
     final AtomicBoolean cancelFlag = DataContext.Variable.CANCEL_FLAG.get(root);
     return new AbstractEnumerable<Object[]>() {

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvStreamScannableTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvStreamScannableTable.java
@@ -17,19 +17,16 @@
 package org.apache.calcite.adapter.csv;
 
 import org.apache.calcite.DataContext;
-import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.linq4j.AbstractEnumerable;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Enumerator;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.schema.StreamableTable;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.util.Source;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -45,16 +42,8 @@ public class CsvStreamScannableTable extends CsvScannableTable
     super(source, protoRowType);
   }
 
-  public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-    if (protoRowType != null) {
-      return protoRowType.apply(typeFactory);
-    }
-    if (fieldTypes == null) {
-      fieldTypes = new ArrayList<>();
-      return CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source, fieldTypes, true);
-    } else {
-      return CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source, null, true);
-    }
+  @Override protected boolean isStream() {
+    return true;
   }
 
   public String toString() {
@@ -62,6 +51,7 @@ public class CsvStreamScannableTable extends CsvScannableTable
   }
 
   public Enumerable<Object[]> scan(DataContext root) {
+    final List<CsvFieldType> fieldTypes = getFieldTypes(root.getTypeFactory());
     final int[] fields = CsvEnumerator.identityList(fieldTypes.size());
     final AtomicBoolean cancelFlag = DataContext.Variable.CANCEL_FLAG.get(root);
     return new AbstractEnumerable<Object[]>() {

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTable.java
@@ -32,7 +32,8 @@ import java.util.List;
 public abstract class CsvTable extends AbstractTable {
   protected final Source source;
   protected final RelProtoDataType protoRowType;
-  protected List<CsvFieldType> fieldTypes;
+  private RelDataType rowType;
+  private List<CsvFieldType> fieldTypes;
 
   /** Creates a CsvTable. */
   CsvTable(Source source, RelProtoDataType protoRowType) {
@@ -44,14 +45,26 @@ public abstract class CsvTable extends AbstractTable {
     if (protoRowType != null) {
       return protoRowType.apply(typeFactory);
     }
+    if (rowType == null) {
+      rowType = CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source,
+          null, isStream());
+    }
+    return rowType;
+  }
+
+  /** Returns the field types of this CSV table. */
+  public List<CsvFieldType> getFieldTypes(RelDataTypeFactory typeFactory) {
     if (fieldTypes == null) {
       fieldTypes = new ArrayList<>();
-      return CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source,
-          fieldTypes);
-    } else {
-      return CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source,
-          null);
+      CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source,
+          fieldTypes, isStream());
     }
+    return fieldTypes;
+  }
+
+  /** Returns whether the table represents a stream. */
+  protected boolean isStream() {
+    return false;
   }
 
   /** Various degrees of table "intelligence". */

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTranslatableTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/CsvTranslatableTable.java
@@ -57,7 +57,11 @@ public class CsvTranslatableTable extends CsvTable
     final AtomicBoolean cancelFlag = DataContext.Variable.CANCEL_FLAG.get(root);
     return new AbstractEnumerable<Object>() {
       public Enumerator<Object> enumerator() {
-        return new CsvEnumerator<>(source, cancelFlag, fieldTypes, fields);
+        return new CsvEnumerator<>(
+            source,
+            cancelFlag,
+            getFieldTypes(root.getTypeFactory()),
+            fields);
       }
     };
   }

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonEnumerator.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonEnumerator.java
@@ -61,7 +61,7 @@ public class JsonEnumerator implements Enumerator<Object[]> {
    * of a JSON file. */
   static JsonDataConverter deduceRowType(RelDataTypeFactory typeFactory, Source source) {
     final ObjectMapper objectMapper = new ObjectMapper();
-    List<Object> list = new ArrayList<>();
+    List<Object> list;
     LinkedHashMap<String, Object> jsonFieldMap = new LinkedHashMap<>(1);
     Object jsonObj = null;
     try {

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonScannableTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonScannableTable.java
@@ -45,7 +45,7 @@ public class JsonScannableTable extends JsonTable
   public Enumerable<Object[]> scan(DataContext root) {
     return new AbstractEnumerable<Object[]>() {
       public Enumerator<Object[]> enumerator() {
-        return new JsonEnumerator(list);
+        return new JsonEnumerator(getDataList(root.getTypeFactory()));
       }
     };
   }

--- a/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonTable.java
+++ b/example/csv/src/main/java/org/apache/calcite/adapter/csv/JsonTable.java
@@ -24,7 +24,6 @@ import org.apache.calcite.schema.Statistics;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.util.Source;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,16 +31,28 @@ import java.util.List;
  */
 public class JsonTable extends AbstractTable {
   private final Source source;
-  protected List<Object> list = new ArrayList<>();
+  private RelDataType rowType;
+  protected List<Object> dataList;
 
   public JsonTable(Source source) {
     this.source = source;
   }
 
   public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-    JsonDataConverter jsonDataConverter = JsonEnumerator.deduceRowType(typeFactory, source);
-    list = jsonDataConverter.getDataList();
-    return jsonDataConverter.getRelDataType();
+    if (rowType == null) {
+      rowType = JsonEnumerator.deduceRowType(typeFactory, source).getRelDataType();
+    }
+    return rowType;
+  }
+
+  /** Returns the data list of the table. */
+  public List<Object> getDataList(RelDataTypeFactory typeFactory) {
+    if (dataList == null) {
+      JsonDataConverter jsonDataConverter =
+          JsonEnumerator.deduceRowType(typeFactory, source);
+      dataList = jsonDataConverter.getDataList();
+    }
+    return dataList;
   }
 
   public Statistic getStatistic() {

--- a/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
+++ b/example/csv/src/test/java/org/apache/calcite/test/CsvTest.java
@@ -215,8 +215,7 @@ public class CsvTest {
   @Test public void testPushDownProjectDumb() throws SQLException {
     // rule does not fire, because we're using 'dumb' tables in simple model
     final String sql = "explain plan for select * from EMPS";
-    final String expected = "PLAN=EnumerableInterpreter\n"
-        + "  BindableTableScan(table=[[SALES, EMPS]])\n";
+    final String expected = "PLAN=EnumerableTableScan(table=[[SALES, EMPS]])\n";
     sql("model", sql).returns(expected).ok();
   }
 


### PR DESCRIPTION
…leset

* Add BindableTableScanRule into the default ruleset, so there are 2
table implementations, the planner would choose the one with cheaper
cost
* Fix the cost estimation of BindableTableScan if there are no pushings
* Allows the Scannable table to have the EnumerableTableScan as impl