### PR TITLE
[CALCITE-4191] Improve the logic of creating aggregate calls

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -920,9 +920,9 @@ public abstract class RelOptUtil {
 
     for (int i = 0; i < aggCallCnt; i++) {
       aggCalls.add(
-          AggregateCall.create(SqlStdOperatorTable.SINGLE_VALUE, false, false,
-              false, ImmutableList.of(i), -1, RelCollations.EMPTY, 0, rel, null,
-              null));
+          AggregateCall.builder()
+              .aggFunction(SqlStdOperatorTable.SINGLE_VALUE)
+              .argList(ImmutableList.of(i)).input(rel).build());
     }
 
     return LogicalAggregate.create(rel, ImmutableList.of(), ImmutableBitSet.of(),

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1906,12 +1906,8 @@ public class SubstitutionVisitor {
           return null;
         }
         aggregateCalls.add(
-            AggregateCall.create(aggFunction,
-                aggregateCall.isDistinct(), aggregateCall.isApproximate(),
-                aggregateCall.ignoreNulls(),
-                ImmutableList.of(target.groupSet.cardinality() + i), -1,
-                aggregateCall.collation, aggregateCall.type,
-                aggregateCall.name));
+            AggregateCall.builder(aggregateCall).aggFunction(aggFunction)
+            .argList(ImmutableList.of(target.groupSet.cardinality() + i)).filterArg(-1).build());
       }
       if (targetCond != null && !targetCond.isAlwaysTrue()) {
         RexProgram compenRexProgram = RexProgram.create(

--- a/core/src/main/java/org/apache/calcite/rel/core/Window.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Window.java
@@ -332,10 +332,9 @@ public abstract class Window extends SingleRel {
         public AggregateCall get(int index) {
           final RexWinAggCall aggCall = aggCalls.get(index);
           final SqlAggFunction op = (SqlAggFunction) aggCall.getOperator();
-          return AggregateCall.create(op, aggCall.distinct, false,
-              aggCall.ignoreNulls, getProjectOrdinals(aggCall.getOperands()),
-              -1, RelCollations.EMPTY,
-              aggCall.getType(), fieldNames.get(aggCall.ordinal));
+          return AggregateCall.builder().aggFunction(op).distinct(aggCall.distinct)
+              .ignoreNulls(aggCall.ignoreNulls).argList(getProjectOrdinals(aggCall.getOperands()))
+              .type(aggCall.getType()).name(fieldNames.get(aggCall.ordinal)).build();
         }
       };
     }

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJsonReader.java
@@ -22,7 +22,6 @@ import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
@@ -286,10 +285,9 @@ public class RelJsonReader {
     final RelDataType type =
         relJson.toType(cluster.getTypeFactory(), jsonAggCall.get("type"));
     final String name = (String) jsonAggCall.get("name");
-    return AggregateCall.create(aggregation, distinct, false, false, operands,
-        filterOperand == null ? -1 : filterOperand,
-        RelCollations.EMPTY,
-        type, name);
+    return AggregateCall.builder().aggFunction(aggregation).distinct(distinct)
+        .argList(operands).filterArg(filterOperand == null ? -1 : filterOperand)
+        .type(type).name(name).build();
   }
 
   private RelNode lookupInput(String jsonInput) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
@@ -144,10 +144,8 @@ public class AggregateFilterTransposeRule
           return;
         }
         topAggCallList.add(
-            AggregateCall.create(rollup, aggregateCall.isDistinct(),
-                aggregateCall.isApproximate(), aggregateCall.ignoreNulls(),
-                ImmutableList.of(i++), -1, aggregateCall.collation,
-                aggregateCall.type, aggregateCall.name));
+            AggregateCall.builder(aggregateCall).aggFunction(rollup)
+            .argList(ImmutableList.of(i++)).filterArg(-1).build());
       }
       final Aggregate topAggregate =
           aggregate.copy(aggregate.getTraitSet(), newFilter,

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
@@ -345,15 +345,12 @@ public class AggregateReduceFunctionsRule
         new Aggregate.AggCallBinding(typeFactory, aggFunction,
             ImmutableList.of(operandType), oldAggRel.getGroupCount(),
             filter >= 0);
-    return AggregateCall.create(aggFunction,
-        oldCall.isDistinct(),
-        oldCall.isApproximate(),
-        oldCall.ignoreNulls(),
-        ImmutableIntList.of(argOrdinal),
-        filter,
-        oldCall.collation,
-        aggFunction.inferReturnType(binding),
-        null);
+    return AggregateCall.builder(oldCall)
+        .aggFunction(aggFunction)
+        .argList(ImmutableIntList.of(argOrdinal))
+        .filterArg(filter)
+        .type(aggFunction.inferReturnType(binding))
+        .name(null).build();
   }
 
   private RexNode reduceAvg(
@@ -369,30 +366,18 @@ public class AggregateReduceFunctionsRule
         getFieldType(
             oldAggRel.getInput(),
             iAvgInput);
-    final AggregateCall sumCall =
-        AggregateCall.create(SqlStdOperatorTable.SUM,
-            oldCall.isDistinct(),
-            oldCall.isApproximate(),
-            oldCall.ignoreNulls(),
-            oldCall.getArgList(),
-            oldCall.filterArg,
-            oldCall.collation,
-            oldAggRel.getGroupCount(),
-            oldAggRel.getInput(),
-            null,
-            null);
-    final AggregateCall countCall =
-        AggregateCall.create(SqlStdOperatorTable.COUNT,
-            oldCall.isDistinct(),
-            oldCall.isApproximate(),
-            oldCall.ignoreNulls(),
-            oldCall.getArgList(),
-            oldCall.filterArg,
-            oldCall.collation,
-            oldAggRel.getGroupCount(),
-            oldAggRel.getInput(),
-            null,
-            null);
+    final AggregateCall sumCall = AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.SUM)
+        .groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel.getInput())
+        .type(null)
+        .name(null).build();
+    final AggregateCall countCall = AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.COUNT)
+        .groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel.getInput())
+        .type(null)
+        .name(null).build();
 
     // NOTE:  these references are with respect to the output
     // of newAggRel
