### PR TITLE
[CALCITE-3782]Bitwise agg operator Bit_And, Bit_OR and Bit_XOR support binary and varbinary type

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.avatica.util.TimeUnitRange;
@@ -1231,8 +1232,14 @@ public class RexImpTable {
   static class BitOpImplementor extends StrictAggImplementor {
     @Override protected void implementNotNullReset(AggContext info,
         AggResetContext reset) {
-      Object initValue = info.aggregation() == BIT_AND ? -1 : 0;
-      Expression start = Expressions.constant(initValue, info.returnType());
+
+      Expression start;
+      if (SqlTypeUtil.isBinary(info.returnRelType())) {
+        start = Expressions.field(null, ByteString.class, "EMPTY");
+      } else {
+        Object initValue = info.aggregation() == BIT_AND ? -1L : 0;
+        start = Expressions.constant(initValue, info.returnType());
+      }
 
       reset.currentBlock().add(
           Expressions.statement(

--- a/core/src/main/java/org/apache/calcite/runtime/BitwiseFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/BitwiseFunctions.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.runtime;
+
+import org.apache.calcite.avatica.util.ByteString;
+
+import java.util.stream.IntStream;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * A collection of functions used in Bitwise processing.
+ */
+public class BitwiseFunctions {
+
+  private BitwiseFunctions(){}
+
+  // &
+  /** Helper function for implementing <code>BIT_AND</code> applied to integer values */
+  public static long bitAnd(long b0, long b1) {
+    return b0 & b1;
+  }
+
+  /** Helper function for implementing <code>BIT_AND</code> applied to binary values */
+  public static ByteString bitAnd(ByteString b0, ByteString b1) {
+
+    return binaryOperator(b0, b1, BitwiseOperators.BITAND);
+  }
+
+  // |
+  /** Helper function for implementing <code>BIT_OR</code> applied to integer values */
+  public static long bitOr(long b0, long b1) {
+    return b0 | b1;
+  }
+
+  /** Helper function for implementing <code>BIT_OR</code> applied to binary values */
+  public static ByteString bitOr(ByteString b0, ByteString b1) {
+    return binaryOperator(b0, b1, BitwiseOperators.BITOR);
+  }
+
+  // ^
+  /** Helper function for implementing <code>BIT_XOR</code> applied to integer values */
+  public static long bitXor(long b0, long b1) {
+    return b0 ^ b1;
+  }
+
+  /** Helper function for implementing <code>BIT_XOR</code> applied to binary values */
+  public static ByteString bitXor(ByteString b0, ByteString b1) {
+
+    return binaryOperator(b0, b1, BitwiseOperators.BITXOR);
+  }
+
+  /**
+   * Util for bitwise function applied to two byteString values.
+   * @param b0 The first byteString value operand of bitwise function.
+   * @param b1 The second byteString value operand of bitwise function.
+   * @param operator BitWise Operator.
+   * @return
+   */
+  private static ByteString binaryOperator(
+      ByteString b0, ByteString b1, BitwiseOperators operator) {
+
+    if (b0.length() == 0) {
+      return b1;
+    }
+    if (b1.length() == 0) {
+      return b0;
+    }
+
+    if (b0.length() != b1.length()) {
+      throw RESOURCE.differentLengthForBitwiseOperands(b0.length(), b1.length()).ex();
+    }
+    byte[] bytes0 = b0.getBytes();
+    byte[] bytes1 = b1.getBytes();
+    byte[] result = new byte[b0.length()];
+
+    switch (operator) {
+    case BITAND:
+      IntStream.range(0, bytes0.length).forEach(i -> {
+        result[i] = (byte) (bytes0[i] & bytes1[i]);
+      });
+      break;
+    case BITOR:
+      IntStream.range(0, bytes0.length).forEach(i -> {
+        result[i] = (byte) (bytes0[i] | bytes1[i]);
+      });
+      break;
+    case BITXOR:
+      IntStream.range(0, bytes0.length).forEach(i -> {
+        result[i] = (byte) (bytes0[i] ^ bytes1[i]);
+      });
+      break;
+    default:
+      throw new IllegalArgumentException("Unknown " + operator.name()
+          + ". Only support bit_and, bit_or and bit_xor.");
+    }
+    return new ByteString(result);
+  }
+
+  /**
+   * Bitwise Operators which include BITAND, BITOR and BITXOR.
+   * For later, We will add BITANDNOT, BITSHIFTLEFT, BITSHIFTRIGHT, BITNOT and BITCOUNT.
+   */
+  public enum BitwiseOperators {
+    BITAND,
+    BITOR,
+    BITXOR
+  }
+
+}

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -918,4 +918,7 @@ public interface CalciteResource {
 
   @BaseMessage("Invalid input for EXTRACTVALUE: xml: ''{0}'', xpath expression: ''{1}''")
   ExInst<CalciteException> invalidInputForExtractValue(String xml, String xpath);
+
+  @BaseMessage("Different length for bitwise operands: the first: {0,number,#}, the second: {1,number,#}")
+  ExInst<CalciteException> differentLengthForBitwiseOperands(int l0, int l1);
 }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -74,7 +74,6 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 
 import static org.apache.calcite.util.Static.RESOURCE;
@@ -1108,93 +1107,6 @@ public class SqlFunctions {
       Object b1) {
     return RESOURCE.invalidTypesForComparison(b0.getClass().toString(),
         op, b1.getClass().toString()).ex();
-  }
-
-  // &
-  /** Helper function for implementing <code>BIT_AND</code> applied to integer values */
-  public static long bitAnd(long b0, long b1) {
-    return b0 & b1;
-  }
-
-  /** Helper function for implementing <code>BIT_AND</code> applied to binary values */
-  public static ByteString bitAnd(ByteString b0, ByteString b1) {
-
-    if (b0.length() == 0) {
-      return b1;
-    }
-    if (b1.length() == 0) {
-      return b0;
-    }
-
-    if (b0.length() != b1.length()) {
-      throw RESOURCE.differentLengthForBitwiseOperands(b0.length(), b1.length()).ex();
-    }
-    byte[] bytes0 = b0.getBytes();
-    byte[] bytes1 = b1.getBytes();
-    byte[] result = new byte[b0.length()];
-
-    IntStream.range(0, bytes0.length).forEach(i -> {
-      result[i] = (byte) (bytes0[i] & bytes1[i]);
-    });
-    return new ByteString(result);
-  }
-
-  // |
-  /** Helper function for implementing <code>BIT_OR</code> applied to integer values */
-  public static long bitOr(long b0, long b1) {
-    return b0 | b1;
-  }
-
-  /** Helper function for implementing <code>BIT_OR</code> applied to binary values */
-  public static ByteString bitOr(ByteString b0, ByteString b1) {
-
-    if (b0.length() == 0) {
-      return b1;
-    }
-    if (b1.length() == 0) {
-      return b0;
-    }
-
-    if (b0.length() != b1.length()) {
-      throw RESOURCE.differentLengthForBitwiseOperands(b0.length(), b1.length()).ex();
-    }
-    byte[] bytes0 = b0.getBytes();
-    byte[] bytes1 = b1.getBytes();
-    byte[] result = new byte[b0.length()];
-
-    IntStream.range(0, bytes0.length).forEach(i -> {
-      result[i] = (byte) (bytes0[i] | bytes1[i]);
-    });
-    return new ByteString(result);
-  }
-
-  // ^
-  /** Helper function for implementing <code>BIT_XOR</code> applied to integer values */
-  public static long bitXor(long b0, long b1) {
-    return b0 ^ b1;
-  }
-
-  /** Helper function for implementing <code>BIT_XOR</code> applied to binary values */
-  public static ByteString bitXor(ByteString b0, ByteString b1) {
-
-    if (b0.length() == 0) {
-      return b1;
-    }
-    if (b1.length() == 0) {
-      return b0;
-    }
-
-    if (b0.length() != b1.length()) {
-      throw RESOURCE.differentLengthForBitwiseOperands(b0.length(), b1.length()).ex();
-    }
-    byte[] bytes0 = b0.getBytes();
-    byte[] bytes1 = b1.getBytes();
-    byte[] result = new byte[b0.length()];
-
-    IntStream.range(0, bytes0.length).forEach(i -> {
-      result[i] = (byte) (bytes0[i] ^ bytes1[i]);
-    });
-    return new ByteString(result);
   }
 
   // EXP

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -74,6 +74,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 
 import static org.apache.calcite.util.Static.RESOURCE;
@@ -1110,21 +1111,90 @@ public class SqlFunctions {
   }
 
   // &
-  /** Helper function for implementing <code>BIT_AND</code> */
+  /** Helper function for implementing <code>BIT_AND</code> applied to integer values */
   public static long bitAnd(long b0, long b1) {
     return b0 & b1;
   }
 
+  /** Helper function for implementing <code>BIT_AND</code> applied to binary values */
+  public static ByteString bitAnd(ByteString b0, ByteString b1) {
+
+    if (b0.length() == 0) {
+      return b1;
+    }
+    if (b1.length() == 0) {
+      return b0;
+    }
+
+    if (b0.length() != b1.length()) {
+      throw RESOURCE.differentLengthForBitwiseOperands(b0.length(), b1.length()).ex();
+    }
+    byte[] bytes0 = b0.getBytes();
+    byte[] bytes1 = b1.getBytes();
+    byte[] result = new byte[b0.length()];
+
+    IntStream.range(0, bytes0.length).forEach(i -> {
+      result[i] = (byte) (bytes0[i] & bytes1[i]);
+    });
+    return new ByteString(result);
+  }
+
   // |
-  /** Helper function for implementing <code>BIT_OR</code> */
+  /** Helper function for implementing <code>BIT_OR</code> applied to integer values */
   public static long bitOr(long b0, long b1) {
     return b0 | b1;
   }
 
+  /** Helper function for implementing <code>BIT_OR</code> applied to binary values */
+  public static ByteString bitOr(ByteString b0, ByteString b1) {
+
+    if (b0.length() == 0) {
+      return b1;
+    }
+    if (b1.length() == 0) {
+      return b0;
+    }
+
+    if (b0.length() != b1.length()) {
+      throw RESOURCE.differentLengthForBitwiseOperands(b0.length(), b1.length()).ex();
+    }
+    byte[] bytes0 = b0.getBytes();
+    byte[] bytes1 = b1.getBytes();
+    byte[] result = new byte[b0.length()];
+
+    IntStream.range(0, bytes0.length).forEach(i -> {
+      result[i] = (byte) (bytes0[i] | bytes1[i]);
+    });
+    return new ByteString(result);
+  }
+
   // ^
-  /** Helper function for implementing <code>BIT_XOR</code> */
+  /** Helper function for implementing <code>BIT_XOR</code> applied to integer values */
   public static long bitXor(long b0, long b1) {
     return b0 ^ b1;
+  }
+
+  /** Helper function for implementing <code>BIT_XOR</code> applied to binary values */
+  public static ByteString bitXor(ByteString b0, ByteString b1) {
+
+    if (b0.length() == 0) {
+      return b1;
+    }
+    if (b1.length() == 0) {
+      return b0;
+    }
+
+    if (b0.length() != b1.length()) {
+      throw RESOURCE.differentLengthForBitwiseOperands(b0.length(), b1.length()).ex();
+    }
+    byte[] bytes0 = b0.getBytes();
+    byte[] bytes1 = b1.getBytes();
+    byte[] result = new byte[b0.length()];
+
+    IntStream.range(0, bytes0.length).forEach(i -> {
+      result[i] = (byte) (bytes0[i] ^ bytes1[i]);
+    });
+    return new ByteString(result);
   }
 
   // EXP

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
@@ -62,6 +62,17 @@ public class SqlBitOpAggFunction extends SqlAggFunction {
   }
 
   @Override public Optionality getDistinctOptionality() {
-    return Optionality.IGNORED;
+    final Optionality optionality;
+
+    switch (kind) {
+    case BIT_AND:
+    case BIT_OR:
+      optionality = Optionality.IGNORED;
+      break;
+    default:
+      //We set optional for default
+      optionality = Optionality.OPTIONAL;
+    }
+    return optionality;
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
@@ -69,6 +69,9 @@ public class SqlBitOpAggFunction extends SqlAggFunction {
     case BIT_OR:
       optionality = Optionality.IGNORED;
       break;
+    case BIT_XOR:
+      optionality = Optionality.OPTIONAL;
+      break;
     default:
       //We set optional for default
       optionality = Optionality.OPTIONAL;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
@@ -30,8 +30,8 @@ import com.google.common.base.Preconditions;
  * Definition of the <code>BIT_AND</code> and <code>BIT_OR</code> aggregate functions,
  * returning the bitwise AND/OR of all non-null input values, or null if none.
  *
- * <p>Only INTEGER types are supported:
- * tinyint, smallint, int, bigint
+ * <p>INTEGER and BINARY types are supported:
+ * tinyint, smallint, int, bigint, binary, varbinary
  */
 public class SqlBitOpAggFunction extends SqlAggFunction {
 
@@ -44,7 +44,7 @@ public class SqlBitOpAggFunction extends SqlAggFunction {
         kind,
         ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
         null,
-        OperandTypes.INTEGER,
+        OperandTypes.or(OperandTypes.INTEGER, OperandTypes.BINARY),
         SqlFunctionCategory.NUMERIC,
         false,
         false,

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -82,6 +82,7 @@ import org.apache.calcite.runtime.ArrayBindable;
 import org.apache.calcite.runtime.Automaton;
 import org.apache.calcite.runtime.BinarySearch;
 import org.apache.calcite.runtime.Bindable;
+import org.apache.calcite.runtime.BitwiseFunctions;
 import org.apache.calcite.runtime.CompressionFunctions;
 import org.apache.calcite.runtime.Enumerables;
 import org.apache.calcite.runtime.FlatLists;
@@ -423,9 +424,9 @@ public enum BuiltInMethod {
   NOT(SqlFunctions.class, "not", Boolean.class),
   LESSER(SqlFunctions.class, "lesser", Comparable.class, Comparable.class),
   GREATER(SqlFunctions.class, "greater", Comparable.class, Comparable.class),
-  BIT_AND(SqlFunctions.class, "bitAnd", long.class, long.class),
-  BIT_OR(SqlFunctions.class, "bitOr", long.class, long.class),
-  BIT_XOR(SqlFunctions.class, "bitXor", long.class, long.class),
+  BIT_AND(BitwiseFunctions.class, "bitAnd", long.class, long.class),
+  BIT_OR(BitwiseFunctions.class, "bitOr", long.class, long.class),
+  BIT_XOR(BitwiseFunctions.class, "bitXor", long.class, long.class),
   MODIFIABLE_TABLE_GET_MODIFIABLE_COLLECTION(ModifiableTable.class,
       "getModifiableCollection"),
   SCANNABLE_TABLE_SCAN(ScannableTable.class, "scan", DataContext.class),

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -301,4 +301,5 @@ InvalidInputForXmlTransform=Invalid input for XMLTRANSFORM xml: ''{0}''
 InvalidInputForExtractValue=Invalid input for EXTRACTVALUE: xml: ''{0}'', xpath expression: ''{1}''
 InvalidInputForExtractXml=Invalid input for EXTRACT xpath: ''{0}'', namespace: ''{1}''
 InvalidInputForExistsNode=Invalid input for EXISTSNODE xpath: ''{0}'', namespace: ''{1}''
+DifferentLengthForBitwiseOperands=Different length for bitwise operands: the first: {0,number,#}, the second: {1,number,#}
 # End CalciteResource.properties

--- a/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
@@ -526,6 +526,22 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
     assertExceptionIsThrown(sql, expectedError);
   }
 
+  @Override public void checkAggFails(
+      String expr,
+      String[] inputValues,
+      String expectedError,
+      boolean runtime) {
+    final String sql =
+        SqlTests.generateAggQuery(expr, inputValues);
+    if (runtime) {
+      SqlValidator validator = getValidator();
+      SqlNode n = parseAndValidate(validator, sql);
+      assertNotNull(n);
+    } else {
+      checkQueryFails(sql, expectedError);
+    }
+  }
+
   public void checkQuery(String sql) {
     assertExceptionIsThrown(sql, null);
   }

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -9163,6 +9163,7 @@ public abstract class SqlOperatorBaseTest {
         "cast(x'02' AS BINARY)",
         "cast(null AS BINARY)"};
     tester.checkAgg("bit_and(x)", binaryValues, "02", 0);
+    tester.checkAgg("bit_and(x)", new String[]{"CAST(x'02' AS BINARY)"}, "02", 0);
   }
 
   @Test void testBitOrFunc() {
@@ -9193,6 +9194,7 @@ public abstract class SqlOperatorBaseTest {
         "cast(x'02' AS BINARY)",
         "cast(null AS BINARY)"};
     tester.checkAgg("bit_or(x)", binaryValues, "03", 0);
+    tester.checkAgg("bit_or(x)", new String[]{"CAST(x'02' AS BINARY)"}, "02", 0);
   }
 
   @Test void testBitXorFunc() {
@@ -9223,6 +9225,7 @@ public abstract class SqlOperatorBaseTest {
         "cast(x'01' AS BINARY)",
         "cast(null AS BINARY)"};
     tester.checkAgg("bit_xor(x)", binaryValues, "02", 0);
+    tester.checkAgg("bit_xor(x)", new String[]{"CAST(x'02' AS BINARY)"}, "02", 0);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -9142,8 +9142,10 @@ public abstract class SqlOperatorBaseTest {
     tester.checkType("bit_and(CAST(2 AS TINYINT))", "TINYINT");
     tester.checkType("bit_and(CAST(2 AS SMALLINT))", "SMALLINT");
     tester.checkType("bit_and(distinct CAST(2 AS BIGINT))", "BIGINT");
+    tester.checkType("bit_and(CAST(x'02' AS BINARY(1)))", "BINARY(1)");
     tester.checkFails("^bit_and(1.2)^",
-        "Cannot apply 'BIT_AND' to arguments of type 'BIT_AND\\(<DECIMAL\\(2, 1\\)>\\)'\\. Supported form\\(s\\): 'BIT_AND\\(<INTEGER>\\)'",
+        "Cannot apply 'BIT_AND' to arguments of type 'BIT_AND\\(<DECIMAL\\(2, 1\\)>\\)'\\. Supported form\\(s\\): 'BIT_AND\\(<INTEGER>\\)'\n"
+            + "'BIT_AND\\(<BINARY>\\)'",
         false);
     tester.checkFails(
         "^bit_and()^",
@@ -9154,7 +9156,13 @@ public abstract class SqlOperatorBaseTest {
         "Invalid number of arguments to function 'BIT_AND'. Was expecting 1 arguments",
         false);
     final String[] values = {"3", "2", "2"};
-    tester.checkAgg("bit_and(x)", values, 2, 0);
+    tester.checkAgg("bit_and(x)", values, "2", 0);
+    final String[] binaryValues = {
+        "CAST(x'03' AS BINARY)",
+        "cast(x'02' as BINARY)",
+        "cast(x'02' AS BINARY)",
+        "cast(null AS BINARY)"};
+    tester.checkAgg("bit_and(x)", binaryValues, "02", 0);
   }
 
   @Test void testBitOrFunc() {
@@ -9164,8 +9172,10 @@ public abstract class SqlOperatorBaseTest {
     tester.checkType("bit_or(CAST(2 AS TINYINT))", "TINYINT");
     tester.checkType("bit_or(CAST(2 AS SMALLINT))", "SMALLINT");
     tester.checkType("bit_or(distinct CAST(2 AS BIGINT))", "BIGINT");
+    tester.checkType("bit_or(CAST(x'02' AS BINARY(1)))", "BINARY(1)");
     tester.checkFails("^bit_or(1.2)^",
-        "Cannot apply 'BIT_OR' to arguments of type 'BIT_OR\\(<DECIMAL\\(2, 1\\)>\\)'\\. Supported form\\(s\\): 'BIT_OR\\(<INTEGER>\\)'",
+        "Cannot apply 'BIT_OR' to arguments of type 'BIT_OR\\(<DECIMAL\\(2, 1\\)>\\)'\\. Supported form\\(s\\): 'BIT_OR\\(<INTEGER>\\)'\n"
+            + "'BIT_OR\\(<BINARY>\\)'",
         false);
     tester.checkFails(
         "^bit_or()^",
@@ -9177,6 +9187,12 @@ public abstract class SqlOperatorBaseTest {
         false);
     final String[] values = {"1", "2", "2"};
     tester.checkAgg("bit_or(x)", values, 3, 0);
+    final String[] binaryValues = {
+        "CAST(x'01' AS BINARY)",
+        "cast(x'02' as BINARY)",
+        "cast(x'02' AS BINARY)",
+        "cast(null AS BINARY)"};
+    tester.checkAgg("bit_or(x)", binaryValues, "03", 0);
   }
 
   @Test void testBitXorFunc() {
@@ -9186,8 +9202,10 @@ public abstract class SqlOperatorBaseTest {
     tester.checkType("bit_xor(CAST(2 AS TINYINT))", "TINYINT");
     tester.checkType("bit_xor(CAST(2 AS SMALLINT))", "SMALLINT");
     tester.checkType("bit_xor(distinct CAST(2 AS BIGINT))", "BIGINT");
+    tester.checkType("bit_xor(CAST(x'02' AS BINARY(1)))", "BINARY(1)");
     tester.checkFails("^bit_xor(1.2)^",
-        "Cannot apply 'BIT_XOR' to arguments of type 'BIT_XOR\\(<DECIMAL\\(2, 1\\)>\\)'\\. Supported form\\(s\\): 'BIT_XOR\\(<INTEGER>\\)'",
+        "Cannot apply 'BIT_XOR' to arguments of type 'BIT_XOR\\(<DECIMAL\\(2, 1\\)>\\)'\\. Supported form\\(s\\): 'BIT_XOR\\(<INTEGER>\\)'\n"
+            + "'BIT_XOR\\(<BINARY>\\)'",
         false);
     tester.checkFails(
         "^bit_xor()^",
@@ -9199,6 +9217,12 @@ public abstract class SqlOperatorBaseTest {
         false);
     final String[] values = {"1", "2", "1"};
     tester.checkAgg("bit_xor(x)", values, 2, 0);
+    final String[] binaryValues = {
+        "CAST(x'01' AS BINARY)",
+        "cast(x'02' as BINARY)",
+        "cast(x'01' AS BINARY)",
+        "cast(null AS BINARY)"};
+    tester.checkAgg("bit_xor(x)", binaryValues, "02", 0);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -9226,6 +9226,8 @@ public abstract class SqlOperatorBaseTest {
         "cast(null AS BINARY)"};
     tester.checkAgg("bit_xor(x)", binaryValues, "02", 0);
     tester.checkAgg("bit_xor(x)", new String[]{"CAST(x'02' AS BINARY)"}, "02", 0);
+    tester.checkAgg("bit_xor(distinct(x))",
+        new String[]{"CAST(x'02' AS BINARY)", "CAST(x'02' AS BINARY)"}, "02", 0);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -9164,6 +9164,16 @@ public abstract class SqlOperatorBaseTest {
         "cast(null AS BINARY)"};
     tester.checkAgg("bit_and(x)", binaryValues, "02", 0);
     tester.checkAgg("bit_and(x)", new String[]{"CAST(x'02' AS BINARY)"}, "02", 0);
+
+    tester.checkAggFails(
+        "bit_and(x)",
+        new String[]{"CAST(x'0201' AS VARBINARY)", "CAST(x'02' AS VARBINARY)"},
+        "Error while executing SQL"
+          +  " \"SELECT bit_and\\(x\\)"
+          +  " FROM \\(SELECT CAST\\(x'0201' AS VARBINARY\\) AS x FROM \\(VALUES \\(1\\)\\)"
+          + " UNION ALL SELECT CAST\\(x'02' AS VARBINARY\\) AS x FROM \\(VALUES \\(1\\)\\)\\)\":"
+          + " Different length for bitwise operands: the first: 2, the second: 1",
+        true);
   }
 
   @Test void testBitOrFunc() {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlRuntimeTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlRuntimeTester.java
@@ -50,6 +50,16 @@ class SqlRuntimeTester extends AbstractSqlTester {
     assertExceptionIsThrown(sql, expectedError, runtime);
   }
 
+  @Override public void checkAggFails(
+      String expr,
+      String[] inputValues,
+      String expectedError,
+      boolean runtime) {
+    String query =
+        SqlTests.generateAggQuery(expr, inputValues);
+    assertExceptionIsThrown(query, expectedError, runtime);
+  }
+
   public void assertExceptionIsThrown(
       String sql,
       String expectedMsgPattern) {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTester.java
@@ -371,6 +371,20 @@ public interface SqlTester extends AutoCloseable, SqlValidatorTestCase.Tester {
       double delta);
 
   /**
+   * Tests that an aggregate expression fails at run time.
+   * @param expr An aggregate expression
+   * @param inputValues Array of input values
+   * @param expectedError Pattern for expected error
+   * @param runtime       If true, must fail at runtime; if false, must fail at
+   *                      validate time
+   */
+  void checkAggFails(
+      String expr,
+      String[] inputValues,
+      String expectedError,
+      boolean runtime);
+
+  /**
    * Tests that a scalar SQL expression fails at run time.
    *
    * @param expression    SQL scalar expression

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1776,9 +1776,9 @@ and `LISTAGG`).
 | ANY_VALUE( [ ALL &#124; DISTINCT ] value)     | Returns one of the values of *value* across all input values; this is NOT specified in the SQL standard
 | SOME(condition)                               | Returns true if any condition is true.
 | EVERY(condition)                              | Returns true if all conditions are true.
-| BIT_AND( [ ALL &#124; DISTINCT ] value)       | Returns the bitwise AND of all non-null input values, or null if none
-| BIT_OR( [ ALL &#124; DISTINCT ] value)        | Returns the bitwise OR of all non-null input values, or null if none
-| BIT_XOR( [ ALL &#124; DISTINCT ] value)       | Returns the bitwise XOR of all non-null input values, or null if none
+| BIT_AND( [ ALL &#124; DISTINCT ] value)       | Returns the bitwise AND of all non-null input values, or null if none; integer and binary types are supported
+| BIT_OR( [ ALL &#124; DISTINCT ] value)        | Returns the bitwise OR of all non-null input values, or null if none; integer and binary types are supported
+| BIT_XOR( [ ALL &#124; DISTINCT ] value)       | Returns the bitwise XOR of all non-null input values, or null if none; integer and binary types are supported
 | STDDEV_POP( [ ALL &#124; DISTINCT ] numeric)  | Returns the population standard deviation of *numeric* across all input values
 | STDDEV_SAMP( [ ALL &#124; DISTINCT ] numeric) | Returns the sample standard deviation of *numeric* across all input values
 | STDDEV( [ ALL &#124; DISTINCT ] numeric)      | Synonym for `STDDEV_SAMP`


### PR DESCRIPTION
According to the discussion [CALCITE-3732](https://issues.apache.org/jira/browse/CALCITE-3732) , We should make bitwise operators work on all integer types, BINARY and VARBINARY. So Bit_And, Bit_OR and Bit_XOR agg operator should also support BINARY and VARBINARY. 