### PR TITLE
[CALCITE-3648] MySQL UNCOMPRESS function support

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -129,6 +129,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.STRCMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TANH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TO_BASE64;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TRANSLATE3;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.UNCOMPRESS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.XML_TRANSFORM;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ABS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ACOS;
@@ -555,6 +556,7 @@ public class RexImpTable {
 
     // Compression Operators
     defineMethod(COMPRESS, BuiltInMethod.COMPRESS.method, NullPolicy.ARG0);
+    defineMethod(UNCOMPRESS, BuiltInMethod.UNCOMPRESS.method, NullPolicy.ARG0);
 
     // Xml Operators
     defineMethod(EXTRACT_VALUE, BuiltInMethod.EXTRACT_VALUE.method, NullPolicy.ARG0);

--- a/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
@@ -84,11 +84,4 @@ public class CompressionFunctions {
       return null;
     }
   }
-
-  /**
-   * MySQl Supports uncompress function for string which returns NULL value.
-   */
-  public static String uncompress(String data) {
-    return null;
-  }
 }

--- a/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
@@ -72,8 +72,10 @@ public class CompressionFunctions {
    */
   public static String uncompress(ByteString data) {
     try {
-      if (data == null || data.length() == 0) {
+      if (data == null) {
         return null;
+      } else if (data.length() == 0) {
+        return "";
       }
       InflaterInputStream inflaterStream = new InflaterInputStream(
           new ByteArrayInputStream(data.getBytes(), 4, data.length()));

--- a/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
@@ -18,14 +18,17 @@ package org.apache.calcite.runtime;
 
 import org.apache.calcite.avatica.util.ByteString;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
 
 /**
  * A collection of functions used in compression and decompression.
@@ -62,4 +65,21 @@ public class CompressionFunctions {
     }
   }
 
+  /**
+   * MySql Decompression is based on zlib.
+   * <a href="https://docs.oracle.com/javase/8/docs/api/java/util/zip/Inflater.html">Inflater</a>
+   * is used to implement decompression.
+   */
+  public static String uncompress(ByteString data) {
+    try {
+      if (data == null || data.length() == 0) {
+        return null;
+      }
+      InflaterInputStream inflaterStream = new InflaterInputStream(
+          new ByteArrayInputStream(data.getBytes(), 4, data.length()));
+      return IOUtils.toString(inflaterStream);
+    } catch (IOException e) {
+      return null;
+    }
+  }
 }

--- a/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CompressionFunctions.java
@@ -84,4 +84,11 @@ public class CompressionFunctions {
       return null;
     }
   }
+
+  /**
+   * MySQl Supports uncompress function for string which returns NULL value.
+   */
+  public static String uncompress(String data) {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -181,7 +181,7 @@ public abstract class SqlLibraryOperators {
   public static final SqlFunction UNCOMPRESS = new SqlFunction("UNCOMPRESS", SqlKind.OTHER_FUNCTION,
       ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR),
           SqlTypeTransforms.FORCE_NULLABLE), null,
-      OperandTypes.BINARY, SqlFunctionCategory.STRING);
+      OperandTypes.or(OperandTypes.STRING, OperandTypes.BINARY), SqlFunctionCategory.STRING);
 
   @LibraryOperator(libraries = {MYSQL})
   public static final SqlFunction EXTRACT_VALUE = new SqlFunction(

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -177,6 +177,11 @@ public abstract class SqlLibraryOperators {
       ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARBINARY),
           SqlTypeTransforms.TO_NULLABLE), null, OperandTypes.STRING, SqlFunctionCategory.STRING);
 
