### PR TITLE
[CALCITE-3866]  "numeric field overflow" when running the generated SQL in PostgreSQL

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.rel.type;
 
+import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -217,6 +218,21 @@ public abstract class RelDataTypeSystemImpl implements RelDataTypeSystem {
 
   @Override public RelDataType deriveSumType(RelDataTypeFactory typeFactory,
       RelDataType argumentType) {
+    if (argumentType instanceof BasicSqlType) {
+      SqlTypeName typeName = argumentType.getSqlTypeName();
+      if (typeName.allowsPrec()
+          && argumentType.getPrecision() != RelDataType.PRECISION_NOT_SPECIFIED) {
+        int precision = typeFactory.getTypeSystem().getMaxPrecision(typeName);
+        if (typeName.allowsScale()) {
+          argumentType = typeFactory.createTypeWithNullability(
+              typeFactory.createSqlType(typeName, precision, argumentType.getScale()),
+              argumentType.isNullable());
+        } else {
+          argumentType = typeFactory.createTypeWithNullability(
+              typeFactory.createSqlType(typeName, precision), argumentType.isNullable());
+        }
+      }
+    }
     return argumentType;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
@@ -260,7 +260,10 @@ public interface SqlSplittableAggFunction {
         RelDataType inputRowType, AggregateCall aggregateCall) {
       final int arg = aggregateCall.getArgList().get(0);
       final RelDataTypeField field = inputRowType.getFieldList().get(arg);
-      return rexBuilder.makeInputRef(field.getType(), arg);
+      final RelDataType fieldType = field.getType();
+      final RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+      RelDataType type = typeFactory.getTypeSystem().deriveSumType(typeFactory, fieldType);
+      return rexBuilder.makeInputRef(type, arg);
     }
 
     public AggregateCall split(AggregateCall aggregateCall,
@@ -346,7 +349,9 @@ public interface SqlSplittableAggFunction {
         RelDataType inputRowType, AggregateCall aggregateCall) {
       final int arg = aggregateCall.getArgList().get(0);
       final RelDataType type = inputRowType.getFieldList().get(arg).getType();
-      final RexNode inputRef = rexBuilder.makeInputRef(type, arg);
+      final RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+      final RelDataType type1 = typeFactory.getTypeSystem().deriveSumType(typeFactory, type);
+      final RexNode inputRef = rexBuilder.makeInputRef(type1, arg);
       if (type.isNullable()) {
         return rexBuilder.makeCall(SqlStdOperatorTable.COALESCE, inputRef,
             rexBuilder.makeExactLiteral(BigDecimal.ZERO, type));

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -8469,8 +8469,8 @@ public abstract class SqlOperatorBaseTest {
         false);
     tester.checkType("sum('name')", "DECIMAL(19, 19)");
     checkAggType(tester, "sum(1)", "INTEGER NOT NULL");
-    checkAggType(tester, "sum(1.2)", "DECIMAL(2, 1) NOT NULL");
-    checkAggType(tester, "sum(DISTINCT 1.5)", "DECIMAL(2, 1) NOT NULL");
+    checkAggType(tester, "sum(1.2)", "DECIMAL(19, 1) NOT NULL");
+    checkAggType(tester, "sum(DISTINCT 1.5)", "DECIMAL(19, 1) NOT NULL");
     tester.checkFails(
         "^sum()^",
         "Invalid number of arguments to function 'SUM'. Was expecting 1 arguments",

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -1235,7 +1235,7 @@ select deptno,
 from "scott".emp
 group by deptno;
 DEPTNO TINYINT(3)
-SAL_10 DECIMAL(7, 2)
+SAL_10 DECIMAL(19, 2)
 !type
 +--------+---------+
 | DEPTNO | SAL_10  |


### PR DESCRIPTION
Pull request for https://issues.apache.org/jira/browse/CALCITE-3866
As for aggregate function sum, most of the time, its return type is  equal to its operand's type, but if its operand's type has precision, the precision of the result may be larger than the oeprans's type. So may be we can set precision to the Max value if the oeprand's type has precision, especially for the type decimal.