### PR TITLE
[CALCITE-4083] RelTraitSet failed to canonize traits

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -159,7 +159,7 @@ class RelSet {
 
   public RelSubset getSubset(RelTraitSet traits) {
     for (RelSubset subset : subsets) {
-      if (subset.getTraitSet() == traits) {
+      if (subset.getTraitSet().equals(traits)) {
         return subset;
       }
     }

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFieldImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFieldImpl.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.type;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Default implementation of {@link RelDataTypeField}.
@@ -49,9 +50,7 @@ public class RelDataTypeFieldImpl implements RelDataTypeField, Serializable {
   //~ Methods ----------------------------------------------------------------
 
   @Override public int hashCode() {
-    return index
-        ^ name.hashCode()
-        ^ type.hashCode();
+    return Objects.hash(index, name, type);
   }
 
   @Override public boolean equals(Object obj) {


### PR DESCRIPTION
RelTraitSet#plus uses FlatLists and ImmutableList. They have different hash
algorithms, and they are all different classes from RelTraitSet. The
RelTraitSet equality requires the other object must be RelTraitSet too, and the
HashMap#get(key) uses key.equals() to check equality, instead of the other way.
In case we pass RelTraitSet as the search key to cache, but the cached entry
has key with FlatLists or ImmutableList, we may fail to find the cached
RelTraitSet. Due to this, using == to check traitSet equality may fail, even
they have same traits.

Also modified hashCode() of RelDataTypeFieldImpl, the original implementation
generates hash collision easily.

CALCITE-4083