### PR TITLE
[CALCITE-4195] Cast between types with different collators must be evaluated as not monotonic

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -42,6 +42,9 @@ import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
 
+import java.text.Collator;
+import java.util.Objects;
+
 import static org.apache.calcite.util.Static.RESOURCE;
 
 /**
@@ -188,11 +191,22 @@ public class SqlCastFunction extends SqlFunction {
   }
 
   @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
-    RelDataTypeFamily castFrom = call.getOperandType(0).getFamily();
-    RelDataTypeFamily castTo = call.getOperandType(1).getFamily();
-    if (castFrom instanceof SqlTypeFamily
-        && castTo instanceof SqlTypeFamily
-        && nonMonotonicCasts.containsEntry(castFrom, castTo)) {
+    final RelDataType castFromType = call.getOperandType(0);
+    final RelDataTypeFamily castFromFamily = castFromType.getFamily();
+    final Collator castFromCollator = castFromType.getCollation() == null
+        ? null
+        : castFromType.getCollation().getCollator();
+    final RelDataType castToType = call.getOperandType(1);
+    final RelDataTypeFamily castToFamily = castToType.getFamily();
+    final Collator castToCollator = castToType.getCollation() == null
+        ? null
+        : castToType.getCollation().getCollator();
+    if (!Objects.equals(castFromCollator, castToCollator)) {
+      // Cast between types compared with different collators: not monotonic.
+      return SqlMonotonicity.NOT_MONOTONIC;
+    } else if (castFromFamily instanceof SqlTypeFamily
+        && castToFamily instanceof SqlTypeFamily
+        && nonMonotonicCasts.containsEntry(castFromFamily, castToFamily)) {
       return SqlMonotonicity.NOT_MONOTONIC;
     } else {
       return call.getOperandMonotonicity(0);


### PR DESCRIPTION
Jira: [CALCITE-4195](https://issues.apache.org/jira/browse/CALCITE-4195)
Problem related to the feature CALCITE-3951.
A cast operation from a character type to another character type that has a different collator must be evaluated as not monotonic. Currently this is not the case.
This has an impact e.g. in SortProjectTransposeRule, since we can incorrectly transpose a sort after a projection than contains such a cast, and we end up with a plan that will return a different result than the original one.
