### PR TITLE
[CALCITE-4215] Ensure org.apache.calcite.schema.Statistic uses null vs emptyList appropriately

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -129,10 +129,16 @@ public class ReflectiveSchema
         FieldTable table =
             (FieldTable) tableMap.get(Util.last(rc.getSourceQualifiedName()));
         assert table != null;
+        List<RelReferentialConstraint> referentialConstraints =
+            table.getStatistic().getReferentialConstraints();
+        if (referentialConstraints == null) {
+          // This enables to keep the same Statistics.of below
+          referentialConstraints = ImmutableList.of();
+        }
         table.statistic = Statistics.of(
             ImmutableList.copyOf(
                 Iterables.concat(
-                    table.getStatistic().getReferentialConstraints(),
+                    referentialConstraints,
                     Collections.singleton(rc))));
       }
     }

--- a/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
@@ -240,6 +240,9 @@ public final class RelTraitSet extends AbstractList<RelTrait> {
       return this; // trait is not enabled; ignore it
     }
     final List<T> traitList = traitSupplier.get();
+    if (traitList == null) {
+      return replace(index, def.getDefault());
+    }
     return replace(index, RelCompositeTrait.of(def, traitList));
   }
 
@@ -250,7 +253,10 @@ public final class RelTraitSet extends AbstractList<RelTrait> {
     if (index < 0) {
       return this; // trait is not enabled; ignore it
     }
-    final T traitList = traitSupplier.get();
+    T traitList = traitSupplier.get();
+    if (traitList == null) {
+      traitList = def.getDefault();
+    }
     return replace(index, traitList);
   }
 

--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -341,7 +341,11 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
   }
 
   public SqlMonotonicity getMonotonicity(String columnName) {
-    for (RelCollation collation : table.getStatistic().getCollations()) {
+    List<RelCollation> collations = table.getStatistic().getCollations();
+    if (collations == null) {
+      return null;
+    }
+    for (RelCollation collation : collations) {
       final RelFieldCollation fieldCollation =
           collation.getFieldCollations().get(0);
       final int fieldIndex = fieldCollation.getFieldIndex();

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
@@ -519,6 +519,9 @@ public class RelMdCollation
     // (i) join type is INNER or LEFT;
     // (ii) RelCollation always orders nulls last.
     final ImmutableList<RelCollation> leftCollations = mq.collations(left);
+    if (leftCollations == null) {
+      return null;
+    }
     switch (joinType) {
     case SEMI:
     case ANTI:
@@ -530,12 +533,12 @@ public class RelMdCollation
       for (RelCollation collation : leftCollations) {
         for (RelFieldCollation field : collation.getFieldCollations()) {
           if (!(RelFieldCollation.NullDirection.LAST == field.nullDirection)) {
-            return ImmutableList.of();
+            return null;
           }
         }
       }
       return leftCollations;
     }
-    return ImmutableList.of();
+    return null;
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
@@ -112,17 +112,21 @@ public class RelMdCollation
    */
   public ImmutableList<RelCollation> collations(RelNode rel,
       RelMetadataQuery mq) {
-    return ImmutableList.of();
+    return null;
+  }
+
+  private static <E> ImmutableList<E> copyOf(Collection<? extends E> values) {
+    return values == null ? null : ImmutableList.copyOf(values);
   }
 
   public ImmutableList<RelCollation> collations(Window rel,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(window(mq, rel.getInput(), rel.groups));
+    return copyOf(window(mq, rel.getInput(), rel.groups));
   }
 
   public ImmutableList<RelCollation> collations(Match rel,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         match(mq, rel.getInput(), rel.getRowType(), rel.getPattern(),
             rel.isStrictStart(), rel.isStrictEnd(),
             rel.getPatternDefinitions(), rel.getMeasures(), rel.getAfter(),
@@ -142,14 +146,14 @@ public class RelMdCollation
 
   public ImmutableList<RelCollation> collations(TableScan scan,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(table(scan.getTable()));
+    return copyOf(table(scan.getTable()));
   }
 
   public ImmutableList<RelCollation> collations(EnumerableMergeJoin join,
       RelMetadataQuery mq) {
     // In general a join is not sorted. But a merge join preserves the sort
     // order of the left and right sides.
-    return ImmutableList.copyOf(
+    return copyOf(
         RelMdCollation.mergeJoin(mq, join.getLeft(), join.getRight(),
             join.analyzeCondition().leftKeys, join.analyzeCondition().rightKeys,
             join.getJoinType()));
@@ -157,50 +161,50 @@ public class RelMdCollation
 
   public ImmutableList<RelCollation> collations(EnumerableHashJoin join,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         RelMdCollation.enumerableHashJoin(mq, join.getLeft(), join.getRight(), join.getJoinType()));
   }
 
   public ImmutableList<RelCollation> collations(EnumerableNestedLoopJoin join,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         RelMdCollation.enumerableNestedLoopJoin(mq, join.getLeft(), join.getRight(),
             join.getJoinType()));
   }
 
   public ImmutableList<RelCollation> collations(EnumerableCorrelate join,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         RelMdCollation.enumerableCorrelate(mq, join.getLeft(), join.getRight(),
             join.getJoinType()));
   }
 
   public ImmutableList<RelCollation> collations(Sort sort,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         RelMdCollation.sort(sort.getCollation()));
   }
 
   public ImmutableList<RelCollation> collations(SortExchange sort,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         RelMdCollation.sort(sort.getCollation()));
   }
 
   public ImmutableList<RelCollation> collations(Project project,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         project(mq, project.getInput(), project.getProjects()));
   }
 
   public ImmutableList<RelCollation> collations(Calc calc,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(calc(mq, calc.getInput(), calc.getProgram()));
+    return copyOf(calc(mq, calc.getInput(), calc.getProgram()));
   }
 
   public ImmutableList<RelCollation> collations(Values values,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         values(mq, values.getRowType(), values.getTuples()));
   }
 
