### PR TITLE
[CALCITE-4025] Fix early exit in DelegatingScope#fullyQualify

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10130,6 +10130,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     checkCustomColumnResolving("T_10");
   }
 
+  @Test void testCustomColumnResolvingAndSimilarAlias() {
+    // Check that lower case alias 'f1' doesn't prevent validator to resolve 'F1' column name
+    sql("select F1.C0 from struct.T as \"f1\"")
+      .type("RecordType(INTEGER C0) NOT NULL");
+  }
+
   private void checkCustomColumnResolving(String table) {
     // Table STRUCT.T is defined as: (
     //   K0 VARCHAR(20) NOT NULL,


### PR DESCRIPTION
Address an issue in fullyQualify method when fully qualifying an
identifier and the prefix cannot be resolved but could if name matching
was not case sensitive, the method would throw an exception instead of
trying to continue matching smaller prefixes (in case of compound
columns keys).