### PR TITLE
[CALCITE-4203] RelMdUniqueKeys should not return empty when meeting Intersect and Minus if its input has unique keys

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1188,6 +1188,20 @@ public class RelMetadataTest extends SqlToRelTestBase {
         ImmutableSet.of(ImmutableBitSet.of(0)));
   }
 
+  @Test void testUniqueKeysMinus() {
+    checkGetUniqueKeys("select distinct deptno from emp\n"
+            + "except all\n"
+            + "select deptno from dept",
+        ImmutableSet.of(ImmutableBitSet.of(0)));
+  }
+
+  @Test void testUniqueKeysIntersect() {
+    checkGetUniqueKeys("select distinct deptno from emp\n"
+            + "intersect all\n"
+            + "select deptno from dept",
+        ImmutableSet.of(ImmutableBitSet.of(0)));
+  }
+
   @Test void testSingleKeyTableScanUniqueKeys() {
     // select key column
     checkGetUniqueKeys("select empno, ename from emp",


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-4203