### PR TITLE
[CALCITE-4369] COUNTIF Support (aryeh-looker)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -393,7 +393,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
 
   /** List of all system function names defined by JDBC. */
   private static final String SYSTEM_FUNCTIONS = constructFuncList(
-      "CONVERT", "DATABASE", "IFNULL", "USER");
+      "CONVERT", "DATABASE", "IFNULL", "USER", "COUNTIF'");
 
   //~ Instance fields --------------------------------------------------------
 
@@ -752,6 +752,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
               return super.createCall(pos, operands);
             }
           });
+      map.put("COUNTIF", simple(SqlLibraryOperators.COUNTIF));
       map.put("USER", simple(SqlStdOperatorTable.CURRENT_USER));
       map.put("CONVERT",
           new SimpleMakeCall(SqlStdOperatorTable.CAST) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -393,7 +393,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
 
   /** List of all system function names defined by JDBC. */
   private static final String SYSTEM_FUNCTIONS = constructFuncList(
-      "CONVERT", "DATABASE", "IFNULL", "USER", "COUNTIF'");
+      "CONVERT", "DATABASE", "IFNULL", "USER");
 
   //~ Instance fields --------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -752,7 +752,6 @@ public class SqlJdbcFunctionCall extends SqlFunction {
               return super.createCall(pos, operands);
             }
           });
