### PR TITLE
[CALCITE-4147] Rename master branch to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,9 +90,9 @@ jobs:
           ./gradlew --no-parallel --no-daemon build javadoc
 
   linux-slow:
-    # Run slow tests when the commit is on master or it is requested explicitly by adding an
+    # Run slow tests when the commit is on main or it is requested explicitly by adding an
     # appropriate label in the PR
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'slow-tests-needed')
+    if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'slow-tests-needed')
     name: 'Linux (JDK 8) Slow Tests'
     runs-on: ubuntu-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
     - jdk: openjdk14
 branches:
   only:
-    - master
-    - new-master
+    - main
+    - new-main
     - javadoc
     - /^branch-.*$/
     - /^[0-9]+-.*$/

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ limitations under the License.
 -->
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.calcite/calcite-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.calcite/calcite-core)
-[![Travis Build Status](https://travis-ci.org/apache/calcite.svg?branch=master)](https://travis-ci.org/apache/calcite)
-[![CI Status](https://github.com/apache/calcite/workflows/CI/badge.svg?branch=master)](https://github.com/apache/calcite/actions?query=branch%3Amaster)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/apache/calcite?svg=true&branch=master)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/calcite)
+[![Travis Build Status](https://travis-ci.org/apache/calcite.svg?branch=main)](https://travis-ci.org/apache/calcite)
+[![CI Status](https://github.com/apache/calcite/workflows/CI/badge.svg?branch=main)](https://github.com/apache/calcite/actions?query=branch%3Amain)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/apache/calcite?svg=true&branch=main)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/calcite)
 
 # Apache Calcite
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ init:
 branches:
   # whitelist
   only:
-    - master
-    - new-master
+    - main
+    - new-main
     - javadoc
     - /^branch-.*$/
     - /^[0-9]+-.*$/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,9 @@ releaseParams {
     releaseTag.set("calcite-$buildVersion")
     rcTag.set(rc.map { "calcite-$buildVersion-rc$it" })
     sitePreviewEnabled.set(false)
+    source {
+        branch.set("main")
+    }
     nexus {
         // https://github.com/marcphilipp/nexus-publish-plugin/issues/35
         packageGroup.set("org.apache.calcite")

--- a/site/README.md
+++ b/site/README.md
@@ -127,12 +127,12 @@ release. For this reason, we generally edit the site on the "site" git
 branch.
 
 Before making a release, release manager must ensure that "site" is in
-sync with "master". Immediately after a release, the release manager
+sync with "main". Immediately after a release, the release manager
 will publish the site, including all of the features that have just
 been released. When making an edit to the site, a Calcite committer
-must commit the change to the git "master" branch (as well as
+must commit the change to the git "main" branch (as well as
 git, to publish the site, of course). If the edit is to appear
 on the site immediately, the committer should then cherry-pick the
 change into the "site" branch.  If there have been no feature-related
 changes on the site since the release, then "site" should be a
-fast-forward merge of "master".
+fast-forward merge of "main".

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -28,7 +28,7 @@ collections:
     output: true
 
 # The URL where the code can be found
-sourceRoot: https://github.com/apache/calcite/blob/master
+sourceRoot: https://github.com/apache/calcite/blob/main
 
 # The URL where Javadocs are located
 apiRoot: /javadocAggregate

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -576,7 +576,7 @@ protocol that you are using (HTTPS vs. SSH).
 ## Merging pull requests
 
 These are instructions for a Calcite committer who has reviewed a pull request
-from a contributor, found it satisfactory, and is about to merge it to master.
+from a contributor, found it satisfactory, and is about to merge it to main.
 Usually the contributor is not a committer (otherwise they would be committing
 it themselves, after you gave approval in a review).
 
@@ -679,7 +679,7 @@ git clean -xn
 ## Making a release candidate
 
 Note: release artifacts (dist.apache.org and repository.apache.org) are managed with
-[stage-vote-release-plugin](https://github.com/vlsi/vlsi-release-plugins/tree/master/plugins/stage-vote-release-plugin)
+[stage-vote-release-plugin](https://github.com/vlsi/vlsi-release-plugins/tree/main/plugins/stage-vote-release-plugin)
 
 Before you start:
 
@@ -970,8 +970,8 @@ javadoc, and release note appear correctly and then publish the site following t
 in the same file. Now checkout again the release branch (`git checkout branch-X.Y`) and commit
 the release announcement.
 
-Merge the release branch back into `master` (e.g., `git merge --ff-only branch-X.Y`) and align
-the `master` with the `site` branch (e.g., `git merge --ff-only site`).
+Merge the release branch back into `main` (e.g., `git merge --ff-only branch-X.Y`) and align
+the `main` with the `site` branch (e.g., `git merge --ff-only site`).
 
 In JIRA, search for
 [all issues resolved in this release](https://issues.apache.org/jira/issues/?jql=project%20%3D%20CALCITE%20and%20fixVersion%20%3D%201.5.0%20and%20status%20%3D%20Resolved%20and%20resolution%20%3D%20Fixed),

--- a/site/_docs/powered_by.md
+++ b/site/_docs/powered_by.md
@@ -30,7 +30,7 @@ The following companies and projects are powered by Apache Calcite.
 {:toc}
 
 Is your company or project powered by Calcite?
-[Add it to this page](https://github.com/apache/calcite/blob/master/site/_docs/powered_by.md)
+[Add it to this page](https://github.com/apache/calcite/blob/main/site/_docs/powered_by.md)
 and then use the "powered by Apache Calcite" logo
 ([140 px]({{ site.baseurl }}/img/pb-calcite-140.png)
 or [240 px]({{ site.baseurl }}/img/pb-calcite-240.png))

--- a/site/_docs/redis_adapter.md
+++ b/site/_docs/redis_adapter.md
@@ -121,7 +121,7 @@ A basic example of a model file is given below:
 }
 {% endhighlight %}
 
-This file is stored as [`redis/src/test/resources/redis-mix-model.json`](https://github.com/apache/calcite/blob/master/redis/src/test/resources/redis-mix-model.json),
+This file is stored as [`redis/src/test/resources/redis-mix-model.json`](https://github.com/apache/calcite/blob/main/redis/src/test/resources/redis-mix-model.json),
 so you can connect to Redis via
 [`sqlline`](https://github.com/julianhyde/sqlline)
 as follows:

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -78,7 +78,7 @@ Need help with Calcite? Try these resources:
   your question.
 * **Browse the code**.
   One of the advantages of open source software is that you can browse the code.
-  The code is available on [github](https://github.com/apache/calcite/tree/master).
+  The code is available on [GitHub](https://github.com/apache/calcite/tree/main).
 
 # Talks
 

--- a/site/develop/index.md
+++ b/site/develop/index.md
@@ -139,7 +139,7 @@ the JIRA case number, like this:
 [CALCITE-345] AssertionError in RexToLixTranslator comparing to date literal (FirstName LastName)
 {% endhighlight %}
 
-If your change had multiple commits, use `git rebase -i master` to
+If your change had multiple commits, use `git rebase -i main` to
 squash them into a single commit, and to bring your code up to date
 with the latest on the main line.
 
@@ -165,7 +165,7 @@ the implementation ("Add handler for FileNotFound").
  of the message.
 
 Then push your commit(s) to GitHub, and create a pull request from
-your branch to the calcite master branch. Update the JIRA case
+your branch to the calcite main branch. Update the JIRA case
 to reference your pull request, and a committer will review your
 changes.
 


### PR DESCRIPTION
See the associated JIRA for more on the full migration plan.

**Note: This PR is merely to help with review. It should not be merged as it will eventually replace `master`**