### PR TITLE
[CALCITE-4140] Add Gradle Remote Build Cache configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,14 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: burrunan/gradle-cache-action@v1
+      name: Cache .gradle
+      with:
+        job-id: jdk${{ matrix.jdk }}
     - name: 'Test'
       shell: cmd
       run: |
-        ./gradlew --no-parallel --no-daemon build javadoc
+        ./gradlew --scan --no-parallel --no-daemon build javadoc
 
   linux-avatica:
     if: github.event.action != 'labeled'
@@ -71,7 +75,7 @@ jobs:
         fetch-depth: 50
     - name: 'Test'
       run: |
-        ./gradlew --no-parallel --no-daemon build javadoc -Pcalcite.avatica.version=1.0.0-dev-master-SNAPSHOT -PenableMavenLocal
+        ./gradlew --scan --no-parallel --no-daemon build javadoc -Pcalcite.avatica.version=1.0.0-dev-master-SNAPSHOT -PenableMavenLocal
 
   mac:
     if: github.event.action != 'labeled'
@@ -85,9 +89,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14
+      - uses: burrunan/gradle-cache-action@v1
+        name: Cache .gradle
+        with:
+          job-id: jdk14
       - name: 'Test'
         run: |
-          ./gradlew --no-parallel --no-daemon build javadoc
+          ./gradlew --scan --no-parallel --no-daemon build javadoc
 
   linux-slow:
     # Run slow tests when the commit is on master or it is requested explicitly by adding an
@@ -103,6 +111,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: burrunan/gradle-cache-action@v1
+        name: Cache .gradle
+        with:
+          job-id: jdk8
       - name: 'Test'
         run: |
-          ./gradlew --no-parallel --no-daemon testSlow
+          ./gradlew --scan --no-parallel --no-daemon testSlow

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -530,6 +530,9 @@ allprojects {
                 options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Werror"))
             }
             configureEach<Test> {
+                outputs.cacheIf("test results depend on the database configuration, so we souldn't cache it") {
+                    false
+                }
                 useJUnitPlatform {
                     excludeTags("slow")
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 org.gradle.parallel=true
+# Build cache can be disabled with --no-build-cache option
+org.gradle.caching=true
+#org.gradle.caching.debug=true
 # See https://github.com/gradle/gradle/pull/11358 , https://issues.apache.org/jira/browse/INFRA-14923
 # repository.apache.org does not yet support .sha256 and .sha512 checksums
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    `gradle-enterprise`
+}
+
 // This is the name of a current project
 // Note: it cannot be inferred from the directory name as developer might clone Calcite to calcite_tmp folder
 rootProject.name = "calcite"
@@ -77,6 +81,25 @@ fun property(name: String) =
         true -> extra.get(name) as? String
         else -> null
     }
+
+val isCiServer = System.getenv().containsKey("CI")
+
+if (isCiServer) {
+    gradleEnterprise {
+        buildScan {
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+            tag("CI")
+        }
+    }
+}
+
+// Cache build artifacts, so expensive operations do not need to be re-computed
+buildCache {
+    local {
+        isEnabled = !isCiServer || System.getenv().containsKey("GITHUB_ACTIONS")
+    }
+}
 
 // This enables to use local clone of vlsi-release-plugins for debugging purposes
 property("localReleasePlugins")?.ifBlank { "../vlsi-release-plugins" }?.let {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CALCITE-4140

---

Gradle build cache enables to reuse build artifacts across different build executions: https://docs.gradle.org/current/userguide/build_cache.html

For instance, if linq4j code is not modified, its `compileJava` and `javadoc` results can be reused in the other builds (e.g. PR builds).

`test` tasks should probably not be cached as the tests often include integrations with databases, so we should execute them from scratch.


Note: the cache is sensitive to Gradle version, Java version, and extra files in the workspace, so the common practice is to seed the cache only from CI jobs.

There's ticket for ASF build cache: https://issues.apache.org/jira/browse/INFRA-20516, however, it is likely we won't be able to use it in GitHub Actions :-/

An alternative option is to setup AWS S3-backed cache via https://github.com/burrunan/gradle-s3-build-cache
