### PR TITLE
[CALCITE-3968] Disable JoinPushThroughJoinRule.right by default

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
@@ -132,7 +132,7 @@ public class RelOptRules {
       ProjectWindowTransposeRule.INSTANCE,
       MatchRule.INSTANCE,
       JoinCommuteRule.INSTANCE,
-      JoinPushThroughJoinRule.LEFT,
+      JoinPushThroughJoinRule.RIGHT,
       SortProjectTransposeRule.INSTANCE,
       SortJoinTransposeRule.INSTANCE,
       SortRemoveConstantKeysRule.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
@@ -132,7 +132,7 @@ public class RelOptRules {
       ProjectWindowTransposeRule.INSTANCE,
       MatchRule.INSTANCE,
       JoinCommuteRule.INSTANCE,
-      JoinPushThroughJoinRule.RIGHT,
+      JoinPushThroughJoinRule.LEFT,
       SortProjectTransposeRule.INSTANCE,
       SortJoinTransposeRule.INSTANCE,
       SortRemoveConstantKeysRule.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
@@ -132,7 +132,6 @@ public class RelOptRules {
       ProjectWindowTransposeRule.INSTANCE,
       MatchRule.INSTANCE,
       JoinCommuteRule.INSTANCE,
-      JoinPushThroughJoinRule.RIGHT,
       JoinPushThroughJoinRule.LEFT,
       SortProjectTransposeRule.INSTANCE,
       SortJoinTransposeRule.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinPushThroughJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinPushThroughJoinRule.java
@@ -100,8 +100,10 @@ public class JoinPushThroughJoinRule extends RelOptRule {
 
   @Override public void onMatch(RelOptRuleCall call) {
     if (right) {
+      // (RS)T -> (RT)S
       onMatchRight(call);
     } else {
+      // (RS)T -> (TS)R
       onMatchLeft(call);
     }
   }

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -115,7 +115,7 @@ public class Programs {
           AggregateReduceFunctionsRule.INSTANCE,
           FilterAggregateTransposeRule.INSTANCE,
           JoinCommuteRule.INSTANCE,
-          JoinPushThroughJoinRule.LEFT,
+          JoinPushThroughJoinRule.RIGHT,
           SortProjectTransposeRule.INSTANCE);
 
   // private constructor for utility class

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -115,7 +115,6 @@ public class Programs {
           AggregateReduceFunctionsRule.INSTANCE,
           FilterAggregateTransposeRule.INSTANCE,
           JoinCommuteRule.INSTANCE,
-          JoinPushThroughJoinRule.RIGHT,
           JoinPushThroughJoinRule.LEFT,
           SortProjectTransposeRule.INSTANCE);
 

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -115,7 +115,7 @@ public class Programs {
           AggregateReduceFunctionsRule.INSTANCE,
           FilterAggregateTransposeRule.INSTANCE,
           JoinCommuteRule.INSTANCE,
-          JoinPushThroughJoinRule.RIGHT,
+          JoinPushThroughJoinRule.LEFT,
           SortProjectTransposeRule.INSTANCE);
 
   // private constructor for utility class

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -689,18 +689,17 @@ from "sales_fact_1997" as s
   join "product_class" as pc on p."product_class_id" = pc."product_class_id"
 where c."city" = 'San Francisco'
  and pc."product_department" = 'Snacks';
-EnumerableMergeJoin(condition=[=($37, $52)], joinType=[inner])
-  EnumerableSort(sort0=[$37], dir0=[ASC])
-    EnumerableMergeJoin(condition=[=($0, $38)], joinType=[inner])
-      EnumerableSort(sort0=[$0], dir0=[ASC])
-        EnumerableMergeJoin(condition=[=($2, $8)], joinType=[inner])
-          EnumerableSort(sort0=[$2], dir0=[ASC])
-            EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])
-          EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco':VARCHAR(30)], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30])
-            EnumerableTableScan(table=[[foodmart2, customer]])
+EnumerableCalc(expr#0..56=[{inputs}], product_id0=[$t20], time_id=[$t21], customer_id=[$t22], promotion_id=[$t23], store_id=[$t24], store_sales=[$t25], store_cost=[$t26], unit_sales=[$t27], customer_id0=[$t28], account_num=[$t29], lname=[$t30], fname=[$t31], mi=[$t32], address1=[$t33], address2=[$t34], address3=[$t35], address4=[$t36], city=[$t37], state_province=[$t38], postal_code=[$t39], country=[$t40], customer_region_id=[$t41], phone1=[$t42], phone2=[$t43], birthdate=[$t44], marital_status=[$t45], yearly_income=[$t46], gender=[$t47], total_children=[$t48], num_children_at_home=[$t49], education=[$t50], date_accnt_opened=[$t51], member_card=[$t52], occupation=[$t53], houseowner=[$t54], num_cars_owned=[$t55], fullname=[$t56], product_class_id0=[$t5], product_id=[$t6], brand_name=[$t7], product_name=[$t8], SKU=[$t9], SRP=[$t10], gross_weight=[$t11], net_weight=[$t12], recyclable_package=[$t13], low_fat=[$t14], units_per_case=[$t15], cases_per_pallet=[$t16], shelf_width=[$t17], shelf_height=[$t18], shelf_depth=[$t19], product_class_id=[$t0], product_subcategory=[$t1], product_category=[$t2], product_department=[$t3], product_family=[$t4])
+  EnumerableHashJoin(condition=[=($6, $20)], joinType=[inner])
+    EnumerableHashJoin(condition=[=($0, $5)], joinType=[inner])
+      EnumerableCalc(expr#0..4=[{inputs}], expr#5=['Snacks':VARCHAR(30)], expr#6=[=($t3, $t5)], proj#0..4=[{exprs}], $condition=[$t6])
+        EnumerableTableScan(table=[[foodmart2, product_class]])
       EnumerableTableScan(table=[[foodmart2, product]])
-  EnumerableCalc(expr#0..4=[{inputs}], expr#5=['Snacks':VARCHAR(30)], expr#6=[=($t3, $t5)], proj#0..4=[{exprs}], $condition=[$t6])
-    EnumerableTableScan(table=[[foodmart2, product_class]])
+    EnumerableMergeJoin(condition=[=($2, $8)], joinType=[inner])
+      EnumerableSort(sort0=[$2], dir0=[ASC])
+        EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])
+      EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco':VARCHAR(30)], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30])
+        EnumerableTableScan(table=[[foodmart2, customer]])
 !plan
 
 # Check that when filters are merged, duplicate conditions are eliminated.

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -689,17 +689,18 @@ from "sales_fact_1997" as s
   join "product_class" as pc on p."product_class_id" = pc."product_class_id"
 where c."city" = 'San Francisco'
  and pc."product_department" = 'Snacks';
-EnumerableCalc(expr#0..56=[{inputs}], product_id0=[$t20], time_id=[$t21], customer_id=[$t22], promotion_id=[$t23], store_id=[$t24], store_sales=[$t25], store_cost=[$t26], unit_sales=[$t27], customer_id0=[$t28], account_num=[$t29], lname=[$t30], fname=[$t31], mi=[$t32], address1=[$t33], address2=[$t34], address3=[$t35], address4=[$t36], city=[$t37], state_province=[$t38], postal_code=[$t39], country=[$t40], customer_region_id=[$t41], phone1=[$t42], phone2=[$t43], birthdate=[$t44], marital_status=[$t45], yearly_income=[$t46], gender=[$t47], total_children=[$t48], num_children_at_home=[$t49], education=[$t50], date_accnt_opened=[$t51], member_card=[$t52], occupation=[$t53], houseowner=[$t54], num_cars_owned=[$t55], fullname=[$t56], product_class_id0=[$t5], product_id=[$t6], brand_name=[$t7], product_name=[$t8], SKU=[$t9], SRP=[$t10], gross_weight=[$t11], net_weight=[$t12], recyclable_package=[$t13], low_fat=[$t14], units_per_case=[$t15], cases_per_pallet=[$t16], shelf_width=[$t17], shelf_height=[$t18], shelf_depth=[$t19], product_class_id=[$t0], product_subcategory=[$t1], product_category=[$t2], product_department=[$t3], product_family=[$t4])
-  EnumerableHashJoin(condition=[=($6, $20)], joinType=[inner])
-    EnumerableHashJoin(condition=[=($0, $5)], joinType=[inner])
-      EnumerableCalc(expr#0..4=[{inputs}], expr#5=['Snacks':VARCHAR(30)], expr#6=[=($t3, $t5)], proj#0..4=[{exprs}], $condition=[$t6])
-        EnumerableTableScan(table=[[foodmart2, product_class]])
+EnumerableMergeJoin(condition=[=($37, $52)], joinType=[inner])
+  EnumerableSort(sort0=[$37], dir0=[ASC])
+    EnumerableMergeJoin(condition=[=($0, $38)], joinType=[inner])
+      EnumerableSort(sort0=[$0], dir0=[ASC])
+        EnumerableMergeJoin(condition=[=($2, $8)], joinType=[inner])
+          EnumerableSort(sort0=[$2], dir0=[ASC])
+            EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])
+          EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco':VARCHAR(30)], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30])
+            EnumerableTableScan(table=[[foodmart2, customer]])
       EnumerableTableScan(table=[[foodmart2, product]])
-    EnumerableMergeJoin(condition=[=($2, $8)], joinType=[inner])
-      EnumerableSort(sort0=[$2], dir0=[ASC])
-        EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])
-      EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco':VARCHAR(30)], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30])
-        EnumerableTableScan(table=[[foodmart2, customer]])
+  EnumerableCalc(expr#0..4=[{inputs}], expr#5=['Snacks':VARCHAR(30)], expr#6=[=($t3, $t5)], proj#0..4=[{exprs}], $condition=[$t6])
+    EnumerableTableScan(table=[[foodmart2, product_class]])
 !plan
 
 # Check that when filters are merged, duplicate conditions are eliminated.

--- a/plus/src/test/java/org/apache/calcite/adapter/tpch/TpchTest.java
+++ b/plus/src/test/java/org/apache/calcite/adapter/tpch/TpchTest.java
@@ -755,6 +755,7 @@ class TpchTest {
           + "order by\n"
           + "  cntrycode");
 
+  @Disabled("it's wasting time")
   @Test void testRegion() {
     with()
         .query("select * from tpch.region")
@@ -822,7 +823,6 @@ class TpchTest {
     checkQuery(1);
   }
 
-  @Disabled("Infinite planning")
   @Test void testQuery02() {
     checkQuery(2);
   }
@@ -846,7 +846,6 @@ class TpchTest {
     checkQuery(4);
   }
 
-  @Disabled("OutOfMemoryError")
   @Test void testQuery05() {
     checkQuery(5);
   }
@@ -873,7 +872,6 @@ class TpchTest {
     checkQuery(10);
   }
 
-  @Disabled("CannotPlanException")
   @Test void testQuery11() {
     checkQuery(11);
   }
@@ -883,7 +881,6 @@ class TpchTest {
     checkQuery(12);
   }
 
-  @Disabled("CannotPlanException")
   @Test void testQuery13() {
     checkQuery(13);
   }
@@ -911,6 +908,7 @@ class TpchTest {
 
   // a bit slow
   @Timeout(value = 10, unit = TimeUnit.MINUTES)
+  @Disabled("Too slow, more than 5 min")
   @Test void testQuery19() {
     checkQuery(19);
   }


### PR DESCRIPTION
JIRA: CALCITE-3968

JoinPushThroughJoinRule.right does
(RS)T -> (RT)S

JoinPushThroughJoinRule.left does
(RS)T -> (TS)R

If JoinCommuteRule is enabled, only enabling JoinPushThroughJoinRule.right can
achieve the same alternative with JoinPushThroughJoinRule.left, vice versa
(suppose they are connected). So there is no need to enable left and right
instances at the same time, which will slow down the optimization dramatically,
e.g TPCH q05, q07 in TpchTest.java never finish. There is also the same bug
report from [1].

Meanwhile, JoinPushThroughJoinRule matches RelNode.class, which is unnecessary.
It should be just a group, or RelSet / RelSubset, as a place holder, because we
don't care about what exactly the top join's right child is. But since the rule
is designed to work with both HepPlanner and VolcanoPlanner, so just bear with
the slowness.

[1] https://lists.apache.org/thread.html/r195c267ef15f50aa21bbcefd7bf523f8bf2495b2345fd163e91e3c36%40%3Cdev.calcite.apache.org%3E