### PR TITLE
Enable more tests in TpchTest

### DIFF
--- a/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/VolcanoPlannerTest.java
@@ -485,7 +485,6 @@ class VolcanoPlannerTest {
         resultLeaf.label);
   }
 
-  @Disabled("CALCITE-2592 EnumerableMergeJoin is never taken")
   @Test void testMergeJoin() {
     VolcanoPlanner planner = new VolcanoPlanner();
     planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
@@ -519,8 +518,8 @@ class VolcanoPlannerTest {
         + "  EnumerableSort(sort0=[$0], dir0=[ASC])\n"
         + "    EnumerableValues(tuples=[[{ '2', 'a' }, { '1', 'b' }]])\n"
         + "  EnumerableValues(tuples=[[{ '1', 'x' }, { '2', 'y' }]])\n";
-    assertThat("Merge join + sort is expected", plan,
-        isLinux(RelOptUtil.toString(bestExp)));
+    assertThat("Merge join + sort is expected", RelOptUtil.toString(bestExp),
+        isLinux(plan));
   }
 
   @Test public void testPruneNode() {

--- a/plus/src/test/java/org/apache/calcite/adapter/tpch/TpchTest.java
+++ b/plus/src/test/java/org/apache/calcite/adapter/tpch/TpchTest.java
@@ -18,7 +18,6 @@ package org.apache.calcite.adapter.tpch;
 
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.test.CalciteAssert;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.TestUtil;
 
 import com.google.common.collect.ImmutableList;
@@ -33,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Unit test for {@link org.apache.calcite.adapter.tpch.TpchSchema}.
  *
@@ -821,12 +819,10 @@ class TpchTest {
     checkQuery(1);
   }
 
-  @Disabled("Infinite planning")
   @Test void testQuery02() {
     checkQuery(2);
   }
 
-  @Disabled("Infinite planning")
   @Test void testQuery02Conversion() {
     query(2)
         .convertMatches(relNode -> {
@@ -840,12 +836,10 @@ class TpchTest {
     checkQuery(3);
   }
 
-  @Disabled("NoSuchMethodException: SqlFunctions.lt(Date, Date)")
   @Test void testQuery04() {
     checkQuery(4);
   }
 
-  @Disabled("OutOfMemoryError")
   @Test void testQuery05() {
     checkQuery(5);
   }
@@ -855,7 +849,6 @@ class TpchTest {
   }
 
   @Test void testQuery07() {
-    assumeTrue(Bug.CALCITE_2223_FIXED);
     checkQuery(7);
   }
 
@@ -863,7 +856,6 @@ class TpchTest {
     checkQuery(8);
   }
 
-  @Disabled("no method found")
   @Test void testQuery09() {
     checkQuery(9);
   }
@@ -872,17 +864,14 @@ class TpchTest {
     checkQuery(10);
   }
 
-  @Disabled("CannotPlanException")
   @Test void testQuery11() {
     checkQuery(11);
   }
 
-  @Disabled("NoSuchMethodException: SqlFunctions.lt(Date, Date)")
   @Test void testQuery12() {
     checkQuery(12);
   }
 
-  @Disabled("CannotPlanException")
   @Test void testQuery13() {
     checkQuery(13);
   }
@@ -891,7 +880,6 @@ class TpchTest {
     checkQuery(14);
   }
 
-  @Disabled("AssertionError")
   @Test void testQuery15() {
     checkQuery(15);
   }
@@ -923,7 +911,6 @@ class TpchTest {
     checkQuery(21);
   }
 
-  @Disabled("IllegalArgumentException during decorrelation")
   @Test void testQuery22() {
     checkQuery(22);
   }


### PR DESCRIPTION
As Calcite is evolving, more and more queries are supported now. It would be nice to enable more tests to show what Calcite can achieve.