### PR TITLE
[CALCITE-3979] Simplification might have removed CAST expressi…

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -558,6 +558,23 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3979">[CALCITE-3979]
+   * ReduceExpressionsRule might have removed CAST expression(s) incorrectly</a>. */
+  @Test public void testCastRemove() throws Exception {
+    final String sql = "select\n"
+        + "case when cast(ename as double) < 5 then 0.0\n"
+        + "     else coalesce(cast(ename as double), 1.0)\n"
+        + "     end as t\n"
+        + " from (\n"
+        + "       select\n"
+        + "          case when ename > 'abc' then ename\n"
+        + "               else null\n"
+        + "               end as ename from emp\n"
+        + " )";
+    sql(sql).withRule(ReduceExpressionsRule.PROJECT_INSTANCE).checkUnchanged();
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3887">[CALCITE-3887]
    * Filter and Join conditions may not need to retain nullability during simplifications</a>. */
   @Test void testPushSemiJoinConditions() {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -684,6 +684,32 @@ LogicalProject(EMPNO=[$0])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testCastRemove">
+        <Resource name="sql">
+            <![CDATA[select
+case when cast(ename as double) < 5 then 0.0
+     else coalesce(cast(ename as double), 1.0)
+     end as t
+ from (
+       select
+          case when ename > 'abc' then ename
+               else null
+               end as ename from emp
+ )]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(T=[CASE(<(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE, 5), 0.0:DOUBLE, CASE(IS NOT NULL(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE), CAST(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE):DOUBLE NOT NULL, 1.0:DOUBLE))])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(T=[CASE(<(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE, 5), 0.0:DOUBLE, CASE(IS NOT NULL(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE), CAST(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE):DOUBLE NOT NULL, 1.0:DOUBLE))])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testCorrelationScalarAggAndFilter">
         <Resource name="sql">
             <![CDATA[SELECT e1.empno
@@ -12485,7 +12511,9 @@ LogicalProject(**=[$1])
     </TestCase>
     <TestCase name="testSwapOuterJoinFieldAccess">
         <Resource name="sql">
-            <![CDATA[select t1.name, e.ename from DEPT_NESTED as t1 left outer join sales.emp e on t1.skill.type = e.job]]>
+            <![CDATA[select t1.name, e.ename
+from DEPT_NESTED as t1 left outer join sales.emp e
+ on t1.skill.type = e.job]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[


### PR DESCRIPTION
…ncorrectly

ReduceExpressionsRule might have removed cast expressions and inadvertly changed the type of some subexpressions.
In case the rewriting have at some point arrived at: CAST(CAST(X,T),T) AND <(CAST(X,T),N)