### PR TITLE
[CALCITE-4124] Stop invalidating metadata cache in VolcanoRuleCall

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -147,7 +147,6 @@ public class VolcanoRuleCall extends RelOptRuleCall {
       // The subset is not used, but we need it, just for debugging
       //noinspection unused
       RelSubset subset = volcanoPlanner.ensureRegistered(rel, rels[0]);
-      rels[0].getCluster().invalidateMetadataQuery();
 
       if (volcanoPlanner.getListener() != null) {
         RelOptListener.RuleProductionEvent event =


### PR DESCRIPTION
After CALCITE-2018, we don't need to invalidate metadata query when a new
RelNode is generated.