### PR TITLE
[CALCITE-4390] Fix SqlMatchRecognize operand list

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlMatchRecognize.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlMatchRecognize.java
@@ -105,7 +105,8 @@ public class SqlMatchRecognize extends SqlCall {
 
   @Override public List<SqlNode> getOperandList() {
     return ImmutableNullableList.of(tableRef, pattern, strictStart, strictEnd,
-        patternDefList, measureList, after, subsetList, partitionList, orderList);
+        patternDefList, measureList, after, subsetList, rowsPerMatch, partitionList, orderList,
+        interval);
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec,

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -6186,6 +6186,25 @@ public class SqlParserTest {
     assertEquals(linux(sqlNodeVisited1.toString()), str1);
   }
 
+  @Test void testVisitSqlMatchRecognizeWithSqlShuttle() throws Exception {
+    final String sql = "select *\n"
+        + "from emp \n"
+        + "match_recognize (\n"
+        + "  pattern (strt down+ up+)\n"
+        + "  define\n"
+        + "    down as down.sal < PREV(down.sal),\n"
+        + "    up as up.sal > PREV(up.sal)\n"
+        + ") mr";
+    final SqlNode sqlNode = getSqlParser(sql).parseStmt();
+    final SqlNode sqlNodeVisited = sqlNode.accept(new SqlShuttle() {
+      @Override public SqlNode visit(SqlIdentifier identifier) {
+        return new SqlIdentifier(identifier.names,
+            identifier.getParserPosition());
+      }
+    });
+    assertNotSame(sqlNodeVisited, sqlNode);
+  }
+
   /**
    * Runs tests for INTERVAL... DAY TO HOUR that should pass parser but fail
    * validator. A substantially identical set of tests exists in


### PR DESCRIPTION
The PR fixes the list of returned operands in `SqlMatchRecognize`. Without the change e.g. `SqlShuttle` cannot be used with `MATCH_RECOGNIZE` clause.