### PR TITLE
[CALCITE-3878] Make ArrayList creation with initial capacity when size is fixed

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -161,9 +161,10 @@ public class CalciteMetaImpl extends MetaImpl {
 
   private <E> MetaResultSet createResultSet(Enumerable<E> enumerable,
       Class clazz, String... names) {
-    final List<ColumnMetaData> columns = new ArrayList<>();
-    final List<Field> fields = new ArrayList<>();
-    final List<String> fieldNames = new ArrayList<>();
+    Objects.requireNonNull(names);
+    final List<ColumnMetaData> columns = new ArrayList<>(names.length);
+    final List<Field> fields = new ArrayList<>(names.length);
+    final List<String> fieldNames = new ArrayList<>(names.length);
     for (String name : names) {
       final int index = fields.size();
       final String fieldName = AvaticaUtils.toCamelCase(name);

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -777,7 +777,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
       int typeOrdinal = getTypeOrdinal(type);
       switch (typeOrdinal) {
       case Types.STRUCT:
-        final List<ColumnMetaData> columns = new ArrayList<>();
+        final List<ColumnMetaData> columns = new ArrayList<>(type.getFieldList().size());
         for (RelDataTypeField field : type.getFieldList()) {
           columns.add(
               metaData(typeFactory, field.getIndex(), field.getName(),

--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -138,7 +138,8 @@ public abstract class Prepare {
     final DataContext dataContext = context.getDataContext();
     planner.setExecutor(new RexExecutorImpl(dataContext));
 
-    final List<RelOptMaterialization> materializationList = new ArrayList<>();
+    final List<RelOptMaterialization> materializationList =
+        new ArrayList<>(materializations.size());
     for (Materialization materialization : materializations) {
       List<String> qualifiedTableName = materialization.materializedTable.path();
       materializationList.add(
@@ -148,7 +149,7 @@ public abstract class Prepare {
               qualifiedTableName));
     }
 
-    final List<RelOptLattice> latticeList = new ArrayList<>();
+    final List<RelOptLattice> latticeList = new ArrayList<>(lattices.size());
     for (CalciteSchema.LatticeEntry lattice : lattices) {
       final CalciteSchema.TableEntry starTable = lattice.getStarTable();
       final JavaTypeFactory typeFactory = context.getTypeFactory();

--- a/core/src/main/java/org/apache/calcite/rel/RelRoot.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelRoot.java
@@ -161,7 +161,7 @@ public class RelRoot {
             || rel instanceof LogicalProject)) {
       return rel;
     }
-    final List<RexNode> projects = new ArrayList<>();
+    final List<RexNode> projects = new ArrayList<>(fields.size());
     final RexBuilder rexBuilder = rel.getCluster().getRexBuilder();
     for (Pair<Integer, String> field : fields) {
       projects.add(rexBuilder.makeInputRef(rel, field.left));

--- a/core/src/main/java/org/apache/calcite/rel/core/TableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/TableScan.java
@@ -154,8 +154,9 @@ public abstract class TableScan
         && extraFields.isEmpty()) {
       return this;
     }
-    final List<RexNode> exprList = new ArrayList<>();
-    final List<String> nameList = new ArrayList<>();
+    int fieldSize = fieldsUsed.size() + extraFields.size();
+    final List<RexNode> exprList = new ArrayList<>(fieldSize);
+    final List<String> nameList = new ArrayList<>(fieldSize);
     final RexBuilder rexBuilder = getCluster().getRexBuilder();
     final List<RelDataTypeField> fields = getRowType().getFieldList();
 

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
@@ -179,7 +179,7 @@ public abstract class MutableRels {
    */
   public static List<RexNode> createProjects(final MutableRel child,
       final List<RexNode> projs) {
-    List<RexNode> rexNodeList = new ArrayList<>();
+    List<RexNode> rexNodeList = new ArrayList<>(projs.size());
     for (int i = 0; i < projs.size(); i++) {
       if (projs.get(i) instanceof RexInputRef) {
         RexInputRef rexInputRef = (RexInputRef) projs.get(i);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -562,7 +562,7 @@ public class RelToSqlConverter extends SqlImplementor
             ? x.builder(e, Clause.WHERE)
             : x.builder(e);
     if (!isStar(program)) {
-      final List<SqlNode> selectList = new ArrayList<>();
+      final List<SqlNode> selectList = new ArrayList<>(program.getProjectList().size());
       for (RexLocalRef ref : program.getProjectList()) {
         SqlNode sqlExpr = builder.context.toSql(program, ref);
         addSelect(selectList, sqlExpr, e.getRowType());
@@ -610,7 +610,7 @@ public class RelToSqlConverter extends SqlImplementor
         // In this case we need to construct the following query:
         // SELECT NULL as C0, NULL as C1, NULL as C2 ... FROM DUAL WHERE FALSE
         // This would return an empty result set with the same number of columns as the field names.
-        final List<SqlNode> nullColumnNames = new ArrayList<>();
+        final List<SqlNode> nullColumnNames = new ArrayList<>(fieldNames.size());
         for (String fieldName : fieldNames) {
           SqlCall nullColumnName = as(SqlLiteral.createNull(POS), fieldName);
           nullColumnNames.add(nullColumnName);


### PR DESCRIPTION
I find many places in Calcite where `new ArrayList<>()` is used, if the list is expected to be immutable or not resizing, it is always a good manner to create with initial capacity, better for memory usage and performance.

I search all occurrences, focus on the core module, to make it safe, I only update local variables with fixed size and not working in recursive method. If the local variable reference goes out of scope, if resizing is needed, things will work normally as well, so no side effect, but for the "escaping" case, I am very conservative and do not change them.

see [https://issues.apache.org/jira/browse/CALCITE-3878](https://issues.apache.org/jira/browse/CALCITE-3878)