### PR TITLE
[CALCITE-4321] Include Filter Where Expressions in JDBC Adapter SQL

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -704,6 +704,10 @@ public class JdbcRules {
           throw new InvalidRelException("cannot implement aggregate function "
               + aggCall.getAggregation());
         }
+        if (aggCall.hasFilter() && !dialect.supportsAggregateFunctionFilter()) {
+          throw new InvalidRelException("dialect does not support aggregate functions FILTER " +
+              "clauses");
+        }
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1167,8 +1167,18 @@ public abstract class SqlImplementor {
         return SqlStdOperatorTable.COALESCE.createCall(POS, node,
             SqlLiteral.createExactNumeric("0", POS));
       } else {
-        return withOrder(op.createCall(qualifier, POS, operands), orderList);
+        return withOrder(
+            withFilter(op.createCall(qualifier, POS, operands), aggCall.filterArg), orderList);
       }
+    }
+
+    /** Wraps a call in a {@link SqlKind#FILTER} call if
+     * {@code filterArg} is greater than zero. */
+    private SqlCall withFilter(SqlCall call, int filterArg) {
+      if (filterArg < 0) {
+        return call;
+      }
+      return SqlStdOperatorTable.FILTER.createCall(POS, call, field(filterArg));
     }
 
     /** Wraps a call in a {@link SqlKind#WITHIN_GROUP} call, if

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -714,6 +714,14 @@ public class SqlDialect {
     return false;
   }
 
+  /**
+   * Returns whether the dialect supports the use of FILTER clauses for
+   * aggregate functions. e.g. count(*) FILTER (WHERE a = 2)
+   */
+  public boolean supportsAggregateFunctionFilter() {
+    return true;
+  }
+
   /** Returns whether this dialect supports window functions (OVER clause). */
   public boolean supportsWindowFunctions() {
     return true;

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -117,6 +117,10 @@ public class BigQuerySqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean supportsAggregateFunctionFilter() {
+    return false;
+  }
+
   @Override public @Nonnull SqlParser.Config configureParser(
       SqlParser.Config configBuilder) {
     return super.configureParser(configBuilder)

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -203,6 +203,21 @@ class RelToSqlConverterTest {
     sql(query).ok("SELECT *\nFROM \"foodmart\".\"product\"");
   }
 
+  @Test void testAggregateFilterWhereToSqlFromProductTable() {
+    String query = "select " +
+          "sum(\"shelf_width\") " +
+            "filter (where \"net_weight\" > 0), " +
+          "sum(\"shelf_width\")" +
+        "from \"foodmart\".\"product\"" +
+        "where \"product_id\" > 0 " +
+        "group by \"product_id\"";
+    sql(query).ok("SELECT SUM(\"shelf_width\") FILTER (WHERE \"net_weight\" > 0 IS TRUE), SUM" +
+        "(\"shelf_width\")\n" +
+        "FROM \"foodmart\".\"product\"\n" +
+        "WHERE \"product_id\" > 0\n" +
+        "GROUP BY \"product_id\"");
+  }
+
   @Test void testSimpleSelectQueryFromProductTable() {
     String query = "select \"product_id\", \"product_class_id\" from \"product\"";
     final String expected = "SELECT \"product_id\", \"product_class_id\"\n"


### PR DESCRIPTION
Hi folks. I was excited to see pivot support merged and decided to try it out. I found that it works great for the CSV adapter and Reflective schema, but did not get the results I expected when using a JDBC adapter.

Digging into I found that the SQL issued to the database was lacking the `FILTER (WHERE ...)` expressions. Digging further, I found that `FILTER (WHERE ...)` relational expressions appear to be ignored by `SqlImplementor.java` in all cases that I tried.

This change wraps the aggregate call with a filter when present.

https://issues.apache.org/jira/browse/CALCITE-4321