### PR TITLE
[CALCITE-3885] Restore trace logging for rules queue and Volcano planner's internal state (Roman Kondakov)

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -28,6 +28,8 @@ import com.google.common.collect.Multimap;
 
 import org.slf4j.Logger;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.EnumMap;
@@ -165,6 +167,8 @@ class RuleQueue {
    *                              {@link #phaseCompleted(VolcanoPlannerPhase)}.
    */
   VolcanoRuleMatch popMatch(VolcanoPlannerPhase phase) {
+    dumpPlannerState();
+
     PhaseMatchList phaseMatchList = matchListMap.get(phase);
     if (phaseMatchList == null) {
       throw new AssertionError("Used match list for phase " + phase
@@ -176,6 +180,8 @@ class RuleQueue {
       if (phaseMatchList.list.isEmpty()) {
         return null;
       }
+
+      dumpRuleQueue(phaseMatchList);
 
       match = phaseMatchList.list.poll();
 
@@ -195,6 +201,35 @@ class RuleQueue {
 
     LOGGER.debug("Pop match: {}", match);
     return match;
+  }
+
+  /**
+   * Dumps rules queue to the logger when debug level is set to {@code TRACE}.
+   */
+  private void dumpRuleQueue(PhaseMatchList phaseMatchList) {
+    if (LOGGER.isTraceEnabled()) {
+      StringBuilder b = new StringBuilder();
+      b.append("Sorted rule queue:");
+      for (VolcanoRuleMatch rule : phaseMatchList.list) {
+        b.append("\n");
+        b.append(rule);
+      }
+      LOGGER.trace(b.toString());
+    }
+  }
+
+  /**
+   * Dumps planner's state to the logger when debug level is set to {@code TRACE}.
+   */
+  private void dumpPlannerState() {
+    if (LOGGER.isTraceEnabled()) {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      planner.dump(pw);
+      pw.flush();
+      LOGGER.trace(sw.toString());
+      planner.getRoot().getCluster().invalidateMetadataQuery();
+    }
   }
 
   /** Returns whether to skip a match. This happens if any of the


### PR DESCRIPTION
The patch is pretty simple: I've just added the logging of the rules queue and planner's internal state as it was before. 
See https://issues.apache.org/jira/browse/CALCITE-3885