### PR TITLE
[CALCITE-4033] Does not produce parenthesized table expressions for U…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1238,6 +1238,7 @@ public enum SqlKind {
    * {@link #ORDER_BY},
    * {@link #COLLECTION_TABLE},
    * {@link #TABLESAMPLE},
+   * {@link #UNNEST}
    * or an aggregate function, DML or DDL.
    */
   public static final Set<SqlKind> EXPRESSION =
@@ -1252,7 +1253,7 @@ public enum SqlKind {
                   LITERAL_CHAIN, JDBC_FN, PRECEDING, FOLLOWING, ORDER_BY,
                   NULLS_FIRST, NULLS_LAST, COLLECTION_TABLE, TABLESAMPLE,
                   VALUES, WITH, WITH_ITEM, ITEM, SKIP_TO_FIRST, SKIP_TO_LAST,
-                  JSON_VALUE_EXPRESSION),
+                  JSON_VALUE_EXPRESSION, UNNEST),
               AGGREGATE, DML, DDL));
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -7153,10 +7153,10 @@ public class SqlParserTest {
   @Test void testUnnest() {
     sql("select*from unnest(x)")
         .ok("SELECT *\n"
-            + "FROM (UNNEST(`X`))");
+            + "FROM UNNEST(`X`)");
     sql("select*from unnest(x) AS T")
         .ok("SELECT *\n"
-            + "FROM (UNNEST(`X`)) AS `T`");
+            + "FROM UNNEST(`X`) AS `T`");
 
     // UNNEST cannot be first word in query
     sql("^unnest^(x)")
@@ -7167,24 +7167,41 @@ public class SqlParserTest {
         + "unnest(dept.employees, dept.managers)";
     final String expected = "SELECT *\n"
         + "FROM `DEPT`,\n"
-        + "(UNNEST(`DEPT`.`EMPLOYEES`, `DEPT`.`MANAGERS`))";
+        + "UNNEST(`DEPT`.`EMPLOYEES`, `DEPT`.`MANAGERS`)";
     sql(sql).ok(expected);
 
     // LATERAL UNNEST is not valid
     sql("select * from dept, lateral ^unnest^(dept.employees)")
         .fails("(?s)Encountered \"unnest\" at .*");
+
+    // Does not generate extra parentheses around UNNEST because UNNEST is
+    // a table expression.
+    final String sql1 = ""
+        + "SELECT\n"
+        + "  item.name,\n"
+        + "  relations.*\n"
+        + "FROM dfs.tmp item\n"
+        + "JOIN (\n"
+        + "  SELECT * FROM UNNEST(item.related) i(rels)\n"
+        + ") relations\n"
+        + "ON TRUE";
+    final String expected1 = "SELECT `ITEM`.`NAME`, `RELATIONS`.*\n"
+        + "FROM `DFS`.`TMP` AS `ITEM`\n"
+        + "INNER JOIN (SELECT *\n"
+        + "FROM UNNEST(`ITEM`.`RELATED`) AS `I` (`RELS`)) AS `RELATIONS` ON TRUE";
+    sql(sql1).ok(expected1);
   }
 
   @Test void testUnnestWithOrdinality() {
     sql("select * from unnest(x) with ordinality")
         .ok("SELECT *\n"
-            + "FROM (UNNEST(`X`) WITH ORDINALITY)");
+            + "FROM UNNEST(`X`) WITH ORDINALITY");
     sql("select*from unnest(x) with ordinality AS T")
         .ok("SELECT *\n"
-            + "FROM (UNNEST(`X`) WITH ORDINALITY) AS `T`");
+            + "FROM UNNEST(`X`) WITH ORDINALITY AS `T`");
     sql("select*from unnest(x) with ordinality AS T(c, o)")
         .ok("SELECT *\n"
-            + "FROM (UNNEST(`X`) WITH ORDINALITY) AS `T` (`C`, `O`)");
+            + "FROM UNNEST(`X`) WITH ORDINALITY AS `T` (`C`, `O`)");
     sql("select*from unnest(x) as T ^with^ ordinality")
         .fails("(?s)Encountered \"with\" at .*");
   }


### PR DESCRIPTION
…NNEST (Rui Wang).

Before this change, Calcite parser produces "(UNEST(...))". However, Calcite parser fails to parse UNNEST as parenthesized table expressions: "JOIN (SELECT * FROM ^(UNNEST(...))^)". This change stops produces parenthesized table expressions for UNNEST to fix this problem.


See: https://issues.apache.org/jira/browse/CALCITE-4033