### PR TITLE
Fix:  the equalsDeep of SqlCall

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCall.java
@@ -146,7 +146,10 @@ public abstract class SqlCall extends SqlNode {
       return litmus.fail("{} != {}", this, node);
     }
     SqlCall that = (SqlCall) node;
-
+    SqlCall that = (SqlCall) node;
+    if (!equalDeep(this.getFunctionQuantifier(), that.getFunctionQuantifier(), litmus)) {
+      return litmus.fail("{} != {}", this, node);
+    }
     // Compare operators by name, not identity, because they may not
     // have been resolved yet. Use case insensitive comparison since
     // this may be a case insensitive system.


### PR DESCRIPTION
The method equalsDeep of SqlCall will return wrong result when used to compare count and count_distinct, because it does not compare the functionQuantifier