### PR TITLE
[CALCITE-4192] RelMdColumnOrigins should obtain the true column index of the group by column of the aggregation operator instead of passing through directly

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
@@ -65,8 +65,8 @@ public class RelMdColumnOrigins
   public Set<RelColumnOrigin> getColumnOrigins(Aggregate rel,
       RelMetadataQuery mq, int iOutputColumn) {
     if (iOutputColumn < rel.getGroupCount()) {
-      // Group columns pass through directly.
-      return mq.getColumnOrigins(rel.getInput(), iOutputColumn);
+      // get actual index of Group columns.
+      return mq.getColumnOrigins(rel.getInput(), rel.getGroupSet().asList().get(iOutputColumn));
     }
 
     // Aggregate columns are derived from input columns

--- a/core/src/test/java/org/apache/calcite/test/RelMdColumnOriginsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMdColumnOriginsTest.java
@@ -17,24 +17,31 @@
 package org.apache.calcite.test;
 
 import org.apache.calcite.jdbc.CalciteConnection;
+
+import com.google.common.collect.ImmutableMultiset;
+
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
+
 import org.apache.calcite.rel.metadata.RelColumnOrigin;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.AggregateProjectMergeRule;
 
-import com.google.common.collect.ImmutableMultiset;
-
 import org.junit.jupiter.api.Test;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+
 
 /** Test case for CALCITE-542. */
 class RelMdColumnOriginsTest extends SqlToRelConverterTest {
@@ -82,7 +89,7 @@ class RelMdColumnOriginsTest extends SqlToRelConverterTest {
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-4192">[CALCITE-4192]
    * fix aggregate column origins searching by RelMdColumnOrigins</a>. */
-  @Test void testColumnOriginAfterAggProjectMergeRule() throws Exception {
+  @Test void testColumnOriginAfterAggProjectMergeRule() {
     final String sql = "select count(ename), SAL from emp group by SAL";
     final RelNode rel = tester.convertSqlToRel(sql).rel;
     final HepProgramBuilder programBuilder = HepProgram.builder();

--- a/core/src/test/java/org/apache/calcite/test/RelMdColumnOriginsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMdColumnOriginsTest.java
@@ -47,12 +47,12 @@ class RelMdColumnOriginsTest {
     Statement statement = calciteConnection.createStatement();
     ResultSet resultSet =
         statement.executeQuery("SELECT TABLE1.ID, TABLE2.ID FROM "
-            + "(SELECT GROUPING(A) AS ID FROM T1 "
-            + "GROUP BY ROLLUP(A,B)) TABLE1 "
-            + "JOIN "
-            + "(SELECT GROUPING(A) AS ID FROM T1 "
-            + "GROUP BY ROLLUP(A,B)) TABLE2 "
-            + "ON TABLE1.ID = TABLE2.ID");
+                + "(SELECT GROUPING(A) AS ID FROM T1 "
+                + "GROUP BY ROLLUP(A,B)) TABLE1 "
+                + "JOIN "
+                + "(SELECT GROUPING(A) AS ID FROM T1 "
+                + "GROUP BY ROLLUP(A,B)) TABLE2 "
+                + "ON TABLE1.ID = TABLE2.ID");
 
     final String result1 = "ID=0; ID=0";
     final String result2 = "ID=1; ID=1";

--- a/core/src/test/java/org/apache/calcite/test/RelMdColumnOriginsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMdColumnOriginsTest.java
@@ -17,23 +17,27 @@
 package org.apache.calcite.test;
 
 import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.RelColumnOrigin;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.rules.AggregateProjectMergeRule;
 
 import com.google.common.collect.ImmutableMultiset;
 
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.Statement;
+import java.sql.*;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Test case for CALCITE-542. */
-class RelMdColumnOriginsTest {
+class RelMdColumnOriginsTest extends SqlToRelConverterTest {
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-542">[CALCITE-542]
    * Support for Aggregate with grouping sets in RelMdColumnOrigins</a>. */
@@ -73,5 +77,26 @@ class RelMdColumnOriginsTest {
     resultSet.close();
     statement.close();
     connection.close();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4192">[CALCITE-4192]
+   * fix aggregate column origins searching by RelMdColumnOrigins</a>. */
+  @Test void testColumnOriginAfterAggProjectMergeRule() throws Exception {
+    final String sql = "select count(ename), SAL from emp group by SAL";
+    final RelNode rel = tester.convertSqlToRel(sql).rel;
+    final HepProgramBuilder programBuilder = HepProgram.builder();
+    programBuilder.addRuleInstance(AggregateProjectMergeRule.Config.DEFAULT.toRule());
+    final HepPlanner planner = new HepPlanner(programBuilder.build());
+    planner.setRoot(rel);
+    RelNode finalRel = planner.findBestExp();
+
+    Set<RelColumnOrigin> origins = RelMetadataQuery.instance().getColumnOrigins(finalRel, 1);
+    assertThat(origins.size(), equalTo(1));
+
+    RelColumnOrigin columnOrigin = origins.iterator().next();
+    assertThat(columnOrigin.getOriginColumnOrdinal(), equalTo(5));
+    assertThat(columnOrigin.getOriginTable().getRowType().getFieldNames().get(5),
+        equalTo("SAL"));
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -127,11 +127,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.function.Predicate;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -6767,27 +6764,5 @@ class RelOptRulesTest extends RelOptTestBase {
         .withTester(t -> createDynamicTester())
         .withRule(CoreRules.FILTER_REDUCE_EXPRESSIONS)
         .checkUnchanged();
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-4192">[CALCITE-4192]
-   * fix aggregate column origins searching by RelMdColumnOrigins</a>. */
-  @Test void testColumnOriginAfterAggProjectMergeRule() {
-    final String sql = "select count(ename), SAL from emp group by SAL";
-    final RelNode rel = tester.convertSqlToRel(sql).rel;
-    final HepProgramBuilder programBuilder = HepProgram.builder();
-    programBuilder.addRuleInstance(CoreRules.AGGREGATE_PROJECT_MERGE);
-    final HepPlanner planner = new HepPlanner(programBuilder.build());
-    planner.setRoot(rel);
-    final RelNode optimizedRel = planner.findBestExp();
-
-    Set<RelColumnOrigin> origins = RelMetadataQuery.instance()
-        .getColumnOrigins(optimizedRel, 1);
-    assertThat(origins.size(), equalTo(1));
-
-    RelColumnOrigin columnOrigin = origins.iterator().next();
-    assertThat(columnOrigin.getOriginColumnOrdinal(), equalTo(5));
-    assertThat(columnOrigin.getOriginTable().getRowType().getFieldNames().get(5),
-        equalTo("SAL"));
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -58,8 +58,6 @@ import org.apache.calcite.rel.logical.LogicalCorrelate;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalTableModify;
-import org.apache.calcite.rel.metadata.RelColumnOrigin;
-import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.AggregateExtractProjectRule;
 import org.apache.calcite.rel.rules.AggregateProjectMergeRule;
 import org.apache.calcite.rel.rules.AggregateProjectPullUpConstantsRule;

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -130,8 +130,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -130,6 +130,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -6781,10 +6783,11 @@ class RelOptRulesTest extends RelOptTestBase {
 
     Set<RelColumnOrigin> origins = RelMetadataQuery.instance()
         .getColumnOrigins(optimizedRel, 1);
-    assertEquals(1, origins.size());
+    assertThat(origins.size(), equalTo(1));
 
     RelColumnOrigin columnOrigin = origins.iterator().next();
-    assertEquals(5, columnOrigin.getOriginColumnOrdinal());
-    assertEquals("SAL", columnOrigin.getOriginTable().getRowType().getFieldNames().get(5));
+    assertThat(columnOrigin.getOriginColumnOrdinal(), equalTo(5));
+    assertThat(columnOrigin.getOriginTable().getRowType().getFieldNames().get(5),
+        equalTo("SAL"));
   }
 }


### PR DESCRIPTION
fix aggregate column origins searching by RelMdColumnOrigins when relNode has optimized by AggregateProjectMergeRule.