### PR TITLE
[CALCITE-4258] SqlToRelConverter: SELECT 1 IS [NOT] DISTINCT FROM NULL fails with AssertionError

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptPredicateList.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPredicateList.java
@@ -217,10 +217,11 @@ public class RelOptPredicateList {
       }
     }
     if (SqlKind.COMPARISON.contains(e.getKind())) {
-      // A comparison with a literal, such as 'ref < 10', is not null if 'ref'
+      // A comparison with a (non-null) literal, such as 'ref < 10', is not null if 'ref'
       // is not null.
       RexCall call = (RexCall) e;
-      if (call.getOperands().get(1) instanceof RexLiteral) {
+      if (call.getOperands().get(1) instanceof RexLiteral
+          && !((RexLiteral) call.getOperands().get(1)).isNull()) {
         return isEffectivelyNotNull(call.getOperands().get(0));
       }
     }

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -64,6 +64,28 @@ group by "hr"."emps"."empid";
 
 !ok
 
+# [CALCITE-4258] SqlToRelConverter: SELECT 1 IS [NOT] DISTINCT FROM NULL fails with AssertionError
+SELECT 1 IS DISTINCT FROM NULL;
++--------+
+| EXPR$0 |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+# [CALCITE-4258] SqlToRelConverter: SELECT 1 IS [NOT] DISTINCT FROM NULL fails with AssertionError
+SELECT 1 IS NOT DISTINCT FROM NULL;
++--------+
+| EXPR$0 |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
 # Case-sensitive errors
 select empid from "hr"."emps";
 Column 'EMPID' not found in any table; did you mean 'empid'?


### PR DESCRIPTION
Fixes root cause in RelOptPredicateList#isEffectivelyNotNull