### PR TITLE
[CALCITE-4428] Remove the equiv rel from mapRel2Subset when merging set (Jiatao Tao)

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -96,8 +96,8 @@ public abstract class RuleQueue {
    */
   private void checkDuplicateSubsets(Deque<RelSubset> subsets,
       RelOptRuleOperand operand, RelNode[] rels) {
-    final RelSubset subset = planner.getSubsetNonNull(rels[operand.ordinalInRule]);
-    if (subsets.contains(subset)) {
+    final RelSubset subset = planner.getSubset(rels[operand.ordinalInRule]);
+    if (subset == null || subsets.contains(subset)) {
       throw Util.FoundOne.NULL;
     }
     if (!operand.getChildOperands().isEmpty()) {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -933,6 +933,12 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
         // get merged.)
         final RelSubset subset = mapRel2Subset.put(rel, equivRelSubset);
         assert subset != null;
+
+        // Remove the rel from mapRel2Subset
+        // So its outdated rule match will not fire
+        // Avoid lots of useless rule matches
+        mapRel2Subset.remove(rel);
+
         boolean existed = subset.set.rels.remove(rel);
         assert existed : "rel was not known to its set";
         final RelSubset equivSubset = getSubsetNonNull(equivRel);

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -196,11 +196,7 @@ public class VolcanoRuleCall extends RelOptRuleCall {
           return;
         }
 
-        if ((subset.set.equivalentSet != null)
-            // When rename RelNode via VolcanoPlanner#rename(RelNode rel),
-            // we may remove rel from its subset: "subset.set.rels.remove(rel)".
-            // Skip rule match when the rel has been removed from set.
-            || (subset != rel && !subset.getRelList().contains(rel))) {
+        if (subset.set.equivalentSet != null) {
           LOGGER.debug(
               "Rule [{}] not fired because operand #{} ({}) belongs to obsolete set",
               getRule(), i, rel);


### PR DESCRIPTION
Previous in #2222, we will skip the origin rule match when rel has been removed from its subset, but this implement calls subset.getRelList() and it has a performance issue. The correct way to do this is to remove the subset from mapRel2Subset.

We can use TpchTest#testQuery07 can directly reproduce the situation that #2222 wanted to fix.  Put this in VolcanoRuleCall#match, delete the previous code, and run the test, we can see the prints are full of the console(about 8k+). So I think still it is necessary to do it, it can avoid lots of unless rule match.
```
        if (subset != rel && !subset.getRelList().contains(rel)) {
          System.out.println("Rule [{}] not fired because operand #{} ({}) belongs to obsolete set");;
        }
```

@julianhyde @vlsi Could you help review this pr.