### PR TITLE
[CALCITE-3956] Unify comparison logic for RelOptCost

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptCost.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+/**
+ * The super class for concrete {@link RelOptCost} classes.
+ * Please note that it concentrates the comparison logic into a single method
+ * to avoid the problems of duplicate/contradicting logic.
+ * So client code is supposed to extend this class, rather than directly implementing
+ * the {@link RelOptCost} interface.
+ */
+public abstract class AbstractRelOptCost implements RelOptCost {
+
+  /**
+   * This is used to represent the result of comparing two {@link RelOptCost} objects.
+   * Please note that a set of {@link RelOptCost} objects forms a partial order,
+   * so there can be objects that cannot be compared. We use UD to represent
+   * the results of such comparisons.
+   */
+  public enum ComparisonResult {
+    /**
+     * Less than.
+     */
+    LT,
+
+    /**
+     * Equal to.
+     */
+    EQ,
+
+    /**
+     * Greater than.
+     */
+    GT,
+
+    /**
+     * Undefined.
+     */
+    UD;
+
+    /**
+     * Converts the result of a signum function to an enum.
+     */
+    public static ComparisonResult signumToEnum(int signum) {
+      if (signum > 0) {
+        return GT;
+      } else if (signum < 0) {
+        return LT;
+      } else {
+        // signum == 0
+        return EQ;
+      }
+    }
+  }
+
+  /**
+   * Compare two {@link RelOptCost} objects.
+   * @param cost the other cost to compare.
+   * @return the comparison result.
+   */
+  public abstract ComparisonResult compareCost(RelOptCost cost);
+
+  /**
+   * Compares this to another cost.
+   * This is based on the implementation of method {@link #compareCost(RelOptCost)},
+   *  and is not intended to be overridden.
+   *
+   * @param cost another cost
+   * @return true iff this is less than or equal to other cost
+   */
+  @Override public final boolean isLe(RelOptCost cost) {
+    ComparisonResult result = compareCost(cost);
+    return result == ComparisonResult.LT || result == ComparisonResult.EQ;
+  }
+
+  /**
+   * Compares this to another cost.
+   * This is based on the implementation of method {@link #compareCost(RelOptCost)},
+   * and is not intended to be overridden.
+   *
+   * @param cost another cost
+   * @return true iff this is strictly less than other cost
+   */
+  @Override public final boolean isLt(RelOptCost cost) {
+    return compareCost(cost) == ComparisonResult.LT;
+  }
+
+  /**
+   * Compares this to another cost.
+   * This is based on the implementation of  method {@link #compareCost(RelOptCost)},
+   * and is not intended to be overridden.
+   *
+   * @param cost another cost
+   * @return true iff this is exactly equal to other cost
+   */
+  @Override public final boolean equals(RelOptCost cost) {
+    return compareCost(cost) == ComparisonResult.EQ;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
@@ -27,49 +27,6 @@ package org.apache.calcite.plan;
  * with additional cost metrics such as memory usage.
  */
 public interface RelOptCost {
-
-  /**
-   * This is used to represent the result of comparing two {@link RelOptCost} objects.
-   * Please note that a set of {@link RelOptCost} objects forms a partial order,
-   * so there can be objects that cannot be compared. We use UD to represent
-   * the results of such comparisons.
-   */
-  enum ComparisonResult {
-    /**
-     * Less than.
-     */
-    LT,
-
-    /**
-     * Equal to.
-     */
-    EQ,
-
-    /**
-     * Greater than.
-     */
-    GT,
-
-    /**
-     * Undefined.
-     */
-    UD;
-
-    /**
-     * Converts the result of a signum function to an enum.
-     */
-    public static ComparisonResult signumToEnum(int signum) {
-      if (signum > 0) {
-        return GT;
-      } else if (signum < 0) {
-        return LT;
-      } else {
-        // signum == 0
-        return EQ;
-      }
-    }
-  }
-
   //~ Methods ----------------------------------------------------------------
 
   /**
@@ -101,25 +58,12 @@ public interface RelOptCost {
   // to Comparator/equals/hashCode
 
   /**
-   * Compare two {@link RelOptCost} objects.
-   * @param cost the other cost to compare.
-   * @return the comparison result.
-   */
-  default ComparisonResult compareCost(RelOptCost cost) {
-    return ComparisonResult.UD;
-  }
-
-  /**
    * Compares this to another cost.
-   * This is based on the implementation of  method {@link #compareCost(RelOptCost)},
-   * and is not intended to be overridden.
    *
    * @param cost another cost
    * @return true iff this is exactly equal to other cost
    */
-  default boolean equals(RelOptCost cost) {
-    return compareCost(cost) == ComparisonResult.EQ;
-  }
+  boolean equals(RelOptCost cost);
 
   /**
    * Compares this to another cost, allowing for slight roundoff errors.
@@ -132,28 +76,19 @@ public interface RelOptCost {
 
   /**
    * Compares this to another cost.
-   * This is based on the implementation of method {@link #compareCost(RelOptCost)},
-   *  and is not intended to be overridden.
    *
    * @param cost another cost
    * @return true iff this is less than or equal to other cost
    */
-  default boolean isLe(RelOptCost cost) {
-    ComparisonResult result = compareCost(cost);
-    return result == ComparisonResult.LT || result == ComparisonResult.EQ;
-  }
+  boolean isLe(RelOptCost cost);
 
   /**
    * Compares this to another cost.
-   * This is based on the implementation of method {@link #compareCost(RelOptCost)},
-   * and is not intended to be overridden.
    *
    * @param cost another cost
    * @return true iff this is strictly less than other cost
    */
-  default boolean isLt(RelOptCost cost) {
-    return compareCost(cost) == ComparisonResult.LT;
-  }
+  boolean isLt(RelOptCost cost);
 
   /**
    * Adds another cost to this.

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
@@ -26,7 +26,7 @@ package org.apache.calcite.plan;
  * Optimizers which supply their own cost models may also extend this interface
  * with additional cost metrics such as memory usage.
  */
-public interface RelOptCost {
+public interface RelOptCost extends Comparable<RelOptCost> {
   //~ Methods ----------------------------------------------------------------
 
   /**
@@ -63,7 +63,10 @@ public interface RelOptCost {
    * @param cost another cost
    * @return true iff this is exactly equal to other cost
    */
-  boolean equals(RelOptCost cost);
+  @Deprecated
+  default boolean equals(RelOptCost cost) {
+    return this.compareTo(cost) == 0;
+  }
 
   /**
    * Compares this to another cost, allowing for slight roundoff errors.
@@ -80,7 +83,10 @@ public interface RelOptCost {
    * @param cost another cost
    * @return true iff this is less than or equal to other cost
    */
-  boolean isLe(RelOptCost cost);
+  @Deprecated
+  default boolean isLe(RelOptCost cost) {
+    return this.compareTo(cost) <= 0;
+  }
 
   /**
    * Compares this to another cost.
@@ -88,7 +94,10 @@ public interface RelOptCost {
    * @param cost another cost
    * @return true iff this is strictly less than other cost
    */
-  boolean isLt(RelOptCost cost);
+  @Deprecated
+  default boolean isLt(RelOptCost cost) {
+    return this.compareTo(cost) < 0;
+  }
 
   /**
    * Adds another cost to this.

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
@@ -59,15 +59,13 @@ public interface RelOptCost {
      * Converts the result of a signum function to an enum.
      */
     public static ComparisonResult signumToEnum(int signum) {
-      switch (signum) {
-      case -1:
-        return LT;
-      case 0:
-        return EQ;
-      case 1:
+      if (signum > 0) {
         return GT;
-      default:
-        return UD;
+      } else if (signum < 0) {
+        return LT;
+      } else {
+        // signum == 0
+        return EQ;
       }
     }
   }
@@ -107,7 +105,9 @@ public interface RelOptCost {
    * @param cost the other cost to compare.
    * @return the comparison result.
    */
-  ComparisonResult compareCost(RelOptCost cost);
+  default ComparisonResult compareCost(RelOptCost cost) {
+    return ComparisonResult.UD;
+  }
 
   /**
    * Compares this to another cost.

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
@@ -57,30 +57,19 @@ public class RelOptCostImpl implements RelOptCost {
     return Double.isInfinite(value);
   }
 
-  // implement RelOptCost
-  public boolean isLe(RelOptCost other) {
-    return getRows() <= other.getRows();
-  }
-
-  // implement RelOptCost
-  public boolean isLt(RelOptCost other) {
-    return getRows() < other.getRows();
-  }
-
   @Override public int hashCode() {
     return Double.hashCode(getRows());
   }
 
-  // implement RelOptCost
-  public boolean equals(RelOptCost other) {
-    return getRows() == other.getRows();
-  }
-
   @Override public boolean equals(Object obj) {
     if (obj instanceof RelOptCostImpl) {
-      return equals((RelOptCost) obj);
+      return getRows() == ((RelOptCostImpl) obj).getRows();
     }
     return false;
+  }
+
+  @Override public int compareTo(RelOptCost other) {
+    return Double.compare(this.getRows(), other.getRows());
   }
 
   // implement RelOptCost

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
@@ -69,6 +69,9 @@ public class RelOptCostImpl implements RelOptCost {
   }
 
   @Override public ComparisonResult compareCost(RelOptCost other) {
+    if (Double.isNaN(this.getRows()) || Double.isNaN(other.getRows())) {
+      return ComparisonResult.UD;
+    }
     return ComparisonResult.signumToEnum(Double.compare(this.getRows(), other.getRows()));
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
@@ -68,8 +68,8 @@ public class RelOptCostImpl implements RelOptCost {
     return false;
   }
 
-  @Override public int compareTo(RelOptCost other) {
-    return Double.compare(this.getRows(), other.getRows());
+  @Override public ComparisonResult compareCost(RelOptCost other) {
+    return ComparisonResult.signumToEnum(Double.compare(this.getRows(), other.getRows()));
   }
 
   // implement RelOptCost

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
@@ -22,7 +22,7 @@ package org.apache.calcite.plan;
  * arbitrarily, it returns this scalar for rows processed and zero for both CPU
  * and I/O.
  */
-public class RelOptCostImpl implements RelOptCost {
+public class RelOptCostImpl extends AbstractRelOptCost {
   public static final RelOptCostFactory FACTORY = new Factory();
 
   //~ Instance fields --------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
@@ -114,6 +114,9 @@ class VolcanoCost implements RelOptCost {
 
   @Override public ComparisonResult compareCost(RelOptCost other) {
     VolcanoCost that = (VolcanoCost) other;
+    if (Double.isNaN(this.rowCount) || Double.isNaN(that.rowCount)) {
+      return ComparisonResult.UD;
+    }
     return ComparisonResult.signumToEnum(Double.compare(this.rowCount, that.rowCount));
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.plan.volcano;
 
+import org.apache.calcite.plan.AbstractRelOptCost;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptCostFactory;
 import org.apache.calcite.plan.RelOptUtil;
@@ -28,7 +29,7 @@ import java.util.Objects;
  * <p>This class is immutable: none of the methods modify any member
  * variables.</p>
  */
-class VolcanoCost implements RelOptCost {
+class VolcanoCost extends AbstractRelOptCost {
   //~ Static fields/initializers ---------------------------------------------
 
   static final VolcanoCost INFINITY =

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
@@ -95,26 +95,6 @@ class VolcanoCost implements RelOptCost {
     return io;
   }
 
-  public boolean isLe(RelOptCost other) {
-    VolcanoCost that = (VolcanoCost) other;
-    if (true) {
-      return this == that
-          || this.rowCount <= that.rowCount;
-    }
-    return (this == that)
-        || ((this.rowCount <= that.rowCount)
-        && (this.cpu <= that.cpu)
-        && (this.io <= that.io));
-  }
-
-  public boolean isLt(RelOptCost other) {
-    if (true) {
-      VolcanoCost that = (VolcanoCost) other;
-      return this.rowCount < that.rowCount;
-    }
-    return isLe(other) && !equals(other);
-  }
-
   public double getRows() {
     return rowCount;
   }
@@ -123,19 +103,18 @@ class VolcanoCost implements RelOptCost {
     return Objects.hash(rowCount, cpu, io);
   }
 
-  public boolean equals(RelOptCost other) {
-    return this == other
-        || other instanceof VolcanoCost
-        && (this.rowCount == ((VolcanoCost) other).rowCount)
-        && (this.cpu == ((VolcanoCost) other).cpu)
-        && (this.io == ((VolcanoCost) other).io);
-  }
-
   @Override public boolean equals(Object obj) {
     if (obj instanceof VolcanoCost) {
-      return equals((VolcanoCost) obj);
+      return (this.rowCount == ((VolcanoCost) obj).rowCount)
+          && (this.cpu == ((VolcanoCost) obj).cpu)
+          && (this.io == ((VolcanoCost) obj).io);
     }
     return false;
+  }
+
+  @Override public int compareTo(RelOptCost other) {
+    VolcanoCost that = (VolcanoCost) other;
+    return Double.compare(this.rowCount, that.rowCount);
   }
 
   public boolean isEqWithEpsilon(RelOptCost other) {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
@@ -112,9 +112,9 @@ class VolcanoCost implements RelOptCost {
     return false;
   }
 
-  @Override public int compareTo(RelOptCost other) {
+  @Override public ComparisonResult compareCost(RelOptCost other) {
     VolcanoCost that = (VolcanoCost) other;
-    return Double.compare(this.rowCount, that.rowCount);
+    return ComparisonResult.signumToEnum(Double.compare(this.rowCount, that.rowCount));
   }
 
   public boolean isEqWithEpsilon(RelOptCost other) {

--- a/core/src/test/java/org/apache/calcite/test/MockRelOptCost.java
+++ b/core/src/test/java/org/apache/calcite/test/MockRelOptCost.java
@@ -18,6 +18,8 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.plan.RelOptCost;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * MockRelOptCost is a mock implementation of the {@link RelOptCost} interface.
  * TODO: constructors for various scenarios
@@ -47,20 +49,12 @@ public class MockRelOptCost implements RelOptCost {
     return 0;
   }
 
-  public boolean isLe(RelOptCost cost) {
-    return true;
-  }
-
-  public boolean isLt(RelOptCost cost) {
-    return false;
-  }
-
   public double getRows() {
     return 0;
   }
 
-  public boolean equals(RelOptCost cost) {
-    return true;
+  @Override public int compareTo(@NotNull RelOptCost o) {
+    return 0;
   }
 
   public boolean isEqWithEpsilon(RelOptCost cost) {

--- a/core/src/test/java/org/apache/calcite/test/MockRelOptCost.java
+++ b/core/src/test/java/org/apache/calcite/test/MockRelOptCost.java
@@ -16,13 +16,14 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.plan.AbstractRelOptCost;
 import org.apache.calcite.plan.RelOptCost;
 
 /**
  * MockRelOptCost is a mock implementation of the {@link RelOptCost} interface.
  * TODO: constructors for various scenarios
  */
-public class MockRelOptCost implements RelOptCost {
+public class MockRelOptCost extends AbstractRelOptCost {
   //~ Methods ----------------------------------------------------------------
 
   @Override public boolean equals(Object obj) {
@@ -51,7 +52,7 @@ public class MockRelOptCost implements RelOptCost {
     return 0;
   }
 
-  @Override public ComparisonResult compareCost(RelOptCost o) {
+  @Override public AbstractRelOptCost.ComparisonResult compareCost(RelOptCost o) {
     return ComparisonResult.EQ;
   }
 

--- a/core/src/test/java/org/apache/calcite/test/MockRelOptCost.java
+++ b/core/src/test/java/org/apache/calcite/test/MockRelOptCost.java
@@ -18,8 +18,6 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.plan.RelOptCost;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * MockRelOptCost is a mock implementation of the {@link RelOptCost} interface.
  * TODO: constructors for various scenarios
@@ -53,8 +51,8 @@ public class MockRelOptCost implements RelOptCost {
     return 0;
   }
 
-  @Override public int compareTo(@NotNull RelOptCost o) {
-    return 0;
+  @Override public ComparisonResult compareCost(RelOptCost o) {
+    return ComparisonResult.EQ;
   }
 
   public boolean isEqWithEpsilon(RelOptCost cost) {


### PR DESCRIPTION
Currently, comparisons between RelOptCost objects are based on 3 methods:
1. ``boolean isLe(RelOptCost cost)``
2. ``boolean isLt(RelOptCost cost)``
3. ``boolean equals(RelOptCost cost)``

The 3 methods used in combination determine the relation between RelOptCost objects.

There are some problems with this implementation:
1. Some logic is duplicate in the above methods, making it difficult to maintain.
2. To determine the relation between RelOptCost objects, we often need to call more than one comparison methods, leading to performance overhead.
3. Since the logic is spread in multiple methods, it is easy to end up with contradictive comparison logic, which will suprise the users. For example, the following assertion should hold according to common sense:

``if a >=b, then we have a > b or a == b``

However, with the current implementation of VolcanoCost, we can easily create instances that violate the above assertion.

To solve the problems, we want to make RelOptCost extends the Comparable<RelOptCost>, so the comparison logic is unified in the compareTo method, which solves the above problems.