### PR TITLE
[CALCITE-4176] Key descriptor can be optional in SESSION table function

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlHopTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlHopTableFunction.java
@@ -48,6 +48,9 @@ public class SqlHopTableFunction extends SqlWindowTableFunction {
       if (!checkTableAndDescriptorOperands(callBinding, 1)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }
+      if (!checkTimeColumnDescriptorOperand(callBinding, 1)) {
+        return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+      }
       if (!checkIntervalOperands(callBinding, 2)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSessionTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSessionTableFunction.java
@@ -29,7 +29,8 @@ import com.google.common.collect.ImmutableList;
  * <ol>
  *   <li>table as data source</li>
  *   <li>a descriptor to provide a watermarked column name from the input table</li>
- *   <li>a descriptor to provide a column as key, on which sessionization will be applied</li>
+ *   <li>a descriptor to provide a column as key, on which sessionization will be applied,
+ *   optional</li>
  *   <li>an interval parameter to specify a inactive activity gap to break sessions</li>
  * </ol>
  */
@@ -42,25 +43,41 @@ public class SqlSessionTableFunction extends SqlWindowTableFunction {
   private static class OperandMetadataImpl extends AbstractOperandMetadata {
     OperandMetadataImpl() {
       super(ImmutableList.of(PARAM_DATA, PARAM_TIMECOL, PARAM_KEY, PARAM_SIZE),
-          4);
+          3);
     }
 
     @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
         boolean throwOnFailure) {
-      final SqlValidator validator = callBinding.getValidator();
-      if (!checkTableAndDescriptorOperands(callBinding, 2)) {
+      if (!checkTableAndDescriptorOperands(callBinding, 1)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }
-      final RelDataType type3 = validator.getValidatedNodeType(callBinding.operand(3));
-      if (!SqlTypeUtil.isInterval(type3)) {
+      if (!checkTimeColumnDescriptorOperand(callBinding, 1)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+      }
+
+      final SqlValidator validator = callBinding.getValidator();
+      final SqlNode operand2 = callBinding.operand(2);
+      final RelDataType type2 = validator.getValidatedNodeType(operand2);
+      if (operand2.getKind() == SqlKind.DESCRIPTOR) {
+        final SqlNode operand0 = callBinding.operand(0);
+        final RelDataType type = validator.getValidatedNodeType(operand0);
+        validateColumnNames(
+            validator, type.getFieldNames(), ((SqlCall) operand2).getOperandList());
+      } else if (!SqlTypeUtil.isInterval(type2)) {
+        return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+      }
+      if (callBinding.getOperandCount() > 3) {
+        final RelDataType type3 = validator.getValidatedNodeType(callBinding.operand(3));
+        if (!SqlTypeUtil.isInterval(type3)) {
+          return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+        }
       }
       return true;
     }
 
     @Override public String getAllowedSignatures(SqlOperator op, String opName) {
       return opName + "(TABLE table_name, DESCRIPTOR(timecol), "
-          + "DESCRIPTOR(key), datetime interval)";
+          + "DESCRIPTOR(key) optional, datetime interval)";
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlTumbleTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTumbleTableFunction.java
@@ -49,6 +49,9 @@ public class SqlTumbleTableFunction extends SqlWindowTableFunction {
       if (!checkTableAndDescriptorOperands(callBinding, 1)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }
+      if (!checkTimeColumnDescriptorOperand(callBinding, 1)) {
+        return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+      }
       if (!checkIntervalOperands(callBinding, 2)) {
         return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
       }


### PR DESCRIPTION
This PR try to make the key descriptor optional in SESSION table function

* Handling the optional key descriptor when checking operand  types
* Add validation and checks for operands of time column descriptor