### PR TITLE
[CALCITE-3901] Introduce an option to disable metadata handler regeneration

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -311,6 +311,17 @@ public final class CalciteSystemProperty<T> {
       intProperty("calcite.metadata.handler.cache.maximum.size", 1000);
 
   /**
+   * A flag to indicate if we allow regenerating metadata handlers in
+   * {@link org.apache.calcite.rel.metadata.JaninoRelMetadataProvider}.
+   *
+   * <p>It would be desirable if we never have to regenerate metadata handlers, as
+   * the regenerating process involves recompiling code by Janino, which is time-consuming.
+   * </p>
+   */
+  public static final CalciteSystemProperty<Boolean> ENABLE_REGENERATE_METADATA_HANDLER =
+      booleanProperty("calcite.enable.regenerate.metadata.handler", true);
+
+  /**
    * The maximum size of the cache used for storing Bindable objects, instantiated via
    * dynamically generated Java classes.
    *

--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -311,17 +311,6 @@ public final class CalciteSystemProperty<T> {
       intProperty("calcite.metadata.handler.cache.maximum.size", 1000);
 
   /**
-   * A flag to indicate if we allow regenerating metadata handlers in
-   * {@link org.apache.calcite.rel.metadata.JaninoRelMetadataProvider}.
-   *
-   * <p>It would be desirable if we never have to regenerate metadata handlers, as
-   * the regenerating process involves recompiling code by Janino, which is time-consuming.
-   * </p>
-   */
-  public static final CalciteSystemProperty<Boolean> ENABLE_REGENERATE_METADATA_HANDLER =
-      booleanProperty("calcite.enable.regenerate.metadata.handler", true);
-
-  /**
    * The maximum size of the cache used for storing Bindable objects, instantiated via
    * dynamically generated Java classes.
    *


### PR DESCRIPTION
According to our investigation, Calcite can produce large performance overhead due to meta data handler regeneration.

To illustrate, suppose we want to get the average size of a rel node, by calling the RelMetadataQuery#getAverageRowSize method. If the rel node type has not been registered before, JaninoRelMetadataProvider#revise method will be called, which will regerenate and recompile the code for the metadata handler.

This process is time-consuming, as compiling code by Janino is time-consuming: It takes more than 10ms to compile a single source file, even if the file is small. According to our investigation, performance overhead due to this problem can be over 10% of the total optimization time.

Therefore, we introduce an option to disable metadata handler regeneration. This forces the client to register all rel node types before calling the metadata service, so as to avoid performance being stolen silently.

For some scenarios, the client mistakenly believes they have registered all rel node types, and this option helps them find the types they have missed.