### PR TITLE
[CALCITE-3351] [WIP]In JDBC adapter, when generating SQL for MYSQL, MySQLSyntaxErrorException throws when there is non-ascii literal

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.config;
 
+import org.apache.calcite.runtime.Hook;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
@@ -430,6 +432,9 @@ public final class CalciteSystemProperty<T> {
             allProperties.setProperty(newKey, (String) prop.getValue());
           }
         });
+
+    Hook.LOAD_SYSTEM_PROPERTY.run(allProperties);
+
     return allProperties;
   }
 

--- a/core/src/main/java/org/apache/calcite/runtime/Hook.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Hook.java
@@ -97,7 +97,10 @@ public enum Hook {
    * The hook supplies {@link RelRoot} as an argument.
    */
   @API(since = "1.22", status = API.Status.EXPERIMENTAL)
-  PLAN_BEFORE_IMPLEMENTATION;
+  PLAN_BEFORE_IMPLEMENTATION,
+
+  /** Called when load properties. */
+  LOAD_SYSTEM_PROPERTY;
 
   private final List<Consumer<Object>> handlers =
       new CopyOnWriteArrayList<>();

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -224,6 +224,15 @@ public class MysqlSqlDialect extends SqlDialect {
   }
 
   /**
+   * mysql not support a unicode string literal. For example,
+   * <code>u'can''t\0009run\\'</code> will cause MySQLSyntaxErrorException: Unknown column 'u'
+   */
+  @Override public void quoteStringLiteralUnicode(StringBuilder buf, String val) {
+    buf.append("'");
+    buf.append(val);
+    buf.append("'");
+  }
+  /**
    * Unparses datetime floor for MySQL. There is no TRUNC function, so simulate
    * this using calls to DATE_FORMAT.
    *


### PR DESCRIPTION
@julianhyde  
hi, julian, https://github.com/apache/calcite/blob/37b8cdbb381369e773229a81ae69ab5c1df34f3e/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java#L712 discard literal charset，I think you did it on purpose.
To resolve this bug, if we only need to rewrite the quoteStringLiteralUnicode of MysqlSqlDialect.