### PR TITLE
[CALCITE-1861] Spatial index, based on Hilbert space-filling curve

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
         apiv("com.google.code.findbugs:jsr305", "findbugs.jsr305")
         apiv("com.google.guava:guava")
         apiv("com.google.protobuf:protobuf-java", "protobuf")
+        apiv("com.google.uzaygezen:uzaygezen-core", "uzaygezen")
         apiv("com.h2database:h2")
         apiv("com.jayway.jsonpath:json-path")
         apiv("com.joestelmach:natty")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.google.code.findbugs:jsr305"/* optional*/)
     implementation("com.google.guava:guava")
+    implementation("com.google.uzaygezen:uzaygezen-core")
     implementation("com.jayway.jsonpath:json-path")
     implementation("com.yahoo.datasketches:sketches-core")
     implementation("commons-codec:commons-codec")

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -47,6 +47,8 @@ import org.apache.calcite.rex.RexRangeRef;
 import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexVisitor;
+import org.apache.calcite.runtime.GeoFunctions;
+import org.apache.calcite.runtime.Geometries;
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlOperator;
@@ -732,6 +734,11 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
           Expressions.constant(
               literal.getValueAs(byte[].class),
               byte[].class));
+    case GEOMETRY:
+      final Geometries.Geom geom = literal.getValueAs(Geometries.Geom.class);
+      final String wkt = GeoFunctions.ST_AsWKT(geom);
+      return Expressions.call(null, BuiltInMethod.ST_GEOM_FROM_TEXT.method,
+          Expressions.constant(wkt));
     case SYMBOL:
       value2 = literal.getValueAs(Enum.class);
       javaClass = value2.getClass();

--- a/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
@@ -27,7 +27,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.type.RelRecordType;
-import org.apache.calcite.runtime.GeoFunctions;
+import org.apache.calcite.runtime.Geometries;
 import org.apache.calcite.runtime.Unit;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.IntervalSqlType;
@@ -209,7 +209,7 @@ public class JavaTypeFactoryImpl
       case VARBINARY:
         return ByteString.class;
       case GEOMETRY:
-        return GeoFunctions.Geom.class;
+        return Geometries.Geom.class;
       case SYMBOL:
         return Enum.class;
       case ANY:

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -96,7 +96,7 @@ import org.apache.calcite.sql.parser.SqlParserImplFactory;
 import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.type.ExtraSqlTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
+import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
@@ -704,8 +704,10 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     final SqlOperatorTable opTab0 =
         context.config().fun(SqlOperatorTable.class,
             SqlStdOperatorTable.instance());
