### PR TITLE
[CALCITE-4043] Improve IllegalArgumentException message in RelBuilder#field

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -487,8 +487,8 @@ public class RelBuilder {
                 p.e.right.getName()));
       }
     }
-    throw new IllegalArgumentException("no aliased field found; fields are: "
-        + fields);
+    throw new IllegalArgumentException("{alias=" + alias + ",fieldName=" + fieldName + "} "
+        + "field not found; fields are: " + fields);
   }
 
   /** Returns a reference to a given field of a record-valued expression. */


### PR DESCRIPTION
The RelBuilder#field method that creates a RexNode based on alias + fieldName throws an IllegalArgumentException if the corresponding field is not found.
However, the exception message does not include the requested alias & fieldName, which is relevant information, definitively useful for troubleshooting.