@@ -431,24 +416,12 @@ public class AggregateReduceFunctionsRule
             oldAggRel.getInput(),
             arg);
 
-    final AggregateCall sumZeroCall =
-        AggregateCall.create(SqlStdOperatorTable.SUM0, oldCall.isDistinct(),
-            oldCall.isApproximate(), oldCall.ignoreNulls(),
-            oldCall.getArgList(), oldCall.filterArg,
-            oldCall.collation, oldAggRel.getGroupCount(), oldAggRel.getInput(),
-            null, oldCall.name);
-    final AggregateCall countCall =
-        AggregateCall.create(SqlStdOperatorTable.COUNT,
-            oldCall.isDistinct(),
-            oldCall.isApproximate(),
-            oldCall.ignoreNulls(),
-            oldCall.getArgList(),
-            oldCall.filterArg,
-            oldCall.collation,
-            oldAggRel.getGroupCount(),
-            oldAggRel,
-            null,
-            null);
+    final AggregateCall sumZeroCall = AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.SUM0).groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel.getInput()).type(null).build();
+    final AggregateCall countCall = AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.COUNT).groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel.getInput()).type(null).name(null).build();
 
     // NOTE:  these references are with respect to the output
     // of newAggRel
@@ -526,18 +499,13 @@ public class AggregateReduceFunctionsRule
             aggCallMapping,
             ImmutableList.of(sumArgSquaredAggCall.getType()));
 
