### PR TITLE
CALCITE-4210 Replaying subquery from ON clause on to right node

### DIFF
--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -7211,6 +7211,64 @@ LogicalProject(EMPNO=[$0])
     LogicalProject(EMPNO=[$0])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+
+        </Resource>
+    </TestCase>
+    <TestCase name="testJoinExpandAndDecorrelation">
+        <Resource name="plan_extended">
+            <![CDATA[
+LogicalProject(DEPTNO=[$9], SAL=[$7])
+  LogicalJoin(condition=[AND(=($9, $0), <($7, $0))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EXPR$0=[$10])
+      LogicalJoin(condition=[=($0, $9)], joinType=[left])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalAggregate(group=[{0}], EXPR$0=[AVG($1)])
+          LogicalProject(DEPTNO=[$7], SAL=[$5])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="plan_not_extended">
+            <![CDATA[
+LogicalProject(DEPTNO=[$9], SAL=[$7])
+  LogicalJoin(condition=[AND(=($9, $0), <($7, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testImplicitJoinExpandAndDecorrelation">
+        <Resource name="plan_extended">
+            <![CDATA[
+LogicalProject(DEPTNO=[$9], SAL=[$7])
+  LogicalProject(DEPTNO=[$0], NAME=[$1], EMPNO=[$2], ENAME=[$3], JOB=[$4], MGR=[$5], HIREDATE=[$6], SAL=[$7], COMM=[$8], DEPTNO0=[$9], SLACKER=[$10], DEPTNO1=[CAST($11):INTEGER], EXPR$0=[CAST($12):INTEGER])
+    LogicalJoin(condition=[AND(=($0, $11), <($7, $12))], joinType=[inner])
+      LogicalJoin(condition=[=($9, $0)], joinType=[inner])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{0}], EXPR$0=[AVG($1)])
+        LogicalProject(DEPTNO=[$7], SAL=[$5])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="plan_not_extended">
+            <![CDATA[
+LogicalProject(DEPTNO=[$9], SAL=[$7])
+  LogicalFilter(condition=[AND(=($9, $0), <($7, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})))], variablesSet=[[$cor0]])
+    LogicalJoin(condition=[true], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
         </Resource>
     </TestCase>
 </Root>


### PR DESCRIPTION
My changes replay the registered subqueries on the right rel node then joins on the modified rel right node to left rel node with the rewritten condition. The right node is chosen to maintain the the correct multiplicity of the LEFT JOINs.  The algorithm for support outer joins is much more complex, and this change does not attempt to support OUTER JOINs.  Maybe we should throw an exception when we try to rewrite an outer join.

A good way to observer the subquery node being dropped is to place a breakpoint on SqlToRelConverter.java:2201 and run a query with sub-query in the ON clause.  The rewrites are fromBlackboard.root, but are not accounted for when the join is created.My changes replay the registered subqueries on the right rel node then joins on the modified rel right node to left rel node with the rewritten condition. There is no particular reason I decided on the right over the left, but they cannot be played on the top of the node to maintain left and outer join semantics.

Currently **no** queries with subqueries in the ON clause generate the correct rel.

Concerning the other changes, the code is functionally identical but I have reworked the control statement into one if else expression in convertJoin.  Previously, the logic was split across convertFrom to handling natural joins or an if statement combined with a case statement in convertJoinCondition.  Since, the condition with on clauses requires the left or right rel node to be rewritten, I abstraction is instead generating the resulting rel node not just the condition.

This should handle all sub-query function expect for ones that use inner joins and ARRAY_QUERY_CONSTRUCTOR, MULTISET_VALUE_CONSTRUCTOR, MULTISET_QUERY_CONSTRUCTOR assuming that they worked for in the where clause.  Those these case might require OR conditions as well as multiple subqueries to not work.  