### PR TITLE
Site: fix aggregate function doc

### DIFF
--- a/site/_docs/adapter.md
+++ b/site/_docs/adapter.md
@@ -275,7 +275,7 @@ Accumulator merge(Accumulator a, Accumulator a2) {
   return new Accumulator(a.sum + a2.sum);
 }
 int result(Accumulator a) {
-  return new Accumulator(a.sum + x);
+  return a.sum;
 }
 {% endhighlight %}
 


### PR DESCRIPTION
Method result() now returns an int value, as required by the method signature
(Alexander Trushev)