### PR TITLE
[CALCITE-3954] Always compare types using equals

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -2160,7 +2160,7 @@ public abstract class RelOptUtil {
   }
 
   /**
-   * Returns whether two types are equal using '='.
+   * Returns whether two types are equal using 'equals'.
    *
    * @param desc1 Description of first type
    * @param type1 First type
@@ -2181,7 +2181,7 @@ public abstract class RelOptUtil {
       return litmus.succeed();
     }
 
-    if (type1 != type2) {
+    if (!type1.equals(type2)) {
       return litmus.fail("type mismatch:\n{}:\n{}\n{}:\n{}",
           desc1, type1.getFullTypeString(),
           desc2, type2.getFullTypeString());

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -180,11 +180,9 @@ public abstract class RelDataTypeImpl
   }
 
   @Override public boolean equals(Object obj) {
-    if (obj instanceof RelDataTypeImpl) {
-      final RelDataTypeImpl that = (RelDataTypeImpl) obj;
-      return this.digest.equals(that.digest);
-    }
-    return false;
+    return this == obj
+        || obj instanceof RelDataTypeImpl
+          && this.digest.equals(((RelDataTypeImpl) obj).digest);
   }
 
   @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/rex/RexLocalRef.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLocalRef.java
@@ -63,7 +63,7 @@ public class RexLocalRef extends RexSlot {
   public boolean equals(Object obj) {
     return this == obj
         || obj instanceof RexLocalRef
-        && this.type == ((RexLocalRef) obj).type
+        && Objects.equals(this.type, ((RexLocalRef) obj).type)
         && this.index == ((RexLocalRef) obj).index;
   }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -2601,13 +2601,13 @@ public class RexUtil {
     @Override public RexNode visitInputRef(RexInputRef ref) {
       final RelDataType rightType = typeList.get(ref.getIndex());
       final RelDataType refType = ref.getType();
-      if (refType == rightType) {
+      if (refType.equals(rightType)) {
         return ref;
       }
       final RelDataType refType2 =
           rexBuilder.getTypeFactory().createTypeWithNullability(refType,
               rightType.isNullable());
-      if (refType2 == rightType) {
+      if (refType2.equals(rightType)) {
         return new RexInputRef(ref.getIndex(), refType2);
       }
       throw new AssertionError("mismatched type " + ref + " " + rightType);

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -820,7 +820,7 @@ public abstract class SqlTypeUtil {
       RelDataType toType,
       RelDataType fromType,
       boolean coerce) {
-    if (toType == fromType) {
+    if (toType.equals(fromType)) {
       return true;
     }
     if (isAny(toType) || isAny(fromType)) {


### PR DESCRIPTION
Current interning of types use weak references.
Change from MUST intern to SHOULD intern, and always
compare types using equals.

We clearly want to do some interning, especially within a query, so that
there aren't hundreds of copies of the same record type all over the
place. But if people don't intern, or intern in different query-specific
caches, then the logic will still work.

If equals is written using the standard template
```java
return this == o
  || o instanceof TheType && field1 == o.field1 && field2 == o.field2
```
(that is, avoiding deep comparison if possible) then the performance
will be pretty much the same.