### PR TITLE
[CALCITE-3851] Replace the node importance map with a set for pruned nodes

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -221,7 +221,11 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
     return 0;
   }
 
+  @Deprecated // to be removed before 1.24
   public void setImportance(RelNode rel, double importance) {
+  }
+
+  @Override public void prune(RelNode rel) {
   }
 
   public void registerClass(RelNode node) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
@@ -307,8 +307,23 @@ public interface RelOptPlanner {
    *
    * @param rel        Relational expression
    * @param importance Importance
+   *
+   * @deprecated This API will be removed in a future release, as we no longer
+   * support the concept of node importance. Please use
+   * {@link RelOptPlanner#prune(RelNode)} method instead.
    */
+  @Deprecated // to be removed before 1.24
   void setImportance(RelNode rel, double importance);
+
+  /**
+   * Prunes a node from the planner.
+   *
+   * <p>When a node is pruned, the related pending rule
+   * calls are cancelled, and future rules will not fire.
+   * This can be used to reduce the search space. </p>
+   * @param rel the node to prune.
+   */
+  void prune(RelNode rel);
 
   /**
    * Registers a class of RelNode. If this class of RelNode has been seen

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -349,8 +349,7 @@ class RelSet {
 
     Set<RelNode> parentRels = new HashSet<>(parents);
     for (RelNode otherRel : otherSet.rels) {
-      Double importance = planner.getImportance(otherRel);
-      if (importance != null && importance == 0d) {
+      if (planner.prunedNodes.contains(otherRel)) {
         continue;
       }
 
@@ -366,7 +365,7 @@ class RelSet {
       }
 
       if (pruned) {
-        planner.setImportance(otherRel, 0d);
+        planner.prune(otherRel);
       } else {
         planner.reregister(this, otherRel);
       }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -237,8 +237,7 @@ class RuleQueue {
    * {@link RelNode}s have importance zero. */
   private boolean skipMatch(VolcanoRuleMatch match) {
     for (RelNode rel : match.rels) {
-      Double importance = planner.relImportances.get(rel);
-      if (importance != null && importance == 0d) {
+      if (planner.prunedNodes.contains(rel)) {
         return true;
       }
     }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -126,12 +126,12 @@ public class VolcanoRuleCall extends RelOptRuleCall {
 
       final RelNode relCopy = rel;
       if (rels[0].getInputs().stream().anyMatch(n -> n == relCopy)) {
-        volcanoPlanner.setImportance(rels[0], 0d);
+        volcanoPlanner.prune(rels[0]);
       }
 
       if (this.getRule() instanceof SubstitutionRule
           && ((SubstitutionRule) getRule()).autoPruneOld()) {
-        volcanoPlanner.setImportance(rels[0], 0d);
+        volcanoPlanner.prune(rels[0]);
       }
 
       // Registering the root relational expression implicitly registers
@@ -194,9 +194,7 @@ public class VolcanoRuleCall extends RelOptRuleCall {
           return;
         }
 
-        final Double importance =
-            volcanoPlanner.relImportances.get(rel);
-        if ((importance != null) && (importance == 0d)) {
+        if (volcanoPlanner.prunedNodes.contains(rel)) {
           LOGGER.debug("Rule [{}] not fired because operand #{} ({}) has importance=0",
               getRule(), i, rel);
           return;

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateCaseToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateCaseToFilterRule.java
@@ -138,7 +138,7 @@ public class AggregateCaseToFilterRule extends RelOptRule {
         .convert(aggregate.getRowType(), false);
 
     call.transformTo(relBuilder.build());
-    call.getPlanner().setImportance(aggregate, 0.0);
+    call.getPlanner().prune(aggregate);
   }
 
   private @Nullable AggregateCall transform(AggregateCall aggregateCall,

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValuesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValuesRule.java
@@ -105,6 +105,6 @@ public class AggregateValuesRule extends RelOptRule implements SubstitutionRule 
             .build());
 
     // New plan is absolutely better than old plan.
-    call.getPlanner().setImportance(aggregate, 0.0);
+    call.getPlanner().prune(aggregate);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
@@ -89,7 +89,7 @@ public class CalcMergeRule extends RelOptRule {
         && newCalc.getRowType().equals(bottomCalc.getRowType())) {
       // newCalc is equivalent to bottomCalc, which means that topCalc
       // must be trivial. Take it out of the game.
-      call.getPlanner().setImportance(topCalc, 0.0);
+      call.getPlanner().prune(topCalc);
     }
 
     call.transformTo(newCalc);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ExchangeRemoveConstantKeysRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ExchangeRemoveConstantKeysRule.java
@@ -117,7 +117,7 @@ public class ExchangeRemoveConstantKeysRule extends RelOptRule
               ? RelDistributions.SINGLETON
               : RelDistributions.hash(distributionKeys))
           .build());
-      call.getPlanner().setImportance(exchange, 0.0);
+      call.getPlanner().prune(exchange);
     }
   }
 
@@ -194,7 +194,7 @@ public class ExchangeRemoveConstantKeysRule extends RelOptRule
             .push(sortExchange.getInput())
             .sortExchange(distribution, collation)
             .build());
-        call.getPlanner().setImportance(sortExchange, 0.0);
+        call.getPlanner().prune(sortExchange);
       }
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
@@ -215,7 +215,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule
       }
 
       // New plan is absolutely better than old plan.
