### PR TITLE
[CALCITE-2593] [CALCITE-2010] Plan error when transforming multiple collations to single collation

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregateRule.java
@@ -35,13 +35,13 @@ class EnumerableAggregateRule extends ConverterRule {
 
   public RelNode convert(RelNode rel) {
     final LogicalAggregate agg = (LogicalAggregate) rel;
-    final RelTraitSet traitSet =
-        agg.getTraitSet().replace(EnumerableConvention.INSTANCE);
+    final RelTraitSet traitSet = rel.getCluster()
+        .traitSet().replace(EnumerableConvention.INSTANCE);
     try {
       return new EnumerableAggregate(
           rel.getCluster(),
           traitSet,
-          convert(agg.getInput(), EnumerableConvention.INSTANCE),
+          convert(agg.getInput(), traitSet),
           agg.getGroupSet(),
           agg.getGroupSets(),
           agg.getAggCallList());

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnionRule.java
@@ -22,6 +22,10 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.logical.LogicalUnion;
 
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
 /**
  * Rule to convert an {@link org.apache.calcite.rel.logical.LogicalUnion} to an
  * {@link EnumerableUnion}.
@@ -35,8 +39,10 @@ class EnumerableUnionRule extends ConverterRule {
   public RelNode convert(RelNode rel) {
     final LogicalUnion union = (LogicalUnion) rel;
     final EnumerableConvention out = EnumerableConvention.INSTANCE;
-    final RelTraitSet traitSet = union.getTraitSet().replace(out);
+    final RelTraitSet traitSet = rel.getCluster().traitSet().replace(out);
+    final List<RelNode> newInputs = Lists.transform(
+        union.getInputs(), n -> convert(n, traitSet));
     return new EnumerableUnion(rel.getCluster(), traitSet,
-        convertList(union.getInputs(), out), union.all);
+        newInputs, union.all);
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -7147,6 +7147,35 @@ public class JdbcTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2593">[CALCITE-2593]
+   * Error when transforming multiple collations to single collation</a>. */
+  @Test void testWithinGroupClause7() {
+    CalciteAssert
+        .that()
+        .query("select sum(X + 1) filter (where Y) as S\n"
+            + "from (values (1, TRUE), (2, TRUE)) AS t(X, Y)")
+        .explainContains("EnumerableAggregate(group=[{}], S=[SUM($0) FILTER $1])\n"
+            + "  EnumerableCalc(expr#0..1=[{inputs}], expr#2=[1], expr#3=[+($t0, $t2)], $f0=[$t3], Y=[$t1])\n"
+            + "    EnumerableValues(tuples=[[{ 1, true }, { 2, true }]])\n")
+        .returns("S=5\n");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2010">[CALCITE-2010]
+   * Fails to plan query that is UNION ALL applied to VALUES</a>. */
+  @Test public void testUnionAllValues() {
+    CalciteAssert.hr()
+        .query("select x, y from (values (1, 2)) as t(x, y)\n"
+            + "union all\n"
+            + "select a + b, a - b from (values (3, 4), (5, 6)) as u(a, b)")
+        .explainContains("EnumerableUnion(all=[true])\n"
+            + "  EnumerableValues(tuples=[[{ 1, 2 }]])\n"
+            + "  EnumerableCalc(expr#0..1=[{inputs}], expr#2=[+($t0, $t1)], expr#3=[-($t0, $t1)], EXPR$0=[$t2], EXPR$1=[$t3])\n"
+            + "    EnumerableValues(tuples=[[{ 3, 4 }, { 5, 6 }]])\n")
+        .returnsUnordered("X=11; Y=-1\nX=1; Y=2\nX=7; Y=-1");
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3565">[CALCITE-3565]
    * Explicitly cast assignable operand types to decimal for udf</a>. */
   @Test void testAssignableTypeCast() {


### PR DESCRIPTION
Just add test cases for JIRA CALCITE-2593 and CALCITE-2010, which is actually
fixed by f17367e (PR #1860). But if we turn off abstract converter for
EnumerableConvention, these problems still exist. The root cause is that
EnumerableAggregate and EnumerableUnion make collation request to its children,
but actually they don't require any collation. The fundamental change is fixing
RelCompositeTrait, but that is a long never end discussion.