### PR TITLE
[CALCITE-3961] VolcanoPlanner.prunedNodes information is lost when duplicate relNode is discarded

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -124,11 +124,6 @@ public class VolcanoRuleCall extends RelOptRuleCall {
         volcanoPlanner.getListener().ruleProductionSucceeded(event);
       }
 
-      final RelNode relCopy = rel;
-      if (rels[0].getInputs().stream().anyMatch(n -> n == relCopy)) {
-        volcanoPlanner.prune(rels[0]);
-      }
-
       if (this.getRule() instanceof SubstitutionRule
           && ((SubstitutionRule) getRule()).autoPruneOld()) {
         volcanoPlanner.prune(rels[0]);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-3961