### PR TITLE
[CALCITE-3846]  EnumerableMergeJoin: wrong comparison of composite key with null values

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -189,7 +189,7 @@ public enum BuiltInMethod {
       List.class, int.class, Consumer.class),
   MERGE_JOIN(EnumerableDefaults.class, "mergeJoin", Enumerable.class,
       Enumerable.class, Function1.class, Function1.class, Predicate2.class, Function2.class,
-      boolean.class, boolean.class),
+      boolean.class, boolean.class, Comparator.class),
   SLICE0(Enumerables.class, "slice0", Enumerable.class),
   SEMI_JOIN(EnumerableDefaults.class, "semiJoin", Enumerable.class,
       Enumerable.class, Function1.class, Function1.class,

--- a/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
@@ -241,7 +241,7 @@ public class EnumerablesTest {
             e1 -> e1.name,
             e2 -> e2.name,
             (e1, e2) -> e1.deptno < e2.deptno,
-            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+            (v0, v1) -> v0 + "-" + v1, false, false, null).toList().toString(),
         equalTo("["
             + "Emp(1, Fred)-Emp(2, Fred), "
             + "Emp(1, Fred)-Emp(3, Fred), "
@@ -257,7 +257,7 @@ public class EnumerablesTest {
             e2 -> e2.name,
             e1 -> e1.name,
             (e2, e1) -> e2.deptno > e1.deptno,
-            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+            (v0, v1) -> v0 + "-" + v1, false, false, null).toList().toString(),
         equalTo("["
             + "Emp(2, Fred)-Emp(1, Fred), "
             + "Emp(3, Fred)-Emp(1, Fred), "
@@ -273,7 +273,7 @@ public class EnumerablesTest {
             e1 -> e1.name,
             e2 -> e2.name,
             (e1, e2) -> e1.deptno == e2.deptno * 2,
-            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+            (v0, v1) -> v0 + "-" + v1, false, false, null).toList().toString(),
         equalTo("[]"));
 
     assertThat(
@@ -283,7 +283,7 @@ public class EnumerablesTest {
             e2 -> e2.name,
             e1 -> e1.name,
             (e2, e1) -> e2.deptno == e1.deptno * 2,
-            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+            (v0, v1) -> v0 + "-" + v1, false, false, null).toList().toString(),
         equalTo("[Emp(2, Fred)-Emp(1, Fred)]"));
 
     assertThat(
@@ -293,7 +293,7 @@ public class EnumerablesTest {
             e2 -> e2.name,
             e1 -> e1.name,
             (e2, e1) -> e2.deptno == e1.deptno + 2,
-            (v0, v1) -> v0 + "-" + v1, false, false).toList().toString(),
+            (v0, v1) -> v0 + "-" + v1, false, false, null).toList().toString(),
         equalTo("[Emp(3, Fred)-Emp(1, Fred), Emp(5, Joe)-Emp(3, Joe)]"));
   }
 


### PR DESCRIPTION
Jira: [CALCITE-3846](https://issues.apache.org/jira/browse/CALCITE-3846)

EnumerableMergeJoin implementation expects its inputs to be sorted in ascending order, nulls last (see EnumerableMergeJoinRule). In case of a composite key, EnumerableMergeJoin will represent keys as `JavaRowFormat.LIST`, which is a comparable list, whose comparison is implemented via `FlatLists.ComparableListImpl#compare`. This method will compare both lists, item by item, but it will consider that a null item is less-than a non-null item. This is a de-facto nulls-first collation, which contradicts the pre-requisite of the mergeJoin algorithm.

Proposed solution: merge join algorithm should not compare keys using compareTo method, instead an ad-hoc Comparator should be generated by EnumerableMergeJoin, similar to EnumerableSort approach (i.e. this Comparator could be null, in which case compareTo method will be used, this will guarantee backwards compatibility).