### PR TITLE
[CALCITE-3910] Enhance ProjectJoinTransposeRule to support SemiJoin and AntiJoin

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -93,10 +93,6 @@ public class ProjectJoinTransposeRule extends RelOptRule {
     Project origProj = call.rel(0);
     final Join join = call.rel(1);
 
-    if (!join.getJoinType().projectsRight()) {
-      return; // TODO: support SemiJoin / AntiJoin
-    }
-
     // Normalize the join condition so we don't end up misidentified expanded
     // form of IS NOT DISTINCT FROM as PushProject also visit the filter condition
     // and push down expressions.

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -2750,27 +2750,4 @@ public class RexUtil {
       return simplify.rexBuilder.makeCast(call.getType(), simplifiedNode, matchNullability);
     }
   }
-
-  /**
-   * Utility to fix the inconsistencies of nullable/non-nullable types.
-   */
-  public static class RexInputRefNullabilityFixer extends RexShuttle {
-
-    private final RexBuilder rexBuilder;
-
-    private final RelDataType desiredTypes;
-
-    public RexInputRefNullabilityFixer(RexBuilder rexBuilder, RelDataType desiredTypes) {
-      this.rexBuilder = rexBuilder;
-      this.desiredTypes = desiredTypes;
-    }
-
-    @Override public RexNode visitInputRef(RexInputRef inputRef) {
-      RelDataType desiredType = desiredTypes.getFieldList().get(inputRef.index).getType();
-      if (inputRef.getType().isNullable() != desiredType.isNullable()) {
-        return rexBuilder.makeInputRef(desiredType, inputRef.index);
-      }
-      return inputRef;
-    }
-  }
 }

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -2750,4 +2750,27 @@ public class RexUtil {
       return simplify.rexBuilder.makeCast(call.getType(), simplifiedNode, matchNullability);
     }
   }
