### PR TITLE
[CALCITE-3976] Generify the DefaultEdge class

### DIFF
--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -511,14 +511,6 @@ public class Lattice {
     Edge(Vertex source, Vertex target) {
       super(source, target);
     }
-
-    Vertex getTarget() {
-      return target;
-    }
-
-    Vertex getSource() {
-      return source;
-    }
   }
 
   /** Vertex in the temporary graph. */

--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -502,7 +502,7 @@ public class Lattice {
   }
 
   /** Edge in the temporary graph. */
-  private static class Edge extends DefaultEdge {
+  private static class Edge extends DefaultEdge<Vertex> {
     public static final DirectedGraph.EdgeFactory<Vertex, Edge> FACTORY =
         Edge::new;
 
@@ -513,11 +513,11 @@ public class Lattice {
     }
 
     Vertex getTarget() {
-      return (Vertex) target;
+      return target;
     }
 
     Vertex getSource() {
-      return (Vertex) source;
+      return source;
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -52,9 +52,9 @@ import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
+import org.apache.calcite.util.graph.TypedEdge;
 import org.apache.calcite.util.mapping.IntPair;
 
 import com.google.common.base.Preconditions;
@@ -502,7 +502,7 @@ public class Lattice {
   }
 
   /** Edge in the temporary graph. */
-  private static class Edge extends DefaultEdge<Vertex> {
+  private static class Edge extends TypedEdge<Vertex> {
     public static final DirectedGraph.EdgeFactory<Vertex, Edge> FACTORY =
         Edge::new;
 

--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -832,10 +832,10 @@ public class Lattice {
                 "child node must have precisely one parent: " + vertex);
           }
           final Edge edge = edges.get(0);
-          final MutableNode parent = map.get(edge.getSource().table);
+          final MutableNode parent = map.get(edge.source.table);
           final Step step =
-              Step.create(edge.getSource().table,
-                  edge.getTarget().table, edge.pairs, space);
+              Step.create(edge.source.table,
+                  edge.target.table, edge.pairs, space);
           node = new MutableNode(vertex.table, parent, step);
           node.alias = vertex.alias;
         }

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
@@ -644,7 +644,7 @@ public class LatticeSuggester {
   }
 
   /** Use of a step within a query. A step can be used more than once. */
-  private static class StepRef extends DefaultEdge {
+  private static class StepRef extends DefaultEdge<TableRef> {
     final Step step;
     private final int ordinalInQuery;
 
@@ -670,11 +670,11 @@ public class LatticeSuggester {
     }
 
     TableRef source() {
-      return (TableRef) source;
+      return source;
     }
 
     TableRef target() {
-      return (TableRef) target;
+      return target;
     }
 
     /** Creates {@link StepRef} instances. */

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
@@ -44,8 +44,8 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.graph.AttributedDirectedGraph;
 import org.apache.calcite.util.graph.CycleDetector;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
+import org.apache.calcite.util.graph.TypedEdge;
 import org.apache.calcite.util.mapping.IntPair;
 
 import com.google.common.collect.ImmutableList;
@@ -644,7 +644,7 @@ public class LatticeSuggester {
   }
 
   /** Use of a step within a query. A step can be used more than once. */
-  private static class StepRef extends DefaultEdge<TableRef> {
+  private static class StepRef extends TypedEdge<TableRef> {
     final Step step;
     private final int ordinalInQuery;
 

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
@@ -159,9 +159,9 @@ public class LatticeSuggester {
       final TableRef target = e.getKey().right;
       final StepRef stepRef =
           q.stepRef(source, target, ImmutableList.copyOf(e.getValue()));
-      g.addVertex(stepRef.source());
-      g.addVertex(stepRef.target());
-      g.addEdge(stepRef.source(), stepRef.target(), stepRef.step,
+      g.addVertex(stepRef.source);
+      g.addVertex(stepRef.target);
+      g.addEdge(stepRef.source, stepRef.target, stepRef.step,
           stepRef.ordinalInQuery);
     }
 
@@ -185,7 +185,7 @@ public class LatticeSuggester {
         break;
       case 1:
         final StepRef edge = edges.get(0);
-        final MutableNode parent = nodes.get(edge.source());
+        final MutableNode parent = nodes.get(edge.source);
         final List key =
             ImmutableList.of(parent, tableRef.table, edge.step.keys);
         final MutableNode existingNode = nodesByParent.get(key);
@@ -198,7 +198,7 @@ public class LatticeSuggester {
         break;
       default:
         for (StepRef edge2 : edges) {
-          final MutableNode parent2 = nodes.get(edge2.source());
+          final MutableNode parent2 = nodes.get(edge2.source);
           final MutableNode node2 =
               new MutableNode(tableRef.table, parent2, edge2.step);
           parent2.children.add(node2);
@@ -570,10 +570,10 @@ public class LatticeSuggester {
       final Step h = Step.create(source.table, target.table, keys, space);
       if (h.isBackwards(space.statisticProvider)) {
         final List<IntPair> keys1 = LatticeSpace.swap(h.keys);
-        final Step h2 = space.addEdge(h.target(), h.source(), keys1);
+        final Step h2 = space.addEdge(h.target, h.source, keys1);
         return new StepRef(target, source, h2, stepRefCount++);
       } else {
-        final Step h2 = space.addEdge(h.source(), h.target(), h.keys);
+        final Step h2 = space.addEdge(h.source, h.target, h.keys);
         return new StepRef(source, target, h2, stepRefCount++);
       }
     }
@@ -667,14 +667,6 @@ public class LatticeSuggester {
     @Override public String toString() {
       return "StepRef(" + source + ", " + target + "," + step.keyString + "):"
           + ordinalInQuery;
-    }
-
-    TableRef source() {
-      return source;
-    }
-
-    TableRef target() {
-      return target;
     }
 
     /** Creates {@link StepRef} instances. */

--- a/core/src/main/java/org/apache/calcite/materialize/MutableNode.java
+++ b/core/src/main/java/org/apache/calcite/materialize/MutableNode.java
@@ -104,7 +104,7 @@ class MutableNode {
     for (Step step1 : path.steps) {
       MutableNode n2 = n.findChild(step1);
       if (n2 == null) {
-        n2 = new MutableNode(step1.target(), n, step1);
+        n2 = new MutableNode(step1.target, n, step1);
         if (alias != null) {
           n2.alias = alias;
         }
@@ -115,7 +115,7 @@ class MutableNode {
 
   private MutableNode findChild(Step step) {
     for (MutableNode child : children) {
-      if (child.table.equals(step.target())
+      if (child.table.equals(step.target)
           && child.step.equals(step)) {
         return child;
       }

--- a/core/src/main/java/org/apache/calcite/materialize/Step.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Step.java
@@ -18,7 +18,7 @@ package org.apache.calcite.materialize;
 
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.util.graph.AttributedDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
+import org.apache.calcite.util.graph.TypedEdge;
 import org.apache.calcite.util.mapping.IntPair;
 
 import com.google.common.collect.ImmutableList;
@@ -36,7 +36,7 @@ import java.util.Objects;
  * <p>When created via
  * {@link LatticeSpace#addEdge(LatticeTable, LatticeTable, List)}
  * it is unique within the {@link LatticeSpace}. */
-class Step extends DefaultEdge<LatticeTable> {
+class Step extends TypedEdge<LatticeTable> {
   final List<IntPair> keys;
 
   /** String representation of {@link #keys}. Computing the string requires a

--- a/core/src/main/java/org/apache/calcite/materialize/Step.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Step.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * <p>When created via
  * {@link LatticeSpace#addEdge(LatticeTable, LatticeTable, List)}
  * it is unique within the {@link LatticeSpace}. */
-class Step extends DefaultEdge {
+class Step extends DefaultEdge<LatticeTable> {
   final List<IntPair> keys;
 
   /** String representation of {@link #keys}. Computing the string requires a
@@ -81,11 +81,11 @@ class Step extends DefaultEdge {
   }
 
   LatticeTable source() {
-    return (LatticeTable) source;
+    return source;
   }
 
   LatticeTable target() {
-    return (LatticeTable) target;
+    return target;
   }
 
   boolean isBackwards(SqlStatisticProvider statisticProvider) {

--- a/core/src/main/java/org/apache/calcite/materialize/Step.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Step.java
@@ -80,18 +80,10 @@ class Step extends TypedEdge<LatticeTable> {
     return "Step(" + source + ", " + target + "," + keyString + ")";
   }
 
-  LatticeTable source() {
-    return source;
-  }
-
-  LatticeTable target() {
-    return target;
-  }
-
   boolean isBackwards(SqlStatisticProvider statisticProvider) {
-    final RelOptTable sourceTable = source().t;
+    final RelOptTable sourceTable = source.t;
     final List<Integer> sourceColumns = IntPair.left(keys);
-    final RelOptTable targetTable = target().t;
+    final RelOptTable targetTable = target.t;
     final List<Integer> targetColumns = IntPair.right(keys);
     final boolean noDerivedSourceColumns =
         sourceColumns.stream().allMatch(i ->

--- a/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
@@ -208,7 +208,7 @@ public class ConventionTraitDef extends RelTraitDef<Convention> {
 
   /** Workspace for converting from one convention to another. */
   private static final class ConversionData {
-    final DirectedGraph<Convention, DefaultEdge> conversionGraph =
+    final DirectedGraph<Convention, DefaultEdge<Convention>> conversionGraph =
         DefaultDirectedGraph.create();
 
     /**
@@ -219,7 +219,7 @@ public class ConventionTraitDef extends RelTraitDef<Convention> {
     final Multimap<Pair<Convention, Convention>, ConverterRule> mapArcToConverterRule =
         HashMultimap.create();
 
-    private Graphs.FrozenGraph<Convention, DefaultEdge> pathMap;
+    private Graphs.FrozenGraph<Convention, DefaultEdge<Convention>> pathMap;
 
     public List<List<Convention>> getPaths(
         Convention fromConvention,
@@ -227,7 +227,7 @@ public class ConventionTraitDef extends RelTraitDef<Convention> {
       return getPathMap().getPaths(fromConvention, toConvention);
     }
 
-    private Graphs.FrozenGraph<Convention, DefaultEdge> getPathMap() {
+    private Graphs.FrozenGraph<Convention, DefaultEdge<Convention>> getPathMap() {
       if (pathMap == null) {
         pathMap = Graphs.makeImmutable(conversionGraph);
       }

--- a/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/plan/ConventionTraitDef.java
@@ -21,9 +21,9 @@ import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.Graphs;
+import org.apache.calcite.util.graph.TypedEdge;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -208,18 +208,18 @@ public class ConventionTraitDef extends RelTraitDef<Convention> {
 
   /** Workspace for converting from one convention to another. */
   private static final class ConversionData {
-    final DirectedGraph<Convention, DefaultEdge<Convention>> conversionGraph =
+    final DirectedGraph<Convention, TypedEdge<Convention>> conversionGraph =
         DefaultDirectedGraph.create();
 
     /**
      * For a given source/target convention, there may be several possible
-     * conversion rules. Maps {@link DefaultEdge} to a
+     * conversion rules. Maps {@link TypedEdge} to a
      * collection of {@link ConverterRule} objects.
      */
     final Multimap<Pair<Convention, Convention>, ConverterRule> mapArcToConverterRule =
         HashMultimap.create();
 
-    private Graphs.FrozenGraph<Convention, DefaultEdge<Convention>> pathMap;
+    private Graphs.FrozenGraph<Convention, TypedEdge<Convention>> pathMap;
 
     public List<List<Convention>> getPaths(
         Convention fromConvention,
@@ -227,7 +227,7 @@ public class ConventionTraitDef extends RelTraitDef<Convention> {
       return getPathMap().getPaths(fromConvention, toConvention);
     }
 
-    private Graphs.FrozenGraph<Convention, DefaultEdge<Convention>> getPathMap() {
+    private Graphs.FrozenGraph<Convention, TypedEdge<Convention>> getPathMap() {
       if (pathMap == null) {
         pathMap = Graphs.makeImmutable(conversionGraph);
       }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
@@ -27,10 +27,10 @@ import org.apache.calcite.sql2rel.RelFieldTrimmer;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.Graphs;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
+import org.apache.calcite.util.graph.TypedEdge;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -127,7 +127,7 @@ public abstract class RelOptMaterializations {
    */
   public static List<RelOptMaterialization> getApplicableMaterializations(
       RelNode rel, List<RelOptMaterialization> materializations) {
-    DirectedGraph<List<String>, DefaultEdge<List<String>>> usesGraph =
+    DirectedGraph<List<String>, TypedEdge<List<String>>> usesGraph =
         DefaultDirectedGraph.create();
     final Map<List<String>, RelOptMaterialization> qnameMap = new HashMap<>();
     for (RelOptMaterialization materialization : materializations) {
@@ -154,7 +154,7 @@ public abstract class RelOptMaterializations {
     // the graph will contain
     //   (T, Emps), (T, Depts), (T2, T)
     // and therefore we can deduce T2 uses Emps.
-    final Graphs.FrozenGraph<List<String>, DefaultEdge<List<String>>> frozenGraph =
+    final Graphs.FrozenGraph<List<String>, TypedEdge<List<String>>> frozenGraph =
         Graphs.makeImmutable(usesGraph);
     final Set<RelOptTable> queryTablesUsed = RelOptUtil.findTables(rel);
     final List<RelOptMaterialization> applicableMaterializations =
@@ -240,7 +240,7 @@ public abstract class RelOptMaterializations {
   private static boolean usesTable(
       List<String> qualifiedName,
       Set<RelOptTable> usedTables,
-      Graphs.FrozenGraph<List<String>, DefaultEdge<List<String>>> usesGraph) {
+      Graphs.FrozenGraph<List<String>, TypedEdge<List<String>>> usesGraph) {
     for (RelOptTable queryTable : usedTables) {
       if (usesGraph.getShortestDistance(queryTable.getQualifiedName(), qualifiedName)
           != -1) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
@@ -127,7 +127,7 @@ public abstract class RelOptMaterializations {
    */
   public static List<RelOptMaterialization> getApplicableMaterializations(
       RelNode rel, List<RelOptMaterialization> materializations) {
-    DirectedGraph<List<String>, DefaultEdge> usesGraph =
+    DirectedGraph<List<String>, DefaultEdge<List<String>>> usesGraph =
         DefaultDirectedGraph.create();
     final Map<List<String>, RelOptMaterialization> qnameMap = new HashMap<>();
     for (RelOptMaterialization materialization : materializations) {
@@ -154,7 +154,7 @@ public abstract class RelOptMaterializations {
     // the graph will contain
     //   (T, Emps), (T, Depts), (T2, T)
     // and therefore we can deduce T2 uses Emps.
-    final Graphs.FrozenGraph<List<String>, DefaultEdge> frozenGraph =
+    final Graphs.FrozenGraph<List<String>, DefaultEdge<List<String>>> frozenGraph =
         Graphs.makeImmutable(usesGraph);
     final Set<RelOptTable> queryTablesUsed = RelOptUtil.findTables(rel);
     final List<RelOptMaterialization> applicableMaterializations =
@@ -240,7 +240,7 @@ public abstract class RelOptMaterializations {
   private static boolean usesTable(
       List<String> qualifiedName,
       Set<RelOptTable> usedTables,
-      Graphs.FrozenGraph<List<String>, DefaultEdge> usesGraph) {
+      Graphs.FrozenGraph<List<String>, DefaultEdge<List<String>>> usesGraph) {
     for (RelOptTable queryTable : usedTables) {
       if (usesGraph.getShortestDistance(queryTable.getQualifiedName(), qualifiedName)
           != -1) {

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -45,11 +45,11 @@ import org.apache.calcite.util.Util;
 import org.apache.calcite.util.graph.BreadthFirstIterator;
 import org.apache.calcite.util.graph.CycleDetector;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DepthFirstIterator;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.Graphs;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
+import org.apache.calcite.util.graph.TypedEdge;
 
 import com.google.common.collect.ImmutableList;
 
@@ -101,7 +101,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
    * single-rooted DAG, possibly with additional roots corresponding to
    * discarded plan fragments which remain to be garbage-collected.
    */
-  private final DirectedGraph<HepRelVertex, DefaultEdge<HepRelVertex>> graph =
+  private final DirectedGraph<HepRelVertex, TypedEdge<HepRelVertex>> graph =
       DefaultDirectedGraph.create();
 
   private final Function2<RelNode, RelNode, Void> onCopyHook;
@@ -879,10 +879,10 @@ public class HepPlanner extends AbstractRelOptPlanner {
     if (!RelMdUtil.clearCache(vertex)) {
       return;
     }
-    Queue<DefaultEdge<HepRelVertex>> queue =
+    Queue<TypedEdge<HepRelVertex>> queue =
         new LinkedList<>(graph.getInwardEdges(vertex));
     while (!queue.isEmpty()) {
-      DefaultEdge<HepRelVertex> edge = queue.remove();
+      TypedEdge<HepRelVertex> edge = queue.remove();
       HepRelVertex source = (HepRelVertex) edge.source;
       RelMdUtil.clearCache(source.getCurrentRel());
       if (RelMdUtil.clearCache(source)) {
@@ -989,7 +989,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
 
   private void assertNoCycles() {
     // Verify that the graph is acyclic.
-    final CycleDetector<HepRelVertex, DefaultEdge<HepRelVertex>> cycleDetector =
+    final CycleDetector<HepRelVertex, TypedEdge<HepRelVertex>> cycleDetector =
         new CycleDetector<>(graph);
     Set<HepRelVertex> cyclicVertices = cycleDetector.findCycles();
     if (cyclicVertices.isEmpty()) {

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -883,7 +883,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
         new LinkedList<>(graph.getInwardEdges(vertex));
     while (!queue.isEmpty()) {
       TypedEdge<HepRelVertex> edge = queue.remove();
-      HepRelVertex source = (HepRelVertex) edge.source;
+      HepRelVertex source = edge.source;
       RelMdUtil.clearCache(source.getCurrentRel());
       if (RelMdUtil.clearCache(source)) {
         queue.addAll(graph.getInwardEdges(source));

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -101,7 +101,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
    * single-rooted DAG, possibly with additional roots corresponding to
    * discarded plan fragments which remain to be garbage-collected.
    */
-  private final DirectedGraph<HepRelVertex, DefaultEdge> graph =
+  private final DirectedGraph<HepRelVertex, DefaultEdge<HepRelVertex>> graph =
       DefaultDirectedGraph.create();
 
   private final Function2<RelNode, RelNode, Void> onCopyHook;
@@ -879,10 +879,10 @@ public class HepPlanner extends AbstractRelOptPlanner {
     if (!RelMdUtil.clearCache(vertex)) {
       return;
     }
-    Queue<DefaultEdge> queue =
+    Queue<DefaultEdge<HepRelVertex>> queue =
         new LinkedList<>(graph.getInwardEdges(vertex));
     while (!queue.isEmpty()) {
-      DefaultEdge edge = queue.remove();
+      DefaultEdge<HepRelVertex> edge = queue.remove();
       HepRelVertex source = (HepRelVertex) edge.source;
       RelMdUtil.clearCache(source.getCurrentRel());
       if (RelMdUtil.clearCache(source)) {
@@ -989,7 +989,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
 
   private void assertNoCycles() {
     // Verify that the graph is acyclic.
-    final CycleDetector<HepRelVertex, DefaultEdge> cycleDetector =
+    final CycleDetector<HepRelVertex, DefaultEdge<HepRelVertex>> cycleDetector =
         new CycleDetector<>(graph);
     Set<HepRelVertex> cyclicVertices = cycleDetector.findCycles();
     if (cyclicVertices.isEmpty()) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
@@ -39,9 +39,9 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
+import org.apache.calcite.util.graph.TypedEdge;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
@@ -428,7 +428,7 @@ public abstract class CalcRelSplitter {
   private List<Integer> computeTopologicalOrdering(
       RexNode[] exprs,
       List<Set<Integer>> cohorts) {
-    final DirectedGraph<Integer, DefaultEdge<Integer>> graph =
+    final DirectedGraph<Integer, TypedEdge<Integer>> graph =
         DefaultDirectedGraph.create();
     for (int i = 0; i < exprs.length; i++) {
       graph.addVertex(i);
@@ -452,7 +452,7 @@ public abstract class CalcRelSplitter {
             }
           });
     }
-    TopologicalOrderIterator<Integer, DefaultEdge<Integer>> iter =
+    TopologicalOrderIterator<Integer, TypedEdge<Integer>> iter =
         new TopologicalOrderIterator<>(graph);
     final List<Integer> permutation = new ArrayList<>();
     while (iter.hasNext()) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
@@ -428,7 +428,7 @@ public abstract class CalcRelSplitter {
   private List<Integer> computeTopologicalOrdering(
       RexNode[] exprs,
       List<Set<Integer>> cohorts) {
-    final DirectedGraph<Integer, DefaultEdge> graph =
+    final DirectedGraph<Integer, DefaultEdge<Integer>> graph =
         DefaultDirectedGraph.create();
     for (int i = 0; i < exprs.length; i++) {
       graph.addVertex(i);
@@ -452,7 +452,7 @@ public abstract class CalcRelSplitter {
             }
           });
     }
-    TopologicalOrderIterator<Integer, DefaultEdge> iter =
+    TopologicalOrderIterator<Integer, DefaultEdge<Integer>> iter =
         new TopologicalOrderIterator<>(graph);
     final List<Integer> permutation = new ArrayList<>();
     while (iter.hasNext()) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
@@ -41,9 +41,9 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
+import org.apache.calcite.util.graph.TypedEdge;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -267,7 +267,7 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       // (1). They have the same RexWindow
       // (2). They are not dependent on each other
       final List<RexNode> exprs = this.program.getExprList();
-      final DirectedGraph<Integer, DefaultEdge<Integer>> graph =
+      final DirectedGraph<Integer, TypedEdge<Integer>> graph =
           createGraphFromExpression(exprs);
       final List<Integer> rank = getRank(graph);
 
@@ -315,7 +315,7 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       return cohorts;
     }
 
-    private boolean isDependent(final DirectedGraph<Integer, DefaultEdge<Integer>> graph,
+    private boolean isDependent(final DirectedGraph<Integer, TypedEdge<Integer>> graph,
         final List<Integer> rank,
         final int ordinal1,
         final int ordinal2) {
@@ -339,7 +339,7 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
         }
 
         visited.add(source);
-        for (DefaultEdge<Integer> e : graph.getOutwardEdges(source)) {
+        for (TypedEdge<Integer> e : graph.getOutwardEdges(source)) {
           int target = e.target;
           if (rank.get(target) <= rank.get(ordinal1)) {
             dfs.push(target);
@@ -350,7 +350,7 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       return false;
     }
 
-    private List<Integer> getRank(DirectedGraph<Integer, DefaultEdge<Integer>> graph) {
+    private List<Integer> getRank(DirectedGraph<Integer, TypedEdge<Integer>> graph) {
       final int[] rankArr = new int[graph.vertexSet().size()];
       int rank = 0;
       for (int i : TopologicalOrderIterator.of(graph)) {
@@ -359,9 +359,9 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       return ImmutableIntList.of(rankArr);
     }
 
-    private DirectedGraph<Integer, DefaultEdge<Integer>> createGraphFromExpression(
+    private DirectedGraph<Integer, TypedEdge<Integer>> createGraphFromExpression(
         final List<RexNode> exprs) {
-      final DirectedGraph<Integer, DefaultEdge<Integer>> graph =
+      final DirectedGraph<Integer, TypedEdge<Integer>> graph =
           DefaultDirectedGraph.create();
       for (int i = 0; i < exprs.size(); i++) {
         graph.addVertex(i);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
@@ -267,7 +267,7 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       // (1). They have the same RexWindow
       // (2). They are not dependent on each other
       final List<RexNode> exprs = this.program.getExprList();
-      final DirectedGraph<Integer, DefaultEdge> graph =
+      final DirectedGraph<Integer, DefaultEdge<Integer>> graph =
           createGraphFromExpression(exprs);
       final List<Integer> rank = getRank(graph);
 
@@ -315,7 +315,7 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       return cohorts;
     }
 
-    private boolean isDependent(final DirectedGraph<Integer, DefaultEdge> graph,
+    private boolean isDependent(final DirectedGraph<Integer, DefaultEdge<Integer>> graph,
         final List<Integer> rank,
         final int ordinal1,
         final int ordinal2) {
@@ -339,8 +339,8 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
         }
 
         visited.add(source);
-        for (DefaultEdge e : graph.getOutwardEdges(source)) {
-          int target = (int) e.target;
+        for (DefaultEdge<Integer> e : graph.getOutwardEdges(source)) {
+          int target = e.target;
           if (rank.get(target) <= rank.get(ordinal1)) {
             dfs.push(target);
           }
@@ -350,7 +350,7 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       return false;
     }
 
-    private List<Integer> getRank(DirectedGraph<Integer, DefaultEdge> graph) {
+    private List<Integer> getRank(DirectedGraph<Integer, DefaultEdge<Integer>> graph) {
       final int[] rankArr = new int[graph.vertexSet().size()];
       int rank = 0;
       for (int i : TopologicalOrderIterator.of(graph)) {
@@ -359,9 +359,9 @@ public abstract class ProjectToWindowRule extends RelOptRule implements Transfor
       return ImmutableIntList.of(rankArr);
     }
 
-    private DirectedGraph<Integer, DefaultEdge> createGraphFromExpression(
+    private DirectedGraph<Integer, DefaultEdge<Integer>> createGraphFromExpression(
         final List<RexNode> exprs) {
-      final DirectedGraph<Integer, DefaultEdge> graph =
+      final DirectedGraph<Integer, DefaultEdge<Integer>> graph =
           DefaultDirectedGraph.create();
       for (int i = 0; i < exprs.size(); i++) {
         graph.addVertex(i);

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
@@ -52,8 +52,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
+import org.apache.calcite.util.graph.TypedEdge;
 import org.apache.calcite.util.mapping.Mapping;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -1348,7 +1348,7 @@ public abstract class MaterializedViewRule extends RelOptRule {
   }
 
   /** Edge for graph */
-  protected static class Edge extends DefaultEdge<RelTableRef> {
+  protected static class Edge extends TypedEdge<RelTableRef> {
     final Multimap<RexTableInputRef, RexTableInputRef> equiColumns =
         ArrayListMultimap.create();
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
@@ -1348,7 +1348,7 @@ public abstract class MaterializedViewRule extends RelOptRule {
   }
 
   /** Edge for graph */
-  protected static class Edge extends DefaultEdge {
+  protected static class Edge extends DefaultEdge<RelTableRef> {
     final Multimap<RexTableInputRef, RexTableInputRef> equiColumns =
         ArrayListMultimap.create();
 

--- a/core/src/main/java/org/apache/calcite/util/graph/AttributedDirectedGraph.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/AttributedDirectedGraph.java
@@ -27,14 +27,14 @@ import java.util.List;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class AttributedDirectedGraph<V, E extends DefaultEdge<V>>
+public class AttributedDirectedGraph<V, E extends TypedEdge<V>>
     extends DefaultDirectedGraph<V, E> {
   /** Creates an attributed graph. */
   public AttributedDirectedGraph(AttributedEdgeFactory<V, E> edgeFactory) {
     super(edgeFactory);
   }
 
-  public static <V, E extends DefaultEdge<V>> AttributedDirectedGraph<V, E> create(
+  public static <V, E extends TypedEdge<V>> AttributedDirectedGraph<V, E> create(
       AttributedEdgeFactory<V, E> edgeFactory) {
     return new AttributedDirectedGraph<>(edgeFactory);
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/AttributedDirectedGraph.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/AttributedDirectedGraph.java
@@ -27,14 +27,14 @@ import java.util.List;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class AttributedDirectedGraph<V, E extends DefaultEdge>
+public class AttributedDirectedGraph<V, E extends DefaultEdge<V>>
     extends DefaultDirectedGraph<V, E> {
   /** Creates an attributed graph. */
   public AttributedDirectedGraph(AttributedEdgeFactory<V, E> edgeFactory) {
     super(edgeFactory);
   }
 
-  public static <V, E extends DefaultEdge> AttributedDirectedGraph<V, E> create(
+  public static <V, E extends DefaultEdge<V>> AttributedDirectedGraph<V, E> create(
       AttributedEdgeFactory<V, E> edgeFactory) {
     return new AttributedDirectedGraph<>(edgeFactory);
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/BreadthFirstIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/BreadthFirstIterator.java
@@ -53,7 +53,7 @@ public class BreadthFirstIterator<V, E extends TypedEdge<V>>
     while (!deque.isEmpty()) {
       V v = deque.removeFirst();
       for (E e : graph.getOutwardEdges(v)) {
-        @SuppressWarnings("unchecked") V target = (V) e.target;
+        @SuppressWarnings("unchecked") V target = e.target;
         if (set.add(target)) {
           deque.addLast(target);
         }
@@ -68,7 +68,7 @@ public class BreadthFirstIterator<V, E extends TypedEdge<V>>
   public V next() {
     V v = deque.removeFirst();
     for (E e : graph.getOutwardEdges(v)) {
-      @SuppressWarnings("unchecked") V target = (V) e.target;
+      @SuppressWarnings("unchecked") V target = e.target;
       if (set.add(target)) {
         deque.addLast(target);
       }

--- a/core/src/main/java/org/apache/calcite/util/graph/BreadthFirstIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/BreadthFirstIterator.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class BreadthFirstIterator<V, E extends DefaultEdge<V>>
+public class BreadthFirstIterator<V, E extends TypedEdge<V>>
     implements Iterator<V> {
   private final DirectedGraph<V, E> graph;
   private final Deque<V> deque = new ArrayDeque<>();
@@ -39,13 +39,13 @@ public class BreadthFirstIterator<V, E extends DefaultEdge<V>>
     this.deque.add(root);
   }
 
-  public static <V, E extends DefaultEdge<V>> Iterable<V> of(
+  public static <V, E extends TypedEdge<V>> Iterable<V> of(
       final DirectedGraph<V, E> graph, final V root) {
     return () -> new BreadthFirstIterator<>(graph, root);
   }
 
   /** Populates a set with the nodes reachable from a given node. */
-  public static <V, E extends DefaultEdge<V>> void reachable(Set<V> set,
+  public static <V, E extends TypedEdge<V>> void reachable(Set<V> set,
       final DirectedGraph<V, E> graph, final V root) {
     final Deque<V> deque = new ArrayDeque<>();
     deque.add(root);

--- a/core/src/main/java/org/apache/calcite/util/graph/BreadthFirstIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/BreadthFirstIterator.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class BreadthFirstIterator<V, E extends DefaultEdge>
+public class BreadthFirstIterator<V, E extends DefaultEdge<V>>
     implements Iterator<V> {
   private final DirectedGraph<V, E> graph;
   private final Deque<V> deque = new ArrayDeque<>();
@@ -39,13 +39,13 @@ public class BreadthFirstIterator<V, E extends DefaultEdge>
     this.deque.add(root);
   }
 
-  public static <V, E extends DefaultEdge> Iterable<V> of(
+  public static <V, E extends DefaultEdge<V>> Iterable<V> of(
       final DirectedGraph<V, E> graph, final V root) {
     return () -> new BreadthFirstIterator<>(graph, root);
   }
 
   /** Populates a set with the nodes reachable from a given node. */
-  public static <V, E extends DefaultEdge> void reachable(Set<V> set,
+  public static <V, E extends DefaultEdge<V>> void reachable(Set<V> set,
       final DirectedGraph<V, E> graph, final V root) {
     final Deque<V> deque = new ArrayDeque<>();
     deque.add(root);

--- a/core/src/main/java/org/apache/calcite/util/graph/CycleDetector.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/CycleDetector.java
@@ -24,7 +24,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class CycleDetector<V, E extends DefaultEdge> {
+public class CycleDetector<V, E extends DefaultEdge<V>> {
   private final DirectedGraph<V, E> graph;
 
   public CycleDetector(DirectedGraph<V, E> graph) {

--- a/core/src/main/java/org/apache/calcite/util/graph/DefaultDirectedGraph.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DefaultDirectedGraph.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class DefaultDirectedGraph<V, E extends DefaultEdge<V>>
+public class DefaultDirectedGraph<V, E extends TypedEdge<V>>
     implements DirectedGraph<V, E> {
   final Set<E> edges = new LinkedHashSet<>();
   final Map<V, VertexInfo<V, E>> vertexMap = new LinkedHashMap<>();
@@ -45,11 +45,11 @@ public class DefaultDirectedGraph<V, E extends DefaultEdge<V>>
     this.edgeFactory = edgeFactory;
   }
 
-  public static <V> DefaultDirectedGraph<V, DefaultEdge<V>> create() {
-    return create(DefaultEdge.factory());
+  public static <V> DefaultDirectedGraph<V, TypedEdge<V>> create() {
+    return create(TypedEdge.factory());
   }
 
-  public static <V, E extends DefaultEdge<V>> DefaultDirectedGraph<V, E> create(
+  public static <V, E extends TypedEdge<V>> DefaultDirectedGraph<V, E> create(
       EdgeFactory<V, E> edgeFactory) {
     return new DefaultDirectedGraph<>(edgeFactory);
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/DefaultDirectedGraph.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DefaultDirectedGraph.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class DefaultDirectedGraph<V, E extends DefaultEdge>
+public class DefaultDirectedGraph<V, E extends DefaultEdge<V>>
     implements DirectedGraph<V, E> {
   final Set<E> edges = new LinkedHashSet<>();
   final Map<V, VertexInfo<V, E>> vertexMap = new LinkedHashMap<>();
@@ -45,11 +45,11 @@ public class DefaultDirectedGraph<V, E extends DefaultEdge>
     this.edgeFactory = edgeFactory;
   }
 
-  public static <V> DefaultDirectedGraph<V, DefaultEdge> create() {
+  public static <V> DefaultDirectedGraph<V, DefaultEdge<V>> create() {
     return create(DefaultEdge.factory());
   }
 
-  public static <V, E extends DefaultEdge> DefaultDirectedGraph<V, E> create(
+  public static <V, E extends DefaultEdge<V>> DefaultDirectedGraph<V, E> create(
       EdgeFactory<V, E> edgeFactory) {
     return new DefaultDirectedGraph<>(edgeFactory);
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/DefaultDirectedGraph.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DefaultDirectedGraph.java
@@ -182,14 +182,14 @@ public class DefaultDirectedGraph<V, E extends TypedEdge<V>>
 
       // remove all edges pointing to v
       for (E edge : info.inEdges) {
-        final V source = (V) edge.source;
+        final V source = edge.source;
         final VertexInfo<V, E> sourceInfo = vertexMap.get(source);
         sourceInfo.outEdges.removeIf(e -> e.target.equals(v));
       }
 
       // remove all edges starting from v
       for (E edge : info.outEdges) {
-        final V target = (V) edge.target;
+        final V target = edge.target;
         final VertexInfo<V, E> targetInfo = vertexMap.get(target);
         targetInfo.inEdges.removeIf(e -> e.source.equals(v));
       }
@@ -203,8 +203,8 @@ public class DefaultDirectedGraph<V, E extends TypedEdge<V>>
   private void removeMajorityVertices(Set<V> vertexSet) {
     vertexMap.keySet().removeAll(vertexSet);
     for (VertexInfo<V, E> info : vertexMap.values()) {
-      info.outEdges.removeIf(e -> vertexSet.contains((V) e.target));
-      info.inEdges.removeIf(e -> vertexSet.contains((V) e.source));
+      info.outEdges.removeIf(e -> vertexSet.contains(e.target));
+      info.inEdges.removeIf(e -> vertexSet.contains(e.source));
     }
   }
 
@@ -218,12 +218,12 @@ public class DefaultDirectedGraph<V, E extends TypedEdge<V>>
 
   final V source(E edge) {
     //noinspection unchecked
-    return (V) edge.source;
+    return edge.source;
   }
 
   final V target(E edge) {
     //noinspection unchecked
-    return (V) edge.target;
+    return edge.target;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
@@ -20,12 +20,13 @@ import java.util.Objects;
 
 /**
  * Default implementation of Edge.
+ * @param <V> vertex type.
  */
-public class DefaultEdge {
-  public final Object source;
-  public final Object target;
+public class DefaultEdge<V> {
+  public final V source;
+  public final V target;
 
-  public DefaultEdge(Object source, Object target) {
+  public DefaultEdge(V source, V target) {
     this.source = Objects.requireNonNull(source);
     this.target = Objects.requireNonNull(target);
   }
@@ -37,11 +38,11 @@ public class DefaultEdge {
   @Override public boolean equals(Object obj) {
     return this == obj
         || obj instanceof DefaultEdge
-        && ((DefaultEdge) obj).source.equals(source)
-        && ((DefaultEdge) obj).target.equals(target);
+        && ((DefaultEdge<V>) obj).source.equals(source)
+        && ((DefaultEdge<V>) obj).target.equals(target);
   }
 
-  public static <V> DirectedGraph.EdgeFactory<V, DefaultEdge> factory() {
+  public static <V> DirectedGraph.EdgeFactory<V, DefaultEdge<V>> factory() {
     return DefaultEdge::new;
   }
 }

--- a/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
@@ -20,13 +20,12 @@ import java.util.Objects;
 
 /**
  * Default implementation of Edge.
- * @param <V> vertex type.
  */
-public class DefaultEdge<V> {
-  public final V source;
-  public final V target;
+public class DefaultEdge {
+  public final Object source;
+  public final Object target;
 
-  public DefaultEdge(V source, V target) {
+  public DefaultEdge(Object source, Object target) {
     this.source = Objects.requireNonNull(source);
     this.target = Objects.requireNonNull(target);
   }
@@ -38,11 +37,11 @@ public class DefaultEdge<V> {
   @Override public boolean equals(Object obj) {
     return this == obj
         || obj instanceof DefaultEdge
-        && ((DefaultEdge<V>) obj).source.equals(source)
-        && ((DefaultEdge<V>) obj).target.equals(target);
+        && ((DefaultEdge) obj).source.equals(source)
+        && ((DefaultEdge) obj).target.equals(target);
   }
 
-  public static <V> DirectedGraph.EdgeFactory<V, DefaultEdge<V>> factory() {
+  public static <V> DirectedGraph.EdgeFactory<V, DefaultEdge> factory() {
     return DefaultEdge::new;
   }
 }

--- a/core/src/main/java/org/apache/calcite/util/graph/DepthFirstIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DepthFirstIterator.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class DepthFirstIterator<V, E extends DefaultEdge<V>>
+public class DepthFirstIterator<V, E extends TypedEdge<V>>
     implements Iterator<V> {
   private final Iterator<V> iterator;
 
@@ -38,7 +38,7 @@ public class DepthFirstIterator<V, E extends DefaultEdge<V>>
     iterator = buildList(graph, start).iterator();
   }
 
-  private static <V, E extends DefaultEdge<V>> List<V> buildList(
+  private static <V, E extends TypedEdge<V>> List<V> buildList(
       DirectedGraph<V, E> graph, V start) {
     final List<V> list = new ArrayList<>();
     buildListRecurse(list, new HashSet<>(), graph, start);
@@ -47,7 +47,7 @@ public class DepthFirstIterator<V, E extends DefaultEdge<V>>
 
   /** Creates an iterable over the vertices in the given graph in a depth-first
    * iteration order. */
-  public static <V, E extends DefaultEdge<V>> Iterable<V> of(
+  public static <V, E extends TypedEdge<V>> Iterable<V> of(
       DirectedGraph<V, E> graph, V start) {
     // Doesn't actually return a DepthFirstIterator, but a list with the same
     // contents, which is more efficient.
@@ -55,12 +55,12 @@ public class DepthFirstIterator<V, E extends DefaultEdge<V>>
   }
 
   /** Populates a collection with the nodes reachable from a given node. */
-  public static <V, E extends DefaultEdge<V>> void reachable(Collection<V> list,
+  public static <V, E extends TypedEdge<V>> void reachable(Collection<V> list,
       final DirectedGraph<V, E> graph, final V start) {
     buildListRecurse(list, new HashSet<>(), graph, start);
   }
 
-  private static <V, E extends DefaultEdge<V>> void buildListRecurse(
+  private static <V, E extends TypedEdge<V>> void buildListRecurse(
       Collection<V> list, Set<V> activeVertices, DirectedGraph<V, E> graph,
       V start) {
     if (!activeVertices.add(start)) {

--- a/core/src/main/java/org/apache/calcite/util/graph/DepthFirstIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DepthFirstIterator.java
@@ -70,7 +70,7 @@ public class DepthFirstIterator<V, E extends TypedEdge<V>>
     List<E> edges = graph.getOutwardEdges(start);
     for (E edge : edges) {
       //noinspection unchecked
-      buildListRecurse(list, activeVertices, graph, (V) edge.target);
+      buildListRecurse(list, activeVertices, graph, edge.target);
     }
     activeVertices.remove(start);
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/DepthFirstIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DepthFirstIterator.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class DepthFirstIterator<V, E extends DefaultEdge>
+public class DepthFirstIterator<V, E extends DefaultEdge<V>>
     implements Iterator<V> {
   private final Iterator<V> iterator;
 
@@ -38,7 +38,7 @@ public class DepthFirstIterator<V, E extends DefaultEdge>
     iterator = buildList(graph, start).iterator();
   }
 
-  private static <V, E extends DefaultEdge> List<V> buildList(
+  private static <V, E extends DefaultEdge<V>> List<V> buildList(
       DirectedGraph<V, E> graph, V start) {
     final List<V> list = new ArrayList<>();
     buildListRecurse(list, new HashSet<>(), graph, start);
@@ -47,7 +47,7 @@ public class DepthFirstIterator<V, E extends DefaultEdge>
 
   /** Creates an iterable over the vertices in the given graph in a depth-first
    * iteration order. */
-  public static <V, E extends DefaultEdge> Iterable<V> of(
+  public static <V, E extends DefaultEdge<V>> Iterable<V> of(
       DirectedGraph<V, E> graph, V start) {
     // Doesn't actually return a DepthFirstIterator, but a list with the same
     // contents, which is more efficient.
@@ -55,12 +55,12 @@ public class DepthFirstIterator<V, E extends DefaultEdge>
   }
 
   /** Populates a collection with the nodes reachable from a given node. */
-  public static <V, E extends DefaultEdge> void reachable(Collection<V> list,
+  public static <V, E extends DefaultEdge<V>> void reachable(Collection<V> list,
       final DirectedGraph<V, E> graph, final V start) {
     buildListRecurse(list, new HashSet<>(), graph, start);
   }
 
-  private static <V, E extends DefaultEdge> void buildListRecurse(
+  private static <V, E extends DefaultEdge<V>> void buildListRecurse(
       Collection<V> list, Set<V> activeVertices, DirectedGraph<V, E> graph,
       V start) {
     if (!activeVertices.add(start)) {

--- a/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
@@ -36,7 +36,7 @@ public class Graphs {
   private Graphs() {
   }
 
-  public static <V, E extends DefaultEdge> List<V> predecessorListOf(
+  public static <V, E extends DefaultEdge<V>> List<V> predecessorListOf(
       DirectedGraph<V, E> graph, V vertex) {
     final List<E> edges = graph.getInwardEdges(vertex);
     return new AbstractList<V>() {
@@ -52,7 +52,7 @@ public class Graphs {
   }
 
   /** Returns a map of the shortest paths between any pair of nodes. */
-  public static <V, E extends DefaultEdge> FrozenGraph<V, E> makeImmutable(
+  public static <V, E extends DefaultEdge<V>> FrozenGraph<V, E> makeImmutable(
       DirectedGraph<V, E> graph) {
     DefaultDirectedGraph<V, E> graph1 = (DefaultDirectedGraph<V, E>) graph;
     Map<Pair<V, V>, int[]> shortestDistances = new HashMap<>();
@@ -97,7 +97,7 @@ public class Graphs {
    * @param <V> Vertex type
    * @param <E> Edge type
    */
-  public static class FrozenGraph<V, E extends DefaultEdge> {
+  public static class FrozenGraph<V, E extends DefaultEdge<V>> {
     private final DefaultDirectedGraph<V, E> graph;
     private final Map<Pair<V, V>, int[]> shortestDistances;
 

--- a/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
@@ -36,7 +36,7 @@ public class Graphs {
   private Graphs() {
   }
 
-  public static <V, E extends DefaultEdge<V>> List<V> predecessorListOf(
+  public static <V, E extends TypedEdge<V>> List<V> predecessorListOf(
       DirectedGraph<V, E> graph, V vertex) {
     final List<E> edges = graph.getInwardEdges(vertex);
     return new AbstractList<V>() {
@@ -52,7 +52,7 @@ public class Graphs {
   }
 
   /** Returns a map of the shortest paths between any pair of nodes. */
-  public static <V, E extends DefaultEdge<V>> FrozenGraph<V, E> makeImmutable(
+  public static <V, E extends TypedEdge<V>> FrozenGraph<V, E> makeImmutable(
       DirectedGraph<V, E> graph) {
     DefaultDirectedGraph<V, E> graph1 = (DefaultDirectedGraph<V, E>) graph;
     Map<Pair<V, V>, int[]> shortestDistances = new HashMap<>();
@@ -97,7 +97,7 @@ public class Graphs {
    * @param <V> Vertex type
    * @param <E> Edge type
    */
-  public static class FrozenGraph<V, E extends DefaultEdge<V>> {
+  public static class FrozenGraph<V, E extends TypedEdge<V>> {
     private final DefaultDirectedGraph<V, E> graph;
     private final Map<Pair<V, V>, int[]> shortestDistances;
 

--- a/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
@@ -42,7 +42,7 @@ public class Graphs {
     return new AbstractList<V>() {
       public V get(int index) {
         //noinspection unchecked
-        return (V) edges.get(index).source;
+        return edges.get(index).source;
       }
 
       public int size() {

--- a/core/src/main/java/org/apache/calcite/util/graph/TopologicalOrderIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/TopologicalOrderIterator.java
@@ -73,7 +73,7 @@ public class TopologicalOrderIterator<V, E extends TypedEdge<V>>
     V v = empties.remove(0);
     for (E o : graph.vertexMap.get(v).outEdges) {
       //noinspection unchecked
-      final V target = (V) o.target;
+      final V target = o.target;
       if (--countMap.get(target)[0] == 0) {
         countMap.remove(target);
         empties.add(target);

--- a/core/src/main/java/org/apache/calcite/util/graph/TopologicalOrderIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/TopologicalOrderIterator.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class TopologicalOrderIterator<V, E extends DefaultEdge>
+public class TopologicalOrderIterator<V, E extends DefaultEdge<V>>
     implements Iterator<V> {
   final Map<V, int[]> countMap = new HashMap<>();
   final List<V> empties = new ArrayList<>();
@@ -40,7 +40,7 @@ public class TopologicalOrderIterator<V, E extends DefaultEdge>
     populate(countMap, empties);
   }
 
-  public static <V, E extends DefaultEdge> Iterable<V> of(
+  public static <V, E extends DefaultEdge<V>> Iterable<V> of(
       final DirectedGraph<V, E> graph) {
     return () -> new TopologicalOrderIterator<>(graph);
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/TopologicalOrderIterator.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/TopologicalOrderIterator.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * @param <V> Vertex type
  * @param <E> Edge type
  */
-public class TopologicalOrderIterator<V, E extends DefaultEdge<V>>
+public class TopologicalOrderIterator<V, E extends TypedEdge<V>>
     implements Iterator<V> {
   final Map<V, int[]> countMap = new HashMap<>();
   final List<V> empties = new ArrayList<>();
@@ -40,7 +40,7 @@ public class TopologicalOrderIterator<V, E extends DefaultEdge<V>>
     populate(countMap, empties);
   }
 
-  public static <V, E extends DefaultEdge<V>> Iterable<V> of(
+  public static <V, E extends TypedEdge<V>> Iterable<V> of(
       final DirectedGraph<V, E> graph) {
     return () -> new TopologicalOrderIterator<>(graph);
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/TypedEdge.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/TypedEdge.java
@@ -42,14 +42,6 @@ public class TypedEdge<V> {
         && ((TypedEdge<V>) obj).target.equals(target);
   }
 
-  public V getTarget() {
-    return target;
-  }
-
-  public V getSource() {
-    return source;
-  }
-
   public static <V> DirectedGraph.EdgeFactory<V, TypedEdge<V>> factory() {
     return TypedEdge::new;
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/TypedEdge.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/TypedEdge.java
@@ -42,6 +42,14 @@ public class TypedEdge<V> {
         && ((TypedEdge<V>) obj).target.equals(target);
   }
 
+  public V getTarget() {
+    return target;
+  }
+
+  public V getSource() {
+    return source;
+  }
+
   public static <V> DirectedGraph.EdgeFactory<V, TypedEdge<V>> factory() {
     return TypedEdge::new;
   }

--- a/core/src/main/java/org/apache/calcite/util/graph/TypedEdge.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/TypedEdge.java
@@ -16,22 +16,33 @@
  */
 package org.apache.calcite.util.graph;
 
-import java.util.Set;
+import java.util.Objects;
 
 /**
- * Detects cycles in directed graphs.
- *
- * @param <V> Vertex type
- * @param <E> Edge type
+ * Edge implementation with generic vertex type.
+ * @param <V> vertex type.
  */
-public class CycleDetector<V, E extends TypedEdge<V>> {
-  private final DirectedGraph<V, E> graph;
+public class TypedEdge<V> {
+  public final V source;
+  public final V target;
 
-  public CycleDetector(DirectedGraph<V, E> graph) {
-    this.graph = graph;
+  public TypedEdge(V source, V target) {
+    this.source = Objects.requireNonNull(source);
+    this.target = Objects.requireNonNull(target);
   }
 
-  public Set<V> findCycles() {
-    return new TopologicalOrderIterator<>(graph).findCycles();
+  @Override public int hashCode() {
+    return source.hashCode() * 31 + target.hashCode();
+  }
+
+  @Override public boolean equals(Object obj) {
+    return this == obj
+        || obj instanceof TypedEdge
+        && ((TypedEdge<V>) obj).source.equals(source)
+        && ((TypedEdge<V>) obj).target.equals(target);
+  }
+
+  public static <V> DirectedGraph.EdgeFactory<V, TypedEdge<V>> factory() {
+    return TypedEdge::new;
   }
 }

--- a/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
+++ b/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class DirectedGraphTest {
   @Test void testOne() {
-    DirectedGraph<String, DefaultEdge<String>> g = DefaultDirectedGraph.create();
+    DirectedGraph<String, TypedEdge<String>> g = DefaultDirectedGraph.create();
     g.addVertex("A");
     g.addVertex("B");
     g.addVertex("C");
@@ -69,25 +69,25 @@ class DirectedGraphTest {
     assertEquals("[[A, B, D], [A, B, C, D]]", paths(g, "A", "D").toString());
   }
 
-  private <V> List<V> shortestPath(DirectedGraph<V, DefaultEdge<V>> g,
+  private <V> List<V> shortestPath(DirectedGraph<V, TypedEdge<V>> g,
       V source, V target) {
     List<List<V>> paths = Graphs.makeImmutable(g).getPaths(source, target);
     return paths.isEmpty() ? null : paths.get(0);
   }
 
-  private <V> List<V> shortestPath(Graphs.FrozenGraph<V, DefaultEdge<V>> g,
+  private <V> List<V> shortestPath(Graphs.FrozenGraph<V, TypedEdge<V>> g,
                                    V source, V target) {
     List<List<V>> paths = g.getPaths(source, target);
     return paths.isEmpty() ? null : paths.get(0);
   }
 
-  private <V> List<List<V>> paths(DirectedGraph<V, DefaultEdge<V>> g,
+  private <V> List<List<V>> paths(DirectedGraph<V, TypedEdge<V>> g,
       V source, V target) {
     return Graphs.makeImmutable(g).getPaths(source, target);
   }
 
   @Test void testVertexMustExist() {
-    DirectedGraph<String, DefaultEdge<String>> g = DefaultDirectedGraph.create();
+    DirectedGraph<String, TypedEdge<String>> g = DefaultDirectedGraph.create();
 
     final boolean b = g.addVertex("A");
     assertTrue(b);
@@ -96,42 +96,42 @@ class DirectedGraphTest {
     assertFalse(b2);
 
     try {
-      DefaultEdge<String> x = g.addEdge("A", "B");
+      TypedEdge<String> x = g.addEdge("A", "B");
       fail("expected exception, got " + x);
     } catch (IllegalArgumentException e) {
       // ok
     }
     g.addVertex("B");
-    DefaultEdge<String> x = g.addEdge("A", "B");
+    TypedEdge<String> x = g.addEdge("A", "B");
     assertNotNull(x);
-    DefaultEdge<String> x2 = g.addEdge("A", "B");
+    TypedEdge<String> x2 = g.addEdge("A", "B");
     assertNull(x2);
     try {
-      DefaultEdge<String> x3 = g.addEdge("Z", "A");
+      TypedEdge<String> x3 = g.addEdge("Z", "A");
       fail("expected exception, got " + x3);
     } catch (IllegalArgumentException e) {
       // ok
     }
     g.addVertex("Z");
-    DefaultEdge<String> x3 = g.addEdge("Z", "A");
+    TypedEdge<String> x3 = g.addEdge("Z", "A");
     assertNotNull(x3);
-    DefaultEdge<String> x4 = g.addEdge("Z", "A");
+    TypedEdge<String> x4 = g.addEdge("Z", "A");
     assertNull(x4);
 
     // Attempting to add a vertex already present does not change the graph.
-    final List<DefaultEdge<String>> in1 = g.getInwardEdges("A");
-    final List<DefaultEdge<String>> out1 = g.getOutwardEdges("A");
+    final List<TypedEdge<String>> in1 = g.getInwardEdges("A");
+    final List<TypedEdge<String>> out1 = g.getOutwardEdges("A");
     final boolean b3 = g.addVertex("A");
     assertFalse(b3);
-    final List<DefaultEdge<String>> in2 = g.getInwardEdges("A");
-    final List<DefaultEdge<String>> out2 = g.getOutwardEdges("A");
+    final List<TypedEdge<String>> in2 = g.getInwardEdges("A");
+    final List<TypedEdge<String>> out2 = g.getOutwardEdges("A");
     assertEquals(in1, in2);
     assertEquals(out1, out2);
   }
 
   /** Unit test for {@link DepthFirstIterator}. */
   @Test void testDepthFirst() {
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag();
     final List<String> list = new ArrayList<String>();
     for (String s : DepthFirstIterator.of(graph, "A")) {
       list.add(s);
@@ -144,7 +144,7 @@ class DirectedGraphTest {
 
   /** Unit test for {@link DepthFirstIterator}. */
   @Test void testPredecessorList() {
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag();
     final List<String> list = Graphs.predecessorListOf(graph, "C");
     assertEquals("[B, E]", list.toString());
   }
@@ -152,14 +152,14 @@ class DirectedGraphTest {
   /** Unit test for
    * {@link DefaultDirectedGraph#removeAllVertices(java.util.Collection)}. */
   @Test void testRemoveAllVertices() {
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag();
     graph.removeAllVertices(Arrays.asList("B", "E"));
     assertEquals("[A, C, D, F]", graph.vertexSet().toString());
   }
 
   /** Unit test for {@link TopologicalOrderIterator}. */
   @Test void testTopologicalOrderIterator() {
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag();
     final List<String> list = new ArrayList<String>();
     for (String s : TopologicalOrderIterator.of(graph)) {
       list.add(s);
@@ -167,7 +167,7 @@ class DirectedGraphTest {
     assertEquals("[A, B, E, C, F, D]", list.toString());
   }
 
-  private DefaultDirectedGraph<String, DefaultEdge<String>> createDag() {
+  private DefaultDirectedGraph<String, TypedEdge<String>> createDag() {
     //    D         F
     //    ^         ^
     //    |         |
@@ -176,7 +176,7 @@ class DirectedGraphTest {
     //    |         |
     //    |         |
     //    B <- A -> E
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph =
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph =
         DefaultDirectedGraph.create();
     graph.addVertex("A");
     graph.addVertex("B");
@@ -193,7 +193,7 @@ class DirectedGraphTest {
     return graph;
   }
 
-  private DefaultDirectedGraph<String, DefaultEdge<String>> createDag1() {
+  private DefaultDirectedGraph<String, TypedEdge<String>> createDag1() {
     //    +--> E <--+
     //    |         |
     //    C         |
@@ -202,7 +202,7 @@ class DirectedGraphTest {
     //    |         |
     //    |         |
     //    B <-- A --+
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph =
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph =
         DefaultDirectedGraph.create();
     graph.addVertex("A");
     graph.addVertex("B");
@@ -221,8 +221,8 @@ class DirectedGraphTest {
   /** Unit test for
    * {@link org.apache.calcite.util.graph.Graphs.FrozenGraph}. */
   @Test void testPaths() {
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag1();
-    final Graphs.FrozenGraph<String, DefaultEdge<String>> frozenGraph =
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag1();
+    final Graphs.FrozenGraph<String, TypedEdge<String>> frozenGraph =
         Graphs.makeImmutable(graph);
     assertEquals("[A, B]", shortestPath(frozenGraph, "A", "B").toString());
     assertEquals("[[A, B]]", frozenGraph.getPaths("A", "B").toString());
@@ -237,8 +237,8 @@ class DirectedGraphTest {
   }
 
   @Test void testDistances() {
-    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag1();
-    final Graphs.FrozenGraph<String, DefaultEdge<String>> frozenGraph =
+    final DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag1();
+    final Graphs.FrozenGraph<String, TypedEdge<String>> frozenGraph =
         Graphs.makeImmutable(graph);
     assertEquals(1, frozenGraph.getShortestDistance("A", "B"));
     assertEquals(2, frozenGraph.getShortestDistance("A", "E"));
@@ -253,7 +253,7 @@ class DirectedGraphTest {
     // A - B - C - D
     //  \     /
     //   +- E - F
-    DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
+    DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag();
     assertThat(new CycleDetector<>(graph).findCycles(),
         CoreMatchers.equalTo(ImmutableSet.of()));
 
@@ -321,14 +321,14 @@ class DirectedGraphTest {
   /** Unit test for
    * {@link org.apache.calcite.util.graph.BreadthFirstIterator}. */
   @Test void testBreadthFirstIterator() {
-    DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
+    DefaultDirectedGraph<String, TypedEdge<String>> graph = createDag();
     final List<String> expected =
         ImmutableList.of("A", "B", "E", "C", "F", "D");
     assertThat(getA(graph, "A"), equalTo(expected));
     assertThat(Lists.newArrayList(getB(graph, "A")), equalTo(expected));
   }
 
-  private List<String> getA(DefaultDirectedGraph<String, DefaultEdge<String>> graph,
+  private List<String> getA(DefaultDirectedGraph<String, TypedEdge<String>> graph,
       String root) {
     final List<String> list = new ArrayList<String>();
     for (String s : BreadthFirstIterator.of(graph, root)) {
@@ -337,7 +337,7 @@ class DirectedGraphTest {
     return list;
   }
 
-  private Set<String> getB(DefaultDirectedGraph<String, DefaultEdge<String>> graph,
+  private Set<String> getB(DefaultDirectedGraph<String, TypedEdge<String>> graph,
       String root) {
     final Set<String> list = new LinkedHashSet<String>();
     BreadthFirstIterator.reachable(list, graph, root);
@@ -345,7 +345,7 @@ class DirectedGraphTest {
   }
 
   @Test void testAttributed() {
-    AttributedDirectedGraph<String, DefaultEdge<String>> g =
+    AttributedDirectedGraph<String, TypedEdge<String>> g =
         AttributedDirectedGraph.create(new DefaultAttributedEdgeFactory());
     g.addVertex("A");
     g.addVertex("B");
@@ -376,7 +376,7 @@ class DirectedGraphTest {
   }
 
   /** Edge that stores its attributes in a list. */
-  private static class DefaultAttributedEdge extends DefaultEdge<String> {
+  private static class DefaultAttributedEdge extends TypedEdge<String> {
     private final List list;
 
     DefaultAttributedEdge(String source, String target, List list) {
@@ -400,13 +400,13 @@ class DirectedGraphTest {
     /** Factory for {@link DefaultAttributedEdge}. */
   private static class DefaultAttributedEdgeFactory
       implements AttributedDirectedGraph.AttributedEdgeFactory<String,
-          DefaultEdge<String>> {
-    public DefaultEdge<String> createEdge(String v0, String v1, Object... attributes) {
+        TypedEdge<String>> {
+    public TypedEdge<String> createEdge(String v0, String v1, Object... attributes) {
       return new DefaultAttributedEdge(v0, v1,
           ImmutableList.copyOf(attributes));
     }
 
-    public DefaultEdge<String> createEdge(String v0, String v1) {
+    public TypedEdge<String> createEdge(String v0, String v1) {
       throw new UnsupportedOperationException();
     }
   }

--- a/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
+++ b/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class DirectedGraphTest {
   @Test void testOne() {
-    DirectedGraph<String, DefaultEdge> g = DefaultDirectedGraph.create();
+    DirectedGraph<String, DefaultEdge<String>> g = DefaultDirectedGraph.create();
     g.addVertex("A");
     g.addVertex("B");
     g.addVertex("C");
@@ -69,25 +69,25 @@ class DirectedGraphTest {
     assertEquals("[[A, B, D], [A, B, C, D]]", paths(g, "A", "D").toString());
   }
 
-  private <V> List<V> shortestPath(DirectedGraph<V, DefaultEdge> g,
+  private <V> List<V> shortestPath(DirectedGraph<V, DefaultEdge<V>> g,
       V source, V target) {
     List<List<V>> paths = Graphs.makeImmutable(g).getPaths(source, target);
     return paths.isEmpty() ? null : paths.get(0);
   }
 
-  private <V> List<V> shortestPath(Graphs.FrozenGraph<V, DefaultEdge> g,
+  private <V> List<V> shortestPath(Graphs.FrozenGraph<V, DefaultEdge<V>> g,
                                    V source, V target) {
     List<List<V>> paths = g.getPaths(source, target);
     return paths.isEmpty() ? null : paths.get(0);
   }
 
-  private <V> List<List<V>> paths(DirectedGraph<V, DefaultEdge> g,
+  private <V> List<List<V>> paths(DirectedGraph<V, DefaultEdge<V>> g,
       V source, V target) {
     return Graphs.makeImmutable(g).getPaths(source, target);
   }
 
   @Test void testVertexMustExist() {
-    DirectedGraph<String, DefaultEdge> g = DefaultDirectedGraph.create();
+    DirectedGraph<String, DefaultEdge<String>> g = DefaultDirectedGraph.create();
 
     final boolean b = g.addVertex("A");
     assertTrue(b);
@@ -96,42 +96,42 @@ class DirectedGraphTest {
     assertFalse(b2);
 
     try {
-      DefaultEdge x = g.addEdge("A", "B");
+      DefaultEdge<String> x = g.addEdge("A", "B");
       fail("expected exception, got " + x);
     } catch (IllegalArgumentException e) {
       // ok
     }
     g.addVertex("B");
-    DefaultEdge x = g.addEdge("A", "B");
+    DefaultEdge<String> x = g.addEdge("A", "B");
     assertNotNull(x);
-    DefaultEdge x2 = g.addEdge("A", "B");
+    DefaultEdge<String> x2 = g.addEdge("A", "B");
     assertNull(x2);
     try {
-      DefaultEdge x3 = g.addEdge("Z", "A");
+      DefaultEdge<String> x3 = g.addEdge("Z", "A");
       fail("expected exception, got " + x3);
     } catch (IllegalArgumentException e) {
       // ok
     }
     g.addVertex("Z");
-    DefaultEdge x3 = g.addEdge("Z", "A");
+    DefaultEdge<String> x3 = g.addEdge("Z", "A");
     assertNotNull(x3);
-    DefaultEdge x4 = g.addEdge("Z", "A");
+    DefaultEdge<String> x4 = g.addEdge("Z", "A");
     assertNull(x4);
 
     // Attempting to add a vertex already present does not change the graph.
-    final List<DefaultEdge> in1 = g.getInwardEdges("A");
-    final List<DefaultEdge> out1 = g.getOutwardEdges("A");
+    final List<DefaultEdge<String>> in1 = g.getInwardEdges("A");
+    final List<DefaultEdge<String>> out1 = g.getOutwardEdges("A");
     final boolean b3 = g.addVertex("A");
     assertFalse(b3);
-    final List<DefaultEdge> in2 = g.getInwardEdges("A");
-    final List<DefaultEdge> out2 = g.getOutwardEdges("A");
+    final List<DefaultEdge<String>> in2 = g.getInwardEdges("A");
+    final List<DefaultEdge<String>> out2 = g.getOutwardEdges("A");
     assertEquals(in1, in2);
     assertEquals(out1, out2);
   }
 
   /** Unit test for {@link DepthFirstIterator}. */
   @Test void testDepthFirst() {
-    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag();
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
     final List<String> list = new ArrayList<String>();
     for (String s : DepthFirstIterator.of(graph, "A")) {
       list.add(s);
@@ -144,7 +144,7 @@ class DirectedGraphTest {
 
   /** Unit test for {@link DepthFirstIterator}. */
   @Test void testPredecessorList() {
-    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag();
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
     final List<String> list = Graphs.predecessorListOf(graph, "C");
     assertEquals("[B, E]", list.toString());
   }
@@ -152,14 +152,14 @@ class DirectedGraphTest {
   /** Unit test for
    * {@link DefaultDirectedGraph#removeAllVertices(java.util.Collection)}. */
   @Test void testRemoveAllVertices() {
-    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag();
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
     graph.removeAllVertices(Arrays.asList("B", "E"));
     assertEquals("[A, C, D, F]", graph.vertexSet().toString());
   }
 
   /** Unit test for {@link TopologicalOrderIterator}. */
   @Test void testTopologicalOrderIterator() {
-    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag();
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
     final List<String> list = new ArrayList<String>();
     for (String s : TopologicalOrderIterator.of(graph)) {
       list.add(s);
@@ -167,7 +167,7 @@ class DirectedGraphTest {
     assertEquals("[A, B, E, C, F, D]", list.toString());
   }
 
-  private DefaultDirectedGraph<String, DefaultEdge> createDag() {
+  private DefaultDirectedGraph<String, DefaultEdge<String>> createDag() {
     //    D         F
     //    ^         ^
     //    |         |
@@ -176,7 +176,7 @@ class DirectedGraphTest {
     //    |         |
     //    |         |
     //    B <- A -> E
-    final DefaultDirectedGraph<String, DefaultEdge> graph =
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph =
         DefaultDirectedGraph.create();
     graph.addVertex("A");
     graph.addVertex("B");
@@ -193,7 +193,7 @@ class DirectedGraphTest {
     return graph;
   }
 
-  private DefaultDirectedGraph<String, DefaultEdge> createDag1() {
+  private DefaultDirectedGraph<String, DefaultEdge<String>> createDag1() {
     //    +--> E <--+
     //    |         |
     //    C         |
@@ -202,7 +202,7 @@ class DirectedGraphTest {
     //    |         |
     //    |         |
     //    B <-- A --+
-    final DefaultDirectedGraph<String, DefaultEdge> graph =
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph =
         DefaultDirectedGraph.create();
     graph.addVertex("A");
     graph.addVertex("B");
@@ -221,8 +221,8 @@ class DirectedGraphTest {
   /** Unit test for
    * {@link org.apache.calcite.util.graph.Graphs.FrozenGraph}. */
   @Test void testPaths() {
-    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag1();
-    final Graphs.FrozenGraph<String, DefaultEdge> frozenGraph =
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag1();
+    final Graphs.FrozenGraph<String, DefaultEdge<String>> frozenGraph =
         Graphs.makeImmutable(graph);
     assertEquals("[A, B]", shortestPath(frozenGraph, "A", "B").toString());
     assertEquals("[[A, B]]", frozenGraph.getPaths("A", "B").toString());
@@ -237,8 +237,8 @@ class DirectedGraphTest {
   }
 
   @Test void testDistances() {
-    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag1();
-    final Graphs.FrozenGraph<String, DefaultEdge> frozenGraph =
+    final DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag1();
+    final Graphs.FrozenGraph<String, DefaultEdge<String>> frozenGraph =
         Graphs.makeImmutable(graph);
     assertEquals(1, frozenGraph.getShortestDistance("A", "B"));
     assertEquals(2, frozenGraph.getShortestDistance("A", "E"));
@@ -253,8 +253,8 @@ class DirectedGraphTest {
     // A - B - C - D
     //  \     /
     //   +- E - F
-    DefaultDirectedGraph<String, DefaultEdge> graph = createDag();
-    assertThat(new CycleDetector<String, DefaultEdge>(graph).findCycles(),
+    DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
+    assertThat(new CycleDetector<>(graph).findCycles(),
         CoreMatchers.equalTo(ImmutableSet.of()));
 
     // Add cycle C-D-E-C
@@ -265,7 +265,7 @@ class DirectedGraphTest {
     //      ^      /
     //      \_____/
     graph.addEdge("D", "E");
-    assertThat(new CycleDetector<String, DefaultEdge>(graph).findCycles(),
+    assertThat(new CycleDetector<>(graph).findCycles(),
         CoreMatchers.equalTo(
             ImmutableSet.of("C", "D", "E", "F")));
 
@@ -278,7 +278,7 @@ class DirectedGraphTest {
     //      ^      /
     //      \_____/
     graph.addEdge("D", "C");
-    assertThat(new CycleDetector<String, DefaultEdge>(graph).findCycles(),
+    assertThat(new CycleDetector<>(graph).findCycles(),
         CoreMatchers.equalTo(
             ImmutableSet.of("C", "D", "E", "F")));
 
@@ -295,7 +295,7 @@ class DirectedGraphTest {
     //
     // Detected cycle contains "D", which is downstream from the cycle but not
     // in the cycle. Not sure whether that is correct.
-    assertThat(new CycleDetector<String, DefaultEdge>(graph).findCycles(),
+    assertThat(new CycleDetector<>(graph).findCycles(),
         CoreMatchers.equalTo(
             ImmutableSet.of("B", "C", "D")));
 
@@ -308,27 +308,27 @@ class DirectedGraphTest {
     //   +- E - F
     graph.removeEdge("C", "B");
     graph.addEdge("C", "C");
-    assertThat(new CycleDetector<String, DefaultEdge>(graph).findCycles(),
+    assertThat(new CycleDetector<>(graph).findCycles(),
         CoreMatchers.equalTo(
             ImmutableSet.of("C", "D")));
 
     // Empty graph is not cyclic.
     graph.removeAllVertices(graph.vertexSet());
-    assertThat(new CycleDetector<String, DefaultEdge>(graph).findCycles(),
+    assertThat(new CycleDetector<>(graph).findCycles(),
         CoreMatchers.equalTo(ImmutableSet.of()));
   }
 
   /** Unit test for
    * {@link org.apache.calcite.util.graph.BreadthFirstIterator}. */
   @Test void testBreadthFirstIterator() {
-    DefaultDirectedGraph<String, DefaultEdge> graph = createDag();
+    DefaultDirectedGraph<String, DefaultEdge<String>> graph = createDag();
     final List<String> expected =
         ImmutableList.of("A", "B", "E", "C", "F", "D");
     assertThat(getA(graph, "A"), equalTo(expected));
     assertThat(Lists.newArrayList(getB(graph, "A")), equalTo(expected));
   }
 
-  private List<String> getA(DefaultDirectedGraph<String, DefaultEdge> graph,
+  private List<String> getA(DefaultDirectedGraph<String, DefaultEdge<String>> graph,
       String root) {
     final List<String> list = new ArrayList<String>();
     for (String s : BreadthFirstIterator.of(graph, root)) {
@@ -337,7 +337,7 @@ class DirectedGraphTest {
     return list;
   }
 
-  private Set<String> getB(DefaultDirectedGraph<String, DefaultEdge> graph,
+  private Set<String> getB(DefaultDirectedGraph<String, DefaultEdge<String>> graph,
       String root) {
     final Set<String> list = new LinkedHashSet<String>();
     BreadthFirstIterator.reachable(list, graph, root);
@@ -345,7 +345,7 @@ class DirectedGraphTest {
   }
 
   @Test void testAttributed() {
-    AttributedDirectedGraph<String, DefaultEdge> g =
+    AttributedDirectedGraph<String, DefaultEdge<String>> g =
         AttributedDirectedGraph.create(new DefaultAttributedEdgeFactory());
     g.addVertex("A");
     g.addVertex("B");
@@ -376,7 +376,7 @@ class DirectedGraphTest {
   }
 
   /** Edge that stores its attributes in a list. */
-  private static class DefaultAttributedEdge extends DefaultEdge {
+  private static class DefaultAttributedEdge extends DefaultEdge<String> {
     private final List list;
 
     DefaultAttributedEdge(String source, String target, List list) {
@@ -400,13 +400,13 @@ class DirectedGraphTest {
     /** Factory for {@link DefaultAttributedEdge}. */
   private static class DefaultAttributedEdgeFactory
       implements AttributedDirectedGraph.AttributedEdgeFactory<String,
-          DefaultEdge> {
-    public DefaultEdge createEdge(String v0, String v1, Object... attributes) {
+          DefaultEdge<String>> {
+    public DefaultEdge<String> createEdge(String v0, String v1, Object... attributes) {
       return new DefaultAttributedEdge(v0, v1,
           ImmutableList.copyOf(attributes));
     }
 
-    public DefaultEdge createEdge(String v0, String v1) {
+    public DefaultEdge<String> createEdge(String v0, String v1) {
       throw new UnsupportedOperationException();
     }
   }

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/DefaultDirectedGraphBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/DefaultDirectedGraphBenchmark.java
@@ -17,8 +17,8 @@
 package org.apache.calcite.benchmarks;
 
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
-import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
+import org.apache.calcite.util.graph.TypedEdge;
 
 import com.google.common.collect.Lists;
 
@@ -72,7 +72,7 @@ public class DefaultDirectedGraphBenchmark {
 
     static final int NUM_LAYERS = 8;
 
-    DirectedGraph<Node, DefaultEdge<Node>> graph;
+    DirectedGraph<Node, TypedEdge<Node>> graph;
 
     List<Node> nodes;
 
@@ -114,7 +114,7 @@ public class DefaultDirectedGraphBenchmark {
   }
 
   /**
-   * State object for {@link DefaultDirectedGraphBenchmark#removeVerticesBenchmark(GraphRemoveState)}..
+   * State object for {@link DefaultDirectedGraphBenchmark#removeVertices(GraphRemoveState)}..
    */
   @State(Scope.Benchmark)
   public static class GraphRemoveState {
@@ -142,7 +142,7 @@ public class DefaultDirectedGraphBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public int getInwardEdgesBenchmark(GraphState state) {
+  public int getInwardEdges(GraphState state) {
     int sum = 0;
     int curId = 1;
     for (int i = 0; i < GraphState.NUM_LAYERS; i++) {
@@ -157,7 +157,7 @@ public class DefaultDirectedGraphBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public int getOutwardEdgesBenchmark(GraphState state) {
+  public int getOutwardEdges(GraphState state) {
     int sum = 0;
     int curId = 1;
     for (int i = 0; i < GraphState.NUM_LAYERS; i++) {
@@ -172,42 +172,42 @@ public class DefaultDirectedGraphBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public boolean addVertexBenchmark(GraphState state) {
+  public boolean addVertex(GraphState state) {
     return state.graph.addVertex(new Node(100));
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public DefaultEdge<Node> addEdgeBenchmark(GraphState state) {
+  public TypedEdge<Node> addEdge(GraphState state) {
     return state.graph.addEdge(state.nodes.get(0), state.nodes.get(5));
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public DefaultEdge<Node> getEdgeBenchmark(GraphState state) {
+  public TypedEdge<Node> getEdge(GraphState state) {
     return state.graph.getEdge(state.nodes.get(0), state.nodes.get(1));
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public boolean removeEdgeBenchmark(GraphState state) {
+  public boolean removeEdge(GraphState state) {
     return state.graph.removeEdge(state.nodes.get(0), state.nodes.get(1));
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeVerticesBenchmark(GraphRemoveState state) {
+  public void removeVertices(GraphRemoveState state) {
     state.innerState.graph.removeAllVertices(state.nodesToRemove);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVerticesBenchmark(GraphState state) {
+  public void removeAllVertices(GraphState state) {
     state.graph.removeAllVertices(state.nodes);
   }
 

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/DefaultDirectedGraphBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/DefaultDirectedGraphBenchmark.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -71,19 +72,9 @@ public class DefaultDirectedGraphBenchmark {
 
     static final int NUM_LAYERS = 8;
 
-    DirectedGraph<Node, DefaultEdge> graph;
+    DirectedGraph<Node, DefaultEdge<Node>> graph;
 
     List<Node> nodes;
-
-    List<Node> tenNodes;
-    List<Node> twentyNodes;
-    List<Node> thirtyNodes;
-    List<Node> fortyNodes;
-    List<Node> fiftyNodes;
-    List<Node> sixtyNodes;
-    List<Node> seventyNodes;
-    List<Node> eightyNodes;
-    List<Node> ninetyNodes;
 
     @Setup(Level.Invocation)
     public void setUp() {
@@ -119,25 +110,32 @@ public class DefaultDirectedGraphBenchmark {
         }
         prevLayerNodes = curLayerNodes;
       }
+    }
+  }
 
-      int tenNodeCount = (int) (nodes.size() * 0.1);
-      int twentyNodeCount = (int) (nodes.size() * 0.2);
-      int thirtyNodeCount = (int) (nodes.size() * 0.3);
-      int fortyNodeCount = (int) (nodes.size() * 0.4);
-      int fiftyNodeCount = (int) (nodes.size() * 0.5);
-      int sixtyNodeCount = (int) (nodes.size() * 0.6);
-      int seventyNodeCount = (int) (nodes.size() * 0.7);
-      int eightyNodeCount = (int) (nodes.size() * 0.8);
-      int ninetyNodeCount = (int) (nodes.size() * 0.9);
-      tenNodes = nodes.subList(0, tenNodeCount);
-      twentyNodes = nodes.subList(0, twentyNodeCount);
-      thirtyNodes = nodes.subList(0, thirtyNodeCount);
-      fortyNodes = nodes.subList(0, fortyNodeCount);
-      fiftyNodes = nodes.subList(0, fiftyNodeCount);
-      sixtyNodes = nodes.subList(0, sixtyNodeCount);
-      seventyNodes = nodes.subList(0, seventyNodeCount);
-      eightyNodes = nodes.subList(0, eightyNodeCount);
-      ninetyNodes = nodes.subList(0, ninetyNodeCount);
+  /**
+   * State object for {@link DefaultDirectedGraphBenchmark#removeVerticesBenchmark(GraphRemoveState)}..
+   */
+  @State(Scope.Benchmark)
+  public static class GraphRemoveState {
+
+    GraphState innerState;
+
+    /**
+     * The fraction of nodes that will be removed.
+     */
+    @Param({"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9"})
+    public double removeFraction;
+
+    List<Node> nodesToRemove;
+
+    @Setup(Level.Invocation)
+    public void setUp() {
+      innerState = new GraphState();
+      innerState.setUp();
+
+      int removeNodeCount = (int) (innerState.nodes.size() * removeFraction);
+      nodesToRemove = innerState.nodes.subList(0, removeNodeCount);
     }
   }
 
@@ -181,14 +179,14 @@ public class DefaultDirectedGraphBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public DefaultEdge addEdgeBenchmark(GraphState state) {
+  public DefaultEdge<Node> addEdgeBenchmark(GraphState state) {
     return state.graph.addEdge(state.nodes.get(0), state.nodes.get(5));
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public DefaultEdge getEdgeBenchmark(GraphState state) {
+  public DefaultEdge<Node> getEdgeBenchmark(GraphState state) {
     return state.graph.getEdge(state.nodes.get(0), state.nodes.get(1));
   }
 
@@ -202,70 +200,14 @@ public class DefaultDirectedGraphBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices10Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.tenNodes);
+  public void removeVerticesBenchmark(GraphRemoveState state) {
+    state.innerState.graph.removeAllVertices(state.nodesToRemove);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices20Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.twentyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices30Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.thirtyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices40Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.fortyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices50Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.fiftyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices60Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.sixtyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices70Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.seventyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices80Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.eightyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices90Benchmark(GraphState state) {
-    state.graph.removeAllVertices(state.ninetyNodes);
-  }
-
-  @Benchmark
-  @BenchmarkMode(Mode.AverageTime)
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void removeAllVertices100Benchmark(GraphState state) {
+  public void removeAllVerticesBenchmark(GraphState state) {
     state.graph.removeAllVertices(state.nodes);
   }
 


### PR DESCRIPTION
Currently, the source and target fields of class DefaultEdge is Object. This makes it necessary for some casts in the code base. In addition, it does not enforce the assertion that in a graph, the vertices have the same type as sources and targes in the edges.

To solve the problem, we generify the DefaultEdge class with the type of the source/target vertices.

The benefits of generfication includes type safety: the above assertion can be enforced by the generified class. It also gives the compiler an opportunity to detect type related problems at compilation time. Without generification, some problems can only be detected at runtime, when a ClassCastException is thrown.