### PR TITLE
[CALCITE-4053] RexSimplify should not pass exprs containing non-const…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -1950,7 +1950,7 @@ public class RexSimplify {
         break;
       }
       final List<RexNode> reducedValues = new ArrayList<>();
-      RexNode simplifiedExpr = rexBuilder.makeCast(e.getType(), operand);
+      final RexNode simplifiedExpr = rexBuilder.makeCast(e.getType(), operand);
       executor.reduce(rexBuilder, ImmutableList.of(simplifiedExpr), reducedValues);
       return Objects.requireNonNull(
           Iterables.getOnlyElement(reducedValues));

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -1950,7 +1950,8 @@ public class RexSimplify {
         break;
       }
       final List<RexNode> reducedValues = new ArrayList<>();
-      executor.reduce(rexBuilder, ImmutableList.of(e), reducedValues);
+      RexNode simplifiedExpr = rexBuilder.makeCast(e.getType(), operand);
+      executor.reduce(rexBuilder, ImmutableList.of(simplifiedExpr), reducedValues);
       return Objects.requireNonNull(
           Iterables.getOnlyElement(reducedValues));
     default:

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2610,6 +2610,11 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).decorrelate(true).ok();
   }
 
+  @Test void testReduceConstExpr() {
+    final String sql = "select sum(case when 'y' = 'n' then ename else 1 end) from emp";
+    sql(sql).ok();
+  }
+
   /**
    * Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-695">[CALCITE-695]

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -3717,6 +3717,18 @@ LogicalProject(DEPTNO=[$7])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testReduceConstExpr">
+        <Resource name="sql">
+            <![CDATA[select sum(case when 'y' = 'n' then ename else 1 end) from emp]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
+  LogicalProject($f0=[1:DECIMAL(19, 19)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testSimplifyNotExistsValuesSubQuery">
         <Resource name="sql">
             <![CDATA[select deptno
@@ -3731,6 +3743,7 @@ LogicalProject(DEPTNO=[$7])
 ]]>
         </Resource>
     </TestCase>
+
     <TestCase name="testSubQueryAggregateFunctionFollowedBySimpleOperation">
         <Resource name="sql">
             <![CDATA[select deptno


### PR DESCRIPTION
… subExprs to RexExecutor

Currently in RexSimplify#simplifyCast, if an expression is judged as a const expression but the outer CAST can not be removed, we pass the original expression to `RexExecutor` to reduce the expression which may leads to unexpected exception when the original expression contains `RexInputRef`.