### PR TITLE
[CALCITE-4049] Reduce the time complexity of getting shortest distances

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/ConsList.java
+++ b/core/src/main/java/org/apache/calcite/runtime/ConsList.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 public class ConsList<E> extends AbstractImmutableList<E> {
   private final E first;
   private final List<E> rest;
+  private final int size;
 
   /** Creates a ConsList.
    * It consists of an element pre-pended to another list.
@@ -51,6 +52,7 @@ public class ConsList<E> extends AbstractImmutableList<E> {
   private ConsList(E first, List<E> rest) {
     this.first = first;
     this.rest = rest;
+    this.size = 1 + rest.size();
   }
 
   public E get(int index) {
@@ -66,12 +68,7 @@ public class ConsList<E> extends AbstractImmutableList<E> {
   }
 
   public int size() {
-    int s = 1;
-    for (ConsList c = this;; c = (ConsList) c.rest, ++s) {
-      if (!(c.rest instanceof ConsList)) {
-        return s + c.rest.size();
-      }
-    }
+    return size;
   }
 
   @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/Graphs.java
@@ -137,6 +137,20 @@ public class Graphs {
       return shortestPaths.get(Pair.of(from, to));
     }
 
+    /**
+     * Returns the shortest distance between two points, -1, if there is no path.
+     * @param from From
+     * @param to To
+     * @return The shortest distance, -1, if there is no path.
+     */
+    public int getShortestDistance(V from, V to) {
+      if (from.equals(to)) {
+        return 0;
+      }
+      List<V> path = shortestPaths.get(Pair.of(from, to));
+      return path == null ? -1 : path.size() - 1;
+    }
+
     private void findPaths(V from, V to, List<List<V>> list) {
       final List<V> shortestPath = shortestPaths.get(Pair.of(from, to));
       if (shortestPath == null) {

--- a/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
+++ b/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
@@ -161,9 +161,14 @@ class DirectedGraphTest {
   }
 
   private DefaultDirectedGraph<String, DefaultEdge> createDag() {
-    // A - B - C - D
-    //  \     /
-    //   +- E - F
+    //    D         F
+    //    ^         ^
+    //    |         |
+    //    C <------ +
+    //    ^         |
+    //    |         |
+    //    |         |
+    //    B <- A -> E
     final DefaultDirectedGraph<String, DefaultEdge> graph =
         DefaultDirectedGraph.create();
     graph.addVertex("A");
@@ -181,14 +186,15 @@ class DirectedGraphTest {
     return graph;
   }
 
-  /** Unit test for
-   * {@link org.apache.calcite.util.graph.Graphs.FrozenGraph}. */
-  @Test void testPaths() {
-    //       B -> C
-    //      /      \
-    //     A        E
-    //      \      /
-    //       D -->
+  private DefaultDirectedGraph<String, DefaultEdge> createDag1() {
+    //    +--> E <--+
+    //    |         |
+    //    C         |
+    //    ^         D
+    //    |         ^
+    //    |         |
+    //    |         |
+    //    B <-- A --+
     final DefaultDirectedGraph<String, DefaultEdge> graph =
         DefaultDirectedGraph.create();
     graph.addVertex("A");
@@ -202,6 +208,13 @@ class DirectedGraphTest {
     graph.addEdge("A", "D");
     graph.addEdge("D", "E");
     graph.addEdge("C", "E");
+    return graph;
+  }
+
+  /** Unit test for
+   * {@link org.apache.calcite.util.graph.Graphs.FrozenGraph}. */
+  @Test void testPaths() {
+    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag1();
     final Graphs.FrozenGraph<String, DefaultEdge> frozenGraph =
         Graphs.makeImmutable(graph);
     assertEquals("[A, B]", frozenGraph.getShortestPath("A", "B").toString());
@@ -213,6 +226,18 @@ class DirectedGraphTest {
     assertNull(frozenGraph.getShortestPath("D", "C"));
     assertEquals("[[D, E]]", frozenGraph.getPaths("D", "E").toString());
     assertEquals("[D, E]", frozenGraph.getShortestPath("D", "E").toString());
+  }
+
+  @Test void testDistances() {
+    final DefaultDirectedGraph<String, DefaultEdge> graph = createDag1();
+    final Graphs.FrozenGraph<String, DefaultEdge> frozenGraph =
+        Graphs.makeImmutable(graph);
+    assertEquals(1, frozenGraph.getShortestDistance("A", "B"));
+    assertEquals(2, frozenGraph.getShortestDistance("A", "E"));
+    assertEquals(-1, frozenGraph.getShortestDistance("B", "A"));
+    assertEquals(-1, frozenGraph.getShortestDistance("D", "C"));
+    assertEquals(1, frozenGraph.getShortestDistance("D", "E"));
+    assertEquals(0, frozenGraph.getShortestDistance("B", "B"));
   }
 
   /** Unit test for {@link org.apache.calcite.util.graph.CycleDetector}. */


### PR DESCRIPTION
Currently, we have `Graphs#makeImmutable` to compute the shortest paths between all pairs of nodes. For many scenarios, however, we do not need the exact paths between nodes. Instead, we are only interested in the lengths of the shortest paths.

To get the path length, we need to get the shortest path first, which is returned as a `List`, then we call the `List#size()` method. According to the current implementation, the returned list is of type `ConsList`. The time complexity of `ConsList#size` is O(p) (p is the number of vertices on the path), which is inefficient.

In this issue, we revise the implementation of `ConsList#size` so that it takes O(1) time. In addition, we also give a utiltiy to get the shortest distances between nodes.