### PR TITLE
[CALCITE-4395] Add an interface in RelOptMaterializations to allow re…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterializations.java
@@ -22,7 +22,6 @@ import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.sql2rel.RelFieldTrimmer;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Pair;
@@ -38,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -206,20 +206,7 @@ public abstract class RelOptMaterializations {
     target = trimUnusedfields(target);
     HepProgram program =
         new HepProgramBuilder()
-            .addRuleInstance(CoreRules.FILTER_PROJECT_TRANSPOSE)
-            .addRuleInstance(CoreRules.FILTER_MERGE)
-            .addRuleInstance(CoreRules.FILTER_INTO_JOIN)
-            .addRuleInstance(CoreRules.JOIN_CONDITION_PUSH)
-            .addRuleInstance(CoreRules.FILTER_AGGREGATE_TRANSPOSE)
-            .addRuleInstance(CoreRules.PROJECT_MERGE)
-            .addRuleInstance(CoreRules.PROJECT_REMOVE)
-            .addRuleInstance(CoreRules.PROJECT_JOIN_TRANSPOSE)
-            .addRuleInstance(CoreRules.PROJECT_SET_OP_TRANSPOSE)
-            .addRuleInstance(CoreRules.FILTER_TO_CALC)
-            .addRuleInstance(CoreRules.PROJECT_TO_CALC)
-            .addRuleInstance(CoreRules.FILTER_CALC_MERGE)
-            .addRuleInstance(CoreRules.PROJECT_CALC_MERGE)
-            .addRuleInstance(CoreRules.CALC_MERGE)
+            .addRuleCollection(rules)
             .build();
 
     // We must use the same HEP planner for the two optimizations below.

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -36,6 +36,8 @@ import org.apache.calcite.rel.mutable.MutableRels;
 import org.apache.calcite.rel.mutable.MutableScan;
 import org.apache.calcite.rel.mutable.MutableSetOp;
 import org.apache.calcite.rel.mutable.MutableUnion;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.rules.TransformationRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
@@ -140,6 +142,23 @@ public class SubstitutionVisitor {
           UnionOnCalcsToUnionUnifyRule.INSTANCE,
           IntersectToIntersectUnifyRule.INSTANCE,
           IntersectOnCalcsToIntersectUnifyRule.INSTANCE);
+
+  public static final ImmutableList<RelOptRule> NORMALIZATION_RULES =
+      ImmutableList.of(
+          CoreRules.FILTER_PROJECT_TRANSPOSE,
+          CoreRules.FILTER_MERGE,
+          CoreRules.FILTER_INTO_JOIN,
+          CoreRules.JOIN_CONDITION_PUSH,
+          CoreRules.FILTER_AGGREGATE_TRANSPOSE,
+          CoreRules.PROJECT_MERGE,
+          CoreRules.PROJECT_REMOVE,
+          CoreRules.PROJECT_JOIN_TRANSPOSE,
+          CoreRules.PROJECT_SET_OP_TRANSPOSE,
+          CoreRules.FILTER_TO_CALC,
+          CoreRules.PROJECT_TO_CALC,
+          CoreRules.FILTER_CALC_MERGE,
+          CoreRules.PROJECT_CALC_MERGE,
+          CoreRules.CALC_MERGE);
 
   /**
    * Factory for a builder for relational expressions.

--- a/core/src/test/java/org/apache/calcite/materialize/CustomNormalizationRules.java
+++ b/core/src/test/java/org/apache/calcite/materialize/CustomNormalizationRules.java
@@ -14,18 +14,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.calcite.materialize;
 
+import static org.apache.calcite.test.Matchers.isLinux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.calcite.materialize.CustomNormalizationRules.CustomizedNormalizationRule.Config;
 import org.apache.calcite.plan.RelOptMaterialization;
 import org.apache.calcite.plan.RelOptMaterializations;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.SubstitutionVisitor;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalCalc;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.rules.AggregateMergeRule;
+import org.apache.calcite.rel.rules.TransformationRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -37,19 +60,9 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.apache.calcite.test.Matchers.isLinux;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-
-/** Tests trimming unused fields before materialized view matching. */
-public class NormalizationTrimFieldTest extends SqlToRelTestBase {
+public class CustomNormalizationRules extends SqlToRelTestBase {
 
   public static Frameworks.ConfigBuilder config() {
     final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
@@ -68,7 +81,7 @@ public class NormalizationTrimFieldTest extends SqlToRelTestBase {
         .traitDefs((List<RelTraitDef>) null);
   }
 
-  @Test void testMVTrimUnusedFiled() {
+  @Test void testCustomNormalizationRule() {
     final RelBuilder relBuilder = RelBuilder.create(config().build());
     final LogicalProject project = (LogicalProject) relBuilder.scan("EMP")
         .project(relBuilder.field("EMPNO"),
@@ -95,6 +108,9 @@ public class NormalizationTrimFieldTest extends SqlToRelTestBase {
     final RelOptMaterialization relOptMaterialization =
         new RelOptMaterialization(replacement,
             target, null, Lists.newArrayList("mv0"));
+    final List<RelOptRule> optRules = new ArrayList<>();
+    optRules.addAll(SubstitutionVisitor.NORMALIZATION_RULES);
+    optRules.add(CustomizedNormalizationRule.Config.DEFAULT.toRule());
     final List<Pair<RelNode, List<RelOptMaterialization>>> relOptimized =
         RelOptMaterializations.useMaterializedViews(query,
             ImmutableList.of(relOptMaterialization), ImmutableList.of());
@@ -105,4 +121,46 @@ public class NormalizationTrimFieldTest extends SqlToRelTestBase {
     final String relOptimizedStr = RelOptUtil.toString(relOptimized.get(0).getKey());
     assertThat(relOptimizedStr, isLinux(optimized));
   }
+
+  /**
+   * A customized normalization rule, which compensate project on Agggreate.
+   */
+  public static class CustomizedNormalizationRule extends
+      RelRule<Config> implements TransformationRule {
+
+    public boolean visited = false;
+
+    public CustomizedNormalizationRule(Config config) {
+      super(config);
+    }
+
+    @Override public void onMatch(RelOptRuleCall call) {
+      Aggregate aggregate = call.rel(0);
+      RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
+      RelDataType rowType = aggregate.getRowType();
+      List<String> fieldNames = aggregate.getRowType().getFieldNames();
+      List<RexNode> projs = aggregate.getCluster().getRexBuilder()
+          .identityProjects(rowType);
+      RexProgramBuilder rexProgram = new RexProgramBuilder(rowType, rexBuilder);
+      for (int i = 0; i < projs.size(); i++) {
+        rexProgram.addProject(projs.get(i), fieldNames.get(i));
+      }
+      LogicalCalc project = LogicalCalc
+          .create(aggregate, rexProgram.getProgram());
+      visited = true;
+      call.transformTo(project);
+    }
+
+    /** Rule configuration. */
+    public interface Config extends RelRule.Config {
+      CustomizedNormalizationRule.Config DEFAULT = EMPTY
+          .withOperandSupplier(b ->
+              b.operand(LogicalAggregate.class).anyInputs())
+          .as(CustomizedNormalizationRule.Config.class);
+      @Override default CustomizedNormalizationRule toRule() {
+        return new CustomizedNormalizationRule(this);
+      }
+    }
+  }
+
 }

--- a/core/src/test/java/org/apache/calcite/materialize/CustomNormalizationRules.java
+++ b/core/src/test/java/org/apache/calcite/materialize/CustomNormalizationRules.java
@@ -108,12 +108,13 @@ public class CustomNormalizationRules extends SqlToRelTestBase {
     final RelOptMaterialization relOptMaterialization =
         new RelOptMaterialization(replacement,
             target, null, Lists.newArrayList("mv0"));
+
     final List<RelOptRule> optRules = new ArrayList<>();
     optRules.addAll(SubstitutionVisitor.NORMALIZATION_RULES);
     optRules.add(CustomizedNormalizationRule.Config.DEFAULT.toRule());
     final List<Pair<RelNode, List<RelOptMaterialization>>> relOptimized =
         RelOptMaterializations.useMaterializedViews(query,
-            ImmutableList.of(relOptMaterialization), ImmutableList.of());
+            ImmutableList.of(relOptMaterialization), SubstitutionVisitor.DEFAULT_RULES, optRules);
 
     final String optimized = ""
         + "LogicalProject(deptno=[CAST($0):TINYINT], count_sal=[$1])\n"
@@ -123,7 +124,7 @@ public class CustomNormalizationRules extends SqlToRelTestBase {
   }
 
   /**
-   * A customized normalization rule, which compensate project on Agggreate.
+   * A customized normalization rule, which compensate Calc on Agggreate.
    */
   public static class CustomizedNormalizationRule extends
       RelRule<Config> implements TransformationRule {
@@ -145,10 +146,10 @@ public class CustomNormalizationRules extends SqlToRelTestBase {
       for (int i = 0; i < projs.size(); i++) {
         rexProgram.addProject(projs.get(i), fieldNames.get(i));
       }
-      LogicalCalc project = LogicalCalc
+      LogicalCalc calc = LogicalCalc
           .create(aggregate, rexProgram.getProgram());
       visited = true;
-      call.transformTo(project);
+      call.transformTo(calc);
     }
 
     /** Rule configuration. */

--- a/core/src/test/java/org/apache/calcite/materialize/NormalizationTrimFieldTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/NormalizationTrimFieldTest.java
@@ -97,7 +97,7 @@ public class NormalizationTrimFieldTest extends SqlToRelTestBase {
             target, null, Lists.newArrayList("mv0"));
     final List<Pair<RelNode, List<RelOptMaterialization>>> relOptimized =
         RelOptMaterializations.useMaterializedViews(query,
-            ImmutableList.of(relOptMaterialization), ImmutableList.of());
+            ImmutableList.of(relOptMaterialization));
 
     final String optimized = ""
         + "LogicalProject(deptno=[CAST($0):TINYINT], count_sal=[$1])\n"

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
@@ -1691,6 +1691,12 @@ public class MaterializedViewSubstitutionVisitorTest extends AbstractMaterialize
             + "EnumerableTableScan(table=[[hr, MV0]])")).ok();
   }
 
+  @Test public void testQueryWithoutTopCalc() {
+    final String mv = "select sum(\"empid\"), \"deptno\" from \"emps\" group by \"deptno\"";
+    final String query = "select \"deptno\" from \"emps\" group by \"deptno\"";
+    sql(mv, query).noMat();
+  }
+
   final JavaTypeFactoryImpl typeFactory =
       new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
   private final RexBuilder rexBuilder = new RexBuilder(typeFactory);


### PR DESCRIPTION
…gistering normalization rules (xzh)
https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-4395?filter=allopenissues
In the current framework of materialized recognition, the commonly used relational algebra materialized view recognition algorithm has been implemented, but in specific scenarios, users need to customize the algorithm of materialized view recognition to enhance the ability of materialized view recognition. The algorithm of user-defined materialized view recognition has been implemented here[1]. In addition, the ability of normalization is a very important point before materialized recognition. Normalization can simplify the difficulty of materialized view recognition. Currently, the ability of normalization based on relation algebra can not well support the needs of users. Users need to be able to customize normalization rules, which may be equivalent transformation of some relational algebra. Therefore, we should allow users to customize some normalization algorithms, enhance the normalization ability before the recognition of materialized views.

[1][Add an interface in RelOptMaterializations to allow registering UnifyRule](https://github.com/apache/calcite/pull/2094)