### PR TITLE
[CALCITE-2593] [CALCITE-2010] Error when transforming multiple collations to single collation

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -7147,6 +7147,28 @@ public class JdbcTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2593">[CALCITE-2593]
+   * Error when transforming multiple collations to single collation</a>. */
+  @Test void testWithinGroupClause7() {
+    CalciteAssert
+        .that()
+        .query("select sum(X + 1) filter (where Y) as S\n"
+            + "from (values (1, TRUE), (2, TRUE)) AS t(X, Y)")
+        .returns("S=5\n");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2010">[CALCITE-2010]
+   * Fails to plan query that is UNION ALL applied to VALUES</a>. */
+  @Test public void testUnionAllValues() {
+    CalciteAssert.hr()
+        .query("select x, y from (values (1, 2)) as t(x, y)\n"
+            + "union all\n"
+            + "select a + b, a - b from (values (3, 4), (5, 6)) as u(a, b)")
+        .returnsUnordered("X=11; Y=-1\nX=1; Y=2\nX=7; Y=-1");
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3565">[CALCITE-3565]
    * Explicitly cast assignable operand types to decimal for udf</a>. */
   @Test void testAssignableTypeCast() {


### PR DESCRIPTION
Just add test cases for the JIRA CALCITE-2593 and CALCITE-2010, which is actually fixed by
f17367e (PR #1860), because parent RelNode never requires MultipleTrait from
child RelNode.