### PR TITLE
[CALCITE-4425] Class DefaultEdge lacks a proper toString implementation (Liya Fan)

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
@@ -43,6 +43,10 @@ public class DefaultEdge {
         && ((DefaultEdge) obj).target.equals(target);
   }
 
+  @Override public String toString() {
+    return source + " -> " + target;
+  }
+
   public static <V extends Object> DirectedGraph.EdgeFactory<V, DefaultEdge> factory() {
     // see https://github.com/typetools/checker-framework/issues/3637
     //noinspection Convert2MethodRef

--- a/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
+++ b/core/src/test/java/org/apache/calcite/util/graph/DirectedGraphTest.java
@@ -375,6 +375,18 @@ class DirectedGraphTest {
     assertThat(Iterables.size(g.getEdges("A", "B")), is(2));
   }
 
+  @Test void testToString() {
+    DefaultDirectedGraph<String, DefaultEdge> g = createDag();
+    assertThat(
+        g.toString(), is("graph(vertices: [A, B, C, D, E, F], "
+            + "edges: [A -> B, A -> E, B -> C, C -> D, E -> C, E -> F])"));
+
+    DefaultDirectedGraph<String, DefaultEdge> g1 = createDag1();
+    assertThat(
+        g1.toString(), is("graph(vertices: [A, B, C, D, E, F], "
+            + "edges: [A -> B, A -> D, B -> C, C -> E, D -> E])"));
+  }
+
   /** Edge that stores its attributes in a list. */
   private static class DefaultAttributedEdge extends DefaultEdge {
     private final List list;


### PR DESCRIPTION
It is convenient to build a graph as an object of `DefaultDirectedGraph`. The class has a good `toString` implementation, which greatly helps examining the structure of the graph.
However, the output of the method may be confusing. In our system, the `toString` method produces the following result:

```
graph(vertices: [0, 1, 2, 3, 4, 5, 6], edges: [org.apache.calcite.util.graph.DefaultEdge@1a550334, 
org.apache.calcite.util.graph.DefaultEdge@891ce8a1, org.apache.calcite.util.graph.DefaultEdge@ba5c5190, 
org.apache.calcite.util.graph.DefaultEdge@c894f6b3, org.apache.calcite.util.graph.DefaultEdge@d72993fe, 
org.apache.calcite.util.graph.DefaultEdge@da030cc4, org.apache.calcite.util.graph.DefaultEdge@de17986f, 
org.apache.calcite.util.graph.DefaultEdge@e20be355, org.apache.calcite.util.graph.DefaultEdge@ef7b8a83, 
org.apache.calcite.util.graph.DefaultEdge@f2b672ef, org.apache.calcite.util.graph.DefaultEdge@f547e446])
```

The reason is that the default edge type is `DefaultEdge`, and the `DefaultEdge` class does not have a proper `toString` implementation. So we want to provide one, so that it helps investigating the internals of the graph.