### PR TITLE
[CALCITE-3963] Maintains logical properties at RelSet (equivalent gro…

### DIFF
--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
@@ -100,8 +100,8 @@ class CassandraAdapterTest {
         .returns("tweet_id=f3c329de-d05b-11e5-b58b-90e2ba530b12\n"
                + "tweet_id=f3dbb03a-d05b-11e5-b58b-90e2ba530b12\n")
         .explainContains("PLAN=CassandraToEnumerableConverter\n"
-                + "  CassandraLimit(fetch=[2])\n"
-                + "    CassandraProject(tweet_id=[$2])\n"
+                + "  CassandraProject(tweet_id=[$2])\n"
+                + "    CassandraLimit(fetch=[2])\n"
                 + "      CassandraFilter(condition=[=($0, '!PUBLIC!')])\n");
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -225,6 +225,10 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
   @Override public void prune(RelNode rel) {
   }
 
+  @Override public boolean isPruned(RelNode rel) {
+    return false;
+  }
+
   public void registerClass(RelNode node) {
     final Class<? extends RelNode> clazz = node.getClass();
     if (classes.add(clazz)) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
@@ -307,6 +307,13 @@ public interface RelOptPlanner {
   void prune(RelNode rel);
 
   /**
+   * Check whether or not a RelNode is pruned
+   * @param rel the node to check
+   * @return true if rel is pruned, false if otherwise
+   */
+  boolean isPruned(RelNode rel);
+
+  /**
    * Registers a class of RelNode. If this class of RelNode has been seen
    * before, does nothing.
    *

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -535,7 +535,7 @@ class RelSet {
 
     for (RelNode rel : getParentRels()) {
       RelSet set = planner.getSet(rel);
-      if (set.id != this.id) {
+      if (set.id != this.id && !planner.isPruned(rel)) {
         results.add(set);
       }
     }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.PhysicalNode;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.Converter;
@@ -73,7 +74,14 @@ class RelSet {
    * set.
    */
   RelSet equivalentSet;
-  RelNode rel;
+
+  /**
+   * The first RelNode added to the set or the RelNode with highest confidence
+   * level of estimated statistics.
+   * The logical properties of the RelSet, including row count, uniqueness, etc,
+   * are determined by this RelNode.
+   */
+  RelNode originalRel;
 
   /**
    * The position indicator of rel node that is to be processed.
@@ -211,6 +219,7 @@ class RelSet {
     final RelSubset subset = getOrCreateSubset(
         rel.getCluster(), traitSet, rel.isEnforcer());
     subset.add(rel);
+    checkAndUpdateOriginalRel(rel);
     return subset;
   }
 
@@ -350,15 +359,16 @@ class RelSet {
         postEquivalenceEvent(planner, rel);
       }
     }
-    if (this.rel == null) {
-      this.rel = rel;
+    if (this.originalRel == null) {
+      this.originalRel = rel;
     } else {
       // Row types must be the same, except for field names.
       RelOptUtil.verifyTypeEquivalence(
-          this.rel,
+          this.originalRel,
           rel,
           this);
     }
+    checkAndUpdateOriginalRel(rel);
   }
 
   /**
@@ -383,7 +393,7 @@ class RelSet {
     assert otherSet.equivalentSet == null;
     LOGGER.trace("Merge set#{} into set#{}", otherSet.id, id);
     otherSet.equivalentSet = this;
-    RelOptCluster cluster = rel.getCluster();
+    RelOptCluster cluster = originalRel.getCluster();
     RelMetadataQuery mq = cluster.getMetadataQuery();
 
     // remove from table
@@ -485,5 +495,51 @@ class RelSet {
     for (RelSubset subset : subsets) {
       planner.fireRules(subset);
     }
+  }
+
+  private void checkAndUpdateOriginalRel(RelNode newRel) {
+    if (newRel instanceof LogicalNode && this.originalRel instanceof LogicalNode
+        && ((LogicalNode) newRel).getStatsEstimateConfidence().compareTo(
+            ((LogicalNode) this.originalRel).getStatsEstimateConfidence()) > 0) {
+      this.originalRel = newRel;
+
+      // Invalidate parent sets original rel meta cache since child set properties might
+      // have been changed.
+      HashSet<RelSet> newParentSets = getParentSets();
+      HashSet<RelSet> allParentSets = new HashSet<>();
+      while (!newParentSets.isEmpty()) {
+        allParentSets.addAll(newParentSets);
+        HashSet<RelSet> validParents = new HashSet<>();
+        for (RelSet set : newParentSets) {
+          HashSet<RelSet> parents = set.getParentSets();
+          for (RelSet s : parents) {
+            // To handle cycle references between sets
+            if (!allParentSets.contains(s)) {
+              validParents.add(s);
+            }
+          }
+        }
+        newParentSets = validParents;
+      }
+      for (RelSet set : allParentSets) {
+        final RelMetadataQuery mq = set.originalRel.getCluster().getMetadataQuery();
+        mq.clearCache(set.originalRel);
+      }
+    }
+  }
+
+  private HashSet<RelSet> getParentSets() {
+    HashSet<RelSet> results = new HashSet<>();
+    VolcanoPlanner planner = (VolcanoPlanner) this.originalRel.getCluster().getPlanner();
+    assert planner != null;
+
+    for (RelNode rel : getParentRels()) {
+      RelSet set = planner.getSet(rel);
+      if (set.id != this.id) {
+        results.add(set);
+      }
+    }
+
+    return results;
   }
 }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -185,7 +185,7 @@ public class RelSubset extends AbstractRelNode {
   }
 
   public RelNode getOriginal() {
-    return set.rel;
+    return set.originalRel;
   }
 
   public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
@@ -207,7 +207,7 @@ public class RelSubset extends AbstractRelNode {
     if (best != null) {
       return mq.getRowCount(best);
     } else {
-      return mq.getRowCount(set.rel);
+      return mq.getRowCount(set.originalRel);
     }
   }
 
@@ -234,7 +234,7 @@ public class RelSubset extends AbstractRelNode {
   }
 
   @Override protected RelDataType deriveRowType() {
-    return set.rel.getRowType();
+    return set.originalRel.getRowType();
   }
 
   /**
@@ -293,7 +293,7 @@ public class RelSubset extends AbstractRelNode {
     return list;
   }
 
-  RelSet getSet() {
+  public RelSet getSet() {
     return set;
   }
 
@@ -318,7 +318,7 @@ public class RelSubset extends AbstractRelNode {
 
     // If this isn't the first rel in the set, it must have compatible
     // row type.
-    if (set.rel != null) {
+    if (set.originalRel != null) {
       RelOptUtil.equal("rowtype of new rel", rel.getRowType(),
           "rowtype of set", getRowType(), Litmus.THROW);
     }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -293,7 +293,7 @@ public class RelSubset extends AbstractRelNode {
     return list;
   }
 
-  public RelSet getSet() {
+  RelSet getSet() {
     return set;
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -848,6 +848,10 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     prunedNodes.add(rel);
   }
 
+  @Override public boolean isPruned(RelNode rel) {
+    return prunedNodes.contains(rel);
+  }
+
   /**
    * Dumps the internal state of this VolcanoPlanner to a writer.
    *

--- a/core/src/main/java/org/apache/calcite/rel/LogicalNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/LogicalNode.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel;
+
+/**
+ * Represents a logical node in Calcite
+ */
+public interface LogicalNode extends RelNode {
+
+  /**
+   * Confidence levels of statistics estimation
+   */
+  enum StatsEstimateConfidenceLevel {
+    None,
+    Low,
+    Medium,
+    High
+  }
+
+  /**
+   * Get confidence level of statistics estimation
+   * @return Confidence level of statistics estimation
+   */
+  default StatsEstimateConfidenceLevel getStatsEstimateConfidence() {
+    return StatsEstimateConfidenceLevel.Medium;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalAggregate.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
@@ -43,7 +44,7 @@ import java.util.List;
  * <li>{@link org.apache.calcite.rel.rules.AggregateReduceFunctionsRule}.
  * </ul>
  */
-public final class LogicalAggregate extends Aggregate {
+public final class LogicalAggregate extends Aggregate implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistributionTraitDef;
@@ -63,7 +64,7 @@ import java.util.Set;
  *     merges two {@code LogicalCalc}s
  * </ul>
  */
-public final class LogicalCalc extends Calc {
+public final class LogicalCalc extends Calc implements LogicalNode {
   //~ Static fields/initializers ---------------------------------------------
 
   //~ Constructors -----------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
@@ -20,6 +20,7 @@ import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
@@ -41,7 +42,7 @@ import org.apache.calcite.util.Litmus;
  *
  * @see org.apache.calcite.rel.core.CorrelationId
  */
-public final class LogicalCorrelate extends Correlate {
+public final class LogicalCorrelate extends Correlate implements LogicalNode {
   //~ Instance fields --------------------------------------------------------
 
   //~ Constructors -----------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalExchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalExchange.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelInput;
@@ -30,7 +31,7 @@ import org.apache.calcite.rel.core.Exchange;
  * Sub-class of {@link Exchange} not
  * targeted at any particular engine or calling convention.
  */
-public final class LogicalExchange extends Exchange {
+public final class LogicalExchange extends Exchange implements LogicalNode {
   private LogicalExchange(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelDistribution distribution) {
     super(cluster, traitSet, input, distribution);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelInput;
@@ -42,7 +43,8 @@ import java.util.Set;
  * Sub-class of {@link org.apache.calcite.rel.core.Filter}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalFilter extends Filter {
+public final class LogicalFilter extends Filter implements LogicalNode {
+
   private final ImmutableSet<CorrelationId> variablesSet;
 
   //~ Constructors -----------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalIntersect.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalIntersect.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
@@ -30,7 +31,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Intersect}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalIntersect extends Intersect {
+public final class LogicalIntersect extends Intersect implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
@@ -54,7 +55,7 @@ import java.util.Set;
  *
  * </ul>
  */
-public final class LogicalJoin extends Join {
+public final class LogicalJoin extends Join implements LogicalNode {
   //~ Instance fields --------------------------------------------------------
 
   // NOTE jvs 14-Mar-2006:  Normally we don't use state like this

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalMatch.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalMatch.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
@@ -35,7 +36,7 @@ import java.util.SortedSet;
  * Sub-class of {@link Match}
  * not targeted at any particular engine or calling convention.
  */
-public class LogicalMatch extends Match {
+public class LogicalMatch extends Match implements LogicalNode {
 
   /**
    * Creates a LogicalMatch.

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalMinus.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalMinus.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
@@ -30,7 +31,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Minus}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalMinus extends Minus {
+public final class LogicalMinus extends Minus implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelInput;
@@ -42,7 +43,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Project} not
  * targeted at any particular engine or calling convention.
  */
-public final class LogicalProject extends Project {
+public final class LogicalProject extends Project implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalRepeatUnion.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalRepeatUnion.java
@@ -20,6 +20,7 @@ import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.RepeatUnion;
 
@@ -33,7 +34,7 @@ import java.util.List;
  * notice.
  */
 @Experimental
-public class LogicalRepeatUnion extends RepeatUnion {
+public class LogicalRepeatUnion extends RepeatUnion implements LogicalNode {
 
   //~ Constructors -----------------------------------------------------------
   private LogicalRepeatUnion(RelOptCluster cluster, RelTraitSet traitSet,

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSnapshot.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSnapshot.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelNode;
@@ -32,7 +33,7 @@ import org.apache.calcite.rex.RexNode;
  * Sub-class of {@link org.apache.calcite.rel.core.Snapshot}
  * not targeted at any particular engine or calling convention.
  */
-public class LogicalSnapshot extends Snapshot {
+public class LogicalSnapshot extends Snapshot implements LogicalNode {
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelInput;
@@ -31,7 +32,7 @@ import org.apache.calcite.rex.RexNode;
  * Sub-class of {@link org.apache.calcite.rel.core.Sort} not
  * targeted at any particular engine or calling convention.
  */
-public final class LogicalSort extends Sort {
+public final class LogicalSort extends Sort implements LogicalNode {
   private LogicalSort(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelCollation collation, RexNode offset, RexNode fetch) {
     super(cluster, traitSet, input, collation, offset, fetch);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSortExchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSortExchange.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistribution;
@@ -31,7 +32,7 @@ import org.apache.calcite.rel.core.SortExchange;
  * Sub-class of {@link org.apache.calcite.rel.core.SortExchange} not
  * targeted at any particular engine or calling convention.
  */
-public class LogicalSortExchange extends SortExchange {
+public class LogicalSortExchange extends SortExchange implements LogicalNode {
   private LogicalSortExchange(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelDistribution distribution, RelCollation collation) {
     super(cluster, traitSet, input, distribution, collation);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableFunctionScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableFunctionScan.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableFunctionScan;
@@ -37,7 +38,7 @@ import java.util.Set;
  * Sub-class of {@link org.apache.calcite.rel.core.TableFunctionScan}
  * not targeted at any particular engine or calling convention.
  */
-public class LogicalTableFunctionScan extends TableFunctionScan {
+public class LogicalTableFunctionScan extends TableFunctionScan implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableModify.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
@@ -32,7 +33,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.TableModify}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalTableModify extends TableModify {
+public final class LogicalTableModify extends TableModify implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableScan.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
@@ -57,7 +58,7 @@ import java.util.List;
  * <p>can. It is the optimizer's responsibility to find these ways, by applying
  * transformation rules.</p>
  */
-public final class LogicalTableScan extends TableScan {
+public final class LogicalTableScan extends TableScan implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**
@@ -92,6 +93,10 @@ public final class LogicalTableScan extends TableScan {
     assert traitSet.containsIfApplicable(Convention.NONE);
     assert inputs.isEmpty();
     return this;
+  }
+
+  @Override public LogicalNode.StatsEstimateConfidenceLevel getStatsEstimateConfidence() {
+    return StatsEstimateConfidenceLevel.High;
   }
 
   /** Creates a LogicalTableScan.

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableSpool.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalTableSpool.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelNode;
@@ -36,7 +37,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
  * notice.
  */
 @Experimental
-public class LogicalTableSpool extends TableSpool {
+public class LogicalTableSpool extends TableSpool implements LogicalNode {
 
   //~ Constructors -----------------------------------------------------------
   public LogicalTableSpool(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalUnion.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalUnion.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
@@ -30,7 +31,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Union}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalUnion extends Union {
+public final class LogicalUnion extends Union implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalValues.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.logical;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelInput;
@@ -41,7 +42,7 @@ import java.util.List;
  * Sub-class of {@link org.apache.calcite.rel.core.Values}
  * not targeted at any particular engine or calling convention.
  */
-public class LogicalValues extends Values {
+public class LogicalValues extends Values implements LogicalNode {
   //~ Constructors -----------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalWindow.java
@@ -20,6 +20,7 @@ import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Window;
@@ -56,7 +57,7 @@ import java.util.Objects;
  * Sub-class of {@link org.apache.calcite.rel.core.Window}
  * not targeted at any particular engine or calling convention.
  */
-public final class LogicalWindow extends Window {
+public final class LogicalWindow extends Window implements LogicalNode {
   /**
    * Creates a LogicalWindow.
    *

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
@@ -41,7 +41,6 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.calcite.util.Util;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -99,7 +98,7 @@ public class RelMdAllPredicates
 
   public RelOptPredicateList getAllPredicates(RelSubset rel,
       RelMetadataQuery mq) {
-    return mq.getAllPredicates(Util.first(rel.getBest(), rel.getOriginal()));
+    return mq.getAllPredicates(rel.getOriginal());
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -391,31 +391,7 @@ public class RelMdColumnUniqueness
 
   public Boolean areColumnsUnique(RelSubset rel, RelMetadataQuery mq,
       ImmutableBitSet columns, boolean ignoreNulls) {
-    columns = decorateWithConstantColumnsFromPredicates(columns, rel, mq);
-    int nullCount = 0;
-    for (RelNode rel2 : rel.getRels()) {
-      if (rel2 instanceof Aggregate
-          || rel2 instanceof Filter
-          || rel2 instanceof Values
-          || rel2 instanceof Sort
-          || rel2 instanceof TableScan
-          || simplyProjects(rel2, columns)) {
-        try {
-          final Boolean unique = mq.areColumnsUnique(rel2, columns, ignoreNulls);
-          if (unique != null) {
-            if (unique) {
-              return true;
-            }
-          } else {
-            ++nullCount;
-          }
-        } catch (CyclicMetadataException e) {
-          // Ignore this relational expression; there will be non-cyclic ones
-          // in this set.
-        }
-      }
-    }
-    return nullCount == 0 ? false : null;
+    return mq.areColumnsUnique(rel.getOriginal(), columns, ignoreNulls);
   }
 
   private boolean simplyProjects(RelNode rel, ImmutableBitSet columns) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
@@ -31,7 +31,6 @@ import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.NumberUtil;
@@ -264,23 +263,6 @@ public class RelMdDistinctRowCount
 
   public Double getDistinctRowCount(RelSubset rel, RelMetadataQuery mq,
       ImmutableBitSet groupKey, RexNode predicate) {
-    final RelNode best = rel.getBest();
-    if (best != null) {
-      return mq.getDistinctRowCount(best, groupKey, predicate);
-    }
-    if (!Bug.CALCITE_1048_FIXED) {
-      return getDistinctRowCount((RelNode) rel, mq, groupKey, predicate);
-    }
-    Double d = null;
-    for (RelNode r2 : rel.getRels()) {
-      try {
-        Double d2 = mq.getDistinctRowCount(r2, groupKey, predicate);
-        d = NumberUtil.min(d, d2);
-      } catch (CyclicMetadataException e) {
-        // Ignore this relational expression; there will be non-cyclic ones
-        // in this set.
-      }
-    }
-    return d;
+    return mq.getDistinctRowCount(rel.getOriginal(), groupKey, predicate);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -42,7 +42,6 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.calcite.util.Util;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -105,8 +104,7 @@ public class RelMdExpressionLineage
 
   public Set<RexNode> getExpressionLineage(RelSubset rel,
       RelMetadataQuery mq, RexNode outputExpression) {
-    return mq.getExpressionLineage(Util.first(rel.getBest(), rel.getOriginal()),
-        outputExpression);
+    return mq.getExpressionLineage(rel.getOriginal(), outputExpression);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
@@ -35,9 +35,7 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.BuiltInMethod;
-import org.apache.calcite.util.Util;
 
 /**
  * RelMdMaxRowCount supplies a default implementation of
@@ -202,19 +200,7 @@ public class RelMdMaxRowCount
   }
 
   public Double getMaxRowCount(RelSubset rel, RelMetadataQuery mq) {
-    // FIXME This is a short-term fix for [CALCITE-1018]. A complete
-    // solution will come with [CALCITE-1048].
-    Util.discard(Bug.CALCITE_1048_FIXED);
-    for (RelNode node : rel.getRels()) {
-      if (node instanceof Sort) {
-        Sort sort = (Sort) node;
-        if (sort.fetch != null) {
-          return (double) RexLiteral.intValue(sort.fetch);
-        }
-      }
-    }
-
-    return Double.POSITIVE_INFINITY;
+    return mq.getMaxRowCount(rel.getOriginal());
   }
 
   // Catch-all rule when none of the others apply.

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
@@ -33,9 +33,7 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.BuiltInMethod;
-import org.apache.calcite.util.Util;
 
 /**
  * RelMdMinRowCount supplies a default implementation of
@@ -162,19 +160,7 @@ public class RelMdMinRowCount
   }
 
   public Double getMinRowCount(RelSubset rel, RelMetadataQuery mq) {
-    // FIXME This is a short-term fix for [CALCITE-1018]. A complete
-    // solution will come with [CALCITE-1048].
-    Util.discard(Bug.CALCITE_1048_FIXED);
-    for (RelNode node : rel.getRels()) {
-      if (node instanceof Sort) {
-        Sort sort = (Sort) node;
-        if (sort.fetch != null) {
-          return (double) RexLiteral.intValue(sort.fetch);
-        }
-      }
-    }
-
-    return 0D;
+    return getMinRowCount(rel.getOriginal(), mq);
   }
 
   // Catch-all rule when none of the others apply.

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
@@ -37,7 +37,6 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.util.BuiltInMethod;
-import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -76,7 +75,7 @@ public class RelMdNodeTypes
 
   public Multimap<Class<? extends RelNode>, RelNode> getNodeTypes(RelSubset rel,
       RelMetadataQuery mq) {
-    return mq.getNodeTypes(Util.first(rel.getBest(), rel.getOriginal()));
+    return mq.getNodeTypes(rel.getOriginal());
   }
 
   public Multimap<Class<? extends RelNode>, RelNode> getNodeTypes(Union rel,

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -53,7 +53,6 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.BitSets;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
@@ -488,18 +487,7 @@ public class RelMdPredicates
   /** @see RelMetadataQuery#getPulledUpPredicates(RelNode) */
   public RelOptPredicateList getPredicates(RelSubset r,
       RelMetadataQuery mq) {
-    if (!Bug.CALCITE_1048_FIXED) {
-      return RelOptPredicateList.EMPTY;
-    }
-    final RexBuilder rexBuilder = r.getCluster().getRexBuilder();
-    RelOptPredicateList list = null;
-    for (RelNode r2 : r.getRels()) {
-      RelOptPredicateList list2 = mq.getPulledUpPredicates(r2);
-      if (list2 != null) {
-        list = list == null ? list2 : list.union(rexBuilder, list2);
-      }
-    }
-    return Util.first(list, RelOptPredicateList.EMPTY);
+    return getPredicates(r.getOriginal(), mq);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -35,11 +35,8 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.calcite.util.NumberUtil;
-import org.apache.calcite.util.Util;
 
 /**
  * RelMdRowCount supplies a default implementation of
@@ -68,20 +65,7 @@ public class RelMdRowCount
   }
 
   public Double getRowCount(RelSubset subset, RelMetadataQuery mq) {
-    if (!Bug.CALCITE_1048_FIXED) {
-      return mq.getRowCount(Util.first(subset.getBest(), subset.getOriginal()));
-    }
-    Double v = null;
-    for (RelNode r : subset.getRels()) {
-      try {
-        v = NumberUtil.min(v, mq.getRowCount(r));
-      } catch (CyclicMetadataException e) {
-        // ignore this rel; there will be other, non-cyclic ones
-      } catch (Throwable e) {
-        e.printStackTrace();
-      }
-    }
-    return Util.first(v, 1e6d); // if set is empty, estimate large
+    return mq.getRowCount(subset.getOriginal());
   }
 
   public Double getRowCount(Union rel, RelMetadataQuery mq) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
@@ -33,7 +33,6 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rex.RexTableInputRef.RelTableRef;
 import org.apache.calcite.util.BuiltInMethod;
-import org.apache.calcite.util.Util;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -85,7 +84,7 @@ public class RelMdTableReferences
   }
 
   public Set<RelTableRef> getTableReferences(RelSubset rel, RelMetadataQuery mq) {
-    return mq.getTableReferences(Util.first(rel.getBest(), rel.getOriginal()));
+    return mq.getTableReferences(rel.getOriginal());
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/rules/MultiJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MultiJoin.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.LogicalNode;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.JoinRelType;
@@ -44,7 +45,7 @@ import java.util.Map;
  * A MultiJoin represents a join of N inputs, whereas regular Joins
  * represent strictly binary joins.
  */
-public final class MultiJoin extends AbstractRelNode {
+public final class MultiJoin extends AbstractRelNode implements LogicalNode {
   //~ Instance fields --------------------------------------------------------
 
   private final List<RelNode> inputs;
@@ -264,6 +265,10 @@ public final class MultiJoin extends AbstractRelNode {
    */
   public RexNode getPostJoinFilter() {
     return postJoinFilter;
+  }
+
+  @Override public StatsEstimateConfidenceLevel getStatsEstimateConfidence() {
+    return StatsEstimateConfidenceLevel.Low;
   }
 
   boolean containsOuter() {

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -988,13 +988,13 @@ public class PlannerTest {
         + "left join \"depts\" as d on e.\"deptno\" = d.\"deptno\"\n"
         + "join \"dependents\" as p on e.\"empid\" = p.\"empid\"";
     final String expected = ""
-        + "EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], location=[ROW($10, $11)], empid0=[$0], name1=[$1])\n"
-        + "  EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
-        + "    EnumerableTableScan(table=[[hr, dependents]])\n"
+        + "EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], location=[ROW($8, $9)], empid0=[$10], name1=[$11])\n"
+        + "  EnumerableHashJoin(condition=[=($0, $10)], joinType=[inner])\n"
         + "    EnumerableHashJoin(condition=[=($1, $5)], joinType=[left])\n"
         + "      EnumerableTableScan(table=[[hr, emps]])\n"
         + "      EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
-        + "        EnumerableTableScan(table=[[hr, depts]])";
+        + "        EnumerableTableScan(table=[[hr, depts]])\n"
+        + "    EnumerableTableScan(table=[[hr, dependents]])";
     checkHeuristic(sql, expected);
   }
 
@@ -1009,14 +1009,14 @@ public class PlannerTest {
         + "right join \"depts\" as d on e.\"deptno\" = d.\"deptno\"\n"
         + "join \"dependents\" as p on e.\"empid\" = p.\"empid\"";
     final String expected = ""
-        + "EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], location=[ROW($10, $11)], empid0=[$0], name1=[$1])\n"
-        + "  EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
-        + "    EnumerableTableScan(table=[[hr, dependents]])\n"
+        + "EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], location=[ROW($8, $9)], empid0=[$10], name1=[$11])\n"
+        + "  EnumerableHashJoin(condition=[=($0, $10)], joinType=[inner])\n"
         + "    EnumerableProject(empid=[$5], deptno=[$6], name=[$7], salary=[$8], commission=[$9], deptno0=[$0], name0=[$1], employees=[$2], x=[$3], y=[$4])\n"
         + "      EnumerableHashJoin(condition=[=($0, $6)], joinType=[left])\n"
         + "        EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
         + "          EnumerableTableScan(table=[[hr, depts]])\n"
-        + "        EnumerableTableScan(table=[[hr, emps]])";
+        + "        EnumerableTableScan(table=[[hr, emps]])\n"
+        + "    EnumerableTableScan(table=[[hr, dependents]])";
     checkHeuristic(sql, expected);
   }
 
@@ -1027,13 +1027,13 @@ public class PlannerTest {
         + "join \"depts\" as d on e.\"deptno\" = d.\"deptno\"\n"
         + "right join \"dependents\" as p on e.\"empid\" = p.\"empid\"";
     final String expected = ""
-        + "EnumerableProject(empid=[$2], deptno=[$3], name=[$4], salary=[$5], commission=[$6], deptno0=[$7], name0=[$8], employees=[$9], location=[ROW($10, $11)], empid0=[$0], name1=[$1])\n"
-        + "  EnumerableHashJoin(condition=[=($0, $2)], joinType=[left])\n"
-        + "    EnumerableTableScan(table=[[hr, dependents]])\n"
+        + "EnumerableProject(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4], deptno0=[$5], name0=[$6], employees=[$7], location=[ROW($8, $9)], empid0=[$10], name1=[$11])\n"
+        + "  EnumerableHashJoin(condition=[=($0, $10)], joinType=[right])\n"
         + "    EnumerableHashJoin(condition=[=($1, $5)], joinType=[inner])\n"
         + "      EnumerableTableScan(table=[[hr, emps]])\n"
         + "      EnumerableProject(deptno=[$0], name=[$1], employees=[$2], x=[$3.x], y=[$3.y])\n"
-        + "        EnumerableTableScan(table=[[hr, depts]])";
+        + "        EnumerableTableScan(table=[[hr, depts]])\n"
+        + "    EnumerableTableScan(table=[[hr, dependents]])";
     checkHeuristic(sql, expected);
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/TopDownOptTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/TopDownOptTest.xml
@@ -1080,11 +1080,11 @@ LogicalSort(sort0=[$1], dir0=[ASC])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-EnumerableCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{7}])
-  EnumerableSort(sort0=[$1], dir0=[ASC])
+EnumerableSort(sort0=[$1], dir0=[ASC])
+  EnumerableCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{7}])
     EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
-  EnumerableFilter(condition=[=($cor0.DEPTNO, $0)])
-    EnumerableTableScan(table=[[CATALOG, SALES, DEPT]])
+    EnumerableFilter(condition=[=($cor0.DEPTNO, $0)])
+      EnumerableTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>
@@ -1130,11 +1130,11 @@ LogicalSort(sort0=[$1], dir0=[ASC])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
-  EnumerableSort(sort0=[$1], dir0=[ASC])
+EnumerableSort(sort0=[$1], dir0=[ASC])
+  EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
     EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
-  EnumerableFilter(condition=[=($cor0.DEPTNO, $0)])
-    EnumerableTableScan(table=[[CATALOG, SALES, DEPT]])
+    EnumerableFilter(condition=[=($cor0.DEPTNO, $0)])
+      EnumerableTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>
@@ -1183,12 +1183,12 @@ LogicalSort(sort0=[$1], dir0=[ASC])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-EnumerableCorrelate(correlation=[$cor2], joinType=[semi], requiredColumns=[{0}])
-  EnumerableSort(sort0=[$1], dir0=[ASC])
+EnumerableSort(sort0=[$1], dir0=[ASC])
+  EnumerableCorrelate(correlation=[$cor2], joinType=[semi], requiredColumns=[{0}])
     EnumerableTableScan(table=[[CATALOG, SALES, DEPT]])
-  EnumerableFilter(condition=[=($cor2.DEPTNO, $0)])
-    EnumerableProject(DEPTNO=[$7], $f0=[true])
-      EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
+    EnumerableFilter(condition=[=($cor2.DEPTNO, $0)])
+      EnumerableProject(DEPTNO=[$7], $f0=[true])
+        EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
…up) instead of RelNode

1. Add new LogicalNode interface that supports reporting stats estimation confidence.
2. Re-purpose set.rel and rename it into set.originalRel to report logical properties of RelSet.
3. When a new RelNode is added to the set, we check the stats confidence of the new node, and update set.originalRel if it has a higher confidence level.
4. Meta data handler will always report logical properties from set.originalRel for RelSubset.

CALCITE-3963