### PR TITLE
[CALCITE-3517] Rework DiffRepository as a JUnit extension

### DIFF
--- a/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
@@ -25,10 +25,12 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.test.DiffRepository;
+import org.apache.calcite.test.DiffRepositoryExtension;
 import org.apache.calcite.util.Litmus;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -42,9 +44,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>You must provide the system property "source.dir".
  */
+@ExtendWith(DiffRepositoryExtension.class)
 class SqlPrettyWriterTest {
-  protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(SqlPrettyWriterTest.class);
+  private final DiffRepository repository;
+
+  SqlPrettyWriterTest(DiffRepository repository) {
+    this.repository = repository;
   }
 
   /**
@@ -125,12 +130,12 @@ class SqlPrettyWriterTest {
         prettyWriter.describe(pw, true);
         pw.flush();
         final String desc = sw.toString();
-        getDiffRepos().assertEquals("desc", this.desc, desc);
+        repository.assertEquals("desc", this.desc, desc);
       }
 
       // Format
       final String formatted = prettyWriter.format(node);
-      getDiffRepos().assertEquals("formatted", this.formatted, formatted);
+      repository.assertEquals("formatted", this.formatted, formatted);
 
       // Now parse the result, and make sure it is structurally equivalent
       // to the original.

--- a/core/src/test/java/org/apache/calcite/test/DiffRepositoryExtension.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffRepositoryExtension.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.apache.calcite.util.Sources;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A JUnit extension to manage access to {@code DiffRepository}
+ *
+ * The extension injects a {@code DiffRepository} instance to constructor or test method parameter.
+ * By default the repository is based on the test class name, but a different repository can be
+ * used thanks to the {@code DiffRepositoryName} annotation.
+ *
+ * At the end of the test run, all instances are dumped on disk.
+ */
+public class DiffRepositoryExtension extends TypeBasedParameterResolver<DiffRepository>
+    implements BeforeAllCallback, AfterAllCallback {
+  private static final String DIFF_REPOSITORIES = "diff repositories";
+
+  public DiffRepositoryExtension() {
+  }
+
+  @Override public DiffRepository resolveParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    // Get the enclosing class
+    final Class<?> clazz = parameterContext.findAnnotation(DiffRepositoryName.class)
+        .<Class<?>>map(DiffRepositoryName::value)
+        .orElseGet(() -> getDefaultClass(parameterContext));
+
+    @SuppressWarnings("unchecked")
+    final Map<Class<?>, DiffRepository> repositories = (Map<Class<?>, DiffRepository>) getStore(
+        extensionContext).get(DIFF_REPOSITORIES);
+    DiffRepository repository = repositories.computeIfAbsent(clazz, this::toRepo);
+    return repository;
+  }
+
+  private Class<?> getDefaultClass(ParameterContext parameterContext) {
+    return parameterContext.getTarget().<Class<?>>map(Object::getClass)
+        .orElse(parameterContext.getDeclaringExecutable().getDeclaringClass());
+  }
+
+  @Override public void beforeAll(ExtensionContext context) throws Exception {
+    final Store store = getStore(context);
+    store.put(DIFF_REPOSITORIES, new ConcurrentHashMap<String, DiffRepository>());
+  }
+
+  @Override public void afterAll(ExtensionContext context) throws Exception {
+    @SuppressWarnings("unchecked")
+    Map<Class<?>, DiffRepository> repositories = (Map<Class<?>, DiffRepository>) getStore(context)
+        .get(DIFF_REPOSITORIES);
+    for (Map.Entry<Class<?>, DiffRepository> entry : repositories.entrySet()) {
+      final Class<?> clazz = entry.getKey();
+      final DiffRepository repository = entry.getValue();
+
+      final URL refFile = findFile(clazz, ".xml");
+      final String refFilePath = Sources.of(refFile).file().getAbsolutePath();
+      final String logFilePath = refFilePath.replace(".xml", "_actual.xml");
+      final File logFile = new File(logFilePath);
+      assert !refFilePath.equals(logFile.getAbsolutePath());
+
+      int indent = logFile.getPath().contains("RelOptRulesTest")
+          || logFile.getPath().contains("SqlToRelConverterTest")
+          || logFile.getPath().contains("SqlLimitsTest") ? 4 : 2;
+
+      repository.writeToFile(logFile, indent);
+    }
+  }
+
+  private Store getStore(ExtensionContext context) {
+    return context.getStore(Namespace.create(getClass(), context.getRoot()));
+  }
+
+  private static URL findFile(Class<?> clazz, final String suffix) {
+    // The reference file for class "com.foo.Bar" is "com/foo/Bar.xml"
+    String rest = "/" + clazz.getName().replace('.', File.separatorChar) + suffix;
+    return clazz.getResource(rest);
+  }
+
+  private DiffRepository toRepo(Class<?> clazz) {
+    final URL refFile = findFile(clazz, ".xml");
+
+    return new DiffRepository(refFile);
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/DiffRepositoryName.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffRepositoryName.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to specify a different {@code DiffRepository} name to be injected
+ * by {@code DiffRepositoryExtension}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface DiffRepositoryName {
+  Class<?> value();
+}

--- a/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
@@ -38,6 +38,7 @@ import org.apache.calcite.rel.rules.UnionToDistinctRule;
 import com.google.common.collect.ImmutableList;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * convenience only, whereas the tests in that class are targeted at exercising
  * specific rules, and use the planner for convenience only. Hence the split.
  */
+@ExtendWith(DiffRepositoryExtension.class)
 class HepPlannerTest extends RelOptTestBase {
   //~ Static fields/initializers ---------------------------------------------
 
@@ -82,9 +84,8 @@ class HepPlannerTest extends RelOptTestBase {
       + ") a";
 
   //~ Methods ----------------------------------------------------------------
-
-  protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(HepPlannerTest.class);
+  HepPlannerTest(DiffRepository repository) {
+    super(repository);
   }
 
   @Test void testRuleClass() throws Exception {

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -3098,7 +3098,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
       implements MetadataHandler<ColType> {
     static final ThreadLocal<List<String>> THREAD_LIST = new ThreadLocal<>();
 
-    public MetadataDef<ColType> getDef() {
+    @Override public MetadataDef<ColType> getDef() {
       return ColType.DEF;
     }
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -225,8 +225,8 @@ class RelOptRulesTest extends RelOptTestBase {
       expr instanceof RexCall
           && "item".equalsIgnoreCase(((RexCall) expr).getOperator().getName());
 
-  protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(RelOptRulesTest.class);
+  RelOptRulesTest(DiffRepository repository) {
+    super(repository);
   }
 
   @Test void testReduceNot() {
@@ -3971,7 +3971,7 @@ class RelOptRulesTest extends RelOptTestBase {
                     new Predicate<Project>() {
                       int matchCount = 0;
 
-                      public boolean test(Project project) {
+                      @Override public boolean test(Project project) {
                         return matchCount++ == 0;
                       }
                     },
@@ -6686,7 +6686,7 @@ class RelOptRulesTest extends RelOptTestBase {
       super(cluster, traitSet, child, condition);
     }
 
-    public MyFilter copy(RelTraitSet traitSet, RelNode input,
+    @Override public MyFilter copy(RelTraitSet traitSet, RelNode input,
         RexNode condition) {
       return new MyFilter(getCluster(), traitSet, input, condition);
     }
@@ -6731,7 +6731,7 @@ class RelOptRulesTest extends RelOptTestBase {
       super(cluster, traitSet, ImmutableList.of(), input, projects, rowType);
     }
 
-    public MyProject copy(RelTraitSet traitSet, RelNode input,
+    @Override public MyProject copy(RelTraitSet traitSet, RelNode input,
         List<RexNode> projects, RelDataType rowType) {
       return new MyProject(getCluster(), traitSet, input, projects, rowType);
     }

--- a/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
@@ -59,6 +59,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 abstract class RelOptTestBase extends SqlToRelTestBase {
   //~ Methods ----------------------------------------------------------------
+  protected RelOptTestBase(DiffRepository repository) {
+    super(repository);
+  }
 
   @Override protected Tester createTester() {
     return super.createTester().withDecorrelation(false);

--- a/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
@@ -96,10 +96,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Unit test for {@link org.apache.calcite.rel.hint.RelHint}.
  */
+
 class SqlHintsConverterTest extends SqlToRelTestBase {
 
-  protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(SqlHintsConverterTest.class);
+  SqlHintsConverterTest(DiffRepository repository) {
+    super(repository);
   }
 
   //~ Tests ------------------------------------------------------------------
@@ -503,7 +504,7 @@ class SqlHintsConverterTest extends SqlToRelTestBase {
       super(operand(LogicalJoin.class, any()), "MockJoinRule");
     }
 
-    public void onMatch(RelOptRuleCall call) {
+    @Override public void onMatch(RelOptRuleCall call) {
       LogicalJoin join = call.rel(0);
       assertThat(1, is(join.getHints().size()));
       call.transformTo(
@@ -695,15 +696,15 @@ class SqlHintsConverterTest extends SqlToRelTestBase {
   private static class MockAppender extends AppenderSkeleton {
     public final List<LoggingEvent> loggingEvents = new ArrayList<>();
 
-    protected void append(org.apache.log4j.spi.LoggingEvent event) {
+    @Override protected void append(org.apache.log4j.spi.LoggingEvent event) {
       loggingEvents.add(event);
     }
 
-    public void close() {
+    @Override public void close() {
       // no-op
     }
 
-    public boolean requiresLayout() {
+    @Override public boolean requiresLayout() {
       return false;
     }
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlLimitsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlLimitsTest.java
@@ -31,6 +31,7 @@ import org.apache.calcite.testlib.annotations.LocaleEnUs;
 import com.google.common.collect.ImmutableList;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -43,10 +44,13 @@ import java.util.Locale;
 /**
  * Unit test for SQL limits.
  */
+@ExtendWith(DiffRepositoryExtension.class)
 @LocaleEnUs
 public class SqlLimitsTest {
-  protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(SqlLimitsTest.class);
+  private final DiffRepository repository;
+
+  public SqlLimitsTest(DiffRepository repository) {
+    this.repository = repository;
   }
 
   /** Returns a list of typical types. */
@@ -151,7 +155,7 @@ public class SqlLimitsTest {
       pw.println();
     }
     pw.flush();
-    getDiffRepos().assertEquals("output", "${output}", sw.toString());
+    repository.assertEquals("output", "${output}", sw.toString());
   }
 
   private void printLimit(

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
@@ -49,6 +49,11 @@ class SqlToRelConverterExtendedTest extends SqlToRelConverterTest {
     }
   }
 
+  SqlToRelConverterExtendedTest(
+      @DiffRepositoryName(SqlToRelConverterTest.class) DiffRepository repository) {
+    super(repository);
+  }
+
   public static void foo(RelNode rel) {
     // Convert rel tree to JSON.
     final RelJsonWriter writer = new RelJsonWriter();

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -78,8 +78,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for {@link org.apache.calcite.sql2rel.SqlToRelConverter}.
  */
 class SqlToRelConverterTest extends SqlToRelTestBase {
-  protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(SqlToRelConverterTest.class);
+  SqlToRelConverterTest(DiffRepository repository) {
+    super(repository);
   }
 
   /** Sets the SQL statement for a test. */
@@ -3843,7 +3843,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     int invalidCount;
     final Deque<RelNode> stack = new ArrayDeque<>();
 
-    public Set<CorrelationId> correlationIds() {
+    @Override public Set<CorrelationId> correlationIds() {
       final ImmutableSet.Builder<CorrelationId> builder =
           ImmutableSet.builder();
       for (RelNode r : stack) {
@@ -3852,7 +3852,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
       return builder.build();
     }
 
-    public void visit(RelNode node, int ordinal, RelNode parent) {
+    @Override public void visit(RelNode node, int ordinal, RelNode parent) {
       try {
         stack.push(node);
         if (!node.isValid(Litmus.THROW, this)) {

--- a/core/src/test/java/org/apache/calcite/test/TopDownOptTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TopDownOptTest.java
@@ -65,9 +65,8 @@ import org.junit.jupiter.api.Test;
  * </ol>
  */
 class TopDownOptTest extends RelOptTestBase {
-
-  protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(TopDownOptTest.class);
+  TopDownOptTest(DiffRepository repository) {
+    super(repository);
   }
 
   Sql sql(String sql) {

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
  */
 class TypeCoercionConverterTest extends SqlToRelTestBase {
 
-  @Override protected DiffRepository getDiffRepos() {
-    return DiffRepository.lookup(TypeCoercionConverterTest.class);
+  TypeCoercionConverterTest(DiffRepository repository) {
+    super(repository);
   }
 
   @Override protected Tester createTester() {


### PR DESCRIPTION
Introduce JUnit DiffRepositoryExtension extension to manage concurrent access to DiffRepository instances by test classes, and dumping their content on disk at the end of the test run.
    
DiffRepositoryExtension automatically injects DiffRepository instance to the constructor based on the test class, but a different repository can be used by using the DiffRepositoryName annotation.
    
Update all the tests using DiffRepository to leverage the extension.
Cleanup DiffRepository class, and remove all unused code.