### PR TITLE
[CALCITE-3888] Switch avatica-server to be test dependency for core

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     implementation("com.yahoo.datasketches:sketches-core")
     implementation("commons-codec:commons-codec")
     implementation("net.hydromatic:aggdesigner-algorithm")
-    implementation("org.apache.calcite.avatica:avatica-server")
     implementation("org.apache.commons:commons-dbcp2")
     implementation("org.apache.commons:commons-lang3")
     implementation("commons-io:commons-io")
@@ -69,6 +68,7 @@ dependencies {
     testImplementation("net.hydromatic:foodmart-queries")
     testImplementation("net.hydromatic:quidem")
     testImplementation("net.hydromatic:scott-data-hsqldb")
+    testImplementation("org.apache.calcite.avatica:avatica-server")
     testImplementation("org.apache.commons:commons-pool2")
     testImplementation("log4j:log4j") {
         because("SqlHintsConverterTest needs to implement a MockAppender")


### PR DESCRIPTION
`avatica-server` was a test only dependencies in [`calcite-core` pre 1.21.0](https://github.com/apache/calcite/blob/calcite-1.21.0/core/pom.xml#L52).
But during the switch to gradle in 1.22.0, it's configured to be an implementation dependency.

This PR switches it back to testImplementation only.