### PR TITLE
[CALCITE-4116] Remove unused code for tracking RexNode's nullable state in codegen

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregateBase.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregateBase.java
@@ -276,8 +276,7 @@ public abstract class EnumerableAggregateBase extends Aggregate {
                   new RexToLixTranslator.InputGetterImpl(
                       Collections.singletonList(
                           Pair.of(inParameter, inputPhysType))),
-                  implementor.getConformance())
-                  .setNullable(currentNullables());
+                  implementor.getConformance());
             }
           };
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/NestedBlockBuilder.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/NestedBlockBuilder.java
@@ -17,13 +17,9 @@
 package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.linq4j.tree.BlockBuilder;
-import org.apache.calcite.rex.RexNode;
-
-import java.util.Map;
 
 /**
- * Allows to build nested code blocks with tracking of current context and the
- * nullability of particular {@link org.apache.calcite.rex.RexNode} expressions.
+ * Allows to build nested code blocks with tracking of current context.
  *
  * @see org.apache.calcite.adapter.enumerable.StrictAggImplementor#implementAdd(AggContext, AggAddContext)
  */
@@ -45,27 +41,10 @@ public interface NestedBlockBuilder {
   void nestBlock(BlockBuilder block);
 
   /**
-   * Uses given block as the new code context and the map of nullability.
-   * The current block will be restored after {@link #exitBlock()} call.
-   * @param block new code block
-   * @param nullables map of expression to its nullability state
-   * @see #exitBlock()
-   */
-  void nestBlock(BlockBuilder block,
-      Map<RexNode, Boolean> nullables);
-
-  /**
    * Returns the current code block
    * @return current code block
    */
   BlockBuilder currentBlock();
-
-  /**
-   * Returns the current nullability state of rex nodes.
-   * The resulting value is the summary of all the maps in the block hierarchy.
-   * @return current nullability state of rex nodes
-   */
-  Map<RexNode, Boolean> currentNullables();
 
   /**
    * Leaves the current code block.

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -856,11 +856,6 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
     return e.getType().isNullable();
   }
 
-  public RexToLixTranslator setNullable(
-      Map<? extends RexNode, Boolean> nullable) {
-    return this;
-  }
-
   public RexToLixTranslator setBlock(BlockBuilder block) {
     if (block == list) {
       return this;

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/StrictAggImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/StrictAggImplementor.java
@@ -28,9 +28,7 @@ import org.apache.calcite.rex.RexNode;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * The base implementation of strict aggregate function.
@@ -148,13 +146,7 @@ public abstract class StrictAggImplementor implements AggImplementor {
       return;
     }
 
-    final Map<RexNode, Boolean> nullables = new HashMap<>();
-    for (RexNode arg : args) {
-      if (translator.isNullable(arg)) {
-        nullables.put(arg, false);
-      }
-    }
-    add.nestBlock(thenBlock, nullables);
+    add.nestBlock(thenBlock);
     implementNotNullAdd(info, add);
     add.exitBlock();
     add.currentBlock().add(Expressions.ifThen(condition, thenBlock.toBlock()));

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/WinAggResultContextImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/impl/WinAggResultContextImpl.java
@@ -80,8 +80,7 @@ public abstract class WinAggResultContextImpl extends AggResultContextImpl
   }
 
   public RexToLixTranslator rowTranslator(Expression rowIndex) {
-    return getFrame().rowTranslator(rowIndex)
-        .setNullable(currentNullables());
+    return getFrame().rowTranslator(rowIndex);
   }
 
   public Expression compareRows(Expression a, Expression b) {

--- a/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
@@ -242,8 +242,7 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
                   new RexToLixTranslator.InputGetterImpl(
                       Collections.singletonList(
                           Pair.of((Expression) inParameter, inputPhysType))),
-                  conformance)
-                  .setNullable(currentNullables());
+                  conformance);
             }
           };
 


### PR DESCRIPTION
Since `RexNode`'s nullable state is immutable, we can safely remove unused code that changes and tracks `RexNode`'s nullable.