### PR TITLE
[CALCITE-3884] Correct return type for SIGN with DECIMAL (Kyle Porter)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1714,7 +1714,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       new SqlFunction(
           "SIGN",
           SqlKind.OTHER_FUNCTION,
-          ReturnTypes.ARG0,
+          ReturnTypes.ARG0_OR_EXACT_NO_SCALE,
           null,
           OperandTypes.NUMERIC,
           SqlFunctionCategory.NUMERIC);

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5978,7 +5978,7 @@ public abstract class SqlOperatorBaseTest {
         "^sign('abc')^",
         "Cannot apply 'SIGN' to arguments of type 'SIGN\\(<CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): 'SIGN\\(<NUMERIC>\\)'",
         false);
-    tester.checkType("sign('abc')", "DECIMAL(19, 19) NOT NULL");
+    tester.checkType("sign('abc')", "DECIMAL(19, 0) NOT NULL");
     tester.checkScalar(
         "sign(1)",
         1,
@@ -5993,6 +5993,24 @@ public abstract class SqlOperatorBaseTest {
         "FLOAT NOT NULL");
     tester.checkNull("sign(cast(null as integer))");
     tester.checkNull("sign(cast(null as double))");
+    tester.checkType("sign(cast(0.1 as float))", "FLOAT NOT NULL");
+    tester.checkType("sign(cast(.1 as decimal))", "DECIMAL(19, 0) NOT NULL");
+    tester.checkScalar(
+        "sign(0.1)",
+        1,
+        "DECIMAL(2, 0) NOT NULL");
+    tester.checkScalar(
+        "sign(cast(-0.1 as decimal(2, 0)))",
+        BigDecimal.valueOf(-1),
+        "DECIMAL(2, 0) NOT NULL");
+    tester.checkScalar(
+        "sign(cast(-.1 as decimal(1, 0)))",
+        BigDecimal.valueOf(-1),
+        "DECIMAL(1, 0) NOT NULL");
+    tester.checkScalar(
+        "sign(cast(0.1 as float))",
+        1d,
+        "FLOAT NOT NULL");
   }
 
   @Test void testSinFunc() {


### PR DESCRIPTION
Having a return type that matches the input DECIMAL
when the precision and scale is equivalent means
there can be no whole digits, however the SIGN
function by definition needs to return a whole number.

Change the return type to instead have matching
precision and 0 scale to allow for whole digits.

Change-Id: Iea973818d25c1466215b1d71a6989a5f3fb7e13b