-      call.getPlanner().setImportance(filter, 0.0);
+      call.getPlanner().prune(filter);
     }
 
     /**
@@ -273,7 +273,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule
             call.transformTo(createEmptyRelOrEquivalent(call, filter));
           }
           // New plan is absolutely better than old plan.
-          call.getPlanner().setImportance(filter, 0.0);
+          call.getPlanner().prune(filter);
         }
       }
     }
@@ -313,7 +313,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule
                 .build());
 
         // New plan is absolutely better than old plan.
-        call.getPlanner().setImportance(project, 0.0);
+        call.getPlanner().prune(project);
       }
     }
   }
@@ -361,7 +361,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule
               join.isSemiJoinDone()));
 
       // New plan is absolutely better than old plan.
-      call.getPlanner().setImportance(join, 0.0);
+      call.getPlanner().prune(join);
     }
   }
 
@@ -436,7 +436,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule
             calc.copy(calc.getTraitSet(), calc.getInput(), builder.getProgram()));
 
         // New plan is absolutely better than old plan.
-        call.getPlanner().setImportance(calc, 0.0);
+        call.getPlanner().prune(calc);
       }
     }
 
@@ -529,7 +529,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule
         call.transformTo(LogicalWindow
             .create(window.getTraitSet(), window.getInput(),
                 window.getConstants(), window.getRowType(), groups));
-        call.getPlanner().setImportance(window, 0);
+        call.getPlanner().prune(window);
       }
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveConstantKeysRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveConstantKeysRule.java
@@ -74,13 +74,13 @@ public class SortRemoveConstantKeysRule extends RelOptRule
     // No active collations. Remove the sort completely
     if (collationsList.isEmpty() && sort.offset == null && sort.fetch == null) {
       call.transformTo(input);
-      call.getPlanner().setImportance(sort, 0.0);
+      call.getPlanner().prune(sort);
       return;
     }
 
     final Sort result =
         sort.copy(sort.getTraitSet(), input, RelCollations.of(collationsList));
     call.transformTo(result);
-    call.getPlanner().setImportance(sort, 0.0);
+    call.getPlanner().prune(sort);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ValuesReduceRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ValuesReduceRule.java
@@ -250,7 +250,7 @@ public abstract class ValuesReduceRule extends RelOptRule {
     // changeCount == 0, we've proved that the filter was trivial, and that
     // can send the volcano planner into a loop; see dtbug 2070.)
     if (filter != null) {
-      call.getPlanner().setImportance(filter, 0.0);
+      call.getPlanner().prune(filter);
     }
   }
 


### PR DESCRIPTION
Currently, volcano planner stores rel node importances with a map. In fact, the value of the map can only be 0.
So there is no need to store the values, and we replace the map with a set to store nodes whose importances are 0.

This makes the code logic clearer, and avoids instability caused by comparing floating point values.