### PR TITLE
Improve caching of .gradle folder at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,5 @@ cache:
     - $HOME/.gradle/wrapper/
 
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
-# End .travis.yml
+  - ./gradlew --stop
+  - F=CleanupGradleCache sh -x -c 'curl -O https://raw.githubusercontent.com/vlsi/cleanup-gradle-cache/v1.x/$F.java && javac -J-Xmx128m $F.java && java -Xmx128m $F'

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,6 +38,13 @@ allprojects {
         gradlePluginPortal()
     }
     applyKotlinProjectConventions()
+    tasks.withType<AbstractArchiveTask>().configureEach {
+        // Ensure builds are reproducible
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
+        dirMode = "775".toInt(8)
+        fileMode = "664".toInt(8)
+    }
 }
 
 fun Project.applyKotlinProjectConventions() {


### PR DESCRIPTION
Remove files that change often from Travis cache, remove broken files automatically

The cache itself is useful, however, there might be two problems:
* Corrupted files might get cached, so the subsequent builds would fail
* Too large cache might slowdown the build

https://github.com/vlsi/cleanup-gradle-cache solves both issues.

The cache itself is still re-uploaded on every build (see "store build cache"),
so it might need more investigations.
