### PR TITLE
[CALCITE-4280] Replace Guava's Lists.transform and Iterables.transform with Util.transform

### DIFF
--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraToEnumerableConverter.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraToEnumerableConverter.java
@@ -38,8 +38,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
-
-import com.google.common.collect.Lists;
+import org.apache.calcite.util.Util;
 
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -143,6 +142,6 @@ public class CassandraToEnumerableConverter
   /** E.g. {@code constantList("x", "y")} returns
    * {@code {ConstantExpression("x"), ConstantExpression("y")}}. */
   private static <T> List<Expression> constantList(List<T> values) {
-    return Lists.transform(values, Expressions::constant);
+    return Util.transform(values, Expressions::constant);
   }
 }

--- a/core/src/main/java/org/apache/calcite/adapter/clone/ColumnLoader.java
+++ b/core/src/main/java/org/apache/calcite/adapter/clone/ColumnLoader.java
@@ -25,8 +25,7 @@ import org.apache.calcite.linq4j.tree.Primitive;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelProtoDataType;
-
-import com.google.common.collect.Lists;
+import org.apache.calcite.util.Util;
 
 import java.lang.reflect.Type;
 import java.sql.Date;
@@ -238,7 +237,7 @@ class ColumnLoader<T> {
       switch (rep) {
       case OBJECT:
       case JAVA_SQL_TIMESTAMP:
-        return Lists.transform(list,
+        return Util.transform(list,
             (Timestamp t) -> t == null ? null : t.getTime());
       }
       break;
@@ -246,7 +245,7 @@ class ColumnLoader<T> {
       switch (rep) {
       case OBJECT:
       case JAVA_SQL_TIME:
-        return Lists.transform(list, (Time t) -> t == null
+        return Util.transform(list, (Time t) -> t == null
             ? null
             : (int) (t.getTime() % DateTimeUtils.MILLIS_PER_DAY));
       }
@@ -255,7 +254,7 @@ class ColumnLoader<T> {
       switch (rep) {
       case OBJECT:
       case JAVA_SQL_DATE:
-        return Lists.transform(list, (Date d) -> d == null
+        return Util.transform(list, (Date d) -> d == null
             ? null
             : (int) (d.getTime() / DateTimeUtils.MILLIS_PER_DAY));
       }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalc.java
@@ -50,7 +50,6 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -269,7 +268,7 @@ public class EnumerableCalc extends Calc implements EnumerableRel {
 
   @Override public Pair<RelTraitSet, List<RelTraitSet>> passThroughTraits(
       final RelTraitSet required) {
-    final List<RexNode> exps = Lists.transform(program.getProjectList(),
+    final List<RexNode> exps = Util.transform(program.getProjectList(),
         program::expandLocalRef);
 
     return EnumerableTraitsUtils.passThroughTraitsForProject(required, exps,
@@ -278,7 +277,7 @@ public class EnumerableCalc extends Calc implements EnumerableRel {
 
   @Override public Pair<RelTraitSet, List<RelTraitSet>> deriveTraits(
       final RelTraitSet childTraits, final int childId) {
-    final List<RexNode> exps = Lists.transform(program.getProjectList(),
+    final List<RexNode> exps = Util.transform(program.getProjectList(),
         program::expandLocalRef);
 
     return EnumerableTraitsUtils.deriveTraitsForProject(childTraits, childId, exps,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnionRule.java
@@ -21,8 +21,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.logical.LogicalUnion;
-
-import com.google.common.collect.Lists;
+import org.apache.calcite.util.Util;
 
 import java.util.List;
 
@@ -48,7 +47,7 @@ class EnumerableUnionRule extends ConverterRule {
     final LogicalUnion union = (LogicalUnion) rel;
     final EnumerableConvention out = EnumerableConvention.INSTANCE;
     final RelTraitSet traitSet = rel.getCluster().traitSet().replace(out);
-    final List<RelNode> newInputs = Lists.transform(
+    final List<RelNode> newInputs = Util.transform(
         union.getInputs(), n -> convert(n, traitSet));
     return new EnumerableUnion(rel.getCluster(), traitSet,
         newInputs, union.all);

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -54,8 +54,6 @@ import org.apache.calcite.sql.util.SqlString;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Lists;
-
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -130,7 +128,7 @@ public class JdbcTable extends AbstractQueryableTable
   private List<Pair<ColumnMetaData.Rep, Integer>> fieldClasses(
       final JavaTypeFactory typeFactory) {
     final RelDataType rowType = protoRowType.apply(typeFactory);
-    return Lists.transform(rowType.getFieldList(), f -> {
+    return Util.transform(rowType.getFieldList(), f -> {
       final RelDataType type = f.getType();
       final Class clazz = (Class) typeFactory.getJavaClass(type);
       final ColumnMetaData.Rep rep =

--- a/core/src/main/java/org/apache/calcite/interpreter/SortNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/SortNode.java
@@ -19,8 +19,8 @@ package org.apache.calcite.interpreter;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 
 import java.util.ArrayList;
@@ -86,7 +86,7 @@ public class SortNode extends AbstractSingleNode<Sort> {
       return comparator(rel.getCollation().getFieldCollations().get(0));
     }
     return Ordering.compound(
-        Iterables.transform(rel.getCollation().getFieldCollations(),
+        Util.transform(rel.getCollation().getFieldCollations(),
             this::comparator));
   }
 

--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -62,7 +62,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
 
@@ -391,12 +390,12 @@ public class Lattice {
   }
 
   public List<Measure> toMeasures(List<AggregateCall> aggCallList) {
-    return Lists.transform(aggCallList, this::toMeasure);
+    return Util.transform(aggCallList, this::toMeasure);
   }
 
   private Measure toMeasure(AggregateCall aggCall) {
     return new Measure(aggCall.getAggregation(), aggCall.isDistinct(),
-        aggCall.name, Lists.transform(aggCall.getArgList(), columns::get));
+        aggCall.name, Util.transform(aggCall.getArgList(), columns::get));
   }
 
   public Iterable<? extends Tile> computeTiles() {
@@ -451,7 +450,7 @@ public class Lattice {
   }
 
   public List<String> uniqueColumnNames() {
-    return Lists.transform(columns, column -> column.alias);
+    return Util.transform(columns, column -> column.alias);
   }
 
   Pair<Path, Integer> columnToPathOffset(BaseColumn c) {
@@ -610,7 +609,7 @@ public class Lattice {
 
     /** Returns a list of argument ordinals. */
     public List<Integer> argOrdinals() {
-      return Lists.transform(args, column -> column.ordinal);
+      return Util.transform(args, column -> column.ordinal);
     }
 
     private static int compare(List<Column> list0, List<Column> list1) {

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeSpace.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeSpace.java
@@ -24,7 +24,6 @@ import org.apache.calcite.util.graph.AttributedDirectedGraph;
 import org.apache.calcite.util.mapping.IntPair;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -120,7 +119,7 @@ class LatticeSpace {
   /** Returns a list of {@link IntPair}, transposing source and target fields,
    * and ensuring the result is sorted and unique. */
   static List<IntPair> swap(List<IntPair> keys) {
-    return sortUnique(Lists.transform(keys, IntPair.SWAP));
+    return sortUnique(Util.transform(keys, x -> IntPair.of(x.target, x.source)));
   }
 
   Path addPath(List<Step> steps) {

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
@@ -51,7 +51,6 @@ import org.apache.calcite.util.mapping.IntPair;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 import java.util.ArrayList;
@@ -231,7 +230,7 @@ public class LatticeSuggester {
         latticeBuilder.addMeasure(
             new Lattice.Measure(measure.aggregate, measure.distinct,
                 measure.name,
-                Lists.transform(measure.arguments, colRef -> {
+                Util.transform(measure.arguments, colRef -> {
                   final Lattice.Column column;
                   if (colRef instanceof BaseColRef) {
                     final BaseColRef baseColRef = (BaseColRef) colRef;

--- a/core/src/main/java/org/apache/calcite/materialize/MaterializationService.java
+++ b/core/src/main/java/org/apache/calcite/materialize/MaterializationService.java
@@ -39,7 +39,6 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -371,7 +370,7 @@ public class MaterializationService {
       return CloneSchema.createCloneTable(connection.getTypeFactory(),
           RelDataTypeImpl.proto(calciteSignature.rowType),
           calciteSignature.getCollationList(),
-          Lists.transform(calciteSignature.columns, column -> column.type.rep),
+          Util.transform(calciteSignature.columns, column -> column.type.rep),
           new AbstractQueryable<Object>() {
             public Enumerator<Object> enumerator() {
               final DataContext dataContext =

--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.sql2rel.RelFieldTrimmer;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
 import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
@@ -34,7 +35,6 @@ import org.apache.calcite.util.graph.TopologicalOrderIterator;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
@@ -102,7 +102,7 @@ public abstract class RelOptMaterializations {
     final List<Pair<RelNode, RelOptLattice>> latticeUses = new ArrayList<>();
     final Set<List<String>> queryTableNames =
         Sets.newHashSet(
-            Iterables.transform(queryTables, RelOptTable::getQualifiedName));
+            Util.transform(queryTables, RelOptTable::getQualifiedName));
     // Remember leaf-join form of root so we convert at most once.
     final Supplier<RelNode> leafJoinRoot =
         Suppliers.memoize(() -> RelOptMaterialization.toLeafJoinForm(rel))::get;

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.convert.Converter;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -630,7 +631,7 @@ public abstract class RelOptRule {
    */
   protected static List<RelNode> convertList(List<RelNode> rels,
       final RelTrait trait) {
-    return Lists.transform(rels,
+    return Util.transform(rels,
         rel -> convert(rel, rel.getTraitSet().replace(trait)));
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -318,7 +318,7 @@ public abstract class RelOptUtil {
    * @see org.apache.calcite.rel.type.RelDataType#getFieldNames()
    */
   public static List<RelDataType> getFieldTypeList(final RelDataType type) {
-    return Lists.transform(type.getFieldList(), RelDataTypeField::getType);
+    return Util.transform(type.getFieldList(), RelDataTypeField::getType);
   }
 
   public static boolean areRowTypesEqual(
@@ -3052,7 +3052,7 @@ public abstract class RelOptUtil {
         multiJoin.isFullOuterJoin(),
         multiJoin.getOuterJoinConditions(),
         multiJoin.getJoinTypes(),
-        Lists.transform(newProjFields, ImmutableBitSet::fromBitSet),
+        Util.transform(newProjFields, ImmutableBitSet::fromBitSet),
         multiJoin.getJoinFieldRefCountsMap(),
         multiJoin.getPostJoinFilter());
   }

--- a/core/src/main/java/org/apache/calcite/profile/ProfilerImpl.java
+++ b/core/src/main/java/org/apache/calcite/profile/ProfilerImpl.java
@@ -433,7 +433,7 @@ public class ProfilerImpl implements Profiler {
 
     private ImmutableSortedSet<Column> toColumns(Iterable<Integer> ordinals) {
       return ImmutableSortedSet.copyOf(
-          Iterables.transform(ordinals, columns::get));
+          Util.transform(ordinals, columns::get));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/profile/SimpleProfiler.java
+++ b/core/src/main/java/org/apache/calcite/profile/SimpleProfiler.java
@@ -200,7 +200,7 @@ public class SimpleProfiler implements Profiler {
         if (space.columns.size() == 1) {
           nullCount = space.nullCount;
           valueSet = ImmutableSortedSet.copyOf(
-              Iterables.transform(space.values, Iterables::getOnlyElement));
+              Util.transform(space.values, Iterables::getOnlyElement));
         } else {
           nullCount = -1;
           valueSet = null;
@@ -279,7 +279,7 @@ public class SimpleProfiler implements Profiler {
 
     private ImmutableSortedSet<Column> toColumns(Iterable<Integer> ordinals) {
       return ImmutableSortedSet.copyOf(
-          Iterables.transform(ordinals, columns::get));
+          Util.transform(ordinals, columns::get));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/RelCollations.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollations.java
@@ -23,7 +23,6 @@ import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -147,7 +146,7 @@ public class RelCollations {
   /** Returns the indexes of the fields in a list of field collations. */
   public static List<Integer> ordinals(
       List<RelFieldCollation> fieldCollations) {
-    return Lists.transform(fieldCollations, RelFieldCollation::getFieldIndex);
+    return Util.transform(fieldCollations, RelFieldCollation::getFieldIndex);
   }
 
   /** Returns whether a collation indicates that the collection is sorted on

--- a/core/src/main/java/org/apache/calcite/rel/core/Project.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Project.java
@@ -45,7 +45,6 @@ import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import org.apiguardian.api.API;
 
@@ -222,7 +221,7 @@ public abstract class Project extends SingleRel implements Hintable {
       return litmus.fail("field names not distinct: {}", rowType);
     }
     //CHECKSTYLE: IGNORE 1
-    if (false && !Util.isDistinct(Lists.transform(exps, RexNode::toString))) {
+    if (false && !Util.isDistinct(Util.transform(exps, RexNode::toString))) {
       // Projecting the same expression twice is usually a bad idea,
       // because it may create expressions downstream which are equivalent
       // but which look different. We can't ban duplicate projects,

--- a/core/src/main/java/org/apache/calcite/rel/core/RepeatUnion.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RepeatUnion.java
@@ -26,8 +26,6 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Lists;
-
 import java.util.List;
 
 /**
@@ -99,7 +97,7 @@ public abstract class RepeatUnion extends BiRel {
 
   @Override protected RelDataType deriveRowType() {
     final List<RelDataType> inputRowTypes =
-        Lists.transform(getInputs(), RelNode::getRowType);
+        Util.transform(getInputs(), RelNode::getRowType);
     final RelDataType rowType =
         getCluster().getTypeFactory().leastRestrictive(inputRowTypes);
     if (rowType == null) {

--- a/core/src/main/java/org/apache/calcite/rel/core/SetOp.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/SetOp.java
@@ -30,7 +30,6 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -102,7 +101,7 @@ public abstract class SetOp extends AbstractRelNode {
 
   @Override protected RelDataType deriveRowType() {
     final List<RelDataType> inputRowTypes =
-        Lists.transform(inputs, RelNode::getRowType);
+        Util.transform(inputs, RelNode::getRowType);
     final RelDataType rowType =
         getCluster().getTypeFactory().leastRestrictive(inputRowTypes);
     if (rowType == null) {

--- a/core/src/main/java/org/apache/calcite/rel/core/Sort.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Sort.java
@@ -33,8 +33,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Lists;
-
 import java.util.List;
 import java.util.Objects;
 
@@ -171,7 +169,7 @@ public abstract class Sort extends SingleRel {
   /** Returns the sort expressions. */
   public List<RexNode> getSortExps() {
     //noinspection StaticPseudoFunctionalStyleMethod
-    return Lists.transform(collation.getFieldCollations(), field ->
+    return Util.transform(collation.getFieldCollations(), field ->
         getCluster().getRexBuilder().makeInputRef(input,
             Objects.requireNonNull(field).getFieldIndex()));
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
@@ -45,8 +45,6 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 import java.util.Collection;
@@ -204,10 +202,10 @@ public class RelMdAllPredicates
           currentTablesMapping.put(rightRef,
               RelTableRef.of(rightRef.getTable(), shift + rightRef.getEntityNumber()));
         }
-        final List<RexNode> updatedPreds = Lists.newArrayList(
-            Iterables.transform(inputPreds.pulledUpPredicates,
+        final List<RexNode> updatedPreds =
+            Util.transform(inputPreds.pulledUpPredicates,
                 e -> RexUtil.swapTableReferences(rexBuilder, e,
-                    currentTablesMapping)));
+                    currentTablesMapping));
         newPreds = newPreds.union(rexBuilder,
             RelOptPredicateList.of(rexBuilder, updatedPreds));
       }
@@ -303,10 +301,10 @@ public class RelMdAllPredicates
           qualifiedNamesToRefs.put(newRef.getQualifiedName(), newRef);
         }
         // Update preds
-        final List<RexNode> updatedPreds = Lists.newArrayList(
-            Iterables.transform(inputPreds.pulledUpPredicates,
+        final List<RexNode> updatedPreds =
+            Util.transform(inputPreds.pulledUpPredicates,
                 e -> RexUtil.swapTableReferences(rexBuilder, e,
-                    currentTablesMapping)));
+                    currentTablesMapping));
         newPreds = newPreds.union(rexBuilder,
             RelOptPredicateList.of(rexBuilder, updatedPreds));
       }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -49,9 +49,9 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -219,7 +219,7 @@ public class RelMdColumnUniqueness
     RexProgram program = rel.getProgram();
 
     return areProjectColumnsUnique(rel, mq, columns, ignoreNulls,
-        Lists.transform(program.getProjectList(), program::expandLocalRef));
+        Util.transform(program.getProjectList(), program::expandLocalRef));
   }
 
   private Boolean areProjectColumnsUnique(

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -47,7 +47,6 @@ import org.apache.calcite.util.Util;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 
 import java.util.ArrayList;
@@ -269,7 +268,7 @@ public class RelMdExpressionLineage
             null,
             ImmutableList.of());
         final Set<RexNode> updatedExprs = ImmutableSet.copyOf(
-            Iterables.transform(originalExprs, e ->
+            Util.transform(originalExprs, e ->
                 RexUtil.swapTableReferences(rexBuilder, e,
                     currentTablesMapping)));
         mapping.put(RexInputRef.of(idx, fullRowType), updatedExprs);

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
@@ -38,11 +38,10 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Permutation;
+import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import java.util.HashSet;
@@ -101,7 +100,7 @@ public class RelMdUniqueKeys
     RexProgram program = rel.getProgram();
     Permutation permutation = program.getPermutation();
     return getProjectUniqueKeys(rel, mq, ignoreNulls,
-        Lists.transform(program.getProjectList(), program::expandLocalRef));
+        Util.transform(program.getProjectList(), program::expandLocalRef));
   }
 
   private Set<ImmutableBitSet> getProjectUniqueKeys(SingleRel rel, RelMetadataQuery mq,
@@ -159,10 +158,10 @@ public class RelMdUniqueKeys
       // the resulting unique keys would be {{0},{3}}, {{0},{4}}, {{0},{1},{4}}, ...
 
       Iterable<List<ImmutableBitSet>> product = Linq4j.product(
-          Iterables.transform(colMask,
-              in -> Iterables.filter(mapInToOutPos.get(in).powerSet(), bs -> !bs.isEmpty())));
+          Util.transform(colMask,
+              in -> Util.filter(mapInToOutPos.get(in).powerSet(), bs -> !bs.isEmpty())));
 
-      resultBuilder.addAll(Iterables.transform(product, ImmutableBitSet::union));
+      resultBuilder.addAll(Util.transform(product, ImmutableBitSet::union));
     }
     return resultBuilder.build();
   }

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableMultiRel.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableMultiRel.java
@@ -19,8 +19,7 @@ package org.apache.calcite.rel.mutable;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.rel.type.RelDataType;
-
-import com.google.common.collect.Lists;
+import org.apache.calcite.util.Util;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,6 +57,6 @@ abstract class MutableMultiRel extends MutableRel {
   }
 
   protected List<MutableRel> cloneChildren() {
-    return Lists.transform(inputs, MutableRel::clone);
+    return Util.transform(inputs, MutableRel::clone);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
@@ -60,8 +60,6 @@ import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
-import com.google.common.collect.Lists;
-
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -319,7 +317,7 @@ public abstract class MutableRels {
 
   private static List<RelNode> fromMutables(List<MutableRel> nodes,
       final RelBuilder relBuilder) {
-    return Lists.transform(nodes,
+    return Util.transform(nodes,
         mutableRel -> fromMutable(mutableRel, relBuilder));
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -84,12 +84,12 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Permutation;
 import org.apache.calcite.util.ReflectUtil;
 import org.apache.calcite.util.ReflectiveVisitor;
+import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 
 import java.util.ArrayDeque;
@@ -848,14 +848,14 @@ public class RelToSqlConverter extends SqlImplementor
   private SqlNodeList exprList(final Context context,
       List<? extends RexNode> exprs) {
     return new SqlNodeList(
-        Lists.transform(exprs, e -> context.toSql(null, e)), POS);
+        Util.transform(exprs, e -> context.toSql(null, e)), POS);
   }
 
   /** Converts a list of names expressions to a list of single-part
    * {@link SqlIdentifier}s. */
   private SqlNodeList identifierList(List<String> names) {
     return new SqlNodeList(
-        Lists.transform(names, name -> new SqlIdentifier(name, POS)), POS);
+        Util.transform(names, name -> new SqlIdentifier(name, POS)), POS);
   }
 
   /** Visits a Match; called by {@link #dispatch} via reflection. */

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExtractProjectRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExtractProjectRule.java
@@ -28,12 +28,12 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -114,7 +114,7 @@ public class AggregateExtractProjectRule
         Mappings.apply(mapping, aggregate.getGroupSet());
 
     final Iterable<ImmutableBitSet> newGroupSets =
-        Iterables.transform(aggregate.getGroupSets(),
+        Util.transform(aggregate.getGroupSets(),
             bitSet -> Mappings.apply(mapping, bitSet));
     final List<RelBuilder.AggCall> newAggCallList = new ArrayList<>();
     for (AggregateCall aggCall : aggregate.getAggCallList()) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
@@ -29,10 +29,10 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -125,7 +125,7 @@ public class AggregateProjectMergeRule
     final RelBuilder relBuilder = call.builder();
     relBuilder.push(newAggregate);
     final List<Integer> newKeys =
-        Lists.transform(aggregate.getGroupSet().asList(), map::get);
+        Util.transform(aggregate.getGroupSet().asList(), map::get);
     if (!newKeys.equals(newGroupSet.asList())) {
       final List<Integer> posList = new ArrayList<>();
       for (int newKey : newKeys) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
@@ -39,6 +39,7 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 import org.apache.calcite.util.graph.DefaultDirectedGraph;
 import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
@@ -46,7 +47,6 @@ import org.apache.calcite.util.graph.TopologicalOrderIterator;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -173,8 +173,7 @@ public abstract class ProjectToWindowRule
           }
           if (!program.projectsOnlyIdentity()) {
             relBuilder.project(
-                Lists.transform(program.getProjectList(),
-                    program::expandLocalRef),
+                Util.transform(program.getProjectList(), program::expandLocalRef),
                 calc.getRowType().getFieldNames());
           }
           return relBuilder.build();

--- a/core/src/main/java/org/apache/calcite/rex/RexAnalyzer.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexAnalyzer.java
@@ -25,7 +25,6 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashSet;
@@ -58,8 +57,7 @@ public class RexAnalyzer {
         variables.stream().map(RexAnalyzer::getComparables)
             .collect(Util.toImmutableList());
     final Iterable<List<Comparable>> product = Linq4j.product(generators);
-    //noinspection StaticPseudoFunctionalStyleMethod
-    return Iterables.transform(product,
+    return Util.transform(product,
         values -> ImmutableMap.copyOf(Pair.zip(variables, values)));
   }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -54,7 +54,6 @@ import org.apache.calcite.util.Util;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
@@ -137,7 +136,7 @@ public class RexBuilder {
   /** Creates a list of {@link org.apache.calcite.rex.RexInputRef} expressions,
    * projecting the fields of a given record type. */
   public List<? extends RexNode> identityProjects(final RelDataType rowType) {
-    return Lists.transform(rowType.getFieldList(),
+    return Util.transform(rowType.getFieldList(),
         input -> new RexInputRef(input.getIndex(), input.getType()));
   }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1813,11 +1813,11 @@ public class RexUtil {
 
   /** Transforms a list of expressions into a list of their types. */
   public static List<RelDataType> types(List<? extends RexNode> nodes) {
-    return Lists.transform(nodes, RexNode::getType);
+    return Util.transform(nodes, RexNode::getType);
   }
 
   public static List<RelDataTypeFamily> families(List<RelDataType> types) {
-    return Lists.transform(types, RelDataType::getFamily);
+    return Util.transform(types, RelDataType::getFamily);
   }
 
   /** Removes all expressions from a list that are equivalent to a given
@@ -2091,7 +2091,7 @@ public class RexUtil {
     }
     return composeConjunction(rexBuilder,
         Iterables.concat(ImmutableList.of(e),
-            Iterables.transform(notTerms, e2 -> not(rexBuilder, e2))));
+            Util.transform(notTerms, e2 -> not(rexBuilder, e2))));
   }
 
   /** Returns whether a given operand of a CASE expression is a predicate.
@@ -2474,11 +2474,11 @@ public class RexUtil {
         case OR:
           operands = ((RexCall) arg).getOperands();
           return toCnf2(
-              and(Lists.transform(flattenOr(operands), RexUtil::addNot)));
+              and(Util.transform(flattenOr(operands), RexUtil::addNot)));
         case AND:
           operands = ((RexCall) arg).getOperands();
           return toCnf2(
-              or(Lists.transform(flattenAnd(operands), RexUtil::addNot)));
+              or(Util.transform(flattenAnd(operands), RexUtil::addNot)));
         default:
           incrementAndCheck();
           return rex;
@@ -2577,7 +2577,7 @@ public class RexUtil {
 
   /** Transforms a list of expressions to the list of digests. */
   public static List<String> strings(List<RexNode> list) {
-    return Lists.transform(list, Object::toString);
+    return Util.transform(list, Object::toString);
   }
 
   /** Helps {@link org.apache.calcite.rex.RexUtil#toDnf}. */
@@ -2617,11 +2617,11 @@ public class RexUtil {
         case OR:
           operands = ((RexCall) arg).getOperands();
           return toDnf(
-              and(Lists.transform(flattenOr(operands), RexUtil::addNot)));
+              and(Util.transform(flattenOr(operands), RexUtil::addNot)));
         case AND:
           operands = ((RexCall) arg).getOperands();
           return toDnf(
-              or(Lists.transform(flattenAnd(operands), RexUtil::addNot)));
+              or(Util.transform(flattenAnd(operands), RexUtil::addNot)));
         default:
           return rex;
         }

--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -39,6 +39,7 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.tools.RelRunner;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -443,7 +444,7 @@ public final class Schemas {
   public static List<CalciteSchema.TableEntry> getStarTables(
       CalciteSchema schema) {
     final List<CalciteSchema.LatticeEntry> list = getLatticeEntries(schema);
-    return Lists.transform(list, entry -> {
+    return Util.transform(list, entry -> {
       final CalciteSchema.TableEntry starTable =
           Objects.requireNonNull(entry).getStarTable();
       assert starTable.getTable().getJdbcTableType()
@@ -457,7 +458,7 @@ public final class Schemas {
    * @param schema Schema */
   public static List<Lattice> getLattices(CalciteSchema schema) {
     final List<CalciteSchema.LatticeEntry> list = getLatticeEntries(schema);
-    return Lists.transform(list, CalciteSchema.LatticeEntry::getLattice);
+    return Util.transform(list, LatticeEntry::getLattice);
   }
 
   /** Returns the lattices defined in a schema.

--- a/core/src/main/java/org/apache/calcite/sql/SqlIdentifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIdentifier.java
@@ -27,7 +27,6 @@ import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -122,7 +121,7 @@ public class SqlIdentifier extends SqlNode {
   public static SqlIdentifier star(List<String> names, SqlParserPos pos,
       List<SqlParserPos> componentPositions) {
     return new SqlIdentifier(
-        Lists.transform(names, s -> s.equals("*") ? "" : s), null, pos,
+        Util.transform(names, s -> s.equals("*") ? "" : s), null, pos,
         componentPositions);
   }
 
@@ -147,7 +146,7 @@ public class SqlIdentifier extends SqlNode {
 
   /** Converts empty strings in a list of names to stars. */
   public static List<String> toStar(List<String> names) {
-    return Lists.transform(names,
+    return Util.transform(names,
         s -> s.equals("") ? "*" : s.equals("*") ? "\"*\"" : s);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserPos.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserPos.java
@@ -17,8 +17,8 @@
 package org.apache.calcite.sql.parser;
 
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import java.io.Serializable;
@@ -194,14 +194,8 @@ public class SqlParserPos implements Serializable {
     };
   }
 
-  private static Iterable<SqlParserPos> toPos(Iterable<SqlNode> nodes) {
-    return Iterables.transform(nodes, node -> {
-      if (node == null) {
-        return null;
-      } else {
-        return node.getParserPosition();
-      }
-    });
+  private static Iterable<SqlParserPos> toPos(Iterable<? extends SqlNode> nodes) {
+    return Util.transform(nodes, node -> node == null ? null : node.getParserPosition());
   }
 
   /**
@@ -209,7 +203,7 @@ public class SqlParserPos implements Serializable {
    * which spans from the beginning of the first to the end of the last.
    */
   public static SqlParserPos sum(final List<? extends SqlNode> nodes) {
-    return sum(Lists.transform(nodes, SqlNode::getParserPosition));
+    return sum(Util.transform(nodes, SqlNode::getParserPosition));
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
@@ -24,7 +24,6 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -67,7 +66,7 @@ public abstract class ListScope extends DelegatingScope {
    * @return list of child namespaces
    */
   public List<SqlValidatorNamespace> getChildren() {
-    return Lists.transform(children, scopeChild -> scopeChild.namespace);
+    return Util.transform(children, scopeChild -> scopeChild.namespace);
   }
 
   /**
@@ -76,7 +75,7 @@ public abstract class ListScope extends DelegatingScope {
    * @return list of child namespaces
    */
   List<String> getChildNames() {
-    return Lists.transform(children, scopeChild -> scopeChild.name);
+    return Util.transform(children, scopeChild -> scopeChild.name);
   }
 
   private ScopeChild findChild(List<String> names,

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
@@ -29,8 +29,6 @@ import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Lists;
-
 import java.util.List;
 
 /**
@@ -92,7 +90,6 @@ public class SqlUserDefinedFunction extends SqlFunction {
 
   @SuppressWarnings("deprecation")
   @Override public List<String> getParamNames() {
-    return Lists.transform(function.getParameters(),
-        FunctionParameter::getName);
+    return Util.transform(function.getParameters(), FunctionParameter::getName);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableMacro.java
@@ -35,8 +35,6 @@ import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -81,8 +79,7 @@ public class SqlUserDefinedTableMacro extends SqlFunction
 
   @SuppressWarnings("deprecation")
   @Override public List<String> getParamNames() {
-    return Lists.transform(tableMacro.getParameters(),
-        FunctionParameter::getName);
+    return Util.transform(tableMacro.getParameters(), FunctionParameter::getName);
   }
 
   /** Returns the table in this UDF, or null if there is no table. */

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorScope.java
@@ -25,10 +25,10 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -242,7 +242,7 @@ public interface SqlValidatorScope {
 
     /** Returns a list ["step1", "step2"]. */
     List<String> stepNames() {
-      return Lists.transform(steps(), input -> input.name);
+      return Util.transform(steps(), input -> input.name);
     }
 
     protected void build(ImmutableList.Builder<Step> paths) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -62,7 +62,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -227,8 +226,7 @@ public class SqlValidatorUtil {
       RelDataType sourceRowType,
       Map<Integer, RelDataTypeField> indexToField) {
     ImmutableBitSet source = ImmutableBitSet.of(
-        Lists.transform(sourceRowType.getFieldList(),
-            RelDataTypeField::getIndex));
+        Util.transform(sourceRowType.getFieldList(), RelDataTypeField::getIndex));
     ImmutableBitSet target =
         ImmutableBitSet.of(indexToField.keySet());
     return source.intersect(target);
@@ -275,8 +273,7 @@ public class SqlValidatorUtil {
    */
   static void checkIdentifierListForDuplicates(List<SqlNode> columnList,
       SqlValidatorImpl.ValidationErrorFunction validationErrorFunction) {
-    final List<List<String>> names = Lists.transform(columnList,
-        o -> ((SqlIdentifier) o).names);
+    final List<List<String>> names = Util.transform(columnList, o -> ((SqlIdentifier) o).names);
     final int i = Util.firstDuplicate(names);
     if (i >= 0) {
       throw validationErrorFunction.apply(columnList.get(i),

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -600,7 +600,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
           ImmutableBitSet.range(oldGroupKeyCount, newGroupKeyCount);
       newGroupSets =
           ImmutableBitSet.ORDERING.immutableSortedCopy(
-              Iterables.transform(rel.getGroupSets(),
+              Util.transform(rel.getGroupSets(),
                   bitSet -> bitSet.union(addedGroupSet)));
     }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
@@ -73,8 +73,6 @@ import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -364,7 +362,7 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
       ImmutableBitSet fieldsUsed,
       Set<RelDataTypeField> extraFields) {
     final RexProgram rexProgram = calc.getProgram();
-    final List<RexNode> projs = Lists.transform(rexProgram.getProjectList(),
+    final List<RexNode> projs = Util.transform(rexProgram.getProjectList(),
         rexProgram::expandLocalRef);
 
     final RelDataType rowType = calc.getRowType();
@@ -426,7 +424,7 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
     final RelNode newInputRelNode = relBuilder.push(newInput).build();
     RexNode newConditionExpr = null;
     if (rexProgram.getCondition() != null) {
-      final List<RexNode> filter = Lists.transform(
+      final List<RexNode> filter = Util.transform(
           ImmutableList.of(
               rexProgram.getCondition()), rexProgram::expandLocalRef);
       assert filter.size() == 1;
@@ -1051,7 +1049,7 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
 
     final ImmutableList<ImmutableBitSet> newGroupSets =
         ImmutableList.copyOf(
-            Iterables.transform(aggregate.getGroupSets(),
+            Util.transform(aggregate.getGroupSets(),
                 input1 -> Mappings.apply(inputMapping, input1)));
 
     // Populate mapping of where to find the fields. System, group key and

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1522,7 +1522,7 @@ public class SqlToRelConverter {
             && call.operandCount() == leftKeys.size();
         rexComparison =
             RexUtil.composeConjunction(rexBuilder,
-                Iterables.transform(
+                Util.transform(
                     Pair.zip(leftKeys, call.getOperandList()),
                     pair -> rexBuilder.makeCall(comparisonOp, pair.left,
                         ensureSqlType(pair.left.getType(),

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -114,12 +114,12 @@ public class Programs {
 
   /** Creates a list of programs based on an array of rule sets. */
   public static List<Program> listOf(RuleSet... ruleSets) {
-    return Lists.transform(Arrays.asList(ruleSets), Programs::of);
+    return Util.transform(Arrays.asList(ruleSets), Programs::of);
   }
 
   /** Creates a list of programs based on a list of rule sets. */
   public static List<Program> listOf(List<RuleSet> ruleSets) {
-    return Lists.transform(ruleSets, Programs::of);
+    return Util.transform(ruleSets, Programs::of);
   }
 
   /** Creates a program from a list of rules. */

--- a/core/src/main/java/org/apache/calcite/util/ImmutableBitSet.java
+++ b/core/src/main/java/org/apache/calcite/util/ImmutableBitSet.java
@@ -21,7 +21,6 @@ import org.apache.calcite.runtime.Utilities;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 
 import java.io.Serializable;
@@ -264,7 +263,7 @@ public class ImmutableBitSet
       singletons.add(
           ImmutableList.of(ImmutableBitSet.of(), ImmutableBitSet.of(bit)));
     }
-    return Iterables.transform(Linq4j.product(singletons),
+    return Util.transform(Linq4j.product(singletons),
         ImmutableBitSet::union);
   }
 
@@ -886,7 +885,7 @@ public class ImmutableBitSet
   public static Iterable<ImmutableBitSet> permute(
       Iterable<ImmutableBitSet> bitSets,
       final Map<Integer, Integer> map) {
-    return Iterables.transform(bitSets, bitSet -> bitSet.permute(map));
+    return Util.transform(bitSets, bitSet -> bitSet.permute(map));
   }
 
   /** Returns a bit set with every bit moved up {@code offset} positions.

--- a/core/src/main/java/org/apache/calcite/util/ImmutableNullableSet.java
+++ b/core/src/main/java/org/apache/calcite/util/ImmutableNullableSet.java
@@ -108,7 +108,7 @@ public class ImmutableNullableSet<E> extends AbstractSet<E> {
       }
     } else {
       set = ImmutableSet.copyOf(
-          Iterables.transform(elements, e ->
+          Util.transform(elements, e ->
               e == null ? NullSentinel.INSTANCE : e));
     }
     if (set.contains(NullSentinel.INSTANCE)) {

--- a/core/src/main/java/org/apache/calcite/util/Pair.java
+++ b/core/src/main/java/org/apache/calcite/util/Pair.java
@@ -286,8 +286,8 @@ public class Pair<T1, T2>
    * @return Iterable over the left elements
    */
   public static <L, R> Iterable<L> left(
-      final Iterable<? extends Map.Entry<L, R>> iterable) {
-    return () -> new LeftIterator<>(iterable.iterator());
+      final Iterable<? extends Map.Entry<? extends L, ? extends R>> iterable) {
+    return Util.transform(iterable, Map.Entry::getKey);
   }
 
   /**
@@ -299,34 +299,18 @@ public class Pair<T1, T2>
    * @return Iterable over the right elements
    */
   public static <L, R> Iterable<R> right(
-      final Iterable<? extends Map.Entry<L, R>> iterable) {
-    return () -> new RightIterator<>(iterable.iterator());
+      final Iterable<? extends Map.Entry<? extends L, ? extends R>> iterable) {
+    return Util.transform(iterable, Map.Entry::getValue);
   }
 
   public static <K, V> List<K> left(
-      final List<? extends Map.Entry<K, V>> pairs) {
-    return new AbstractList<K>() {
-      public K get(int index) {
-        return pairs.get(index).getKey();
-      }
-
-      public int size() {
-        return pairs.size();
-      }
-    };
+      final List<? extends Map.Entry<? extends K, ? extends V>> pairs) {
+    return Util.transform(pairs, Map.Entry::getKey);
   }
 
   public static <K, V> List<V> right(
-      final List<? extends Map.Entry<K, V>> pairs) {
-    return new AbstractList<V>() {
-      public V get(int index) {
-        return pairs.get(index).getValue();
-      }
-
-      public int size() {
-        return pairs.size();
-      }
-    };
+      final List<? extends Map.Entry<? extends K, ? extends V>> pairs) {
+    return Util.transform(pairs, Map.Entry::getValue);
   }
 
   /**
@@ -367,54 +351,6 @@ public class Pair<T1, T2>
       final T first = iterator.next();
       return new FirstAndIterator<>(iterator, first);
     };
-  }
-
-  /** Iterator that returns the left field of each pair.
-   *
-   * @param <L> Left-hand type
-   * @param <R> Right-hand type */
-  private static class LeftIterator<L, R> implements Iterator<L> {
-    private final Iterator<? extends Map.Entry<L, R>> iterator;
-
-    LeftIterator(Iterator<? extends Map.Entry<L, R>> iterator) {
-      this.iterator = Objects.requireNonNull(iterator);
-    }
-
-    public boolean hasNext() {
-      return iterator.hasNext();
-    }
-
-    public L next() {
-      return iterator.next().getKey();
-    }
-
-    public void remove() {
-      iterator.remove();
-    }
-  }
-
-  /** Iterator that returns the right field of each pair.
-   *
-   * @param <L> Left-hand type
-   * @param <R> Right-hand type */
-  private static class RightIterator<L, R> implements Iterator<R> {
-    private final Iterator<? extends Map.Entry<L, R>> iterator;
-
-    RightIterator(Iterator<? extends Map.Entry<L, R>> iterator) {
-      this.iterator = Objects.requireNonNull(iterator);
-    }
-
-    public boolean hasNext() {
-      return iterator.hasNext();
-    }
-
-    public R next() {
-      return iterator.next().getValue();
-    }
-
-    public void remove() {
-      iterator.remove();
-    }
   }
 
   /** Iterator that returns the first element of a collection paired with every

--- a/core/src/main/java/org/apache/calcite/util/mapping/IntPair.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/IntPair.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.util.mapping;
 
 import org.apache.calcite.runtime.Utilities;
+import org.apache.calcite.util.Util;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 
 import java.util.AbstractList;
@@ -33,6 +33,7 @@ import java.util.List;
  */
 public class IntPair {
   /** Function that swaps source and target fields of an {@link IntPair}. */
+  @Deprecated
   public static final Function<IntPair, IntPair> SWAP =
       new Function<IntPair, IntPair>() {
         public IntPair apply(IntPair pair) {
@@ -55,6 +56,7 @@ public class IntPair {
           });
 
   /** Function that returns the left (source) side of a pair. */
+  @Deprecated
   public static final Function<IntPair, Integer> LEFT =
       new Function<IntPair, Integer>() {
         public Integer apply(IntPair pair) {
@@ -63,6 +65,7 @@ public class IntPair {
       };
 
   /** Function that returns the right (target) side of a pair. */
+  @Deprecated
   public static final Function<IntPair, Integer> RIGHT =
       new Function<IntPair, Integer>() {
         public Integer apply(IntPair pair) {
@@ -156,11 +159,11 @@ public class IntPair {
 
   /** Returns the left side of a list of pairs. */
   public static List<Integer> left(final List<IntPair> pairs) {
-    return Lists.transform(pairs, LEFT);
+    return Util.transform(pairs, x -> x.source);
   }
 
   /** Returns the right side of a list of pairs. */
   public static List<Integer> right(final List<IntPair> pairs) {
-    return Lists.transform(pairs, RIGHT);
+    return Util.transform(pairs, x -> x.target);
   }
 }

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -22,7 +22,6 @@ import org.apache.calcite.util.Permutation;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
 
 import java.util.AbstractList;
@@ -220,7 +219,7 @@ public abstract class Mappings {
       Iterable<ImmutableBitSet> bitSets) {
     return ImmutableList.copyOf(
         ImmutableBitSet.ORDERING.sortedCopy(
-            Iterables.transform(bitSets, input1 -> apply(mapping, input1))));
+            Util.transform(bitSets, input1 -> apply(mapping, input1))));
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/test/QuidemTest.java
+++ b/core/src/test/java/org/apache/calcite/test/QuidemTest.java
@@ -33,7 +33,6 @@ import org.apache.calcite.util.Closer;
 import org.apache.calcite.util.Sources;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.Lists;
 import com.google.common.io.PatternFilenameFilter;
 
 import net.hydromatic.quidem.CommandHandler;
@@ -111,7 +110,7 @@ public abstract class QuidemTest {
     for (File f : Util.first(dir.listFiles(filter), new File[0])) {
       paths.add(f.getAbsolutePath().substring(commonPrefixLength));
     }
-    return Lists.transform(paths, path -> new Object[] {path});
+    return Util.transform(paths, path -> new Object[] {path});
   }
 
   protected void checkRun(String path) throws Exception {

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidDateTimeUtils.java
@@ -34,7 +34,6 @@ import org.apache.calcite.util.trace.CalciteTrace;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.TreeRangeSet;
 
@@ -80,7 +79,7 @@ public class DruidDateTimeUtils {
 
   protected static List<Interval> toInterval(
       List<Range<Long>> ranges) {
-    List<Interval> intervals = Lists.transform(ranges, range -> {
+    List<Interval> intervals = Util.transform(ranges, range -> {
       if (!range.hasLowerBound() && !range.hasUpperBound()) {
         return DruidTable.DEFAULT_INTERVAL;
       }

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -71,7 +71,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.joda.time.Interval;
@@ -1099,7 +1098,7 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
         // Case we have transformed the group by time to druid timeseries with Granularity.
         // Need to replace the name of the column with druid timestamp field name.
         final List<String> timeseriesFieldNames =
-            Lists.transform(queryOutputFieldNames, input -> {
+            Util.transform(queryOutputFieldNames, input -> {
               if (timeExtractColumn.equals(input)) {
                 return "timestamp";
               }

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeToEnumerableConverter.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeToEnumerableConverter.java
@@ -38,8 +38,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
-
-import com.google.common.collect.Lists;
+import org.apache.calcite.util.Util;
 
 import java.lang.reflect.Method;
 import java.util.AbstractList;
@@ -152,6 +151,6 @@ public class GeodeToEnumerableConverter extends ConverterImpl implements Enumera
    * {@code {ConstantExpression("x"), ConstantExpression("y")}}.
    */
   private static <T> List<Expression> constantList(List<T> values) {
-    return Lists.transform(values, Expressions::constant);
+    return Util.transform(values, Expressions::constant);
   }
 }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstructorDeclaration.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstructorDeclaration.java
@@ -16,10 +16,10 @@
  */
 package org.apache.calcite.linq4j.tree;
 
-import com.google.common.collect.Lists;
 
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -62,16 +62,17 @@ public class ConstructorDeclaration extends MemberDeclaration {
     if (!modifiers.isEmpty()) {
       writer.append(' ');
     }
+    //noinspection unchecked
     writer
         .append(resultType)
         .list("(", ", ", ")",
-            Lists.transform(parameters, parameter -> {
+            () -> (Iterator) parameters.stream().map(parameter -> {
               final String modifiers1 =
                   Modifier.toString(parameter.modifier);
               return modifiers1 + (modifiers1.isEmpty() ? "" : " ")
                   + Types.className(parameter.getType()) + " "
                   + parameter.name;
-            }))
+            }).iterator())
         .append(' ').append(body);
     writer.newlineAndIndent();
   }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/MethodDeclaration.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/MethodDeclaration.java
@@ -16,10 +16,10 @@
  */
 package org.apache.calcite.linq4j.tree;
 
-import com.google.common.collect.Lists;
 
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -63,12 +63,13 @@ public class MethodDeclaration extends MemberDeclaration {
     if (!modifiers.isEmpty()) {
       writer.append(' ');
     }
+    //noinspection unchecked
     writer
         .append(resultType)
         .append(' ')
         .append(name)
         .list("(", ", ", ")",
-            Lists.transform(parameters, ParameterExpression::declString))
+            () -> (Iterator) parameters.stream().map(ParameterExpression::declString).iterator())
         .append(' ')
         .append(body);
     writer.newlineAndIndent();

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoToEnumerableConverter.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoToEnumerableConverter.java
@@ -38,8 +38,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
-
-import com.google.common.collect.Lists;
+import org.apache.calcite.util.Util;
 
 import java.util.AbstractList;
 import java.util.List;
@@ -156,6 +155,6 @@ public class MongoToEnumerableConverter
   /** E.g. {@code constantList("x", "y")} returns
    * {@code {ConstantExpression("x"), ConstantExpression("y")}}. */
   private static <T> List<Expression> constantList(List<T> values) {
-    return Lists.transform(values, Expressions::constant);
+    return Util.transform(values, Expressions::constant);
   }
 }

--- a/src/main/config/forbidden-apis/signatures.txt
+++ b/src/main/config/forbidden-apis/signatures.txt
@@ -84,6 +84,12 @@ com.google.common.base.Joiner
 @defaultMessage Use "new ArrayList<>()"
 com.google.common.collect.Lists#newArrayList()
 
+@defaultMessage Use "org.apache.calcite.util.Util#transform(List, Function)"
+com.google.common.collect.Lists#transform(java.util.List, com.google.common.base.Function)
+
+@defaultMessage Use "org.apache.calcite.util.Util#transform(Iterable, Function)"
+com.google.common.collect.Iterables#transform(java.lang.Iterable, com.google.common.base.Function)
+
 @defaultMessage Use "new HashMap<>()"
 com.google.common.collect.Maps#newHashMap()
 
@@ -95,5 +101,3 @@ com.google.common.collect.Maps#newTreeMap()
 
 @defaultMessage Use "new HashSet<>()"
 com.google.common.collect.Sets#newHashSet()
-
-# End signatures.txt


### PR DESCRIPTION
The key drivers are:
1) Move to Java's `Function`
2) Use `List<? extends F>`  rather than `List<F>` to clarify that the function won't write to the given list