### PR TITLE
[CALCITE-4069] Elasticsearch adapter. Optimize the process of adding count(*) to the result set.

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
@@ -287,11 +287,11 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
       result.add(new LinkedHashMap<>());
     }
 
-    // elastic exposes total number of documents matching a query in "/hits/total" path
-    // this can be used for simple "select count(*) from table"
-    final long total = res.searchHits().total().value();
+    if (groupBy.isEmpty() && aggregations.size() == 1) {
+      // elastic exposes total number of documents matching a query in "/hits/total" path
+      // this can be used for simple "select count(*) from table"
+      final long total = res.searchHits().total().value();
 
-    if (groupBy.isEmpty()) {
       // put totals automatically for count(*) expression(s), unless they contain group by
       for (String expr : countAll) {
         result.forEach(m -> m.put(expr, total));


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-4069
In Elasticsearch adapter, the result of count(*) will be added to the result set twice when use multiple aggregations without group by.