-      map.put("COUNTIF", simple(SqlLibraryOperators.COUNTIF));
       map.put("USER", simple(SqlStdOperatorTable.CURRENT_USER));
       map.put("CONVERT",
           new SimpleMakeCall(SqlStdOperatorTable.CAST) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -805,6 +805,9 @@ public enum SqlKind {
   /** The {@code STRING_AGG} aggregate function. */
   STRING_AGG,
 
+  /** The {@code COUNT_IF} aggregate function. */
+  COUNT_IF,
+
   /** The {@code ARRAY_AGG} aggregate function. */
   ARRAY_AGG,
 
@@ -1041,7 +1044,7 @@ public enum SqlKind {
           FUSION, SINGLE_VALUE, ROW_NUMBER, RANK, PERCENT_RANK, DENSE_RANK,
           CUME_DIST, JSON_ARRAYAGG, JSON_OBJECTAGG, BIT_AND, BIT_OR, BIT_XOR,
           LISTAGG, STRING_AGG, ARRAY_AGG, ARRAY_CONCAT_AGG,
-          INTERSECTION, ANY_VALUE);
+          COUNT_IF, INTERSECTION, ANY_VALUE);
 
   /**
    * Category consisting of all DML operators.

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCountIfAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCountIfAggFunction.java
@@ -71,7 +71,8 @@ public class SqlCountIfAggFunction extends SqlAggFunction {
     SqlNodeList thenList = new SqlNodeList(pos);
     whenList.add(operands.get(0));
     thenList.add(SqlLiteral.createExactNumeric("1", SqlParserPos.ZERO));
-    return SqlCase.createSwitched(pos, null, whenList, thenList, SqlLiteral.createExactNumeric("0", SqlParserPos.ZERO));
+    return SqlCase.createSwitched(pos, null, whenList, thenList,
+        SqlLiteral.createExactNumeric("0", SqlParserPos.ZERO));
   }
 
   @Override public SqlOperandCountRange getOperandCountRange() {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCountIfAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCountIfAggFunction.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.sql.fun;
 
-import java.util.List;
-
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
@@ -35,6 +33,8 @@ import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Optionality;
+
+import java.util.List;
 
 /**
  * Definition of the SQL <code>COUNTIF</code> aggregation function.

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCountIfAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCountIfAggFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.config.CalciteSystemProperty;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.util.Optionality;
+
+/**
+ * Definition of the SQL <code>COUNT</code> aggregation function.
+ *
+ * <p><code>COUNT</code> is an aggregator which returns the number of rows which
+ * have gone into it. With one argument (or more), it returns the number of rows
+ * for which that argument (or all) is not <code>null</code>.
+ */
+public class SqlCountIfAggFunction extends SqlAggFunction {
+  //~ Constructors -----------------------------------------------------------
+
+  public SqlCountIfAggFunction(String name) {
+    this(name, CalciteSystemProperty.STRICT.value() ? OperandTypes.ANY : OperandTypes.ONE_OR_MORE);
+  }
+
+  public SqlCountIfAggFunction(String name,
+      SqlOperandTypeChecker sqlOperandTypeChecker) {
+    super(name, null, SqlKind.COUNT, ReturnTypes.BIGINT, null,
+        sqlOperandTypeChecker, SqlFunctionCategory.NUMERIC, false, false,
+        Optionality.FORBIDDEN);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -605,5 +605,5 @@ public abstract class SqlLibraryOperators {
     */
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction COUNTIF =
-      new SqlCountAggFunction("COUNTIF", null);
+      new SqlCountIfAggFunction("COUNTIF", null);
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -598,4 +598,16 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = { POSTGRESQL })
   public static final SqlOperator INFIX_CAST =
       new SqlCastOperator();
+
+  /** The "COUNTIF(expression)  [OVER (...)]" function;
+   * Returns the count of TRUE values for expression. Returns 0 if there are
+   * zero input rows, or if expression evaluates to FALSE or NULL for all rows.
+    */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction COUNTIF =
+      new SqlFunction("COUNTIF", SqlKind.OTHER_FUNCTION,
+          ReturnTypes.BIGINT_NULLABLE,
+          null,
+          OperandTypes.BOOLEAN,
+          SqlFunctionCategory.SYSTEM);
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -605,9 +605,5 @@ public abstract class SqlLibraryOperators {
     */
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction COUNTIF =
-      new SqlFunction("COUNTIF", SqlKind.OTHER_FUNCTION,
-          ReturnTypes.BIGINT_NULLABLE,
-          null,
-          OperandTypes.BOOLEAN,
-          SqlFunctionCategory.SYSTEM);
+      new SqlCountAggFunction("COUNTIF", null);
 }

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -210,7 +210,7 @@ public abstract class OperandTypes {
     };
   }
 
-  public static final SqlSingleOperandTypeChecker BOOLEAN =
+  public static final FamilyOperandTypeChecker BOOLEAN =
       family(SqlTypeFamily.BOOLEAN);
 
   public static final SqlSingleOperandTypeChecker BOOLEAN_BOOLEAN =

--- a/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
@@ -20,6 +20,7 @@ import org.apache.calcite.prepare.PlannerImpl;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlDialect.DatabaseProduct;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.fun.SqlLibrary;
@@ -613,6 +614,19 @@ class LatticeSuggesterTest {
         + "  avg(\"total_children\" - \"num_children_at_home\")\n"
         + "from \"customer\" join \"sales_fact_1997\" using (\"customer_id\")\n"
         + "group by \"fname\", \"lname\"";
+    t.addQuery(q0);
+    assertThat(t.s.latticeMap.size(), is(1));
+  }
+
+  @Test void testBigQueryDialect() throws Exception {
+    final Tester t = new Tester().foodmart().withEvolve(true)
+        .withDialect(DatabaseProduct.BIG_QUERY.getDialect())
+        .withLibrary(SqlLibrary.BIG_QUERY);
+
+    final String q0 = "select\n"
+        + "  countif(unit_sales > 1000) as num_over_thousand\n"
+        + "from\n"
+        + "  `sales_fact_1997`";
     t.addQuery(q0);
     assertThat(t.s.latticeMap.size(), is(1));
   }

--- a/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
@@ -624,11 +624,11 @@ class LatticeSuggesterTest {
         .withLibrary(SqlLibrary.BIG_QUERY);
 
     final String q0 = "select\n"
-        + "  sum(unit_sales),"
-        + "  countif(unit_sales > 1000) as num_over_thousand\n"
+        + "  SUM(unit_sales),"
+        + "  COUNTIF(unit_sales > 1000) as num_over_thousand\n"
         + "from\n"
         + "  `sales_fact_1997`"
-        + "group by product_id";
+        + "group by unit_sales";
     t.addQuery(q0);
     assertThat(t.s.latticeMap.size(), is(1));
   }

--- a/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
@@ -624,9 +624,11 @@ class LatticeSuggesterTest {
         .withLibrary(SqlLibrary.BIG_QUERY);
 
     final String q0 = "select\n"
+        + "  sum(unit_sales),"
         + "  countif(unit_sales > 1000) as num_over_thousand\n"
         + "from\n"
-        + "  `sales_fact_1997`";
+        + "  `sales_fact_1997`"
+        + "group by product_id";
     t.addQuery(q0);
     assertThat(t.s.latticeMap.size(), is(1));
   }

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -7091,6 +7091,16 @@ public abstract class SqlOperatorBaseTest {
     tester.checkAgg("listagg(cast(x as CHAR))", values2, "0,1,2,3", 0d);
   }
 
+  @Test void testCountIf() {
+    tester.setFor(SqlLibraryOperators.COUNTIF, VM_FENNEL, VM_JAVA);
+    final SqlTester tester = libraryTester(SqlLibrary.BIG_QUERY);
+    final String sql = "select"
+        + "  countif(a > 0) + countif(a > 1) + countif(c > 1)"
+        + "from"
+        + "  (select 1 as a, 2 as b, 3 as c)";
+    tester.check(sql, new SqlTests.StringTypeChecker("INTEGER NOT NULL"), "2", 0);
+  }
+
   @Test void testStringAggFunc() {
     checkStringAggFunc(libraryTester(SqlLibrary.POSTGRESQL));
     checkStringAggFunc(libraryTester(SqlLibrary.BIG_QUERY));

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1793,6 +1793,7 @@ and `LISTAGG`).
 | LISTAGG( [ ALL &#124; DISTINCT ] value [, separator]) | Returns values concatenated into a string, delimited by separator (default ',')
 | COUNT( [ ALL &#124; DISTINCT ] value [, value ]*) | Returns the number of input rows for which *value* is not null (wholly not null if *value* is composite)
 | COUNT(*)                           | Returns the number of input rows
+| COUNTIF(boolean)                   | Returns the number of input rows that fulfil given boolean expression
 | FUSION(multiset)                   | Returns the multiset union of *multiset* across all input values
 | INTERSECTION(multiset)             | Returns the multiset intersection of *multiset* across all input values
 | APPROX_COUNT_DISTINCT(value [, value ]*)      | Returns the approximate number of distinct values of *value*; the database is allowed to use an approximation but is not required to


### PR DESCRIPTION
Adds support for the `COUNTIF` function, which is defined in BigQuery (i.e. https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#countif). Resolves https://issues.apache.org/jira/browse/CALCITE-4369