### PR TITLE
[CALCITE-3837] AntiJoin with empty right input can always be transformed as its left input

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -338,11 +338,8 @@ public abstract class PruneEmptyRules {
             return;
           }
           if (join.getJoinType() == JoinRelType.ANTI) {
-            // "select * from emp anti join dept" is not necessarily empty if dept is empty
-            if (join.analyzeCondition().isEqui()) {
-              // In case of anti (equi) join: Join(X, Empty, ANTI) becomes X
-              call.transformTo(join.getLeft());
-            }
+            // In case of anti join: Join(X, Empty, ANTI) becomes X
+            call.transformTo(join.getLeft());
             return;
           }
           call.transformTo(call.builder().push(join).empty().build());

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3316,7 +3316,7 @@ public class RelOptRulesTest extends RelOptTestBase {
     final String planAfter = NL + RelOptUtil.toString(output);
     final DiffRepository diffRepos = getDiffRepos();
     diffRepos.assertEquals("planBefore", "${planBefore}", planBefore);
-    // Cannot optimize away the join because it is not equi join.
+    // Plan should be scan("EMP") (i.e. join's left child)
     diffRepos.assertEquals("planAfter", "${planAfter}", planAfter);
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -3102,9 +3102,7 @@ LogicalProject(EMPNO=[$0])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalJoin(condition=[AND(=($7, $8), =($5, 2000))], joinType=[anti])
-    LogicalTableScan(table=[[scott, EMP]])
-    LogicalValues(tuples=[[]])
+  LogicalTableScan(table=[[scott, EMP]])
 ]]>
         </Resource>
     </TestCase>


### PR DESCRIPTION
Jira: [CALCITE-3837](https://issues.apache.org/jira/browse/CALCITE-3837)