### PR TITLE
[CALCITE-3936] JDBC adapter, when generating SQL, changes target of ambiguous HAVING clause with a Project on Filter on Aggregate

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverter.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcToEnumerableConverter.java
@@ -330,7 +330,7 @@ public class JdbcToEnumerableConverter
         new JdbcImplementor(dialect,
             (JavaTypeFactory) getCluster().getTypeFactory());
     final JdbcImplementor.Result result =
-        jdbcImplementor.visitChild(0, getInput());
+        jdbcImplementor.visitInput(this, 0);
     return result.asStatement().toSqlString(dialect);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -305,13 +305,9 @@ public class RelToSqlConverter extends SqlImplementor
     Result x = visitChild(0, input);
     parseCorrelTable(e, x);
     if (input instanceof Aggregate) {
-      final Builder builder;
-      if (((Aggregate) input).getInput() instanceof Project) {
-        builder = x.builder(e);
-        builder.clauses.add(Clause.HAVING);
-      } else {
-        builder = x.builder(e, Clause.HAVING);
-      }
+      final Aggregate aggregate = (Aggregate) input;
+      final boolean ignoreClauses = aggregate.getInput() instanceof Project;
+      final Builder builder = x.builder(e, ignoreClauses, Clause.HAVING);
       builder.setHaving(builder.context.toSql(null, e.getCondition()));
       return builder.result();
     } else {
@@ -387,13 +383,8 @@ public class RelToSqlConverter extends SqlImplementor
   private Result visitAggregate(Aggregate e, List<Integer> groupKeyList) {
     // "select a, b, sum(x) from ( ... ) group by a, b"
     final Result x = visitChild(0, e.getInput());
-    final Builder builder;
-    if (e.getInput() instanceof Project) {
-      builder = x.builder(e);
-      builder.clauses.add(Clause.GROUP_BY);
-    } else {
-      builder = x.builder(e, Clause.GROUP_BY);
-    }
+    final boolean ignoreClauses = e.getInput() instanceof Project;
+    final Builder builder = x.builder(e, ignoreClauses, Clause.GROUP_BY);
     final List<SqlNode> selectList = new ArrayList<>();
     final List<SqlNode> groupByList =
         generateGroupList(builder, selectList, e, groupKeyList);
@@ -411,13 +402,7 @@ public class RelToSqlConverter extends SqlImplementor
    */
   protected Builder getAggregateBuilder(Aggregate e, Result inputResult,
       boolean inputIsProject) {
-    if (inputIsProject) {
-      final Builder builder = inputResult.builder(e);
-      builder.clauses.add(Clause.GROUP_BY);
-      return builder;
-    } else {
-      return inputResult.builder(e, Clause.GROUP_BY);
-    }
+    return inputResult.builder(e, inputIsProject, Clause.GROUP_BY);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -319,7 +319,6 @@ public class RelToSqlConverter extends SqlImplementor
 
   /** @see #dispatch */
   public Result visit(Project e) {
-    e.getVariablesSet();
     Result x = visitChild(0, e.getInput());
     parseCorrelTable(e, x);
     if (isStar(e.getProjects(), e.getInput().getRowType(), e.getRowType())) {
@@ -389,20 +388,6 @@ public class RelToSqlConverter extends SqlImplementor
     final List<SqlNode> groupByList =
         generateGroupList(builder, selectList, e, groupKeyList);
     return buildAggregate(e, builder, selectList, groupByList);
-  }
-
-  /**
-   * Gets the {@link org.apache.calcite.rel.rel2sql.SqlImplementor.Builder} for
-   * the given {@link Aggregate} node.
-   *
-   * @param e Aggregate node
-   * @param inputResult Result from the input
-   * @param inputIsProject Whether the input is a Project
-   * @return A SQL builder
-   */
-  protected Builder getAggregateBuilder(Aggregate e, Result inputResult,
-      boolean inputIsProject) {
-    return inputResult.builder(e, inputIsProject, Clause.GROUP_BY);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -87,6 +87,7 @@ import java.math.BigDecimal;
 import java.util.AbstractList;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -126,20 +127,21 @@ public abstract class SqlImplementor {
   /** Visits an input of the current relational expression,
    * deducing {@code anon} using {@link #isAnon()}. */
   public final Result visitChild(int i, RelNode e) {
-    return visitChild(i, e, isAnon(), false, null);
+    return visitChild(i, e, isAnon(), false, ImmutableSet.of());
   }
 
   /** Visits an input of the current relational expression,
    * deducing {@code anon} using {@link #isAnon()}. */
   public final Result visitChild(int i, RelNode e, boolean ignoreClauses,
       Clause... clauses) {
-    return visitChild(i, e, isAnon(), ignoreClauses, clauses);
+    return visitChild(i, e, isAnon(), ignoreClauses,
+        ImmutableSet.copyOf(clauses));
   }
 
   /** Visits an input of the current relational expression,
    * deducing {@code anon} using {@link #isAnon()}. */
   public final Result visitChild(int i, RelNode e, Clause... clauses) {
-    return visitChild(i, e, isAnon(), false, clauses);
+    return visitChild(i, e, isAnon(), false, ImmutableSet.copyOf(clauses));
   }
 
   /** Visits {@code e}, the {@code i}th input of the current relational
@@ -148,12 +150,16 @@ public abstract class SqlImplementor {
    * @param i Ordinal of input within its consumer
    * @param e Relational expression
    * @param anon Whether to remove trivial aliases such as "EXPR$0"
+   * @param ignoreClauses Whether to ignore the expected clauses when deciding
+   *   whether a sub-query is required
+   * @param expectedClauses Set of clauses that we expect the builder that
+   *   consumes this result will create
    * @return Result
    *
    * @see #isAnon()
    */
   public abstract Result visitChild(int i, RelNode e, boolean anon,
-      boolean ignoreClauses, Clause[] clauses);
+      boolean ignoreClauses, Set<Clause> expectedClauses);
 
   public void addSelect(List<SqlNode> selectList, SqlNode node,
       RelDataType rowType) {
@@ -417,7 +423,7 @@ public abstract class SqlImplementor {
         && !aliases.isEmpty()
         && (!dialect.hasImplicitTableAlias()
           || aliases.size() > 1)) {
-      return new Result(node, clauses, alias4, rowType, aliases);
+      return result(node, clauses, alias4, rowType, aliases);
     }
     final String alias5;
     if (alias2 == null
@@ -427,8 +433,18 @@ public abstract class SqlImplementor {
     } else {
       alias5 = null;
     }
-    return new Result(node, clauses, alias5, rowType,
-        ImmutableMap.of(alias4, rowType), isAnon(), false, null);
+    return result(node, clauses, alias5, rowType,
+        ImmutableMap.of(alias4, rowType));
+  }
+
+  /** Factory method for {@link Result}.
+   *
+   * <p>Call this method rather than creating a {@code Result} directly,
+   * because sub-classes may override. */
+  protected Result result(SqlNode node, Collection<Clause> clauses,
+      String neededAlias, RelDataType neededType,
+      Map<String, RelDataType> aliases) {
+    return new Result(node, clauses, neededAlias, neededType, aliases);
   }
 
   /** Returns the row type of {@code rel}, adjusting the field names if
@@ -483,10 +499,10 @@ public abstract class SqlImplementor {
       collectAliases(builder, join,
           Iterables.concat(leftResult.aliases.values(),
               rightResult.aliases.values()).iterator());
-      return new Result(join, Expressions.list(Clause.FROM), null, null,
+      return result(join, ImmutableList.of(Clause.FROM), null, null,
           builder.build());
     } else {
-      return new Result(join, Expressions.list(Clause.FROM), null, null,
+      return new Result(join, ImmutableList.of(Clause.FROM), null, null,
           leftResult.aliases);
     }
   }
@@ -1322,31 +1338,36 @@ public abstract class SqlImplementor {
     final String neededAlias;
     private final RelDataType neededType;
     private final Map<String, RelDataType> aliases;
-    final Expressions.FluentList<Clause> clauses;
+    final List<Clause> clauses;
     private final boolean anon;
-    /** Whether to treat {@link #newClauses} as empty for the
+    /** Whether to treat {@link #expectedClauses} as empty for the
      * purposes of figuring out whether we need a new sub-query. */
     private final boolean ignoreClauses;
     /** Clauses that will be generated to implement current relational
      * expression. */
-    private final Clause[] newClauses;
+    private final ImmutableSet<Clause> expectedClauses;
 
     public Result(SqlNode node, Collection<Clause> clauses, String neededAlias,
         RelDataType neededType, Map<String, RelDataType> aliases) {
-      this(node, clauses, neededAlias, neededType, aliases, false, false, null);
+      this(node, clauses, neededAlias, neededType, aliases, false, false,
+          ImmutableSet.of());
     }
 
     private Result(SqlNode node, Collection<Clause> clauses, String neededAlias,
-        RelDataType neededType, Map<String, RelDataType> aliases,
-        boolean anon, boolean ignoreClauses, Clause[] newClauses) {
+        RelDataType neededType, Map<String, RelDataType> aliases, boolean anon,
+        boolean ignoreClauses, Set<Clause> expectedClauses) {
       this.node = node;
       this.neededAlias = neededAlias;
       this.neededType = neededType;
       this.aliases = aliases;
-      this.clauses = Expressions.list(clauses);
+      this.clauses = ImmutableList.copyOf(clauses);
       this.anon = anon;
       this.ignoreClauses = ignoreClauses;
-      this.newClauses = newClauses;
+      this.expectedClauses = ImmutableSet.copyOf(expectedClauses);
+    }
+
+    public Builder builderX(RelNode rel) {
+      return builder(rel, expectedClauses.toArray(new Clause[0]));
     }
 
     /** Once you have a Result of implementing a child relational expression,
@@ -1367,8 +1388,9 @@ public abstract class SqlImplementor {
      * @param rel Relational expression being implemented
      * @return A builder
      */
-    public Builder builder(RelNode rel) {
-      final Clause[] clauses2 = ignoreClauses ? new Clause[0] : newClauses;
+    public Builder builder(RelNode rel, Clause... clauses) {
+      assert expectedClauses.containsAll(Arrays.asList(clauses));
+      final Clause[] clauses2 = ignoreClauses ? new Clause[0] : clauses;
       final boolean needNew = needNewSubQuery(rel, clauses2);
       SqlSelect select;
       Expressions.FluentList<Clause> clauseList = Expressions.list();
@@ -1653,7 +1675,8 @@ public abstract class SqlImplementor {
         return this;
       } else {
         return new Result(node, clauses, neededAlias, neededType,
-            ImmutableMap.of(neededAlias, neededType));
+            ImmutableMap.of(neededAlias, neededType), anon, ignoreClauses,
+            expectedClauses);
       }
     }
 
@@ -1665,14 +1688,26 @@ public abstract class SqlImplementor {
      */
     public Result resetAlias(String alias, RelDataType type) {
       return new Result(node, clauses, alias, neededType,
-          ImmutableMap.of(alias, type));
+          ImmutableMap.of(alias, type), anon, ignoreClauses,
+          expectedClauses);
     }
 
     /** Returns a copy of this Result, overriding the value of {@code anon}. */
     Result withAnon(boolean anon) {
       return anon == this.anon ? this
           : new Result(node, clauses, neededAlias, neededType, aliases, anon,
-              ignoreClauses, newClauses);
+              ignoreClauses, expectedClauses);
+    }
+
+    /** Returns a copy of this Result, overriding the value of
+     * {@code ignoreClauses} and {@code expectedClauses}. */
+    Result withExpectedClauses(boolean ignoreClauses,
+        Set<? extends Clause> expectedClauses) {
+      return ignoreClauses == this.ignoreClauses
+          && expectedClauses.equals(this.expectedClauses)
+          ? this
+          : new Result(node, clauses, neededAlias, neededType, aliases, anon,
+              ignoreClauses, ImmutableSet.copyOf(expectedClauses));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1327,6 +1327,12 @@ public abstract class SqlImplementor {
       this.anon = anon;
     }
 
+    /** As {@link #builder(RelNode, boolean, Clause...)}, but with
+     * {@code ignoreClauses} false. */
+    public Builder builder(RelNode rel, Clause... clauses) {
+      return builder(rel, false, clauses);
+    }
+
     /** Once you have a Result of implementing a child relational expression,
      * call this method to create a Builder to implement the current relational
      * expression by adding additional clauses to the SQL query.
@@ -1343,12 +1349,16 @@ public abstract class SqlImplementor {
      * to fix the new query.
      *
      * @param rel Relational expression being implemented
+     * @param ignoreClauses Whether to treat {@code clauses} as empty for the
+     *                 purposes of figuring out whether we need a new sub-query
      * @param clauses Clauses that will be generated to implement current
      *                relational expression
      * @return A builder
      */
-    public Builder builder(RelNode rel, Clause... clauses) {
-      final boolean needNew = needNewSubQuery(rel, clauses);
+    public Builder builder(RelNode rel, boolean ignoreClauses,
+        Clause... clauses) {
+      final Clause[] clauses2 = ignoreClauses ? new Clause[0] : clauses;
+      final boolean needNew = needNewSubQuery(rel, clauses2);
       SqlSelect select;
       Expressions.FluentList<Clause> clauseList = Expressions.list();
       if (needNew) {
@@ -1667,7 +1677,7 @@ public abstract class SqlImplementor {
         Context context, boolean anon,
         @Nullable Map<String, RelDataType> aliases) {
       this.rel = Objects.requireNonNull(rel);
-      this.clauses = Objects.requireNonNull(clauses);
+      this.clauses = ImmutableList.copyOf(clauses);
       this.select = Objects.requireNonNull(select);
       this.context = Objects.requireNonNull(context);
       this.anon = anon;

--- a/core/src/main/java/org/apache/calcite/statistic/QuerySqlStatisticProvider.java
+++ b/core/src/main/java/org/apache/calcite/statistic/QuerySqlStatisticProvider.java
@@ -192,7 +192,7 @@ public class QuerySqlStatisticProvider implements SqlStatisticProvider {
 
   protected String toSql(RelNode rel, SqlDialect dialect) {
     final RelToSqlConverter converter = new RelToSqlConverter(dialect);
-    SqlImplementor.Result result = converter.visitChild(0, rel);
+    SqlImplementor.Result result = converter.visitRoot(rel);
     final SqlNode sqlNode = result.asStatement();
     final String sql = sqlNode.toSqlString(dialect).getSql();
     sqlConsumer.accept(sql);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1052,7 +1052,8 @@ class RelToSqlConverterTest {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3896">[CALCITE-3896]
    * JDBC adapter, when generating SQL, changes target of ambiguous HAVING
    * clause with a Project on Filter on Aggregate</a>. */
-//  @Disabled // TODO
+  @Disabled
+  // TODO similar, but 'as \"gross_weight\"'; BQ columns are case-insensitive
   @Test void testHavingAlias2() {
     final String query = "select \"product_id\" + 1,\n"
         + "  sum(\"gross_weight\") as gross_weight\n"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -196,7 +196,7 @@ class RelToSqlConverterTest {
   /** Converts a relational expression to SQL in a given dialect. */
   private static String toSql(RelNode root, SqlDialect dialect) {
     final RelToSqlConverter converter = new RelToSqlConverter(dialect);
-    final SqlNode sqlNode = converter.visitChild(0, root).asStatement();
+    final SqlNode sqlNode = converter.visitRoot(root).asStatement();
     return sqlNode.toSqlString(dialect).getSql();
   }
 
@@ -680,8 +680,8 @@ class RelToSqlConverterTest {
         .build();
     final SqlDialect dialect = SqlDialect.DatabaseProduct.CALCITE.getDialect();
     final RelNode root = relFn.apply(relBuilder());
-    final SqlNode sqlNode = new RelToSqlConverter(dialect)
-        .visitChild(0, root).asStatement();
+    final RelToSqlConverter converter = new RelToSqlConverter(dialect);
+    final SqlNode sqlNode = converter.visitRoot(root).asStatement();
     final String sqlString = sqlNode.accept(new SqlShuttle())
         .toSqlString(dialect).getSql();
     assertThat(sqlString, notNullValue());
@@ -1052,7 +1052,7 @@ class RelToSqlConverterTest {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3896">[CALCITE-3896]
    * JDBC adapter, when generating SQL, changes target of ambiguous HAVING
    * clause with a Project on Filter on Aggregate</a>. */
-  @Disabled // TODO
+//  @Disabled // TODO
   @Test void testHavingAlias2() {
     final String query = "select \"product_id\" + 1,\n"
         + "  sum(\"gross_weight\") as gross_weight\n"

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigConverter.java
@@ -246,7 +246,7 @@ public class PigConverter extends PigServer {
     final List<RelNode> finalRels = pigQuery2Rel(pigQuery);
     final List<String> sqlStatements = new ArrayList<>();
     for (RelNode rel : finalRels) {
-      final SqlNode sqlNode = sqlConverter.visitChild(0, rel).asStatement();
+      final SqlNode sqlNode = sqlConverter.visitRoot(rel).asStatement();
       sqlNode.unparse(writer, 0, 0);
       sqlStatements.add(writer.toString());
     }

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
@@ -53,7 +53,7 @@ public class PigRelToSqlConverter extends RelToSqlConverter {
   }
 
   @Override public Result visit(Aggregate e) {
-    final Result x = visitChild(0, e.getInput());
+    final Result x = visitInput(e, 0);
     final boolean isProjectOutput = e.getInput() instanceof Project
         || (e.getInput() instanceof EnumerableInterpreter
             && ((EnumerableInterpreter) e.getInput()).getInput()
@@ -84,7 +84,7 @@ public class PigRelToSqlConverter extends RelToSqlConverter {
 
   /** @see #dispatch */
   public Result visit(Window e) {
-    final Result x = visitChild(0, e.getInput());
+    final Result x = visitInput(e, 0);
     final Builder builder = x.builder(e, Clause.SELECT);
     final List<SqlNode> selectList =
         new ArrayList<>(builder.context.fieldList());

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
@@ -58,7 +58,7 @@ public class PigRelToSqlConverter extends RelToSqlConverter {
         || (e.getInput() instanceof EnumerableInterpreter
             && ((EnumerableInterpreter) e.getInput()).getInput()
                 instanceof Project);
-    final Builder builder = getAggregateBuilder(e, x, isProjectOutput);
+    final Builder builder = x.builder(e, isProjectOutput, Clause.GROUP_BY);
 
     final List<SqlNode> groupByList = Expressions.list();
     final List<SqlNode> selectList = new ArrayList<>();

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
@@ -32,6 +32,8 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,12 +55,14 @@ public class PigRelToSqlConverter extends RelToSqlConverter {
   }
 
   @Override public Result visit(Aggregate e) {
-    final Result x = visitInput(e, 0);
     final boolean isProjectOutput = e.getInput() instanceof Project
         || (e.getInput() instanceof EnumerableInterpreter
             && ((EnumerableInterpreter) e.getInput()).getInput()
                 instanceof Project);
-    final Builder builder = x.builder(e, isProjectOutput, Clause.GROUP_BY);
+    final Result x =
+        visitInput(e, 0, isAnon(), isProjectOutput,
+            ImmutableSet.of(Clause.GROUP_BY));
+    final Builder builder = x.builderX(e);
 
     final List<SqlNode> groupByList = Expressions.list();
     final List<SqlNode> selectList = new ArrayList<>();
@@ -79,13 +83,13 @@ public class PigRelToSqlConverter extends RelToSqlConverter {
       groupBy = new SqlNodeList(cubeRollupList, POS);
     }
 
-    return buildAggregate(e, builder, selectList, groupBy.getList());
+    return buildAggregate(e, builder, selectList, groupBy.getList()).result();
   }
 
   /** @see #dispatch */
   public Result visit(Window e) {
-    final Result x = visitInput(e, 0);
-    final Builder builder = x.builder(e, Clause.SELECT);
+    final Result x = visitInput(e, 0, Clause.SELECT);
+    final Builder builder = x.builderX(e);
     final List<SqlNode> selectList =
         new ArrayList<>(builder.context.fieldList());
 

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelToSqlConverter.java
@@ -62,7 +62,7 @@ public class PigRelToSqlConverter extends RelToSqlConverter {
     final Result x =
         visitInput(e, 0, isAnon(), isProjectOutput,
             ImmutableSet.of(Clause.GROUP_BY));
-    final Builder builder = x.builderX(e);
+    final Builder builder = x.builder(e);
 
     final List<SqlNode> groupByList = Expressions.list();
     final List<SqlNode> selectList = new ArrayList<>();
@@ -89,7 +89,7 @@ public class PigRelToSqlConverter extends RelToSqlConverter {
   /** @see #dispatch */
   public Result visit(Window e) {
     final Result x = visitInput(e, 0, Clause.SELECT);
-    final Builder builder = x.builderX(e);
+    final Builder builder = x.builder(e);
     final List<SqlNode> selectList =
         new ArrayList<>(builder.context.fieldList());
 

--- a/spark/src/main/java/org/apache/calcite/adapter/spark/JdbcToSparkConverter.java
+++ b/spark/src/main/java/org/apache/calcite/adapter/spark/JdbcToSparkConverter.java
@@ -113,7 +113,7 @@ public class JdbcToSparkConverter
         new JdbcImplementor(dialect,
             (JavaTypeFactory) getCluster().getTypeFactory());
     final JdbcImplementor.Result result =
-        jdbcImplementor.visitChild(0, getInput());
+        jdbcImplementor.visitInput(this, 0);
     return result.asStatement().toSqlString(dialect).getSql();
   }
 }


### PR DESCRIPTION
In order to fix https://issues.apache.org/jira/browse/CALCITE-3936, we needed significant refactoring of `SqlImplementor` and `RelToSqlConverter`.

There are various changes to the signatures of protected methods; I don't consider them public APIs: Renamed `SqlImplementor.visitChild` to `visitInput`, replaced `Sqlmplementor.Result.builder(RelNode, Clause...)` with two methods, `builder(RelNode)` and `builder(RelNode, Clause, Clause...)`, the latter of which is deprecated.

The changes have not yet been squashed, and incorrectly reference CALCITE-3896; should be CALCITE-3936.