### PR TITLE
[CALCITE-3947] AbstractRelOptPlanner.classes should be LinkedHashSet so that rule match order is deterministic across runs

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +61,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
 
   protected final AtomicBoolean cancelFlag;
 
-  private final Set<Class<? extends RelNode>> classes = new HashSet<>();
+  private final Set<Class<? extends RelNode>> classes = new LinkedHashSet<>();
 
   private final Set<Convention> conventions = new HashSet<>();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-3947