### PR TITLE
[CALCITE-4176] Key descriptor can be optional in SESSION table function (Rui Wang)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSessionTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSessionTableFunction.java
@@ -64,7 +64,10 @@ public class SqlSessionTableFunction extends SqlWindowTableFunction {
       final SqlNode operand2 = callBinding.operand(2);
       final RelDataType type2 = validator.getValidatedNodeType(operand2);
       if (operand2.getKind() == SqlKind.DESCRIPTOR) {
-        validateColumnNames(validator, type2.getFieldNames(), ((SqlCall) operand2).getOperandList());
+        final SqlNode operand0 = callBinding.operand(0);
+        final RelDataType type = validator.getValidatedNodeType(operand0);
+        validateColumnNames(
+            validator, type.getFieldNames(), ((SqlCall) operand2).getOperandList());
       } else if (!SqlTypeUtil.isInterval(type2)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }
@@ -91,7 +94,7 @@ public class SqlSessionTableFunction extends SqlWindowTableFunction {
     }
 
     @Override public boolean isOptional(int i) {
-      return false;
+      return i == 2;
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlTumbleTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTumbleTableFunction.java
@@ -51,7 +51,7 @@ public class SqlTumbleTableFunction extends SqlWindowTableFunction {
   //  Inner Class
   // -------------------------------------------------------------------------
 
-  /** Operand type checker for SESSION. */
+  /** Operand type checker for TUMBLE. */
   private static class OperandTypeCheckerImpl implements SqlOperandTypeChecker {
     static final OperandTypeCheckerImpl INSTANCE = new OperandTypeCheckerImpl();
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlWindowTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWindowTableFunction.java
@@ -133,7 +133,7 @@ public class SqlWindowTableFunction extends SqlFunction
     return true;
   }
 
-  private static void validateColumnNames(SqlValidator validator,
+  public static void validateColumnNames(SqlValidator validator,
       List<String> fieldNames, List<SqlNode> columnNames) {
     final SqlNameMatcher matcher = validator.getCatalogReader().nameMatcher();
     for (SqlNode columnName : columnNames) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10435,11 +10435,10 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "size => interval '1' hour))")
         .fails("Param 'data' not found in function 'SESSION'; did you mean 'DATA'\\?");
     sql("select * from table(\n"
-        + "^session(\n"
+        + "session(\n"
         + "data => table orders,\n"
         + "key => descriptor(productid),\n"
-        + "size => interval '1' hour)^)")
-        .fails("Invalid number of arguments to function 'SESSION'. Was expecting 4 arguments");
+        + "size => interval '1' hour))").ok();
     sql("select * from table(\n"
         + "^session(table orders, descriptor(rowtime), interval '2' hour)^)").ok();
     sql("select * from table(\n"
@@ -10447,19 +10446,19 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("Cannot apply 'SESSION' to arguments of type 'SESSION\\(<RECORDTYPE\\(TIMESTAMP\\("
             + "0\\) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID\\)>, <COLUMN_LIST>, <COLUMN_LIST>, "
             + "<CHAR\\(4\\)>\\)'. Supported form\\(s\\): SESSION\\(TABLE table_name, DESCRIPTOR\\("
-            + "col\\), DESCRIPTOR\\(col\\) optional, datetime interval\\)");
+            + "timecol\\), DESCRIPTOR\\(key\\) optional, datetime interval\\)");
     sql("select * from table(\n"
         + "^session(table orders, descriptor(rowtime), 'test', interval '2' hour)^)")
         .fails("Cannot apply 'SESSION' to arguments of type 'SESSION\\(<RECORDTYPE\\(TIMESTAMP\\("
             + "0\\) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID\\)>, <COLUMN_LIST>, <CHAR\\(4\\)>, "
             + "<INTERVAL HOUR>\\)'. Supported form\\(s\\): SESSION\\(TABLE table_name, DESCRIPTOR\\("
-            + "col\\), DESCRIPTOR\\(col\\) optional, datetime interval\\)");
+            + "timecol\\), DESCRIPTOR\\(key\\) optional, datetime interval\\)");
     sql("select * from table(\n"
         + "^session(table orders, 'test', descriptor(productid), interval '2' hour)^)")
         .fails("Cannot apply 'SESSION' to arguments of type 'SESSION\\(<RECORDTYPE\\(TIMESTAMP\\("
             + "0\\) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID\\)>, <CHAR\\(4\\)>, <COLUMN_LIST>, "
             + "<INTERVAL HOUR>\\)'. Supported form\\(s\\): SESSION\\(TABLE table_name, DESCRIPTOR\\("
-            + "col\\), DESCRIPTOR\\(col\\) optional, datetime interval\\)");
+            + "timecol\\), DESCRIPTOR\\(key\\) optional, datetime interval\\)");
     sql("select * from table(\n"
         + "session(TABLE ^tabler_not_exist^, descriptor(rowtime), descriptor(productid), interval '1' hour))")
         .fails("Object 'TABLER_NOT_EXIST' not found");

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10441,26 +10441,25 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "size => interval '1' hour)^)")
         .fails("Invalid number of arguments to function 'SESSION'. Was expecting 4 arguments");
     sql("select * from table(\n"
-        + "^session(table orders, descriptor(rowtime), interval '2' hour)^)")
-        .fails("Invalid number of arguments to function 'SESSION'. Was expecting 4 arguments");
+        + "^session(table orders, descriptor(rowtime), interval '2' hour)^)").ok();
     sql("select * from table(\n"
         + "^session(table orders, descriptor(rowtime), descriptor(productid), 'test')^)")
         .fails("Cannot apply 'SESSION' to arguments of type 'SESSION\\(<RECORDTYPE\\(TIMESTAMP\\("
             + "0\\) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID\\)>, <COLUMN_LIST>, <COLUMN_LIST>, "
             + "<CHAR\\(4\\)>\\)'. Supported form\\(s\\): SESSION\\(TABLE table_name, DESCRIPTOR\\("
-            + "timecol\\), DESCRIPTOR\\(key\\), datetime interval\\)");
+            + "col\\), DESCRIPTOR\\(col\\) optional, datetime interval\\)");
     sql("select * from table(\n"
         + "^session(table orders, descriptor(rowtime), 'test', interval '2' hour)^)")
         .fails("Cannot apply 'SESSION' to arguments of type 'SESSION\\(<RECORDTYPE\\(TIMESTAMP\\("
             + "0\\) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID\\)>, <COLUMN_LIST>, <CHAR\\(4\\)>, "
             + "<INTERVAL HOUR>\\)'. Supported form\\(s\\): SESSION\\(TABLE table_name, DESCRIPTOR\\("
-            + "timecol\\), DESCRIPTOR\\(key\\), datetime interval\\)");
+            + "col\\), DESCRIPTOR\\(col\\) optional, datetime interval\\)");
     sql("select * from table(\n"
         + "^session(table orders, 'test', descriptor(productid), interval '2' hour)^)")
         .fails("Cannot apply 'SESSION' to arguments of type 'SESSION\\(<RECORDTYPE\\(TIMESTAMP\\("
             + "0\\) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID\\)>, <CHAR\\(4\\)>, <COLUMN_LIST>, "
             + "<INTERVAL HOUR>\\)'. Supported form\\(s\\): SESSION\\(TABLE table_name, DESCRIPTOR\\("
-            + "timecol\\), DESCRIPTOR\\(key\\), datetime interval\\)");
+            + "col\\), DESCRIPTOR\\(col\\) optional, datetime interval\\)");
     sql("select * from table(\n"
         + "session(TABLE ^tabler_not_exist^, descriptor(rowtime), descriptor(productid), interval '1' hour))")
         .fails("Object 'TABLER_NOT_EXIST' not found");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-4176