### PR TITLE
[CALCITE-4156] ReflectiveRelMetadataProvider constructor should throw an exception (instead of assertion) when called with an empty map

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -78,7 +78,9 @@ public class ReflectiveRelMetadataProvider
       ConcurrentMap<Class<RelNode>, UnboundMetadata> map,
       Class<? extends Metadata> metadataClass0,
       Multimap<Method, MetadataHandler> handlerMap) {
-    assert !map.isEmpty() : "are your methods named wrong?";
+    if (map.isEmpty()) {
+      throw new IllegalArgumentException("ReflectiveRelMetadataProvider methods map is empty");
+    }
     this.map = map;
     this.metadataClass0 = metadataClass0;
     this.handlerMap = ImmutableMultimap.copyOf(handlerMap);


### PR DESCRIPTION
Jira ticket: [CALCITE-4156](https://issues.apache.org/jira/browse/CALCITE-4156)

ReflectiveRelMetadataProvider's constructor verifies that it is not created with an empty map, using an assertion. However, this is not the most reliable way of verifying this situation, since assertions can be deactivated. In such scenario, we could silently end up having an invalid ReflectiveRelMetadataProvider, with no actual methods attached.
Also, since the map is private and has no getter, there is no way for a caller module to verify this situation on its side.
For this reason, it is proposed a minor change: replace the assertion with an IllegalArgumentException, which will work in 100% of the cases and will always prevent constructing an invalid ReflectiveRelMetadataProvider.