-    final AggregateCall sumArgAggCall =
-        AggregateCall.create(SqlStdOperatorTable.SUM,
-            oldCall.isDistinct(),
-            oldCall.isApproximate(),
-            oldCall.ignoreNulls(),
-            ImmutableIntList.of(argOrdinal),
-            oldCall.filterArg,
-            oldCall.collation,
-            oldAggRel.getGroupCount(),
-            oldAggRel.getInput(),
-            null,
-            null);
+    final AggregateCall sumArgAggCall = AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.SUM)
+        .argList(ImmutableIntList.of(argOrdinal))
+        .groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel.getInput())
+        .type(null)
+        .name(null).build();
 
     final RexNode sumArg =
         rexBuilder.addAggCall(sumArgAggCall,
@@ -551,17 +519,12 @@ public class AggregateReduceFunctionsRule
             SqlStdOperatorTable.MULTIPLY, sumArgCast, sumArgCast);
 
     final AggregateCall countArgAggCall =
-        AggregateCall.create(SqlStdOperatorTable.COUNT,
-            oldCall.isDistinct(),
-            oldCall.isApproximate(),
-            oldCall.ignoreNulls(),
-            oldCall.getArgList(),
-            oldCall.filterArg,
-            oldCall.collation,
-            oldAggRel.getGroupCount(),
-            oldAggRel,
-            null,
-            null);
+        AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.COUNT)
+        .groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel)
+        .type(null)
+        .name(null).build();
 
     final RexNode countArg =
         rexBuilder.addAggCall(countArgAggCall,
@@ -595,18 +558,14 @@ public class AggregateReduceFunctionsRule
       RexBuilder rexBuilder,
       int argOrdinal,
       int filterArg) {
-    final AggregateCall aggregateCall =
-        AggregateCall.create(SqlStdOperatorTable.SUM,
-            oldCall.isDistinct(),
-            oldCall.isApproximate(),
-            oldCall.ignoreNulls(),
-            ImmutableIntList.of(argOrdinal),
-            filterArg,
-            oldCall.collation,
-            oldAggRel.getGroupCount(),
-            oldAggRel.getInput(),
-            null,
-            null);
+    final AggregateCall aggregateCall = AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.SUM)
+        .argList(ImmutableIntList.of(argOrdinal))
+        .filterArg(filterArg)
+        .groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel.getInput())
+        .type(null)
+        .name(null).build();
     return rexBuilder.addAggCall(aggregateCall,
         oldAggRel.getGroupCount(),
         newCalls,
@@ -640,18 +599,14 @@ public class AggregateReduceFunctionsRule
       ImmutableIntList argOrdinals,
       ImmutableList<RelDataType> operandTypes,
       int filterArg) {
-    final AggregateCall countArgAggCall =
-        AggregateCall.create(SqlStdOperatorTable.REGR_COUNT,
-            oldCall.isDistinct(),
-            oldCall.isApproximate(),
-            oldCall.ignoreNulls(),
-            argOrdinals,
-            filterArg,
-            oldCall.collation,
-            oldAggRel.getGroupCount(),
-            oldAggRel,
-            null,
-            null);
+    final AggregateCall countArgAggCall = AggregateCall.builder(oldCall)
+        .aggFunction(SqlStdOperatorTable.REGR_COUNT)
+        .argList(argOrdinals)
+        .filterArg(filterArg)
+        .groupCount(oldAggRel.getGroupCount())
+        .input(oldAggRel.getInput())
+        .type(null)
+        .name(null).build();
 
     return oldAggRel.getCluster().getRexBuilder().addAggCall(countArgAggCall,
         oldAggRel.getGroupCount(),

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
@@ -206,10 +206,9 @@ public class AggregateStarTableRule
       if (roll == null) {
         break tryRoll;
       }
-      return AggregateCall.create(roll, false, aggregateCall.isApproximate(),
-          aggregateCall.ignoreNulls(), ImmutableList.of(offset + i), -1,
-          aggregateCall.collation,
-          groupCount, relBuilder.peek(), null, aggregateCall.name);
+      return AggregateCall.builder().aggFunction(roll).distinct(false)
+          .argList(ImmutableList.of(offset + i)).filterArg(-1).groupCount(groupCount)
+          .input(relBuilder.peek()).type(null).build();
     }
 
     // Second, try to satisfy the aggregation based on group set columns.
@@ -223,10 +222,9 @@ public class AggregateStarTableRule
         }
         newArgs.add(z);
       }
