### PR TITLE
[CALCITE-4167] Group by COALESCE IN throws NullPointerException

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3968,6 +3968,10 @@ public class SqlToRelConverter {
       RexInputRef inputRef) {
     RelDataTypeField field = bb.getRootField(inputRef);
     if (field != null) {
+      if (!SqlTypeUtil.equalSansNullability(typeFactory,
+          field.getType(), inputRef.getType())) {
+        return inputRef;
+      }
       return rexBuilder.makeInputRef(
           field.getType(),
           inputRef.getIndex());

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3861,6 +3861,18 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4167">[CALCITE-4167]
+   * Group by COALESCE IN throws NullPointerException</a>.
+   */
+  @Test void testGroupByCoalesceIn() {
+    final String sql = "select case when coalesce(ename, 'a') in ('1', '2')\n"
+        + "then 'CKA' else 'QT' END, count(distinct deptno) from emp\n"
+        + "group by case when coalesce(ename, 'a') in ('1', '2') then 'CKA' else 'QT' END";
+    sql(sql).ok();
+  }
+
+  /**
    * Visitor that checks that every {@link RelNode} in a tree is valid.
    *
    * @see RelNode#isValid(Litmus, RelNode.Context)

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6909,4 +6909,18 @@ LogicalProject(DEPTNO=[$0], F0=[STRUCTURED_FUNC().F0], F1=[STRUCTURED_FUNC().F1]
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testGroupByCoalesceIn">
+        <Resource name="sql">
+            <![CDATA[select case when coalesce(ename, 'a') in ('1', '2')
+then 'CKA' else 'QT' END, count(distinct deptno) from emp
+group by case when coalesce(ename, 'a') in ('1', '2') then 'CKA' else 'QT' END]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT(DISTINCT $1)])
+  LogicalProject(EXPR$0=[CASE(OR(=($1, '1'), =($1, '2')), 'CKA', 'QT ')], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
The root cause is that the COALESCE operand type was wrongly replaced by
`SqlToRelConverter#adjustInputRef`, actually, for an agg as bb root, there is
no need to do such adjust. Because the nullability does not change and
the agg type is not same with the bb's scope.

Tweak the `#adjustInputRef` to only fix type nullability, if there
are cases that the type name also changes, just return the original node and
let the subsequent conversion work flow throw.