### PR TITLE
[CALCITE-3889] Add apply(Mappings.Mapping) to RelTrait and RelTraitSet

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTrait.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.plan;
 
+import org.apache.calcite.util.mapping.Mappings;
+
 /**
  * RelTrait represents the manifestation of a relational expression trait within
  * a trait definition. For example, a {@code CallingConvention.JAVA} is a trait
@@ -85,4 +87,14 @@ public interface RelTrait {
    * @param planner Planner
    */
   void register(RelOptPlanner planner);
+
+  /**
+   * Applies a mapping to this trait.
+   *
+   * @param mapping   Mapping
+   * @return trait with mapping applied
+   */
+  default <T extends RelTrait> T apply(Mappings.TargetMapping mapping) {
+    return (T) this;
+  }
 }

--- a/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.plan;
 
 import org.apache.calcite.runtime.FlatLists;
+import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 
@@ -247,6 +248,20 @@ public final class RelTraitSet extends AbstractList<RelTrait> {
     }
     final T traitList = traitSupplier.get();
     return replace(index, traitList);
+  }
+
+  /**
+   * Applies a mapping to this traitSet.
+   *
+   * @param mapping   Mapping
+   * @return traitSet with mapping applied
+   */
+  public RelTraitSet apply(Mappings.TargetMapping mapping) {
+    RelTrait[] newTraits = new RelTrait[traits.length];
+    for (int i = 0; i < traits.length; i++) {
+      newTraits[i] = traits[i].apply(mapping);
+    }
+    return cache.getOrAdd(new RelTraitSet(cache, newTraits));
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
@@ -21,8 +21,10 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.runtime.Utilities;
 import org.apache.calcite.util.Util;
+import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -114,6 +116,11 @@ public class RelCollationImpl implements RelCollation {
   }
 
   public void register(RelOptPlanner planner) {}
+
+  @Override public RelCollationImpl apply(
+      final Mappings.TargetMapping mapping) {
+    return (RelCollationImpl) RexUtil.apply(mapping, this);
+  }
 
   public boolean satisfies(RelTrait trait) {
     return this == trait


### PR DESCRIPTION
RelTrait Collation, Distribution have key indices, when we pass down the
traitset to child or propagate to parent operator, we have to remap these keys.
It would be nice to have apply(Mappings.Mapping) on RelTrait and RelTraitSet.
RelDistribution already has the method, but we may want it on every RelTrait
except Convention. (CALCITE-3889)