-      return AggregateCall.create(aggregation, false,
-          aggregateCall.isApproximate(), aggregateCall.ignoreNulls(),
-          newArgs, -1, aggregateCall.collation,
-          groupCount, relBuilder.peek(), null, aggregateCall.name);
+      return AggregateCall.builder().aggFunction(aggregation).distinct(false)
+          .argList(newArgs).filterArg(-1).groupCount(groupCount).input(relBuilder.peek())
+          .type(null).build();
     }
 
     // No roll up possible.

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
@@ -181,10 +181,9 @@ public class AggregateUnionTransposeRule
         aggType = origCall.getType();
       }
       AggregateCall newCall =
-          AggregateCall.create(aggFun, origCall.isDistinct(),
-              origCall.isApproximate(), origCall.ignoreNulls(),
-              ImmutableList.of(groupCount + ord.i), -1, origCall.collation,
-              groupCount, input, aggType, origCall.getName());
+          AggregateCall.builder(origCall).aggFunction(aggFun)
+              .argList(ImmutableList.of(groupCount + ord.i)).filterArg(-1)
+              .groupCount(groupCount).input(input).type(aggType).build();
       newCalls.add(newCall);
     }
     return newCalls;

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateMergeRule.java
@@ -156,11 +156,8 @@ public class ProjectAggregateMergeRule
    * or creates one and adds it to the list. Returns the index. */
   private static int findSum0(RelDataTypeFactory typeFactory, AggregateCall sum,
       List<AggregateCall> aggCallList) {
-    final AggregateCall sum0 =
-        AggregateCall.create(SqlStdOperatorTable.SUM0, sum.isDistinct(),
-            sum.isApproximate(), sum.ignoreNulls(), sum.getArgList(),
-            sum.filterArg, sum.collation,
-            typeFactory.createTypeWithNullability(sum.type, false), null);
+    final AggregateCall sum0 = AggregateCall.builder(sum).aggFunction(SqlStdOperatorTable.SUM0)
+        .type(typeFactory.createTypeWithNullability(sum.type, false)).name(null).build();
     final int i = aggCallList.indexOf(sum0);
     if (i >= 0) {
       return i;

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -304,8 +304,7 @@ public class RexBuilder {
       final List<Integer> args = aggCall.getArgList();
       final List<Integer> nullableArgs = nullableArgs(args, aggArgTypes);
       if (!nullableArgs.equals(args)) {
-        aggCall = aggCall.copy(nullableArgs, aggCall.filterArg,
-            aggCall.collation);
+        aggCall = AggregateCall.builder(aggCall).argList(nullableArgs).build();
       }
     }
     RexNode rex = aggCallMapping.get(aggCall);

--- a/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
@@ -132,9 +132,8 @@ public interface SqlSplittableAggFunction {
     }
 
     public AggregateCall other(RelDataTypeFactory typeFactory, AggregateCall e) {
-      return AggregateCall.create(SqlStdOperatorTable.COUNT, false, false,
-          false, ImmutableIntList.of(), -1, RelCollations.EMPTY,
-          typeFactory.createSqlType(SqlTypeName.BIGINT), null);
+      return AggregateCall.builder().aggFunction(SqlStdOperatorTable.COUNT)
+          .type(typeFactory.createSqlType(SqlTypeName.BIGINT)).build();
     }
 
     public AggregateCall topSplit(RexBuilder rexBuilder,
@@ -161,9 +160,9 @@ public interface SqlSplittableAggFunction {
         throw new AssertionError("unexpected count " + merges);
       }
       int ordinal = extra.register(node);
-      return AggregateCall.create(SqlStdOperatorTable.SUM0, false, false,
-          false, ImmutableList.of(ordinal), -1, aggregateCall.collation,
-          aggregateCall.type, aggregateCall.name);
+      return AggregateCall.builder().aggFunction(SqlStdOperatorTable.SUM0)
+          .argList(ImmutableList.of(ordinal)).collation(aggregateCall.collation)
+          .type(aggregateCall.type).name(aggregateCall.name).build();
     }
 
     /**
@@ -200,10 +199,7 @@ public interface SqlSplittableAggFunction {
       if (bottom.getAggregation().getKind() == SqlKind.COUNT
           && (top.getAggregation().getKind() == SqlKind.SUM
               || top.getAggregation().getKind() == SqlKind.SUM0)) {
-        return AggregateCall.create(bottom.getAggregation(),
-            bottom.isDistinct(), bottom.isApproximate(), false,
-            bottom.getArgList(), bottom.filterArg, bottom.getCollation(),
-            bottom.getType(), top.getName());
+        return AggregateCall.builder(bottom).ignoreNulls(false).name(top.getName()).build();
       } else {
         return null;
       }
@@ -238,16 +234,13 @@ public interface SqlSplittableAggFunction {
       assert (leftSubTotal >= 0) != (rightSubTotal >= 0);
       assert aggregateCall.collation.getFieldCollations().isEmpty();
       final int arg = leftSubTotal >= 0 ? leftSubTotal : rightSubTotal;
-      return aggregateCall.copy(ImmutableIntList.of(arg), -1,
-          RelCollations.EMPTY);
+      return AggregateCall.builder(aggregateCall).argList(ImmutableIntList.of(arg))
+          .filterArg(-1).collation(RelCollations.EMPTY).build();
     }
 
     public AggregateCall merge(AggregateCall top, AggregateCall bottom) {
       if (top.getAggregation().getKind() == bottom.getAggregation().getKind()) {
-        return AggregateCall.create(bottom.getAggregation(),
-            bottom.isDistinct(), bottom.isApproximate(), false,
-            bottom.getArgList(), bottom.filterArg, bottom.getCollation(),
-            bottom.getType(), top.getName());
+        return AggregateCall.builder(bottom).ignoreNulls(false).name(top.getName()).build();
       } else {
         return null;
       }
@@ -273,11 +266,8 @@ public interface SqlSplittableAggFunction {
     }
 
     public AggregateCall other(RelDataTypeFactory typeFactory, AggregateCall e) {
-      return AggregateCall.create(SqlStdOperatorTable.COUNT, false, false,
-          false,
-          ImmutableIntList.of(), -1,
-          RelCollations.EMPTY,
-          typeFactory.createSqlType(SqlTypeName.BIGINT), null);
+      return AggregateCall.builder().aggFunction(SqlStdOperatorTable.COUNT)
+          .type(typeFactory.createSqlType(SqlTypeName.BIGINT)).build();
     }
 
     public AggregateCall topSplit(RexBuilder rexBuilder,
@@ -306,9 +296,9 @@ public interface SqlSplittableAggFunction {
         throw new AssertionError("unexpected count " + merges);
       }
       int ordinal = extra.register(node);
-      return AggregateCall.create(getMergeAggFunctionOfTopSplit(), false, false,
-          false, ImmutableList.of(ordinal), -1, aggregateCall.collation,
-          aggregateCall.type, aggregateCall.name);
+      return AggregateCall.builder().aggFunction(getMergeAggFunctionOfTopSplit())
+          .argList(ImmutableList.of(ordinal)).collation(aggregateCall.collation)
+          .type(aggregateCall.type).name(aggregateCall.name).build();
     }
 
     public AggregateCall merge(AggregateCall top, AggregateCall bottom) {
@@ -316,10 +306,7 @@ public interface SqlSplittableAggFunction {
       if (topKind == bottom.getAggregation().getKind()
           && (topKind == SqlKind.SUM
               || topKind == SqlKind.SUM0)) {
-        return AggregateCall.create(bottom.getAggregation(),
-            bottom.isDistinct(), bottom.isApproximate(), false,
-            bottom.getArgList(), bottom.filterArg, bottom.getCollation(),
-            bottom.getType(), top.getName());
+        return AggregateCall.builder(bottom).ignoreNulls(false).name(top.getName()).build();
       } else {
         return null;
       }

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1167,11 +1167,10 @@ public class SqlToRelConverter {
                 ImmutableBitSet.of(),
                 null,
                 ImmutableList.of(
-                    AggregateCall.create(SqlStdOperatorTable.COUNT, false,
-                        false, false, ImmutableList.of(), -1, RelCollations.EMPTY,
-                        longType, null),
-                    AggregateCall.create(SqlStdOperatorTable.COUNT, false,
-                        false, false, args, -1, RelCollations.EMPTY, longType, null)));
+                    AggregateCall.builder().aggFunction(SqlStdOperatorTable.COUNT)
+                        .type(longType).build(),
+                    AggregateCall.builder().aggFunction(SqlStdOperatorTable.COUNT)
+                        .argList(args).type(longType).build()));
         LogicalJoin join =
             LogicalJoin.create(bb.root, aggregate, ImmutableList.of(),
                 rexBuilder.makeLiteral(true), ImmutableSet.of(), JoinRelType.INNER);
@@ -5402,16 +5401,16 @@ public class SqlToRelConverter {
                 .collect(Collectors.toList()));
       }
       final AggregateCall aggCall =
-          AggregateCall.create(
-              aggFunction,
-              distinct,
-              approximate,
-              ignoreNulls,
-              args,
-              filterArg,
-              collation,
-              type,
-              nameMap.get(outerCall.toString()));
+          AggregateCall.builder()
+              .aggFunction(aggFunction)
+              .distinct(distinct)
+              .approximate(approximate)
+              .ignoreNulls(ignoreNulls)
+              .argList(args)
+              .filterArg(filterArg)
+              .collation(collation)
+              .type(type)
+              .name(nameMap.get(outerCall.toString())).build();
       RexNode rex =
           rexBuilder.addAggCall(
               aggCall,

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -1722,11 +1722,11 @@ public class RelBuilder {
                     collation(orderKey, RelFieldCollation.Direction.ASCENDING,
                         null, Collections.emptyList()))
                 .collect(Collectors.toList()));
-        aggregateCall =
-            AggregateCall.create(aggCall1.aggFunction, aggCall1.distinct,
-                aggCall1.approximate,
-                aggCall1.ignoreNulls, args, filterArg, collation,
-                groupSet.cardinality(), r, null, aggCall1.alias);
+        aggregateCall = AggregateCall.builder().aggFunction(aggCall1.aggFunction)
+            .distinct(aggCall1.distinct).approximate(aggCall1.approximate)
+            .ignoreNulls(aggCall1.ignoreNulls).argList(args).filterArg(filterArg)
+            .collation(collation).groupCount(groupSet.cardinality()).input(r).type(null)
+            .name(aggCall1.alias).build();
       } else {
         aggregateCall = ((AggCallImpl2) aggCall).aggregateCall;
       }

--- a/core/src/test/java/org/apache/calcite/materialize/NormalizationTrimFieldTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/NormalizationTrimFieldTest.java
@@ -84,10 +84,7 @@ public class NormalizationTrimFieldTest extends SqlToRelTestBase {
         .build();
     final ImmutableBitSet groupSet = ImmutableBitSet.of(4);
     final AggregateCall count = aggregate.getAggCallList().get(0);
-    final AggregateCall call = AggregateCall.create(count.getAggregation(),
-        count.isDistinct(), count.isApproximate(),
-        count.ignoreNulls(), ImmutableList.of(3),
-        count.filterArg, count.collation, count.getType(), count.getName());
+    final AggregateCall call = AggregateCall.builder(count).argList(ImmutableList.of(3)).build();
     final RelNode query = LogicalAggregate.create(project, aggregate.getHints(),
         groupSet, ImmutableList.of(groupSet), ImmutableList.of(call));
     final RelNode target = aggregate;

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -447,12 +447,11 @@ class RelWriterTest {
                   ImmutableBitSet.of(0),
                   null,
                   ImmutableList.of(
-                      AggregateCall.create(SqlStdOperatorTable.COUNT,
-                          true, false, false, ImmutableList.of(1), -1,
-                          RelCollations.EMPTY, bigIntType, "c"),
-                      AggregateCall.create(SqlStdOperatorTable.COUNT,
-                          false, false, false, ImmutableList.of(), -1,
-                          RelCollations.EMPTY, bigIntType, "d")));
+                      AggregateCall.builder().aggFunction(SqlStdOperatorTable.COUNT)
+                          .distinct(true).argList(ImmutableList.of(1)).type(bigIntType)
+                          .name("c").build(),
+                      AggregateCall.builder().aggFunction(SqlStdOperatorTable.COUNT)
+                          .type(bigIntType).name("d").build()));
           aggregate.explain(writer);
           return writer.asString();
         });

--- a/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
@@ -166,9 +166,9 @@ class TraitPropagationTest {
           .build());
 
       // aggregate on s, count
-      AggregateCall aggCall = AggregateCall.create(SqlStdOperatorTable.COUNT,
-          false, false, false, Collections.singletonList(1), -1, RelCollations.EMPTY,
-          sqlBigInt, "cnt");
+      AggregateCall aggCall = AggregateCall.builder()
+          .aggFunction(SqlStdOperatorTable.COUNT).argList(Collections.singletonList(1))
+          .type(sqlBigInt).name("cnt").build();
       RelNode agg = new LogicalAggregate(cluster,
           cluster.traitSetOf(Convention.NONE), ImmutableList.of(), project,
           ImmutableBitSet.of(0), null, Collections.singletonList(aggCall));

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1808,9 +1808,8 @@ public class RelMetadataTest extends SqlToRelTestBase {
             ImmutableBitSet.of(2, 0),
             ImmutableList.of(),
             ImmutableList.of(
-                AggregateCall.create(SqlStdOperatorTable.COUNT,
-                    false, false, false, ImmutableIntList.of(),
-                    -1, RelCollations.EMPTY, 2, join, null, null)));
+                AggregateCall.builder().aggFunction(SqlStdOperatorTable.COUNT)
+                .groupCount(2).input(join).build()));
     rowSize = mq.getAverageRowSize(aggregate);
     columnSizes = mq.getAverageColumnSizes(aggregate);
     assertThat(columnSizes.size(), equalTo(3));

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidRules.java
@@ -668,7 +668,7 @@ public class DruidRules {
             && allHaveFilters) // filters get extracted
             || aggCall.hasFilter()
             && project.getProjects().get(aggCall.filterArg).isAlwaysTrue()) {
-          aggCall = aggCall.copy(aggCall.getArgList(), -1, aggCall.collation);
+          aggCall = AggregateCall.builder(aggCall).filterArg(-1).build();
         }
         newCalls.add(aggCall);
       }


### PR DESCRIPTION
According to the current code base, the only way to create AggregateCall objects is by calling one of the two AggregateCall#create methods (other create methods are deprecated).

The two create methods have 9 and 11 parameters, respectively, 3 of which are booleans and 2 are ints. We find this makes the code less readable and error-prone, as some bugs are caused by specifying the wrong parameters.

In this issue, we improve the related logic by the builder pattern, which results in the following benefits:
1. By creating the objects by the builder pattern, there is no need to maintain multiple overrides of the create methods.
2. There is no need to maintain multiple overrides of the copy methods, either.
3. The code becomes more readable and less error-prone, as it is less like to specify the wrong parameter.
4. Creating AggregateCall objects becomes easier, as the user does not have specify the default parameters repeatedly.

Options