### PR TITLE
[CALCITE-3468] JDBC adapter may generate casts on Oracle for varchar without the precision and for char with the precision exceeding max length of Oracle

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -772,19 +772,41 @@ public class SqlDialect {
     return true;
   }
 
- /** Returns SqlNode for type in "cast(column as type)", which might be
+  /**
+   * Returns whether this dialect allows a given type with unspecified precision.
+   * Most of the dialects allow type with unspecified precision (cast node as VARCHAR), So
+   * the default result is true. However there are some dialects that do not allowed, these dialects
+   * can override this method.
+   * For example,
+   * Oracle does not allow VARCHAR with unspecified precision.
+   *
+   * @param type The given type
+   * @return whether this dialect allows a given type with unspecified precision. if returns
+   * true, it allows the given type with unspecified precision, otherwise, returns false.
+   */
+  public boolean allowsTypeWithUnspecifiedPrecision(RelDataType type) {
+    return true;
+  }
+
+  /** Returns SqlNode for type in "cast(column as type)", which might be
   * different between databases by type name, precision etc. */
   public SqlNode getCastSpec(RelDataType type) {
     if (type instanceof BasicSqlType) {
       int maxPrecision = -1;
       switch (type.getSqlTypeName()) {
       case VARCHAR:
+      case CHAR:
         // if needed, adjust varchar length to max length supported by the system
         maxPrecision = getTypeSystem().getMaxPrecision(type.getSqlTypeName());
       }
       String charSet = type.getCharset() != null && supportsCharSet()
           ? type.getCharset().name()
           : null;
+      if (type.getPrecision() == RelDataType.PRECISION_NOT_SPECIFIED
+          && !allowsTypeWithUnspecifiedPrecision(type)) {
+        return SqlTypeUtil.convertTypeToSpec(type, charSet, maxPrecision,
+            getTypeSystem().getDefaultPrecision(type.getSqlTypeName()));
+      }
       return SqlTypeUtil.convertTypeToSpec(type, charSet, maxPrecision);
     }
     return SqlTypeUtil.convertTypeToSpec(type);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -52,10 +52,31 @@ public class OracleSqlDialect extends SqlDialect {
         @Override public int getMaxPrecision(SqlTypeName typeName) {
           switch (typeName) {
           case VARCHAR:
-            // Maximum size of 4000 bytes for varchar2.
+            // The standard maximum size of 4000 bytes for varchar2.
+            // Since Oracle Database 12c, you can uses the MAX_STRING_SIZE parameter for controlling
+            // the maximum size. If you specify the maximum size of 32767 for the
+            // VARCHAR2 data type. you can create a new oracle type system to override the
+            // maximum size.
             return 4000;
+          case CHAR:
+            return 2000;
           default:
             return super.getMaxPrecision(typeName);
+          }
+        }
+        @Override public int getDefaultPrecision(SqlTypeName typeName) {
+          switch (typeName) {
+          case VARCHAR:
+            // The standard maximum size of 4000 bytes for varchar2.
+            // Since Oracle Database 12c, you can uses the MAX_STRING_SIZE parameter for controlling
+            // the maximum size. If you specify the maximum size of 32767 for the
+            // VARCHAR2 data type. you can create a new oracle type system to override the
+            // maximum size.
+            // Because Oracle does not allow VARCHAR with unspecified precision, set the maximum
+            // precision as the default precision of VARCHAR.
+            return 4000;
+          default:
+            return super.getDefaultPrecision(typeName);
           }
         }
       };
@@ -82,6 +103,19 @@ public class OracleSqlDialect extends SqlDialect {
       return false;
     default:
       return super.supportsDataType(type);
+    }
+  }
+
+  /**
+   * Oracle does not allow the type VARCHAR with unspecified precision. When use cast(node as
+   * varchar), we should specify the precision of VARCHAR. For example, cast(node as varchar(256)).
+   */
+  @Override public boolean allowsTypeWithUnspecifiedPrecision(RelDataType type) {
+    switch (type.getSqlTypeName()) {
+    case VARCHAR:
+      return false;
+    default:
+      return true;
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -1015,17 +1015,20 @@ public abstract class SqlTypeUtil {
    * @param type         type descriptor
    * @param charSetName  charSet name
    * @param maxPrecision The max allowed precision.
+   * @param explicitPrecision If explicitPrecision is specified, use it as the type's precision.
+   *                          When explicitPrecision is not specified, it should be -1.
    * @return corresponding parse representation
    */
   public static SqlDataTypeSpec convertTypeToSpec(RelDataType type,
-      String charSetName, int maxPrecision) {
+      String charSetName, int maxPrecision, int explicitPrecision) {
     SqlTypeName typeName = type.getSqlTypeName();
 
     // TODO jvs 28-Dec-2004:  support row types, user-defined types,
     // interval types, multiset types, etc
     assert typeName != null;
 
-    int precision = typeName.allowsPrec() ? type.getPrecision() : -1;
+    int precision = typeName.allowsPrec()
+        ? (explicitPrecision != -1 ? explicitPrecision : type.getPrecision()) : -1;
     // fix up the precision.
     if (maxPrecision > 0 && precision > maxPrecision) {
       precision = maxPrecision;
@@ -1057,7 +1060,19 @@ public abstract class SqlTypeUtil {
   public static SqlDataTypeSpec convertTypeToSpec(RelDataType type) {
     // TODO jvs 28-Dec-2004:  collation
     String charSetName = inCharFamily(type) ? type.getCharset().name() : null;
-    return convertTypeToSpec(type, charSetName, -1);
+    return convertTypeToSpec(type, charSetName, -1, -1);
+  }
+
+  /**
+   * Converts an instance of RelDataType to an instance of SqlDataTypeSpec.
+   * @param type type descriptor
+   * @param charSetName  charSet name
+   * @param maxPrecision The max allowed precision.
+   * @return corresponding parse representation
+   */
+  public static SqlDataTypeSpec convertTypeToSpec(RelDataType type,
+      String charSetName, int maxPrecision) {
+    return convertTypeToSpec(type, charSetName, maxPrecision, -1);
   }
 
   public static RelDataType createMultisetType(

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -594,6 +594,31 @@ public class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3468">[CALCITE-3468]
+   * JDBC adapter may generate casts on Oracle for varchar without the precision
+   * and for char with the precision exceeding max length of Oracle.</a>
+   */
+  @Test public void testOracleCastAsVarcharChar() {
+    final String query = "select cast(\"store_id\" as VARCHAR)\n"
+        + "from \"expense_fact\"";
+
+    final String expectedOracle = "SELECT CAST(\"store_id\" AS VARCHAR(4000))\n"
+        + "FROM \"foodmart\".\"expense_fact\"";
+    sql(query)
+        .withOracle()
+        .ok(expectedOracle);
+
+    final String query1 = "select cast(\"store_id\" as CHAR(65500))\n"
+        + "from \"expense_fact\"";
+
+    final String expectedOracle1 = "SELECT CAST(\"store_id\" AS CHAR(2000))\n"
+        + "FROM \"foodmart\".\"expense_fact\"";
+    sql(query1)
+        .withOracle()
+        .ok(expectedOracle1);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1174">[CALCITE-1174]
    * When generating SQL, translate SUM0(x) to COALESCE(SUM(x), 0)</a>. */
   @Test public void testSum0BecomesCoalesce() {


### PR DESCRIPTION
Oracle requires VARCHAR with precision, and the max precision of VARCHAR is 4000, the max precision of CHAR is 2000. When the precision of CHAR is not assigned,  it has the default value 1 which is the same as Calcite.