### PR TITLE
[CALCITE-3973] Hints should not be enclosed in parentheses (Alex Baden)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -147,7 +147,7 @@ public class SqlSelectOperator extends SqlOperator {
 
     if (select.hasHints()) {
       writer.sep("/*+");
-      select.hints.unparse(writer, leftPrec, rightPrec);
+      select.hints.unparse(writer, 0, 0);
       writer.print("*/");
       writer.newlineAndIndent();
     }

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8664,6 +8664,14 @@ public class SqlParserTest {
         + "`EMPNO`\n"
         + "FROM `EMPS`";
     sql(sql2).ok(expected2);
+    // Hint item without parentheses
+    final String sql3 = "select /*+ simple_hint */ empno, ename, deptno from emps limit 2";
+    final String expected3 = "SELECT\n"
+        + "/*+ `SIMPLE_HINT` */\n"
+        + "`EMPNO`, `ENAME`, `DEPTNO`\n"
+        + "FROM `EMPS`\n"
+        + "FETCH NEXT 2 ROWS ONLY";
+    sql(sql3).ok(expected3);
   }
 
   @Test void testTableHintsInQuery() {


### PR DESCRIPTION
https://jira.apache.org/jira/browse/CALCITE-3973 

Resolves an issue where sql hints could be enclosed in parentheses when writing a select operator call to string. 