### PR TITLE
CALCITE-4257 Improving CachingRelMetadataProvider.cached

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
@@ -18,6 +18,7 @@ package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.util.BuiltInMethod;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -32,13 +33,13 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Implementation of the {@link RelMetadataProvider}
- * interface that caches results from an underlying provider.
+ * Implementation of the {@link RelMetadataProvider} interface that caches results from an
+ * underlying provider.
  */
 public class CachingRelMetadataProvider implements RelMetadataProvider {
   //~ Instance fields --------------------------------------------------------
 
-  private final Map<List, CacheEntry> cache = new HashMap<>();
+  private final Map<List<Object>, CacheEntry> cache;
 
   private final RelMetadataProvider underlyingProvider;
 
@@ -48,9 +49,17 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
 
   public CachingRelMetadataProvider(
       RelMetadataProvider underlyingProvider,
-      RelOptPlanner planner) {
+      RelOptPlanner planner,
+      Map<List<Object>, CacheEntry> cache) {
     this.underlyingProvider = underlyingProvider;
     this.planner = planner;
+    this.cache = cache;
+  }
+
+  public CachingRelMetadataProvider(
+      RelMetadataProvider underlyingProvider,
+      RelOptPlanner planner) {
+    this(underlyingProvider, planner, new HashMap<>());
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -67,7 +76,7 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
     // TODO jvs 30-Mar-2006: Use meta-metadata to decide which metadata
     // query results can stay fresh until the next Ice Age.
     return (rel, mq) -> {
-      final Metadata metadata = function.bind(rel, mq);
+      final M metadata = function.bind(rel, mq);
       return metadataClass.cast(
           Proxy.newProxyInstance(metadataClass.getClassLoader(),
               new Class[]{metadataClass},
@@ -86,10 +95,14 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
    * when the entry is valid. If read at a later timestamp, the entry will be
    * invalid and will be re-computed as if it did not exist. The net effect is a
    * lazy-flushing cache. */
-  private static class CacheEntry {
-    long timestamp;
+  public static class CacheEntry {
+    private long timestamp;
+    private Object result;
 
-    Object result;
+    public CacheEntry(long timestamp, Object result) {
+      this.timestamp = timestamp;
+      this.result = result;
+    }
   }
 
   /** Implementation of {@link InvocationHandler} for calls to a
@@ -105,6 +118,11 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
 
     public Object invoke(Object proxy, Method method, Object[] args)
         throws Throwable {
+      //Do not cache trivial functions
+      if (method.getDeclaringClass() == Object.class
+          || BuiltInMethod.METADATA_REL.method.equals(method)) {
+        return method.invoke(metadata, args);
+      }
       // Compute hash key.
       final ImmutableList.Builder<Object> builder = ImmutableList.builder();
       builder.add(method);
@@ -130,12 +148,8 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
       // Cache miss or stale.
       try {
         Object result = method.invoke(metadata, args);
-        if (result != null) {
-          entry = new CacheEntry();
-          entry.timestamp = timestamp;
-          entry.result = result;
-          cache.put(key, entry);
-        }
+        entry = new CacheEntry(timestamp, result);
+        cache.put(key, entry);
         return result;
       } catch (InvocationTargetException e) {
         throw e.getCause();

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -97,6 +97,8 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql2rel.InitializerExpressionFactory;
+import org.apache.calcite.test.catalog.CountingFactory;
 import org.apache.calcite.test.catalog.MockCatalogReader;
 import org.apache.calcite.test.catalog.MockCatalogReaderSimple;
 import org.apache.calcite.tools.FrameworkConfig;
@@ -1452,6 +1454,81 @@ public class RelMetadataTest extends SqlToRelTestBase {
     assertThat(buf.size(), equalTo(7));
     assertThat(colType(mq, input, 0), equalTo("DEPTNO-agg"));
     assertThat(buf.size(), equalTo(7));
+  }
+
+  @Test void testCachingRelMetadataProvider() {
+    final List<String> buf = new ArrayList<>();
+    ColTypeImpl.THREAD_LIST.set(buf);
+
+    final String sql = "select * from emp";
+    Map<List<Object>, CachingRelMetadataProvider.CacheEntry> cached = new HashMap<>();
+
+    final RelNode rel  = tester
+        .withClusterFactory(cluster -> {
+          // Create a custom provider that includes ColType.
+          cluster.setMetadataProvider(
+              new CachingRelMetadataProvider(
+                  ChainedRelMetadataProvider.of(
+                      ImmutableList.of(ColTypeImpl.SOURCE, cluster.getMetadataProvider())),
+                  cluster.getPlanner(),
+                  cached));
+          return cluster;
+        }).convertSqlToRel(sql).rel;
+    RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    RelOptCluster cluster = rel.getCluster();
+    ColType colTypeMetaData = cluster.getMetadataFactory().query(rel, mq, ColType.class);
+
+    assertThat(colTypeMetaData.rel(), is(rel));
+    assertThat(colTypeMetaData.toString(), notNullValue());
+    assertThat("Trivial calls are not cached", cached.size(), is(0));
+
+    colTypeMetaData.getColType(0);
+    assertThat("Non Trivial calls are cached", cached.size(), is(1));
+    colTypeMetaData.getColType(0);
+    assertThat("Non Trivial calls are read from the cache and not inserted again",
+        cached.size(),
+        is(1));
+  }
+
+  @Test void testCachingNullValues(){
+    Tester newTester = tester.withCatalogReaderFactory((typeFactory, caseSensitive) ->
+        new MockCatalogReader(typeFactory, caseSensitive) {
+          @Override
+          public MockCatalogReader init() {
+
+            // Register "SALES" schema.
+            MockSchema salesSchema = new MockSchema("my_schema");
+            registerSchema(salesSchema);
+
+            // Register "EMP" table with customer InitializerExpressionFactory
+            // to check whether newDefaultValue method called or not.
+            final InitializerExpressionFactory countingInitializerExpressionFactory =
+                new CountingFactory(ImmutableList.of("DEPTNO"));
+
+            registerType(
+                ImmutableList.of(salesSchema.getCatalogName(), salesSchema.getName(),
+                    "customBigInt"),
+                typeFactory -> typeFactory.createSqlType(SqlTypeName.BIGINT));
+
+            // Register "EMP" table.
+            final MockTable empTable =
+                MockTable.create(this, salesSchema, "EMP", false, 14, null,
+                    countingInitializerExpressionFactory, false);
+            empTable.addColumn("EMPNO", fixture.intType, true);
+            empTable.addColumn("ENAME", fixture.varchar20Type);
+            empTable.addColumn("JOB", fixture.varchar10Type);
+            empTable.addColumn("MGR", fixture.intTypeNull);
+            empTable.addColumn("HIREDATE", fixture.timestampType);
+            empTable.addColumn("SAL", fixture.intType);
+            empTable.addColumn("COMM", fixture.intType);
+            empTable.addColumn("DEPTNO", fixture.intType);
+            empTable.addColumn("SLACKER", fixture.booleanType);
+            registerTable(empTable);
+
+            return null;
+          }
+        }
+    );
   }
 
   @Test void testCustomProviderWithRelMetadataQuery() {


### PR DESCRIPTION
Allowing for CachingRelMetadataProvider.cache to be paramerterized so
soft reference or LRU maps can be used.  Not caching trivial calls to
Metadata.  Also, adding a marker interface MutableRelNode, to block
caching.