### PR TITLE
[CALCITE-3900] Add Config for SqlValidator

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -58,7 +58,7 @@ import org.apache.calcite.sql.advise.SqlAdvisor;
 import org.apache.calcite.sql.advise.SqlAdvisorValidator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
-import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorWithHints;
 import org.apache.calcite.tools.RelRunner;
 import org.apache.calcite.util.BuiltInMethod;
@@ -472,7 +472,7 @@ abstract class CalciteConnectionImpl
           new SqlAdvisorValidator(SqlStdOperatorTable.instance(),
               new CalciteCatalogReader(rootSchema,
                   schemaPath, typeFactory, con.config()),
-              typeFactory, SqlConformanceEnum.DEFAULT);
+              typeFactory, SqlValidator.Config.DEFAULT);
       final CalciteConnectionConfig config = con.config();
       // This duplicates org.apache.calcite.prepare.CalcitePrepareImpl.prepare2_
       final SqlParser.Config parserConfig = SqlParser.configBuilder()

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -628,8 +628,6 @@ public class CalcitePrepareImpl implements CalcitePrepare {
 
       final SqlValidator validator =
           createSqlValidator(context, catalogReader);
-      validator.setIdentifierExpansion(true);
-      validator.setDefaultNullCollation(config.defaultNullCollation());
 
       preparedResult = preparingStmt.prepareSql(
           sqlNode, Object.class, validator, true);
@@ -709,9 +707,14 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     final SqlOperatorTable opTab =
         ChainedSqlOperatorTable.of(opTab0, catalogReader);
     final JavaTypeFactory typeFactory = context.getTypeFactory();
-    final SqlConformance conformance = context.config().conformance();
+    final CalciteConnectionConfig connectionConfig = context.config();
+    final SqlValidator.Config config = SqlValidator.Config.DEFAULT
+        .withLenientOperatorLookup(connectionConfig.lenientOperatorLookup())
+        .withSqlConformance(connectionConfig.conformance())
+        .withDefaultNullCollation(connectionConfig.defaultNullCollation())
+        .withIdentifierExpansion(true);
     return new CalciteSqlValidator(opTab, catalogReader, typeFactory,
-        conformance);
+        config);
   }
 
   private List<ColumnMetaData> getColumnMetaDataList(

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteSqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteSqlValidator.java
@@ -20,7 +20,6 @@ import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlOperatorTable;
-import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
 
 /** Validator. */
@@ -28,8 +27,8 @@ class CalciteSqlValidator extends SqlValidatorImpl {
 
   CalciteSqlValidator(SqlOperatorTable opTab,
       CalciteCatalogReader catalogReader, JavaTypeFactory typeFactory,
-      SqlConformance conformance) {
-    super(opTab, catalogReader, typeFactory, conformance);
+      Config config) {
+    super(opTab, catalogReader, typeFactory, config);
   }
 
   @Override protected RelDataType getLogicalSourceRowType(

--- a/core/src/main/java/org/apache/calcite/sql/SqlCallBinding.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCallBinding.java
@@ -294,4 +294,12 @@ public class SqlCallBinding extends SqlOperatorBinding {
       Resources.ExInst<SqlValidatorException> ex) {
     return validator.newValidationError(call, ex);
   }
+
+  /**
+   * Returns whether to allow implicit type coercion when validation.
+   * This is a short-cut method.
+   */
+  public boolean isTypeCoercionEnabled() {
+    return validator.config().typeCoercionEnabled();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
@@ -276,7 +276,7 @@ public class SqlFunction extends SqlOperator {
 
       validCoercionType:
       if (function == null) {
-        if (validator.isTypeCoercionEnabled()) {
+        if (validator.config().typeCoercionEnabled()) {
           // try again if implicit type coercion is allowed.
           function = (SqlFunction)
               SqlUtil.lookupRoutine(validator.getOperatorTable(), getNameAsId(),
@@ -304,7 +304,7 @@ public class SqlFunction extends SqlOperator {
 
         // if function doesn't exist within operator table and known function
         // handling is turned off then create a more permissive function
-        if (function == null && validator.isLenientOperatorLookup()) {
+        if (function == null && validator.config().lenientOperatorLookup()) {
           function = new SqlUnresolvedFunction(identifier, null,
               null, OperandTypes.VARIADIC, null, x.getFunctionType());
           break validCoercionType;

--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -674,9 +674,7 @@ public abstract class SqlOperator {
         if (operand.e != null
             && operand.e.getKind() == SqlKind.DEFAULT
             && !operandTypeChecker.isOptional(operand.i)) {
-          throw callBinding.getValidator().newValidationError(
-              callBinding.getCall(),
-              RESOURCE.defaultForOptionalParameter());
+          throw callBinding.newValidationError(RESOURCE.defaultForOptionalParameter());
         }
       }
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlWindow.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWindow.java
@@ -557,8 +557,8 @@ public class SqlWindow extends SqlCall {
 
     for (SqlNode orderItem : orderList) {
       boolean savedColumnReferenceExpansion =
-          validator.getColumnReferenceExpansion();
-      validator.setColumnReferenceExpansion(false);
+          validator.config().columnReferenceExpansion();
+      validator.transform(config -> config.withColumnReferenceExpansion(false));
       try {
         orderItem.accept(Util.OverFinder.INSTANCE);
       } catch (ControlFlowException e) {
@@ -569,8 +569,8 @@ public class SqlWindow extends SqlCall {
       try {
         orderItem.validateExpr(validator, scope);
       } finally {
-        validator.setColumnReferenceExpansion(
-            savedColumnReferenceExpansion);
+        validator.transform(config ->
+            config.withColumnReferenceExpansion(savedColumnReferenceExpansion));
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/advise/SqlAdvisorValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/advise/SqlAdvisorValidator.java
@@ -28,7 +28,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.OverScope;
 import org.apache.calcite.sql.validate.SelectScope;
-import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlModality;
 import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
@@ -61,14 +60,14 @@ public class SqlAdvisorValidator extends SqlValidatorImpl {
    * @param opTab         Operator table
    * @param catalogReader Catalog reader
    * @param typeFactory   Type factory
-   * @param conformance   Compatibility mode
+   * @param config        Config
    */
   public SqlAdvisorValidator(
       SqlOperatorTable opTab,
       SqlValidatorCatalogReader catalogReader,
       RelDataTypeFactory typeFactory,
-      SqlConformance conformance) {
-    super(opTab, catalogReader, typeFactory, conformance);
+      Config config) {
+    super(opTab, catalogReader, typeFactory, config);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCaseOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCaseOperator.java
@@ -207,7 +207,7 @@ public class SqlCaseOperator extends SqlOperator {
     if (!foundNotNull) {
       // according to the sql standard we can not have all of the THEN
       // statements and the ELSE returning null
-      if (throwOnFailure && !callBinding.getValidator().isTypeCoercionEnabled()) {
+      if (throwOnFailure && !callBinding.isTypeCoercionEnabled()) {
         throw callBinding.newError(RESOURCE.mustNotNullInElse());
       }
       return false;
@@ -264,7 +264,7 @@ public class SqlCaseOperator extends SqlOperator {
     RelDataType ret = typeFactory.leastRestrictive(argTypes);
     if (null == ret) {
       boolean coerced = false;
-      if (callBinding.getValidator().isTypeCoercionEnabled()) {
+      if (callBinding.isTypeCoercionEnabled()) {
         TypeCoercion typeCoercion = callBinding.getValidator().getTypeCoercion();
         RelDataType commonType = typeCoercion.getWiderTypeFor(argTypes, true);
         // commonType is always with nullability as false, we do not consider the

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlInOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlInOperator.java
@@ -114,7 +114,7 @@ public class SqlInOperator extends SqlBinaryOperator {
       // First check that the expressions in the IN list are compatible
       // with each other. Same rules as the VALUES operator (per
       // SQL:2003 Part 2 Section 8.4, <in predicate>).
-      if (null == rightType && validator.isTypeCoercionEnabled()) {
+      if (null == rightType && validator.config().typeCoercionEnabled()) {
         // Do implicit type cast if it is allowed to.
         rightType = validator.getTypeCoercion().getWiderTypeFor(rightTypeList, true);
       }
@@ -131,7 +131,7 @@ public class SqlInOperator extends SqlBinaryOperator {
     }
     SqlCallBinding callBinding = new SqlCallBinding(validator, scope, call);
     // Coerce type first.
-    if (callBinding.getValidator().isTypeCoercionEnabled()) {
+    if (callBinding.isTypeCoercionEnabled()) {
       boolean coerced = callBinding.getValidator().getTypeCoercion()
           .inOperationCoercion(callBinding);
       if (coerced) {

--- a/core/src/main/java/org/apache/calcite/sql/type/ComparableOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ComparableOperandTypeChecker.java
@@ -64,7 +64,7 @@ public class ComparableOperandTypeChecker extends SameOperandTypeChecker {
     }
     if (b) {
       // Coerce type first.
-      if (callBinding.getValidator().isTypeCoercionEnabled()) {
+      if (callBinding.isTypeCoercionEnabled()) {
         TypeCoercion typeCoercion = callBinding.getValidator().getTypeCoercion();
         // For comparison operators, i.e. >, <, =, >=, <=.
         typeCoercion.binaryComparisonCoercion(callBinding);

--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
@@ -240,7 +240,7 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
     // 1. Check eagerly for binary arithmetic expressions.
     // 2. Check the comparability.
     // 3. Check if the operands have the right type.
-    if (callBinding.getValidator().isTypeCoercionEnabled()) {
+    if (callBinding.isTypeCoercionEnabled()) {
       final TypeCoercion typeCoercion = callBinding.getValidator().getTypeCoercion();
       typeCoercion.binaryArithmeticCoercion(callBinding);
     }
@@ -292,7 +292,7 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
             callBinding.getCall().operand(ord.i),
             0,
             false)) {
-          if (callBinding.getValidator().isTypeCoercionEnabled()) {
+          if (callBinding.isTypeCoercionEnabled()) {
             // Try type coercion for the call,
             // collect SqlTypeFamily and data type of all the operands.
             final List<SqlTypeFamily> families = allowedRules.stream()
@@ -348,7 +348,7 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
   }
 
   private boolean checkWithoutTypeCoercion(SqlCallBinding callBinding) {
-    if (!callBinding.getValidator().isTypeCoercionEnabled()) {
+    if (!callBinding.isTypeCoercionEnabled()) {
       return false;
     }
     for (SqlOperandTypeChecker rule : allowedRules) {

--- a/core/src/main/java/org/apache/calcite/sql/type/FamilyOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FamilyOperandTypeChecker.java
@@ -71,7 +71,7 @@ public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
       return true;
     }
     if (SqlUtil.isNullLiteral(node, false)) {
-      if (callBinding.getValidator().isTypeCoercionEnabled()) {
+      if (callBinding.isTypeCoercionEnabled()) {
         return true;
       } else if (throwOnFailure) {
         throw callBinding.getValidator().newValidationError(node,
@@ -116,7 +116,7 @@ public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
           false)) {
         // try to coerce type if it is allowed.
         boolean coerced = false;
-        if (callBinding.getValidator().isTypeCoercionEnabled()) {
+        if (callBinding.isTypeCoercionEnabled()) {
           TypeCoercion typeCoercion = callBinding.getValidator().getTypeCoercion();
           ImmutableList.Builder<RelDataType> builder = ImmutableList.builder();
           for (int i = 0; i < callBinding.getOperandCount(); i++) {

--- a/core/src/main/java/org/apache/calcite/sql/type/SameOperandTypeExceptLastOperandChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SameOperandTypeExceptLastOperandChecker.java
@@ -61,7 +61,7 @@ public class SameOperandTypeExceptLastOperandChecker extends SameOperandTypeChec
         getOperandList(operatorBinding.getOperandCount());
     for (int i : operandList) {
       if (operatorBinding.isOperandNull(i, false)) {
-        if (callBinding.getValidator().isTypeCoercionEnabled()) {
+        if (callBinding.isTypeCoercionEnabled()) {
           types[i] = operatorBinding.getTypeFactory()
               .createSqlType(SqlTypeName.NULL);
         } else if (throwOnFailure) {

--- a/core/src/main/java/org/apache/calcite/sql/type/SetopOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SetopOperandTypeChecker.java
@@ -114,7 +114,7 @@ public class SetopOperandTypeChecker implements SqlOperandTypeChecker {
           callBinding.getTypeFactory().leastRestrictive(columnIthTypes);
       if (type == null) {
         boolean coerced = false;
-        if (validator.isTypeCoercionEnabled()) {
+        if (callBinding.isTypeCoercionEnabled()) {
           for (int j = 0; j < callBinding.getOperandCount(); j++) {
             TypeCoercion typeCoercion = validator.getTypeCoercion();
             RelDataType widenType = typeCoercion.getWiderTypeFor(columnIthTypes, true);

--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -184,7 +184,7 @@ public class IdentifierNamespace extends AbstractNamespace {
     resolvedNamespace = Objects.requireNonNull(resolveImpl(id));
     if (resolvedNamespace instanceof TableNamespace) {
       SqlValidatorTable table = resolvedNamespace.getTable();
-      if (validator.shouldExpandIdentifiers()) {
+      if (validator.config().identifierExpansion()) {
         // TODO:  expand qualifiers for column references also
         List<String> qualifiedNames = table.getQualifiedName();
         if (qualifiedNames != null) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/OrderByScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/OrderByScope.java
@@ -70,7 +70,7 @@ public class OrderByScope extends DelegatingScope {
   public SqlQualified fullyQualify(SqlIdentifier identifier) {
     // If it's a simple identifier, look for an alias.
     if (identifier.isSimple()
-        && validator.getConformance().isSortByAlias()) {
+        && validator.config().sqlConformance().isSortByAlias()) {
       final String name = identifier.names.get(0);
       final SqlValidatorNamespace selectNs =
           validator.getNamespace(select);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -44,9 +44,13 @@ import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.type.SqlTypeCoercionRule;
 import org.apache.calcite.sql.validate.implicit.TypeCoercion;
+import org.apache.calcite.util.ImmutableBeans;
+
+import org.apiguardian.api.API;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 /**
@@ -112,7 +116,10 @@ public interface SqlValidator {
    * Default is {@link SqlConformanceEnum#DEFAULT}.
    *
    * @return dialect of SQL this validator recognizes
+   *
+   * @deprecated Use {@link Config#sqlConformance}
    */
+  @Deprecated // to be removed before 1.24
   SqlConformance getConformance();
 
   /**
@@ -620,7 +627,10 @@ public interface SqlValidator {
    * references.
    *
    * @param expandIdentifiers new setting
+   *
+   * @deprecated Use {@link Config#withIdentifierExpansion}
    */
+  @Deprecated // to be removed before 1.24
   void setIdentifierExpansion(boolean expandIdentifiers);
 
   /**
@@ -628,34 +638,56 @@ public interface SqlValidator {
    * not apply to the ORDER BY clause; may be fixed in the future.)
    *
    * @param expandColumnReferences new setting
+   *
+   * @deprecated Use {@link Config#columnReferenceExpansion}
    */
+  @Deprecated // to be removed before 1.24
   void setColumnReferenceExpansion(boolean expandColumnReferences);
 
   /**
    * @return whether column reference expansion is enabled
+   *
+   * @deprecated  Use {@link Config#columnReferenceExpansion}
    */
+  @Deprecated // to be removed before 1.24
   boolean getColumnReferenceExpansion();
 
-  /** Sets how NULL values should be collated if an ORDER BY item does not
-   * contain NULLS FIRST or NULLS LAST. */
+  /**
+   * Sets how NULL values should be collated if an ORDER BY item does not
+   * contain NULLS FIRST or NULLS LAST.
+   *
+   * @deprecated Use {@link Config#defaultNullCollation}
+   */
+  @Deprecated // to be removed before 1.24
   void setDefaultNullCollation(NullCollation nullCollation);
 
-  /** Returns how NULL values should be collated if an ORDER BY item does not
-   * contain NULLS FIRST or NULLS LAST. */
+  /**
+   * Returns how NULL values should be collated if an ORDER BY item does not
+   * contain NULLS FIRST or NULLS LAST.
+   *
+   * @deprecated Use {@link Config#defaultNullCollation}
+   */
+  @Deprecated // to be removed before 1.24
   NullCollation getDefaultNullCollation();
 
   /**
    * Returns expansion of identifiers.
    *
    * @return whether this validator should expand identifiers
+   *
+   * @deprecated Use {@link Config#identifierExpansion}
    */
+  @Deprecated // to be removed before 1.24
   boolean shouldExpandIdentifiers();
 
   /**
    * Enables or disables rewrite of "macro-like" calls such as COALESCE.
    *
    * @param rewriteCalls new setting
+   *
+   * @deprecated Use {@link Config#callRewrite}
    */
+  @Deprecated // to be removed before 1.24
   void setCallRewrite(boolean rewriteCalls);
 
   /**
@@ -787,7 +819,10 @@ public interface SqlValidator {
    * function.
    *
    * @param lenient Whether to be lenient when encountering an unknown function
+   *
+   * @deprecated Use {@link Config#withLenientOperatorLookup}
    */
+  @Deprecated // to be removed before 1.24
   SqlValidator setLenientOperatorLookup(boolean lenient);
 
   /** Returns whether this validator should be lenient upon encountering an
@@ -800,7 +835,11 @@ public interface SqlValidator {
    * {@link #getUnknownType() UNKNOWN}.
    *
    * <p>If false (the default behavior), an unknown function call causes a
-   * validation error to be thrown. */
+   * validation error to be thrown.
+   *
+   * @deprecated Use {@link Config#lenientOperatorLookup}
+   */
+  @Deprecated // to be removed before 1.24
   boolean isLenientOperatorLookup();
 
   /**
@@ -809,10 +848,18 @@ public interface SqlValidator {
    * @param enabled if enable the type coercion, default is true
    *
    * @see org.apache.calcite.sql.validate.implicit.TypeCoercionImpl TypeCoercionImpl
+   *
+   * @deprecated Use {@link Config#withTypeCoercionEnabled}
    */
+  @Deprecated // to be removed before 1.24
   SqlValidator setEnableTypeCoercion(boolean enabled);
 
-  /** Returns if this validator supports implicit type coercion. */
+  /**
+   * Returns if this validator supports implicit type coercion.
+   *
+   * @deprecated Use {@link Config#typeCoercionEnabled}
+   */
+  @Deprecated // to be removed before 1.24
   boolean isTypeCoercionEnabled();
 
   /**
@@ -839,4 +886,128 @@ public interface SqlValidator {
    *                          for how to customize the rules.
    */
   void setSqlTypeCoercionRules(SqlTypeCoercionRule typeCoercionRules);
+
+  /** Returns the config of the validator. */
+  Config config();
+
+  /**
+   * Returns this SqlValidator, with the same state, applying
+   * a transform to the config.
+   *
+   * <p>This is mainly used for tests, otherwise constructs a {@link Config} directly
+   * through the constructor.
+   */
+  @API(status = API.Status.INTERNAL, since = "1.23")
+  SqlValidator transform(UnaryOperator<SqlValidator.Config> transform);
+
+  //~ Inner Class ------------------------------------------------------------
+
+  /**
+   * Interface to define the configuration for a SqlValidator.
+   * Provides methods to set each configuration option.
+   */
+  public interface Config {
+    /** Default configuration. */
+    SqlValidator.Config DEFAULT = ImmutableBeans.create(Config.class);
+
+    /**
+     * Returns whether to enable rewrite of "macro-like" calls such as COALESCE.
+     */
+    @ImmutableBeans.Property
+    @ImmutableBeans.BooleanDefault(true)
+    boolean callRewrite();
+
+    /**
+     * Sets whether to enable rewrite of "macro-like" calls such as COALESCE.
+     */
+    Config withCallRewrite(boolean rewrite);
+
+    /** Returns how NULL values should be collated if an ORDER BY item does not
+     * contain NULLS FIRST or NULLS LAST. */
+    @ImmutableBeans.Property
+    @ImmutableBeans.EnumDefault("HIGH")
+    NullCollation defaultNullCollation();
+
+    /** Sets how NULL values should be collated if an ORDER BY item does not
+     * contain NULLS FIRST or NULLS LAST. */
+    Config withDefaultNullCollation(NullCollation nullCollation);
+
+    /**
+     * Returns whether column reference expansion is enabled
+     */
+    @ImmutableBeans.Property
+    @ImmutableBeans.BooleanDefault(true)
+    boolean columnReferenceExpansion();
+
+    /**
+     * Sets whether to enable expansion of column references. (Currently this does
+     * not apply to the ORDER BY clause; may be fixed in the future.)
+     */
+    Config withColumnReferenceExpansion(boolean expand);
+
+    /**
+     * Returns whether to expand identifiers other than column
+     * references.
+     *
+     * <p>REVIEW jvs 30-June-2006: subclasses may override shouldExpandIdentifiers
+     * in a way that ignores this; we should probably get rid of the protected
+     * method and always use this variable (or better, move preferences like
+     * this to a separate "parameter" class).
+     */
+    @ImmutableBeans.Property
+    @ImmutableBeans.BooleanDefault(false)
+    boolean identifierExpansion();
+
+    /**
+     * Sets whether to enable expansion of identifiers other than column
+     * references.
+     */
+    Config withIdentifierExpansion(boolean expand);
+
+    /**
+     * Returns whether this validator should be lenient upon encountering an
+     * unknown function, default false.
+     *
+     * <p>If true, if a statement contains a call to a function that is not
+     * present in the operator table, or if the call does not have the required
+     * number or types of operands, the validator nevertheless regards the
+     * statement as valid. The type of the function call will be
+     * {@link #getUnknownType() UNKNOWN}.
+     *
+     * <p>If false (the default behavior), an unknown function call causes a
+     * validation error to be thrown.
+     */
+    @ImmutableBeans.Property
+    @ImmutableBeans.BooleanDefault(false)
+    boolean lenientOperatorLookup();
+
+    /**
+     * Sets whether this validator should be lenient upon encountering an unknown
+     * function.
+     *
+     * @param lenient Whether to be lenient when encountering an unknown function
+     */
+    Config withLenientOperatorLookup(boolean lenient);
+
+    /** Returns whether the validator supports implicit type coercion. */
+    @ImmutableBeans.Property
+    @ImmutableBeans.BooleanDefault(true)
+    boolean typeCoercionEnabled();
+
+    /**
+     * Sets whether to enable implicit type coercion for validation, default true.
+     *
+     * @see org.apache.calcite.sql.validate.implicit.TypeCoercionImpl TypeCoercionImpl
+     */
+    Config withTypeCoercionEnabled(boolean enabled);
+
+    /** Returns the dialect of SQL (SQL:2003, etc.) this validator recognizes.
+     * Default is {@link SqlConformanceEnum#DEFAULT}. */
+    @ImmutableBeans.Property
+    @ImmutableBeans.EnumDefault("DEFAULT")
+    SqlConformance sqlConformance();
+
+    /** Sets up the sql conformance of the validator. */
+    Config withSqlConformance(SqlConformance conformance);
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -340,9 +340,9 @@ public class SqlValidatorUtil {
       SqlOperatorTable opTab,
       SqlValidatorCatalogReader catalogReader,
       RelDataTypeFactory typeFactory,
-      SqlConformance conformance) {
+      SqlValidator.Config config) {
     return new SqlValidatorImpl(opTab, catalogReader, typeFactory,
-        conformance);
+        config);
   }
 
   /**
@@ -354,7 +354,7 @@ public class SqlValidatorUtil {
       SqlValidatorCatalogReader catalogReader,
       RelDataTypeFactory typeFactory) {
     return newValidator(opTab, catalogReader, typeFactory,
-        SqlConformanceEnum.DEFAULT);
+        SqlValidator.Config.DEFAULT);
   }
 
   /**
@@ -1159,7 +1159,7 @@ public class SqlValidatorUtil {
     SqlValidator validator = newValidator(operatorTable,
         catalogReader,
         typeFactory,
-        SqlConformanceEnum.DEFAULT);
+        SqlValidator.Config.DEFAULT);
     final SqlSelect select = (SqlSelect) validator.validate(select0);
     assert select.getSelectList().size() == 1
         : "Expression " + expr + " should be atom expression";

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2276,7 +2276,7 @@ public class SqlToRelConverter {
         break;
       }
       final RelFieldCollation.NullDirection nullDirection =
-          validator.getDefaultNullCollation().last(desc(direction))
+          validator.config().defaultNullCollation().last(desc(direction))
               ? RelFieldCollation.NullDirection.LAST
               : RelFieldCollation.NullDirection.FIRST;
       RexNode e = matchBb.convertExpression(order);
@@ -3285,7 +3285,7 @@ public class SqlToRelConverter {
 
     switch (nullDirection) {
     case UNSPECIFIED:
-      nullDirection = validator.getDefaultNullCollation().last(desc(direction))
+      nullDirection = validator.config().defaultNullCollation().last(desc(direction))
           ? RelFieldCollation.NullDirection.LAST
           : RelFieldCollation.NullDirection.FIRST;
     }
@@ -3702,7 +3702,7 @@ public class SqlToRelConverter {
     final RelDataType tableRowType = targetTable.getRowType();
     SqlNodeList targetColumnList = call.getTargetColumnList();
     if (targetColumnList == null) {
-      if (validator.getConformance().isInsertSubsetColumnsAllowed()) {
+      if (validator.config().sqlConformance().isInsertSubsetColumnsAllowed()) {
         final RelDataType targetRowType =
             typeFactory.createStructType(
                 tableRowType.getFieldList()
@@ -4873,12 +4873,12 @@ public class SqlToRelConverter {
         switch (nullDirection) {
         case UNSPECIFIED:
           final RelFieldCollation.NullDirection nullDefaultDirection =
-              validator.getDefaultNullCollation().last(desc(direction))
+              validator.config().defaultNullCollation().last(desc(direction))
                   ? RelFieldCollation.NullDirection.LAST
                   : RelFieldCollation.NullDirection.FIRST;
           if (nullDefaultDirection != direction.defaultNullDirection()) {
             SqlKind nullDirectionSqlKind =
-                validator.getDefaultNullCollation().last(desc(direction))
+                validator.config().defaultNullCollation().last(desc(direction))
                     ? SqlKind.NULLS_LAST
                     : SqlKind.NULLS_FIRST;
             flags.add(nullDirectionSqlKind);

--- a/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
+++ b/core/src/main/java/org/apache/calcite/tools/FrameworkConfig.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 
@@ -42,6 +43,11 @@ public interface FrameworkConfig {
    * The configuration of SQL parser.
    */
   SqlParser.Config getParserConfig();
+
+  /**
+   * The configuration of {@link SqlValidator}.
+   */
+  SqlValidator.Config getSqlValidatorConfig();
 
   /**
    * The configuration of {@link SqlToRelConverter}.

--- a/core/src/main/java/org/apache/calcite/tools/Frameworks.java
+++ b/core/src/main/java/org/apache/calcite/tools/Frameworks.java
@@ -35,6 +35,7 @@ import org.apache.calcite.server.CalciteServerStatement;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
@@ -218,6 +219,7 @@ public class Frameworks {
     private Context context;
     private ImmutableList<RelTraitDef> traitDefs;
     private SqlParser.Config parserConfig;
+    private SqlValidator.Config sqlValidatorConfig;
     private SqlToRelConverter.Config sqlToRelConverterConfig;
     private SchemaPlus defaultSchema;
     private RexExecutor executor;
@@ -234,6 +236,7 @@ public class Frameworks {
       programs = ImmutableList.of();
       context = Contexts.empty();
       parserConfig = SqlParser.Config.DEFAULT;
+      sqlValidatorConfig = SqlValidator.Config.DEFAULT;
       sqlToRelConverterConfig = SqlToRelConverter.Config.DEFAULT;
       typeSystem = RelDataTypeSystem.DEFAULT;
       evolveLattice = false;
@@ -248,6 +251,7 @@ public class Frameworks {
       context = config.getContext();
       traitDefs = config.getTraitDefs();
       parserConfig = config.getParserConfig();
+      sqlValidatorConfig = config.getSqlValidatorConfig();
       sqlToRelConverterConfig = config.getSqlToRelConverterConfig();
       defaultSchema = config.getDefaultSchema();
       executor = config.getExecutor();
@@ -259,7 +263,7 @@ public class Frameworks {
 
     public FrameworkConfig build() {
       return new StdFrameworkConfig(context, convertletTable, operatorTable,
-          programs, traitDefs, parserConfig, sqlToRelConverterConfig,
+          programs, traitDefs, parserConfig, sqlValidatorConfig, sqlToRelConverterConfig,
           defaultSchema, costFactory, typeSystem, executor, evolveLattice,
           statisticProvider, viewExpander);
     }
@@ -301,6 +305,11 @@ public class Frameworks {
 
     public ConfigBuilder parserConfig(SqlParser.Config parserConfig) {
       this.parserConfig = Objects.requireNonNull(parserConfig);
+      return this;
+    }
+
+    public ConfigBuilder sqlValidatorConfig(SqlValidator.Config sqlValidatorConfig) {
+      this.sqlValidatorConfig = Objects.requireNonNull(sqlValidatorConfig);
       return this;
     }
 
@@ -372,6 +381,7 @@ public class Frameworks {
     private final ImmutableList<Program> programs;
     private final ImmutableList<RelTraitDef> traitDefs;
     private final SqlParser.Config parserConfig;
+    private final SqlValidator.Config sqlValidatorConfig;
     private final SqlToRelConverter.Config sqlToRelConverterConfig;
     private final SchemaPlus defaultSchema;
     private final RelOptCostFactory costFactory;
@@ -387,6 +397,7 @@ public class Frameworks {
         ImmutableList<Program> programs,
         ImmutableList<RelTraitDef> traitDefs,
         SqlParser.Config parserConfig,
+        SqlValidator.Config sqlValidatorConfig,
         SqlToRelConverter.Config sqlToRelConverterConfig,
         SchemaPlus defaultSchema,
         RelOptCostFactory costFactory,
@@ -401,6 +412,7 @@ public class Frameworks {
       this.programs = programs;
       this.traitDefs = traitDefs;
       this.parserConfig = parserConfig;
+      this.sqlValidatorConfig = sqlValidatorConfig;
       this.sqlToRelConverterConfig = sqlToRelConverterConfig;
       this.defaultSchema = defaultSchema;
       this.costFactory = costFactory;
@@ -413,6 +425,10 @@ public class Frameworks {
 
     public SqlParser.Config getParserConfig() {
       return parserConfig;
+    }
+
+    public SqlValidator.Config getSqlValidatorConfig() {
+      return sqlValidatorConfig;
     }
 
     public SqlToRelConverter.Config getSqlToRelConverterConfig() {

--- a/core/src/main/java/org/apache/calcite/util/ImmutableBeans.java
+++ b/core/src/main/java/org/apache/calcite/util/ImmutableBeans.java
@@ -16,6 +16,9 @@
  */
 package org.apache.calcite.util;
 
+import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 
@@ -282,7 +285,11 @@ public class ImmutableBeans {
   }
 
   private static Object convertDefault(Object defaultValue, String propertyName,
-      Class propertyType) {
+      Class<?> propertyType) {
+    if (propertyType.equals(SqlConformance.class)) {
+      // Workaround for SqlConformance because it is actually not a Enum.
+      propertyType = SqlConformanceEnum.class;
+    }
     if (defaultValue == null || !propertyType.isEnum()) {
       return defaultValue;
     }

--- a/core/src/test/java/org/apache/calcite/rel/logical/ToLogicalConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/logical/ToLogicalConverterTest.java
@@ -28,7 +28,6 @@ import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.RelBuilderTest;
@@ -85,7 +84,6 @@ class ToLogicalConverterTest {
     final SchemaPlus schema = CalciteAssert.addSchema(rootSchema,
         CalciteAssert.SchemaSpec.JDBC_FOODMART);
     return Frameworks.newConfigBuilder()
-        .parserConfig(SqlParser.Config.DEFAULT)
         .defaultSchema(schema)
         .sqlToRelConverterConfig(DEFAULT_REL_CONFIG)
         .build();

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -54,8 +54,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @ExtendWith(SqlValidatorTestCase.LexConfiguration.class)
 class SqlAdvisorTest extends SqlValidatorTestCase {
-  public static final SqlTestFactory ADVISOR_TEST_FACTORY = SqlTestFactory.INSTANCE.withValidator(
-      SqlAdvisorValidator::new);
+  public static final SqlTestFactory ADVISOR_TEST_FACTORY =
+      SqlTestFactory.INSTANCE.withValidator(SqlAdvisorValidator::new);
 
   private static final List<String> STAR_KEYWORD =
       Arrays.asList(

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTestFactory.java
@@ -134,12 +134,14 @@ public class SqlTestFactory {
     final boolean lenientOperatorLookup =
         (boolean) options.get("lenientOperatorLookup");
     final boolean enableTypeCoercion = (boolean) options.get("enableTypeCoercion");
+    final SqlValidator.Config config = SqlValidator.Config.DEFAULT
+        .withSqlConformance(conformance)
+        .withTypeCoercionEnabled(enableTypeCoercion)
+        .withLenientOperatorLookup(lenientOperatorLookup);
     return validatorFactory.create(operatorTable.get(),
         catalogReader.get(),
         typeFactory.get(),
-        conformance)
-        .setEnableTypeCoercion(enableTypeCoercion)
-        .setLenientOperatorLookup(lenientOperatorLookup);
+        config);
   }
 
   public SqlAdvisor createAdvisor() {
@@ -206,7 +208,7 @@ public class SqlTestFactory {
         SqlOperatorTable opTab,
         SqlValidatorCatalogReader catalogReader,
         RelDataTypeFactory typeFactory,
-        SqlConformance conformance);
+        SqlValidator.Config config);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
@@ -85,7 +85,7 @@ class SqlTestGen {
    */
   private static class SqlValidatorSpooler extends SqlValidatorTest {
     private static final SqlTestFactory SPOOLER_VALIDATOR = SqlTestFactory.INSTANCE.withValidator(
-        (opTab, catalogReader, typeFactory, conformance) ->
+        (opTab, catalogReader, typeFactory, config) ->
             (SqlValidator) Proxy.newProxyInstance(
                 SqlValidatorSpooler.class.getClassLoader(),
                 new Class[]{SqlValidator.class},

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorFeatureTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorFeatureTest.java
@@ -25,7 +25,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.test.SqlTester;
 import org.apache.calcite.sql.test.SqlValidatorTester;
-import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
 
@@ -114,8 +113,8 @@ class SqlValidatorFeatureTest extends SqlValidatorTestCase {
         SqlOperatorTable opTab,
         SqlValidatorCatalogReader catalogReader,
         RelDataTypeFactory typeFactory,
-        SqlConformance conformance) {
-      super(opTab, catalogReader, typeFactory, conformance);
+        Config config) {
+      super(opTab, catalogReader, typeFactory, config);
     }
 
     protected void validateFeature(

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8368,7 +8368,7 @@ class SqlValidatorTest extends SqlValidatorTestCase {
         + "FROM `EMP`";
     sql(sql)
         .withValidatorCallRewrite(false)
-        .rewritesTo(tester.getValidator().shouldExpandIdentifiers()
+        .rewritesTo(tester.getValidator().config().identifierExpansion()
             ? expected1 : expected2);
   }
 
@@ -8382,7 +8382,7 @@ class SqlValidatorTest extends SqlValidatorTestCase {
         + "FROM `EMP`";
     sql(sql)
         .withValidatorCallRewrite(true)
-        .rewritesTo(tester.getValidator().shouldExpandIdentifiers()
+        .rewritesTo(tester.getValidator().config().identifierExpansion()
             ? expected1 : expected2);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
@@ -428,26 +428,20 @@ public class SqlValidatorTestCase {
     }
 
     public Sql withValidatorIdentifierExpansion(boolean expansion) {
-      final UnaryOperator<SqlValidator> after = sqlValidator -> {
-        sqlValidator.setIdentifierExpansion(expansion);
-        return sqlValidator;
-      };
+      final UnaryOperator<SqlValidator> after = sqlValidator ->
+          sqlValidator.transform(config -> config.withIdentifierExpansion(expansion));
       return withTester(tester -> addTransform(tester, after));
     }
 
     public Sql withValidatorCallRewrite(boolean rewrite) {
-      final UnaryOperator<SqlValidator> after = sqlValidator -> {
-        sqlValidator.setCallRewrite(rewrite);
-        return sqlValidator;
-      };
+      final UnaryOperator<SqlValidator> after = sqlValidator ->
+          sqlValidator.transform(config -> config.withCallRewrite(rewrite));
       return withTester(tester -> addTransform(tester, after));
     }
 
     public Sql withValidatorColumnReferenceExpansion(boolean expansion) {
-      final UnaryOperator<SqlValidator> after = sqlValidator -> {
-        sqlValidator.setColumnReferenceExpansion(expansion);
-        return sqlValidator;
-      };
+      final UnaryOperator<SqlValidator> after = sqlValidator ->
+          sqlValidator.transform(config -> config.withColumnReferenceExpansion(expansion));
       return withTester(tester -> addTransform(tester, after));
     }
 


### PR DESCRIPTION
The SqlValidator now has 7 setXXX methods for all kinds of control flags,
which is hard for code evolving.

There is also no way to config these things through the FrameworkConfig.

Add a SqlValidator.Config to solve these problems.