### PR TITLE
Add JIRA links in Git in IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /.idea/*
 # Icon for JetBrains Toolbox
 !/.idea/icon.png
+!/.idea/vcs.xml
 *.iml
 
 settings.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="[A-Z]+\-\d+" />
+          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.ratignore
+++ b/.ratignore
@@ -12,8 +12,7 @@
 **/src/test/resources/*.json
 **/data.txt
 **/data2.txt
-#bu ildSrc/build
-#b uildSrc/subprojects/*/build
+.idea/vcs.xml
 
 # TODO: remove when pom.xml files are removed
 src/main/config/licenses


### PR DESCRIPTION
Here's sample from IDEA's Git log.
Now CALCITE-... are clickable

<img width="702" alt="git log" src="https://user-images.githubusercontent.com/213894/78499619-6399b080-775a-11ea-9275-ee9a9a6fe51c.png">