### PR TITLE
[CALCITE-3216] ClassCastException when running aggregate function and  window function over Union

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -223,6 +223,7 @@ public enum BuiltInMethod {
       Comparator.class),
   UNION(ExtendedEnumerable.class, "union", Enumerable.class),
   CONCAT(ExtendedEnumerable.class, "concat", Enumerable.class),
+  EXTENDED_CAST(ExtendedEnumerable.class, "extendedCast", Class.class),
   REPEAT_UNION(EnumerableDefaults.class, "repeatUnion", Enumerable.class,
       Enumerable.class, int.class, boolean.class, EqualityComparer.class),
   LAZY_COLLECTION_SPOOL(EnumerableDefaults.class, "lazyCollectionSpool", Collection.class,

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3504,6 +3504,238 @@ public class JdbcTest {
             "empid=110; name=Theodore");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3216">[CALCITE-3216]
+   * ClassCastException when running aggregate function and window function over Union.</a>. */
+  @Test public void testAggregateOrWindowOverUnion() {
+    String query;
+    CalciteAssert.AssertThat assertThat = CalciteAssert.that()
+        .with(CalciteAssert.Config.JDBC_FOODMART);
+
+    query = "select count(*) as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS TINYINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(2)) \"foo\"(\"id\"))";
+    // cast Byte to int,Integer
+    assertThat.query(query).returns("C=2\n");
+
+    query = "select count(*) as C from (\n"
+        + "select \"id\" from (VALUES(CAST(null AS TINYINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(2)) \"foo\"(\"id\"))";
+    // cast Byte to int,Integer
+    assertThat.query(query).returns("C=2\n");
+
+    query = "select count(*) over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS TINYINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(2)) \"foo\"(\"id\"))";
+    // cast Byte to Integer
+    assertThat.query(query).returns("C=1\nC=1\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(1)) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS SMALLINT))) \"foo\"(\"id\"))";
+    // cast Short to Integer
+    assertThat.query(query).returns("C=1\nC=2\n");
+
+    query = "select count(*) as C from (\n"
+        + "select \"id\" from (VALUES(1)) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS SMALLINT))) \"foo\"(\"id\"))";
+    // cast Short to int, Integer
+    assertThat.query(query).returns("C=2\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS TINYINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS SMALLINT))) \"foo\"(\"id\"))";
+    // cast Byte to Short
+    assertThat.query(query).returns("C=1\nC=2\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS SMALLINT))) \"foo\"(\"id\"))";
+    // cast Short to Long
+    assertThat.query(query).returns("C=1\nC=2\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS TINYINT))) \"foo\"(\"id\"))";
+    // cast Byte to Long
+    assertThat.query(query).returns("C=1\nC=2\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS INTEGER))) \"foo\"(\"id\"))";
+    // cast Integer to Long
+    assertThat.query(query).returns("C=1\nC=2\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS TINYINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DOUBLE))) \"foo\"(\"id\"))";
+    // cast Byte to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS SMALLINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DOUBLE))) \"foo\"(\"id\"))";
+    // cast Short to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS INTEGER))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DOUBLE))) \"foo\"(\"id\"))";
+    // cast Integer to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DOUBLE))) \"foo\"(\"id\"))";
+    // cast Long to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS DECIMAL))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DOUBLE))) \"foo\"(\"id\"))";
+    // cast BigDecimal to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS REAL))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DOUBLE))) \"foo\"(\"id\"))";
+    // cast Float to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS REAL))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(null AS DOUBLE))) \"foo\"(\"id\"))";
+    // cast Float to Double
+    assertThat.query(query).returns("C=1.0\nC=null\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS TINYINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS REAL))) \"foo\"(\"id\"))";
+    // cast Byte to Float
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS SMALLINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS REAL))) \"foo\"(\"id\"))";
+    // cast Short to Float
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS INTEGER))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS REAL))) \"foo\"(\"id\"))";
+    // cast Integer to Float
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS REAL))) \"foo\"(\"id\"))";
+    // cast Long to Float
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS REAL))) \"foo\"(\"id\"))";
+    // cast Long to Float
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(null AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(null AS REAL))) \"foo\"(\"id\"))";
+    // cast Long to Float
+    assertThat.query(query).returns("C=null\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS DECIMAL))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS REAL))) \"foo\"(\"id\"))";
+    // cast Float to Double, cast BigDecimal to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS FLOAT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS REAL))) \"foo\"(\"id\"))";
+    // cast Float to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS TINYINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DECIMAL))) \"foo\"(\"id\"))";
+    // cast Byte to BigDecimal
+    assertThat.query(query).returns("C=2\nC=1\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS SMALLINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DECIMAL))) \"foo\"(\"id\"))";
+    // cast Short to BigDecimal
+    assertThat.query(query).returns("C=2\nC=1\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS INTEGER))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DECIMAL))) \"foo\"(\"id\"))";
+    // cast Integer to BigDecimal
+    assertThat.query(query).returns("C=2\nC=1\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS BIGINT))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DECIMAL))) \"foo\"(\"id\"))";
+    // cast Long to BigDecimal
+    assertThat.query(query).returns("C=2\nC=1\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS REAL))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DECIMAL))) \"foo\"(\"id\"))";
+    // cast Float to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select sum(\"id\") over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(CAST(1 AS Double))) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(2 AS DECIMAL))) \"foo\"(\"id\"))";
+    // cast BigDecimal to Double
+    assertThat.query(query).returns("C=1.0\nC=2.0\n");
+
+    query = "select count(*) over (partition by \"id\") as C from (\n"
+        + "select \"id\" from (VALUES(DATE '2018-02-03')) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(TIMESTAMP '2008-03-31 12:23:34')) \"foo\"(\"id\"))";
+    // cast Long to Integer
+    assertThat.query(query).returns("C=1\nC=1\n");
+
+    query = "select * from (\n"
+        + "select \"id\" from (VALUES(1.2)) \"foo\"(\"id\")\n"
+        + "union\n"
+        + "select \"id\" from (VALUES(cast(1.2 as INT))) \"foo\"(\"id\"))";
+    assertThat.query(query).returns("id=1.2\nid=1\n");
+  }
+
   /** Tests that SUM and AVG over empty set return null. COUNT returns 0. */
   @Test public void testAggregateEmpty() {
     CalciteAssert.hr()

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
@@ -164,6 +164,10 @@ public abstract class DefaultEnumerable<T> implements OrderedEnumerable<T> {
     return EnumerableDefaults.cast(getThis(), clazz);
   }
 
+  public <T2> Enumerable<T2> extendedCast(Class<T2> clazz) {
+    return EnumerableDefaults.extendedCast(getThis(), clazz);
+  }
+
   public Enumerable<T> concat(Enumerable<T> enumerable1) {
     return EnumerableDefaults.concat(getThis(), enumerable1);
   }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableQueryable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableQueryable.java
@@ -161,6 +161,10 @@ class EnumerableQueryable<T> extends DefaultEnumerable<T>
     return EnumerableDefaults.cast(getThis(), clazz).asQueryable();
   }
 
+  public <T2> Queryable<T2> extendedCast(Class<T2> clazz) {
+    return EnumerableDefaults.extendedCast(getThis(), clazz).asQueryable();
+  }
+
   // Queryable methods
 
   public Type getElementType() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
@@ -230,6 +230,41 @@ public interface ExtendedEnumerable<TSource> {
   <T2> Enumerable<T2> cast(Class<T2> clazz);
 
   /**
+   * Converts the elements of this Enumerable to the specified type.
+   *
+   * <p>This method is the extension of {@link #cast(Class)}.</p>
+   *
+   * <p>Besides the things what {@link #cast(Class)} can do, this method supports the
+   * cast between these types:
+   * <ol>
+   *   <li>{@link Short}</li>
+   *   <li>{@link Byte}</li>
+   *   <li>{@link Integer}</li>
+   *   <li>{@link Long}</li>
+   *   <li>{@link Double}</li>
+   *   <li>{@link java.math.BigDecimal}</li>
+   *   <li>{@link Float}</li>
+   *   <li>{@code int}</li>
+   *   <li>{@code long}</li>
+   *   <li>{@code short}</li>
+   *   <li>{@code byte}</li>
+   *   <li>{@code double}</li>
+   *   <li>{@code float}</li>
+   * </ol>
+   *
+   * <p>If an element cannot be cast to type TResult, the
+   * {@link Enumerator#current()} method will throw a
+   * {@link ClassCastException} a exception when the element it accessed. To
+   * obtain only those elements that can be cast to type TResult, use the
+   * {@link #ofType(Class)} method instead.
+   *
+   * @see EnumerableDefaults#extendedCast(Enumerable, Class)
+   * @see #ofType(Class)
+   * @see #cast(Class)
+   */
+  <T2> Enumerable<T2> extendedCast(Class<T2> clazz);
+
+  /**
    * Concatenates two sequences.
    */
   Enumerable<TSource> concat(Enumerable<TSource> enumerable1);

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
@@ -248,6 +248,72 @@ public abstract class Linq4j {
   }
 
   /**
+   * Converts the elements of a given Iterable to the specified type.
+   *
+   * <p>This method is the extension of {@link #cast(Iterable, Class)}.</p>
+   *
+   * <p>Besides the things what {@link #cast(Iterable, Class)} can do, this method supports the
+   * cast between these types:
+   * <ol>
+   *   <li>{@link Short}</li>
+   *   <li>{@link Byte}</li>
+   *   <li>{@link Integer}</li>
+   *   <li>{@link Long}</li>
+   *   <li>{@link Double}</li>
+   *   <li>{@link java.math.BigDecimal}</li>
+   *   <li>{@link Float}</li>
+   *   <li>{@code int}</li>
+   *   <li>{@code long}</li>
+   *   <li>{@code short}</li>
+   *   <li>{@code byte}</li>
+   *   <li>{@code double}</li>
+   *   <li>{@code float}</li>
+   * </ol>
+   *
+   * <p>This method supports for casting to below types by using the constructor of these types.</p>
+   * <ol>
+   *   <li>{@link Short}</li>
+   *   <li>{@link Byte}</li>
+   *   <li>{@link Integer}</li>
+   *   <li>{@link Long}</li>
+   *   <li>{@link Double}</li>
+   *   <li>{@link java.math.BigDecimal}</li>
+   *   <li>{@link Float}</li>
+   * </ol>
+   * <p>This method support for casting to below types by using corresponding method such as
+   * {@code intValue()}, {@code longValue()}, {@code shortValue()}, and so on.</p>
+   * <ol>
+   *   <li>{@code int}</li>
+   *   <li>{@code long}</li>
+   *   <li>{@code short}</li>
+   *   <li>{@code byte}</li>
+   *   <li>{@code double}</li>
+   *   <li>{@code float}</li>
+   * </ol>
+   *
+   * <p> For example,
+   * <ol>
+   *   <li>This method allows {@link Byte} cast to {@link Integer} by using
+   *   {@code new Integer(Byte.toString)}.</li>
+   *   <li>This method allows {@link Long} cast to {@code double} by using the method
+   *   {@link Long#doubleValue()}.</li>
+   * </ol>
+   *
+   * <p>Same as {@link #cast(Iterable, Class)} you can invoke
+   *    <blockquote><code>Linq4j.extendedCast(list, Integer.class)</code></blockquote>
+   * to convert the list of an enumerable that can be queried using the standard query operators.
+   *
+   * @see Enumerable#extendedCast(Class)
+   * @see Enumerable#cast(Class)
+   * @see #cast(Iterable, Class)
+   * @see #asEnumerable(Iterable)
+   */
+  public static <TSource, TResult> Enumerable<TResult> extendedCast(
+      Iterable<TSource> source, Class<TResult> clazz) {
+    return asEnumerable(source).extendedCast(clazz);
+  }
+
+  /**
    * Returns elements of a given {@link Iterable} that are of the specified
    * type.
    *

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -778,6 +778,14 @@ public class Linq4jTest {
     checkCast(enumerator);
   }
 
+  @Test public void testIterableExtendedCast() {
+    final List<Number> numbers = Arrays.asList((Number) 2, null, 3.14, 5L);
+    final Enumerator<Integer> enumerator =
+        Linq4j.extendedCast(numbers, Integer.class)
+            .enumerator();
+    checkCast(enumerator);
+  }
+
   private void checkCast(Enumerator<Integer> enumerator) {
     assertTrue(enumerator.moveNext());
     assertEquals(Integer.valueOf(2), enumerator.current());


### PR DESCRIPTION
This pull request for the issue https://issues.apache.org/jira/browse/CALCITE-3216
According to SqlTypeAssignmentRule which determine whether a type is assignable from another type, this pull request  mainly realized  a ExtendedCastingEnumerator which enable the cast between most of the Java numeric types during the codegen phase. 