### PR TITLE
[CALCITE-3966] Trigger rules for existing RelSubset when it becomes delivered

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/Convention.java
+++ b/core/src/main/java/org/apache/calcite/plan/Convention.java
@@ -63,7 +63,7 @@ public interface Convention extends RelTrait {
    */
   default boolean useAbstractConvertersForConversion(RelTraitSet fromTraits,
       RelTraitSet toTraits) {
-    return true;
+    return false;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -169,14 +169,14 @@ class RelSet {
   }
 
   /**
-   * If the subset is required, convert derived subsets to this subset.
+   * If the subset is required, convert delivered subsets to this subset.
    * Otherwise, convert this subset to required subsets in this RelSet.
-   * The subset can be both required and derived.
+   * The subset can be both required and delivered.
    */
   private void addAbstractConverters(
       RelOptCluster cluster, RelSubset subset, boolean required) {
     List<RelSubset> others = subsets.stream().filter(
-        n -> required ? n.isDerived() : n.isRequired())
+        n -> required ? n.isDelivered() : n.isRequired())
         .collect(Collectors.toList());
 
     for (RelSubset other : others) {
@@ -246,7 +246,7 @@ class RelSet {
         postEquivalenceEvent(planner, subset);
       }
     } else if ((required && !subset.isRequired())
-        || (!required && !subset.isDerived())) {
+        || (!required && !subset.isDelivered())) {
       needsConverter = true;
     }
 
@@ -255,7 +255,7 @@ class RelSet {
     } else if (required) {
       subset.setRequired();
     } else {
-      subset.setDerived();
+      subset.setDelivered();
     }
 
     if (needsConverter) {
@@ -342,12 +342,12 @@ class RelSet {
       RelSubset subset = null;
       RelTraitSet otherTraits = otherSubset.getTraitSet();
 
-      // If it is logical or derived physical traitSet
-      if (otherSubset.isDerived() || !otherSubset.isRequired()) {
+      // If it is logical or delivered physical traitSet
+      if (otherSubset.isDelivered() || !otherSubset.isRequired()) {
         subset = getOrCreateSubset(cluster, otherTraits, false);
       }
 
-      // It may be required only, or both derived and required,
+      // It may be required only, or both delivered and required,
       // in which case, register again.
       if (otherSubset.isRequired()) {
         subset = getOrCreateSubset(cluster, otherTraits, true);

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -76,7 +76,7 @@ public class RelSubset extends AbstractRelNode {
   //~ Static fields/initializers ---------------------------------------------
 
   private static final Logger LOGGER = CalciteTrace.getPlannerTracer();
-  private static final int DERIVED = 1;
+  private static final int DELIVERED = 1;
   private static final int REQUIRED = 2;
 
   //~ Instance fields --------------------------------------------------------
@@ -103,12 +103,17 @@ public class RelSubset extends AbstractRelNode {
 
   /**
    * Physical property state of current subset
-   * 0: logical operators, NONE convention is neither DERIVED nor REQUIRED
-   * 1: traitSet DERIVED from child operators or itself
+   * 0: logical operators, NONE convention is neither DELIVERED nor REQUIRED
+   * 1: traitSet DELIVERED from child operators or itself
    * 2: traitSet REQUIRED from parent operators
-   * 3: both DERIVED and REQUIRED
+   * 3: both DELIVERED and REQUIRED
    */
   private int state = 0;
+
+  /**
+   * This subset should trigger rules when it becomes delivered.
+   */
+  boolean triggerRule = false;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -150,18 +155,22 @@ public class RelSubset extends AbstractRelNode {
     }
   }
 
-  void setDerived() {
-    state |= DERIVED;
+  void setDelivered() {
+    triggerRule = !isDelivered();
+    state |= DELIVERED;
   }
 
   void setRequired() {
+    triggerRule = false;
     state |= REQUIRED;
   }
 
-  public boolean isDerived() {
-    return (state & DERIVED) == DERIVED;
+  @API(since = "1.23", status = API.Status.EXPERIMENTAL)
+  public boolean isDelivered() {
+    return (state & DELIVERED) == DELIVERED;
   }
 
+  @API(since = "1.23", status = API.Status.EXPERIMENTAL)
   public boolean isRequired() {
     return (state & REQUIRED) == REQUIRED;
   }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -1232,7 +1232,8 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     fireRules(rel);
 
     // It's a new subset.
-    if (set.subsets.size() > subsetBeforeCount) {
+    if (set.subsets.size() > subsetBeforeCount
+        || subset.triggerRule) {
       fireRules(subset);
     }
 


### PR DESCRIPTION
Existing RelSubset may be first created by parent trait request, so its state
is required. But when there is a new RelNode in the same RelSet can deliver the
same traitset, we mark the subset as derived/delivered too, in which case, we
should also fire rule for the subset.

JIRA: CALCITE-3966