### PR TITLE
[CALCITE-4085] Improve nullability support for fields of structured types

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlDotOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlDotOperator.java
@@ -111,6 +111,9 @@ public class SqlDotOperator extends SqlSpecialOperator {
           Static.RESOURCE.unknownField(fieldName));
     }
     RelDataType type = field.getType();
+    if (nodeType.isNullable()) {
+      type = validator.getTypeFactory().createTypeWithNullability(type, true);
+    }
 
     // Validate and determine coercibility and resulting collation
     // name of binary operator if needed.

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -135,7 +135,11 @@ class SqlItemOperator extends SqlSpecialOperator {
         throw new AssertionError("Cannot infer type of field '"
             + fieldName + "' within ROW type: " + operandType);
       } else {
-        return field.getType();
+        RelDataType fieldType = field.getType();
+        if (operandType.isNullable()) {
+          fieldType = typeFactory.createTypeWithNullability(fieldType, true);
+        }
+        return fieldType;
       }
     case ANY:
     case DYNAMIC_STAR:

--- a/core/src/main/java/org/apache/calcite/sql/validate/AliasNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AliasNamespace.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.sql.validate;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -91,9 +92,18 @@ public class AliasNamespace extends AbstractNamespace {
     for (RelDataTypeField field : rowType.getFieldList()) {
       typeList.add(field.getType());
     }
-    return validator.getTypeFactory().createStructType(
+    RelDataType aliasedType = validator.getTypeFactory().createStructType(
+        rowType.getStructKind(),
         typeList,
         nameList);
+
+    // As per suggestion in CALCITE-4085, JavaType has its special nullability handling.
+    if (rowType instanceof RelDataTypeFactoryImpl.JavaType) {
+      return aliasedType;
+    } else {
+      return validator.getTypeFactory()
+          .createTypeWithNullability(aliasedType, rowType.isNullable());
+    }
   }
 
   private String getString(RelDataType rowType) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11482,4 +11482,12 @@ class SqlValidatorTest extends SqlValidatorTestCase {
     assertThat(resultType.toString(), is("INTEGER"));
   }
 
+  @Test void testAccessingNestedFieldsOfNullableRecord() {
+    sql("select ROW_COLUMN_ARRAY[0].NOT_NULL_FIELD from NULLABLEROWS.NR_T1")
+        .withExtendedCatalog()
+        .type("RecordType(BIGINT EXPR$0) NOT NULL");
+    sql("select ROW_COLUMN_ARRAY[0]['NOT_NULL_FIELD'] from NULLABLEROWS.NR_T1")
+        .withExtendedCatalog()
+        .type("RecordType(BIGINT EXPR$0) NOT NULL");
+  }
 }

--- a/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
@@ -16,9 +16,14 @@
  */
 package org.apache.calcite.test.catalog;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.rel.type.StructKind;
 import org.apache.calcite.schema.TableMacro;
 import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.sql.type.SqlTypeName;
 
 import com.google.common.collect.ImmutableList;
 
@@ -162,6 +167,34 @@ public class MockCatalogReaderExtended extends MockCatalogReaderSimple {
     complexTypeColumnsTable.addColumn("intArrayMultisetType", f.intArrayMultisetType);
     complexTypeColumnsTable.addColumn("rowArrayMultisetType", f.rowArrayMultisetType);
     registerTable(complexTypeColumnsTable);
+
+    MockSchema nullableRowsSchema = new MockSchema("NULLABLEROWS");
+    registerSchema(nullableRowsSchema);
+    final MockTable nullableRowsTable =
+        MockTable.create(this, nullableRowsSchema, "NR_T1", false, 100);
+    RelDataType bigIntNotNull = typeFactory.createSqlType(SqlTypeName.BIGINT);
+    RelDataType nullableRecordType = new RelRecordType(
+        StructKind.FULLY_QUALIFIED,
+        Arrays.asList(
+            new RelDataTypeFieldImpl(
+                "NOT_NULL_FIELD",
+                0,
+                bigIntNotNull),
+            new RelDataTypeFieldImpl(
+                "NULLABLE_FIELD",
+                0,
+                typeFactory.createTypeWithNullability(bigIntNotNull, true)
+            )
+        ),
+        true
+    );
+
+    nullableRowsTable.addColumn("ROW_COLUMN", nullableRecordType, false);
+    nullableRowsTable.addColumn(
+        "ROW_COLUMN_ARRAY",
+        typeFactory.createArrayType(nullableRecordType, -1),
+        true);
+    registerTable(nullableRowsTable);
 
     return this;
   }


### PR DESCRIPTION
This PR tries to improve nullability of records fields when the record itself is nullable,
The PR is split into three commits which in my opinion affect the code base to a different extent. Calcite users should not see a difference in the behaviour, but downstream projects that depend on Calcite can implement a support for not null fields within a nullable record type based on those changes.