### PR TITLE
[CALCITE-4097] Avoid requesting unnecessary trait request when deriving traits

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -236,9 +236,11 @@ class RelSet {
         to = subset;
       }
 
-      if (from == to || useAbstractConverter
-          && !from.getConvention().useAbstractConvertersForConversion(
-              from.getTraitSet(), to.getTraitSet())) {
+      if (from == to
+          || to.isEnforceDisabled()
+          || useAbstractConverter
+              && !from.getConvention().useAbstractConvertersForConversion(
+                  from.getTraitSet(), to.getTraitSet())) {
         continue;
       }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -120,6 +120,14 @@ public class RelSubset extends AbstractRelNode {
    */
   boolean triggerRule = false;
 
+  /**
+   * When the subset state is REQUIRED, whether enable property enforcing
+   * between this subset and other delivered subsets. When it is true,
+   * no enforcer operators will be added even if the other subset can't
+   * satisfy current subset's required traitSet.
+   */
+  private boolean enforceDisabled = false;
+
   //~ Constructors -----------------------------------------------------------
 
   RelSubset(
@@ -177,6 +185,15 @@ public class RelSubset extends AbstractRelNode {
   @API(since = "1.23", status = API.Status.EXPERIMENTAL)
   public boolean isRequired() {
     return (state & REQUIRED) == REQUIRED;
+  }
+
+  void disableEnforcing() {
+    assert isDelivered();
+    enforceDisabled = true;
+  }
+
+  boolean isEnforceDisabled() {
+    return enforceDisabled;
   }
 
   public RelNode getBest() {


### PR DESCRIPTION
If the child subset is used to derive new traits for current relnode, the
subset will be marked REQUIRED when registering the new derived relnode and
later will add enforcers between other delivered subsets.  e.g. a MergeJoin
request both inputs hash distributed by [a,b] sorted by [a,b]. If the left
input R1 happens to be distributed by [a], the MergeJoin can derive new traits
from this input and request both input to be distributed by [a] sorted by
[a,b]. In case there is a alternative R2 with ANY distribution in the left
input's RelSet, we end up with requesting hash distribution [a] on alternative
R2, which is unnecessary and waste, because we request distribution by [a]
because of R1 can deliver the exact same distribution and we don't need to
enforce properties on other subsets that can't satisfy the specific trait
requirement.