### PR TITLE
[CALCITE-4300] EnumerableBatchNestedLoopJoin dynamic code generation can lead to variable name issues if two EBNLJ are nested

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
@@ -162,7 +162,7 @@ public class EnumerableBatchNestedLoopJoin extends Join implements EnumerableRel
     ParameterExpression corrArg;
     final ParameterExpression corrArgList =
         Expressions.parameter(Modifier.FINAL,
-            List.class, "corrList");
+            List.class, "corrList" + this.getId());
 
     // Declare batchSize correlation variables
     if (!Primitive.is(corrVarType)) {


### PR DESCRIPTION
Jira: CALCITE-4300