-    final SqlOperatorTable opTab =
-        ChainedSqlOperatorTable.of(opTab0, catalogReader);
+    final List<SqlOperatorTable> list = new ArrayList<>();
+    list.add(opTab0);
+    list.add(catalogReader);
+    final SqlOperatorTable opTab = SqlOperatorTables.chain(list);
     final JavaTypeFactory typeFactory = context.getTypeFactory();
     final CalciteConnectionConfig connectionConfig = context.config();
     final SqlValidator.Config config = SqlValidator.Config.DEFAULT

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -47,7 +47,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
-import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
+import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
@@ -321,7 +321,7 @@ public class PlannerImpl implements Planner, ViewExpander {
 
   private SqlValidator createSqlValidator(CalciteCatalogReader catalogReader) {
     final SqlOperatorTable opTab =
-        ChainedSqlOperatorTable.of(operatorTable, catalogReader);
+        SqlOperatorTables.chain(operatorTable, catalogReader);
     return new CalciteSqlValidator(opTab,
         catalogReader,
         typeFactory,

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
@@ -105,7 +105,12 @@ public class RelMdAllPredicates
   /**
    * Extract predicates for a table scan.
    */
-  public RelOptPredicateList getAllPredicates(TableScan table, RelMetadataQuery mq) {
+  public RelOptPredicateList getAllPredicates(TableScan scan, RelMetadataQuery mq) {
+    final BuiltInMetadata.AllPredicates.Handler handler =
+        scan.getTable().unwrap(BuiltInMetadata.AllPredicates.Handler.class);
+    if (handler != null) {
+      return handler.getAllPredicates(scan, mq);
+    }
     return RelOptPredicateList.EMPTY;
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -702,50 +702,7 @@ public abstract class SqlImplementor {
         }
 
       case LITERAL:
-        final RexLiteral literal = (RexLiteral) rex;
-        if (literal.getTypeName() == SqlTypeName.SYMBOL) {
-          final Enum symbol = (Enum) literal.getValue();
-          return SqlLiteral.createSymbol(symbol, POS);
-        }
-        switch (literal.getTypeName().getFamily()) {
-        case CHARACTER:
-          return SqlLiteral.createCharString((String) literal.getValue2(), POS);
-        case NUMERIC:
-        case EXACT_NUMERIC:
-          return SqlLiteral.createExactNumeric(
-              literal.getValueAs(BigDecimal.class).toPlainString(), POS);
-        case APPROXIMATE_NUMERIC:
-          return SqlLiteral.createApproxNumeric(
-              literal.getValueAs(BigDecimal.class).toPlainString(), POS);
-        case BOOLEAN:
-          return SqlLiteral.createBoolean(literal.getValueAs(Boolean.class),
-              POS);
-        case INTERVAL_YEAR_MONTH:
-        case INTERVAL_DAY_TIME:
-          final boolean negative = literal.getValueAs(Boolean.class);
-          return SqlLiteral.createInterval(negative ? -1 : 1,
-              literal.getValueAs(String.class),
-              literal.getType().getIntervalQualifier(), POS);
-        case DATE:
-          return SqlLiteral.createDate(literal.getValueAs(DateString.class),
-              POS);
-        case TIME:
-          return SqlLiteral.createTime(literal.getValueAs(TimeString.class),
-              literal.getType().getPrecision(), POS);
-        case TIMESTAMP:
-          return SqlLiteral.createTimestamp(
-              literal.getValueAs(TimestampString.class),
-              literal.getType().getPrecision(), POS);
-        case ANY:
-        case NULL:
-          switch (literal.getTypeName()) {
-          case NULL:
-            return SqlLiteral.createNull(POS);
-          // fall through
-          }
-        default:
-          throw new AssertionError(literal + ": " + literal.getTypeName());
-        }
+        return SqlImplementor.toSql((RexLiteral) rex);
 
       case CASE:
         final RexCall caseCall = (RexCall) rex;
@@ -1200,6 +1157,53 @@ public abstract class SqlImplementor {
 
     public SqlImplementor implementor() {
       throw new UnsupportedOperationException();
+    }
+  }
+
+  /** Converts a {@link RexLiteral} to a {@link SqlLiteral}. */
+  public static SqlLiteral toSql(RexLiteral literal) {
+    if (literal.getTypeName() == SqlTypeName.SYMBOL) {
+      final Enum symbol = (Enum) literal.getValue();
+      return SqlLiteral.createSymbol(symbol, POS);
+    }
+    switch (literal.getTypeName().getFamily()) {
+    case CHARACTER:
+      return SqlLiteral.createCharString((String) literal.getValue2(), POS);
+    case NUMERIC:
+    case EXACT_NUMERIC:
+      return SqlLiteral.createExactNumeric(
+          literal.getValueAs(BigDecimal.class).toPlainString(), POS);
+    case APPROXIMATE_NUMERIC:
+      return SqlLiteral.createApproxNumeric(
+          literal.getValueAs(BigDecimal.class).toPlainString(), POS);
+    case BOOLEAN:
+      return SqlLiteral.createBoolean(literal.getValueAs(Boolean.class),
+          POS);
+    case INTERVAL_YEAR_MONTH:
+    case INTERVAL_DAY_TIME:
+      final boolean negative = literal.getValueAs(Boolean.class);
+      return SqlLiteral.createInterval(negative ? -1 : 1,
+          literal.getValueAs(String.class),
+          literal.getType().getIntervalQualifier(), POS);
+    case DATE:
+      return SqlLiteral.createDate(literal.getValueAs(DateString.class),
+          POS);
+    case TIME:
+      return SqlLiteral.createTime(literal.getValueAs(TimeString.class),
+          literal.getType().getPrecision(), POS);
+    case TIMESTAMP:
+      return SqlLiteral.createTimestamp(
+          literal.getValueAs(TimestampString.class),
+          literal.getType().getPrecision(), POS);
+    case ANY:
+    case NULL:
+      switch (literal.getTypeName()) {
+      case NULL:
+        return SqlLiteral.createNull(POS);
+      // fall through
+      }
+    default:
+      throw new AssertionError(literal + ": " + literal.getTypeName());
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/SpatialRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SpatialRules.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptPredicateList;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.runtime.GeoFunctions;
+import org.apache.calcite.runtime.Geometries;
+import org.apache.calcite.runtime.HilbertCurve2D;
+import org.apache.calcite.runtime.SpaceFillingCurve2D;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+
+import com.esri.core.geometry.Envelope;
+import com.esri.core.geometry.Point;
+import com.google.common.collect.ImmutableList;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * Collection of planner rules that convert
+ * calls to spatial functions into more efficient expressions.
+ *
+ * <p>The rules allow Calcite to use spatial indexes. For example the following
+ * query:
+ *
+ * <blockquote>SELECT ...
+ * FROM Restaurants AS r
+ * WHERE ST_DWithin(ST_Point(10, 20), ST_Point(r.longitude, r.latitude), 5)
+ * </blockquote>
+ *
+ * <p>is rewritten to
+ *
+ * <blockquote>SELECT ...
+ * FROM Restaurants AS r
+ * WHERE (r.h BETWEEN 100 AND 150
+ *        OR r.h BETWEEN 170 AND 185)
+ * AND ST_DWithin(ST_Point(10, 20), ST_Point(r.longitude, r.latitude), 5)
+ * </blockquote>
+ *
+ * <p>if there is the constraint
+ *
+ * <blockquote>CHECK (h = Hilbert(8, r.longitude, r.latitude))</blockquote>
+ *
+ * <p>If the {@code Restaurants} table is sorted on {@code h} then the latter
+ * query can be answered using two limited range-scans, and so is much more
+ * efficient.
+ *
+ * <p>Note that the original predicate
+ * {@code ST_DWithin(ST_Point(10, 20), ST_Point(r.longitude, r.latitude), 5)}
+ * is still present, but is evaluated after the approximate predicate has
+ * eliminated many potential matches.
+ */
+public abstract class SpatialRules {
+
+  private SpatialRules() {}
+
+  private static final RexUtil.RexFinder DWITHIN_FINDER =
+      RexUtil.find(EnumSet.of(SqlKind.ST_DWITHIN, SqlKind.ST_CONTAINS));
+
+  private static final RexUtil.RexFinder HILBERT_FINDER =
+      RexUtil.find(SqlKind.HILBERT);
+
+  public static final RelOptRule INSTANCE =
+      FilterHilbertRule.Config.DEFAULT.toRule();
+
+  /** Returns a geometry if an expression is constant, null otherwise. */
+  private static Geometries.Geom constantGeom(RexNode e) {
+    switch (e.getKind()) {
+    case CAST:
+      return constantGeom(((RexCall) e).getOperands().get(0));
+    case LITERAL:
+      return (Geometries.Geom) ((RexLiteral) e).getValue();
+    default:
+      return null;
+    }
+  }
+
+  /** Rule that converts ST_DWithin in a Filter condition into a predicate on
+   * a Hilbert curve. */
+  @SuppressWarnings("WeakerAccess")
+  public static class FilterHilbertRule
+      extends RelRule<FilterHilbertRule.Config> {
+    protected FilterHilbertRule(Config config) {
+      super(config);
+    }
+
+    @Override public void onMatch(RelOptRuleCall call) {
+      final Filter filter = call.rel(0);
+      final List<RexNode> conjunctions = new ArrayList<>();
+      RelOptUtil.decomposeConjunction(filter.getCondition(), conjunctions);
+
+      // Match a predicate
+      //   r.hilbert = hilbert(r.longitude, r.latitude)
+      // to one of the conjunctions
+      //   ST_DWithin(ST_Point(x, y), ST_Point(r.longitude, r.latitude), d)
+      // and if it matches add a new conjunction before it,
+      //   r.hilbert between h1 and h2
+      //   or r.hilbert between h3 and h4
+      // where {[h1, h2], [h3, h4]} are the ranges of the Hilbert curve
+      // intersecting the square
+      //   (r.longitude - d, r.latitude - d, r.longitude + d, r.latitude + d)
+      final RelOptPredicateList predicates =
+          call.getMetadataQuery().getAllPredicates(filter.getInput());
+      int changeCount = 0;
+      for (RexNode predicate : predicates.pulledUpPredicates) {
+        final RelBuilder builder = call.builder();
+        if (predicate.getKind() == SqlKind.EQUALS) {
+          final RexCall eqCall = (RexCall) predicate;
+          if (eqCall.operands.get(0) instanceof RexInputRef
+              && eqCall.operands.get(1).getKind() == SqlKind.HILBERT) {
+            final RexInputRef ref  = (RexInputRef) eqCall.operands.get(0);
+            final RexCall hilbert = (RexCall) eqCall.operands.get(1);
+            final RexUtil.RexFinder finder = RexUtil.find(ref);
+            if (finder.anyContain(conjunctions)) {
+              // If the condition already contains "ref", it is probable that
+              // this rule has already fired once.
+              continue;
+            }
+            for (int i = 0; i < conjunctions.size();) {
+              final List<RexNode> replacements =
+                  replaceSpatial(conjunctions.get(i), builder, ref, hilbert);
+              if (replacements != null) {
+                conjunctions.remove(i);
+                conjunctions.addAll(i, replacements);
+                i += replacements.size();
+                ++changeCount;
+              } else {
+                ++i;
+              }
+            }
+          }
+        }
+        if (changeCount > 0) {
+          call.transformTo(
+              builder.push(filter.getInput())
+                  .filter(conjunctions)
+                  .build());
+          return; // we found one useful constraint; don't look for more
+        }
+      }
+    }
+
+    /** Rewrites a spatial predicate to a predicate on a Hilbert curve.
+     *
+     * <p>Returns null if the predicate cannot be rewritten;
+     * a 1-element list (new) if the predicate can be fully rewritten;
+     * returns a 2-element list (new, original) if the new predicate allows
+     * some false positives.
+     *
+     * @param conjunction Original predicate
+     * @param builder Builder
+     * @param ref Reference to Hilbert column
+     * @param hilbert Function call that populates Hilbert column
+     *
+     * @return List containing rewritten predicate and original, or null
+     */
+    static List<RexNode> replaceSpatial(RexNode conjunction, RelBuilder builder,
+        RexInputRef ref, RexCall hilbert) {
+      final RexNode op0;
+      final RexNode op1;
+      final Geometries.Geom g0;
+      switch (conjunction.getKind()) {
+      case ST_DWITHIN:
+        final RexCall within = (RexCall) conjunction;
+        op0 = within.operands.get(0);
+        g0 = constantGeom(op0);
+        op1 = within.operands.get(1);
+        final Geometries.Geom g1 = constantGeom(op1);
+        if (RexUtil.isLiteral(within.operands.get(2), true)) {
+          final Number distance =
+              (Number) RexLiteral.value(within.operands.get(2));
+          switch (Double.compare(distance.doubleValue(), 0D)) {
+          case -1: // negative distance
+            return ImmutableList.of(builder.getRexBuilder().makeLiteral(false));
+
+          case 0: // zero distance
+            // Change "ST_DWithin(g, p, 0)" to "g = p"
+            conjunction = builder.equals(op0, op1);
+            // fall through
+
+          case 1:
+            if (g0 != null
+                && op1.getKind() == SqlKind.ST_POINT
+                && ((RexCall) op1).operands.equals(hilbert.operands)) {
+              // Add the new predicate before the existing predicate
+              // because it is cheaper to execute (albeit less selective).
+              return ImmutableList.of(
+                  hilbertPredicate(builder.getRexBuilder(), ref, g0, distance),
+                  conjunction);
+            } else if (g1 != null && op0.getKind() == SqlKind.ST_POINT
+                && ((RexCall) op0).operands.equals(hilbert.operands)) {
+              // Add the new predicate before the existing predicate
+              // because it is cheaper to execute (albeit less selective).
+              return ImmutableList.of(
+                  hilbertPredicate(builder.getRexBuilder(), ref, g1, distance),
+                  conjunction);
+            }
+            return null; // cannot rewrite
+
+          default:
+            throw new AssertionError("invalid sign: " + distance);
+          }
+        }
+        return null; // cannot rewrite
+
+      case ST_CONTAINS:
+        final RexCall contains = (RexCall) conjunction;
+        op0 = contains.operands.get(0);
+        g0 = constantGeom(op0);
+        op1 = contains.operands.get(1);
+        if (g0 != null
+            && op1.getKind() == SqlKind.ST_POINT
+            && ((RexCall) op1).operands.equals(hilbert.operands)) {
+          // Add the new predicate before the existing predicate
+          // because it is cheaper to execute (albeit less selective).
+          return ImmutableList.of(
+              hilbertPredicate(builder.getRexBuilder(), ref, g0),
+              conjunction);
+        }
+        return null; // cannot rewrite
+
+      default:
+        return null; // cannot rewrite
+      }
+    }
+
+    /** Creates a predicate on the column that contains the index on the Hilbert
+     * curve.
+     *
+     * <p>The predicate is a safe approximation. That is, it may allow some
+     * points that are not within the distance, but will never disallow a point
+     * that is within the distance.
+     *
+     * <p>Returns FALSE if the distance is negative (the ST_DWithin function
+     * would always return FALSE) and returns an {@code =} predicate if distance
+     * is 0. But usually returns a list of ranges,
+     * {@code ref BETWEEN c1 AND c2 OR ref BETWEEN c3 AND c4}. */
+    private static RexNode hilbertPredicate(RexBuilder rexBuilder,
+        RexInputRef ref, Geometries.Geom g, Number distance) {
+      if (distance.doubleValue() == 0D
+          && Geometries.type(g.g()) == Geometries.Type.POINT) {
+        final Point p = (Point) g.g();
+        final HilbertCurve2D hilbert = new HilbertCurve2D(8);
+        final long index = hilbert.toIndex(p.getX(), p.getY());
+        return rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref,
+            rexBuilder.makeExactLiteral(BigDecimal.valueOf(index)));
+      }
+      final Geometries.Geom g2 =
+          GeoFunctions.ST_Buffer(g, distance.doubleValue());
+      return hilbertPredicate(rexBuilder, ref, g2);
+    }
+
+    private static RexNode hilbertPredicate(RexBuilder rexBuilder,
+        RexInputRef ref, Geometries.Geom g2) {
+      final Geometries.Geom g3 = GeoFunctions.ST_Envelope(g2);
+      final Envelope env = (Envelope) g3.g();
+      final HilbertCurve2D hilbert = new HilbertCurve2D(8);
+      final List<SpaceFillingCurve2D.IndexRange> ranges =
+          hilbert.toRanges(env.getXMin(), env.getYMin(), env.getXMax(),
+              env.getYMax(), new SpaceFillingCurve2D.RangeComputeHints());
+      final List<RexNode> nodes = new ArrayList<>();
+      for (SpaceFillingCurve2D.IndexRange range : ranges) {
+        final BigDecimal lowerBd = BigDecimal.valueOf(range.lower());
+        final BigDecimal upperBd = BigDecimal.valueOf(range.upper());
+        nodes.add(
+            rexBuilder.makeCall(
+                SqlStdOperatorTable.AND,
+                rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    ref,
+                    rexBuilder.makeExactLiteral(lowerBd)),
+                rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    ref,
+                    rexBuilder.makeExactLiteral(upperBd))));
+      }
+      return rexBuilder.makeCall(SqlStdOperatorTable.OR, nodes);
+    }
+
+    /** Rule configuration. */
+    public interface Config extends RelRule.Config {
+      Config DEFAULT = EMPTY
+          .withOperandSupplier(b ->
+              b.operand(Filter.class)
+                  .predicate(f -> DWITHIN_FINDER.inFilter(f)
+                      && !HILBERT_FINDER.inFilter(f))
+                  .anyInputs())
+          .as(Config.class);
+
+      @Override default FilterHilbertRule toRule() {
+        return new FilterHilbertRule(this);
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
@@ -421,6 +421,7 @@ public interface RelDataTypeFactory {
     private final List<RelDataType> types = new ArrayList<>();
     private StructKind kind = StructKind.FULLY_QUALIFIED;
     private final RelDataTypeFactory typeFactory;
+    private boolean nullableRecord = false;
 
     /**
      * Creates a Builder with the given type factory.
@@ -547,6 +548,12 @@ public interface RelDataTypeFactory {
       return this;
     }
 
+    /** Sets whether the record type will be nullable. */
+    public Builder nullableRecord(boolean nullableRecord) {
+      this.nullableRecord = nullableRecord;
+      return this;
+    }
+
     /**
      * Makes sure that field names are unique.
      */
@@ -564,7 +571,9 @@ public interface RelDataTypeFactory {
      * Creates a struct type with the current contents of this builder.
      */
     public RelDataType build() {
-      return typeFactory.createStructType(kind, types, names);
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createStructType(kind, types, names),
+          nullableRecord);
     }
 
     /** Creates a dynamic struct type with the current contents of this

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -27,6 +27,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.runtime.FlatLists;
+import org.apache.calcite.runtime.Geometries;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlIntervalQualifier;
@@ -1488,6 +1489,9 @@ public class RexBuilder {
       }
       return new RexLiteral((Comparable) FlatLists.of(operands), type,
           sqlTypeName);
+    case GEOMETRY:
+      return new RexLiteral((Comparable) value, guessType(value),
+          SqlTypeName.GEOMETRY);
     case ANY:
       return makeLiteral(value, guessType(value), allowCast);
     default:
@@ -1620,6 +1624,9 @@ public class RexBuilder {
     if (value instanceof ByteString) {
       return typeFactory.createSqlType(SqlTypeName.BINARY,
           ((ByteString) value).length());
+    }
+    if (value instanceof Geometries.Geom) {
+      return typeFactory.createSqlType(SqlTypeName.GEOMETRY);
     }
     throw new AssertionError("unknown type " + value.getClass());
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -22,6 +22,8 @@ import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.GeoFunctions;
+import org.apache.calcite.runtime.Geometries;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
@@ -360,6 +362,8 @@ public class RexLiteral extends RexNode {
     case ROW:
     case MULTISET:
       return value instanceof List;
+    case GEOMETRY:
+      return value instanceof Geometries.Geom;
     case ANY:
       // Literal of type ANY is not legal. "CAST(2 AS ANY)" remains
       // an integer literal surrounded by a cast function.
@@ -680,6 +684,10 @@ public class RexLiteral extends RexNode {
                 return list.size();
               }
             }).toString());
+        break;
+      case GEOMETRY:
+        final String wkt = GeoFunctions.ST_AsWKT((Geometries.Geom) value);
+        destination.append(wkt);
         break;
       default:
         assert valueMatchesType(value, typeName, true);

--- a/core/src/main/java/org/apache/calcite/runtime/Geometries.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Geometries.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.runtime;
+
+import org.apache.calcite.linq4j.function.Deterministic;
+import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.calcite.linq4j.function.Strict;
+import org.apache.calcite.util.Util;
+
+import com.esri.core.geometry.Envelope;
+import com.esri.core.geometry.Geometry;
+import com.esri.core.geometry.Line;
+import com.esri.core.geometry.MapGeometry;
+import com.esri.core.geometry.Operator;
+import com.esri.core.geometry.OperatorFactoryLocal;
+import com.esri.core.geometry.OperatorIntersects;
+import com.esri.core.geometry.Point;
+import com.esri.core.geometry.Polyline;
+import com.esri.core.geometry.SpatialReference;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Objects;
+
+/**
+ * Utilities for geometry.
+ */
+@SuppressWarnings({"UnnecessaryUnboxing", "WeakerAccess", "unused"})
+@Deterministic
+@Strict
+@Experimental
+public class Geometries {
+  static final int NO_SRID = 0;
+  private static final SpatialReference SPATIAL_REFERENCE =
+      SpatialReference.create(4326);
+
+  private Geometries() {}
+
+  static UnsupportedOperationException todo() {
+    return new UnsupportedOperationException();
+  }
+
+  protected static Geom bind(Geometry geometry, int srid) {
+    if (geometry == null) {
+      return null;
+    }
+    if (srid == NO_SRID) {
+      return new SimpleGeom(geometry);
+    }
+    return bind(geometry, SpatialReference.create(srid));
+  }
+
+  static MapGeom bind(Geometry geometry, SpatialReference sr) {
+    return new MapGeom(new MapGeometry(geometry, sr));
+  }
+
+  static Geom makeLine(Geom... geoms) {
+    return makeLine(ImmutableList.copyOf(geoms));
+  }
+
+  public static Geom makeLine(Iterable<? extends Geom> geoms) {
+    final Polyline g = new Polyline();
+    Point p = null;
+    for (Geom geom : geoms) {
+      if (geom.g() instanceof Point) {
+        final Point prev = p;
+        p = (Point) geom.g();
+        if (prev != null) {
+          final Line line = new Line();
+          line.setStart(prev);
+          line.setEnd(p);
+          g.addSegment(line, false);
+        }
+      }
+    }
+    return new SimpleGeom(g);
+  }
+
+  static Geom point(double x, double y) {
+    final Geometry g = new Point(x, y);
+    return new SimpleGeom(g);
+  }
+
+  /** Returns the OGC type of a geometry. */
+  public static Type type(Geometry g) {
+    switch (g.getType()) {
+    case Point:
+      return Type.POINT;
+    case Polyline:
+      return Type.LINESTRING;
+    case Polygon:
+      return Type.POLYGON;
+    case MultiPoint:
+      return Type.MULTIPOINT;
+    case Envelope:
+      return Type.POLYGON;
+    case Line:
+      return Type.LINESTRING;
+    case Unknown:
+      return Type.Geometry;
+    default:
+      throw new AssertionError(g);
+    }
+  }
+
+  static Envelope envelope(Geometry g) {
+    final Envelope env = new Envelope();
+    g.queryEnvelope(env);
+    return env;
+  }
+
+  static boolean intersects(Geometry g1, Geometry g2,
+      SpatialReference sr) {
+    final OperatorIntersects op = (OperatorIntersects) OperatorFactoryLocal
+        .getInstance().getOperator(Operator.Type.Intersects);
+    return op.execute(g1, g2, sr, null);
+  }
+
+  static Geom buffer(Geom geom, double bufferSize,
+      int quadSegCount, CapStyle endCapStyle, JoinStyle joinStyle,
+      float mitreLimit) {
+    Util.discard(endCapStyle + ":" + joinStyle + ":" + mitreLimit
+        + ":" + quadSegCount);
+    throw todo();
+  }
+
+  /** How the "buffer" command terminates the end of a line. */
+  enum CapStyle {
+    ROUND, FLAT, SQUARE;
+
+    static CapStyle of(String value) {
+      switch (value) {
+      case "round":
+        return ROUND;
+      case "flat":
+      case "butt":
+        return FLAT;
+      case "square":
+        return SQUARE;
+      default:
+        throw new IllegalArgumentException("unknown endcap value: " + value);
+      }
+    }
+  }
+
+  /** How the "buffer" command decorates junctions between line segments. */
+  enum JoinStyle {
+    ROUND, MITRE, BEVEL;
+
+    static JoinStyle of(String value) {
+      switch (value) {
+      case "round":
+        return ROUND;
+      case "mitre":
+      case "miter":
+        return MITRE;
+      case "bevel":
+        return BEVEL;
+      default:
+        throw new IllegalArgumentException("unknown join value: " + value);
+      }
+    }
+  }
+
+  /** Geometry types, with the names and codes assigned by OGC. */
+  public enum Type {
+    Geometry(0),
+    POINT(1),
+    LINESTRING(2),
+    POLYGON(3),
+    MULTIPOINT(4),
+    MULTILINESTRING(5),
+    MULTIPOLYGON(6),
+    GEOMCOLLECTION(7),
+    CURVE(13),
+    SURFACE(14),
+    POLYHEDRALSURFACE(15);
+
+    final int code;
+
+    Type(int code) {
+      this.code = code;
+    }
+  }
+
+  /** Geometry. It may or may not have a spatial reference
+   * associated with it. */
+  public interface Geom extends Comparable<Geom> {
+    Geometry g();
+
+    Type type();
+
+    SpatialReference sr();
+
+    Geom transform(int srid);
+
+    Geom wrap(Geometry g);
+  }
+
+  /** Sub-class of geometry that has no spatial reference. */
+  static class SimpleGeom implements Geom {
+    final Geometry g;
+
+    SimpleGeom(Geometry g) {
+      this.g = Objects.requireNonNull(g);
+    }
+
+    @Override public String toString() {
+      return g.toString();
+    }
+
+    public int compareTo(Geom o) {
+      return toString().compareTo(o.toString());
+    }
+
+    public Geometry g() {
+      return g;
+    }
+
+    public Type type() {
+      return Geometries.type(g);
+    }
+
+    public SpatialReference sr() {
+      return SPATIAL_REFERENCE;
+    }
+
+    public Geom transform(int srid) {
+      if (srid == SPATIAL_REFERENCE.getID()) {
+        return this;
+      }
+      return bind(g, srid);
+    }
+
+    public Geom wrap(Geometry g) {
+      return new SimpleGeom(g);
+    }
+  }
+
+  /** Sub-class of geometry that has a spatial reference. */
+  static class MapGeom implements Geom {
+    final MapGeometry mg;
+
+    MapGeom(MapGeometry mg) {
+      this.mg = Objects.requireNonNull(mg);
+    }
+
+    @Override public String toString() {
+      return mg.toString();
+    }
+
+    public int compareTo(Geom o) {
+      return toString().compareTo(o.toString());
+    }
+
+    public Geometry g() {
+      return mg.getGeometry();
+    }
+
+    public Type type() {
+      return Geometries.type(mg.getGeometry());
+    }
+
+    public SpatialReference sr() {
+      return mg.getSpatialReference();
+    }
+
+    public Geom transform(int srid) {
+      if (srid == NO_SRID) {
+        return new SimpleGeom(mg.getGeometry());
+      }
+      if (srid == mg.getSpatialReference().getID()) {
+        return this;
+      }
+      return bind(mg.getGeometry(), srid);
+    }
+
+    public Geom wrap(Geometry g) {
+      return bind(g, this.mg.getSpatialReference());
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/runtime/HilbertCurve2D.java
+++ b/core/src/main/java/org/apache/calcite/runtime/HilbertCurve2D.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.runtime;
+
+import com.google.common.collect.ImmutableList;
+import com.google.uzaygezen.core.BacktrackingQueryBuilder;
+import com.google.uzaygezen.core.BitVector;
+import com.google.uzaygezen.core.BitVectorFactories;
+import com.google.uzaygezen.core.CompactHilbertCurve;
+import com.google.uzaygezen.core.FilteredIndexRange;
+import com.google.uzaygezen.core.LongContent;
+import com.google.uzaygezen.core.PlainFilterCombiner;
+import com.google.uzaygezen.core.Query;
+import com.google.uzaygezen.core.SimpleRegionInspector;
+import com.google.uzaygezen.core.ZoomingSpaceVisitorAdapter;
+import com.google.uzaygezen.core.ranges.LongRange;
+import com.google.uzaygezen.core.ranges.LongRangeHome;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 2-dimensional Hilbert space-filling curve.
+ *
+ * <p>Includes code from
+ * <a href="https://github.com/locationtech/sfcurve">LocationTech SFCurve</a>,
+ * Copyright (c) 2015 Azavea.
+ */
+public class HilbertCurve2D implements SpaceFillingCurve2D {
+  final long precision;
+  final CompactHilbertCurve chc;
+  private final int resolution;
+
+  public HilbertCurve2D(int resolution) {
+    this.resolution = resolution;
+    precision = (long) Math.pow(2, resolution);
+    chc = new CompactHilbertCurve(new int[] {resolution, resolution});
+  }
+
+  long getNormalizedLongitude(double x) {
+    return (long) ((x + 180) * (precision - 1) / 360d);
+  }
+
+  long getNormalizedLatitude(double y) {
+    return (long) ((y + 90) * (precision - 1) / 180d);
+  }
+
+  long setNormalizedLatitude(long latNormal) {
+    if (!(latNormal >= 0 && latNormal <= precision)) {
+      throw new NumberFormatException(
+          "Normalized latitude must be greater than 0 and less than the maximum precision");
+    }
+    return (long) (latNormal * 180d / (precision - 1));
+  }
+
+  long setNormalizedLongitude(long lonNormal) {
+    if (!(lonNormal >= 0 && lonNormal <= precision)) {
+      throw new NumberFormatException(
+          "Normalized longitude must be greater than 0 and less than the maximum precision");
+    }
+    return (long) (lonNormal * 360d / (precision - 1));
+  }
+
+  public long toIndex(double x, double y) {
+    final long normX = getNormalizedLongitude(x);
+    final long normY = getNormalizedLatitude(y);
+    final BitVector[] p = {
+        BitVectorFactories.OPTIMAL.apply(resolution),
+        BitVectorFactories.OPTIMAL.apply(resolution)
+    };
+
+    p[0].copyFrom(normX);
+    p[1].copyFrom(normY);
+
+    final BitVector hilbert = BitVectorFactories.OPTIMAL.apply(resolution * 2);
+
+    chc.index(p, 0, hilbert);
+    return hilbert.toLong();
+  }
+
+  public Point toPoint(long i) {
+    final BitVector h = BitVectorFactories.OPTIMAL.apply(resolution * 2);
+    h.copyFrom(i);
+    final BitVector[] p = {
+        BitVectorFactories.OPTIMAL.apply(resolution),
+        BitVectorFactories.OPTIMAL.apply(resolution)
+    };
+
+    chc.indexInverse(h, p);
+
+    final long x = setNormalizedLongitude(p[0].toLong()) - 180;
+    final long y = setNormalizedLatitude(p[1].toLong()) - 90;
+    return new Point((double) x, (double) y);
+  }
+
+  public List<IndexRange> toRanges(double xMin, double yMin, double xMax,
+      double yMax, RangeComputeHints hints) {
+    final CompactHilbertCurve chc =
+        new CompactHilbertCurve(new int[] {resolution, resolution});
+    final List<LongRange> region = new ArrayList<>();
+
+    final long minNormalizedLongitude = getNormalizedLongitude(xMin);
+    final long minNormalizedLatitude  = getNormalizedLatitude(yMin);
+
+    final long maxNormalizedLongitude = getNormalizedLongitude(xMax);
+    final long maxNormalizedLatitude  = getNormalizedLatitude(yMax);
+
+    region.add(LongRange.of(minNormalizedLongitude, maxNormalizedLongitude));
+    region.add(LongRange.of(minNormalizedLatitude, maxNormalizedLatitude));
+
+    final LongContent zero = new LongContent(0L);
+
+    final SimpleRegionInspector<LongRange, Long, LongContent, LongRange> inspector =
+        SimpleRegionInspector.create(ImmutableList.of(region),
+            new LongContent(1L), range -> range, LongRangeHome.INSTANCE,
+            zero);
+
+    final PlainFilterCombiner<LongRange, Long, LongContent, LongRange> combiner =
+        new PlainFilterCombiner<>(LongRange.of(0, 1));
+
+    final BacktrackingQueryBuilder<LongRange, Long, LongContent, LongRange> queryBuilder =
+        BacktrackingQueryBuilder.create(inspector, combiner, Integer.MAX_VALUE,
+            true, LongRangeHome.INSTANCE, zero);
+
+    chc.accept(new ZoomingSpaceVisitorAdapter(chc, queryBuilder));
+
+    final Query<LongRange, LongRange> query = queryBuilder.get();
+
+    final List<FilteredIndexRange<LongRange, LongRange>> ranges =
+        query.getFilteredIndexRanges();
+
+    // result
+    final List<IndexRange> result = new ArrayList<>();
+
+    for (FilteredIndexRange<LongRange, LongRange> l : ranges) {
+      final LongRange range = l.getIndexRange();
+      final Long start = range.getStart();
+      final Long end = range.getEnd();
+      final boolean contained = l.isPotentialOverSelectivity();
+      result.add(0, IndexRanges.create(start, end, contained));
+    }
+    return result;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/runtime/SpaceFillingCurve2D.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpaceFillingCurve2D.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.runtime;
+
+import com.google.common.collect.Ordering;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Utilities for space-filling curves.
+ *
+ * <p>Includes code from
+ * <a href="https://github.com/locationtech/sfcurve">LocationTech SFCurve</a>,
+ * Copyright (c) 2015 Azavea.
+ */
+public interface SpaceFillingCurve2D {
+  long toIndex(double x, double y);
+  Point toPoint(long i);
+  List<IndexRange> toRanges(double xMin, double yMin, double xMax,
+      double yMax, RangeComputeHints hints);
+
+  /** Hints for the {@link SpaceFillingCurve2D#toRanges} method. */
+  class RangeComputeHints extends HashMap<String, Object> {
+  }
+
+  /** Range. */
+  interface IndexRange {
+    long lower();
+    long upper();
+    boolean contained();
+
+    IndexRangeTuple tuple();
+  }
+
+  /** Data representing a range. */
+  class IndexRangeTuple {
+    final long lower;
+    final long upper;
+    final boolean contained;
+
+    IndexRangeTuple(long lower, long upper, boolean contained) {
+      this.lower = lower;
+      this.upper = upper;
+      this.contained = contained;
+    }
+  }
+
+  /** Base class for Range implementations. */
+  abstract class AbstractRange implements IndexRange {
+    final long lower;
+    final long upper;
+
+    protected AbstractRange(long lower, long upper) {
+      this.lower = lower;
+      this.upper = upper;
+    }
+
+    public long lower() {
+      return lower;
+    }
+
+    public long upper() {
+      return upper;
+    }
+
+    public IndexRangeTuple tuple() {
+      return new IndexRangeTuple(lower, upper, contained());
+    }
+  }
+
+  /** Range that is covered. */
+  class CoveredRange extends AbstractRange {
+    CoveredRange(long lower, long upper) {
+      super(lower, upper);
+    }
+
+    public boolean contained() {
+      return true;
+    }
+
+    @Override public String toString() {
+      return "covered(" + lower + ", " + upper + ")";
+    }
+  }
+
+  /** Range that is not contained. */
+  class OverlappingRange extends AbstractRange {
+    OverlappingRange(long lower, long upper) {
+      super(lower, upper);
+    }
+
+    public boolean contained() {
+      return false;
+    }
+
+    @Override public String toString() {
+      return "overlap(" + lower + ", " + upper + ")";
+    }
+  }
+
+  /** Lexicographic ordering for {@link IndexRange}. */
+  class IndexRangeOrdering extends Ordering<IndexRange> {
+    public int compare(IndexRange x, IndexRange y) {
+      final int c1 = Long.compare(x.lower(), y.lower());
+      if (c1 != 0) {
+        return c1;
+      }
+      return Long.compare(x.upper(), y.upper());
+    }
+  }
+
+  /** Utilities for {@link IndexRange}. */
+  class IndexRanges {
+    private IndexRanges() {}
+
+    static IndexRange create(long l, long u, boolean contained) {
+      return contained ? new CoveredRange(l, u) : new OverlappingRange(l, u);
+    }
+  }
+
+  /** A 2-dimensional point. */
+  class Point {
+    final double x;
+    final double y;
+
+    Point(double x, double y) {
+      this.x = x;
+      this.y = y;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -515,6 +515,8 @@ public final class Schemas {
       return PathImpl.EMPTY;
     }
     if (!rootSchema.name.isEmpty()) {
+      // If path starts with the name of the root schema, ignore the first step
+      // in the path.
       Preconditions.checkState(rootSchema.name.equals(iterator.next()));
     }
     for (;;) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAggFunction.java
@@ -103,7 +103,7 @@ public abstract class SqlAggFunction extends SqlFunction implements Context {
       boolean requiresOver,
       Optionality requiresGroupOrder) {
     super(name, sqlIdentifier, kind, returnTypeInference, operandTypeInference,
-        operandTypeChecker, null, funcType);
+        operandTypeChecker, funcType);
     this.requiresOrder = requiresOrder;
     this.requiresOver = requiresOver;
     this.requiresGroupOrder = Objects.requireNonNull(requiresGroupOrder);

--- a/core/src/main/java/org/apache/calcite/sql/SqlHopTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlHopTableFunction.java
@@ -16,12 +16,7 @@
  */
 package org.apache.calcite.sql;
 
-import org.apache.calcite.sql.type.SqlOperandCountRanges;
-import org.apache.calcite.sql.type.SqlOperandTypeChecker;
-
 import com.google.common.collect.ImmutableList;
-
-import java.util.List;
 
 /**
  * SqlHopTableFunction implements an operator for hopping.
@@ -37,47 +32,31 @@ import java.util.List;
  */
 public class SqlHopTableFunction extends SqlWindowTableFunction {
   public SqlHopTableFunction() {
-    super(SqlKind.HOP.name(), OperandTypeCheckerImpl.INSTANCE);
+    super(SqlKind.HOP.name(), new OperandMetadataImpl());
   }
-
-  @Override public List<String> getParamNames() {
-    return ImmutableList.of(PARAM_DATA, PARAM_TIMECOL, PARAM_SLIDE, PARAM_SIZE, PARAM_OFFSET);
-  }
-
-  // -------------------------------------------------------------------------
-  //  Inner Class
-  // -------------------------------------------------------------------------
 
   /** Operand type checker for HOP. */
-  private static class OperandTypeCheckerImpl implements SqlOperandTypeChecker {
-    static final OperandTypeCheckerImpl INSTANCE = new OperandTypeCheckerImpl();
+  private static class OperandMetadataImpl extends AbstractOperandMetadata {
+    OperandMetadataImpl() {
+      super(
+          ImmutableList.of(PARAM_DATA, PARAM_TIMECOL, PARAM_SLIDE,
+              PARAM_SIZE, PARAM_OFFSET), 4);
+    }
 
-    @Override public boolean checkOperandTypes(
-        SqlCallBinding callBinding, boolean throwOnFailure) {
-      if (!validateTableWithFollowingDescriptors(callBinding, 1)) {
+    @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
+        boolean throwOnFailure) {
+      if (!checkTableAndDescriptorOperands(callBinding, 1)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }
-      if (!validateTailingIntervals(callBinding, 2)) {
+      if (!checkIntervalOperands(callBinding, 2)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }
       return true;
     }
 
-    @Override public SqlOperandCountRange getOperandCountRange() {
-      return SqlOperandCountRanges.between(4, 5);
-    }
-
     @Override public String getAllowedSignatures(SqlOperator op, String opName) {
       return opName + "(TABLE table_name, DESCRIPTOR(timecol), "
           + "datetime interval, datetime interval[, datetime interval])";
-    }
-
-    @Override public Consistency getConsistency() {
-      return Consistency.NONE;
-    }
-
-    @Override public boolean isOptional(int i) {
-      return i == 4;
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -876,6 +876,30 @@ public enum SqlKind {
   /** {@code FOREIGN KEY} constraint. */
   FOREIGN_KEY,
 
+  // Spatial functions. They are registered as "user-defined functions" but it
+  // is convenient to have a "kind" so that we can quickly match them in planner
+  // rules.
+
+  /** The {@code ST_DWithin} geo-spatial function. */
+  ST_DWITHIN,
+
+  /** The {@code ST_Point} function. */
+  ST_POINT,
+
+  /** The {@code ST_Point} function that makes a 3D point. */
+  ST_POINT3,
+
+  /** The {@code ST_MakeLine} function that makes a line. */
+  ST_MAKE_LINE,
+
+  /** The {@code ST_Contains} function that tests whether one geometry contains
+   * another. */
+  ST_CONTAINS,
+
+  /** The {@code Hilbert} function that converts (x, y) to a position on a
+   * Hilbert space-filling curve. */
+  HILBERT,
+
   // DDL and session control statements follow. The list is not exhaustive: feel
   // free to add more.
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -522,7 +522,8 @@ public abstract class SqlOperator {
     // Always disable type coercion for builtin operator operands,
     // they are handled by the TypeCoercion specifically.
     final SqlOperator sqlOperator =
-        SqlUtil.lookupRoutine(validator.getOperatorTable(), getNameAsId(),
+        SqlUtil.lookupRoutine(validator.getOperatorTable(),
+            validator.getTypeFactory(), getNameAsId(),
             argTypes, null, null, getSyntax(), getKind(),
             validator.getCatalogReader().nameMatcher(), false);
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlGeoFunctions.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlGeoFunctions.java
@@ -23,6 +23,7 @@ import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.runtime.GeoFunctions;
+import org.apache.calcite.runtime.Geometries.Geom;
 import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.Statistic;
@@ -51,18 +52,18 @@ public class SqlGeoFunctions {
 
   /** Calculates a regular grid of polygons based on {@code geom}.
    *
-   * @see GeoFunctions#ST_MakeGrid */
+   * @see GeoFunctions ST_MakeGrid */
   @SuppressWarnings({"WeakerAccess", "unused"})
-  public static ScannableTable ST_MakeGrid(final GeoFunctions.Geom geom,
+  public static ScannableTable ST_MakeGrid(final Geom geom,
       final BigDecimal deltaX, final BigDecimal deltaY) {
     return new GridTable(geom, deltaX, deltaY, false);
   }
 
   /** Calculates a regular grid of points based on {@code geom}.
    *
-   * @see GeoFunctions#ST_MakeGridPoints */
+   * @see GeoFunctions ST_MakeGridPoints */
   @SuppressWarnings({"WeakerAccess", "unused"})
-  public static ScannableTable ST_MakeGridPoints(final GeoFunctions.Geom geom,
+  public static ScannableTable ST_MakeGridPoints(final Geom geom,
       final BigDecimal deltaX, final BigDecimal deltaY) {
     return new GridTable(geom, deltaX, deltaY, true);
   }
@@ -70,12 +71,12 @@ public class SqlGeoFunctions {
   /** Returns the points or rectangles in a grid that covers a given
    * geometry. */
   public static class GridTable implements ScannableTable {
-    private final GeoFunctions.Geom geom;
+    private final Geom geom;
     private final BigDecimal deltaX;
     private final BigDecimal deltaY;
     private boolean point;
 
-    GridTable(GeoFunctions.Geom geom, BigDecimal deltaX, BigDecimal deltaY,
+    GridTable(Geom geom, BigDecimal deltaX, BigDecimal deltaY,
         boolean point) {
       this.geom = geom;
       this.deltaX = deltaX;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperatorTableFactory.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperatorTableFactory.java
@@ -16,12 +16,10 @@
  */
 package org.apache.calcite.sql.fun;
 
-import org.apache.calcite.prepare.CalciteCatalogReader;
-import org.apache.calcite.runtime.GeoFunctions;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
-import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.calcite.sql.util.ListSqlOperatorTable;
+import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.util.Util;
 
 import com.google.common.cache.CacheBuilder;
@@ -85,9 +83,7 @@ public class SqlLibraryOperatorTableFactory {
         standard = true;
         break;
       case SPATIAL:
-        list.addAll(
-            CalciteCatalogReader.operatorTable(GeoFunctions.class.getName(),
-                SqlGeoFunctions.class.getName()).getOperatorList());
+        list.addAll(SqlOperatorTables.spatialInstance().getOperatorList());
         break;
       default:
         custom = true;
@@ -116,7 +112,7 @@ public class SqlLibraryOperatorTableFactory {
     SqlOperatorTable operatorTable = new ListSqlOperatorTable(list.build());
     if (standard) {
       operatorTable =
-          ChainedSqlOperatorTable.of(SqlStdOperatorTable.instance(),
+          SqlOperatorTables.chain(SqlStdOperatorTable.instance(),
               operatorTable);
     }
     return operatorTable;

--- a/core/src/main/java/org/apache/calcite/sql/type/ExplicitOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ExplicitOperandTypeChecker.java
@@ -24,6 +24,7 @@ import org.apache.calcite.sql.SqlOperator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Parameter type-checking strategy for Explicit Type.
@@ -31,10 +32,10 @@ import java.util.List;
 public class ExplicitOperandTypeChecker implements SqlOperandTypeChecker {
   //~ Methods ----------------------------------------------------------------
 
-  private RelDataType type;
+  private final RelDataType type;
 
   public ExplicitOperandTypeChecker(RelDataType type) {
-    this.type = type;
+    this.type = Objects.requireNonNull(type);
   }
 
   public boolean isOptional(int i) {

--- a/core/src/main/java/org/apache/calcite/sql/type/JavaToSqlTypeConversionRules.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/JavaToSqlTypeConversionRules.java
@@ -17,7 +17,7 @@
 package org.apache.calcite.sql.type;
 
 import org.apache.calcite.avatica.util.ArrayImpl;
-import org.apache.calcite.runtime.GeoFunctions;
+import org.apache.calcite.runtime.Geometries;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -71,7 +71,7 @@ public class JavaToSqlTypeConversionRules {
           .put(Time.class, SqlTypeName.TIME)
           .put(BigDecimal.class, SqlTypeName.DECIMAL)
 
-          .put(GeoFunctions.Geom.class, SqlTypeName.GEOMETRY)
+          .put(Geometries.Geom.class, SqlTypeName.GEOMETRY)
 
           .put(ResultSet.class, SqlTypeName.CURSOR)
           .put(ColumnList.class, SqlTypeName.COLUMN_LIST)

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandMetadataImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandMetadataImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.linq4j.function.Functions;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+
+/**
+ * Operand type-checking strategy user-defined functions (including user-defined
+ * aggregate functions, table functions, and table macros).
+ *
+ * <p>UDFs have a fixed number of parameters is fixed. Per
+ * {@link SqlOperandMetadata}, this interface provides the name and types of
+ * each parameter.
+ *
+ * @see OperandTypes#operandMetadata
+ */
+public class OperandMetadataImpl extends FamilyOperandTypeChecker
+    implements SqlOperandMetadata {
+  private final Function<RelDataTypeFactory, List<RelDataType>>
+      paramTypesFactory;
+  private final IntFunction<String> paramNameFn;
+
+  //~ Constructors -----------------------------------------------------------
+
+  /** Package private. Create using {@link OperandTypes#operandMetadata}. */
+  OperandMetadataImpl(List<SqlTypeFamily> families,
+      Function<RelDataTypeFactory, List<RelDataType>> paramTypesFactory,
+      IntFunction<String> paramNameFn, Predicate<Integer> optional) {
+    super(families, optional);
+    this.paramTypesFactory = Objects.requireNonNull(paramTypesFactory);
+    this.paramNameFn = paramNameFn;
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public boolean isFixedParameters() {
+    return true;
+  }
+
+  @Override public List<RelDataType> paramTypes(RelDataTypeFactory typeFactory) {
+    return paramTypesFactory.apply(typeFactory);
+  }
+
+  @Override public List<String> paramNames() {
+    return Functions.generate(families.size(), paramNameFn);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -18,6 +18,7 @@ package org.apache.calcite.sql.type;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeComparability;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
@@ -29,6 +30,8 @@ import com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
 import static org.apache.calcite.util.Static.RESOURCE;
@@ -78,6 +81,23 @@ public abstract class OperandTypes {
    */
   public static FamilyOperandTypeChecker family(List<SqlTypeFamily> families) {
     return family(families, i -> false);
+  }
+
+  /**
+   * Creates a checker for user-defined functions (including user-defined
+   * aggregate functions, table functions, and table macros).
+   *
+   * <p>Unlike built-in functions, there is a fixed number of parameters,
+   * and the parameters have names. You can ask for the type of a parameter
+   * without providing a particular call (and with it actual arguments) but you
+   * do need to provide a type factory, and therefore the types are only good
+   * for the duration of the current statement.
+   */
+  public static SqlOperandMetadata operandMetadata(List<SqlTypeFamily> families,
+      Function<RelDataTypeFactory, List<RelDataType>> typesFactory,
+      IntFunction<String> operandName, Predicate<Integer> optional) {
+    return new OperandMetadataImpl(families, typesFactory, operandName,
+        optional);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlOperandMetadata.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlOperandMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * Extension to {@link SqlOperandTypeChecker} that also provides
+ * names and types of particular operands.
+ *
+ * <p>It is intended for user-defined functions (UDFs), and therefore the number
+ * of parameters is fixed.
+ *
+ * @see OperandTypes
+ */
+@Nonnull
+public interface SqlOperandMetadata extends SqlOperandTypeChecker {
+  //~ Methods ----------------------------------------------------------------
+
+  /** Returns the types of the parameters. */
+  List<RelDataType> paramTypes(RelDataTypeFactory typeFactory);
+
+  /** Returns the names of the parameters. */
+  List<String> paramNames();
+}

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlOperandTypeChecker.java
@@ -62,6 +62,15 @@ public interface SqlOperandTypeChecker {
   /** Returns whether the {@code i}th operand is optional. */
   boolean isOptional(int i);
 
+  /** Returns whether the list of parameters is fixed-length. In standard SQL,
+   * user-defined functions are fixed-length.
+   *
+   * <p>If true, the validator should expand calls, supplying a {@code DEFAULT}
+   * value for each parameter for which an argument is not supplied. */
+  default boolean isFixedParameters() {
+    return false;
+  }
+
   /** Strategy used to make arguments consistent. */
   enum Consistency {
     /** Do not try to make arguments consistent. */

--- a/core/src/main/java/org/apache/calcite/sql/util/ChainedSqlOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/util/ChainedSqlOperatorTable.java
@@ -31,6 +31,8 @@ import java.util.List;
 /**
  * ChainedSqlOperatorTable implements the {@link SqlOperatorTable} interface by
  * chaining together any number of underlying operator table instances.
+ *
+ * <p>To create, call {@link SqlOperatorTables#chain}.
  */
 public class ChainedSqlOperatorTable implements SqlOperatorTable {
   //~ Instance fields --------------------------------------------------------
@@ -39,27 +41,19 @@ public class ChainedSqlOperatorTable implements SqlOperatorTable {
 
   //~ Constructors -----------------------------------------------------------
 
-  /**
-   * Creates a table based on a given list.
-   */
+  @Deprecated // to be removed before 2.0
   public ChainedSqlOperatorTable(List<SqlOperatorTable> tableList) {
-    this.tableList = ImmutableList.copyOf(tableList);
+    this(ImmutableList.copyOf(tableList));
   }
 
-  /** Creates a {@code ChainedSqlOperatorTable}. */
-  public static SqlOperatorTable of(SqlOperatorTable... tables) {
-    return new ChainedSqlOperatorTable(ImmutableList.copyOf(tables));
+  /** Internal constructor; call {@link SqlOperatorTables#chain}. */
+  protected ChainedSqlOperatorTable(ImmutableList<SqlOperatorTable> tableList) {
+    this.tableList = ImmutableList.copyOf(tableList);
   }
 
   //~ Methods ----------------------------------------------------------------
 
-  /**
-   * Adds an underlying table. The order in which tables are added is
-   * significant; tables added earlier have higher lookup precedence. A table
-   * is not added if it is already on the list.
-   *
-   * @param table table to add
-   */
+  @Deprecated // to be removed before 2.0
   public void add(SqlOperatorTable table) {
     if (!tableList.contains(table)) {
       tableList.add(table);

--- a/core/src/main/java/org/apache/calcite/sql/util/SqlOperatorTables.java
+++ b/core/src/main/java/org/apache/calcite/sql/util/SqlOperatorTables.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.util;
+
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.runtime.GeoFunctions;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.fun.SqlGeoFunctions;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+
+import java.util.function.Supplier;
+
+/**
+ * Utilities for {@link SqlOperatorTable}s.
+ */
+public class SqlOperatorTables extends ReflectiveSqlOperatorTable {
+
+  private static final Supplier<SqlOperatorTable> SPATIAL =
+      Suppliers.memoize(SqlOperatorTables::createSpatial)::get;
+
+  private static SqlOperatorTable createSpatial() {
+    return CalciteCatalogReader.operatorTable(
+        GeoFunctions.class.getName(),
+        SqlGeoFunctions.class.getName());
+  }
+
+  /** Returns the Spatial operator table, creating it if necessary. */
+  public static SqlOperatorTable spatialInstance() {
+    return SPATIAL.get();
+  }
+
+  /** Creates a composite operator table. */
+  public static SqlOperatorTable chain(Iterable<SqlOperatorTable> tables) {
+    final ImmutableList<SqlOperatorTable> list =
+        ImmutableList.copyOf(tables);
+    if (list.size() == 1) {
+      return list.get(0);
+    }
+    return new ChainedSqlOperatorTable(list);
+  }
+
+  /** Creates a composite operator table from an array of tables. */
+  public static SqlOperatorTable chain(SqlOperatorTable... tables) {
+    return chain(ImmutableList.copyOf(tables));
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedAggFunction.java
@@ -16,28 +16,18 @@
  */
 package org.apache.calcite.sql.validate;
 
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
-import org.apache.calcite.linq4j.function.Experimental;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeFactoryImpl;
 import org.apache.calcite.schema.AggregateFunction;
-import org.apache.calcite.schema.FunctionParameter;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Optionality;
 import org.apache.calcite.util.Util;
-
-import com.google.common.collect.Lists;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * User-defined aggregate function.
@@ -48,58 +38,36 @@ import java.util.List;
 public class SqlUserDefinedAggFunction extends SqlAggFunction {
   public final AggregateFunction function;
 
-  /** This field is is technical debt; see [CALCITE-2082] Remove
-   * RelDataTypeFactory argument from SqlUserDefinedAggFunction constructor. */
-  @Experimental
-  public final RelDataTypeFactory typeFactory;
-
-  /** Creates a SqlUserDefinedAggFunction. */
+  @Deprecated // to be removed before 2.0
   public SqlUserDefinedAggFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       SqlOperandTypeChecker operandTypeChecker, AggregateFunction function,
       boolean requiresOrder, boolean requiresOver,
       Optionality requiresGroupOrder, RelDataTypeFactory typeFactory) {
-    super(Util.last(opName.names), opName, SqlKind.OTHER_FUNCTION,
-        returnTypeInference, operandTypeInference, operandTypeChecker,
+    this(opName, SqlKind.OTHER_FUNCTION, returnTypeInference,
+        operandTypeInference,
+        operandTypeChecker instanceof SqlOperandMetadata
+            ? (SqlOperandMetadata) operandTypeChecker : null, function,
+        requiresOrder, requiresOver, requiresGroupOrder);
+    Util.discard(typeFactory); // no longer used
+  }
+
+  /** Creates a SqlUserDefinedAggFunction. */
+  public SqlUserDefinedAggFunction(SqlIdentifier opName, SqlKind kind,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeInference operandTypeInference,
+      SqlOperandMetadata operandMetadata, AggregateFunction function,
+      boolean requiresOrder, boolean requiresOver,
+      Optionality requiresGroupOrder) {
+    super(Util.last(opName.names), opName, kind,
+        returnTypeInference, operandTypeInference, operandMetadata,
         SqlFunctionCategory.USER_DEFINED_FUNCTION, requiresOrder, requiresOver,
         requiresGroupOrder);
     this.function = function;
-    this.typeFactory = typeFactory;
   }
 
-  @Override public List<RelDataType> getParamTypes() {
-    List<RelDataType> argTypes = new ArrayList<>();
-    for (FunctionParameter o : function.getParameters()) {
-      final RelDataType type = o.getType(typeFactory);
-      argTypes.add(type);
-    }
-    return toSql(argTypes);
-  }
-
-  private List<RelDataType> toSql(List<RelDataType> types) {
-    return Lists.transform(types, this::toSql);
-  }
-
-  private RelDataType toSql(RelDataType type) {
-    if (type instanceof RelDataTypeFactoryImpl.JavaType
-        && ((RelDataTypeFactoryImpl.JavaType) type).getJavaClass()
-        == Object.class) {
-      return typeFactory.createTypeWithNullability(
-          typeFactory.createSqlType(SqlTypeName.ANY), true);
-    }
-    return JavaTypeFactoryImpl.toSql(typeFactory, type);
-  }
-
-  @SuppressWarnings("deprecation")
-  public List<RelDataType> getParameterTypes(
-      final RelDataTypeFactory typeFactory) {
-    return Lists.transform(function.getParameters(),
-        parameter -> parameter.getType(typeFactory));
-  }
-
-  @SuppressWarnings("deprecation")
-  public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
-    return function.getReturnType(typeFactory);
+  @Override public SqlOperandMetadata getOperandTypeChecker() {
+    return (SqlOperandMetadata) super.getOperandTypeChecker();
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
@@ -41,29 +42,44 @@ import java.util.List;
 public class SqlUserDefinedFunction extends SqlFunction {
   public final Function function;
 
-  /** Creates a {@link SqlUserDefinedFunction}. */
+  @Deprecated // to be removed before 2.0
   public SqlUserDefinedFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       SqlOperandTypeChecker operandTypeChecker,
       List<RelDataType> paramTypes,
       Function function) {
-    this(opName, returnTypeInference, operandTypeInference, operandTypeChecker,
-        paramTypes, function, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+    this(opName, SqlKind.OTHER_FUNCTION, returnTypeInference,
+        operandTypeInference,
+        operandTypeChecker instanceof SqlOperandMetadata
+            ? (SqlOperandMetadata) operandTypeChecker : null, function);
+    Util.discard(paramTypes); // no longer used
+  }
+
+  /** Creates a {@link SqlUserDefinedFunction}. */
+  public SqlUserDefinedFunction(SqlIdentifier opName, SqlKind kind,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeInference operandTypeInference,
+      SqlOperandMetadata operandMetadata,
+      Function function) {
+    this(opName, kind, returnTypeInference, operandTypeInference,
+        operandMetadata, function, SqlFunctionCategory.USER_DEFINED_FUNCTION);
   }
 
   /** Constructor used internally and by derived classes. */
-  protected SqlUserDefinedFunction(SqlIdentifier opName,
+  protected SqlUserDefinedFunction(SqlIdentifier opName, SqlKind kind,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
-      SqlOperandTypeChecker operandTypeChecker,
-      List<RelDataType> paramTypes,
+      SqlOperandMetadata operandMetadata,
       Function function,
       SqlFunctionCategory category) {
-    super(Util.last(opName.names), opName, SqlKind.OTHER_FUNCTION,
-        returnTypeInference, operandTypeInference, operandTypeChecker,
-        paramTypes, category);
+    super(Util.last(opName.names), opName, kind, returnTypeInference,
+        operandTypeInference, operandMetadata, category);
     this.function = function;
+  }
+
+  @Override public SqlOperandMetadata getOperandTypeChecker() {
+    return (SqlOperandMetadata) super.getOperandTypeChecker();
   }
 
   /**
@@ -74,6 +90,7 @@ public class SqlUserDefinedFunction extends SqlFunction {
     return function;
   }
 
+  @SuppressWarnings("deprecation")
   @Override public List<String> getParamNames() {
     return Lists.transform(function.getParameters(),
         FunctionParameter::getName);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
@@ -20,8 +20,10 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.schema.TableFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlTableFunction;
+import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
@@ -37,14 +39,28 @@ import java.util.List;
 */
 public class SqlUserDefinedTableFunction extends SqlUserDefinedFunction
     implements SqlTableFunction {
+  @Deprecated // to be removed before 2.0
   public SqlUserDefinedTableFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       SqlOperandTypeChecker operandTypeChecker,
-      List<RelDataType> paramTypes,
+      List<RelDataType> paramTypes, // no longer used
       TableFunction function) {
-    super(opName, returnTypeInference, operandTypeInference, operandTypeChecker,
-        paramTypes, function, SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
+    this(opName, SqlKind.OTHER_FUNCTION, returnTypeInference,
+        operandTypeInference,
+        operandTypeChecker instanceof SqlOperandMetadata
+            ? (SqlOperandMetadata) operandTypeChecker : null, function);
+  }
+
+  /** Creates a user-defined table function. */
+  public SqlUserDefinedTableFunction(SqlIdentifier opName, SqlKind kind,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeInference operandTypeInference,
+      SqlOperandMetadata operandMetadata,
+      TableFunction function) {
+    super(opName, kind, returnTypeInference, operandTypeInference,
+        operandMetadata, function,
+        SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.Util;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -50,6 +51,7 @@ public class SqlUserDefinedTableFunction extends SqlUserDefinedFunction
         operandTypeInference,
         operandTypeChecker instanceof SqlOperandMetadata
             ? (SqlOperandMetadata) operandTypeChecker : null, function);
+    Util.discard(paramTypes);
   }
 
   /** Creates a user-defined table function. */

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
@@ -34,6 +34,7 @@ import org.apache.calcite.sql.SqlUpdate;
 import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlValidator;
@@ -561,19 +562,22 @@ public class TypeCoercionImpl extends AbstractTypeCoercion {
   }
 
   /**
-   * Type coercion for user defined functions(UDFs).
+   * Type coercion for user-defined functions (UDFs).
    */
   public boolean userDefinedFunctionCoercion(SqlValidatorScope scope,
       SqlCall call, SqlFunction function) {
-    final List<RelDataType> paramTypes = function.getParamTypes();
-    assert paramTypes != null;
+    final SqlOperandMetadata operandMetadata =
+        (SqlOperandMetadata) function.getOperandTypeChecker();
+    final List<RelDataType> paramTypes =
+        operandMetadata.paramTypes(scope.getValidator().getTypeFactory());
     boolean coerced = false;
     for (int i = 0; i < call.operandCount(); i++) {
       SqlNode operand = call.operand(i);
       if (operand.getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {
         final List<SqlNode> operandList = ((SqlCall) operand).getOperandList();
         String name = ((SqlIdentifier) operandList.get(1)).getSimple();
-        int formalIndex = function.getParamNames().indexOf(name);
+        final List<String> paramNames = operandMetadata.paramNames();
+        int formalIndex = paramNames.indexOf(name);
         if (formalIndex < 0) {
           return false;
         }

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -85,6 +85,7 @@ import org.apache.calcite.runtime.Bindable;
 import org.apache.calcite.runtime.CompressionFunctions;
 import org.apache.calcite.runtime.Enumerables;
 import org.apache.calcite.runtime.FlatLists;
+import org.apache.calcite.runtime.GeoFunctions;
 import org.apache.calcite.runtime.JsonFunctions;
 import org.apache.calcite.runtime.Matcher;
 import org.apache.calcite.runtime.Pattern;
@@ -373,6 +374,7 @@ public enum BuiltInMethod {
   IS_JSON_OBJECT(JsonFunctions.class, "isJsonObject", String.class),
   IS_JSON_ARRAY(JsonFunctions.class, "isJsonArray", String.class),
   IS_JSON_SCALAR(JsonFunctions.class, "isJsonScalar", String.class),
+  ST_GEOM_FROM_TEXT(GeoFunctions.class, "ST_GeomFromText", String.class),
   INITCAP(SqlFunctions.class, "initcap", String.class),
   SUBSTRING(SqlFunctions.class, "substring", String.class, int.class,
       int.class),

--- a/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
+++ b/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
@@ -157,7 +157,6 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
           null,
           null,
           OperandTypes.NUMERIC,
-          null,
           SqlFunctionCategory.USER_DEFINED_FUNCTION);
     }
 
@@ -185,8 +184,9 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
   public static class SplitFunction extends SqlFunction {
 
     public SplitFunction() {
-      super("SPLIT", new SqlIdentifier("SPLIT", SqlParserPos.ZERO), SqlKind.OTHER_FUNCTION, null,
-          null, OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING), null,
+      super("SPLIT", new SqlIdentifier("SPLIT", SqlParserPos.ZERO),
+          SqlKind.OTHER_FUNCTION, null, null,
+          OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING),
           SqlFunctionCategory.USER_DEFINED_FUNCTION);
     }
 
@@ -239,8 +239,9 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
   /** "STRUCTURED_FUNC" user-defined function whose return type is structured type. */
   public static class StructuredFunction extends SqlFunction {
     StructuredFunction() {
-      super("STRUCTURED_FUNC", new SqlIdentifier("STRUCTURED_FUNC", SqlParserPos.ZERO),
-          SqlKind.OTHER_FUNCTION, null, null, OperandTypes.NILADIC, null,
+      super("STRUCTURED_FUNC",
+          new SqlIdentifier("STRUCTURED_FUNC", SqlParserPos.ZERO),
+          SqlKind.OTHER_FUNCTION, null, null, OperandTypes.NILADIC,
           SqlFunctionCategory.USER_DEFINED_FUNCTION);
     }
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
@@ -34,6 +34,8 @@ import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.runtime.Hook;
+import org.apache.calcite.sql.test.SqlTestFactory;
+import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Closer;
@@ -238,6 +240,15 @@ abstract class RelOptTestBase extends SqlToRelTestBase {
 
     public Sql withTrim(final boolean b) {
       return withTransform(tester -> tester.withTrim(b));
+    }
+
+    public Sql withCatalogReaderFactory(
+        SqlTestFactory.MockCatalogReaderFactory factory) {
+      return withTransform(tester -> tester.withCatalogReaderFactory(factory));
+    }
+
+    public Sql withConformance(final SqlConformance conformance) {
+      return withTransform(tester -> tester.withConformance(conformance));
     }
 
     public Sql withContext(final Context context) {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
@@ -55,6 +55,7 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
@@ -691,8 +692,15 @@ public abstract class SqlToRelTestBase {
     public SqlValidator createValidator(
         SqlValidatorCatalogReader catalogReader,
         RelDataTypeFactory typeFactory) {
+      final SqlOperatorTable operatorTable = getOperatorTable();
+      final SqlConformance conformance = getConformance();
+      final List<SqlOperatorTable> list = new ArrayList<>();
+      list.add(operatorTable);
+      if (conformance.allowGeometry()) {
+        list.add(SqlOperatorTables.spatialInstance());
+      }
       return new FarragoTestValidator(
-          getOperatorTable(),
+          SqlOperatorTables.chain(list),
           catalogReader,
           typeFactory,
           SqlValidator.Config.DEFAULT
@@ -865,7 +873,7 @@ public abstract class SqlToRelTestBase {
     }
   }
 
-    /** Validator for testing. */
+  /** Validator for testing. */
   private static class FarragoTestValidator extends SqlValidatorImpl {
     FarragoTestValidator(
         SqlOperatorTable opTab,

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8111,7 +8111,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select ^sum(ramp(3))^ from (values (1))")
         .fails("Cannot apply 'SUM' to arguments of type 'SUM\\(<CURSOR>\\)'\\. "
             + "Supported form\\(s\\): 'SUM\\(<NUMERIC>\\)'");
-    sql("select * from (values (1)) group by ^ramp(3)^")
+    sql("select 0 from (values (1)) group by ^ramp(3)^")
         .fails("Cannot call table function here: 'RAMP'");
     sql("select count(*) from (values (1)) having ^ramp(3)^")
         .fails("HAVING clause must be a condition");

--- a/core/src/test/java/org/apache/calcite/test/catalog/Fixture.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/Fixture.java
@@ -71,7 +71,7 @@ final class Fixture extends AbstractFixture {
   final RelDataType abRecordType = typeFactory.builder()
       .add("A", varchar10Type)
       .add("B", varchar10Type)
-      .build();;
+      .build();
   final RelDataType skillRecordType = typeFactory.builder()
       .add("TYPE", varchar10Type)
       .add("DESC", varchar20Type)

--- a/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -42,7 +42,7 @@ import java.util.List;
  * Simple catalog reader for testing.
  */
 public class MockCatalogReaderSimple extends MockCatalogReader {
-  private final Fixture fixture;
+  private final ObjectSqlType addressType;
 
   /**
    * Creates a MockCatalogReader.
@@ -55,19 +55,20 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
   public MockCatalogReaderSimple(RelDataTypeFactory typeFactory,
       boolean caseSensitive) {
     super(typeFactory, caseSensitive);
-    fixture = new Fixture(typeFactory);
+
+    addressType = new Fixture(typeFactory).addressType;
   }
 
   @Override public RelDataType getNamedType(SqlIdentifier typeName) {
-    if (typeName.equalsDeep(fixture.addressType.getSqlIdentifier(), Litmus.IGNORE)) {
-      return fixture.addressType;
+    if (typeName.equalsDeep(addressType.getSqlIdentifier(), Litmus.IGNORE)) {
+      return addressType;
     } else {
       return super.getNamedType(typeName);
     }
   }
 
   @Override public MockCatalogReader init() {
-    ObjectSqlType addressType = fixture.addressType;
+    final Fixture fixture = new Fixture(typeFactory);
 
     // Register "SALES" schema.
     MockSchema salesSchema = new MockSchema("SALES");

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -71,8 +71,8 @@ import org.apache.calcite.sql.test.SqlTests;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.calcite.sql.util.ListSqlOperatorTable;
+import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.test.CalciteAssert;
@@ -204,7 +204,7 @@ class PlannerTest {
   @Test void testValidateUserDefinedAggregate() throws Exception {
     final SqlStdOperatorTable stdOpTab = SqlStdOperatorTable.instance();
     SqlOperatorTable opTab =
-        ChainedSqlOperatorTable.of(stdOpTab,
+        SqlOperatorTables.chain(stdOpTab,
             new ListSqlOperatorTable(
                 ImmutableList.of(new MyCountAggFunction())));
     final SchemaPlus rootSchema = Frameworks.createRootSchema(true);

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4169,7 +4169,9 @@ LogicalProject(EXPR$0=[CAST(/($2, $3)):INTEGER NOT NULL])
     </TestCase>
     <TestCase name="testNoOversimplificationBelowIsNull">
         <Resource name="sql">
-            <![CDATA[select * from emp where ( (empno=1 and mgr=1) or (empno=null and mgr=1) ) is null]]>
+            <![CDATA[select *
+from emp
+where ( (empno=1 and mgr=1) or (empno=null and mgr=1) ) is null]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
@@ -8560,6 +8562,28 @@ LogicalProject(N=[$0])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testSpatialDWithinToHilbert">
+        <Resource name="sql">
+            <![CDATA[select *
+from GEO.Restaurants as r
+where ST_DWithin(ST_Point(10.0, 20.0),
+                 ST_Point(r.longitude, r.latitude), 10)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[ST_DWITHIN(ST_POINT(10.0:DECIMAL(3, 1), 20.0:DECIMAL(3, 1)), ST_POINT($2, $1), 10)])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[AND(OR(AND(>=($4, 36556), <=($4, 36568)), AND(>=($4, 36447), <=($4, 36548)), AND(>=($4, 36442), <=($4, 36445)), AND(>=($4, 36425), <=($4, 36427)), AND(>=($4, 36421), <=($4, 36423)), AND(>=($4, 36403), <=($4, 36404)), AND(>=($4, 36392), <=($4, 36401)), AND(>=($4, 33267), <=($4, 33270)), AND(>=($4, 33231), <=($4, 33265)), AND(>=($4, 33226), <=($4, 33229)), AND(>=($4, 33209), <=($4, 33211)), AND(>=($4, 33205), <=($4, 33207)), AND(>=($4, 33187), <=($4, 33190)), AND(>=($4, 33014), <=($4, 33185)), AND(>=($4, 33009), <=($4, 33011)), AND(>=($4, 32973), <=($4, 32975)), AND(>=($4, 32955), <=($4, 32970)), AND(>=($4, 32951), <=($4, 32953)), AND(>=($4, 32942), <=($4, 32949)), AND(>=($4, 32929), <=($4, 32930)), AND(>=($4, 32526), <=($4, 32527)), AND(>=($4, 32511), <=($4, 32514)), AND(>=($4, 32506), <=($4, 32509)), AND(>=($4, 32451), <=($4, 32454)), AND(>=($4, 32446), <=($4, 32449)), AND(>=($4, 32431), <=($4, 32434)), AND(>=($4, 32426), <=($4, 32429)), AND(>=($4, 29011), <=($4, 29014)), AND(>=($4, 29006), <=($4, 29009)), AND(>=($4, 28991), <=($4, 28994)), AND(>=($4, 28988), <=($4, 28989))), ST_DWITHIN(POINT (10 20):GEOMETRY, ST_POINT($2, $1), 10))])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testSwapOuterJoin">
         <Resource name="sql">
             <![CDATA[select 1 from sales.dept d left outer join sales.emp e
@@ -8585,8 +8609,9 @@ LogicalProject(EXPR$0=[1])
     </TestCase>
     <TestCase name="testDistinctCountMultipleViaJoin">
         <Resource name="sql">
-            <![CDATA[select deptno, count(distinct ename), count(distinct job, ename),
-count(distinct deptno, job), sum(sal)
+            <![CDATA[select deptno, count(distinct ename),
+  count(distinct job, ename),
+  count(distinct deptno, job), sum(sal)
 from sales.emp group by deptno]]>
         </Resource>
         <Resource name="planBefore">
@@ -8618,7 +8643,8 @@ LogicalProject(DEPTNO=[$0], EXPR$1=[$3], EXPR$2=[$5], EXPR$3=[$7], EXPR$4=[$1])
     </TestCase>
     <TestCase name="testDistinctCountMultiple">
         <Resource name="sql">
-            <![CDATA[select deptno, count(distinct ename), count(distinct job)
+            <![CDATA[select deptno, count(distinct ename),
+  count(distinct job)
 from sales.emp group by deptno]]>
         </Resource>
         <Resource name="planBefore">
@@ -8661,7 +8687,8 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT($0) FILTER $2], EXPR$1=[COUNT($1) FIL
     </TestCase>
     <TestCase name="testDistinctCountMixed">
         <Resource name="sql">
-            <![CDATA[select deptno, count(distinct deptno, job) as cddj, sum(sal) as s
+            <![CDATA[select deptno, count(distinct deptno, job) as cddj,
+  sum(sal) as s
 from sales.emp group by deptno]]>
         </Resource>
         <Resource name="planBefore">
@@ -9017,7 +9044,8 @@ LogicalAggregate(group=[{}], VOLUME=[$SUM0($0)], C1_SUM_SAL=[SUM($1)])
     </TestCase>
     <TestCase name="testPushDistinctAggregateIntoJoin">
         <Resource name="sql">
-            <![CDATA[select count(distinct sal) from sales.emp join sales.dept on job = name]]>
+            <![CDATA[select count(distinct sal) from sales.emp
+ join sales.dept on job = name]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
@@ -9399,6 +9427,136 @@ LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], EXPR$2=[SUM($2
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testSpatialContainsPoint">
+        <Resource name="sql">
+            <![CDATA[select *
+from GEO.Restaurants as r
+where ST_Contains(
+  ST_Buffer(ST_Point(10.0, 20.0), 6),
+  ST_Point(r.longitude, r.latitude))]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[ST_CONTAINS(ST_BUFFER(ST_POINT(10.0:DECIMAL(3, 1), 20.0:DECIMAL(3, 1)), 6), ST_POINT($2, $1))])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[AND(OR(AND(>=($4, 36496), <=($4, 36520)), AND(>=($4, 36456), <=($4, 36464)), AND(>=($4, 33252), <=($4, 33254)), AND(>=($4, 33236), <=($4, 33244)), AND(>=($4, 33164), <=($4, 33176)), AND(>=($4, 33112), <=($4, 33156)), AND(>=($4, 33092), <=($4, 33100)), AND(>=($4, 33055), <=($4, 33080)), AND(>=($4, 33050), <=($4, 33053)), AND(>=($4, 33033), <=($4, 33035))), ST_CONTAINS(MULTIPOLYGON (((16 20, 15.987153539431617 20.39241877538086, 15.948669168242859 20.78315715332031, 15.884711682419379 21.17054193209677, 15.795554957734407 21.552914270615126, 15.68158077697063 21.92863679181897, 15.543277195067716 22.296100594190538, 15.381236449196127 22.65373214131401, 15.196152422706628 23, 14.98881767381527 23.333421398117615, 14.76012004174741 23.652568574052324, 14.511038844873863 23.956074890600412, 14.242640687119284 24.242640687119284, 13.956074890600412 24.511038844873866, 13.652568574052323 24.760120041747413, 13.333421398117613 24.988817673815273, 13 25.196152422706632, 12.653732141314007 25.38123644919613, 12.296100594190538 25.54327719506772, 11.928636791818969 25.681580776970634, 11.552914270615124 25.79555495773441, 11.17054193209677 25.884711682419383, 10.78315715332031 25.948669168242862, 10.392418775380857 25.98715353943162, 10 26, 9.60758122461914 25.987153539431617, 9.21684284667969 25.94866916824286, 8.82945806790323 25.88471168241938, 8.447085729384876 25.795554957734407, 8.07136320818103 25.68158077697063, 7.703899405809461 25.543277195067716, 7.346267858685993 25.381236449196127, 7 25.19615242270663, 6.666578601882387 24.98881767381527, 6.347431425947676 24.76012004174741, 6.043925109399586 24.511038844873863, 5.757359312880714 24.242640687119284, 5.488961155126135 23.956074890600412, 5.239879958252589 23.652568574052324, 5.011182326184728 23.33342139811761, 4.803847577293368 23, 4.6187635508038705 22.653732141314006, 4.45672280493228 22.296100594190538, 4.318419223029367 21.92863679181897, 4.204445042265591 21.552914270615123, 4.115288317580618 21.170541932096768, 4.051330831757139 20.78315715332031, 4.01284646056838 20.392418775380857, 4 20, 4.012846460568384 19.60758122461914, 4.051330831757142 19.21684284667969, 4.115288317580622 18.82945806790323, 4.204445042265594 18.447085729384874, 4.31841922302937 18.07136320818103, 4.456722804932283 17.703899405809462, 4.618763550803873 17.34626785868599, 4.803847577293371 17, 5.011182326184731 16.666578601882385, 5.239879958252591 16.347431425947676, 5.4889611551261375 16.043925109399588, 5.757359312880716 15.757359312880714, 6.043925109399588 15.488961155126134, 6.347431425947677 15.239879958252589, 6.666578601882387 15.011182326184727, 7.000000000000001 14.803847577293368, 7.346267858685993 14.61876355080387, 7.703899405809462 14.45672280493228, 8.071363208181031 14.318419223029366, 8.447085729384876 14.20444504226559, 8.82945806790323 14.115288317580617, 9.21684284667969 14.051330831757138, 9.607581224619143 14.01284646056838, 10 14, 10.39241877538086 14.012846460568383, 10.78315715332031 14.051330831757141, 11.17054193209677 14.115288317580621, 11.552914270615124 14.204445042265593, 11.92863679181897 14.31841922302937, 12.296100594190538 14.456722804932284, 12.653732141314007 14.618763550803873, 13 14.803847577293372, 13.333421398117613 15.01118232618473, 13.652568574052324 15.23987995825259, 13.956074890600414 15.488961155126137, 14.242640687119286 15.757359312880716, 14.511038844873866 16.043925109399588, 14.760120041747411 16.347431425947676, 14.988817673815273 16.66657860188239, 15.196152422706632 17, 15.38123644919613 17.346267858685994, 15.54327719506772 17.703899405809462, 15.681580776970634 18.07136320818103, 15.79555495773441 18.447085729384877, 15.884711682419383 18.829458067903232, 15.948669168242862 19.21684284667969, 15.98715353943162 19.607581224619143, 16 20))):GEOMETRY, ST_POINT($2, $1)))])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSpatialDWithinLine">
+        <Resource name="sql">
+            <![CDATA[select *
+from GEO.Restaurants as r
+where ST_DWithin(
+  ST_MakeLine(ST_Point(8.0, 20.0), ST_Point(12.0, 20.0)),
+  ST_Point(r.longitude, r.latitude), 4)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[ST_DWITHIN(ST_MAKELINE(ST_POINT(8.0:DECIMAL(2, 1), 20.0:DECIMAL(3, 1)), ST_POINT(12.0:DECIMAL(3, 1), 20.0:DECIMAL(3, 1))), ST_POINT($2, $1), 4)])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[AND(OR(AND(>=($4, 36517), <=($4, 36519)), AND(>=($4, 36505), <=($4, 36507)), AND(>=($4, 36501), <=($4, 36503)), AND(>=($4, 36457), <=($4, 36459)), AND(>=($4, 33236), <=($4, 33240)), AND(>=($4, 33164), <=($4, 33176)), AND(>=($4, 33112), <=($4, 33156)), AND(>=($4, 33092), <=($4, 33100)), AND(>=($4, 33064), <=($4, 33076))), ST_DWITHIN(MULTILINESTRING ((8 20, 12 20)):GEOMETRY, ST_POINT($2, $1), 4))])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSpatialDWithinReversed">
+        <Resource name="sql">
+            <![CDATA[select *
+from GEO.Restaurants as r
+where ST_DWithin(ST_Point(r.longitude, r.latitude),
+                 ST_Point(10.0, 20.0), 6)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[ST_DWITHIN(ST_POINT($2, $1), ST_POINT(10.0:DECIMAL(3, 1), 20.0:DECIMAL(3, 1)), 6)])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[AND(OR(AND(>=($4, 36496), <=($4, 36520)), AND(>=($4, 36456), <=($4, 36464)), AND(>=($4, 33252), <=($4, 33254)), AND(>=($4, 33236), <=($4, 33244)), AND(>=($4, 33164), <=($4, 33176)), AND(>=($4, 33112), <=($4, 33156)), AND(>=($4, 33092), <=($4, 33100)), AND(>=($4, 33055), <=($4, 33080)), AND(>=($4, 33050), <=($4, 33053)), AND(>=($4, 33033), <=($4, 33035))), ST_DWITHIN(ST_POINT($2, $1), POINT (10 20):GEOMETRY, 6))])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSpatialDWithinToHilbertNegative">
+        <Resource name="sql">
+            <![CDATA[select *
+from GEO.Restaurants as r
+where ST_DWithin(ST_Point(10.0, 20.0),
+                 ST_Point(r.longitude, r.latitude), -2)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[ST_DWITHIN(ST_POINT(10.0:DECIMAL(3, 1), 20.0:DECIMAL(3, 1)), ST_POINT($2, $1), -2)])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalValues(tuples=[[]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSpatialDWithinToHilbertZero">
+        <Resource name="sql">
+            <![CDATA[select *
+from GEO.Restaurants as r
+where ST_DWithin(ST_Point(10.0, 20.0),
+                 ST_Point(r.longitude, r.latitude), 0)]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[ST_DWITHIN(ST_POINT(10.0:DECIMAL(3, 1), 20.0:DECIMAL(3, 1)), ST_POINT($2, $1), 0)])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(NAME=[$0], LATITUDE=[$1], LONGITUDE=[$2], CUISINE=[$3], HILBERT=[$4])
+  LogicalFilter(condition=[AND(=($4, 33139), =(POINT (10 20), ST_POINT($2, $1)))])
+    LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testSpatialReduce">
+        <Resource name="sql">
+            <![CDATA[select
+  ST_Buffer(ST_Point(0.0, 1.0), 2) as b
+from GEO.Restaurants as r]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(B=[ST_BUFFER(ST_POINT(0.0:DECIMAL(2, 1), 1.0:DECIMAL(2, 1)), 2)])
+  LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(B=[CAST(MULTIPOLYGON (((2 1, 1.9957178464772056 1.1308062584602858, 1.9828897227476194 1.2610523844401027, 1.9615705608064595 1.3901806440322562, 1.9318516525781353 1.517638090205041, 1.8938602589902103 1.6428789306063227, 1.8477590650225726 1.7653668647301788, 1.7937454830653756 1.8845773804380017, 1.7320508075688765 1.9999999999999991, 1.6629392246050898 2.1111404660392035, 1.5867066805824699 2.217522858017441, 1.5036796149579543 2.318691630200137, 1.4142135623730947 2.4142135623730945, 1.3186916302001375 2.5036796149579543, 1.217522858017441 2.58670668058247, 1.1111404660392044 2.66293922460509, 0.9999999999999999 2.7320508075688767, 0.8845773804380025 2.7937454830653765, 0.7653668647301795 2.847759065022573, 0.6428789306063231 2.893860258990211, 0.5176380902050415 2.9318516525781364, 0.3901806440322565 2.961570560806461, 0.26105238444010315 2.982889722747621, 0.13080625846028612 2.995717846477207, 0 3, -0.13080625846028585 2.9957178464772056, -0.2610523844401028 2.982889722747619, -0.3901806440322561 2.9615705608064595, -0.517638090205041 2.9318516525781355, -0.6428789306063226 2.8938602589902103, -0.7653668647301789 2.8477590650225726, -0.8845773804380018 2.7937454830653756, -0.9999999999999992 2.7320508075688767, -1.1111404660392037 2.66293922460509, -1.2175228580174406 2.58670668058247, -1.318691630200137 2.5036796149579543, -1.4142135623730945 2.414213562373095, -1.5036796149579543 2.3186916302001377, -1.5867066805824699 2.217522858017441, -1.66293922460509 2.1111404660392044, -1.732050807568877 2, -1.7937454830653763 1.8845773804380026, -1.8477590650225733 1.7653668647301795, -1.8938602589902112 1.6428789306063232, -1.9318516525781366 1.5176380902050415, -1.9615705608064609 1.3901806440322564, -1.9828897227476208 1.2610523844401031, -1.995717846477207 1.130806258460286, -2 1, -1.9957178464772056 0.8691937415397142, -1.9828897227476194 0.7389476155598972, -1.9615705608064595 0.6098193559677438, -1.9318516525781353 0.48236190979495897, -1.8938602589902103 0.3571210693936774, -1.8477590650225726 0.2346331352698211, -1.7937454830653756 0.11542261956199817, -1.7320508075688765 7.7715611723760960e-16, -1.6629392246050898 -0.11114046603920369, -1.5867066805824699 -0.21752285801744065, -1.5036796149579543 -0.318691630200137, -1.4142135623730947 -0.4142135623730945, -1.3186916302001375 -0.5036796149579543, -1.217522858017441 -0.5867066805824699, -1.1111404660392044 -0.66293922460509, -0.9999999999999999 -0.732050807568877, -0.8845773804380025 -0.7937454830653763, -0.7653668647301795 -0.8477590650225733, -0.6428789306063231 -0.8938602589902112, -0.5176380902050415 -0.9318516525781366, -0.3901806440322565 -0.9615705608064609, -0.26105238444010315 -0.9828897227476208, -0.13080625846028612 -0.995717846477207, 0 -1, 0.13080625846028585 -0.9957178464772056, 0.2610523844401028 -0.9828897227476194, 0.3901806440322561 -0.9615705608064595, 0.517638090205041 -0.9318516525781353, 0.6428789306063226 -0.8938602589902103, 0.7653668647301789 -0.8477590650225726, 0.8845773804380018 -0.7937454830653756, 0.9999999999999992 -0.7320508075688765, 1.1111404660392037 -0.6629392246050898, 1.2175228580174406 -0.5867066805824699, 1.318691630200137 -0.5036796149579543, 1.4142135623730945 -0.4142135623730947, 1.5036796149579543 -0.31869163020013747, 1.5867066805824699 -0.2175228580174411, 1.66293922460509 -0.11114046603920436, 1.732050807568877 1.1102230246251565e-16, 1.7937454830653763 0.11542261956199751, 1.8477590650225733 0.23463313526982055, 1.8938602589902112 0.35712106939367694, 1.9318516525781366 0.4823619097949585, 1.9615705608064609 0.6098193559677435, 1.9828897227476208 0.7389476155598969, 1.995717846477207 0.8691937415397138, 2 1))):GEOMETRY):GEOMETRY])
+  LogicalTableScan(table=[[CATALOG, GEO, RESTAURANTS]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testAggregateRemove6">
         <Resource name="sql">
             <![CDATA[select deptno, max(sal) from sales.emp group by deptno
@@ -9472,7 +9630,8 @@ LogicalAggregate(group=[{7}])
     </TestCase>
     <TestCase name="testAggregateJoinRemove2">
         <Resource name="sql">
-            <![CDATA[select e.deptno, count(distinct e.job) from sales.emp e
+            <![CDATA[select e.deptno, count(distinct e.job)
+from sales.emp e
 left outer join sales.dept d on e.deptno = d.deptno
 group by e.deptno]]>
         </Resource>
@@ -9494,7 +9653,8 @@ LogicalAggregate(group=[{7}], EXPR$1=[COUNT(DISTINCT $2)])
     </TestCase>
     <TestCase name="testAggregateJoinRemove3">
         <Resource name="sql">
-            <![CDATA[select e.deptno, count(distinct d.name) from sales.emp e
+            <![CDATA[select e.deptno, count(distinct d.name)
+from sales.emp e
 left outer join sales.dept d on e.deptno = d.deptno
 group by e.deptno]]>
         </Resource>
@@ -9518,7 +9678,8 @@ LogicalAggregate(group=[{7}], EXPR$1=[COUNT(DISTINCT $10)])
     </TestCase>
     <TestCase name="testAggregateJoinRemove4">
         <Resource name="sql">
-            <![CDATA[select distinct d.deptno from sales.emp e
+            <![CDATA[select distinct d.deptno
+from sales.emp e
 right outer join sales.dept d on e.deptno = d.deptno]]>
         </Resource>
         <Resource name="planBefore">
@@ -9539,7 +9700,8 @@ LogicalProject(DEPTNO=[$0])
     </TestCase>
     <TestCase name="testAggregateJoinRemove5">
         <Resource name="sql">
-            <![CDATA[select d.deptno, count(distinct d.name) from sales.emp e
+            <![CDATA[select d.deptno, count(distinct d.name)
+from sales.emp e
 right outer join sales.dept d on e.deptno = d.deptno
 group by d.deptno]]>
         </Resource>
@@ -9561,7 +9723,8 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT(DISTINCT $1)])
     </TestCase>
     <TestCase name="testAggregateJoinRemove6">
         <Resource name="sql">
-            <![CDATA[select d.deptno, count(distinct e.job) from sales.emp e
+            <![CDATA[select d.deptno, count(distinct e.job)
+from sales.emp e
 right outer join sales.dept d on e.deptno = d.deptno
 group by d.deptno]]>
         </Resource>
@@ -12724,7 +12887,10 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT($0)], EXPR$2=[BIT_O
     </TestCase>
     <TestCase name="testProjectJoinTransposeItem">
         <Resource name="sql">
-            <![CDATA[select t1.c_nationkey[0], t2.c_nationkey[0] from sales.customer as t1 left outer join sales.customer as t2 on t1.c_nationkey[0] = t2.c_nationkey[0]]]>
+            <![CDATA[select t1.c_nationkey[0], t2.c_nationkey[0]
+from sales.customer as t1
+left outer join sales.customer as t2
+on t1.c_nationkey[0] = t2.c_nationkey[0]]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[
@@ -12751,7 +12917,9 @@ LogicalProject(EXPR$0=[$1], EXPR$1=[$3])
     </TestCase>
     <TestCase name="testSimplifyItemIsNotNull">
         <Resource name="sql">
-            <![CDATA[select * from sales.customer as t1 where t1.c_nationkey[0] is not null]]>
+            <![CDATA[select *
+from sales.customer as t1
+where t1.c_nationkey[0] is not null]]>
         </Resource>
         <Resource name="planBefore">
             <![CDATA[

--- a/core/src/test/resources/sql/spatial.iq
+++ b/core/src/test/resources/sql/spatial.iq
@@ -265,7 +265,17 @@ EXPR$0
 # Not implemented
 
 # ST_MakeEnvelope(xMin, yMin, xMax, yMax  [, srid ]) Creates a rectangular Polygon
-# Not implemented
+SELECT ST_AsText(ST_MakeEnvelope(10.0, 10.0, 11.0, 11.0, 4326));
+
+EXPR$0
+MULTIPOLYGON (((10 10, 11 10, 11 11, 10 11, 10 10)))
+!ok
+
+SELECT ST_AsText(ST_MakeEnvelope(12.0, -1.0, 6.0, 4.0, 4326));
+
+EXPR$0
+MULTIPOLYGON (((12 -1, 12 4, 6 4, 6 -1, 12 -1)))
+!ok
 
 # ST_MakeGrid(geom, deltaX, deltaY) Calculates a regular grid of polygons based on *geom*
 SELECT * FROM TABLE(ST_MakeGrid(ST_Point(13.0,22.0), 10.0, 5.0));
@@ -283,12 +293,12 @@ THE_GEOM, ID, ID_COL, ID_ROW, ABS_COL, ABS_ROW
 select "name", "latitude", "longitude", p.*
 from GEO."countries" AS c,
   lateral table(
-    ST_MakeGridPoints(ST_MakePoint("latitude", "longitude"), 10.0, 10.0)) as p
+    ST_MakeGridPoints(ST_MakePoint("longitude", "latitude"), 10.0, 10.0)) as p
 ORDER BY "latitude" DESC LIMIT 3;
 name, latitude, longitude, THE_GEOM, ID, ID_COL, ID_ROW, ABS_COL, ABS_ROW
-Svalbard and Jan Mayen, 77.553604, 23.670272, {"x":75,"y":25}, 0, 1, 1, 7, 2
-Greenland, 71.706936, -42.604303, {"x":75,"y":-45}, 0, 1, 1, 7, -5
-Iceland, 64.963051, -19.020835, {"x":65,"y":-15}, 0, 1, 1, 6, -2
+Svalbard and Jan Mayen, 77.553604, 23.670272, {"x":25,"y":75}, 0, 1, 1, 2, 7
+Greenland, 71.706936, -42.604303, {"x":-45,"y":75}, 0, 1, 1, -5, 7
+Iceland, 64.963051, -19.020835, {"x":-15,"y":65}, 0, 1, 1, -2, 6
 !ok
 
 # ST_MakeLine(point1 [, point ]*) Creates a line-string from the given points (or multi-points)
@@ -341,13 +351,13 @@ EXPR$0
 1.5
 !ok
 
-select "name", ST_MakePoint("latitude", "longitude") AS p
+select "name", ST_MakePoint("longitude", "latitude") AS p
 from GEO."countries" AS c
 ORDER BY "latitude" DESC LIMIT 3;
 name, P
 U.S.Minor Outlying Islands, null
-Svalbard and Jan Mayen, {"x":77.553604,"y":23.670272}
-Greenland, {"x":71.706936,"y":-42.604303}
+Svalbard and Jan Mayen, {"x":23.670272,"y":77.553604}
+Greenland, {"x":-42.604303,"y":71.706936}
 !ok
 
 # ST_MakePolygon(lineString [, hole ]*) Creates a polygon from *lineString* with the given holes (which are required to be closed line-strings)
@@ -697,7 +707,7 @@ true
 
 # Countries within 10 degrees of London
 select "name" from GEO."countries" AS c
-where ST_Distance(ST_MakePoint(51.5, -0.12), ST_MakePoint("latitude", "longitude")) < 10;
+where ST_Distance(ST_MakePoint(-0.12, 51.5), ST_MakePoint("longitude", "latitude")) < 10;
 name
 Andorra
 Belgium
@@ -714,7 +724,7 @@ United Kingdom
 
 # Countries within 10 degrees of London, formulated a different way
 select "name" from GEO."countries" AS c
-where ST_DWithin(ST_MakePoint(51.5, -0.12), ST_MakePoint("latitude", "longitude"), 10);
+where ST_DWithin(ST_MakePoint(-0.12, 51.5), ST_MakePoint("longitude", "latitude"), 10);
 name
 Andorra
 Belgium
@@ -834,7 +844,7 @@ EXPR$0
 SELECT ST_Buffer(
  ST_GeomFromText('POINT(100 90)'),
  50, 'quad_segs=8');
-at org.apache.calcite.runtime.GeoFunctions.todo
+at org.apache.calcite.runtime.Geometries.todo
 !error GeoFunctions
 
 # ST_BUFFER(geom, bufferSize, quadSegs) variant - not implemented
@@ -842,7 +852,7 @@ at org.apache.calcite.runtime.GeoFunctions.todo
 SELECT ST_Buffer(
  ST_GeomFromText('POINT(100 90)'),
  50, 2);
-at org.apache.calcite.runtime.GeoFunctions.todo
+at org.apache.calcite.runtime.Geometries.todo
 !error GeoFunctions
 !}
 
@@ -1233,6 +1243,29 @@ ID, Yellowstone NP
 MT, Yellowstone NP
 WY, Yellowstone NP
 CA, Yosemite NP
+!ok
+
+# Space-filling curves.
+select x, y, hilbert(ST_Point(x, y))
+from (
+  values (0.0, 0.0),
+     (0, 1),
+     (1, 0),
+     (0, -1),
+     (10, 10),
+     (20, 20)) as t(x, y);
+X, Y, EXPR$2
+0.0, -1.0, 10921
+0.0, 0.0, 10922
+0.0, 1.0, 32767
+1.0, 0.0, 54613
+10.0, 10.0, 32973
+20.0, 20.0, 33204
+!ok
+
+values hilbert(ST_Point(20.0, 20.0));
+EXPR$0
+33204
 !ok
 
 # End spatial.iq

--- a/gradle.properties
+++ b/gradle.properties
@@ -134,5 +134,6 @@ spark.version=2.2.2
 sqlline.version=1.9.0
 teradata.tpcds.version=1.2
 tpch.version=0.1
+uzaygezen.version=0.2
 xalan.version=2.7.1
 xercesImpl.version=2.9.1

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/function/Hints.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/function/Hints.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.linq4j.function;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Annotation applied to a user-defined function that gives extra metadata
+ * about that function.
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>@Hints("SqlKind:ST_DWithin") public static void myFun()</li>
+ * </ul>
+ */
+@Target({METHOD, TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Experimental
+public @interface Hints {
+  String[] value();
+}

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
@@ -16,12 +16,12 @@
  */
 package org.apache.calcite.piglet;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.schema.Function;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
@@ -30,45 +30,33 @@ import org.apache.pig.FuncSpec;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.List;
-
 /** Pig user-defined function. */
 public class PigUserDefinedFunction extends SqlUserDefinedFunction {
   public final FuncSpec funcSpec;
   private PigUserDefinedFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
-      SqlOperandTypeChecker operandTypeChecker,
-      List<RelDataType> paramTypes,
+      SqlOperandMetadata operandMetadata,
       Function function,
       FuncSpec funcSpec) {
-    super(opName, returnTypeInference, operandTypeInference, operandTypeChecker, paramTypes,
-        function,
+    super(opName, SqlKind.OTHER_FUNCTION, returnTypeInference,
+        operandTypeInference, operandMetadata, function,
         SqlFunctionCategory.USER_DEFINED_CONSTRUCTOR);
     this.funcSpec = funcSpec;
   }
 
   public PigUserDefinedFunction(String name,
       SqlReturnTypeInference returnTypeInference,
-      SqlOperandTypeChecker operandTypeChecker,
-      List<RelDataType> paramTypes,
-      Function function,
+      SqlOperandMetadata operandMetadata, Function function,
       FuncSpec funcSpec) {
     this(new SqlIdentifier(ImmutableList.of(name), SqlParserPos.ZERO),
-        returnTypeInference,
-        null,
-        operandTypeChecker,
-        paramTypes,
-        function,
-        funcSpec);
+        returnTypeInference, null, operandMetadata, function, funcSpec);
   }
 
   public PigUserDefinedFunction(String name,
       SqlReturnTypeInference returnTypeInference,
-      SqlOperandTypeChecker operandTypeChecker,
-      List<RelDataType> paramTypes,
-      Function function) {
-    this(name, returnTypeInference, operandTypeChecker, paramTypes, function, null);
+      SqlOperandMetadata operandMetadata, Function function) {
+    this(name, returnTypeInference, operandMetadata, function, null);
   }
 
 }

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 /** Pig user-defined function. */
 public class PigUserDefinedFunction extends SqlUserDefinedFunction {
   public final FuncSpec funcSpec;
+
   private PigUserDefinedFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
@@ -58,5 +59,4 @@ public class PigUserDefinedFunction extends SqlUserDefinedFunction {
       SqlOperandMetadata operandMetadata, Function function) {
     this(name, returnTypeInference, operandMetadata, function, null);
   }
-
 }

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2057,6 +2057,7 @@ Not implemented:
 
 | C | Operator syntax      | Description
 |:- |:-------------------- |:-----------
+| p | ST_MakeEnvelope(xMin, yMin, xMax, yMax  [, srid ]) | Creates a rectangular POLYGON
 | h | ST_MakeGrid(geom, deltaX, deltaY) | Calculates a regular grid of POLYGONs based on *geom*
 | h | ST_MakeGridPoints(geom, deltaX, deltaY) | Calculates a regular grid of points based on *geom*
 | o | ST_MakeLine(point1 [, point ]*) | Creates a line-string from the given POINTs (or MULTIPOINTs)
@@ -2069,7 +2070,6 @@ Not implemented:
 * ST_Expand(geom, distance) Expands *geom*'s envelope
 * ST_Expand(geom, deltaX, deltaY) Expands *geom*'s envelope
 * ST_MakeEllipse(point, width, height) Constructs an ellipse
-* ST_MakeEnvelope(xMin, yMin, xMax, yMax  [, srid ]) Creates a rectangular POLYGON
 * ST_MakePolygon(lineString [, hole ]*) Creates a POLYGON from *lineString* with the given holes (which are required to be closed LINESTRINGs)
 * ST_MinimumDiameter(geom) Returns the minimum diameter of *geom*
 * ST_MinimumRectangle(geom) Returns the minimum rectangle enclosing *geom*

--- a/site/_docs/spatial.md
+++ b/site/_docs/spatial.md
@@ -69,6 +69,85 @@ SELECT ST_PointFromText('POINT(-71.064544 42.28787)');
 1 row selected (0.323 seconds)
 {% endhighlight %}
 
+## Query rewrites
+
+One class of rewrites uses
+[Hilbert space-filling curves](https://en.wikipedia.org/wiki/Hilbert_curve).
+Suppose that a table
+has columns `x` and `y` denoting the position of a point and also a column `h`
+denoting the distance of that point along a curve. Then a predicate involving
+distance of (x, y) from a fixed point can be translated into a predicate
+involving ranges of h.
+
+Suppose we have a table with the locations of restaurants:
+
+{% highlight sql %}
+CREATE TABLE Restaurants (
+  INT id NOT NULL PRIMARY KEY,
+  VARCHAR(30) name,
+  VARCHAR(20) cuisine,
+  INT x NOT NULL,
+  INT y NOT NULL,
+  INT h  NOT NULL DERIVED (ST_Hilbert(x, y)))
+SORT KEY (h);
+{% endhighlight %}
+
+The optimizer requires that `h` is the position on the Hilbert curve of
+point (`x`, `y`), and also requires that the table is sorted on `h`.
+The `DERIVED` and `SORT KEY` clauses in the DDL syntax are invented for the
+purposes of this example, but a clustered table with a `CHECK` constraint
+would work just as well.
+
+The query
+
+{% highlight sql %}
+SELECT *
+FROM Restaurants
+WHERE ST_DWithin(ST_Point(x, y), ST_Point(10.0, 20.0), 6)
+{% endhighlight %}
+
+can be rewritten to
+
+{% highlight sql %}
+SELECT *
+FROM Restaurants
+WHERE (h BETWEEN 36496 AND 36520
+    OR h BETWEEN 36456 AND 36464
+    OR h BETWEEN 33252 AND 33254
+    OR h BETWEEN 33236 AND 33244
+    OR h BETWEEN 33164 AND 33176
+    OR h BETWEEN 33092 AND 33100
+    OR h BETWEEN 33055 AND 33080
+    OR h BETWEEN 33050 AND 33053
+    OR h BETWEEN 33033 AND 33035)
+AND ST_DWithin(ST_Point(x, y), ST_Point(10.0, 20.0), 6)
+{% endhighlight %}
+
+The rewritten query contains a collection of ranges on `h` followed by the
+original `ST_DWithin` predicate. The range predicates are evaluated first and
+are very fast because the table is sorted on `h`.
+
+Here is the full set of transformations:
+
+| Description | Expression
+|:----------- |: ------
+| Test whether a constant rectangle (X, X2, Y, Y2) contains a point (a, b)<br/><br/>Rewrite to use Hilbert index | ST_Contains(&#8203;ST_Rectangle(&#8203;X, X2, Y, Y2), ST_Point(a, b)))<br/><br/>h BETWEEN C1 AND C2<br/>OR ...<br/>OR h BETWEEN C<sub>2k</sub> AND C<sub>2k+1</sub>
+| Test whether a constant geometry G contains a point (a, b)<br/><br/>Rewrite to use bounding box of constant geometry, which is also constant, then rewrite to Hilbert range(s) as above | ST_Contains(&#8203;ST_Envelope(&#8203;G), ST_Point(a, b))<br/><br/>ST_Contains(&#8203;ST_Rectangle(&#8203;X, X2, Y, Y2), ST_Point(a, b)))
+| Test whether a point (a, b) is within a buffer around a constant point (X, Y)<br/><br/>Special case of previous, because buffer is a constant geometry | ST_Contains(&#8203;ST_Buffer(&#8203;ST_Point(a, b), D), ST_Point(X, Y))
+| Test whether a point (a, b) is within a constant distance D of a constant point (X, Y)<br/><br/>First, convert to buffer, then use previous rewrite for constant geometry | ST_DWithin(&#8203;ST_Point(a, b), ST_Point(X, Y), D))<br/><br/>ST_Contains(&#8203;ST_Buffer(&#8203;ST_Point(&#8203;X, Y), D), ST_Point(a, b))
+| Test whether a constant point (X, Y) is within a constant distance D of a point (a, b)<br/><br/>Reverse arguments of call to <code>ST_DWithin</code>, then use previous rewrite | ST_DWithin(&#8203;ST_Point(X, Y), ST_Point(a, b), D))<br/><br/>ST_Contains(&#8203;ST_Buffer(&#8203;ST_Point(&#8203;X, Y), D), ST_Point(a, b))
+
+In the above, `a` and `b` are variables, `X`, `X2`, `Y`, `Y2`, `D` and `G` are
+constants.
+
+Many rewrites are inexact: there are some points where the predicate would
+return false but the rewritten predicate returns true.
+For example, a rewrite might convert a test whether a point is in a circle to a
+test for whether the point is in the circle's bounding square.
+These rewrites are worth performing because they are much quicker to apply,
+and often allow range scans on the Hilbert index.
+But for safety, Calcite applies the original predicate, to remove false positives.
+
 ## Acknowledgements
 
 Calcite's OpenGIS implementation uses the


### PR DESCRIPTION
Add SQL function Hilbert. It uses Google's uzaygezen library,
and our wraper code is copied from LocationTech's SFCurve
project.

Rewrite calls to ST_DWithin to use a range of on a Hilbert
column, plus the call to ST_DWithin for safety.

Implement function ST_MakeEnvelope.

Use constant reduction to recognize constant geometry
expressions before we apply SpatialRules.

Move interface Geom, and other classes, from GeoFunctions into
new utility class Geometries.

Geometry literals (not in the SQL parser (yet), but in
RexNode space).

Make Geom implement Comparable, so that it can be a literal
value.

Move SqlStdOperatorTables to new package, and rename to
SqlOperatorTables.

Add RelOptTestBase.Sql.withCatalogReaderFactory and
withConformance, to make it easier to run planner tests with
a different schema or SQL dialect.

Deprecate RelReferentialConstraint.getNumColumns().