### PR TITLE
[CALCITE-4354] ITEM operator does not support synthetic struct type

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -2963,7 +2963,12 @@ public class SqlFunctions {
     } else {
       Class<?> beanClass = structObject.getClass();
       try {
-        Field structField = beanClass.getDeclaredField(fieldName);
+        Field structField;
+        if (index >= 0 && index < beanClass.getDeclaredFields().length) {
+          structField = beanClass.getDeclaredFields()[index];
+        } else {
+          structField = beanClass.getDeclaredField(fieldName);
+        }
         return structField.get(structObject);
       } catch (NoSuchFieldException | IllegalAccessException ex) {
         throw RESOURCE.failedToAccessField(fieldName, beanClass.getName()).ex(ex);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -2517,6 +2517,18 @@ public class SqlFunctions {
     if (object instanceof List && index instanceof Number) {
       return arrayItem((List) object, ((Number) index).intValue());
     }
+    if (index instanceof Number) {
+      return structAccess(object, ((Number) index).intValue() - 1, ""); // 1 indexed
+    }
+    if (index instanceof String) {
+      String indexAsStr = index.toString();
+      try {
+        return structAccess(object, Integer.parseInt(indexAsStr) - 1, ""); // 1 indexed
+      } catch (NumberFormatException e) {
+        return structAccess(object, -1, indexAsStr);
+      }
+    }
+
     return null;
   }
 

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -2521,12 +2521,7 @@ public class SqlFunctions {
       return structAccess(object, ((Number) index).intValue() - 1, ""); // 1 indexed
     }
     if (index instanceof String) {
-      String indexAsStr = index.toString();
-      try {
-        return structAccess(object, Integer.parseInt(indexAsStr) - 1, ""); // 1 indexed
-      } catch (NumberFormatException e) {
-        return structAccess(object, -1, indexAsStr);
-      }
+      return structAccess(object, -1, index.toString());
     }
 
     return null;

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -2518,7 +2518,7 @@ public class SqlFunctions {
       return arrayItem((List) object, ((Number) index).intValue());
     }
     if (index instanceof Number) {
-      return structAccess(object, ((Number) index).intValue() - 1, ""); // 1 indexed
+      return structAccess(object, ((Number) index).intValue() - 1, null); // 1 indexed
     }
     if (index instanceof String) {
       return structAccess(object, -1, index.toString());
@@ -2964,7 +2964,7 @@ public class SqlFunctions {
       Class<?> beanClass = structObject.getClass();
       try {
         Field structField;
-        if (index >= 0 && index < beanClass.getDeclaredFields().length) {
+        if (fieldName == null) {
           structField = beanClass.getDeclaredFields()[index];
         } else {
           structField = beanClass.getDeclaredField(fieldName);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -115,7 +115,7 @@ class SqlItemOperator extends SqlSpecialOperator {
   @Override public String getAllowedSignatures(String name) {
     return "<ARRAY>[<INTEGER>]\n"
         + "<MAP>[<VALUE>]\n"
-        + "<ROW>[<VALUE>]";
+        + "<ROW>[<CHARACTER>|<INTEGER>]";
   }
 
   @Override public RelDataType inferReturnType(SqlOperatorBinding opBinding) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -33,6 +33,7 @@ import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 
 import java.util.Arrays;
 
@@ -129,10 +130,10 @@ class SqlItemOperator extends SqlSpecialOperator {
       return typeFactory.createTypeWithNullability(operandType.getValueType(),
           true);
     case ROW:
-      RelDataType fieldType = null;
+      RelDataType fieldType;
       RelDataType indexType = opBinding.getOperandType(1);
 
-      if (SqlTypeFamily.STRING.contains(indexType)) {
+      if (SqlTypeUtil.isString(indexType)) {
         String fieldName = opBinding.getOperandLiteralValue(1, String.class);
         RelDataTypeField field = operandType.getField(fieldName, false, false);
         if (field == null) {
@@ -141,7 +142,7 @@ class SqlItemOperator extends SqlSpecialOperator {
         } else {
           fieldType = field.getType();
         }
-      } else if (SqlTypeFamily.INTEGER.contains(indexType)) {
+      } else if (SqlTypeUtil.isIntType(indexType)) {
         Integer index = opBinding.getOperandLiteralValue(1, Integer.class);
         if (index == null || index < 1 || index > operandType.getFieldCount()) {
           throw new AssertionError("Cannot infer type of field at position "

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -39,7 +39,8 @@ import java.util.Arrays;
 
 /**
  * The item operator {@code [ ... ]}, used to access a given element of an
- * array or map. For example, {@code myArray[3]} or {@code "myMap['foo']"}.
+ * array, map or struct. For example, {@code myArray[3]}, {@code "myMap['foo']"},
+ * {@code myStruct[2]} or {@code myStruct['fieldName']}.
  */
 class SqlItemOperator extends SqlSpecialOperator {
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -116,7 +116,7 @@ class SqlItemOperator extends SqlSpecialOperator {
 
   @Override public String getAllowedSignatures(String name) {
     return "<ARRAY>[<INTEGER>]\n"
-        + "<MAP>[<VALUE>]\n"
+        + "<MAP>[<KEY>]\n"
         + "<ROW>[<CHARACTER>|<INTEGER>]";
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -116,7 +116,7 @@ class SqlItemOperator extends SqlSpecialOperator {
 
   @Override public String getAllowedSignatures(String name) {
     return "<ARRAY>[<INTEGER>]\n"
-        + "<MAP>[<KEY>]\n"
+        + "<MAP>[<ANY>]\n"
         + "<ROW>[<CHARACTER>|<INTEGER>]";
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -8073,7 +8073,7 @@ public abstract class SqlOperatorBaseTest {
         "^ARRAY ['foo', 'bar']['baz']^",
         "Cannot apply 'ITEM' to arguments of type 'ITEM\\(<CHAR\\(3\\) ARRAY>, <CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
             + "<MAP>\\[<VALUE>\\]\n"
-            + "<ROW>\\[<VALUE>\\]",
+            + "<ROW>\\[<CHARACTER>\\|<INTEGER>\\]",
         false);
 
     // Array of INTEGER NOT NULL is interesting because we might be tempted

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -8072,7 +8072,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails(
         "^ARRAY ['foo', 'bar']['baz']^",
         "Cannot apply 'ITEM' to arguments of type 'ITEM\\(<CHAR\\(3\\) ARRAY>, <CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
-            + "<MAP>\\[<KEY>\\]\n"
+            + "<MAP>\\[<ANY>\\]\n"
             + "<ROW>\\[<CHARACTER>\\|<INTEGER>\\]",
         false);
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -8072,7 +8072,8 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails(
         "^ARRAY ['foo', 'bar']['baz']^",
         "Cannot apply 'ITEM' to arguments of type 'ITEM\\(<CHAR\\(3\\) ARRAY>, <CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
-            + "<MAP>\\[<VALUE>\\]",
+            + "<MAP>\\[<VALUE>\\]\n"
+            + "<ROW>\\[<VALUE>\\]",
         false);
 
     // Array of INTEGER NOT NULL is interesting because we might be tempted

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -8072,7 +8072,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails(
         "^ARRAY ['foo', 'bar']['baz']^",
         "Cannot apply 'ITEM' to arguments of type 'ITEM\\(<CHAR\\(3\\) ARRAY>, <CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
-            + "<MAP>\\[<VALUE>\\]\n"
+            + "<MAP>\\[<KEY>\\]\n"
             + "<ROW>\\[<CHARACTER>\\|<INTEGER>\\]",
         false);
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -8093,6 +8093,23 @@ public abstract class SqlOperatorBaseTest {
     tester.checkColumnType(
         "select cast(null as any)['x'] from (values(1))",
         "ANY");
+
+    // Row item
+    final String intStructQuery = "select \"T\".\"X\"[1] "
+        + "from (VALUES (ROW(ROW(3, 7), ROW(4, 8)))) as T(x, y)";
+    tester.check(intStructQuery, SqlTests.INTEGER_TYPE_CHECKER, 3, 0);
+    tester.checkColumnType(intStructQuery, "INTEGER NOT NULL");
+
+    tester.check("select \"T\".\"X\"[1] "
+            + "from (VALUES (ROW(ROW(3, CAST(NULL AS INTEGER)), ROW(4, 8)))) as T(x, y)",
+        SqlTests.INTEGER_TYPE_CHECKER, 3, 0);
+    tester.check("select \"T\".\"X\"[2] "
+            + "from (VALUES (ROW(ROW(3, CAST(NULL AS INTEGER)), ROW(4, 8)))) as T(x, y)",
+        SqlTests.ANY_TYPE_CHECKER, null, 0);
+    tester.checkFails("select \"T\".\"X\"[1 + CAST(NULL AS INTEGER)] "
+        + "from (VALUES (ROW(ROW(3, CAST(NULL AS INTEGER)), ROW(4, 8)))) as T(x, y)",
+        "Cannot infer type of field at position null within ROW type: "
+            + "RecordType\\(INTEGER EXPR\\$0, INTEGER EXPR\\$1\\)", false);
   }
 
   @Test void testMapValueConstructor() {

--- a/core/src/test/java/org/apache/calcite/test/QuidemTest.java
+++ b/core/src/test/java/org/apache/calcite/test/QuidemTest.java
@@ -301,6 +301,10 @@ public abstract class QuidemTest {
                   }
                 });
         return connection;
+      case "bookstore":
+        return CalciteAssert.that()
+            .with(CalciteAssert.SchemaSpec.BOOKSTORE)
+            .connect();
       default:
         throw new RuntimeException("unknown connection '" + name + "'");
       }

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -320,10 +320,17 @@ public class ReflectiveSchemaTest {
             "value=true");
   }
 
-  @Test void testSelectRecordTypeFieldViaItemOperator() {
+  @Test void testSelectRecordTypeFieldViaItemOperatorAndFieldName() {
     CalciteAssert.that()
         .with(CalciteAssert.SchemaSpec.BOOKSTORE)
         .query("select au.\"birthPlace\"['city'] as city from \"bookstore\".\"authors\" au\n")
+        .returnsUnordered("CITY=Heraklion", "CITY=Besançon", "CITY=Ionia");
+  }
+
+  @Test void testSelectRecordTypeFieldViaItemOperatorAndFieldIndex() {
+    CalciteAssert.that()
+        .with(CalciteAssert.SchemaSpec.BOOKSTORE)
+        .query("select au.\"birthPlace\"[2] as city from \"bookstore\".\"authors\" au\n")
         .returnsUnordered("CITY=Heraklion", "CITY=Besançon", "CITY=Ionia");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -320,20 +320,6 @@ public class ReflectiveSchemaTest {
             "value=true");
   }
 
-  @Test void testSelectRecordTypeFieldViaItemOperatorAndFieldName() {
-    CalciteAssert.that()
-        .with(CalciteAssert.SchemaSpec.BOOKSTORE)
-        .query("select au.\"birthPlace\"['city'] as city from \"bookstore\".\"authors\" au\n")
-        .returnsUnordered("CITY=Heraklion", "CITY=Besançon", "CITY=Ionia");
-  }
-
-  @Test void testSelectRecordTypeFieldViaItemOperatorAndFieldIndex() {
-    CalciteAssert.that()
-        .with(CalciteAssert.SchemaSpec.BOOKSTORE)
-        .query("select au.\"birthPlace\"[2] as city from \"bookstore\".\"authors\" au\n")
-        .returnsUnordered("CITY=Heraklion", "CITY=Besançon", "CITY=Ionia");
-  }
-
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2404">[CALCITE-2404]
    * Accessing structured-types is not implemented by the runtime</a>. */

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -320,6 +320,13 @@ public class ReflectiveSchemaTest {
             "value=true");
   }
 
+  @Test void testSelectRecordTypeFieldViaItemOperator() {
+    CalciteAssert.that()
+        .with(CalciteAssert.SchemaSpec.BOOKSTORE)
+        .query("select au.\"birthPlace\"['city'] as city from \"bookstore\".\"authors\" au\n")
+        .returnsUnordered("CITY=Heraklion", "CITY=Besançon", "CITY=Ionia");
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2404">[CALCITE-2404]
    * Accessing structured-types is not implemented by the runtime</a>. */

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8490,7 +8490,8 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select ^name[0]^ from dept")
         .fails("Cannot apply 'ITEM' to arguments of type 'ITEM\\(<VARCHAR\\(10\\)>, "
             +  "<INTEGER>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
-            + "<MAP>\\[<VALUE>\\].*");
+            + "<MAP>\\[<VALUE>\\]\n"
+            + "<ROW>\\[<VALUE>]\\.*");
   }
 
   /** Test case for

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8490,7 +8490,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select ^name[0]^ from dept")
         .fails("Cannot apply 'ITEM' to arguments of type 'ITEM\\(<VARCHAR\\(10\\)>, "
             +  "<INTEGER>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
-            + "<MAP>\\[<VALUE>\\]\n"
+            + "<MAP>\\[<KEY>\\]\n"
             + "<ROW>\\[<CHARACTER>\\|<INTEGER>\\].*");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8490,7 +8490,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select ^name[0]^ from dept")
         .fails("Cannot apply 'ITEM' to arguments of type 'ITEM\\(<VARCHAR\\(10\\)>, "
             +  "<INTEGER>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
-            + "<MAP>\\[<KEY>\\]\n"
+            + "<MAP>\\[<ANY>\\]\n"
             + "<ROW>\\[<CHARACTER>\\|<INTEGER>\\].*");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8491,7 +8491,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("Cannot apply 'ITEM' to arguments of type 'ITEM\\(<VARCHAR\\(10\\)>, "
             +  "<INTEGER>\\)'\\. Supported form\\(s\\): <ARRAY>\\[<INTEGER>\\]\n"
             + "<MAP>\\[<VALUE>\\]\n"
-            + "<ROW>\\[<VALUE>]\\.*");
+            + "<ROW>\\[<CHARACTER>\\|<INTEGER>\\].*");
   }
 
   /** Test case for

--- a/core/src/test/resources/sql/operator.iq
+++ b/core/src/test/resources/sql/operator.iq
@@ -245,6 +245,39 @@ select "T"."X"[1] as x1 from (VALUES (ROW(ROW(3, 7), ROW(4, 8)))) as T(x, y);
 
 !ok
 
+select "T"."X"[CAST(2 AS BIGINT)] as x2 from (VALUES (ROW(ROW(3, 7), ROW(4, 8)))) as T(x, y);
+
++----+
+| X2 |
++----+
+|  7 |
++----+
+(1 row)
+
+!ok
+
+select "T"."Y"[CAST(1 AS TINYINT)] as y1 from (VALUES (ROW(ROW(3, 7), ROW(4, 8)))) as T(x, y);
+
++----+
+| Y1 |
++----+
+|  4 |
++----+
+(1 row)
+
+!ok
+
+select "T"."Y"[CAST(2 AS SMALLINT)] as y2 from (VALUES (ROW(ROW(3, 7), ROW(4, 8)))) as T(x, y);
+
++----+
+| Y2 |
++----+
+|  8 |
++----+
+(1 row)
+
+!ok
+
 !use bookstore
 
 select au."birthPlace"['city'] as city from "bookstore"."authors" au;

--- a/core/src/test/resources/sql/operator.iq
+++ b/core/src/test/resources/sql/operator.iq
@@ -234,4 +234,44 @@ order by 1,2;
 
 !ok
 
+select "T"."X"[1] as x1 from (VALUES (ROW(ROW(3, 7), ROW(4, 8)))) as T(x, y);
+
++----+
+| X1 |
++----+
+|  3 |
++----+
+(1 row)
+
+!ok
+
+!use bookstore
+
+select au."birthPlace"['city'] as city from "bookstore"."authors" au;
+
++-----------+
+| CITY      |
++-----------+
+| Besançon  |
+| Heraklion |
+| Ionia     |
++-----------+
+(3 rows)
+
+!ok
+
+# we have "birthPlace(coords, city, country)", so city has index 2
+select au."birthPlace"[2] as city from "bookstore"."authors" au;
+
++-----------+
+| CITY      |
++-----------+
+| Besançon  |
+| Heraklion |
+| Ionia     |
++-----------+
+(3 rows)
+
+!ok
+
 # End operator.iq

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1549,6 +1549,8 @@ Implicit type coercion of following cases are ignored:
 |:--------------- |:-----------
 | ROW (value [, value ]*)  | Creates a row from a list of values.
 | (value [, value ]* )     | Creates a row from a list of values.
+| row '[' index ']'        | Returns the element at a particular location in a row.
+| row '[' name ']'         | Returns the element of a row with a particular name.
 | map '[' key ']'     | Returns the element of a map with a particular key.
 | array '[' index ']' | Returns the element at a particular location in an array.
 | ARRAY '[' value [, value ]* ']' | Creates an array from a list of values.

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1170,7 +1170,7 @@ The operator precedence and associativity, highest to lowest.
 |:------------------------------------------------- |:-------------
 | .                                                 | left
 | ::                                                | left
-| [ ] (array element)                               | left
+| [ ] (collection element)                          | left
 | + - (unary plus, minus)                           | right
 | * / % &#124;&#124;                                | left
 | + -                                               | left
@@ -1549,10 +1549,10 @@ Implicit type coercion of following cases are ignored:
 |:--------------- |:-----------
 | ROW (value [, value ]*)  | Creates a row from a list of values.
 | (value [, value ]* )     | Creates a row from a list of values.
-| row '[' index ']'        | Returns the element at a particular location in a row.
+| row '[' index ']'        | Returns the element at a particular location in a row (1-based index).
 | row '[' name ']'         | Returns the element of a row with a particular name.
 | map '[' key ']'     | Returns the element of a map with a particular key.
-| array '[' index ']' | Returns the element at a particular location in an array.
+| array '[' index ']' | Returns the element at a particular location in an array (1-based index).
 | ARRAY '[' value [, value ]* ']' | Creates an array from a list of values.
 | MAP '[' key, value [, key, value ]* ']' | Creates a map from a list of key-value pairs.
 


### PR DESCRIPTION
The PR extends the ITEM operator support to synthetic struct/row.

How the changes were tested:
1. the relevant unit tests have been adapted/extended to cover the new functionality
2. manually tested using the Cassandra adapter