### PR TITLE
[CALCITE-3921] Support TableModify json serialization and deserialization

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelEnumTypes.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelEnumTypes.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.externalize;
 
 import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.sql.JoinConditionType;
 import org.apache.calcite.sql.JoinType;
 import org.apache.calcite.sql.SqlExplain;
@@ -69,6 +70,7 @@ public abstract class RelEnumTypes {
     register(enumByName, SqlSelectKeyword.class);
     register(enumByName, SqlTrimFunction.Flag.class);
     register(enumByName, TimeUnitRange.class);
+    register(enumByName, TableModify.Operation.class);
     ENUM_BY_NAME = enumByName.build();
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
@@ -199,6 +199,9 @@ public class RelJsonReader {
       public List<RexNode> getExpressionList(String tag) {
         @SuppressWarnings("unchecked")
         final List<Object> jsonNodes = (List) jsonRel.get(tag);
+        if (jsonNodes == null) {
+          return null;
+        }
         final List<RexNode> nodes = new ArrayList<>();
         for (Object jsonNode : jsonNodes) {
           nodes.add(relJson.toRex(this, jsonNode));

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rex.RexNode;
@@ -45,6 +46,13 @@ public final class LogicalTableModify extends TableModify {
       List<RexNode> sourceExpressionList, boolean flattened) {
     super(cluster, traitSet, table, schema, input, operation, updateColumnList,
         sourceExpressionList, flattened);
+  }
+
+  /**
+   * Creates a LogicalTableModify by parsing serialized output.
+   */
+  public LogicalTableModify(RelInput input) {
+    super(input);
   }
 
   @Deprecated // to be removed before 2.0


### PR DESCRIPTION
Currently, trying to serialize a TableModify to json string will cause exception, also for trying to deserialize from json string. See jira [CALCITE-3912](https://issues.apache.org/jira/browse/CALCITE-3921) for full stacktrace.
This PR tries to support serialize TableModify to json string and deserialize from it.