### PR TITLE
[CALCITE-3893] [CALCITE-3895] SQL with GROUP_ID may generate wrong plan

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
@@ -118,7 +118,9 @@ public abstract class Aggregate extends SingleRel implements Hintable {
   /**
    * Creates an Aggregate.
    *
-   * <p>All members of {@code groupSets} must be sub-sets of {@code groupSet}.
+   * <p> The union of {@code groupSets} members should equal to {@code groupSet}. That is,
+   *  i) All members of {@code groupSets} must be sub-sets of {@code groupSet}
+   *  ii) The union of {@code groupSets} members must contain {@code groupSet}
    * For a simple {@code GROUP BY}, {@code groupSets} is a singleton list
    * containing {@code groupSet}.
    *
@@ -158,9 +160,8 @@ public abstract class Aggregate extends SingleRel implements Hintable {
     } else {
       this.groupSets = ImmutableList.copyOf(groupSets);
       assert ImmutableBitSet.ORDERING.isStrictlyOrdered(groupSets) : groupSets;
-      for (ImmutableBitSet set : groupSets) {
-        assert groupSet.contains(set);
-      }
+      assert ImmutableBitSet.union(groupSets).equals(groupSet)
+          : "the union of group sets should equal to group set";
     }
     assert groupSet.length() <= input.getRowType().getFieldCount();
     for (AggregateCall aggCall : aggCalls) {

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -1082,6 +1082,29 @@ public class RelBuilderTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3895">[CALCITE-3895]
+   * When the group sets of Aggregate is not null,
+   * union of its members should contain group key</a>. */
+  @Test void testAggregate6() {
+    // Equivalent SQL (illegal):
+    //   SELECT deptno, count(*) AS C
+    //   FROM emp
+    //   GROUP BY grouping sets (())
+    final RelBuilder builder = RelBuilder.create(config().build());
+    final AssertionError error = assertThrows(AssertionError.class, () -> {
+      builder.scan("EMP")
+          .aggregate(
+              builder.groupKey(ImmutableBitSet.of(0),
+              (Iterable<ImmutableBitSet>) ImmutableList.of(
+                  ImmutableBitSet.of())),
+              builder.countStar("C"))
+          .build();
+    });
+    assertThat(error.getMessage(),
+        containsString("the union of group sets should equal to group set"));
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3839">[CALCITE-3839]
    * After calling RelBuilder.aggregate, cannot lookup field by name</a>. */
   @Test public void testAggregateAndThenProjectNamedField() {

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1761,7 +1761,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
         LogicalAggregate.create(join,
             ImmutableList.of(),
             ImmutableBitSet.of(2, 0),
-            ImmutableList.of(),
+            null,
             ImmutableList.of(
                 AggregateCall.create(SqlStdOperatorTable.COUNT,
                     false, false, false, ImmutableIntList.of(),

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3716,6 +3716,39 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3893">[CALCITE-3893]
+   * SQL with GROUP_ID may generate wrong plan</a>. */
+  @Test public void testGroupId0() {
+    final String sql = "select deptno, group_id() as g, count(*) as c\n"
+        + "from emp\n"
+        + "group by grouping sets (deptno, (), ())";
+    sql(sql).ok();
+  }
+
+  @Test public void testGroupId1() {
+    final String sql = "select deptno, group_id() as g, grouping(deptno) as g1, count(*) as c\n"
+        + "from emp\n"
+        + "group by grouping sets (deptno, (), ())";
+    sql(sql).ok();
+  }
+
+  @Test public void testGroupId2() {
+    final String sql = "select deptno, group_id() as g, grouping(deptno) as g1, count(*) as c\n"
+        + "from emp\n"
+        + "group by grouping sets (deptno, deptno, ())";
+    sql(sql).ok();
+  }
+
+  @Test public void testGroupId3() {
+    final String sql = "select deptno, job, empno, ename, sum(sal) sumsal, "
+        + "group_id() as gid, grouping_id(deptno, job, empno) as g1, grouping(empno) as g2\n"
+        + "from emp\n"
+        + "group by grouping sets((deptno,job,empno,ename), "
+        + "(deptno,job), deptno, deptno, (), ())";
+    sql(sql).ok();
+  }
+
   /**
    * Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3826">[CALCITE-3826]

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6624,4 +6624,85 @@ LogicalProject(EXPR$0=[CASE(IS NOT NULL($3), CAST($3):INTEGER NOT NULL, 0)])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testGroupId0">
+        <Resource name="sql">
+            <![CDATA[select deptno, group_id() as g, count(*) as c
+                     from emp
+                     group by grouping sets (deptno, (), ())]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalUnion(all=[true])
+  LogicalProject(DEPTNO=[$0], G=[0:BIGINT], C=[$1])
+    LogicalAggregate(group=[{0}], groups=[[{0}, {}]], C=[COUNT()])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(DEPTNO=[null:INTEGER], G=[1:BIGINT], C=[$0])
+    LogicalAggregate(group=[{}], C=[COUNT()])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testGroupId1">
+        <Resource name="sql">
+            <![CDATA[select deptno, group_id() as g, grouping(deptno) as g1, count(*) as c
+                     from emp
+                     group by grouping sets (deptno, (), ())]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalUnion(all=[true])
+  LogicalProject(DEPTNO=[$0], G=[0:BIGINT], G1=[$1], C=[$2])
+    LogicalAggregate(group=[{0}], groups=[[{0}, {}]], G1=[GROUPING($0)], C=[COUNT()])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(DEPTNO=[null:INTEGER], G=[1:BIGINT], G1=[1:BIGINT], C=[$0])
+    LogicalAggregate(group=[{}], C=[COUNT()])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testGroupId2">
+        <Resource name="sql">
+            <![CDATA[select deptno, group_id() as g, grouping(deptno) as g1, count(*) as c
+                     from emp
+                     group by grouping sets (deptno, deptno, ())]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalUnion(all=[true])
+  LogicalProject(DEPTNO=[$0], G=[0:BIGINT], G1=[$1], C=[$2])
+    LogicalAggregate(group=[{0}], groups=[[{0}, {}]], G1=[GROUPING($0)], C=[COUNT()])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(DEPTNO=[$0], G=[1:BIGINT], G1=[$1], C=[$2])
+    LogicalAggregate(group=[{0}], G1=[GROUPING($0)], C=[COUNT()])
+      LogicalProject(DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testGroupId3">
+        <Resource name="sql">
+            <![CDATA[select deptno, job, empno, ename, sum(sal) sumsal,
+         group_id() as gid, grouping_id(deptno, job, empno) as g1, grouping(empno) as g2
+   from emp
+   group by grouping sets((deptno,job,empno,ename), (deptno,job), deptno, deptno, (), ())]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalUnion(all=[true])
+  LogicalProject(DEPTNO=[$0], JOB=[$1], EMPNO=[$2], ENAME=[$3], SUMSAL=[$4], GID=[0:BIGINT], G1=[$5], G2=[$6])
+    LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 1, 2, 3}, {0, 1}, {0}, {}]], SUMSAL=[SUM($4)], G1=[GROUPING_ID($0, $1, $2)], G2=[GROUPING($2)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0], ENAME=[$1], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(DEPTNO=[$0], JOB=[null:VARCHAR(10)], EMPNO=[null:INTEGER], ENAME=[null:VARCHAR(20)], SUMSAL=[$1], GID=[1:BIGINT], G1=[+(+(*(*(/(+(+(*(*(/($2, 1), 1), 2), 1), -($2, *(/($2, 1), 1))), 1), 1), 2), 1), -(+(+(*(*(/($2, 1), 1), 2), 1), -($2, *(/($2, 1), 1))), *(/(+(+(*(*(/($2, 1), 1), 2), 1), -($2, *(/($2, 1), 1))), 1), 1)))], G2=[8:BIGINT])
+    LogicalAggregate(group=[{0}], groups=[[{0}, {}]], SUMSAL=[SUM($4)], G1=[GROUPING_ID($0)])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], EMPNO=[$0], ENAME=[$1], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
This PR targets on [CALCITE-3893](https://issues.apache.org/jira/browse/CALCITE-3893) and [CALCITE-3895](https://issues.apache.org/jira/browse/CALCITE-3895).

- Add constraint check on `Aggregate`'s `groupSet` and `groupSets`.
- When rewriting the `group_id()` into `union-all`, we seperate the `groupSets` to many pieces. However, we should not forget to calculate the `groupSet` accordingly.
- Recompute `grouping()` and `grouping_id()` function, which takes `groupSet` as input.