### PR TITLE
[CALCITE-3965] Avoid DiffRepository lock contention

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/DiffRepository.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffRepository.java
@@ -224,7 +224,7 @@ public class DiffRepository {
 
   //~ Methods ----------------------------------------------------------------
 
-  private static URL findFile(Class clazz, final String suffix) {
+  private static URL findFile(Class<?> clazz, final String suffix) {
     // The reference file for class "com.foo.Bar" is "com/foo/Bar.xml"
     String rest = "/" + clazz.getName().replace('.', File.separatorChar)
         + suffix;
@@ -715,7 +715,7 @@ public class DiffRepository {
    * @param clazz Test case class
    * @return The diff repository shared between test cases in this class.
    */
-  public static DiffRepository lookup(Class clazz) {
+  public static DiffRepository lookup(Class<?> clazz) {
     return lookup(clazz, null);
   }
 
@@ -728,7 +728,7 @@ public class DiffRepository {
    * @return The diff repository shared between test cases in this class.
    */
   public static DiffRepository lookup(
-      Class clazz,
+      Class<?> clazz,
       DiffRepository baseRepository) {
     return lookup(clazz, baseRepository, null);
   }
@@ -758,7 +758,7 @@ public class DiffRepository {
    * @param filter    Filters each string returned by the repository
    * @return The diff repository shared between test cases in this class.
    */
-  public static DiffRepository lookup(Class clazz,
+  public static DiffRepository lookup(Class<?> clazz,
       DiffRepository baseRepository,
       Filter filter) {
     final Key key = new Key(clazz, baseRepository, filter);
@@ -789,11 +789,11 @@ public class DiffRepository {
 
   /** Cache key. */
   private static class Key {
-    private final Class clazz;
+    private final Class<?> clazz;
     private final DiffRepository baseRepository;
     private final Filter filter;
 
-    Key(Class clazz, DiffRepository baseRepository, Filter filter) {
+    Key(Class<?> clazz, DiffRepository baseRepository, Filter filter) {
       this.clazz = Objects.requireNonNull(clazz);
       this.baseRepository = baseRepository;
       this.filter = filter;

--- a/core/src/test/java/org/apache/calcite/test/DiffRepository.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffRepository.java
@@ -235,7 +235,7 @@ public class DiffRepository {
    * Expands a string containing one or more variables. (Currently only works
    * if there is one variable.)
    */
-  public synchronized String expand(String tag, String text) {
+  public String expand(String tag, String text) {
     if (text == null) {
       return null;
     } else if (text.startsWith("${")


### PR DESCRIPTION
When many test cases using the same DiffRepository instances are running
on multiple threads, it causes lots of contention because all methods
are synchronized. One of the most used method is
DiffRepository#expand(String, String) which do not alter the state of
the tree in most cases.
    
As the method content itself is thread-safe, remove the synchronized
keyword as it does not bring any extra safety and just increase
artificially the contention around the lock.