### PR TITLE
[CALCITE-4139] Prevent NPE in ListTransientTable

### DIFF
--- a/core/src/main/java/org/apache/calcite/schema/impl/ListTransientTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ListTransientTable.java
@@ -99,7 +99,7 @@ public class ListTransientTable extends AbstractQueryableTable
           // TODO cleaner way to handle non-array objects?
           @Override public Object[] current() {
             Object current = list.get(i);
-            return current.getClass().isArray()
+            return current != null && current.getClass().isArray()
                 ? (Object[]) current
                 : new Object[]{current};
           }

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
@@ -210,4 +210,27 @@ class EnumerableRepeatUnionTest {
             "n=100", "n=200", "n=300", "n=400", "n=500", "n=600", "n=700", "n=800", "n=900");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4139">[CALCITE-4139]
+   * Prevent NPE in ListTransientTable</a>. */
+  @Test void testGenerateNumbersWithNull() {
+    CalciteAssert.that()
+        .query("?")
+        .withRel(
+            builder -> builder
+                .values(new String[] { "i" }, 1, 2, null, 3)
+                .transientScan("DELTA")
+                .filter(
+                    builder.call(SqlStdOperatorTable.LESS_THAN,
+                        builder.field(0),
+                        builder.literal(3)))
+                .project(
+                    builder.call(SqlStdOperatorTable.PLUS,
+                        builder.field(0),
+                        builder.literal(1)))
+                .repeatUnion("DELTA", true)
+                .build())
+        .returnsOrdered("i=1", "i=2", "i=null", "i=3", "i=2", "i=3", "i=3");
+  }
+
 }


### PR DESCRIPTION
ListTransientTable#scan returns an enumerator that can potentially lead to NPE. Code should be fixed to prevent this from happening.