### PR TITLE
[CALCITE-4295] Composite of two checkers with SqlOperandCountRange throws IllegalArgumentException

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
@@ -216,7 +216,7 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
   private int minMin(List<SqlOperandCountRange> ranges) {
     int min = Integer.MAX_VALUE;
     for (SqlOperandCountRange range : ranges) {
-      min = Math.min(min, range.getMax());
+      min = Math.min(min, range.getMin());
     }
     return min;
   }

--- a/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
+++ b/core/src/test/java/org/apache/calcite/test/MockSqlOperatorTable.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.SqlTableFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -70,6 +71,7 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
     opTab.addOperator(new NotATableFunction());
     opTab.addOperator(new BadTableFunction());
     opTab.addOperator(new StructuredFunction());
+    opTab.addOperator(new CompositeFunction());
   }
 
   /** "RAMP" user-defined table function. */
@@ -255,6 +257,27 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
           .add("F0", bigintType)
           .add("F1", varcharType)
           .build();
+    }
+  }
+
+  /** "COMPOSITE" user-defined scalar function. **/
+  public static class CompositeFunction extends SqlFunction {
+    public CompositeFunction() {
+      super("COMPOSITE",
+          new SqlIdentifier("COMPOSITE", SqlParserPos.ZERO),
+          SqlKind.OTHER_FUNCTION,
+          null,
+          null,
+          OperandTypes.or(
+              OperandTypes.variadic(SqlOperandCountRanges.from(1)),
+              OperandTypes.variadic(SqlOperandCountRanges.from(2))),
+          SqlFunctionCategory.USER_DEFINED_FUNCTION);
+    }
+
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+      final RelDataTypeFactory typeFactory =
+          opBinding.getTypeFactory();
+      return typeFactory.createSqlType(SqlTypeName.BIGINT);
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4049,6 +4049,18 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4295">[CALCITE-4295]
+   * Composite of two checker with SqlOperandCountRange throws IllegalArgumentException</a>.
+   */
+  @Test public void testCompositeOfCountRange() {
+    final String sql = ""
+        + "select COMPOSITE(deptno)\n"
+        + "from dept";
+    sql(sql).trim(true).ok();
+  }
+
+  /**
    * Visitor that checks that every {@link RelNode} in a tree is valid.
    *
    * @see RelNode#isValid(Litmus, RelNode.Context)

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -7213,4 +7213,16 @@ LogicalProject(EMPNO=[$0])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testCompositeOfCountRange">
+        <Resource name="sql">
+            <![CDATA[select COMPOSITE(deptno)
+from dept]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[COMPOSITE($0)])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
Root cause is:
The minMin function of CompositeOperandTypeChecker should return the minimum of lower bound of all SqlOperandCountRange.This PR will fix it. 