### PR TITLE
[CALCITE-3949] RelDistributions.of() and RelCollations.of() should canonize trait instance

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/RelCollations.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollations.java
@@ -64,19 +64,22 @@ public class RelCollations {
   }
 
   public static RelCollation of(List<RelFieldCollation> fieldCollations) {
+    RelCollation collation;
     if (Util.isDistinct(ordinals(fieldCollations))) {
-      return new RelCollationImpl(ImmutableList.copyOf(fieldCollations));
-    }
-    // Remove field collations whose field has already been seen
-    final ImmutableList.Builder<RelFieldCollation> builder =
-        ImmutableList.builder();
-    final Set<Integer> set = new HashSet<>();
-    for (RelFieldCollation fieldCollation : fieldCollations) {
-      if (set.add(fieldCollation.getFieldIndex())) {
-        builder.add(fieldCollation);
+      collation = new RelCollationImpl(ImmutableList.copyOf(fieldCollations));
+    } else {
+      // Remove field collations whose field has already been seen
+      final ImmutableList.Builder<RelFieldCollation> builder =
+          ImmutableList.builder();
+      final Set<Integer> set = new HashSet<>();
+      for (RelFieldCollation fieldCollation : fieldCollations) {
+        if (set.add(fieldCollation.getFieldIndex())) {
+          builder.add(fieldCollation);
+        }
       }
+      collation = new RelCollationImpl(builder.build());
     }
-    return new RelCollationImpl(builder.build());
+    return RelCollationTraitDef.INSTANCE.canonize(collation);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
@@ -67,21 +67,18 @@ public class RelDistributions {
         && !Ordering.natural().isOrdered(list)) {
       list = ImmutableIntList.copyOf(Ordering.natural().sortedCopy(list));
     }
-    RelDistributionImpl trait =
-        new RelDistributionImpl(RelDistribution.Type.HASH_DISTRIBUTED, list);
-    return RelDistributionTraitDef.INSTANCE.canonize(trait);
+    return of(RelDistribution.Type.HASH_DISTRIBUTED, list);
   }
 
   /** Creates a range distribution. */
   public static RelDistribution range(Collection<? extends Number> numbers) {
     ImmutableIntList list = ImmutableIntList.copyOf(numbers);
-    RelDistributionImpl trait =
-        new RelDistributionImpl(RelDistribution.Type.RANGE_DISTRIBUTED, list);
-    return RelDistributionTraitDef.INSTANCE.canonize(trait);
+    return of(RelDistribution.Type.RANGE_DISTRIBUTED, list);
   }
 
   public static RelDistribution of(RelDistribution.Type type, ImmutableIntList keys) {
-    return new RelDistributionImpl(type, keys);
+    RelDistribution distribution = new RelDistributionImpl(type, keys);
+    return RelDistributionTraitDef.INSTANCE.canonize(distribution);
   }
 
   /** Implementation of {@link org.apache.calcite.rel.RelDistribution}. */


### PR DESCRIPTION
JIRA: CALCITE-3949