### PR TITLE
[CALCITE-4287] AggregateJoinRemoveRule and ProjectJoinRemoveRule are not fired if the last column of the join's left input is referenced

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinRemoveRule.java
@@ -82,7 +82,7 @@ public class AggregateJoinRemoveRule
     final Join join = call.rel(1);
     boolean isLeftJoin = join.getJoinType() == JoinRelType.LEFT;
     int lower = isLeftJoin
-        ? join.getLeft().getRowType().getFieldCount() - 1 : 0;
+        ? join.getLeft().getRowType().getFieldCount() : 0;
     int upper = isLeftJoin ? join.getRowType().getFieldCount()
         : join.getLeft().getRowType().getFieldCount();
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinRemoveRule.java
@@ -76,7 +76,7 @@ public class ProjectJoinRemoveRule
     final Join join = call.rel(1);
     final boolean isLeftJoin = join.getJoinType() == JoinRelType.LEFT;
     int lower = isLeftJoin
-        ? join.getLeft().getRowType().getFieldCount() - 1 : 0;
+        ? join.getLeft().getRowType().getFieldCount() : 0;
     int upper = isLeftJoin
         ? join.getRowType().getFieldCount()
         : join.getLeft().getRowType().getFieldCount();

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5234,6 +5234,19 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Similar to {@link #testAggregateJoinRemove3()} but with agg call
+   * referencing the last column of the left input. */
+  @Test void testAggregateJoinRemove11() {
+    final String sql = "select e.deptno, count(distinct e.slacker)\n"
+        + "from sales.emp e\n"
+        + "left outer join sales.dept d on e.deptno = d.deptno\n"
+        + "group by e.deptno";
+    sql(sql)
+        .withRule(CoreRules.AGGREGATE_PROJECT_MERGE,
+            CoreRules.AGGREGATE_JOIN_REMOVE)
+        .check();
+  }
+
   /** Similar to {@link #testAggregateJoinRemove1()};
    * Should remove the bottom join since the project uses column in the
    * right input of bottom join. */
@@ -5334,6 +5347,17 @@ class RelOptRulesTest extends RelOptTestBase {
         + "RIGHT JOIN sales.emp e ON e.deptno = d.deptno";
     sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
         .checkUnchanged();
+  }
+
+  /** Similar to {@link #testAggregateJoinRemove4()};
+   * The project references the last column of the left input.
+   * The rule should be fired.*/
+  @Test void testProjectJoinRemove10() {
+    final String sql = "SELECT e.deptno, e.slacker\n"
+        + "FROM sales.emp e\n"
+        + "LEFT JOIN sales.dept d ON e.deptno = d.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
   }
 
   @Test void testSwapOuterJoin() {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -9887,6 +9887,29 @@ LogicalAggregate(group=[{7}], EXPR$1=[COUNT(DISTINCT $10, $12)])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testAggregateJoinRemove11">
+        <Resource name="sql">
+            <![CDATA[select e.deptno, count(distinct e.slacker)
+        from sales.emp e
+        left outer join sales.dept d on e.deptno = d.deptno
+        group by e.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT(DISTINCT $1)])
+  LogicalProject(DEPTNO=[$7], SLACKER=[$8])
+    LogicalJoin(condition=[=($7, $9)], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalAggregate(group=[{7}], EXPR$1=[COUNT(DISTINCT $8)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testProjectJoinRemove1">
         <Resource name="sql">
             <![CDATA[SELECT e.deptno, d2.deptno
@@ -10100,6 +10123,27 @@ LogicalProject(DEPTNO=[$9], NAME=[$1])
   LogicalJoin(condition=[=($9, $0)], joinType=[right])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testProjectJoinRemove10">
+        <Resource name="sql">
+            <![CDATA[SELECT e.deptno, e.slacker
+FROM sales.emp e
+LEFT JOIN sales.dept d ON e.deptno = d.deptno]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(DEPTNO=[$7], SLACKER=[$8])
+  LogicalJoin(condition=[=($7, $9)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(DEPTNO=[$7], SLACKER=[$8])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CALCITE-4287