@@ -216,7 +220,7 @@ public class RelMdCollation
 
   public ImmutableList<RelCollation> collations(RelSubset rel,
       RelMetadataQuery mq) {
-    return ImmutableList.copyOf(
+    return copyOf(
         Objects.requireNonNull(
             rel.getTraitSet().getTraits(RelCollationTraitDef.INSTANCE)));
   }
@@ -326,7 +330,7 @@ public class RelMdCollation
       collations.add(RelCollations.of(fieldCollationsForRexCalls));
     }
 
-    return ImmutableList.copyOf(collations);
+    return copyOf(collations);
   }
 
   /** Helper method to determine a

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
@@ -716,6 +716,9 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
       // Add edges between tables
       List<RelReferentialConstraint> constraints =
           tRef.getTable().getReferentialConstraints();
+      if (constraints == null) {
+        constraints = ImmutableList.of();
+      }
       for (RelReferentialConstraint constraint : constraints) {
         Collection<RelTableRef> parentTableRefs =
             tableVNameToTableRefs.get(constraint.getTargetQualifiedName());

--- a/core/src/main/java/org/apache/calcite/schema/Statistic.java
+++ b/core/src/main/java/org/apache/calcite/schema/Statistic.java
@@ -32,23 +32,35 @@ import java.util.List;
  */
 public interface Statistic {
   /** Returns the approximate number of rows in the table. */
-  Double getRowCount();
+  default Double getRowCount() {
+    return null;
+  }
 
   /** Returns whether the given set of columns is a unique key, or a superset
    * of a unique key, of the table.
    */
-  boolean isKey(ImmutableBitSet columns);
+  default boolean isKey(ImmutableBitSet columns) {
+    return false;
+  }
 
   /** Returns a list of unique keys, or null if no key exist. */
-  List<ImmutableBitSet> getKeys();
+  default List<ImmutableBitSet> getKeys() {
+    return null;
+  }
 
   /** Returns the collection of referential constraints (foreign-keys)
    * for this table. */
-  List<RelReferentialConstraint> getReferentialConstraints();
+  default List<RelReferentialConstraint> getReferentialConstraints() {
+    return null;
+  }
 
   /** Returns the collections of columns on which this table is sorted. */
-  List<RelCollation> getCollations();
+  default List<RelCollation> getCollations() {
+    return null;
+  }
 
   /** Returns the distribution of the data in this table. */
-  RelDistribution getDistribution();
+  default RelDistribution getDistribution()  {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/calcite/schema/Statistics.java
+++ b/core/src/main/java/org/apache/calcite/schema/Statistics.java
@@ -17,8 +17,6 @@
 package org.apache.calcite.schema;
 
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelDistribution;
-import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelReferentialConstraint;
 import org.apache.calcite.util.ImmutableBitSet;
 
@@ -36,42 +34,19 @@ public class Statistics {
   /** Returns a {@link Statistic} that knows nothing about a table. */
   public static final Statistic UNKNOWN =
       new Statistic() {
-        public Double getRowCount() {
-          return null;
-        }
-
-        public boolean isKey(ImmutableBitSet columns) {
-          return false;
-        }
-
-        public List<ImmutableBitSet> getKeys() {
-          return ImmutableList.of();
-        }
-
-        public List<RelReferentialConstraint> getReferentialConstraints() {
-          return ImmutableList.of();
-        }
-
-        public List<RelCollation> getCollations() {
-          return ImmutableList.of();
-        }
-
-        public RelDistribution getDistribution() {
-          return RelDistributionTraitDef.INSTANCE.getDefault();
-        }
       };
 
   /** Returns a statistic with a given set of referential constraints. */
   public static Statistic of(final List<RelReferentialConstraint> referentialConstraints) {
-    return of(null, ImmutableList.of(),
-        referentialConstraints, ImmutableList.of());
+    return of(null, null,
+        referentialConstraints, null);
   }
 
   /** Returns a statistic with a given row count and set of unique keys. */
   public static Statistic of(final double rowCount,
       final List<ImmutableBitSet> keys) {
-    return of(rowCount, keys, ImmutableList.of(),
-        ImmutableList.of());
+    return of(rowCount, keys, null,
+        null);
   }
 
   /** Returns a statistic with a given row count, set of unique keys,
@@ -79,7 +54,7 @@ public class Statistics {
   public static Statistic of(final double rowCount,
       final List<ImmutableBitSet> keys,
       final List<RelCollation> collations) {
-    return of(rowCount, keys, ImmutableList.of(), collations);
+    return of(rowCount, keys, null, collations);
   }
 
   /** Returns a statistic with a given row count, set of unique keys,
@@ -88,13 +63,19 @@ public class Statistics {
       final List<ImmutableBitSet> keys,
       final List<RelReferentialConstraint> referentialConstraints,
       final List<RelCollation> collations) {
+    List<ImmutableBitSet> keysCopy = keys == null ? ImmutableList.of() : ImmutableList.copyOf(keys);
+    List<RelReferentialConstraint> referentialConstraintsCopy =
+        referentialConstraints == null ? null : ImmutableList.copyOf(referentialConstraints);
+    List<RelCollation> collationsCopy =
+        collations == null ? null : ImmutableList.copyOf(collations);
+
     return new Statistic() {
       public Double getRowCount() {
         return rowCount;
       }
 
       public boolean isKey(ImmutableBitSet columns) {
-        for (ImmutableBitSet key : keys) {
+        for (ImmutableBitSet key : keysCopy) {
           if (columns.contains(key)) {
             return true;
           }
@@ -103,19 +84,15 @@ public class Statistics {
       }
 
       public List<ImmutableBitSet> getKeys() {
-        return ImmutableList.copyOf(keys);
+        return keysCopy;
       }
 
       public List<RelReferentialConstraint> getReferentialConstraints() {
-        return referentialConstraints;
+        return referentialConstraintsCopy;
       }
 
       public List<RelCollation> getCollations() {
-        return collations;
-      }
-
-      public RelDistribution getDistribution() {
-        return RelDistributionTraitDef.INSTANCE.getDefault();
+        return collationsCopy;
       }
     };
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlBinaryOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBinaryOperator.java
@@ -153,6 +153,9 @@ public class SqlBinaryOperator extends SqlOperator {
     if (getName().equals("/")) {
       final SqlMonotonicity mono0 = call.getOperandMonotonicity(0);
       final SqlMonotonicity mono1 = call.getOperandMonotonicity(1);
+      if (mono0 == null || mono1 == null) {
+        return null;
+      }
       if (mono1 == SqlMonotonicity.CONSTANT) {
         if (call.isOperandLiteral(1, false)) {
           switch (call.getOperandLiteralValue(1, BigDecimal.class).signum()) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlPrefixOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPrefixOperator.java
@@ -89,7 +89,8 @@ public class SqlPrefixOperator extends SqlOperator {
 
   @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
     if (getName().equals("-")) {
-      return call.getOperandMonotonicity(0).reverse();
+      SqlMonotonicity monotonicity = call.getOperandMonotonicity(0);
+      return monotonicity == null ? null : monotonicity.reverse();
     }
 
     return super.getMonotonicity(call);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlExtractFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlExtractFunction.java
@@ -67,7 +67,8 @@ public class SqlExtractFunction extends SqlFunction {
   @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
     switch (call.getOperandLiteralValue(0, TimeUnitRange.class)) {
     case YEAR:
-      return call.getOperandMonotonicity(1).unstrict();
+      SqlMonotonicity monotonicity = call.getOperandMonotonicity(1);
+      return monotonicity == null ? null : monotonicity.unstrict();
     default:
       return SqlMonotonicity.NOT_MONOTONIC;
     }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlFloorFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlFloorFunction.java
@@ -55,7 +55,8 @@ public class SqlFloorFunction extends SqlMonotonicUnaryFunction {
 
   @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
     // Monotonic iff its first argument is, but not strict.
-    return call.getOperandMonotonicity(0).unstrict();
+    SqlMonotonicity monotonicity = call.getOperandMonotonicity(0);
+    return monotonicity == null ? null : monotonicity.unstrict();
   }
 
   @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlMonotonicBinaryOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlMonotonicBinaryOperator.java
@@ -58,6 +58,10 @@ public class SqlMonotonicBinaryOperator extends SqlBinaryOperator {
     final SqlMonotonicity mono0 = call.getOperandMonotonicity(0);
     final SqlMonotonicity mono1 = call.getOperandMonotonicity(1);
 
+    // unknown <op> unknown --> unknown
+    if (mono0 == null || mono1 == null) {
+      return null;
+    }
     // constant <op> constant --> constant
     if ((mono1 == SqlMonotonicity.CONSTANT)
         && (mono0 == SqlMonotonicity.CONSTANT)) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
@@ -160,7 +160,8 @@ public class SqlSubstringFunction extends SqlFunction {
     // SUBSTRING(x FROM 0 FOR constant) has same monotonicity as x
     if (call.getOperandCount() == 3) {
       final SqlMonotonicity mono0 = call.getOperandMonotonicity(0);
-      if ((mono0 != SqlMonotonicity.NOT_MONOTONIC)
+      if (mono0 != null
+          && mono0 != SqlMonotonicity.NOT_MONOTONIC
           && call.getOperandMonotonicity(1) == SqlMonotonicity.CONSTANT
           && call.getOperandLiteralValue(1, BigDecimal.class)
               .equals(BigDecimal.ZERO)

--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -228,7 +228,7 @@ public class IdentifierNamespace extends AbstractNamespace {
       final String fieldName = field.getName();
       final SqlMonotonicity monotonicity =
           resolvedNamespace.getMonotonicity(fieldName);
-      if (monotonicity != SqlMonotonicity.NOT_MONOTONIC) {
+      if (monotonicity != null && monotonicity != SqlMonotonicity.NOT_MONOTONIC) {
         builder.add(
             Pair.of((SqlNode) new SqlIdentifier(fieldName, SqlParserPos.ZERO),
                 monotonicity));

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -1074,7 +1074,8 @@ public class SqlValidatorUtil {
     for (SqlValidatorNamespace ns : children(scope)) {
       ns = ns.resolve();
       for (String field : ns.getRowType().getFieldNames()) {
-        if (!ns.getMonotonicity(field).mayRepeat()) {
+        SqlMonotonicity monotonicity = ns.getMonotonicity(field);
+        if (monotonicity != null && !monotonicity.mayRepeat()) {
           return true;
         }
       }

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
@@ -195,9 +195,11 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
     // Fields that define the collation cannot be discarded.
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     final ImmutableList<RelCollation> collations = mq.collations(input);
-    for (RelCollation collation : collations) {
-      for (RelFieldCollation fieldCollation : collation.getFieldCollations()) {
-        fieldsUsedBuilder.set(fieldCollation.getFieldIndex());
+    if (collations != null) {
+      for (RelCollation collation : collations) {
+        for (RelFieldCollation fieldCollation : collation.getFieldCollations()) {
+          fieldsUsedBuilder.set(fieldCollation.getFieldIndex());
+        }
       }
     }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
@@ -19,9 +19,6 @@ package org.apache.calcite.rel.rel2sql;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.linq4j.tree.Expression;
-import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelDistribution;
-import org.apache.calcite.rel.RelReferentialConstraint;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelProtoDataType;
@@ -36,7 +33,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -44,7 +40,6 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -159,26 +154,6 @@ class RelToSqlConverterStructsTest {
   private static final Statistic STATS = new Statistic() {
     @Override public Double getRowCount() {
       return 0D;
-    }
-
-    @Override public boolean isKey(ImmutableBitSet columns) {
-      return false;
-    }
-
-    @Override public List<ImmutableBitSet> getKeys() {
-      return ImmutableList.of();
-    }
-
-    @Override public List<RelReferentialConstraint> getReferentialConstraints() {
-      return ImmutableList.of();
-    }
-
-    @Override public List<RelCollation> getCollations() {
-      return ImmutableList.of();
-    }
-
-    @Override public RelDistribution getDistribution() {
-      return null;
     }
   };
 


### PR DESCRIPTION
null means the statistic is not known,
emptyList means the statistic is known, and the value is empty

See https://issues.apache.org/jira/browse/CALCITE-4215