### PR TITLE
Add MaxMetaspaceSize=512m to avoid metaspace issues when building Calcite

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+org.gradle.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true


### PR DESCRIPTION
Gradle defaults to 256m which seems to be too small