### PR TITLE
[CALCITE-3942] Move type-coercion configurations into SqlValidator.Co…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeCoercionRule.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeCoercionRule.java
@@ -62,8 +62,9 @@ import java.util.Set;
  *     SqlTypeCoercionRules typeCoercionRules = SqlTypeCoercionRules.instance(builder.map);
  *
  *     // Set the SqlTypeCoercionRules instance into the SqlValidator.
- *     SqlValidator validator ...;
- *     validator.setSqlTypeCoercionRules(typeCoercionRules);
+ *     SqlValidator.Config validatorConf ...;
+ *     validatorConf.withTypeCoercionRules(typeCoercionRules);
+ *     // Use this conf to initialize the SqlValidator.
  * </pre>
  */
 public class SqlTypeCoercionRule implements SqlTypeMappingRule {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -44,6 +44,8 @@ import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.type.SqlTypeCoercionRule;
 import org.apache.calcite.sql.validate.implicit.TypeCoercion;
+import org.apache.calcite.sql.validate.implicit.TypeCoercionFactory;
+import org.apache.calcite.sql.validate.implicit.TypeCoercions;
 import org.apache.calcite.util.ImmutableBeans;
 
 import org.apiguardian.api.API;
@@ -868,7 +870,10 @@ public interface SqlValidator {
    * {@link org.apache.calcite.sql.validate.implicit.TypeCoercionImpl}.
    *
    * @param typeCoercion {@link TypeCoercion} instance
+   *
+   * @deprecated Use {@link Config#withTypeCoercionFactory}
    */
+  @Deprecated // to be removed before 1.24
   void setTypeCoercion(TypeCoercion typeCoercion);
 
   /** Get the type coercion instance. */
@@ -884,7 +889,10 @@ public interface SqlValidator {
    *
    * @param typeCoercionRules The {@link SqlTypeCoercionRule} instance, see its documentation
    *                          for how to customize the rules.
+   *
+   * @deprecated Use {@link Config#withTypeCoercionRules}
    */
+  @Deprecated // to be removed before 1.24
   void setSqlTypeCoercionRules(SqlTypeCoercionRule typeCoercionRules);
 
   /** Returns the config of the validator. */
@@ -908,7 +916,8 @@ public interface SqlValidator {
    */
   public interface Config {
     /** Default configuration. */
-    SqlValidator.Config DEFAULT = ImmutableBeans.create(Config.class);
+    SqlValidator.Config DEFAULT = ImmutableBeans.create(Config.class)
+        .withTypeCoercionFactory(TypeCoercions::createTypeCoercion);
 
     /**
      * Returns whether to enable rewrite of "macro-like" calls such as COALESCE.
@@ -1000,6 +1009,35 @@ public interface SqlValidator {
      * @see org.apache.calcite.sql.validate.implicit.TypeCoercionImpl TypeCoercionImpl
      */
     Config withTypeCoercionEnabled(boolean enabled);
+
+    /** Returns the type coercion factory. */
+    @ImmutableBeans.Property
+    TypeCoercionFactory typeCoercionFactory();
+
+    /**
+     * Sets a factory to create type coercion instance that overrides the
+     * default coercion rules defined in
+     * {@link org.apache.calcite.sql.validate.implicit.TypeCoercionImpl}.
+     *
+     * @param factory Factory to create {@link TypeCoercion} instance
+     */
+    Config withTypeCoercionFactory(TypeCoercionFactory factory);
+
+    /** Returns the type coercion rules for explicit type coercion. */
+    @ImmutableBeans.Property
+    SqlTypeCoercionRule typeCoercionRules();
+
+    /**
+     * Sets the {@link SqlTypeCoercionRule} instance which defines the type conversion matrix
+     * for the explicit type coercion.
+     *
+     * <p>The {@code rules} setting should be thread safe. In the default implementation,
+     * it is set to a ThreadLocal variable.
+     *
+     * @param rules The {@link SqlTypeCoercionRule} instance,
+     *              see its documentation for how to customize the rules
+     */
+    Config withTypeCoercionRules(SqlTypeCoercionRule rules);
 
     /** Returns the dialect of SQL (SQL:2003, etc.) this validator recognizes.
      * Default is {@link SqlConformanceEnum#DEFAULT}. */

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -91,7 +91,6 @@ import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.sql.util.SqlVisitor;
 import org.apache.calcite.sql.validate.implicit.TypeCoercion;
-import org.apache.calcite.sql.validate.implicit.TypeCoercions;
 import org.apache.calcite.util.BitString;
 import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -315,7 +314,10 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     groupFinder = new AggFinder(opTab, false, false, true, null, nameMatcher);
     aggOrOverOrGroupFinder = new AggFinder(opTab, true, true, true, null,
         nameMatcher);
-    this.typeCoercion = TypeCoercions.getTypeCoercion(this, config.sqlConformance());
+    this.typeCoercion = config.typeCoercionFactory().create(typeFactory, this);
+    if (config.typeCoercionRules() != null) {
+      SqlTypeCoercionRule.THREAD_PROVIDERS.set(config.typeCoercionRules());
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
@@ -70,10 +70,9 @@ public abstract class AbstractTypeCoercion implements TypeCoercion {
 
   //~ Constructors -----------------------------------------------------------
 
-  AbstractTypeCoercion(SqlValidator validator) {
-    Objects.requireNonNull(validator);
-    this.validator = validator;
-    this.factory = validator.getTypeFactory();
+  AbstractTypeCoercion(RelDataTypeFactory typeFactory, SqlValidator validator) {
+    this.factory = Objects.requireNonNull(typeFactory);
+    this.validator = Objects.requireNonNull(validator);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionFactory.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionFactory.java
@@ -19,15 +19,26 @@ package org.apache.calcite.sql.validate.implicit;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.validate.SqlValidator;
 
-/**
- * Factory class for type coercion instantiation of different sql dialects.
- */
-public class TypeCoercions {
-  private TypeCoercions() {}
+import org.apiguardian.api.API;
 
-  /** Creates a default type coercion instance. */
-  public static TypeCoercion createTypeCoercion(RelDataTypeFactory typeFactory,
-      SqlValidator validator) {
-    return new TypeCoercionImpl(typeFactory, validator);
-  }
+/** Factory for {@link TypeCoercion} objects.
+ *
+ * <p>A type coercion factory allows you to include custom rules of
+ * implicit type coercion. Usually you should inherit the {@link TypeCoercionImpl}
+ * and override the methods that you want to customize.
+ *
+ * <p>This interface is experimental and would change without notice.
+ *
+ * @see SqlValidator.Config#withTypeCoercionFactory
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "1.23")
+public interface TypeCoercionFactory {
+
+  /**
+   * Creates a TypeCoercion.
+   *
+   * @param typeFactory Type factory
+   * @param validator   SQL validator
+   */
+  TypeCoercion create(RelDataTypeFactory typeFactory, SqlValidator validator);
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.sql.validate.implicit;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
@@ -51,8 +52,8 @@ import java.util.stream.Collectors;
  */
 public class TypeCoercionImpl extends AbstractTypeCoercion {
 
-  public TypeCoercionImpl(SqlValidator validator) {
-    super(validator);
+  public TypeCoercionImpl(RelDataTypeFactory typeFactory, SqlValidator validator) {
+    super(typeFactory, validator);
   }
 
   /**


### PR DESCRIPTION
…nfig

SqlValidator.Config is the new role to config all kinds of
configurations of SqlValidator.