### PR TITLE
[CALCITE-4156] ReflectiveRelMetadataProvider constructor should throw an exception (instead of assertion) when called with an empty map

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -25,6 +25,7 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.ReflectiveVisitor;
 import org.apache.calcite.util.Util;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -78,9 +79,8 @@ public class ReflectiveRelMetadataProvider
       ConcurrentMap<Class<RelNode>, UnboundMetadata> map,
       Class<? extends Metadata> metadataClass0,
       Multimap<Method, MetadataHandler> handlerMap) {
-    if (map.isEmpty()) {
-      throw new IllegalArgumentException("ReflectiveRelMetadataProvider methods map is empty");
-    }
+    Preconditions.checkArgument(!map.isEmpty(),
+        "ReflectiveRelMetadataProvider methods map is empty");
     this.map = map;
     this.metadataClass0 = metadataClass0;
     this.handlerMap = ImmutableMultimap.copyOf(handlerMap);


### PR DESCRIPTION
minor follow-up: use guava's `Preconditions.checkArgument`