### PR TITLE
[CALCITE-3969] Method RelTrait.apply(Mappings.Mapping) throws exception when mapping doesn't cover collation or distribution keys

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTrait.java
@@ -96,8 +96,8 @@ public interface RelTrait {
    * <p>Some traits may be changed if the columns order is changed by a mapping of the
    * {@link Project} operator. </p>
    *
-   * <p>For example, if relation {@code ORDER BY a, b} is sorted by columns [0, 1], then the
-   * project {@code SELECT b, a} over this relation will be sorted by columns [1, 0].
+   * <p>For example, if relation {@code SELECT a, b ORDER BY a, b} is sorted by columns [0, 1],
+   * then the project {@code SELECT b, a} over this relation will be sorted by columns [1, 0].
    * In the same time project {@code SELECT b} will not be sorted at all because it doesn't
    * contain the collation prefix and this method will return an empty collation. </p>
    *

--- a/core/src/main/java/org/apache/calcite/plan/RelTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTrait.java
@@ -96,7 +96,7 @@ public interface RelTrait {
    * <p>Some traits may be changed if the columns order is changed by a mapping of the
    * {@link Project} operator. </p>
    *
-   * <p>For example, if relation {@code ORDER a, b} is sorted by columns [0, 1], then the
+   * <p>For example, if relation {@code ORDER BY a, b} is sorted by columns [0, 1], then the
    * project {@code SELECT b, a} over this relation will be sorted by columns [1, 0].
    * In the same time project {@code SELECT b} will not be sorted at all because it doesn't
    * contain the collation prefix and this method will return an empty collation. </p>

--- a/core/src/main/java/org/apache/calcite/plan/RelTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTrait.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.plan;
 
+import org.apache.calcite.rel.RelDistributions;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.util.mapping.Mappings;
 
 /**
@@ -90,6 +92,17 @@ public interface RelTrait {
 
   /**
    * Applies a mapping to this trait.
+   *
+   * <p>Some traits may be changed if the columns order is changed by a mapping of the
+   * {@link Project} operator. </p>
+   *
+   * <p>For example, if relation {@code ORDER a, b} is sorted by columns [0, 1], then the
+   * project {@code SELECT b, a} over this relation will be sorted by columns [1, 0].
+   * In the same time project {@code SELECT b} will not be sorted at all because it doesn't
+   * contain the collation prefix and this method will return an empty collation. </p>
+   *
+   * <p>Other traits are independent from the columns remapping. For example {@link Convention} or
+   * {@link RelDistributions#SINGLETON}.</p>
    *
    * @param mapping   Mapping
    * @return trait with mapping applied

--- a/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
@@ -117,6 +117,22 @@ public class RelCollationImpl implements RelCollation {
 
   public void register(RelOptPlanner planner) {}
 
+  /**
+   * Applies mapping to a given collation.
+   *
+   * If mapping destroys the collation prefix, this method returns an empty collation.
+   * Examples of applying mappings to collation [0, 1]:
+   * mapping(0, 1) => [0, 1]
+   * mapping(1, 0) => [1, 0]
+   * mapping(0) => [0]
+   * mapping(1) => []
+   * mapping(2, 0) => [1]
+   * mapping(2, 1, 0) => [2, 1]
+   * mapping(2, 1) => []
+   *
+   * @param mapping   Mapping
+   * @return Collation with applied mapping.
+   */
   @Override public RelCollationImpl apply(
       final Mappings.TargetMapping mapping) {
     return (RelCollationImpl) RexUtil.apply(mapping, this);

--- a/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
@@ -122,13 +122,15 @@ public class RelCollationImpl implements RelCollation {
    *
    * If mapping destroys the collation prefix, this method returns an empty collation.
    * Examples of applying mappings to collation [0, 1]:
-   * mapping(0, 1) => [0, 1]
-   * mapping(1, 0) => [1, 0]
-   * mapping(0) => [0]
-   * mapping(1) => []
-   * mapping(2, 0) => [1]
-   * mapping(2, 1, 0) => [2, 1]
-   * mapping(2, 1) => []
+   * <ul>
+   *   <li>mapping(0, 1) =&gt; [0, 1]</li>
+   *   <li>mapping(1, 0) =&gt; [1, 0]</li>
+   *   <li>mapping(0) =&gt; [0]</li>
+   *   <li>mapping(1) =&gt; []</li>
+   *   <li>mapping(2, 0) =&gt; [1]</li>
+   *   <li>mapping(2, 1, 0) =&gt; [2, 1]</li>
+   *   <li>mapping(2, 1) =&gt; []</li>
+   * </ul>
    *
    * @param mapping   Mapping
    * @return Collation with applied mapping.

--- a/core/src/main/java/org/apache/calcite/rel/RelDistribution.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistribution.java
@@ -48,6 +48,24 @@ public interface RelDistribution extends RelMultipleTrait {
    */
   @Nonnull List<Integer> getKeys();
 
+  /**
+   * Applies mapping to this distribution trait.
+   *
+   * <p>Mapping can change the distribution trait only if it depends on distribution keys.
+   *
+   * <p>For example if relation is HASH distributed by keys [0, 1], after applying
+   * a mapping (3, 2, 1, 0), the relation will have a distribution HASH(2,3) because
+   * distribution keys changed their ordinals.
+   *
+   * <p>If mapping eliminates one of the distribution keys, the {@link Type#ANY}
+   * distribution will be returned.
+   *
+   * <p>If distribution doesn't have keys (BROADCAST or SINGLETON), method will return
+   * the same distribution.
+   *
+   * @param mapping   Mapping
+   * @return distribution with mapping applied
+   */
   RelDistribution apply(Mappings.TargetMapping mapping);
 
   /** Type of distribution. */

--- a/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
@@ -143,7 +143,7 @@ public class RelDistributions {
       }
       for (int key : keys) {
         if (mapping.getTargetOpt(key) == -1) {
-          return RANDOM_DISTRIBUTED; // Some distribution keys are not mapped => random.
+          return ANY; // Some distribution keys are not mapped => any.
         }
       }
       List<Integer> mappedKeys0 = Mappings.apply2((Mapping) mapping, keys);

--- a/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
@@ -77,8 +77,9 @@ public class RelDistributions {
     return RelDistributionTraitDef.INSTANCE.canonize(distribution);
   }
 
-  public static ImmutableIntList normalizeKeys(Collection<? extends Number> numbers) {
-    ImmutableIntList list = ImmutableIntList.copyOf(numbers);
+  /** Creates ordered immutable copy of keys collection.  */
+  private static ImmutableIntList normalizeKeys(Collection<? extends Number> keys) {
+    ImmutableIntList list = ImmutableIntList.copyOf(keys);
     if (list.size() > 1
         && !Ordering.natural().isOrdered(list)) {
       list = ImmutableIntList.copyOf(Ordering.natural().sortedCopy(list));
@@ -140,16 +141,14 @@ public class RelDistributions {
       if (keys.isEmpty()) {
         return this;
       }
-      List<Integer> mapList = Mappings.asList(mapping);
-      for (Integer key : keys) {
-        if (mapList.get(key) == null) {
+      for (int key : keys) {
+        if (mapping.getTargetOpt(key) == -1) {
           return RANDOM_DISTRIBUTED; // Some distribution keys are not mapped => random.
         }
       }
       List<Integer> mappedKeys0 = Mappings.apply2((Mapping) mapping, keys);
       ImmutableIntList mappedKeys = normalizeKeys(mappedKeys0);
-      RelDistribution newDistribution = new RelDistributionImpl(type, mappedKeys);
-      return getTraitDef().canonize(newDistribution);
+      return of(type, mappedKeys);
     }
 
     public boolean satisfies(RelTrait trait) {

--- a/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
@@ -62,11 +62,7 @@ public class RelDistributions {
 
   /** Creates a hash distribution. */
   public static RelDistribution hash(Collection<? extends Number> numbers) {
-    ImmutableIntList list = ImmutableIntList.copyOf(numbers);
-    if (numbers.size() > 1
-        && !Ordering.natural().isOrdered(list)) {
-      list = ImmutableIntList.copyOf(Ordering.natural().sortedCopy(list));
-    }
+    ImmutableIntList list = normalizeKeys(numbers);
     return of(RelDistribution.Type.HASH_DISTRIBUTED, list);
   }
 
@@ -79,6 +75,15 @@ public class RelDistributions {
   public static RelDistribution of(RelDistribution.Type type, ImmutableIntList keys) {
     RelDistribution distribution = new RelDistributionImpl(type, keys);
     return RelDistributionTraitDef.INSTANCE.canonize(distribution);
+  }
+
+  public static ImmutableIntList normalizeKeys(Collection<? extends Number> numbers) {
+    ImmutableIntList list = ImmutableIntList.copyOf(numbers);
+    if (list.size() > 1
+        && !Ordering.natural().isOrdered(list)) {
+      list = ImmutableIntList.copyOf(Ordering.natural().sortedCopy(list));
+    }
+    return list;
   }
 
   /** Implementation of {@link org.apache.calcite.rel.RelDistribution}. */
@@ -135,10 +140,16 @@ public class RelDistributions {
       if (keys.isEmpty()) {
         return this;
       }
-      return getTraitDef().canonize(
-          new RelDistributionImpl(type,
-              ImmutableIntList.copyOf(
-                  Mappings.apply2((Mapping) mapping, keys))));
+      List<Integer> mapList = Mappings.asList(mapping);
+      for (Integer key : keys) {
+        if (mapList.get(key) == null) {
+          return RANDOM_DISTRIBUTED; // Some distribution keys are not mapped => random.
+        }
+      }
+      List<Integer> mappedKeys0 = Mappings.apply2((Mapping) mapping, keys);
+      ImmutableIntList mappedKeys = normalizeKeys(mappedKeys0);
+      RelDistribution newDistribution = new RelDistributionImpl(type, mappedKeys);
+      return getTraitDef().canonize(newDistribution);
     }
 
     public boolean satisfies(RelTrait trait) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -173,11 +173,12 @@ public class ProjectJoinTransposeRule extends RelOptRule {
         final List<RelFieldCollation> fieldCollations = collation.getFieldCollations();
         for (RelFieldCollation relFieldCollation: fieldCollations) {
           final int fieldIndex = relFieldCollation.getFieldIndex();
-          if (fieldIndex < originLeftCnt) {
-            fc.add(RexUtil.apply(leftMapping, relFieldCollation));
-          } else {
-            fc.add(RexUtil.apply(rightMapping, relFieldCollation));
+          Mappings.TargetMapping mapping = fieldIndex < originLeftCnt ? leftMapping : rightMapping;
+          RelFieldCollation newFieldCollation = RexUtil.apply(mapping, relFieldCollation);
+          if (newFieldCollation == null) {
+            break;
           }
+          fc.add(newFieldCollation);
         }
         newCollations.add(RelCollations.of(fc));
       }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Planner rule that pushes
@@ -122,9 +123,10 @@ public class SortProjectTransposeRule extends RelOptRule {
       if (node.isA(SqlKind.CAST)) {
         // Check whether it is a monotonic preserving cast, otherwise we cannot push
         final RexCall cast = (RexCall) node;
+        RelFieldCollation newFc = Objects.requireNonNull(RexUtil.apply(map, fc));
         final RexCallBinding binding =
             RexCallBinding.create(cluster.getTypeFactory(), cast,
-                ImmutableList.of(RelCollations.of(RexUtil.apply(map, fc))));
+                ImmutableList.of(RelCollations.of(newFc)));
         if (cast.getOperator().getMonotonicity(binding) == SqlMonotonicity.NOT_MONOTONIC) {
           return;
         }

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1303,7 +1303,11 @@ public class RexUtil {
       List<RelFieldCollation> fieldCollations) {
     final List<RelFieldCollation> newFieldCollations = new ArrayList<>();
     for (RelFieldCollation fieldCollation : fieldCollations) {
-      newFieldCollations.add(apply(mapping, fieldCollation));
+      RelFieldCollation newFieldCollation = apply(mapping, fieldCollation);
+      if (newFieldCollation == null) {
+        break;
+      }
+      newFieldCollations.add(newFieldCollation);
     }
     return newFieldCollations;
   }

--- a/core/src/main/java/org/apache/calcite/util/Permutation.java
+++ b/core/src/main/java/org/apache/calcite/util/Permutation.java
@@ -521,16 +521,10 @@ public class Permutation implements Mapping, Mappings.TargetMapping {
   }
 
   public int getTargetOpt(int source) {
-    if (source >= targets.length) {
-      return -1;
-    }
     return getTarget(source);
   }
 
   public int getSourceOpt(int target) {
-    if (target >= sources.length) {
-      return -1;
-    }
     return getSource(target);
   }
 

--- a/core/src/main/java/org/apache/calcite/util/Permutation.java
+++ b/core/src/main/java/org/apache/calcite/util/Permutation.java
@@ -521,10 +521,16 @@ public class Permutation implements Mapping, Mappings.TargetMapping {
   }
 
   public int getTargetOpt(int source) {
+    if (source >= targets.length) {
+      return -1;
+    }
     return getTarget(source);
   }
 
   public int getSourceOpt(int target) {
+    if (target >= sources.length) {
+      return -1;
+    }
     return getSource(target);
   }
 

--- a/core/src/main/java/org/apache/calcite/util/Permutation.java
+++ b/core/src/main/java/org/apache/calcite/util/Permutation.java
@@ -415,14 +415,14 @@ public class Permutation implements Mapping, Mappings.TargetMapping {
    * Returns the position that <code>source</code> is mapped to.
    */
   public int getTarget(int source) {
-      return targets[source];
+    return targets[source];
   }
 
   /**
    * Returns the position which maps to <code>target</code>.
    */
   public int getSource(int target) {
-      return sources[target];
+    return sources[target];
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/util/Permutation.java
+++ b/core/src/main/java/org/apache/calcite/util/Permutation.java
@@ -415,22 +415,14 @@ public class Permutation implements Mapping, Mappings.TargetMapping {
    * Returns the position that <code>source</code> is mapped to.
    */
   public int getTarget(int source) {
-    try {
       return targets[source];
-    } catch (ArrayIndexOutOfBoundsException e) {
-      throw new Mappings.NoElementException("invalid source " + source);
-    }
   }
 
   /**
    * Returns the position which maps to <code>target</code>.
    */
   public int getSource(int target) {
-    try {
       return sources[target];
-    } catch (ArrayIndexOutOfBoundsException e) {
-      throw new Mappings.NoElementException("invalid target " + target);
-    }
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -1246,10 +1246,16 @@ public abstract class Mappings {
     }
 
     public int getSourceOpt(int target) {
+      if (target >= sources.length) {
+        return -1;
+      }
       return sources[target];
     }
 
     public int getTargetOpt(int source) {
+      if (source >= targets.length) {
+        return -1;
+      }
       return targets[source];
     }
 
@@ -1384,18 +1390,32 @@ public abstract class Mappings {
     }
 
     public int getTarget(int source) {
+      if (source >= size) {
+        throw new Mappings.NoElementException("source #" + source
+            + " has no target in identity mapping of size " + size);
+      }
       return source;
     }
 
     public int getTargetOpt(int source) {
+      if (source >= size) {
+        return -1;
+      }
       return source;
     }
 
     public int getSource(int target) {
+      if (target >= size) {
+        throw new Mappings.NoElementException("target #" + target
+            + " has no source in identity mapping of size " + size);
+      }
       return target;
     }
 
     public int getSourceOpt(int target) {
+      if (target >= size) {
+        return -1;
+      }
       return target;
     }
 
@@ -1659,6 +1679,9 @@ public abstract class Mappings {
     }
 
     public int getTargetOpt(int source) {
+      if (source >= targets.length) {
+        return -1;
+      }
       return targets[source];
     }
   }

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -1275,14 +1275,14 @@ public abstract class Mappings {
      * Returns the source that a target maps to, or -1 if it is not mapped.
      */
     public int getSourceOpt(int target) {
-        return sources[target];
+      return sources[target];
     }
 
     /**
      * Returns the target that a source maps to, or -1 if it is not mapped.
      */
     public int getTargetOpt(int source) {
-        return targets[source];
+      return targets[source];
     }
 
     public boolean isIdentity() {
@@ -1736,7 +1736,7 @@ public abstract class Mappings {
      * @return target
      */
     public int getTargetOpt(int source) {
-        return targets[source];
+      return targets[source];
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -1273,28 +1273,16 @@ public abstract class Mappings {
 
     /**
      * Returns the source that a target maps to, or -1 if it is not mapped.
-     *
-     *  @throws NoElementException if target is out of sources range.
      */
     public int getSourceOpt(int target) {
-      try {
         return sources[target];
-      } catch (ArrayIndexOutOfBoundsException e) {
-        throw new Mappings.NoElementException("invalid target " + target);
-      }
     }
 
     /**
      * Returns the target that a source maps to, or -1 if it is not mapped.
-     *
-     * @throws NoElementException if source is out of targets range.
      */
     public int getTargetOpt(int source) {
-      try {
         return targets[source];
-      } catch (ArrayIndexOutOfBoundsException e) {
-        throw new Mappings.NoElementException("invalid source " + source);
-      }
     }
 
     public boolean isIdentity() {
@@ -1432,11 +1420,10 @@ public abstract class Mappings {
      *
      * @param source source
      * @return target
-     * @throws NoElementException if source is not mapped
      */
     public int getTarget(int source) {
       if (source < 0 || source >= size) {
-        throw new Mappings.NoElementException("source #" + source
+        throw new IndexOutOfBoundsException("source #" + source
             + " has no target in identity mapping of size " + size);
       }
       return source;
@@ -1445,12 +1432,12 @@ public abstract class Mappings {
     /**
      * Returns the target that a source maps to, or -1 if it is not mapped.
      *
+     * @param source source
      * @return target
-     * @throws NoElementException if source is out of sources range
      */
     public int getTargetOpt(int source) {
       if (source < 0 || source >= size) {
-        throw new Mappings.NoElementException("source #" + source
+        throw new IndexOutOfBoundsException("source #" + source
             + " has no target in identity mapping of size " + size);
       }
       return source;
@@ -1461,11 +1448,10 @@ public abstract class Mappings {
      *
      * @param target target
      * @return source
-     * @throws NoElementException if target is not mapped
      */
     public int getSource(int target) {
       if (target < 0 || target >= size) {
-        throw new Mappings.NoElementException("target #" + target
+        throw new IndexOutOfBoundsException("target #" + target
             + " has no source in identity mapping of size " + size);
       }
       return target;
@@ -1474,12 +1460,12 @@ public abstract class Mappings {
     /**
      * Returns the source that a target maps to, or -1 if it is not mapped.
      *
+     * @param target target
      * @return source
-     * @throws NoElementException if target is out of targets range
      */
     public int getSourceOpt(int target) {
       if (target < 0 || target >= size) {
-        throw new Mappings.NoElementException("target #" + target
+        throw new IndexOutOfBoundsException("target #" + target
             + " has no source in identity mapping of size " + size);
       }
       return target;
@@ -1748,14 +1734,9 @@ public abstract class Mappings {
      * Returns the target that a source maps to, or -1 if it is not mapped.
      *
      * @return target
-     * @throws NoElementException if source is out of sources range
      */
     public int getTargetOpt(int source) {
-      try {
         return targets[source];
-      } catch (ArrayIndexOutOfBoundsException e) {
-        throw new Mappings.NoElementException("invalid source " + source);
-      }
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -1422,7 +1422,7 @@ public abstract class Mappings {
      * @return target
      */
     public int getTarget(int source) {
-      if (source < 0 || source >= size) {
+      if (source < 0 || (size != -1 && source >= size)) {
         throw new IndexOutOfBoundsException("source #" + source
             + " has no target in identity mapping of size " + size);
       }
@@ -1436,7 +1436,7 @@ public abstract class Mappings {
      * @return target
      */
     public int getTargetOpt(int source) {
-      if (source < 0 || source >= size) {
+      if (source < 0 || (size != -1 && source >= size)) {
         throw new IndexOutOfBoundsException("source #" + source
             + " has no target in identity mapping of size " + size);
       }
@@ -1450,7 +1450,7 @@ public abstract class Mappings {
      * @return source
      */
     public int getSource(int target) {
-      if (target < 0 || target >= size) {
+      if (target < 0 || (size != -1 && target >= size)) {
         throw new IndexOutOfBoundsException("target #" + target
             + " has no source in identity mapping of size " + size);
       }
@@ -1464,7 +1464,7 @@ public abstract class Mappings {
      * @return source
      */
     public int getSourceOpt(int target) {
-      if (target < 0 || target >= size) {
+      if (target < 0 || (size != -1 && target >= size)) {
         throw new IndexOutOfBoundsException("target #" + target
             + " has no source in identity mapping of size " + size);
       }

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -818,12 +818,25 @@ public abstract class Mappings {
   public interface SourceMapping extends CoreMapping {
     int getSourceCount();
 
+    /**
+     * Returns the source that a target maps to.
+     *
+     * @param target target
+     * @return source
+     * @throws NoElementException if target is not mapped
+     */
     int getSource(int target);
 
+    /**
+     * Returns the source that a target maps to, or -1 if it is not mapped.
+     */
     int getSourceOpt(int target);
 
     int getTargetCount();
 
+    /**
+     * Returns the target that a source maps to, or -1 if it is not mapped.
+     */
     int getTargetOpt(int source);
 
     MappingType getMappingType();
@@ -849,12 +862,25 @@ public abstract class Mappings {
   public interface TargetMapping extends FunctionMapping {
     int getSourceCount();
 
+    /**
+     * Returns the source that a target maps to, or -1 if it is not mapped.
+     */
     int getSourceOpt(int target);
 
     int getTargetCount();
 
-    int getTarget(int target);
+    /**
+     * Returns the target that a source maps to.
+     *
+     * @param source source
+     * @return target
+     * @throws NoElementException if source is not mapped
+     */
+    int getTarget(int source);
 
+    /**
+     * Returns the target that a source maps to, or -1 if it is not mapped.
+     */
     int getTargetOpt(int source);
 
     void set(int source, int target);
@@ -1245,18 +1271,30 @@ public abstract class Mappings {
       assert isValid();
     }
 
+    /**
+     * Returns the source that a target maps to, or -1 if it is not mapped.
+     *
+     *  @throws NoElementException if target is out of sources range.
+     */
     public int getSourceOpt(int target) {
-      if (target >= sources.length) {
-        return -1;
+      try {
+        return sources[target];
+      } catch (ArrayIndexOutOfBoundsException e) {
+        throw new Mappings.NoElementException("invalid target " + target);
       }
-      return sources[target];
     }
 
+    /**
+     * Returns the target that a source maps to, or -1 if it is not mapped.
+     *
+     * @throws NoElementException if source is out of targets range.
+     */
     public int getTargetOpt(int source) {
-      if (source >= targets.length) {
-        return -1;
+      try {
+        return targets[source];
+      } catch (ArrayIndexOutOfBoundsException e) {
+        throw new Mappings.NoElementException("invalid source " + source);
       }
-      return targets[source];
     }
 
     public boolean isIdentity() {
@@ -1389,32 +1427,60 @@ public abstract class Mappings {
       return size;
     }
 
+    /**
+     * Returns the target that a source maps to.
+     *
+     * @param source source
+     * @return target
+     * @throws NoElementException if source is not mapped
+     */
     public int getTarget(int source) {
-      if (source >= size) {
+      if (source < 0 || source >= size) {
         throw new Mappings.NoElementException("source #" + source
             + " has no target in identity mapping of size " + size);
       }
       return source;
     }
 
+    /**
+     * Returns the target that a source maps to, or -1 if it is not mapped.
+     *
+     * @return target
+     * @throws NoElementException if source is out of sources range
+     */
     public int getTargetOpt(int source) {
-      if (source >= size) {
-        return -1;
+      if (source < 0 || source >= size) {
+        throw new Mappings.NoElementException("source #" + source
+            + " has no target in identity mapping of size " + size);
       }
       return source;
     }
 
+    /**
+     * Returns the source that a target maps to.
+     *
+     * @param target target
+     * @return source
+     * @throws NoElementException if target is not mapped
+     */
     public int getSource(int target) {
-      if (target >= size) {
+      if (target < 0 || target >= size) {
         throw new Mappings.NoElementException("target #" + target
             + " has no source in identity mapping of size " + size);
       }
       return target;
     }
 
+    /**
+     * Returns the source that a target maps to, or -1 if it is not mapped.
+     *
+     * @return source
+     * @throws NoElementException if target is out of targets range
+     */
     public int getSourceOpt(int target) {
-      if (target >= size) {
-        return -1;
+      if (target < 0 || target >= size) {
+        throw new Mappings.NoElementException("target #" + target
+            + " has no source in identity mapping of size " + size);
       }
       return target;
     }
@@ -1678,11 +1744,18 @@ public abstract class Mappings {
       }
     }
 
+    /**
+     * Returns the target that a source maps to, or -1 if it is not mapped.
+     *
+     * @return target
+     * @throws NoElementException if source is out of sources range
+     */
     public int getTargetOpt(int source) {
-      if (source >= targets.length) {
-        return -1;
+      try {
+        return targets[source];
+      } catch (ArrayIndexOutOfBoundsException e) {
+        throw new Mappings.NoElementException("invalid source " + source);
       }
-      return targets[source];
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/RelCollationTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/RelCollationTest.java
@@ -36,6 +36,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Tests for {@link RelCollation} and {@link RelFieldCollation}.
  */
 class RelCollationTest {
+  /** Source count for mapping tests. */
+  private static final int MAPPING_SOURCE_COUNT = 10;
+
   /** Unit test for {@link RelCollations#contains(List, ImmutableIntList)}. */
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
   @Test void testCollationContains() {
@@ -128,6 +131,20 @@ class RelCollationTest {
     assertThat(collation234.apply(mapping(3, 2, 4)), is(collation(1, 0, 2)));
     assertThat(collation234.apply(mapping(4, 3, 2, 0)), is(collation(2, 1, 0)));
     assertThat(collation234.apply(mapping(3, 4, 0)), is(EMPTY));
+
+    // [9] , 9 < mapping.sourceCount()
+    RelCollation collation9 = collation(MAPPING_SOURCE_COUNT - 1);
+    assertThat(collation9.apply(mapping(0)), is(EMPTY));
+    assertThat(collation9.apply(mapping(1)), is(EMPTY));
+    assertThat(collation9.apply(mapping(2)), is(EMPTY));
+    assertThat(collation9.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(collation(0)));
+
+    // [10] , 10 >= mapping.sourceCount()
+    RelCollation collation10 = collation(MAPPING_SOURCE_COUNT);
+    assertThat(collation10.apply(mapping(0)), is(EMPTY));
+    assertThat(collation10.apply(mapping(1)), is(EMPTY));
+    assertThat(collation10.apply(mapping(2)), is(EMPTY));
+    assertThat(collation10.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(EMPTY));
   }
 
   private static RelCollation collation(int... ordinals) {
@@ -139,6 +156,6 @@ class RelCollationTest {
   }
 
   private static Mapping mapping(int... sources) {
-    return Mappings.target(ImmutableIntList.of(sources), 10);
+    return Mappings.target(ImmutableIntList.of(sources), MAPPING_SOURCE_COUNT);
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/RelCollationTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/RelCollationTest.java
@@ -36,9 +36,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Tests for {@link RelCollation} and {@link RelFieldCollation}.
  */
 class RelCollationTest {
-  /** Source count for mapping tests. */
-  private static final int MAPPING_SOURCE_COUNT = 10;
-
   /** Unit test for {@link RelCollations#contains(List, ImmutableIntList)}. */
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
   @Test void testCollationContains() {
@@ -99,52 +96,46 @@ class RelCollationTest {
   }
 
   @Test void testCollationMapping() {
+    final int n = 10; // Mapping source count.
     // [0]
     RelCollation collation0 = collation(0);
-    assertThat(collation0.apply(mapping(0)), is(collation0));
-    assertThat(collation0.apply(mapping(1)), is(EMPTY));
-    assertThat(collation0.apply(mapping(0, 1)), is(collation0));
-    assertThat(collation0.apply(mapping(1, 0)), is(collation(1)));
-    assertThat(collation0.apply(mapping(3, 1, 0)), is(collation(2)));
+    assertThat(collation0.apply(mapping(n, 0)), is(collation0));
+    assertThat(collation0.apply(mapping(n, 1)), is(EMPTY));
+    assertThat(collation0.apply(mapping(n, 0, 1)), is(collation0));
+    assertThat(collation0.apply(mapping(n, 1, 0)), is(collation(1)));
+    assertThat(collation0.apply(mapping(n, 3, 1, 0)), is(collation(2)));
 
     // [0,1]
     RelCollation collation01 = collation(0, 1);
-    assertThat(collation01.apply(mapping(0)), is(collation(0)));
-    assertThat(collation01.apply(mapping(1)), is(EMPTY));
-    assertThat(collation01.apply(mapping(2)), is(EMPTY));
-    assertThat(collation01.apply(mapping(0, 1)), is(collation01));
-    assertThat(collation01.apply(mapping(1, 0)), is(collation(1, 0)));
-    assertThat(collation01.apply(mapping(3, 1, 0)), is(collation(2, 1)));
-    assertThat(collation01.apply(mapping(3, 2, 0)), is(collation(2)));
+    assertThat(collation01.apply(mapping(n, 0)), is(collation(0)));
+    assertThat(collation01.apply(mapping(n, 1)), is(EMPTY));
+    assertThat(collation01.apply(mapping(n, 2)), is(EMPTY));
+    assertThat(collation01.apply(mapping(n, 0, 1)), is(collation01));
+    assertThat(collation01.apply(mapping(n, 1, 0)), is(collation(1, 0)));
+    assertThat(collation01.apply(mapping(n, 3, 1, 0)), is(collation(2, 1)));
+    assertThat(collation01.apply(mapping(n, 3, 2, 0)), is(collation(2)));
 
     // [2,3,4]
     RelCollation collation234 = collation(2, 3, 4);
-    assertThat(collation234.apply(mapping(0)), is(EMPTY));
-    assertThat(collation234.apply(mapping(1)), is(EMPTY));
-    assertThat(collation234.apply(mapping(2)), is(collation(0)));
-    assertThat(collation234.apply(mapping(3)), is(EMPTY));
-    assertThat(collation234.apply(mapping(4)), is(EMPTY));
-    assertThat(collation234.apply(mapping(5)), is(EMPTY));
-    assertThat(collation234.apply(mapping(0, 1, 2)), is(collation(2)));
-    assertThat(collation234.apply(mapping(3, 2)), is(collation(1, 0)));
-    assertThat(collation234.apply(mapping(3, 2, 4)), is(collation(1, 0, 2)));
-    assertThat(collation234.apply(mapping(3, 2, 4)), is(collation(1, 0, 2)));
-    assertThat(collation234.apply(mapping(4, 3, 2, 0)), is(collation(2, 1, 0)));
-    assertThat(collation234.apply(mapping(3, 4, 0)), is(EMPTY));
+    assertThat(collation234.apply(mapping(n, 0)), is(EMPTY));
+    assertThat(collation234.apply(mapping(n, 1)), is(EMPTY));
+    assertThat(collation234.apply(mapping(n, 2)), is(collation(0)));
+    assertThat(collation234.apply(mapping(n, 3)), is(EMPTY));
+    assertThat(collation234.apply(mapping(n, 4)), is(EMPTY));
+    assertThat(collation234.apply(mapping(n, 5)), is(EMPTY));
+    assertThat(collation234.apply(mapping(n, 0, 1, 2)), is(collation(2)));
+    assertThat(collation234.apply(mapping(n, 3, 2)), is(collation(1, 0)));
+    assertThat(collation234.apply(mapping(n, 3, 2, 4)), is(collation(1, 0, 2)));
+    assertThat(collation234.apply(mapping(n, 3, 2, 4)), is(collation(1, 0, 2)));
+    assertThat(collation234.apply(mapping(n, 4, 3, 2, 0)), is(collation(2, 1, 0)));
+    assertThat(collation234.apply(mapping(n, 3, 4, 0)), is(EMPTY));
 
     // [9] , 9 < mapping.sourceCount()
-    RelCollation collation9 = collation(MAPPING_SOURCE_COUNT - 1);
-    assertThat(collation9.apply(mapping(0)), is(EMPTY));
-    assertThat(collation9.apply(mapping(1)), is(EMPTY));
-    assertThat(collation9.apply(mapping(2)), is(EMPTY));
-    assertThat(collation9.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(collation(0)));
-
-    // [10] , 10 >= mapping.sourceCount()
-    RelCollation collation10 = collation(MAPPING_SOURCE_COUNT);
-    assertThat(collation10.apply(mapping(0)), is(EMPTY));
-    assertThat(collation10.apply(mapping(1)), is(EMPTY));
-    assertThat(collation10.apply(mapping(2)), is(EMPTY));
-    assertThat(collation10.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(EMPTY));
+    RelCollation collation9 = collation(n - 1);
+    assertThat(collation9.apply(mapping(n, 0)), is(EMPTY));
+    assertThat(collation9.apply(mapping(n, 1)), is(EMPTY));
+    assertThat(collation9.apply(mapping(n, 2)), is(EMPTY));
+    assertThat(collation9.apply(mapping(n, n - 1)), is(collation(0)));
   }
 
   private static RelCollation collation(int... ordinals) {
@@ -155,7 +146,7 @@ class RelCollationTest {
     return RelCollations.of(list);
   }
 
-  private static Mapping mapping(int... sources) {
-    return Mappings.target(ImmutableIntList.of(sources), MAPPING_SOURCE_COUNT);
+  private static Mapping mapping(int sourceCount, int... sources) {
+    return Mappings.target(ImmutableIntList.of(sources), sourceCount);
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
@@ -17,10 +17,15 @@
 package org.apache.calcite.rel;
 
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 
 import org.junit.jupiter.api.Test;
+
+import static org.apache.calcite.rel.RelDistributions.RANDOM_DISTRIBUTED;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,5 +52,37 @@ class RelDistributionTest {
     assertThat(distribution2.compareTo(distribution1), is(1));
     //noinspection EqualsWithItself
     assertThat(distribution2.compareTo(distribution2), is(0));
+  }
+
+  @Test void testRelDistributionMapping() {
+    // hash[0]
+    RelDistribution hash0 = hash(0);
+    assertThat(hash0.apply(mapping(0)), is(hash0));
+    assertThat(hash0.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash0.apply(mapping(2, 1, 0)), is(hash(2)));
+
+    // hash[0,1]
+    RelDistribution hash01 = hash(0, 1);
+    assertThat(hash01.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash01.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash01.apply(mapping(0, 1)), is(hash01));
+    assertThat(hash01.apply(mapping(1, 2)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash01.apply(mapping(1, 0)), is(hash01));
+    assertThat(hash01.apply(mapping(2, 1, 0)), is(hash(2, 1)));
+
+    // hash[2]
+    RelDistribution hash2 = hash(2);
+    assertThat(hash2.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash2.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash2.apply(mapping(2)), is(hash(0)));
+    assertThat(hash2.apply(mapping(1, 2)), is(hash(1)));
+  }
+
+  private static Mapping mapping(int... sources) {
+    return Mappings.target(ImmutableIntList.of(sources), 10);
+  }
+
+  private static RelDistribution hash(int... keys) {
+    return RelDistributions.hash(ImmutableIntList.of(keys));
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.junit.jupiter.api.Test;
 
-import static org.apache.calcite.rel.RelDistributions.RANDOM_DISTRIBUTED;
+import static org.apache.calcite.rel.RelDistributions.ANY;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,9 +34,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Tests for {@link RelDistribution}.
  */
 class RelDistributionTest {
-  /** Source count for mapping tests. */
-  private static final int MAPPING_SOURCE_COUNT = 10;
-
   @Test void testRelDistributionSatisfy() {
     RelDistribution distribution1 = RelDistributions.hash(ImmutableList.of(0));
     RelDistribution distribution2 = RelDistributions.hash(ImmutableList.of(1));
@@ -58,45 +55,40 @@ class RelDistributionTest {
   }
 
   @Test void testRelDistributionMapping() {
+    final int n = 10; // Mapping source count.
+
     // hash[0]
     RelDistribution hash0 = hash(0);
-    assertThat(hash0.apply(mapping(0)), is(hash0));
-    assertThat(hash0.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash0.apply(mapping(2, 1, 0)), is(hash(2)));
+    assertThat(hash0.apply(mapping(n, 0)), is(hash0));
+    assertThat(hash0.apply(mapping(n, 1)), is(ANY));
+    assertThat(hash0.apply(mapping(n, 2, 1, 0)), is(hash(2)));
 
     // hash[0,1]
     RelDistribution hash01 = hash(0, 1);
-    assertThat(hash01.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash01.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash01.apply(mapping(0, 1)), is(hash01));
-    assertThat(hash01.apply(mapping(1, 2)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash01.apply(mapping(1, 0)), is(hash01));
-    assertThat(hash01.apply(mapping(2, 1, 0)), is(hash(2, 1)));
+    assertThat(hash01.apply(mapping(n, 0)), is(ANY));
+    assertThat(hash01.apply(mapping(n, 1)), is(ANY));
+    assertThat(hash01.apply(mapping(n, 0, 1)), is(hash01));
+    assertThat(hash01.apply(mapping(n, 1, 2)), is(ANY));
+    assertThat(hash01.apply(mapping(n, 1, 0)), is(hash01));
+    assertThat(hash01.apply(mapping(n, 2, 1, 0)), is(hash(2, 1)));
 
     // hash[2]
     RelDistribution hash2 = hash(2);
-    assertThat(hash2.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash2.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash2.apply(mapping(2)), is(hash(0)));
-    assertThat(hash2.apply(mapping(1, 2)), is(hash(1)));
+    assertThat(hash2.apply(mapping(n, 0)), is(ANY));
+    assertThat(hash2.apply(mapping(n, 1)), is(ANY));
+    assertThat(hash2.apply(mapping(n, 2)), is(hash(0)));
+    assertThat(hash2.apply(mapping(n, 1, 2)), is(hash(1)));
 
     // hash[9] , 9 < mapping.sourceCount()
-    RelDistribution hash9 = hash(MAPPING_SOURCE_COUNT - 1);
-    assertThat(hash9.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash9.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash9.apply(mapping(2)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash9.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(hash(0)));
-
-    // hash[10] , 10 >= mapping.sourceCount()
-    RelDistribution hash10 = hash(MAPPING_SOURCE_COUNT);
-    assertThat(hash10.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash10.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash10.apply(mapping(2)), is(RANDOM_DISTRIBUTED));
-    assertThat(hash10.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(RANDOM_DISTRIBUTED));
+    RelDistribution hash9 = hash(n - 1);
+    assertThat(hash9.apply(mapping(n, 0)), is(ANY));
+    assertThat(hash9.apply(mapping(n, 1)), is(ANY));
+    assertThat(hash9.apply(mapping(n, 2)), is(ANY));
+    assertThat(hash9.apply(mapping(n, n - 1)), is(hash(0)));
   }
 
-  private static Mapping mapping(int... sources) {
-    return Mappings.target(ImmutableIntList.of(sources), MAPPING_SOURCE_COUNT);
+  private static Mapping mapping(int sourceCount, int... sources) {
+    return Mappings.target(ImmutableIntList.of(sources), sourceCount);
   }
 
   private static RelDistribution hash(int... keys) {

--- a/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
@@ -34,6 +34,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Tests for {@link RelDistribution}.
  */
 class RelDistributionTest {
+  /** Source count for mapping tests. */
+  private static final int MAPPING_SOURCE_COUNT = 10;
+
   @Test void testRelDistributionSatisfy() {
     RelDistribution distribution1 = RelDistributions.hash(ImmutableList.of(0));
     RelDistribution distribution2 = RelDistributions.hash(ImmutableList.of(1));
@@ -76,10 +79,24 @@ class RelDistributionTest {
     assertThat(hash2.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
     assertThat(hash2.apply(mapping(2)), is(hash(0)));
     assertThat(hash2.apply(mapping(1, 2)), is(hash(1)));
+
+    // hash[9] , 9 < mapping.sourceCount()
+    RelDistribution hash9 = hash(MAPPING_SOURCE_COUNT - 1);
+    assertThat(hash9.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash9.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash9.apply(mapping(2)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash9.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(hash(0)));
+
+    // hash[10] , 10 >= mapping.sourceCount()
+    RelDistribution hash10 = hash(MAPPING_SOURCE_COUNT);
+    assertThat(hash10.apply(mapping(0)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash10.apply(mapping(1)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash10.apply(mapping(2)), is(RANDOM_DISTRIBUTED));
+    assertThat(hash10.apply(mapping(MAPPING_SOURCE_COUNT - 1)), is(RANDOM_DISTRIBUTED));
   }
 
   private static Mapping mapping(int... sources) {
-    return Mappings.target(ImmutableIntList.of(sources), 10);
+    return Mappings.target(ImmutableIntList.of(sources), MAPPING_SOURCE_COUNT);
   }
 
   private static RelDistribution hash(int... keys) {

--- a/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
+++ b/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
@@ -28,8 +28,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for mappings.
@@ -62,20 +62,15 @@ class MappingTest {
     assertThat(identity.getSource(4), equalTo(4));
     assertThat(identity.getTargetOpt(4), equalTo(4));
     assertThat(identity.getSourceOpt(4), equalTo(4));
-    assertThat(identity.getTargetOpt(5), equalTo(-1));
-    assertThat(identity.getSourceOpt(5), equalTo(-1));
-    try {
-      final int target = identity.getTarget(5);
-      fail("expected error, got " + target);
-    } catch (Mappings.NoElementException e) {
-      // ok
-    }
-    try {
-      final int target = identity.getSource(5);
-      fail("expected error, got " + target);
-    } catch (Mappings.NoElementException e) {
-      // ok
-    }
+
+    assertThrows(Mappings.NoElementException.class, () -> identity.getSourceOpt(5));
+    assertThrows(Mappings.NoElementException.class, () -> identity.getSource(5));
+    assertThrows(Mappings.NoElementException.class, () -> identity.getTargetOpt(5));
+    assertThrows(Mappings.NoElementException.class, () -> identity.getTarget(5));
+    assertThrows(Mappings.NoElementException.class, () -> identity.getSourceOpt(-1));
+    assertThrows(Mappings.NoElementException.class, () -> identity.getSource(-1));
+    assertThrows(Mappings.NoElementException.class, () -> identity.getTargetOpt(-1));
+    assertThrows(Mappings.NoElementException.class, () -> identity.getTarget(-1));
   }
 
   /**
@@ -147,13 +142,7 @@ class MappingTest {
     assertEquals(15, mapping2.getSourceCount());
     assertEquals(8, mapping2.getTargetCount());
 
-    try {
-      final Mappings.TargetMapping mapping3 =
-          Mappings.offsetSource(mapping, 3, 4);
-      fail("expected exception, got " + mapping3);
-    } catch (IllegalArgumentException e) {
-      // ok
-    }
+    assertThrows(IllegalArgumentException.class, () -> Mappings.offsetSource(mapping, 3, 4));
   }
 
   /** Unit test for {@link Mappings#source(List, int)}
@@ -166,13 +155,11 @@ class MappingTest {
     assertThat(mapping.getTarget(2), equalTo(4));
     assertThat(mapping.getTargetCount(), equalTo(10));
     assertThat(mapping.getSourceCount(), equalTo(5));
-    assertThat(mapping.getTargetOpt(10), equalTo(-1));
-    try {
-      final int target = mapping.getTarget(10);
-      fail("expected error, got " + target);
-    } catch (Mappings.NoElementException e) {
-      // ok
-    }
+
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(10));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(10));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(-1));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(-1));
 
     final List<Integer> integers = Mappings.asList(mapping);
     assertThat(integers, equalTo(targets));
@@ -190,19 +177,13 @@ class MappingTest {
     assertThat(mapping.getTarget(3), equalTo(0));
     assertThat(mapping.getTarget(1), equalTo(1));
     assertThat(mapping.getTarget(4), equalTo(2));
-    try {
-      final int target = mapping.getTarget(0);
-      fail("expected error, got " + target);
-    } catch (Mappings.NoElementException e) {
-      // ok
-    }
-    assertThat(mapping.getTargetOpt(10), equalTo(-1));
-    try {
-      final int target = mapping.getTarget(10);
-      fail("expected error, got " + target);
-    } catch (Mappings.NoElementException e) {
-      // ok
-    }
+
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(0));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(10));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(10));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(-1));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(-1));
+
     assertThat(mapping.getTargetCount(), equalTo(5));
     assertThat(mapping.getSourceCount(), equalTo(10));
 
@@ -223,20 +204,16 @@ class MappingTest {
     assertThat(mapping.getTargetOpt(3), equalTo(2));
     assertThat(mapping.getSource(3), equalTo(0));
     assertThat(mapping.getSourceOpt(3), equalTo(0));
-    assertThat(mapping.getSourceOpt(4), equalTo(-1));
-    assertThat(mapping.getTargetOpt(4), equalTo(-1));
-    try {
-      final int target = mapping.getTarget(4);
-      fail("expected error, got " + target);
-    } catch (Mappings.NoElementException e) {
-      // ok
-    }
-    try {
-      final int source = mapping.getSource(4);
-      fail("expected error, got " + source);
-    } catch (Mappings.NoElementException e) {
-      // ok
-    }
+
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getSourceOpt(4));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getSource(4));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(4));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(4));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getSourceOpt(-1));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getSource(-1));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(-1));
+    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(-1));
+
     assertThat(mapping.getTargetCount(), equalTo(4));
     assertThat(mapping.getSourceCount(), equalTo(4));
     assertThat(mapping.toString(), equalTo("[3, 0, 1, 2]"));
@@ -248,20 +225,9 @@ class MappingTest {
     assertThat(empty.iterator().hasNext(), equalTo(false));
     assertThat(empty.toString(), equalTo("[]"));
 
-    try {
-      final Mapping x = Mappings.bijection(Arrays.asList(0, 5, 1));
-      fail("expected error, got " + x);
-    } catch (Exception e) {
-      // ok
-      assertThat(e.getMessage(), equalTo("target out of range"));
-    }
-    try {
-      final Mapping x = Mappings.bijection(Arrays.asList(1, 0, 1));
-      fail("expected error, got " + x);
-    } catch (Exception e) {
-      // ok
-      assertThat(e.getMessage(),
-          equalTo("more than one permutation element maps to position 1"));
-    }
+    assertThrows(Exception.class, () -> Mappings.bijection(Arrays.asList(0, 5, 1)),
+        "target out of range");
+    assertThrows(Exception.class, () -> Mappings.bijection(Arrays.asList(1, 0, 1)),
+        "more than one permutation element maps to position 1");
   }
 }

--- a/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
+++ b/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
@@ -71,6 +71,14 @@ class MappingTest {
     assertThrows(IndexOutOfBoundsException.class, () -> identity.getSource(-1));
     assertThrows(IndexOutOfBoundsException.class, () -> identity.getTargetOpt(-1));
     assertThrows(IndexOutOfBoundsException.class, () -> identity.getTarget(-1));
+
+    Mapping infiniteIdentity = Mappings.createIdentity(-1);
+    assertThrows(IndexOutOfBoundsException.class, () -> infiniteIdentity.getTarget(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> infiniteIdentity.getSource(-2));
+    assertThrows(IndexOutOfBoundsException.class, () -> infiniteIdentity.getTargetOpt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> infiniteIdentity.getSourceOpt(-2));
+    assertThat(infiniteIdentity.getTarget(100), equalTo(100));
+    assertThat(infiniteIdentity.getSource(100), equalTo(100));
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
+++ b/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
@@ -50,6 +50,32 @@ class MappingTest {
     assertFalse(
         Mappings.isIdentity(
             Mappings.create(MappingType.PARTIAL_SURJECTION, 4, 4)));
+
+    Mapping identity = Mappings.createIdentity(5);
+    assertThat(identity.getTargetCount(), equalTo(5));
+    assertThat(identity.getSourceCount(), equalTo(5));
+    assertThat(identity.getTarget(0), equalTo(0));
+    assertThat(identity.getTarget(1), equalTo(1));
+    assertThat(identity.getTarget(4), equalTo(4));
+    assertThat(identity.getSource(0), equalTo(0));
+    assertThat(identity.getSource(1), equalTo(1));
+    assertThat(identity.getSource(4), equalTo(4));
+    assertThat(identity.getTargetOpt(4), equalTo(4));
+    assertThat(identity.getSourceOpt(4), equalTo(4));
+    assertThat(identity.getTargetOpt(5), equalTo(-1));
+    assertThat(identity.getSourceOpt(5), equalTo(-1));
+    try {
+      final int target = identity.getTarget(5);
+      fail("expected error, got " + target);
+    } catch (Mappings.NoElementException e) {
+      // ok
+    }
+    try {
+      final int target = identity.getSource(5);
+      fail("expected error, got " + target);
+    } catch (Mappings.NoElementException e) {
+      // ok
+    }
   }
 
   /**
@@ -140,6 +166,13 @@ class MappingTest {
     assertThat(mapping.getTarget(2), equalTo(4));
     assertThat(mapping.getTargetCount(), equalTo(10));
     assertThat(mapping.getSourceCount(), equalTo(5));
+    assertThat(mapping.getTargetOpt(10), equalTo(-1));
+    try {
+      final int target = mapping.getTarget(10);
+      fail("expected error, got " + target);
+    } catch (Mappings.NoElementException e) {
+      // ok
+    }
 
     final List<Integer> integers = Mappings.asList(mapping);
     assertThat(integers, equalTo(targets));
@@ -159,6 +192,13 @@ class MappingTest {
     assertThat(mapping.getTarget(4), equalTo(2));
     try {
       final int target = mapping.getTarget(0);
+      fail("expected error, got " + target);
+    } catch (Mappings.NoElementException e) {
+      // ok
+    }
+    assertThat(mapping.getTargetOpt(10), equalTo(-1));
+    try {
+      final int target = mapping.getTarget(10);
       fail("expected error, got " + target);
     } catch (Mappings.NoElementException e) {
       // ok
@@ -183,6 +223,8 @@ class MappingTest {
     assertThat(mapping.getTargetOpt(3), equalTo(2));
     assertThat(mapping.getSource(3), equalTo(0));
     assertThat(mapping.getSourceOpt(3), equalTo(0));
+    assertThat(mapping.getSourceOpt(4), equalTo(-1));
+    assertThat(mapping.getTargetOpt(4), equalTo(-1));
     try {
       final int target = mapping.getTarget(4);
       fail("expected error, got " + target);

--- a/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
+++ b/core/src/test/java/org/apache/calcite/util/mapping/MappingTest.java
@@ -63,14 +63,14 @@ class MappingTest {
     assertThat(identity.getTargetOpt(4), equalTo(4));
     assertThat(identity.getSourceOpt(4), equalTo(4));
 
-    assertThrows(Mappings.NoElementException.class, () -> identity.getSourceOpt(5));
-    assertThrows(Mappings.NoElementException.class, () -> identity.getSource(5));
-    assertThrows(Mappings.NoElementException.class, () -> identity.getTargetOpt(5));
-    assertThrows(Mappings.NoElementException.class, () -> identity.getTarget(5));
-    assertThrows(Mappings.NoElementException.class, () -> identity.getSourceOpt(-1));
-    assertThrows(Mappings.NoElementException.class, () -> identity.getSource(-1));
-    assertThrows(Mappings.NoElementException.class, () -> identity.getTargetOpt(-1));
-    assertThrows(Mappings.NoElementException.class, () -> identity.getTarget(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getSourceOpt(5));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getSource(5));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getTargetOpt(5));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getTarget(5));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getSourceOpt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getSource(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getTargetOpt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> identity.getTarget(-1));
   }
 
   /**
@@ -156,10 +156,11 @@ class MappingTest {
     assertThat(mapping.getTargetCount(), equalTo(10));
     assertThat(mapping.getSourceCount(), equalTo(5));
 
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(10));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(10));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(-1));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTargetOpt(5));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTargetOpt(10));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTarget(10));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTargetOpt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTarget(-1));
 
     final List<Integer> integers = Mappings.asList(mapping);
     assertThat(integers, equalTo(targets));
@@ -179,10 +180,11 @@ class MappingTest {
     assertThat(mapping.getTarget(4), equalTo(2));
 
     assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(0));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(10));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(10));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(-1));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(-1));
+
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTargetOpt(10));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTarget(10));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTargetOpt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTarget(-1));
 
     assertThat(mapping.getTargetCount(), equalTo(5));
     assertThat(mapping.getSourceCount(), equalTo(10));
@@ -205,14 +207,14 @@ class MappingTest {
     assertThat(mapping.getSource(3), equalTo(0));
     assertThat(mapping.getSourceOpt(3), equalTo(0));
 
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getSourceOpt(4));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getSource(4));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(4));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(4));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getSourceOpt(-1));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getSource(-1));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTargetOpt(-1));
-    assertThrows(Mappings.NoElementException.class, () -> mapping.getTarget(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getSourceOpt(4));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getSource(4));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTargetOpt(4));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTarget(4));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getSourceOpt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getSource(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTargetOpt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> mapping.getTarget(-1));
 
     assertThat(mapping.getTargetCount(), equalTo(4));
     assertThat(mapping.getSourceCount(), equalTo(4));


### PR DESCRIPTION
Currently  method `RelTrait.apply(Mappings.Mapping)` might throw an exception when collation/distribution keys are not covered by mapping. For example when we apply project
`SELECT name`
on input
`id, name ORDER BY id`
Method `RelTrait.apply(Mappings.Mapping)` throws NPE because of internals of `RexUtil.apply` where assumed that all sort keys `[0]` should be covered by project mapping keys `name=[1]`. And when this assumption is wrong, the exception is thrown.

In this patch the graceful handling for such situations added for both collation and distribution traits. When collation or distribution cannot be derived from the mapping, `RelDistributions#RANDOM_DISTRIBUTED` and `RelCollations#EMPTY` are returned accordingly.
([CALCITE-3969](https://issues.apache.org/jira/browse/CALCITE-3969))