### PR TITLE
[CALCITE-3907] Use username and password for Cassandra also when not specifying port

### DIFF
--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSchema.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSchema.java
@@ -114,7 +114,7 @@ public class CassandraSchema extends AbstractSchema {
    */
   public CassandraSchema(String host, String keyspace, String username, String password,
         SchemaPlus parentSchema, String name) {
-    this(host, DEFAULT_CASSANDRA_PORT, keyspace, null, null, parentSchema, name);
+    this(host, DEFAULT_CASSANDRA_PORT, keyspace, username, password, parentSchema, name);
   }
 
   /**


### PR DESCRIPTION
Fixes the constructor

I am not entirely sure of how to test this... The existing tests are more integration test like, so to test the default port constructor we would need to modify the embedded Cassandra to listen on port 9042, which may cause issues on hosts where a Cassandra instance is already running.
If you have a preferred way please give me feedback and I will add a test accordingly :)