### PR TITLE
[CALCITE-4129] Support deep equality check for RelNode

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
@@ -91,13 +91,13 @@ public class HepRelVertex extends AbstractRelNode {
     return currentRel;
   }
 
-  @Override protected boolean digestEquals(Object obj) {
+  @Override public boolean digestEquals(Object obj) {
     return this == obj
         || (obj instanceof HepRelVertex
             && currentRel == ((HepRelVertex) obj).currentRel);
   }
 
-  @Override protected int digestHash() {
+  @Override public int digestHash() {
     return currentRel.getId();
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
@@ -91,13 +91,13 @@ public class HepRelVertex extends AbstractRelNode {
     return currentRel;
   }
 
-  @Override public boolean digestEquals(Object obj) {
+  @Override public boolean deepEquals(Object obj) {
     return this == obj
         || (obj instanceof HepRelVertex
             && currentRel == ((HepRelVertex) obj).currentRel);
   }
 
-  @Override public int digestHash() {
+  @Override public int deepHashCode() {
     return currentRel.getId();
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -255,11 +255,11 @@ public class RelSubset extends AbstractRelNode {
     pw.done(input);
   }
 
-  @Override protected boolean digestEquals(Object obj) {
+  @Override public boolean digestEquals(Object obj) {
     return this == obj;
   }
 
-  @Override protected int digestHash() {
+  @Override public int digestHash() {
     return this.hashCode();
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -255,11 +255,11 @@ public class RelSubset extends AbstractRelNode {
     pw.done(input);
   }
 
-  @Override public boolean digestEquals(Object obj) {
+  @Override public boolean deepEquals(Object obj) {
     return this == obj;
   }
 
-  @Override public int digestHash() {
+  @Override public int deepHashCode() {
     return this.hashCode();
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -401,13 +401,12 @@ public abstract class AbstractRelNode implements RelNode {
    * This should work well for most cases. If this method is a performance
    * bottleneck for your project, or the default behavior can't handle
    * your scenario properly, you can choose to override this method and
-   * {@link #digestHash()}. See {@code LogicalJoin} as an example.</p>
+   * {@link #deepHashCode()}. See {@code LogicalJoin} as an example.</p>
    *
    * @return Whether the 2 RelNodes are equivalent or have the same digest.
-   * @see #digestHash()
+   * @see #deepHashCode()
    */
-  @API(since = "1.24", status = API.Status.EXPERIMENTAL)
-  public boolean digestEquals(Object obj) {
+  public boolean deepEquals(Object obj) {
     if (this == obj) {
       return true;
     }
@@ -429,7 +428,7 @@ public abstract class AbstractRelNode implements RelNode {
       Pair<String, Object> attr1 = items1.get(i);
       Pair<String, Object> attr2 = items2.get(i);
       if (attr1.right instanceof RelNode) {
-        result = ((RelNode) attr1.right).digestEquals(attr2.right);
+        result = ((RelNode) attr1.right).deepEquals(attr2.right);
       } else {
         result = attr1.equals(attr2);
       }
@@ -440,10 +439,9 @@ public abstract class AbstractRelNode implements RelNode {
   /**
    * Compute hash code for RelNode digest.
    *
-   * @see #digestEquals(Object)
+   * @see #deepEquals(Object)
    */
-  @API(since = "1.24", status = API.Status.EXPERIMENTAL)
-  public int digestHash() {
+  public int deepHashCode() {
     int result = 31 + getTraitSet().hashCode();
     List<Pair<String, Object>> items = this.getDigestItems();
     for (Pair<String, Object> item : items) {
@@ -452,7 +450,7 @@ public abstract class AbstractRelNode implements RelNode {
       if (value == null) {
         h = 0;
       } else if (value instanceof RelNode) {
-        h = ((RelNode) value).digestHash();
+        h = ((RelNode) value).deepHashCode();
       } else {
         h = value.hashCode();
       }
@@ -493,12 +491,12 @@ public abstract class AbstractRelNode implements RelNode {
         return false;
       }
       final InnerRelDigest relDigest = (InnerRelDigest) o;
-      return digestEquals(relDigest.getRel());
+      return deepEquals(relDigest.getRel());
     }
 
     @Override public int hashCode() {
       if (hash == 0) {
-        hash = digestHash();
+        hash = deepHashCode();
       }
       return hash;
     }

--- a/core/src/main/java/org/apache/calcite/rel/RelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelNode.java
@@ -310,6 +310,9 @@ public interface RelNode extends RelOptNode, Cloneable {
   RelNode onRegister(RelOptPlanner planner);
 
   /**
+   * Returns digest string of this {@code RelNode}. It will create new digest
+   * string on each call, so don't forget to cache the result if necessary.
+   *
    * @return Digest string of this {@code RelNode}
    */
   default String getDigest() {
@@ -336,24 +339,22 @@ public interface RelNode extends RelOptNode, Cloneable {
   void recomputeDigest();
 
   /**
-   * Equality check for RelNode digest.
+   * Deep equality check for RelNode digest.
    *
    * <p>By default this method collects digest attributes from
    * explain terms, then compares each attribute pair.</p>
    *
    * @return Whether the 2 RelNodes are equivalent or have the same digest.
-   * @see #digestHash()
+   * @see #deepHashCode()
    */
-  @API(since = "1.25", status = API.Status.EXPERIMENTAL)
-  boolean digestEquals(Object obj);
+  boolean deepEquals(Object obj);
 
   /**
-   * Compute hash code for RelNode digest.
+   * Compute deep hash code for RelNode digest.
    *
-   * @see #digestEquals(Object)
+   * @see #deepEquals(Object)
    */
-  @API(since = "1.25", status = API.Status.EXPERIMENTAL)
-  int digestHash();
+  int deepHashCode();
 
   /**
    * Replaces the <code>ordinalInParent</code><sup>th</sup> input. You must

--- a/core/src/main/java/org/apache/calcite/rel/RelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelNode.java
@@ -336,6 +336,26 @@ public interface RelNode extends RelOptNode, Cloneable {
   void recomputeDigest();
 
   /**
+   * Equality check for RelNode digest.
+   *
+   * <p>By default this method collects digest attributes from
+   * explain terms, then compares each attribute pair.</p>
+   *
+   * @return Whether the 2 RelNodes are equivalent or have the same digest.
+   * @see #digestHash()
+   */
+  @API(since = "1.25", status = API.Status.EXPERIMENTAL)
+  boolean digestEquals(Object obj);
+
+  /**
+   * Compute hash code for RelNode digest.
+   *
+   * @see #digestEquals(Object)
+   */
+  @API(since = "1.25", status = API.Status.EXPERIMENTAL)
+  int digestHash();
+
+  /**
    * Replaces the <code>ordinalInParent</code><sup>th</sup> input. You must
    * override this method if you override {@link #getInputs}.
    *

--- a/core/src/main/java/org/apache/calcite/rel/core/Filter.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Filter.java
@@ -157,7 +157,7 @@ public abstract class Filter extends SingleRel {
   }
 
   @API(since = "1.24", status = API.Status.INTERNAL)
-  protected boolean digestEquals0(Object obj) {
+  protected boolean deepEquals0(Object obj) {
     if (this == obj) {
       return true;
     }
@@ -166,13 +166,13 @@ public abstract class Filter extends SingleRel {
     }
     Filter o = (Filter) obj;
     return traitSet.equals(o.traitSet)
-        && input.digestEquals(o.input)
+        && input.deepEquals(o.input)
         && condition.equals(o.condition)
         && getRowType().equalsSansFieldNames(o.getRowType());
   }
 
   @API(since = "1.24", status = API.Status.INTERNAL)
-  protected int digestHash0() {
-    return Objects.hash(traitSet, input.digestHash(), condition);
+  protected int deepHashCode0() {
+    return Objects.hash(traitSet, input.deepHashCode(), condition);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/core/Filter.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Filter.java
@@ -166,13 +166,13 @@ public abstract class Filter extends SingleRel {
     }
     Filter o = (Filter) obj;
     return traitSet.equals(o.traitSet)
-        && input.equals(o.input)
+        && input.digestEquals(o.input)
         && condition.equals(o.condition)
         && getRowType().equalsSansFieldNames(o.getRowType());
   }
 
   @API(since = "1.24", status = API.Status.INTERNAL)
   protected int digestHash0() {
-    return Objects.hash(traitSet, input, condition);
+    return Objects.hash(traitSet, input.digestHash(), condition);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -236,7 +236,7 @@ public abstract class Join extends BiRel implements Hintable {
   }
 
   @API(since = "1.24", status = API.Status.INTERNAL)
-  protected boolean digestEquals0(Object obj) {
+  protected boolean deepEquals0(Object obj) {
     if (this == obj) {
       return true;
     }
@@ -245,8 +245,8 @@ public abstract class Join extends BiRel implements Hintable {
     }
     Join o = (Join) obj;
     return traitSet.equals(o.traitSet)
-        && left.digestEquals(o.left)
-        && right.digestEquals(o.right)
+        && left.deepEquals(o.left)
+        && right.deepEquals(o.right)
         && condition.equals(o.condition)
         && joinType == o.joinType
         && hints.equals(o.hints)
@@ -254,9 +254,9 @@ public abstract class Join extends BiRel implements Hintable {
   }
 
   @API(since = "1.24", status = API.Status.INTERNAL)
-  protected int digestHash0() {
+  protected int deepHashCode0() {
     return Objects.hash(traitSet,
-        left.digestHash(), right.digestHash(),
+        left.deepHashCode(), right.deepHashCode(),
         condition, joinType, hints);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -245,7 +245,8 @@ public abstract class Join extends BiRel implements Hintable {
     }
     Join o = (Join) obj;
     return traitSet.equals(o.traitSet)
-        && getInputs().equals(o.getInputs())
+        && left.digestEquals(o.left)
+        && right.digestEquals(o.right)
         && condition.equals(o.condition)
         && joinType == o.joinType
         && hints.equals(o.hints)
@@ -254,7 +255,8 @@ public abstract class Join extends BiRel implements Hintable {
 
   @API(since = "1.24", status = API.Status.INTERNAL)
   protected int digestHash0() {
-    return Objects.hash(traitSet, left, right,
+    return Objects.hash(traitSet,
+        left.digestHash(), right.digestHash(),
         condition, joinType, hints);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Project.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Project.java
@@ -292,7 +292,7 @@ public abstract class Project extends SingleRel implements Hintable {
   }
 
   @API(since = "1.24", status = API.Status.INTERNAL)
-  protected boolean digestEquals0(Object obj) {
+  protected boolean deepEquals0(Object obj) {
     if (this == obj) {
       return true;
     }
@@ -301,15 +301,15 @@ public abstract class Project extends SingleRel implements Hintable {
     }
     Project o = (Project) obj;
     return traitSet.equals(o.traitSet)
-        && input.digestEquals(o.input)
+        && input.deepEquals(o.input)
         && exps.equals(o.exps)
         && hints.equals(o.hints)
         && getRowType().equalsSansFieldNames(o.getRowType());
   }
 
   @API(since = "1.24", status = API.Status.INTERNAL)
-  protected int digestHash0() {
-    return Objects.hash(traitSet, input.digestHash(), exps, hints);
+  protected int deepHashCode0() {
+    return Objects.hash(traitSet, input.deepHashCode(), exps, hints);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/core/Project.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Project.java
@@ -301,7 +301,7 @@ public abstract class Project extends SingleRel implements Hintable {
     }
     Project o = (Project) obj;
     return traitSet.equals(o.traitSet)
-        && input.equals(o.input)
+        && input.digestEquals(o.input)
         && exps.equals(o.exps)
         && hints.equals(o.hints)
         && getRowType().equalsSansFieldNames(o.getRowType());
@@ -309,7 +309,7 @@ public abstract class Project extends SingleRel implements Hintable {
 
   @API(since = "1.24", status = API.Status.INTERNAL)
   protected int digestHash0() {
-    return Objects.hash(traitSet, input, exps, hints);
+    return Objects.hash(traitSet, input.digestHash(), exps, hints);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -136,12 +136,12 @@ public final class LogicalFilter extends Filter {
         .itemIf("variablesSet", variablesSet, !variablesSet.isEmpty());
   }
 
-  @Override public boolean digestEquals(Object obj) {
-    return digestEquals0(obj)
+  @Override public boolean deepEquals(Object obj) {
+    return deepEquals0(obj)
         && variablesSet.equals(((LogicalFilter) obj).variablesSet);
   }
 
-  @Override public int digestHash() {
-    return Objects.hash(digestHash0(), variablesSet);
+  @Override public int deepHashCode() {
+    return Objects.hash(deepHashCode0(), variablesSet);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -136,12 +136,12 @@ public final class LogicalFilter extends Filter {
         .itemIf("variablesSet", variablesSet, !variablesSet.isEmpty());
   }
 
-  @Override protected boolean digestEquals(Object obj) {
+  @Override public boolean digestEquals(Object obj) {
     return digestEquals0(obj)
         && variablesSet.equals(((LogicalFilter) obj).variablesSet);
   }
 
-  @Override protected int digestHash() {
+  @Override public int digestHash() {
     return Objects.hash(digestHash0(), variablesSet);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -191,17 +191,17 @@ public final class LogicalJoin extends Join {
         .itemIf("semiJoinDone", semiJoinDone, semiJoinDone);
   }
 
-  @Override public boolean digestEquals(Object obj) {
+  @Override public boolean deepEquals(Object obj) {
     if (this == obj) {
       return true;
     }
-    return digestEquals0(obj)
+    return deepEquals0(obj)
         && semiJoinDone == ((LogicalJoin) obj).semiJoinDone
         && systemFieldList.equals(((LogicalJoin) obj).systemFieldList);
   }
 
-  @Override public int digestHash() {
-    return Objects.hash(digestHash0(), semiJoinDone, systemFieldList);
+  @Override public int deepHashCode() {
+    return Objects.hash(deepHashCode0(), semiJoinDone, systemFieldList);
   }
 
   @Override public boolean isSemiJoinDone() {

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -191,7 +191,7 @@ public final class LogicalJoin extends Join {
         .itemIf("semiJoinDone", semiJoinDone, semiJoinDone);
   }
 
-  @Override protected boolean digestEquals(Object obj) {
+  @Override public boolean digestEquals(Object obj) {
     if (this == obj) {
       return true;
     }
@@ -200,7 +200,7 @@ public final class LogicalJoin extends Join {
         && systemFieldList.equals(((LogicalJoin) obj).systemFieldList);
   }
 
-  @Override protected int digestHash() {
+  @Override public int digestHash() {
     return Objects.hash(digestHash0(), semiJoinDone, systemFieldList);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -137,11 +137,11 @@ public final class LogicalProject extends Project {
         input, getProjects(), rowType);
   }
 
-  @Override public boolean digestEquals(Object obj) {
-    return digestEquals0(obj);
+  @Override public boolean deepEquals(Object obj) {
+    return deepEquals0(obj);
   }
 
-  @Override public int digestHash() {
-    return digestHash0();
+  @Override public int deepHashCode() {
+    return deepHashCode0();
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -137,11 +137,11 @@ public final class LogicalProject extends Project {
         input, getProjects(), rowType);
   }
 
-  @Override protected boolean digestEquals(Object obj) {
+  @Override public boolean digestEquals(Object obj) {
     return digestEquals0(obj);
   }
 
-  @Override protected int digestHash() {
+  @Override public int digestHash() {
     return digestHash0();
   }
 }

--- a/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
@@ -147,12 +147,12 @@ public class RexSubQuery extends RexCall {
     RexSubQuery sq = (RexSubQuery) obj;
     return op.equals(sq.op)
         && operands.equals(sq.operands)
-        && rel.digestEquals(sq.rel);
+        && rel.deepEquals(sq.rel);
   }
 
   @Override public int hashCode() {
     if (hash == 0) {
-      hash = Objects.hash(op, operands, rel.digestHash());
+      hash = Objects.hash(op, operands, rel.deepHashCode());
     }
     return hash;
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /**
@@ -137,14 +138,21 @@ public class RexSubQuery extends RexCall {
   }
 
   @Override public boolean equals(Object obj) {
-    return obj == this
-        || obj instanceof RexSubQuery
-        && toString().equals(obj.toString());
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof RexSubQuery)) {
+      return false;
+    }
+    RexSubQuery sq = (RexSubQuery) obj;
+    return op.equals(sq.op)
+        && operands.equals(sq.operands)
+        && rel.digestEquals(sq.rel);
   }
 
   @Override public int hashCode() {
     if (hash == 0) {
-      hash = toString().hashCode();
+      hash = Objects.hash(op, operands, rel.digestHash());
     }
     return hash;
   }


### PR DESCRIPTION
Currently the only way to check rel node tree deep equality is transforming
into String by RelOptUtil.toString(rel) with
SqlExplainLevel.EXPPLAN_ATTRIBUTES, which is inefficient. One example is
RexSubQuery. It has to do it this way, because the rel being reference by
RexSubQuery is possibly not yet registered to VolcanoPlanner, and the digest
equals checks the input RelNode by identity (not content). That is OK for
RelSubset and HepRelVertex, if the RelNode is already registered in planner,
but not for plain RelNode that is outside of planner. Due to this, we have to
implement another set of deep equals logic in our system.

With this patch, `digestEquals()` and `digestHash()` are extended to support
deep equality check for RelNode.

CALCITE-4129
