### PR TITLE
[CALCITE-3946] Add parser support for MULTISET/SET and VOLATILE in CREATE TABLE statements

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -21,11 +21,17 @@ data: {
 
     # List of import statements.
     imports: [
+      "org.apache.calcite.sql.SqlCreate",
+      "org.apache.calcite.sql.babel.SetType",
+      "org.apache.calcite.sql.babel.SqlCreateTable",
+      "org.apache.calcite.sql.babel.SqlDdlNodes",
     ]
 
     # List of keywords.
     keywords: [
+      "IF"
       "SEMI"
+      "VOLATILE"
     ]
 
     # List of keywords from "keywords" section that are not reserved.
@@ -861,6 +867,7 @@ data: {
     # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls.
     # Each must accept arguments "(SqlParserPos pos, boolean replace)".
     createStatementParserMethods: [
+      "SqlCreateTable"
     ]
 
     # List of methods for parsing extensions to "DROP" calls.

--- a/babel/src/main/java/org/apache/calcite/sql/babel/SetType.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SetType.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.babel;
+
+/**
+ * Enumerates the types of sets.
+ */
+public enum SetType {
+  /**
+   * Set type not specified. Defaults to MULTISET in ANSI mode and SET in
+   * Teradata mode. The way to set the session mode in Teradata depends on what
+   * client software is being used. More information can be found at:
+   * https://docs.teradata.com/reader/Daz9Bt8GiwSdtthYFn~vdw/jDfW4crLGusqMwxGjie8Ww
+   */
+  UNSPECIFIED,
+
+  /**
+   * Duplicate rows are not permitted.
+   */
+  SET,
+
+  /**
+   * Duplicate rows are permitted, in compliance with the ANSI SQL:2011 standard.
+   */
+  MULTISET,
+}

--- a/babel/src/main/java/org/apache/calcite/sql/babel/SqlColumnDeclaration.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SqlColumnDeclaration.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.babel;
+
+import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Parse tree for {@code UNIQUE}, {@code PRIMARY KEY} constraints.
+ *
+ * <p>And {@code FOREIGN KEY}, when we support it.
+ */
+public class SqlColumnDeclaration extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("COLUMN_DECL", SqlKind.COLUMN_DECL);
+
+  public final SqlIdentifier name;
+  public final SqlDataTypeSpec dataType;
+  final SqlNode expression;
+  final ColumnStrategy strategy;
+
+  /** Creates a SqlColumnDeclaration; use {@link SqlDdlNodes#column}. */
+  SqlColumnDeclaration(SqlParserPos pos, SqlIdentifier name,
+      SqlDataTypeSpec dataType, SqlNode expression,
+      ColumnStrategy strategy) {
+    super(pos);
+    this.name = name;
+    this.dataType = dataType;
+    this.expression = expression;
+    this.strategy = strategy;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableList.of(name, dataType);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    name.unparse(writer, 0, 0);
+    dataType.unparse(writer, 0, 0);
+    if (dataType.getNullable() != null && !dataType.getNullable()) {
+      writer.keyword("NOT NULL");
+    }
+    if (expression != null) {
+      switch (strategy) {
+      case VIRTUAL:
+      case STORED:
+        writer.keyword("AS");
+        exp(writer);
+        writer.keyword(strategy.name());
+        break;
+      case DEFAULT:
+        writer.keyword("DEFAULT");
+        exp(writer);
+        break;
+      default:
+        throw new AssertionError("unexpected: " + strategy);
+      }
+    }
+  }
+
+  private void exp(SqlWriter writer) {
+    if (writer.isAlwaysUseParentheses()) {
+      expression.unparse(writer, 0, 0);
+    } else {
+      writer.sep("(");
+      expression.unparse(writer, 0, 0);
+      writer.sep(")");
+    }
+  }
+}

--- a/babel/src/main/java/org/apache/calcite/sql/babel/SqlCreateTable.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SqlCreateTable.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.babel;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.SqlCreate;
+import org.apache.calcite.sql.SqlExecutableStatement;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code CREATE TABLE} statement.
+ */
+public class SqlCreateTable extends SqlCreate
+    implements SqlExecutableStatement {
+  public final SqlIdentifier name;
+  private final SetType setType;
+  private final boolean isVolatile;
+  public final SqlNodeList columnList;
+  private final SqlNode query;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE);
+
+  /** Creates a SqlCreateTable. */
+  public SqlCreateTable(SqlParserPos pos, boolean replace, SetType setType, boolean isVolatile,
+      boolean ifNotExists, SqlIdentifier name, SqlNodeList columnList, SqlNode query) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.name = Objects.requireNonNull(name);
+    this.setType = setType;
+    this.isVolatile = isVolatile;
+    this.columnList = columnList; // may be null
+    this.query = query; // for "CREATE TABLE ... AS query"; may be null
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, columnList, query);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE");
+    switch (setType) {
+    case SET:
+      writer.keyword("SET");
+      break;
+    case MULTISET:
+      writer.keyword("MULTISET");
+      break;
+    default:
+      break;
+    }
+    if (isVolatile) {
+      writer.keyword("VOLATILE");
+    }
+    writer.keyword("TABLE");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+    if (columnList != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode c : columnList) {
+        writer.sep(",");
+        c.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+    if (query != null) {
+      writer.keyword("AS");
+      writer.newlineAndIndent();
+      query.unparse(writer, 0, 0);
+    }
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/babel/src/main/java/org/apache/calcite/sql/babel/SqlDdlNodes.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SqlDdlNodes.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.babel;
+
+import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Utilities concerning {@link SqlNode} for DDL.
+ *
+ * <p>It was created by copying {@code org.apache.calcite.ddl.DdlNodes}
+ * and then removing the pieces we didn't need. Feel free to add bits back,
+ * but keep them in the same order so that we can diff/merge.
+ */
+public class SqlDdlNodes {
+  private SqlDdlNodes() {}
+
+  /** Creates a column declaration. */
+  public static SqlNode column(SqlParserPos pos, SqlIdentifier name,
+      SqlDataTypeSpec dataType, SqlNode expression, ColumnStrategy strategy) {
+    return new SqlColumnDeclaration(pos, name, dataType, expression, strategy);
+  }
+}

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -255,4 +255,30 @@ class BabelParserTest extends SqlParserTest {
         + "FROM (VALUES (ROW(1, 2))) AS `TBL` (`X`, `Y`)";
     sql(sql).ok(expected);
   }
+
+  @Test public void testCreateTableWithNoSetTypeSpecified() {
+    final String sql = "create table foo (bar integer not null, baz varchar(30))";
+    final String expected = "CREATE TABLE `FOO` (`BAR` INTEGER NOT NULL, `BAZ` VARCHAR(30))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateSetTable() {
+    final String sql = "create set table foo (bar int not null, baz varchar(30))";
+    final String expected = "CREATE SET TABLE `FOO` (`BAR` INTEGER NOT NULL, `BAZ` VARCHAR(30))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateMultisetTable() {
+    final String sql = "create multiset table foo (bar int not null, baz varchar(30))";
+    final String expected = "CREATE MULTISET TABLE `FOO` "
+        + "(`BAR` INTEGER NOT NULL, `BAZ` VARCHAR(30))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateVolatileTable() {
+    final String sql = "create volatile table foo (bar int not null, baz varchar(30))";
+    final String expected = "CREATE VOLATILE TABLE `FOO` "
+        + "(`BAR` INTEGER NOT NULL, `BAZ` VARCHAR(30))";
+    sql(sql).ok(expected);
+  }
 }


### PR DESCRIPTION
The syntax for these statements is:
CREATE TABLE [SET|MULTISET] [VOLATILE] <table_name> [IF NOT EXISTS] (<column_name> <data_type>, ...);

Support is added by extending the Babel parser.