+  @LibraryOperator(libraries = {MYSQL})
+  public static final SqlFunction UNCOMPRESS = new SqlFunction("UNCOMPRESS", SqlKind.OTHER_FUNCTION,
+      ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR),
+          SqlTypeTransforms.FORCE_NULLABLE), null,
+      OperandTypes.BINARY, SqlFunctionCategory.STRING);
 
   @LibraryOperator(libraries = {MYSQL})
   public static final SqlFunction EXTRACT_VALUE = new SqlFunction(

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -181,7 +181,7 @@ public abstract class SqlLibraryOperators {
   public static final SqlFunction UNCOMPRESS = new SqlFunction("UNCOMPRESS", SqlKind.OTHER_FUNCTION,
       ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR),
           SqlTypeTransforms.FORCE_NULLABLE), null,
-      OperandTypes.or(OperandTypes.STRING, OperandTypes.BINARY), SqlFunctionCategory.STRING);
+      OperandTypes.BINARY, SqlFunctionCategory.STRING);
 
   @LibraryOperator(libraries = {MYSQL})
   public static final SqlFunction EXTRACT_VALUE = new SqlFunction(

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -25,6 +25,7 @@ import org.apache.calcite.adapter.enumerable.MatchUtils;
 import org.apache.calcite.adapter.enumerable.SourceSorter;
 import org.apache.calcite.adapter.java.ReflectiveSchema;
 import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.interpreter.Context;
@@ -326,6 +327,7 @@ public enum BuiltInMethod {
   MD5(SqlFunctions.class, "md5", String.class),
   SHA1(SqlFunctions.class, "sha1", String.class),
   COMPRESS(CompressionFunctions.class, "compress", String.class),
+  UNCOMPRESS(CompressionFunctions.class, "uncompress", ByteString.class),
   EXTRACT_VALUE(XmlFunctions.class, "extractValue", String.class, String.class),
   XML_TRANSFORM(XmlFunctions.class, "xmlTransform", String.class, String.class),
   EXTRACT_XML(XmlFunctions.class, "extractXml", String.class, String.class, String.class),

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5234,6 +5234,8 @@ public abstract class SqlOperatorBaseTest {
 
     sqlTester.checkNull("UNCOMPRESS(x'1233')");
 
+    sqlTester.checkFails("UNCOMPRESS('test')","(?s).*Only ByteString.*", true);
+
     sqlTester.checkString("UNCOMPRESS(COMPRESS('test'))",
         "test", "VARCHAR");
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5230,7 +5230,9 @@ public abstract class SqlOperatorBaseTest {
   @Test public void testUncompress() {
     SqlTester sqlTester = tester(SqlLibrary.MYSQL);
     sqlTester.checkNull("UNCOMPRESS(NULL)");
-    sqlTester.checkNull("UNCOMPRESS(x'')");
+    sqlTester.checkString("UNCOMPRESS(x'')", "", "VARCHAR");
+
+    sqlTester.checkNull("UNCOMPRESS(x'1233')");
 
     sqlTester.checkString("UNCOMPRESS(COMPRESS('test'))",
         "test", "VARCHAR");

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5227,7 +5227,24 @@ public abstract class SqlOperatorBaseTest {
         "07000000789c4bad48cc2dc84905000bc002ed", "VARBINARY NOT NULL");
   }
 
-  @Test void testExtractValue() {
+  @Test public void testUncompress() {
+    SqlTester sqlTester = tester(SqlLibrary.MYSQL);
+    sqlTester.checkNull("UNCOMPRESS(NULL)");
+    sqlTester.checkNull("UNCOMPRESS(x'')");
+
+    sqlTester.checkString("UNCOMPRESS(COMPRESS('test'))",
+        "test", "VARCHAR");
+
+    sqlTester.checkString("UNCOMPRESS(x'10000000789c4b4c44050033980611')",
+        "aaaaaaaaaaaaaaaa", "VARCHAR");
+
+    sqlTester.checkString("UNCOMPRESS(x'06000000789c2b4ecc2dc849050008de0283' )",
+        "sample", "VARCHAR");
+    sqlTester.checkString("UNCOMPRESS(x'07000000789c4bad48cc2dc84905000bc002ed')",
+        "example", "VARCHAR");
+  }
+
+  @Test public void testExtractValue() {
     SqlTester mySqlTester = tester(SqlLibrary.MYSQL);
     mySqlTester.checkNull("ExtractValue(NULL, '//b')");
     mySqlTester.checkNull("ExtractValue('', NULL)");

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5231,6 +5231,7 @@ public abstract class SqlOperatorBaseTest {
     SqlTester sqlTester = tester(SqlLibrary.MYSQL);
     sqlTester.checkNull("UNCOMPRESS(NULL)");
     sqlTester.checkString("UNCOMPRESS(x'')", "", "VARCHAR");
+    sqlTester.checkNull("UNCOMPRESS('string')");
 
     sqlTester.checkNull("UNCOMPRESS(x'1233')");
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5234,8 +5234,6 @@ public abstract class SqlOperatorBaseTest {
 
     sqlTester.checkNull("UNCOMPRESS(x'1233')");
 
-    sqlTester.checkFails("UNCOMPRESS('test')","(?s).*Only ByteString.*", true);
-
     sqlTester.checkString("UNCOMPRESS(COMPRESS('test'))",
         "test", "VARCHAR");
 

--- a/core/src/test/resources/sql/functions.iq
+++ b/core/src/test/resources/sql/functions.iq
@@ -80,6 +80,16 @@ SELECT COMPRESS('sample');
 !ok
 
 
+SELECT UNCOMPRESS(x'06000000789c2b4ecc2dc849050008de0283');
++--------+
+| EXPR$0 |
++--------+
+| sample |
++--------+
+(1 row)
+
+!ok
+
 !use oraclefunc
 
 # COSH

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2363,6 +2363,7 @@ semantics.
 | o p | TO_DATE(string, format)                      | Converts *string* to a date using the format *format*
 | o p | TO_TIMESTAMP(string, format)                 | Converts *string* to a timestamp using the format *format*
 | o p | TRANSLATE(expr, fromString, toString)        | Returns *expr* with all occurrences of each character in *fromString* replaced by its corresponding character in *toString*. Characters in *expr* that are not in *fromString* are not replaced
+| m | UNCOMPRESS(binary)                             | UnCompresses binary using zlib decompression and returns the result as a string.
 | o | XMLTRANSFORM(xml, xslt)                        | Returns a string after applying xslt to supplied xml.
 
 Note:


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_uncompress

e.g.:

SELECT UNCOMPRESS(COMPRESS('any string'));
        -> 'any string'
SELECT UNCOMPRESS('any string');
        -> NULL
Uncompresses a string compressed by the COMPRESS() function. If the argument is not a compressed value, the result is NULL. This function uses zlib library for decompression (https://docs.oracle.com/javase/8/docs/api/java/util/zip/Inflater.html). Otherwise, the return value is always NULL.