### PR TITLE
Remove ClassNotFoundException from ExampleFunctionTest that will never be thrown

### DIFF
--- a/example/function/src/test/java/org/apache/calcite/test/ExampleFunctionTest.java
+++ b/example/function/src/test/java/org/apache/calcite/test/ExampleFunctionTest.java
@@ -48,7 +48,7 @@ class ExampleFunctionTest {
 
   /** Unit test for {@link MazeTable}. */
   @Test void testMazeTableFunction()
-      throws SQLException, ClassNotFoundException {
+      throws SQLException {
     final String maze = ""
         + "+--+--+--+--+--+\n"
         + "|        |     |\n"
@@ -62,7 +62,7 @@ class ExampleFunctionTest {
 
   /** Unit test for {@link MazeTable}. */
   @Test void testMazeTableFunctionWithSolution()
-      throws SQLException, ClassNotFoundException {
+      throws SQLException {
     final String maze = ""
         + "+--+--+--+--+--+\n"
         + "|*  *    |     |\n"


### PR DESCRIPTION
Remove `ClassNotFoundException` from `ExampleFunctionTest` that will never be thrown.