### PR TITLE
[CALCITE-4075] Mock table 'EMPNULLABLES' should allow nulls in all non-pk columns

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -9453,42 +9453,42 @@ class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test void testInsertFailNullability() {
-    sql("insert into ^empnullables^ (ename) values ('Kevin')")
+    sql("insert into ^emp^ (ename) values ('Kevin')")
         .fails("Column 'EMPNO' has no default value and does not allow NULLs");
-    sql("insert into ^empnullables^ (empno) values (10)")
+    sql("insert into ^emp^ (empno) values (10)")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
-    sql("insert into empnullables (empno, ename, deptno) ^values (5, null, 5)^")
+    sql("insert into emp (empno, ename, deptno) ^values (5, null, 5)^")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
   }
 
   @Test void testInsertSubsetFailNullability() {
     final Sql s = sql("?").withConformance(SqlConformanceEnum.PRAGMATIC_2003);
 
-    s.sql("insert into ^empnullables^ values (1)")
+    s.sql("insert into ^emp^ values (1)")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
-    s.sql("insert into empnullables ^values (null, 'Liam')^")
+    s.sql("insert into emp ^values (null, 'Liam')^")
         .fails("Column 'EMPNO' has no default value and does not allow NULLs");
-    s.sql("insert into empnullables ^values (45, null, 5)^")
+    s.sql("insert into emp ^values (45, null, 5)^")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
   }
 
   @Test void testInsertViewFailNullability() {
-    sql("insert into ^empnullables_20^ (ename) values ('Jake')")
+    sql("insert into ^emp_20^ (ename) values ('Jake')")
         .fails("Column 'EMPNO' has no default value and does not allow NULLs");
-    sql("insert into ^empnullables_20^ (empno) values (9)")
+    sql("insert into ^emp_20^ (empno) values (9)")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
-    sql("insert into empnullables_20 (empno, ename, mgr) ^values (5, null, 5)^")
+    sql("insert into emp_20 (empno, ename, mgr) ^values (5, null, 5)^")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
   }
 
   @Test void testInsertSubsetViewFailNullability() {
     final Sql s = sql("?").withConformance(SqlConformanceEnum.PRAGMATIC_2003);
 
-    s.sql("insert into ^empnullables_20^ values (1)")
+    s.sql("insert into ^EMP_20^ values (1)")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
-    s.sql("insert into empnullables_20 ^values (null, 'Liam')^")
+    s.sql("insert into EMP_20 ^values (null, 'Liam')^")
         .fails("Column 'EMPNO' has no default value and does not allow NULLs");
-    s.sql("insert into empnullables_20 ^values (45, null)^")
+    s.sql("insert into EMP_20 ^values (45, null)^")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
   }
 
@@ -9504,11 +9504,11 @@ class SqlValidatorTest extends SqlValidatorTestCase {
   @Test void testInsertBindSubsetFailNullability() {
     final Sql s = sql("?").withConformance(SqlConformanceEnum.PRAGMATIC_2003);
 
-    s.sql("insert into ^empnullables^ values (?)")
+    s.sql("insert into ^emp^ values (?)")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
-    s.sql("insert into empnullables ^values (null, ?)^")
+    s.sql("insert into emp ^values (null, ?)^")
         .fails("Column 'EMPNO' has no default value and does not allow NULLs");
-    s.sql("insert into empnullables ^values (?, null)^")
+    s.sql("insert into emp ^values (?, null)^")
         .fails("Column 'ENAME' has no default value and does not allow NULLs");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -102,7 +102,7 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     final MockTable empNullablesTable =
         MockTable.create(this, salesSchema, "EMPNULLABLES", false, 14);
     empNullablesTable.addColumn("EMPNO", fixture.intType, true);
-    empNullablesTable.addColumn("ENAME", fixture.varchar20Type);
+    empNullablesTable.addColumn("ENAME", fixture.varchar20TypeNull);
     empNullablesTable.addColumn("JOB", fixture.varchar10TypeNull);
     empNullablesTable.addColumn("MGR", fixture.intTypeNull);
     empNullablesTable.addColumn("HIREDATE", fixture.timestampTypeNull);
@@ -340,7 +340,7 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
         };
     salesSchema.addTable(Util.last(empNullables20View.getQualifiedName()));
     empNullables20View.addColumn("EMPNO", fixture.intType);
-    empNullables20View.addColumn("ENAME", fixture.varchar20Type);
+    empNullables20View.addColumn("ENAME", fixture.varchar20TypeNull);
     empNullables20View.addColumn("JOB", fixture.varchar10TypeNull);
     empNullables20View.addColumn("MGR", fixture.intTypeNull);
     empNullables20View.addColumn("HIREDATE", fixture.timestampTypeNull);


### PR DESCRIPTION
The name of the table implies that all columns are nullable so to avoid confusion 'ENAME' is also made nullable.