### PR TITLE
[CALCITE-3937] Fire rule for RelSubset only when it is derived

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -435,7 +435,9 @@ class RelSet {
     }
     // Fire rule match on subsets as well
     for (RelSubset subset : subsets) {
-      planner.fireRules(subset);
+      if (subset.isDerived()) {
+        planner.fireRules(subset);
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -156,11 +156,11 @@ public class RelSubset extends AbstractRelNode {
     state |= REQUIRED;
   }
 
-  public boolean isDerived() {
+  boolean isDerived() {
     return (state & DERIVED) == DERIVED;
   }
 
-  public boolean isRequired() {
+  boolean isRequired() {
     return (state & REQUIRED) == REQUIRED;
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -1532,7 +1532,8 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     fireRules(rel);
 
     // It's a new subset.
-    if (set.subsets.size() > subsetBeforeCount) {
+    if (set.subsets.size() > subsetBeforeCount
+        && subset.isDerived()) {
       fireRules(subset);
     }
 


### PR DESCRIPTION
It is meaningless to fire rule for RelSubset when it is generated by parent's
trait requirement. (CALCITE-3937)
