### PR TITLE
[MINOR] Visit Calc operator in RelShuttle 

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCalc.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.hint.RelHint;
@@ -127,6 +128,11 @@ public final class LogicalCalc extends Calc {
   @Override public LogicalCalc copy(RelTraitSet traitSet, RelNode child,
       RexProgram program) {
     return new LogicalCalc(getCluster(), traitSet, hints, child, program);
+  }
+
+  @Override
+  public RelNode accept(RelShuttle shuttle) {
+    return shuttle.visit(this);
   }
 
   @Override public void collectVariablesUsed(Set<CorrelationId> variableSet) {


### PR DESCRIPTION
This pr can visit calc operator directly, I'm not sure if I should open another JIRA.Here's a previous implementation[1], which has some problems.It can not visit calc operator directly.Specific logical types should have their own RelShuttle.visit methods.
[1]https://issues.apache.org/jira/browse/CALCITE-3938