### PR TITLE
[CALCITE-3931] Add LOOKAHEAD(2) for methods defined in createStatemen…

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3938,7 +3938,7 @@ SqlCreate SqlCreate() :
 <#-- additional literal parser methods are included here -->
 <#list parser.createStatementParserMethods as method>
         create = ${method}(s, replace)
-        <#sep>|</#sep>
+        <#sep>| LOOKAHEAD(2) </#sep>
 </#list>
     )
     {


### PR DESCRIPTION
…tParserMethods

The default LOOKAHEAD is 1 which is very probably to conflict,
especially for custom parse block like SqlCreate.

Sets the LOOKAHEAD(2) to reduce conflict.