### PR TITLE
[CALCITE-4385] Extracts and eliminates/merges the condition that has common expressions (Jiatao Tao)

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -2454,7 +2454,7 @@ public abstract class RelOptUtil {
    */
   public static void decomposeConjunction(
       @Nullable RexNode rexPredicate,
-      List<RexNode> rexList) {
+      Collection<RexNode> rexList) {
     if (rexPredicate == null || rexPredicate.isAlwaysTrue()) {
       return;
     }
@@ -2542,7 +2542,7 @@ public abstract class RelOptUtil {
    */
   public static void decomposeDisjunction(
       @Nullable RexNode rexPredicate,
-      List<RexNode> rexList) {
+      Collection<RexNode> rexList) {
     if (rexPredicate == null || rexPredicate.isAlwaysFalse()) {
       return;
     }
@@ -2568,6 +2568,15 @@ public abstract class RelOptUtil {
   }
 
   /**
+   * Same with {@link #conjunctions} but returns a set instead of list.
+   */
+  public static Set<RexNode> conjunctionSet(@Nullable RexNode rexPredicate) {
+    final Set<RexNode> set = new HashSet<>();
+    decomposeConjunction(rexPredicate, set);
+    return set;
+  }
+
+  /**
    * Returns a condition decomposed by OR.
    *
    * <p>For example, {@code disjunctions(FALSE)} returns the empty list.</p>
@@ -2576,6 +2585,15 @@ public abstract class RelOptUtil {
     final List<RexNode> list = new ArrayList<>();
     decomposeDisjunction(rexPredicate, list);
     return list;
+  }
+
+  /**
+   * Same with {@link #disjunctions} but returns a set instead of list.
+   */
+  public static Set<RexNode> disjunctionSet(RexNode rexPredicate) {
+    final Set<RexNode> set = new HashSet<>();
+    decomposeDisjunction(rexPredicate, set);
+    return set;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -60,6 +60,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
 import static org.apache.calcite.rex.RexUnknownAs.FALSE;
@@ -1696,6 +1697,113 @@ public class RexSimplify {
       // range has been reduced but it's not worth simplifying
       return e;
     }
+  }
+
+  /**
+   * <p>Simplifies AND/OR condition that has common expressions,
+   * extracts and eliminates/merges them as much as possible.</p>
+   * <ul>
+   * <li>(a OR b) AND (a OR b OR c OR d) =&gt; (a OR b)
+   * <li>(a OR b OR c OR d) AND (a OR b OR e OR f) =&gt; (a OR b) OR ((c OR d) AND (e OR f))
+
+   * <li>(a AND b) OR (a AND b AND c) =&gt; (a AND b)
+   * <li>(a AND b AND c AND d) OR (a AND b AND e AND f) =&gt;
+   * (a AND b) AND ((c AND d) OR (e AND f))
+   * </ul>
+   * <p> The difference between {@link #simplifyAnd} is that {@link #simplifyAnd} mainly
+   * simplifies expressions whose answer can be determined without evaluating both sides,
+   * like: FALSE AND (xxx) =&gt; FALSE</p>
+   */
+  public RexNode eliminateCommonExprInCondition(RexNode node) {
+    if (node.getKind() != SqlKind.AND && node.getKind() != SqlKind.OR) {
+      return node;
+    }
+    // Simplify children recursively
+    // so that when we simplify parent node
+    // the child node should be simplified
+    List<RexNode> operands = ((RexCall) node).getOperands();
+    List<RexNode> simplifiedChildren = operands.stream()
+        .map(this::eliminateCommonExprInCondition)
+        .collect(Collectors.toList());
+
+    switch (node.getKind()) {
+    case AND: {
+      // Split the children to get the disjunctive predicates.
+      List<Set<RexNode>> disjunctions = simplifiedChildren.stream()
+          .map(RelOptUtil::disjunctionSet)
+          .collect(Collectors.toList());
+
+      // Find the common predict among the list by retainAll.
+      Set<RexNode> common = new HashSet<>(disjunctions.get(0));
+      disjunctions.forEach(common::retainAll);
+
+      if (common.isEmpty()) {
+        // no common, return the original but with child simplified
+        return and(simplifiedChildren);
+      }
+
+      // Get the predicates that without the common part.
+      disjunctions.forEach(p -> p.removeAll(common));
+
+      if (disjunctions.stream().anyMatch(Collection::isEmpty)) {
+        // (a || b) && (a || b || c || d) => (a || b)
+        return or(common);
+      }
+      // (a || b || c || d) && (a || b || e || f) =>
+      // (a || b) || ((c || d) && (e || f))
+      List<RexNode> splice = disjunctions.stream()
+          .map(this::or)
+          .collect(Collectors.toList());
+      return or(or(common), and(splice));
+    }
+    case OR: {
+      // Split the children to get the conjunctions predicates.
+      List<Set<RexNode>> conjunctions = simplifiedChildren.stream()
+          .map(RelOptUtil::conjunctionSet)
+          .collect(Collectors.toList());
+
+      // Find the common predict among the list by retainAll.
+      Set<RexNode> common = new HashSet<>(conjunctions.get(0));
+      conjunctions.forEach(common::retainAll);
+
+      if (common.isEmpty()) {
+        // no common, return the original but with child simplified
+        return or(simplifiedChildren);
+      }
+
+      // Get the predicates that without the common part.
+      conjunctions.forEach(p -> p.removeAll(common));
+
+      if (conjunctions.stream().anyMatch(Collection::isEmpty)) {
+        // (a && b) || (a && b && c) => (a && b)
+        return and(common);
+      }
+      // (a && b && c && d) || (a && b && e && f) =>
+      // (a && b) && ((c && d) || (e && f))
+      List<RexNode> splice = conjunctions.stream()
+          .map(this::and)
+          .collect(Collectors.toList());
+      return and(and(common), or(splice));
+    }
+    default:
+      return node;
+    }
+  }
+
+  private RexNode and(RexNode... nodes) {
+    return and(ImmutableList.copyOf(nodes));
+  }
+
+  private RexNode and(Iterable<? extends RexNode> nodes) {
+    return RexUtil.composeConjunction(rexBuilder, nodes);
+  }
+
+  private RexNode or(RexNode... nodes) {
+    return or(ImmutableList.copyOf(nodes));
+  }
+
+  private RexNode or(Iterable<? extends RexNode> nodes) {
+    return RexUtil.composeDisjunction(rexBuilder, nodes);
   }
 
   /** Weakens a term so that it checks only what is not implied by predicates.

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
+import static org.apache.calcite.rex.RexUtil.EXECUTOR;
 import static org.apache.calcite.test.Matchers.isRangeSet;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -3158,5 +3159,45 @@ class RexProgramTest extends RexProgramTestBase {
 
   @Test void testSimplifyVarbinary() {
     checkSimplifyUnchanged(cast(cast(vInt(), tVarchar(true, 100)), tVarbinary(true)));
+  }
+
+  @Test public void testEliminateCommonExprInCondition() {
+    RexSimplify rexSimplify = new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY, EXECUTOR);
+
+    // (a=b && c=7) || (a=b && c=7 && d=8) => (a=b && c=7)
+    RexNode or1 = or(
+        and(vBool(0), vBool(1)),
+        and(vBool(0), vBool(1), vBool(2))
+    );
+    RexNode orSimplified1 = rexSimplify.eliminateCommonExprInCondition(or1);
+    checkDigest(orSimplified1, "AND(?0.bool0, ?0.bool1)");
+
+    // (a=b && c=7) || (a=b && d=8) || (a=b && d=9) =>
+    // (a=b) && (c=7 || d=8 || d=9)
+    RexNode or2 = or(
+        and(vBool(0), vBool(1)),
+        and(vBool(0), vBool(2)),
+        and(vBool(0), vBool(3))
+    );
+    RexNode orSimplified2 = rexSimplify.eliminateCommonExprInCondition(or2);
+    checkDigest(orSimplified2, "AND(?0.bool0, OR(?0.bool1, ?0.bool2, ?0.bool3))");
+
+    // (a=b || c=7) && (a=b || c=7 || d=8) => (a=b || c=7)
+    RexNode and1 = and(
+        or(vBool(0), vBool(1)),
+        or(vBool(0), vBool(1), vBool(2))
+    );
+    RexNode andSimplified1 = rexSimplify.eliminateCommonExprInCondition(and1);
+    checkDigest(andSimplified1, "OR(?0.bool0, ?0.bool1)");
+
+    // (a=b || c=7 || d=8) && (a=b || c=9 || d=10) =>
+    // (a=b) || ((c=7 || d=8) && (c=9 || d=10))
+    RexNode and2 = and(
+        or(vBool(0), vBool(1), vBool(2)),
+        or(vBool(0), vBool(3), vBool(4))
+    );
+    RexNode andSimplified2 = rexSimplify.eliminateCommonExprInCondition(and2);
+    checkDigest(andSimplified2,
+        "OR(?0.bool0, AND(OR(?0.bool1, ?0.bool2), OR(?0.bool3, ?0.bool4)))");
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3549,6 +3549,16 @@ class RelOptRulesTest extends RelOptTestBase {
     SqlToRelTestBase.assertValid(output);
   }
 
+  @Test void testJoinEliminateCommonExpr() {
+    final String sql = "select * from sales.emp e\n"
+        + "join sales.dept as d\n"
+        + "on ((e.empno = d.deptno and ename = 'A') "
+        + "or (e.empno = d.deptno and ename = 'B'))";
+    sql(sql).withRule(
+        CoreRules.JOIN_REDUCE_EXPRESSIONS,
+        CoreRules.JOIN_CONDITION_PUSH).check();
+  }
+
   private void basePushAggThroughUnion() {
     sql("${sql}")
         .withRule(CoreRules.PROJECT_SET_OP_TRANSPOSE,

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8471,6 +8471,25 @@ LogicalProject($f0=[CAST(CASE(=(MOD($0, 2:BIGINT), 1), <($0, 2:BIGINT), =(MOD($0
 ]]>
         </Resource>
     </TestCase>
+  <TestCase name="testJoinEliminateCommonExpr">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalJoin(condition=[OR(AND(=($0, $9), =($1, 'A')), AND(=($0, $9), =($1, 'B')))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalJoin(condition=[=($0, $9)], joinType=[inner])
+    LogicalFilter(condition=[SEARCH($1, Sarg['A':VARCHAR(20), 'B':VARCHAR(20)]:VARCHAR(20))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
     <TestCase name="testReduceConstants3">
         <Resource name="sql">
             <![CDATA[select e.mgr is not distinct from f.mgr from emp e join emp f on (e.mgr=f.mgr) where e.mgr is null]]>


### PR DESCRIPTION
Simplifies AND/OR condition that has common expressions, extract and eliminate/merge them.
1. (a || b) && (a || b || c || d) => (a || b)
2. (a || b || c || d) && (a || b || e || f) => (a || b) || ((c || d) && (e || f))

3. (a && b) || (a && b && c) => (a && b)
4. (a && b && c && d) || (a && b && e && f) => (a && b) && ((c && d) || (e && f))

The difference between "implifyAnd" is that "simplifyAnd" mainly
simplifies expressions whose answer can be determined without evaluating both sides,
like: FALSE AND (xxx) => FALSE