### PR TITLE
[CALCITE-4241] Some improvements to metadata query

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -361,7 +361,7 @@ public class RelMdColumnUniqueness
       return true;
     }
     final Set<List<Comparable>> set = new HashSet<>();
-    final List<Comparable> values = new ArrayList<>();
+    final List<Comparable> values = new ArrayList<>(columns.cardinality());
     for (ImmutableList<RexLiteral> tuple : rel.tuples) {
       for (int column : columns) {
         final RexLiteral literal = tuple.get(column);
@@ -392,7 +392,6 @@ public class RelMdColumnUniqueness
   public Boolean areColumnsUnique(RelSubset rel, RelMetadataQuery mq,
       ImmutableBitSet columns, boolean ignoreNulls) {
     columns = decorateWithConstantColumnsFromPredicates(columns, rel, mq);
-    int nullCount = 0;
     for (RelNode rel2 : rel.getRels()) {
       if (rel2 instanceof Aggregate
           || rel2 instanceof Filter
@@ -407,7 +406,7 @@ public class RelMdColumnUniqueness
               return true;
             }
           } else {
-            ++nullCount;
+            return null;
           }
         } catch (CyclicMetadataException e) {
           // Ignore this relational expression; there will be non-cyclic ones
@@ -415,7 +414,7 @@ public class RelMdColumnUniqueness
         }
       }
     }
-    return nullCount == 0 ? false : null;
+    return false;
   }
 
   private boolean simplyProjects(RelNode rel, ImmutableBitSet columns) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
@@ -232,10 +232,7 @@ public class RelMdUtil {
   public static boolean areColumnsDefinitelyUniqueWhenNullsFiltered(
       RelMetadataQuery mq, RelNode rel, ImmutableBitSet colMask) {
     Boolean b = mq.areColumnsUnique(rel, colMask, true);
-    if (b == null) {
-      return false;
-    }
-    return b;
+    return b != null && b;
   }
 
   public static Boolean areColumnsUniqueWhenNullsFiltered(RelMetadataQuery mq,
@@ -252,10 +249,7 @@ public class RelMdUtil {
   public static boolean areColumnsDefinitelyUniqueWhenNullsFiltered(
       RelMetadataQuery mq, RelNode rel, List<RexInputRef> columnRefs) {
     Boolean b = areColumnsUniqueWhenNullsFiltered(mq, rel, columnRefs);
-    if (b == null) {
-      return false;
-    }
-    return b;
+    return b != null && b;
   }
 
   /**


### PR DESCRIPTION
1. For {{RelMdColumnUniqueness#areColumnsUnique(RelSubset, RelMetadataQuery,
ImmutableBitSet, boolean)}}, we can return early as we encounter the first null.

2. For {{RelMdDistinctRowCount#getDistinctRowCount(Values, RelMetadataQuery,
ImmutableBitSet, RexNode)}}, we can get the distinct row count accurately, instead of guessing that half of the elements are distinct. 

3. RelMdUtil#areColumnsDefinitelyUniqueWhenNullsFiltered could be implemented in a more efficient way. 