### PR TITLE
[CALCITE-4168] Configure Gradle local build cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
-    - name: 'Test'
-      shell: cmd
-      run: |
-        ./gradlew --no-parallel --no-daemon build javadoc
+    - uses: burrunan/gradle-cache-action@v1
+      name: Test
+      with:
+        job-id: jdk${{ matrix.jdk }}
+        arguments: --scan --no-parallel --no-daemon build javadoc
 
   linux-avatica:
     if: github.event.action != 'labeled'
@@ -61,17 +62,30 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: 'Install Avatica to Maven Local repository'
+    - name: 'Clone Avatica to Maven Local repository'
       run: |
         git clone --branch master --depth 100 https://github.com/apache/calcite-avatica.git ../calcite-avatica
-        cd ../calcite-avatica
-        ./gradlew publishToMavenLocal -Pcalcite.avatica.version=1.0.0-dev-master -PskipJavadoc
+    - uses: burrunan/gradle-cache-action@v1
+      name: Build Avatica
+      with:
+        job-id: avatica-jdk${{ matrix.jdk }}
+        build-root-directory: ../calcite-avatica
+        arguments: publishToMavenLocal
+        properties: |
+          calcite.avatica.version=1.0.0-dev-master
+          skipJavadoc=
     - uses: actions/checkout@v2
       with:
         fetch-depth: 50
-    - name: 'Test'
-      run: |
-        ./gradlew --no-parallel --no-daemon build javadoc -Pcalcite.avatica.version=1.0.0-dev-master-SNAPSHOT -PenableMavenLocal
+    - uses: burrunan/gradle-cache-action@v1
+      name: Test
+      with:
+        job-id: jdk${{ matrix.jdk }}
+        execution-only-caches: true
+        arguments: --scan --no-parallel --no-daemon build javadoc
+        properties: |
+          calcite.avatica.version=1.0.0-dev-master-SNAPSHOT
+          enableMavenLocal=
 
   mac:
     if: github.event.action != 'labeled'
@@ -85,9 +99,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14
-      - name: 'Test'
-        run: |
-          ./gradlew --no-parallel --no-daemon build javadoc
+      - uses: burrunan/gradle-cache-action@v1
+        name: Test
+        with:
+          job-id: jdk14
+          arguments: --scan --no-parallel --no-daemon build javadoc
 
   linux-slow:
     # Run slow tests when the commit is on master or it is requested explicitly by adding an
@@ -103,6 +119,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: 'Test'
-        run: |
-          ./gradlew --no-parallel --no-daemon testSlow
+      - uses: burrunan/gradle-cache-action@v1
+        name: Test
+        with:
+          job-id: jdk8
+          arguments: --scan --no-parallel --no-daemon testSlow

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -530,6 +530,9 @@ allprojects {
                 options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Werror"))
             }
             configureEach<Test> {
+                outputs.cacheIf("test results depend on the database configuration, so we souldn't cache it") {
+                    false
+                }
                 useJUnitPlatform {
                     excludeTags("slow")
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 org.gradle.parallel=true
+# Build cache can be disabled with --no-build-cache option
+org.gradle.caching=true
+#org.gradle.caching.debug=true
 # See https://github.com/gradle/gradle/pull/11358 , https://issues.apache.org/jira/browse/INFRA-14923
 # repository.apache.org does not yet support .sha256 and .sha512 checksums
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    `gradle-enterprise`
+}
+
 // This is the name of a current project
 // Note: it cannot be inferred from the directory name as developer might clone Calcite to calcite_tmp folder
 rootProject.name = "calcite"
@@ -77,6 +81,25 @@ fun property(name: String) =
         true -> extra.get(name) as? String
         else -> null
     }
+
+val isCiServer = System.getenv().containsKey("CI")
+
+if (isCiServer) {
+    gradleEnterprise {
+        buildScan {
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+            tag("CI")
+        }
+    }
+}
+
+// Cache build artifacts, so expensive operations do not need to be re-computed
+buildCache {
+    local {
+        isEnabled = !isCiServer
+    }
+}
 
 // This enables to use local clone of vlsi-release-plugins for debugging purposes
 property("localReleasePlugins")?.ifBlank { "../vlsi-release-plugins" }?.let {


### PR DESCRIPTION
The commit configures local build cache, and it delegates
Gradle execution to burrunan/gradle-cache-action.

It unlocks fine-grained remote build cache with GitHub Actions backend
(=faster builds), and it adds error markers
(e.g. compilation errors right in the commit diffs)

See https://github.com/burrunan/gradle-cache-action#gradle-cache-action