### PR TITLE
[CALCITE-4126] Stackoverflow error when applying JoinCommuteRule  (Liya Fan)

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -7008,4 +7008,12 @@ class RelOptRulesTest extends RelOptTestBase {
         .checkUnchanged();
   }
 
+  @Test void testJoinCommute() {
+    final HepProgram program = HepProgram.builder()
+        .addRuleInstance(CoreRules.JOIN_COMMUTE)
+        .build();
+    final String sql = "select * \n"
+        + "from sales.emp e join sales.dept d on e.empno > d.deptno";
+    sql(sql).with(program).check();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -12685,4 +12685,27 @@ LogicalProject(NAME=[$10], ENAME=[$1])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testJoinCommute">
+        <Resource name="sql">
+            <![CDATA[select
+from sales.emp e join sales.dept d on e.empno > d.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalJoin(condition=[>($0, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalProject(EMPNO=[$2], ENAME=[$3], JOB=[$4], MGR=[$5], HIREDATE=[$6], SAL=[$7], COMM=[$8], DEPTNO=[$9], SLACKER=[$10], DEPTNO0=[$0], NAME=[$1])
+    LogicalJoin(condition=[>($2, $0)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CALCITE-4126

The reason for stack overflow is that the JoinCommuteRule swaps children indiscriminately, which results in endless firing of the rule.

To solve the problem, we modify the rule so that the children are swapped only when some conditions are satisfied. 