### PR TITLE
[CALCITE-4123] Make EnumerableMergeJoin constructor protected

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -61,7 +61,7 @@ import java.util.Set;
  * {@link EnumerableConvention enumerable calling convention} using
  * a merge algorithm. */
 public class EnumerableMergeJoin extends Join implements EnumerableRel {
-  EnumerableMergeJoin(
+  protected EnumerableMergeJoin(
       RelOptCluster cluster,
       RelTraitSet traits,
       RelNode left,


### PR DESCRIPTION
Minor change.
EnumerableMergeJoin should have a protected constructor (instead of package private), in case downstream projects require to extend it.
This is already the case with other join operators, which provide a protected constructor, e.g.: EnumerableHashJoin, EnumerableNestedLoopJoin, EnumerableBatchNestedLoopJoin.