+
+  /**
+   * Utility to fix the inconsistencies of nullable/non-nullable types.
+   */
+  public static class RexInputRefNullabilityFixer extends RexShuttle {
+
+    private final RexBuilder rexBuilder;
+
+    private final RelDataType desiredTypes;
+
+    public RexInputRefNullabilityFixer(RexBuilder rexBuilder, RelDataType desiredTypes) {
+      this.rexBuilder = rexBuilder;
+      this.desiredTypes = desiredTypes;
+    }
+
+    @Override public RexNode visitInputRef(RexInputRef inputRef) {
+      RelDataType desiredType = desiredTypes.getFieldList().get(inputRef.index).getType();
+      if (inputRef.getType().isNullable() != desiredType.isNullable()) {
+        return rexBuilder.makeInputRef(desiredType, inputRef.index);
+      }
+      return inputRef;
+    }
+  }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -789,6 +789,84 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  @Test void testSemiJoinProjectTranspose() {
+    final RelBuilder relBuilder = RelBuilder.create(RelBuilderTest.config().build());
+    // build a rel equivalent to sql:
+    // select a.name from dept a
+    // where a.deptno in (select b.deptno * 2 from dept);
+
+    RelNode left = relBuilder.scan("DEPT").build();
+    RelNode right = relBuilder.scan("DEPT")
+        .project(
+            relBuilder.call(
+                SqlStdOperatorTable.MULTIPLY, relBuilder.literal(2), relBuilder.field(0)))
+        .aggregate(relBuilder.groupKey(ImmutableBitSet.of(0))).build();
+
+    RelNode plan = relBuilder.push(left)
+        .push(right)
+        .semiJoin(
+            relBuilder.call(SqlStdOperatorTable.EQUALS,
+                relBuilder.field(2, 0, 0),
+                relBuilder.field(2, 1, 0)))
+        .project(relBuilder.field(1))
+        .build();
+
+    final String planBefore = NL + RelOptUtil.toString(plan);
+
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(ProjectJoinTransposeRule.INSTANCE)
+        .build();
+
+    HepPlanner hepPlanner = new HepPlanner(program);
+    hepPlanner.setRoot(plan);
+    RelNode output = hepPlanner.findBestExp();
+
+    final String planAfter = NL + RelOptUtil.toString(output);
+    final DiffRepository diffRepos = getDiffRepos();
+    diffRepos.assertEquals("planBefore", "${planBefore}", planBefore);
+    diffRepos.assertEquals("planAfter", "${planAfter}", planAfter);
+    SqlToRelTestBase.assertValid(output);
+  }
+
+  @Test void testAntiJoinProjectTranspose() {
+    final RelBuilder relBuilder = RelBuilder.create(RelBuilderTest.config().build());
+    // build a rel equivalent to sql:
+    // select a.name from dept a
+    // where a.deptno not in (select b.deptno * 2 from dept);
+
+    RelNode left = relBuilder.scan("DEPT").build();
+    RelNode right = relBuilder.scan("DEPT")
+        .project(
+            relBuilder.call(
+                SqlStdOperatorTable.MULTIPLY, relBuilder.literal(2), relBuilder.field(0)))
+        .aggregate(relBuilder.groupKey(ImmutableBitSet.of(0))).build();
+
+    RelNode plan = relBuilder.push(left)
+        .push(right)
+        .antiJoin(
+            relBuilder.call(SqlStdOperatorTable.EQUALS,
+                relBuilder.field(2, 0, 0),
+                relBuilder.field(2, 1, 0)))
+        .project(relBuilder.field(1))
+        .build();
+
+    final String planBefore = NL + RelOptUtil.toString(plan);
+
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(ProjectJoinTransposeRule.INSTANCE)
+        .build();
+
+    HepPlanner hepPlanner = new HepPlanner(program);
+    hepPlanner.setRoot(plan);
+    RelNode output = hepPlanner.findBestExp();
+
+    final String planAfter = NL + RelOptUtil.toString(output);
+    final DiffRepository diffRepos = getDiffRepos();
+    diffRepos.assertEquals("planBefore", "${planBefore}", planBefore);
+    diffRepos.assertEquals("planAfter", "${planAfter}", planAfter);
+    SqlToRelTestBase.assertValid(output);
+  }
+
   @Test void testJoinProjectTranspose1() {
     final HepProgram preProgram =
         HepProgram.builder()

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -7353,6 +7353,64 @@ LogicalProject(NAME=[$1])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testSemiJoinProjectTranspose">
+        <Resource name="sql">
+            <![CDATA[select a.name from dept a
+where a.deptno in (select b.deptno * 2 from dept);
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(DNAME=[$1])
+  LogicalJoin(condition=[=($0, $3)], joinType=[semi])
+    LogicalTableScan(table=[[scott, DEPT]])
+    LogicalAggregate(group=[{0}])
+      LogicalProject($f0=[*(2, $0)])
+        LogicalTableScan(table=[[scott, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(DNAME=[$1])
+  LogicalJoin(condition=[=($0, $2)], joinType=[semi])
+    LogicalProject(DEPTNO=[$0], DNAME=[$1])
+      LogicalTableScan(table=[[scott, DEPT]])
+    LogicalProject($f0=[$0])
+      LogicalAggregate(group=[{0}])
+        LogicalProject($f0=[*(2, $0)])
+          LogicalTableScan(table=[[scott, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testAntiJoinProjectTranspose">
+        <Resource name="sql">
+            <![CDATA[select a.name from dept a
+where a.deptno not in (select b.deptno * 2 from dept);
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(DNAME=[$1])
+  LogicalJoin(condition=[=($0, $3)], joinType=[anti])
+    LogicalTableScan(table=[[scott, DEPT]])
+    LogicalAggregate(group=[{0}])
+      LogicalProject($f0=[*(2, $0)])
+        LogicalTableScan(table=[[scott, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(DNAME=[$1])
+  LogicalJoin(condition=[=($0, $2)], joinType=[anti])
+    LogicalProject(DEPTNO=[$0], DNAME=[$1])
+      LogicalTableScan(table=[[scott, DEPT]])
+    LogicalProject($f0=[$0])
+      LogicalAggregate(group=[{0}])
+        LogicalProject($f0=[*(2, $0)])
+          LogicalTableScan(table=[[scott, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testJoinProjectTranspose1">
         <Resource name="sql">
             <![CDATA[select a.name


### PR DESCRIPTION
Currently, ProjectJoinTransposeRule does not support push project pass SemiJoin and AntiJoin.

```
public void onMatch(RelOptRuleCall call) {
  Project origProj = call.rel(0);
  final Join join = call.rel(1);

  if (!join.getJoinType().projectsRight()) {
    return; // TODO: support SemiJoin / AntiJoin
  }
  ...
  ...
}
```