### PR TITLE
[CALCITE-4431] Use requireNonNull(var, "var") instead of requireNonNull(var) for better error messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -514,6 +514,7 @@ allprojects {
                     replaceRegex("@Override should not be on its own line", "(@Override)\\s{2,}", "\$1 ")
                     replaceRegex("@Test should not be on its own line", "(@Test)\\s{2,}", "\$1 ")
                     replaceRegex("Newline in string should be at end of line", """\\n" *\+""", "\\n\"\n  +")
+                    replaceRegex("require message for requireNonNull", """(?<!#)requireNonNull\(\s*(\w+)\s*(?:,\s*"(?!\1")\w+"\s*)?\)""", "requireNonNull($1, \"$1\")")
                     // (?-m) disables multiline, so $ matches the very end of the file rather than end of line
                     replaceRegex("Remove '// End file.java' trailer", "(?-m)\n// End [^\n]+\\.\\w+\\s*$", "")
                     replaceRegex("<p> should not be placed a the end of the line", "(?-m)\\s*+<p> *+\n \\* ", "\n *\n * <p>")

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -155,12 +155,12 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
       SqlConformance conformance,
       @Nullable Function1<String, InputGetter> correlates) {
     this.program = program; // may be null
-    this.typeFactory = requireNonNull(typeFactory);
-    this.conformance = requireNonNull(conformance);
-    this.root = requireNonNull(root);
+    this.typeFactory = requireNonNull(typeFactory, "typeFactory");
+    this.conformance = requireNonNull(conformance, "conformance");
+    this.root = requireNonNull(root, "root");
     this.inputGetter = inputGetter;
-    this.list = requireNonNull(list);
-    this.builder = requireNonNull(builder);
+    this.list = requireNonNull(list, "list");
+    this.builder = requireNonNull(builder, "builder");
     this.correlates = correlates; // may be null
   }
 

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcCatalogSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcCatalogSchema.java
@@ -68,9 +68,9 @@ public class JdbcCatalogSchema extends AbstractSchema {
   /** Creates a JdbcCatalogSchema. */
   public JdbcCatalogSchema(DataSource dataSource, SqlDialect dialect,
       JdbcConvention convention, String catalog) {
-    this.dataSource = requireNonNull(dataSource);
-    this.dialect = requireNonNull(dialect);
-    this.convention = requireNonNull(convention);
+    this.dataSource = requireNonNull(dataSource, "dataSource");
+    this.dialect = requireNonNull(dialect, "dialect");
+    this.convention = requireNonNull(convention, "convention");
     this.catalog = catalog;
   }
 

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -86,11 +86,11 @@ public class JdbcTable extends AbstractQueryableTable
       String jdbcSchemaName, String jdbcTableName,
       Schema.TableType jdbcTableType) {
     super(Object[].class);
-    this.jdbcSchema = requireNonNull(jdbcSchema);
+    this.jdbcSchema = requireNonNull(jdbcSchema, "jdbcSchema");
     this.jdbcCatalogName = jdbcCatalogName;
     this.jdbcSchemaName = jdbcSchemaName;
-    this.jdbcTableName = requireNonNull(jdbcTableName);
-    this.jdbcTableType = requireNonNull(jdbcTableType);
+    this.jdbcTableName = requireNonNull(jdbcTableName, "jdbcTableName");
+    this.jdbcTableType = requireNonNull(jdbcTableType, "jdbcTableType");
   }
 
   @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTableScan.java
@@ -41,7 +41,7 @@ public class JdbcTableScan extends TableScan implements JdbcRel {
       JdbcTable jdbcTable,
       JdbcConvention jdbcConvention) {
     super(cluster, cluster.traitSetOf(jdbcConvention), ImmutableList.of(), table);
-    this.jdbcTable = Objects.requireNonNull(jdbcTable);
+    this.jdbcTable = Objects.requireNonNull(jdbcTable, "jdbcTable");
   }
 
   @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {

--- a/core/src/main/java/org/apache/calcite/config/Lex.java
+++ b/core/src/main/java/org/apache/calcite/config/Lex.java
@@ -87,9 +87,9 @@ public enum Lex {
       Casing quotedCasing,
       boolean caseSensitive,
       CharLiteralStyle... charLiteralStyles) {
-    this.quoting = Objects.requireNonNull(quoting);
-    this.unquotedCasing = Objects.requireNonNull(unquotedCasing);
-    this.quotedCasing = Objects.requireNonNull(quotedCasing);
+    this.quoting = Objects.requireNonNull(quoting, "quoting");
+    this.unquotedCasing = Objects.requireNonNull(unquotedCasing, "unquotedCasing");
+    this.quotedCasing = Objects.requireNonNull(quotedCasing, "quotedCasing");
     this.caseSensitive = caseSensitive;
     this.charLiteralStyles = ImmutableSet.copyOf(charLiteralStyles);
   }

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -214,8 +214,8 @@ public class Bindables {
         RelOptTable table, ImmutableList<RexNode> filters,
         ImmutableIntList projects) {
       super(cluster, traitSet, ImmutableList.of(), table);
-      this.filters = Objects.requireNonNull(filters);
-      this.projects = Objects.requireNonNull(projects);
+      this.filters = Objects.requireNonNull(filters, "filters");
+      this.projects = Objects.requireNonNull(projects, "projects");
       Preconditions.checkArgument(canHandle(table));
     }
 

--- a/core/src/main/java/org/apache/calcite/interpreter/Interpreter.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Interpreter.java
@@ -87,7 +87,7 @@ public class Interpreter extends AbstractEnumerable<@Nullable Object[]>
 
   /** Creates an Interpreter. */
   public Interpreter(DataContext dataContext, RelNode rootRel) {
-    this.dataContext = requireNonNull(dataContext);
+    this.dataContext = requireNonNull(dataContext, "dataContext");
     final RelNode rel = optimize(rootRel);
     final CompilerImpl compiler =
         new Nodes.CoreCompiler(this, rootRel.getCluster());
@@ -280,7 +280,7 @@ public class Interpreter extends AbstractEnumerable<@Nullable Object[]>
     private final Enumerator<Row> enumerator;
 
     EnumeratorSource(final Enumerator<Row> enumerator) {
-      this.enumerator = requireNonNull(enumerator);
+      this.enumerator = requireNonNull(enumerator, "enumerator");
     }
 
     @Override public @Nullable Row receive() {

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -509,7 +509,7 @@ abstract class CalciteConnectionImpl
     private final CalciteSchema rootSchema;
 
     ContextImpl(CalciteConnectionImpl connection) {
-      this.connection = requireNonNull(connection);
+      this.connection = requireNonNull(connection, "connection");
       long now = System.currentTimeMillis();
       SchemaVersion schemaVersion = new LongSchemaVersion(now);
       this.mutableRootSchema = connection.rootSchema;
@@ -601,7 +601,7 @@ abstract class CalciteConnectionImpl
     private final AtomicBoolean cancelFlag = new AtomicBoolean();
 
     CalciteServerStatementImpl(CalciteConnectionImpl connection) {
-      this.connection = requireNonNull(connection);
+      this.connection = requireNonNull(connection, "connection");
     }
 
     @Override public Context createPrepareContext() {

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -165,7 +165,7 @@ public class CalciteMetaImpl extends MetaImpl {
 
   private <E> MetaResultSet createResultSet(Enumerable<E> enumerable,
       Class clazz, String... names) {
-    requireNonNull(names);
+    requireNonNull(names, "names");
     final List<ColumnMetaData> columns = new ArrayList<>(names.length);
     final List<Field> fields = new ArrayList<>(names.length);
     final List<String> fieldNames = new ArrayList<>(names.length);
@@ -752,7 +752,7 @@ public class CalciteMetaImpl extends MetaImpl {
         String tableSchem, String tableName) {
       super(tableCat, tableSchem, tableName,
           calciteTable.getJdbcTableType().jdbcName);
-      this.calciteTable = requireNonNull(calciteTable);
+      this.calciteTable = requireNonNull(calciteTable, "calciteTable");
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteSchema.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteSchema.java
@@ -90,17 +90,17 @@ public abstract class CalciteSchema {
     if (tableMap == null) {
       this.tableMap = new NameMap<>();
     } else {
-      this.tableMap = Objects.requireNonNull(tableMap);
+      this.tableMap = Objects.requireNonNull(tableMap, "tableMap");
     }
     if (latticeMap == null) {
       this.latticeMap = new NameMap<>();
     } else {
-      this.latticeMap = Objects.requireNonNull(latticeMap);
+      this.latticeMap = Objects.requireNonNull(latticeMap, "latticeMap");
     }
     if (subSchemaMap == null) {
       this.subSchemaMap = new NameMap<>();
     } else {
-      this.subSchemaMap = Objects.requireNonNull(subSchemaMap);
+      this.subSchemaMap = Objects.requireNonNull(subSchemaMap, "subSchemaMap");
     }
     if (functionMap == null) {
       this.functionMap = new NameMultimap<>();
@@ -109,14 +109,14 @@ public abstract class CalciteSchema {
     } else {
       // If you specify functionMap, you must also specify functionNames and
       // nullaryFunctionMap.
-      this.functionMap = Objects.requireNonNull(functionMap);
-      this.functionNames = Objects.requireNonNull(functionNames);
-      this.nullaryFunctionMap = Objects.requireNonNull(nullaryFunctionMap);
+      this.functionMap = Objects.requireNonNull(functionMap, "functionMap");
+      this.functionNames = Objects.requireNonNull(functionNames, "functionNames");
+      this.nullaryFunctionMap = Objects.requireNonNull(nullaryFunctionMap, "nullaryFunctionMap");
     }
     if (typeMap == null) {
       this.typeMap = new NameMap<>();
     } else {
-      this.typeMap = Objects.requireNonNull(typeMap);
+      this.typeMap = Objects.requireNonNull(typeMap, "typeMap");
     }
     this.path = path;
   }
@@ -568,8 +568,8 @@ public abstract class CalciteSchema {
     public final String name;
 
     protected Entry(CalciteSchema schema, String name) {
-      this.schema = Objects.requireNonNull(schema);
-      this.name = Objects.requireNonNull(name);
+      this.schema = Objects.requireNonNull(schema, "schema");
+      this.name = Objects.requireNonNull(name, "name");
     }
 
     /** Returns this object's path. For example ["hr", "emps"]. */
@@ -585,7 +585,7 @@ public abstract class CalciteSchema {
     protected TableEntry(CalciteSchema schema, String name,
         ImmutableList<String> sqls) {
       super(schema, name);
-      this.sqls = Objects.requireNonNull(sqls);
+      this.sqls = Objects.requireNonNull(sqls, "sqls");
     }
 
     public abstract Table getTable();
@@ -754,7 +754,7 @@ public abstract class CalciteSchema {
     public TableEntryImpl(CalciteSchema schema, String name, Table table,
         ImmutableList<String> sqls) {
       super(schema, name, sqls);
-      this.table = Objects.requireNonNull(table);
+      this.table = Objects.requireNonNull(table, "table");
     }
 
     @Override public Table getTable() {

--- a/core/src/main/java/org/apache/calcite/jdbc/JavaRecordType.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/JavaRecordType.java
@@ -36,7 +36,7 @@ public class JavaRecordType extends RelRecordType {
 
   public JavaRecordType(List<RelDataTypeField> fields, Class clazz) {
     super(fields);
-    this.clazz = Objects.requireNonNull(clazz);
+    this.clazz = Objects.requireNonNull(clazz, "clazz");
   }
 
   @Override public boolean equals(@Nullable Object obj) {

--- a/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
@@ -402,9 +402,9 @@ public class JavaTypeFactoryImpl
         Type type,
         boolean nullable,
         int modifiers) {
-      this.syntheticType = requireNonNull(syntheticType);
-      this.name = requireNonNull(name);
-      this.type = requireNonNull(type);
+      this.syntheticType = requireNonNull(syntheticType, "syntheticType");
+      this.name = requireNonNull(name, "name");
+      this.type = requireNonNull(type, "type");
       this.nullable = nullable;
       this.modifiers = modifiers;
       assert !(nullable && Primitive.is(type))

--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -114,13 +114,13 @@ public class Lattice {
       ImmutableSortedSet<Measure> defaultMeasures, ImmutableList<Tile> tiles,
       ImmutableListMultimap<Integer, Boolean> columnUses) {
     this.rootSchema = rootSchema;
-    this.rootNode = requireNonNull(rootNode);
-    this.columns = requireNonNull(columns);
+    this.rootNode = requireNonNull(rootNode, "rootNode");
+    this.columns = requireNonNull(columns, "columns");
     this.auto = auto;
     this.algorithm = algorithm;
     this.algorithmMaxMillis = algorithmMaxMillis;
     this.defaultMeasures = defaultMeasures.asList(); // unique and sorted
-    this.tiles = requireNonNull(tiles);
+    this.tiles = requireNonNull(tiles, "tiles");
     this.columnUses = columnUses;
 
     assert isValid(Litmus.THROW);
@@ -560,7 +560,7 @@ public class Lattice {
 
     public Measure(SqlAggFunction agg, boolean distinct, @Nullable String name,
         Iterable<Column> args) {
-      this.agg = requireNonNull(agg);
+      this.agg = requireNonNull(agg, "agg");
       this.distinct = distinct;
       this.name = name;
       this.args = ImmutableList.copyOf(args);
@@ -656,7 +656,7 @@ public class Lattice {
 
     private Column(int ordinal, String alias) {
       this.ordinal = ordinal;
-      this.alias = requireNonNull(alias);
+      this.alias = requireNonNull(alias, "alias");
     }
 
     /** Converts a list of columns to a bit set of their ordinals. */
@@ -701,8 +701,8 @@ public class Lattice {
 
     private BaseColumn(int ordinal, String table, String column, String alias) {
       super(ordinal, alias);
-      this.table = requireNonNull(table);
-      this.column = requireNonNull(column);
+      this.table = requireNonNull(table, "table");
+      this.column = requireNonNull(column, "column");
     }
 
     @Override public String toString() {
@@ -1147,8 +1147,8 @@ public class Lattice {
 
     public Tile(ImmutableList<Measure> measures,
         ImmutableList<Column> dimensions) {
-      this.measures = requireNonNull(measures);
-      this.dimensions = requireNonNull(dimensions);
+      this.measures = requireNonNull(measures, "measures");
+      this.dimensions = requireNonNull(dimensions, "dimensions");
       assert Ordering.natural().isStrictlyOrdered(dimensions);
       assert Ordering.natural().isStrictlyOrdered(measures);
       bitSet = Column.toBitSet(dimensions);

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeSpace.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeSpace.java
@@ -51,7 +51,7 @@ class LatticeSpace {
   final Map<LatticeTable, List<RexNode>> tableExpressions = new HashMap<>();
 
   LatticeSpace(SqlStatisticProvider statisticProvider) {
-    this.statisticProvider = Objects.requireNonNull(statisticProvider);
+    this.statisticProvider = Objects.requireNonNull(statisticProvider, "statisticProvider");
   }
 
   /** Derives a unique name for a table, qualifying with schema name only if

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeSuggester.java
@@ -633,7 +633,7 @@ public class LatticeSuggester {
     private final int ordinalInQuery;
 
     private TableRef(LatticeTable table, int ordinalInQuery) {
-      this.table = requireNonNull(table);
+      this.table = requireNonNull(table, "table");
       this.ordinalInQuery = ordinalInQuery;
     }
 
@@ -659,7 +659,7 @@ public class LatticeSuggester {
 
     StepRef(TableRef source, TableRef target, Step step, int ordinalInQuery) {
       super(source, target);
-      this.step = requireNonNull(step);
+      this.step = requireNonNull(step, "step");
       this.ordinalInQuery = ordinalInQuery;
     }
 

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeTable.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeTable.java
@@ -30,7 +30,7 @@ public class LatticeTable {
   public final String alias;
 
   LatticeTable(RelOptTable table) {
-    t = Objects.requireNonNull(table);
+    t = Objects.requireNonNull(table, "table");
     alias = Objects.requireNonNull(Util.last(table.getQualifiedName()));
   }
 

--- a/core/src/main/java/org/apache/calcite/materialize/MaterializationActor.java
+++ b/core/src/main/java/org/apache/calcite/materialize/MaterializationActor.java
@@ -77,7 +77,7 @@ class MaterializationActor {
         RelDataType rowType,
         @Nullable List<String> viewSchemaPath) {
       this.key = key;
-      this.rootSchema = Objects.requireNonNull(rootSchema);
+      this.rootSchema = Objects.requireNonNull(rootSchema, "rootSchema");
       Preconditions.checkArgument(rootSchema.isRoot(), "must be root schema");
       this.materializedTable = materializedTable; // may be null
       this.sql = sql;

--- a/core/src/main/java/org/apache/calcite/materialize/MutableNode.java
+++ b/core/src/main/java/org/apache/calcite/materialize/MutableNode.java
@@ -66,7 +66,7 @@ class MutableNode {
   /** Creates a non-root node. */
   @SuppressWarnings("argument.type.incompatible")
   MutableNode(LatticeTable table, @Nullable MutableNode parent, @Nullable Step step) {
-    this.table = Objects.requireNonNull(table);
+    this.table = Objects.requireNonNull(table, "table");
     this.parent = parent;
     this.step = step;
     if (parent != null) {

--- a/core/src/main/java/org/apache/calcite/materialize/ProfilerLatticeStatisticProvider.java
+++ b/core/src/main/java/org/apache/calcite/materialize/ProfilerLatticeStatisticProvider.java
@@ -46,7 +46,7 @@ class ProfilerLatticeStatisticProvider implements LatticeStatisticProvider {
 
   /** Creates a ProfilerLatticeStatisticProvider. */
   private ProfilerLatticeStatisticProvider(Lattice lattice) {
-    Objects.requireNonNull(lattice);
+    Objects.requireNonNull(lattice, "lattice");
     this.profile = Suppliers.memoize(() -> {
       final ProfilerImpl profiler =
           ProfilerImpl.builder()

--- a/core/src/main/java/org/apache/calcite/materialize/SqlLatticeStatisticProvider.java
+++ b/core/src/main/java/org/apache/calcite/materialize/SqlLatticeStatisticProvider.java
@@ -48,7 +48,7 @@ class SqlLatticeStatisticProvider implements LatticeStatisticProvider {
 
   /** Creates a SqlLatticeStatisticProvider. */
   private SqlLatticeStatisticProvider(Lattice lattice) {
-    this.lattice = requireNonNull(lattice);
+    this.lattice = requireNonNull(lattice, "lattice");
   }
 
   @Override public double cardinality(List<Lattice.Column> columns) {

--- a/core/src/main/java/org/apache/calcite/materialize/Step.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Step.java
@@ -51,7 +51,7 @@ class Step extends DefaultEdge {
       List<IntPair> keys, String keyString) {
     super(source, target);
     this.keys = ImmutableList.copyOf(keys);
-    this.keyString = Objects.requireNonNull(keyString);
+    this.keyString = Objects.requireNonNull(keyString, "keyString");
     assert IntPair.ORDERING.isStrictlyOrdered(keys); // ordered and unique
   }
 
@@ -147,7 +147,7 @@ class Step extends DefaultEdge {
 
     @SuppressWarnings("type.argument.type.incompatible")
     Factory(@UnderInitialization LatticeSpace space) {
-      this.space = Objects.requireNonNull(space);
+      this.space = Objects.requireNonNull(space, "space");
     }
 
     @Override public Step createEdge(LatticeTable source, LatticeTable target) {

--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -94,7 +94,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
    */
   protected AbstractRelOptPlanner(RelOptCostFactory costFactory,
       @Nullable Context context) {
-    this.costFactory = Objects.requireNonNull(costFactory);
+    this.costFactory = Objects.requireNonNull(costFactory, "costFactory");
     if (context == null) {
       context = Contexts.empty();
     }

--- a/core/src/main/java/org/apache/calcite/plan/Contexts.java
+++ b/core/src/main/java/org/apache/calcite/plan/Contexts.java
@@ -117,7 +117,7 @@ public class Contexts {
     final Object target;
 
     WrapContext(Object target) {
-      this.target = Objects.requireNonNull(target);
+      this.target = Objects.requireNonNull(target, "target");
     }
 
     @Override public <T extends Object> @Nullable T unwrap(Class<T> clazz) {
@@ -140,7 +140,7 @@ public class Contexts {
     final ImmutableList<Context> contexts;
 
     ChainContext(ImmutableList<Context> contexts) {
-      this.contexts = Objects.requireNonNull(contexts);
+      this.contexts = Objects.requireNonNull(contexts, "contexts");
       for (Context context : contexts) {
         assert !(context instanceof ChainContext) : "must be flat";
       }

--- a/core/src/main/java/org/apache/calcite/plan/RelCompositeTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelCompositeTrait.java
@@ -42,7 +42,7 @@ class RelCompositeTrait<T extends RelMultipleTrait> implements RelTrait {
   // Must remain private. Does not copy the array.
   private RelCompositeTrait(RelTraitDef traitDef, T[] traits) {
     this.traitDef = traitDef;
-    this.traits = Objects.requireNonNull(traits);
+    this.traits = Objects.requireNonNull(traits, "traits");
     //noinspection unchecked
     assert Ordering.natural()
         .isStrictlyOrdered(Arrays.asList((Comparable[]) traits))

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
@@ -87,8 +87,8 @@ public class RelOptCluster {
       Map<String, RelNode> mapCorrelToRel) {
     this.nextCorrel = nextCorrel;
     this.mapCorrelToRel = mapCorrelToRel;
-    this.planner = Objects.requireNonNull(planner);
-    this.typeFactory = Objects.requireNonNull(typeFactory);
+    this.planner = Objects.requireNonNull(planner, "planner");
+    this.typeFactory = Objects.requireNonNull(typeFactory, "typeFactory");
     this.rexBuilder = rexBuilder;
     this.originalExpression = rexBuilder.makeLiteral("?");
 
@@ -220,7 +220,7 @@ public class RelOptCluster {
    * @param hintStrategies The specified hint strategies to override the default one(empty)
    */
   public void setHintStrategies(HintStrategyTable hintStrategies) {
-    Objects.requireNonNull(hintStrategies);
+    Objects.requireNonNull(hintStrategies, "hintStrategies");
     this.hintStrategies = hintStrategies;
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
@@ -222,7 +222,7 @@ public class RelOptMaterialization {
         Mappings.@Nullable TargetMapping mapping, TableScan scan) {
       this.condition = condition;
       this.mapping = mapping;
-      this.scan = Objects.requireNonNull(scan);
+      this.scan = Objects.requireNonNull(scan, "scan");
     }
 
     static @Nullable ProjectFilterTable of(RelNode node) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPredicateList.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPredicateList.java
@@ -96,12 +96,12 @@ public class RelOptPredicateList {
       ImmutableList<RexNode> leftInferredPredicates,
       ImmutableList<RexNode> rightInferredPredicates,
       ImmutableMap<RexNode, RexNode> constantMap) {
-    this.pulledUpPredicates = Objects.requireNonNull(pulledUpPredicates);
+    this.pulledUpPredicates = Objects.requireNonNull(pulledUpPredicates, "pulledUpPredicates");
     this.leftInferredPredicates =
-        Objects.requireNonNull(leftInferredPredicates);
+        Objects.requireNonNull(leftInferredPredicates, "leftInferredPredicates");
     this.rightInferredPredicates =
-        Objects.requireNonNull(rightInferredPredicates);
-    this.constantMap = Objects.requireNonNull(constantMap);
+        Objects.requireNonNull(rightInferredPredicates, "rightInferredPredicates");
+    this.constantMap = Objects.requireNonNull(constantMap, "constantMap");
   }
 
   /** Creates a RelOptPredicateList with only pulled-up predicates, no inferred

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -99,8 +99,8 @@ public abstract class RelOptRule {
    */
   protected RelOptRule(RelOptRuleOperand operand,
       RelBuilderFactory relBuilderFactory, @Nullable String description) {
-    this.operand = Objects.requireNonNull(operand);
-    this.relBuilderFactory = Objects.requireNonNull(relBuilderFactory);
+    this.operand = Objects.requireNonNull(operand, "operand");
+    this.relBuilderFactory = Objects.requireNonNull(relBuilderFactory, "relBuilderFactory");
     if (description == null) {
       description = guessDescription(getClass().getName());
     }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRuleOperand.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRuleOperand.java
@@ -124,7 +124,7 @@ public class RelOptRuleOperand {
       assert children.size() > 0;
     }
     this.childPolicy = childPolicy;
-    this.clazz = Objects.requireNonNull(clazz);
+    this.clazz = Objects.requireNonNull(clazz, "clazz");
     this.trait = trait;
     //noinspection unchecked
     this.predicate = Objects.requireNonNull((Predicate) predicate);

--- a/core/src/main/java/org/apache/calcite/plan/RelRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelRule.java
@@ -220,7 +220,7 @@ public abstract class RelRule<C extends RelRule.Config> extends RelOptRule {
     static RelOptRuleOperand operand(OperandTransform transform) {
       final OperandBuilderImpl b = new OperandBuilderImpl();
       final Done done = transform.apply(b);
-      Objects.requireNonNull(done);
+      Objects.requireNonNull(done, "done");
       if (b.operands.size() != 1) {
         throw new IllegalArgumentException("operand supplier must call one of "
             + "the following methods: operand or exactly");
@@ -250,12 +250,12 @@ public abstract class RelRule<C extends RelRule.Config> extends RelOptRule {
     private Predicate<? super R> predicate = r -> true;
 
     OperandDetailBuilderImpl(OperandBuilderImpl parent, Class<R> relClass) {
-      this.parent = Objects.requireNonNull(parent);
-      this.relClass = Objects.requireNonNull(relClass);
+      this.parent = Objects.requireNonNull(parent, "parent");
+      this.relClass = Objects.requireNonNull(relClass, "relClass");
     }
 
     @Override public OperandDetailBuilderImpl<R> trait(RelTrait trait) {
-      this.trait = Objects.requireNonNull(trait);
+      this.trait = Objects.requireNonNull(trait, "trait");
       return this;
     }
 
@@ -288,14 +288,14 @@ public abstract class RelRule<C extends RelRule.Config> extends RelOptRule {
 
     @Override public Done oneInput(OperandTransform transform) {
       final Done done = transform.apply(inputBuilder);
-      Objects.requireNonNull(done);
+      Objects.requireNonNull(done, "done");
       return done(RelOptRuleOperandChildPolicy.SOME);
     }
 
     @Override public Done inputs(OperandTransform... transforms) {
       for (OperandTransform transform : transforms) {
         final Done done = transform.apply(inputBuilder);
-        Objects.requireNonNull(done);
+        Objects.requireNonNull(done, "done");
       }
       return done(RelOptRuleOperandChildPolicy.SOME);
     }
@@ -303,7 +303,7 @@ public abstract class RelRule<C extends RelRule.Config> extends RelOptRule {
     @Override public Done unorderedInputs(OperandTransform... transforms) {
       for (OperandTransform transform : transforms) {
         final Done done = transform.apply(inputBuilder);
-        Objects.requireNonNull(done);
+        Objects.requireNonNull(done, "done");
       }
       return done(RelOptRuleOperandChildPolicy.UNORDERED);
     }

--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -71,9 +71,9 @@ public class RexImplicationChecker {
       RexBuilder builder,
       RexExecutor executor,
       RelDataType rowType) {
-    this.builder = Objects.requireNonNull(builder);
-    this.executor = Objects.requireNonNull(executor);
-    this.rowType = Objects.requireNonNull(rowType);
+    this.builder = Objects.requireNonNull(builder, "builder");
+    this.executor = Objects.requireNonNull(executor, "executor");
+    this.rowType = Objects.requireNonNull(rowType, "rowType");
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -935,10 +935,10 @@ public class SubstitutionVisitor {
 
     public UnifyRuleCall(UnifyRule rule, MutableRel query, MutableRel target,
         ImmutableList<MutableRel> slots) {
-      this.rule = requireNonNull(rule);
-      this.query = requireNonNull(query);
-      this.target = requireNonNull(target);
-      this.slots = requireNonNull(slots);
+      this.rule = requireNonNull(rule, "rule");
+      this.query = requireNonNull(query, "query");
+      this.target = requireNonNull(target, "target");
+      this.slots = requireNonNull(slots, "slots");
     }
 
     public UnifyResult result(MutableRel result) {

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepProgramBuilder.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepProgramBuilder.java
@@ -115,7 +115,7 @@ public class HepProgramBuilder {
   public HepProgramBuilder addRuleInstance(RelOptRule rule) {
     HepInstruction.RuleInstance instruction =
         new HepInstruction.RuleInstance();
-    instruction.rule = requireNonNull(rule);
+    instruction.rule = requireNonNull(rule, "rule");
     instructions.add(instruction);
     return this;
   }

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -92,7 +92,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
   public CalciteCatalogReader(CalciteSchema rootSchema,
       List<String> defaultSchema, RelDataTypeFactory typeFactory, CalciteConnectionConfig config) {
     this(rootSchema, SqlNameMatchers.withCaseSensitive(config != null && config.caseSensitive()),
-        ImmutableList.of(Objects.requireNonNull(defaultSchema),
+        ImmutableList.of(Objects.requireNonNull(defaultSchema, "defaultSchema"),
             ImmutableList.of()),
         typeFactory, config);
   }
@@ -100,7 +100,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
   protected CalciteCatalogReader(CalciteSchema rootSchema,
       SqlNameMatcher nameMatcher, List<List<String>> schemaPaths,
       RelDataTypeFactory typeFactory, CalciteConnectionConfig config) {
-    this.rootSchema = Objects.requireNonNull(rootSchema);
+    this.rootSchema = Objects.requireNonNull(rootSchema, "rootSchema");
     this.nameMatcher = nameMatcher;
     this.schemaPaths =
         Util.immutableCopy(Util.isDistinct(schemaPaths)

--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -582,11 +582,11 @@ public abstract class Prepare {
         RelNode rootRel,
         TableModify.@Nullable Operation tableModOp,
         boolean isDml) {
-      this.rowType = requireNonNull(rowType);
-      this.parameterRowType = requireNonNull(parameterRowType);
-      this.fieldOrigins = requireNonNull(fieldOrigins);
+      this.rowType = requireNonNull(rowType, "rowType");
+      this.parameterRowType = requireNonNull(parameterRowType, "parameterRowType");
+      this.fieldOrigins = requireNonNull(fieldOrigins, "fieldOrigins");
       this.collations = ImmutableList.copyOf(collations);
-      this.rootRel = requireNonNull(rootRel);
+      this.rootRel = requireNonNull(rootRel, "rootRel");
       this.tableModOp = tableModOp;
       this.isDml = isDml;
     }

--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -97,7 +97,7 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
       @Nullable Function<Class, Expression> expressionFunction,
       @Nullable Double rowCount) {
     this.schema = schema;
-    this.rowType = requireNonNull(rowType);
+    this.rowType = requireNonNull(rowType, "rowType");
     this.names = ImmutableList.copyOf(names);
     this.table = table; // may be null
     this.expressionFunction = expressionFunction; // may be null

--- a/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistributions.java
@@ -96,7 +96,7 @@ public class RelDistributions {
     private final ImmutableIntList keys;
 
     private RelDistributionImpl(Type type, ImmutableIntList keys) {
-      this.type = Objects.requireNonNull(type);
+      this.type = Objects.requireNonNull(type, "type");
       this.keys = ImmutableIntList.copyOf(keys);
       assert type != Type.HASH_DISTRIBUTED
           || keys.size() < 2

--- a/core/src/main/java/org/apache/calcite/rel/RelFieldCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelFieldCollation.java
@@ -241,8 +241,8 @@ public class RelFieldCollation {
       Direction direction,
       NullDirection nullDirection) {
     this.fieldIndex = fieldIndex;
-    this.direction = Objects.requireNonNull(direction);
-    this.nullDirection = Objects.requireNonNull(nullDirection);
+    this.direction = Objects.requireNonNull(direction, "direction");
+    this.nullDirection = Objects.requireNonNull(nullDirection, "nullDirection");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/RelRoot.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelRoot.java
@@ -94,7 +94,7 @@ public class RelRoot {
     this.validatedRowType = validatedRowType;
     this.kind = kind;
     this.fields = ImmutableList.copyOf(fields);
-    this.collation = Objects.requireNonNull(collation);
+    this.collation = Objects.requireNonNull(collation, "collation");
     this.hints = ImmutableList.copyOf(hints);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
@@ -155,7 +155,7 @@ public abstract class Aggregate extends SingleRel implements Hintable {
     super(cluster, traitSet, input);
     this.hints = ImmutableList.copyOf(hints);
     this.aggCalls = ImmutableList.copyOf(aggCalls);
-    this.groupSet = Objects.requireNonNull(groupSet);
+    this.groupSet = Objects.requireNonNull(groupSet, "groupSet");
     if (groupSets == null) {
       this.groupSets = ImmutableList.of(groupSet);
     } else {

--- a/core/src/main/java/org/apache/calcite/rel/core/AggregateCall.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/AggregateCall.java
@@ -95,12 +95,12 @@ public class AggregateCall {
   private AggregateCall(SqlAggFunction aggFunction, boolean distinct,
       boolean approximate, boolean ignoreNulls, List<Integer> argList,
       int filterArg, RelCollation collation, RelDataType type, @Nullable String name) {
-    this.type = Objects.requireNonNull(type);
+    this.type = Objects.requireNonNull(type, "type");
     this.name = name;
-    this.aggFunction = Objects.requireNonNull(aggFunction);
+    this.aggFunction = Objects.requireNonNull(aggFunction, "aggFunction");
     this.argList = ImmutableList.copyOf(argList);
     this.filterArg = filterArg;
-    this.collation = Objects.requireNonNull(collation);
+    this.collation = Objects.requireNonNull(collation, "collation");
     this.distinct = distinct;
     this.approximate = approximate;
     this.ignoreNulls = ignoreNulls;

--- a/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
@@ -97,9 +97,9 @@ public abstract class Correlate extends BiRel {
       JoinRelType joinType) {
     super(cluster, traitSet, left, right);
     assert !joinType.generatesNullsOnLeft() : "Correlate has invalid join type " + joinType;
-    this.joinType = requireNonNull(joinType);
-    this.correlationId = requireNonNull(correlationId);
-    this.requiredColumns = requireNonNull(requiredColumns);
+    this.joinType = requireNonNull(joinType, "joinType");
+    this.correlationId = requireNonNull(correlationId, "correlationId");
+    this.requiredColumns = requireNonNull(requiredColumns, "requiredColumns");
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/core/EquiJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/EquiJoin.java
@@ -67,8 +67,8 @@ public abstract class EquiJoin extends Join {
       ImmutableIntList rightKeys, Set<CorrelationId> variablesSet,
       JoinRelType joinType) {
     super(cluster, traits, ImmutableList.of(), left, right, condition, variablesSet, joinType);
-    this.leftKeys = Objects.requireNonNull(leftKeys);
-    this.rightKeys = Objects.requireNonNull(rightKeys);
+    this.leftKeys = Objects.requireNonNull(leftKeys, "leftKeys");
+    this.rightKeys = Objects.requireNonNull(rightKeys, "rightKeys");
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/core/Exchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Exchange.java
@@ -59,7 +59,7 @@ public abstract class Exchange extends SingleRel {
   protected Exchange(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
       RelDistribution distribution) {
     super(cluster, traitSet, input);
-    this.distribution = Objects.requireNonNull(distribution);
+    this.distribution = Objects.requireNonNull(distribution, "distribution");
 
     assert traitSet.containsIfApplicable(distribution)
         : "traits=" + traitSet + ", distribution" + distribution;

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -99,9 +99,9 @@ public abstract class Join extends BiRel implements Hintable {
       Set<CorrelationId> variablesSet,
       JoinRelType joinType) {
     super(cluster, traitSet, left, right);
-    this.condition = Objects.requireNonNull(condition);
+    this.condition = Objects.requireNonNull(condition, "condition");
     this.variablesSet = ImmutableSet.copyOf(variablesSet);
-    this.joinType = Objects.requireNonNull(joinType);
+    this.joinType = Objects.requireNonNull(joinType, "joinType");
     this.joinInfo = JoinInfo.of(left, right, condition);
     this.hints = ImmutableList.copyOf(hints);
   }

--- a/core/src/main/java/org/apache/calcite/rel/core/JoinInfo.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/JoinInfo.java
@@ -50,9 +50,9 @@ public class JoinInfo {
   /** Creates a JoinInfo. */
   protected JoinInfo(ImmutableIntList leftKeys, ImmutableIntList rightKeys,
       ImmutableList<RexNode> nonEquiConditions) {
-    this.leftKeys = Objects.requireNonNull(leftKeys);
-    this.rightKeys = Objects.requireNonNull(rightKeys);
-    this.nonEquiConditions = Objects.requireNonNull(nonEquiConditions);
+    this.leftKeys = Objects.requireNonNull(leftKeys, "leftKeys");
+    this.rightKeys = Objects.requireNonNull(rightKeys, "rightKeys");
+    this.nonEquiConditions = Objects.requireNonNull(nonEquiConditions, "nonEquiConditions");
     assert leftKeys.size() == rightKeys.size();
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Match.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Match.java
@@ -103,18 +103,18 @@ public abstract class Match extends SingleRel {
       boolean allRows, ImmutableBitSet partitionKeys, RelCollation orderKeys,
       @Nullable RexNode interval) {
     super(cluster, traitSet, input);
-    this.rowType = Objects.requireNonNull(rowType);
-    this.pattern = Objects.requireNonNull(pattern);
+    this.rowType = Objects.requireNonNull(rowType, "rowType");
+    this.pattern = Objects.requireNonNull(pattern, "pattern");
     Preconditions.checkArgument(patternDefinitions.size() > 0);
     this.strictStart = strictStart;
     this.strictEnd = strictEnd;
     this.patternDefinitions = ImmutableMap.copyOf(patternDefinitions);
     this.measures = ImmutableMap.copyOf(measures);
-    this.after = Objects.requireNonNull(after);
+    this.after = Objects.requireNonNull(after, "after");
     this.subsets = copyMap(subsets);
     this.allRows = allRows;
-    this.partitionKeys = Objects.requireNonNull(partitionKeys);
-    this.orderKeys = Objects.requireNonNull(orderKeys);
+    this.partitionKeys = Objects.requireNonNull(partitionKeys, "partitionKeys");
+    this.orderKeys = Objects.requireNonNull(orderKeys, "orderKeys");
     this.interval = interval;
 
     final AggregateFinder aggregateFinder = new AggregateFinder();

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -657,23 +657,23 @@ public class RelFactories {
         MatchFactory matchFactory,
         SpoolFactory spoolFactory,
         RepeatUnionFactory repeatUnionFactory) {
-      this.filterFactory = requireNonNull(filterFactory);
-      this.projectFactory = requireNonNull(projectFactory);
-      this.aggregateFactory = requireNonNull(aggregateFactory);
-      this.sortFactory = requireNonNull(sortFactory);
-      this.exchangeFactory = requireNonNull(exchangeFactory);
-      this.sortExchangeFactory = requireNonNull(sortExchangeFactory);
-      this.setOpFactory = requireNonNull(setOpFactory);
-      this.joinFactory = requireNonNull(joinFactory);
-      this.correlateFactory = requireNonNull(correlateFactory);
-      this.valuesFactory = requireNonNull(valuesFactory);
-      this.scanFactory = requireNonNull(scanFactory);
+      this.filterFactory = requireNonNull(filterFactory, "filterFactory");
+      this.projectFactory = requireNonNull(projectFactory, "projectFactory");
+      this.aggregateFactory = requireNonNull(aggregateFactory, "aggregateFactory");
+      this.sortFactory = requireNonNull(sortFactory, "sortFactory");
+      this.exchangeFactory = requireNonNull(exchangeFactory, "exchangeFactory");
+      this.sortExchangeFactory = requireNonNull(sortExchangeFactory, "sortExchangeFactory");
+      this.setOpFactory = requireNonNull(setOpFactory, "setOpFactory");
+      this.joinFactory = requireNonNull(joinFactory, "joinFactory");
+      this.correlateFactory = requireNonNull(correlateFactory, "correlateFactory");
+      this.valuesFactory = requireNonNull(valuesFactory, "valuesFactory");
+      this.scanFactory = requireNonNull(scanFactory, "scanFactory");
       this.tableFunctionScanFactory =
-          requireNonNull(tableFunctionScanFactory);
-      this.snapshotFactory = requireNonNull(snapshotFactory);
-      this.matchFactory = requireNonNull(matchFactory);
-      this.spoolFactory = requireNonNull(spoolFactory);
-      this.repeatUnionFactory = requireNonNull(repeatUnionFactory);
+          requireNonNull(tableFunctionScanFactory, "tableFunctionScanFactory");
+      this.snapshotFactory = requireNonNull(snapshotFactory, "snapshotFactory");
+      this.matchFactory = requireNonNull(matchFactory, "matchFactory");
+      this.spoolFactory = requireNonNull(spoolFactory, "spoolFactory");
+      this.repeatUnionFactory = requireNonNull(repeatUnionFactory, "repeatUnionFactory");
     }
 
     public static Struct fromContext(Context context) {

--- a/core/src/main/java/org/apache/calcite/rel/core/Snapshot.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Snapshot.java
@@ -64,7 +64,7 @@ public abstract class Snapshot extends SingleRel  {
   protected Snapshot(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
       RexNode period) {
     super(cluster, traitSet, input);
-    this.period = Objects.requireNonNull(period);
+    this.period = Objects.requireNonNull(period, "period");
     // Too expensive for everyday use:
     assert !CalciteSystemProperty.DEBUG.value() || isValid(Litmus.THROW, null);
   }

--- a/core/src/main/java/org/apache/calcite/rel/core/Sort.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Sort.java
@@ -173,7 +173,7 @@ public abstract class Sort extends SingleRel {
     //noinspection StaticPseudoFunctionalStyleMethod
     return Util.transform(collation.getFieldCollations(), field ->
         getCluster().getRexBuilder().makeInputRef(input,
-            Objects.requireNonNull(field).getFieldIndex()));
+            Objects.requireNonNull(field, "field").getFieldIndex()));
   }
 
   @Override public RelWriter explainTerms(RelWriter pw) {

--- a/core/src/main/java/org/apache/calcite/rel/core/SortExchange.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/SortExchange.java
@@ -57,7 +57,7 @@ public abstract class SortExchange extends Exchange {
   protected SortExchange(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, RelDistribution distribution, RelCollation collation) {
     super(cluster, traitSet, input, distribution);
-    this.collation = Objects.requireNonNull(collation);
+    this.collation = Objects.requireNonNull(collation, "collation");
 
     assert traitSet.containsIfApplicable(collation)
         : "traits=" + traitSet + ", collation=" + collation;

--- a/core/src/main/java/org/apache/calcite/rel/core/Spool.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Spool.java
@@ -73,8 +73,8 @@ public abstract class Spool extends SingleRel {
   protected Spool(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
       Type readType, Type writeType) {
     super(cluster, traitSet, input);
-    this.readType = Objects.requireNonNull(readType);
-    this.writeType = Objects.requireNonNull(writeType);
+    this.readType = Objects.requireNonNull(readType, "readType");
+    this.writeType = Objects.requireNonNull(writeType, "writeType");
   }
 
   @Override public final RelNode copy(RelTraitSet traitSet,

--- a/core/src/main/java/org/apache/calcite/rel/core/TableModify.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/TableModify.java
@@ -124,13 +124,13 @@ public abstract class TableModify extends SingleRel {
     this.updateColumnList = updateColumnList;
     this.sourceExpressionList = sourceExpressionList;
     if (operation == Operation.UPDATE) {
-      requireNonNull(updateColumnList);
-      requireNonNull(sourceExpressionList);
+      requireNonNull(updateColumnList, "updateColumnList");
+      requireNonNull(sourceExpressionList, "sourceExpressionList");
       Preconditions.checkArgument(sourceExpressionList.size()
           == updateColumnList.size());
     } else {
       if (operation == Operation.MERGE) {
-        requireNonNull(updateColumnList);
+        requireNonNull(updateColumnList, "updateColumnList");
       } else {
         Preconditions.checkArgument(updateColumnList == null);
       }

--- a/core/src/main/java/org/apache/calcite/rel/core/TableSpool.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/TableSpool.java
@@ -39,7 +39,7 @@ public abstract class TableSpool extends Spool {
   protected TableSpool(RelOptCluster cluster, RelTraitSet traitSet,
       RelNode input, Type readType, Type writeType, RelOptTable table) {
     super(cluster, traitSet, input, readType, writeType);
-    this.table = Objects.requireNonNull(table);
+    this.table = Objects.requireNonNull(table, "table");
   }
 
   @Override public RelOptTable getTable() {

--- a/core/src/main/java/org/apache/calcite/rel/core/Window.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Window.java
@@ -234,11 +234,11 @@ public abstract class Window extends SingleRel {
         RexWindowBound upperBound,
         RelCollation orderKeys,
         List<RexWinAggCall> aggCalls) {
-      this.keys = Objects.requireNonNull(keys);
+      this.keys = Objects.requireNonNull(keys, "keys");
       this.isRows = isRows;
-      this.lowerBound = Objects.requireNonNull(lowerBound);
-      this.upperBound = Objects.requireNonNull(upperBound);
-      this.orderKeys = Objects.requireNonNull(orderKeys);
+      this.lowerBound = Objects.requireNonNull(lowerBound, "lowerBound");
+      this.upperBound = Objects.requireNonNull(upperBound, "upperBound");
+      this.orderKeys = Objects.requireNonNull(orderKeys, "orderKeys");
       this.aggCalls = ImmutableList.copyOf(aggCalls);
       this.digest = computeString();
     }

--- a/core/src/main/java/org/apache/calcite/rel/hint/HintStrategy.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/HintStrategy.java
@@ -85,14 +85,14 @@ public class HintStrategy {
     private ImmutableSet<ConverterRule> converterRules;
 
     private Builder(HintPredicate predicate) {
-      this.predicate = Objects.requireNonNull(predicate);
+      this.predicate = Objects.requireNonNull(predicate, "predicate");
       this.excludedRules = ImmutableSet.of();
       this.converterRules = ImmutableSet.of();
     }
 
     /** Registers a hint option checker to validate the hint options. */
     public Builder optionChecker(HintOptionChecker optionChecker) {
-      this.optionChecker = Objects.requireNonNull(optionChecker);
+      this.optionChecker = Objects.requireNonNull(optionChecker, "optionChecker");
       return this;
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/hint/HintStrategyTable.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/HintStrategyTable.java
@@ -192,14 +192,14 @@ public class HintStrategyTable {
     private final Map<Key, HintStrategy> strategies = new HashMap<>();
     private Litmus errorHandler = HintErrorLogger.INSTANCE;
 
-    public Builder hintStrategy(String hintName, HintPredicate strategy) {
+    public Builder hintStrategy(String hintName, HintPredicate hintPredicate) {
       this.strategies.put(Key.of(hintName),
-          HintStrategy.builder(requireNonNull(strategy, "HintPredicate")).build());
+          HintStrategy.builder(requireNonNull(hintPredicate, "hintPredicate")).build());
       return this;
     }
 
-    public Builder hintStrategy(String hintName, HintStrategy entry) {
-      this.strategies.put(Key.of(hintName), requireNonNull(entry, "HintStrategy"));
+    public Builder hintStrategy(String hintName, HintStrategy hintStrategy) {
+      this.strategies.put(Key.of(hintName), requireNonNull(hintStrategy, "hintStrategy"));
       return this;
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/hint/Hintable.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/Hintable.java
@@ -60,7 +60,7 @@ public interface Hintable {
    * @return Relational expression with the hints {@code hintList} attached
    */
   default RelNode attachHints(List<RelHint> hintList) {
-    Objects.requireNonNull(hintList);
+    Objects.requireNonNull(hintList, "hintList");
     final Set<RelHint> hints = new LinkedHashSet<>(getHints());
     hints.addAll(hintList);
     return withHints(new ArrayList<>(hints));

--- a/core/src/main/java/org/apache/calcite/rel/hint/RelHint.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/RelHint.java
@@ -103,8 +103,8 @@ public class RelHint {
       String hintName,
       @Nullable List<String> listOption,
       @Nullable Map<String, String> kvOptions) {
-    Objects.requireNonNull(inheritPath);
-    Objects.requireNonNull(hintName);
+    Objects.requireNonNull(inheritPath, "inheritPath");
+    Objects.requireNonNull(hintName, "hintName");
     this.inheritPath = ImmutableList.copyOf(inheritPath);
     this.hintName = hintName;
     this.listOptions = listOption == null ? ImmutableList.of() : ImmutableList.copyOf(listOption);
@@ -125,7 +125,7 @@ public class RelHint {
    * @return the new {@code RelHint}
    */
   public RelHint copy(List<Integer> inheritPath) {
-    Objects.requireNonNull(inheritPath);
+    Objects.requireNonNull(inheritPath, "inheritPath");
     return new RelHint(inheritPath, hintName, listOptions, kvOptions);
   }
 
@@ -185,7 +185,7 @@ public class RelHint {
 
     /** Sets up the inherit path with given integer list. */
     public Builder inheritPath(Iterable<Integer> inheritPath) {
-      this.inheritPath = ImmutableList.copyOf(Objects.requireNonNull(inheritPath));
+      this.inheritPath = ImmutableList.copyOf(Objects.requireNonNull(inheritPath, "inheritPath"));
       return this;
     }
 
@@ -197,7 +197,7 @@ public class RelHint {
 
     /** Add a hint option as string. */
     public Builder hintOption(String hintOption) {
-      Objects.requireNonNull(hintOption);
+      Objects.requireNonNull(hintOption, "hintOption");
       Preconditions.checkState(this.kvOptions.size() == 0,
           "List options and key value options can not be mixed in");
       this.listOptions.add(hintOption);
@@ -206,7 +206,7 @@ public class RelHint {
 
     /** Add multiple string hint options. */
     public Builder hintOptions(Iterable<String> hintOptions) {
-      Objects.requireNonNull(hintOptions);
+      Objects.requireNonNull(hintOptions, "hintOptions");
       Preconditions.checkState(this.kvOptions.size() == 0,
           "List options and key value options can not be mixed in");
       this.listOptions = ImmutableList.copyOf(hintOptions);
@@ -215,8 +215,8 @@ public class RelHint {
 
     /** Add a hint option as string key-value pair. */
     public Builder hintOption(String optionKey, String optionValue) {
-      Objects.requireNonNull(optionKey);
-      Objects.requireNonNull(optionValue);
+      Objects.requireNonNull(optionKey, "optionKey");
+      Objects.requireNonNull(optionValue, "optionValue");
       Preconditions.checkState(this.listOptions.size() == 0,
           "List options and key value options can not be mixed in");
       this.kvOptions.put(optionKey, optionValue);
@@ -225,7 +225,7 @@ public class RelHint {
 
     /** Add multiple string key-value pair hint options. */
     public Builder hintOptions(Map<String, String> kvOptions) {
-      Objects.requireNonNull(kvOptions);
+      Objects.requireNonNull(kvOptions, "kvOptions");
       Preconditions.checkState(this.listOptions.size() == 0,
           "List options and key value options can not be mixed in");
       this.kvOptions = kvOptions;

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -68,7 +68,7 @@ public final class LogicalFilter extends Filter {
       RexNode condition,
       ImmutableSet<CorrelationId> variablesSet) {
     super(cluster, traitSet, child, condition);
-    this.variablesSet = Objects.requireNonNull(variablesSet);
+    this.variablesSet = Objects.requireNonNull(variablesSet, "variablesSet");
     assert isValid(Litmus.THROW, null);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -105,7 +105,7 @@ public final class LogicalJoin extends Join {
       ImmutableList<RelDataTypeField> systemFieldList) {
     super(cluster, traitSet, hints, left, right, condition, variablesSet, joinType);
     this.semiJoinDone = semiJoinDone;
-    this.systemFieldList = requireNonNull(systemFieldList);
+    this.systemFieldList = requireNonNull(systemFieldList, "systemFieldList");
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
@@ -107,7 +107,7 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
     private final Metadata metadata;
 
     CachingInvocationHandler(Metadata metadata) {
-      this.metadata = requireNonNull(metadata);
+      this.metadata = requireNonNull(metadata, "metadata");
     }
 
     @Override public @Nullable Object invoke(Object proxy, Method method, @Nullable Object[] args)

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -304,7 +304,7 @@ public class ReflectiveRelMetadataProvider
      * {@code map}. */
     @SuppressWarnings({ "unchecked", "SuspiciousMethodCalls" })
     Method find(final Class<? extends RelNode> relNodeClass, Method method) {
-      Objects.requireNonNull(relNodeClass);
+      Objects.requireNonNull(relNodeClass, "relNodeClass");
       for (Class r = relNodeClass;;) {
         Method implementingMethod = handlerMap.get(Pair.of(r, method));
         if (implementingMethod != null) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -147,7 +147,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
 
   private RelMetadataQuery(JaninoRelMetadataProvider metadataProvider,
       RelMetadataQuery prototype) {
-    super(requireNonNull(metadataProvider));
+    super(requireNonNull(metadataProvider, "metadataProvider"));
     this.collationHandler = prototype.collationHandler;
     this.columnOriginHandler = prototype.columnOriginHandler;
     this.expressionLineageHandler = prototype.expressionLineageHandler;

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableRel.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableRel.java
@@ -71,9 +71,9 @@ public abstract class MutableRel {
 
   protected MutableRel(RelOptCluster cluster,
       RelDataType rowType, MutableRelType type) {
-    this.cluster = Objects.requireNonNull(cluster);
-    this.rowType = Objects.requireNonNull(rowType);
-    this.type = Objects.requireNonNull(type);
+    this.cluster = Objects.requireNonNull(cluster, "cluster");
+    this.rowType = Objects.requireNonNull(rowType, "rowType");
+    this.type = Objects.requireNonNull(type, "type");
   }
 
   public @Nullable MutableRel getParent() {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -1050,9 +1050,9 @@ public class RelToSqlConverter extends SqlImplementor
 
     Frame(RelNode parent, int ordinalInParent, RelNode r, boolean anon,
         boolean ignoreClauses, Iterable<? extends Clause> expectedClauses) {
-      this.parent = requireNonNull(parent);
+      this.parent = requireNonNull(parent, "parent");
       this.ordinalInParent = ordinalInParent;
-      this.r = requireNonNull(r);
+      this.r = requireNonNull(r, "r");
       this.anon = anon;
       this.ignoreClauses = ignoreClauses;
       this.expectedClauses = ImmutableSet.copyOf(expectedClauses);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -142,7 +142,7 @@ public abstract class SqlImplementor {
       new RexBuilder(new SqlTypeFactoryImpl(RelDataTypeSystemImpl.DEFAULT));
 
   protected SqlImplementor(SqlDialect dialect) {
-    this.dialect = requireNonNull(dialect);
+    this.dialect = requireNonNull(dialect, "dialect");
   }
 
   /** Visits a relational expression that has no parent. */
@@ -2033,10 +2033,10 @@ public abstract class SqlImplementor {
     public Builder(RelNode rel, List<Clause> clauses, SqlSelect select,
         Context context, boolean anon,
         @Nullable Map<String, RelDataType> aliases) {
-      this.rel = requireNonNull(rel);
+      this.rel = requireNonNull(rel, "rel");
       this.clauses = ImmutableList.copyOf(clauses);
-      this.select = requireNonNull(select);
-      this.context = requireNonNull(context);
+      this.select = requireNonNull(select, "select");
+      this.context = requireNonNull(context, "context");
       this.anon = anon;
       this.aliases = aliases;
     }

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
@@ -146,7 +146,7 @@ public class AggregateReduceFunctionsRule
         .as(Config.class)
         .withOperandFor(aggregateClass)
         // reduce specific functions provided by the client
-        .withFunctionsToReduce(Objects.requireNonNull(functionsToReduce)));
+        .withFunctionsToReduce(Objects.requireNonNull(functionsToReduce, "functionsToReduce")));
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
@@ -287,10 +287,10 @@ public abstract class DateRangeRules {
     ExtractShuttle(RexBuilder rexBuilder, TimeUnitRange timeUnit,
         Map<RexNode, RangeSet<Calendar>> operandRanges,
         ImmutableSortedSet<TimeUnitRange> timeUnitRanges, String timeZone) {
-      this.rexBuilder = requireNonNull(rexBuilder);
-      this.timeUnit = requireNonNull(timeUnit);
-      this.operandRanges = requireNonNull(operandRanges);
-      this.timeUnitRanges = requireNonNull(timeUnitRanges);
+      this.rexBuilder = requireNonNull(rexBuilder, "rexBuilder");
+      this.timeUnit = requireNonNull(timeUnit, "timeUnit");
+      this.operandRanges = requireNonNull(operandRanges, "operandRanges");
+      this.timeUnitRanges = requireNonNull(timeUnitRanges, "timeUnitRanges");
       this.timeZone = timeZone;
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/LoptJoinTree.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/LoptJoinTree.java
@@ -198,8 +198,8 @@ public class LoptJoinTree {
 
     public Node(BinaryTree left, BinaryTree right, @UnderInitialization LoptJoinTree parent) {
       super(parent);
-      this.left = Objects.requireNonNull(left);
-      this.right = Objects.requireNonNull(right);
+      this.left = Objects.requireNonNull(left, "left");
+      this.right = Objects.requireNonNull(right, "right");
     }
 
     public BinaryTree getLeft() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinOptimizeBushyRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinOptimizeBushyRule.java
@@ -385,7 +385,7 @@ public class MultiJoinOptimizeBushyRule
       super(id, factors, cost);
       this.leftFactor = leftFactor;
       this.rightFactor = rightFactor;
-      this.conditions = Objects.requireNonNull(conditions);
+      this.conditions = Objects.requireNonNull(conditions, "conditions");
     }
 
     @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
@@ -216,7 +216,7 @@ public class PushProjector {
     this.origFilter = origFilter;
     this.childRel = childRel;
     this.preserveExprCondition = preserveExprCondition;
-    this.relBuilder = requireNonNull(relBuilder);
+    this.relBuilder = requireNonNull(relBuilder, "relBuilder");
     if (origProj == null) {
       origProjExprs = ImmutableList.of();
     } else {

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactory.java
@@ -429,7 +429,7 @@ public interface RelDataTypeFactory {
      * Creates a Builder with the given type factory.
      */
     public Builder(RelDataTypeFactory typeFactory) {
-      this.typeFactory = Objects.requireNonNull(typeFactory);
+      this.typeFactory = Objects.requireNonNull(typeFactory, "typeFactory");
     }
 
     /**

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -106,7 +106,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
 
   /** Creates a type factory. */
   protected RelDataTypeFactoryImpl(RelDataTypeSystem typeSystem) {
-    this.typeSystem = Objects.requireNonNull(typeSystem);
+    this.typeSystem = Objects.requireNonNull(typeSystem, "typeSystem");
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -318,7 +318,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   @Override public RelDataType createTypeWithNullability(
       final RelDataType type,
       final boolean nullable) {
-    Objects.requireNonNull(type);
+    Objects.requireNonNull(type, "type");
     RelDataType newType;
     if (type.isNullable() == nullable) {
       newType = type;

--- a/core/src/main/java/org/apache/calcite/rel/type/RelRecordType.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelRecordType.java
@@ -44,7 +44,7 @@ public class RelRecordType extends RelDataTypeImpl implements Serializable {
   public RelRecordType(StructKind kind, List<RelDataTypeField> fields, boolean nullable) {
     super(fields);
     this.nullable = nullable;
-    this.kind = requireNonNull(kind);
+    this.kind = requireNonNull(kind, "kind");
     computeDigest();
   }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -1082,7 +1082,7 @@ public class RexBuilder {
    * Creates a search argument literal.
    */
   public RexLiteral makeSearchArgumentLiteral(Sarg s, RelDataType type) {
-    return makeLiteral(Objects.requireNonNull(s), type, SqlTypeName.SARG);
+    return makeLiteral(Objects.requireNonNull(s, "s"), type, SqlTypeName.SARG);
   }
 
   /**
@@ -1191,7 +1191,7 @@ public class RexBuilder {
    * Creates a Date literal.
    */
   public RexLiteral makeDateLiteral(DateString date) {
-    return makeLiteral(Objects.requireNonNull(date),
+    return makeLiteral(Objects.requireNonNull(date, "date"),
         typeFactory.createSqlType(SqlTypeName.DATE), SqlTypeName.DATE);
   }
 
@@ -1206,7 +1206,7 @@ public class RexBuilder {
    * Creates a Time literal.
    */
   public RexLiteral makeTimeLiteral(TimeString time, int precision) {
-    return makeLiteral(Objects.requireNonNull(time),
+    return makeLiteral(Objects.requireNonNull(time, "time"),
         typeFactory.createSqlType(SqlTypeName.TIME, precision),
         SqlTypeName.TIME);
   }
@@ -1217,7 +1217,7 @@ public class RexBuilder {
   public RexLiteral makeTimeWithLocalTimeZoneLiteral(
       TimeString time,
       int precision) {
-    return makeLiteral(Objects.requireNonNull(time),
+    return makeLiteral(Objects.requireNonNull(time, "time"),
         typeFactory.createSqlType(SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE, precision),
         SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE);
   }
@@ -1235,7 +1235,7 @@ public class RexBuilder {
    */
   public RexLiteral makeTimestampLiteral(TimestampString timestamp,
       int precision) {
-    return makeLiteral(Objects.requireNonNull(timestamp),
+    return makeLiteral(Objects.requireNonNull(timestamp, "timestamp"),
         typeFactory.createSqlType(SqlTypeName.TIMESTAMP, precision),
         SqlTypeName.TIMESTAMP);
   }
@@ -1246,7 +1246,7 @@ public class RexBuilder {
   public RexLiteral makeTimestampWithLocalTimeZoneLiteral(
       TimestampString timestamp,
       int precision) {
-    return makeLiteral(Objects.requireNonNull(timestamp),
+    return makeLiteral(Objects.requireNonNull(timestamp, "timestamp"),
         typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, precision),
         SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -75,15 +75,15 @@ public class RexCall extends RexNode {
 
   protected RexCall(
       RelDataType type,
-      SqlOperator op,
+      SqlOperator operator,
       List<? extends RexNode> operands) {
     this.type = requireNonNull(type, "type");
-    this.op = requireNonNull(op, "operator");
+    this.op = requireNonNull(operator, "operator");
     this.operands = ImmutableList.copyOf(operands);
     this.nodeCount = RexUtil.nodeCount(1, this.operands);
-    assert op.getKind() != null : op;
-    assert op.validRexOperands(operands.size(), Litmus.THROW) : this;
-    assert op.kind != SqlKind.IN || this instanceof RexSubQuery;
+    assert operator.getKind() != null : operator;
+    assert operator.validRexOperands(operands.size(), Litmus.THROW) : this;
+    assert operator.kind != SqlKind.IN || this instanceof RexSubQuery;
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rex/RexCorrelVariable.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCorrelVariable.java
@@ -40,7 +40,7 @@ public class RexCorrelVariable extends RexVariable {
       CorrelationId id,
       RelDataType type) {
     super(id.getName(), type);
-    this.id = Objects.requireNonNull(id);
+    this.id = Objects.requireNonNull(id, "id");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -225,8 +225,8 @@ public class RexLiteral extends RexNode {
       RelDataType type,
       SqlTypeName typeName) {
     this.value = value;
-    this.type = requireNonNull(type);
-    this.typeName = requireNonNull(typeName);
+    this.type = requireNonNull(type, "type");
+    this.typeName = requireNonNull(typeName, "typeName");
     Preconditions.checkArgument(valueMatchesType(value, typeName, true));
     Preconditions.checkArgument((value == null) == type.isNullable());
     Preconditions.checkArgument(typeName != SqlTypeName.ANY);

--- a/core/src/main/java/org/apache/calcite/rex/RexOver.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexOver.java
@@ -71,7 +71,7 @@ public class RexOver extends RexCall {
       boolean ignoreNulls) {
     super(type, op, operands);
     Preconditions.checkArgument(op.isAggregator());
-    this.window = Objects.requireNonNull(window);
+    this.window = Objects.requireNonNull(window, "window");
     this.distinct = distinct;
     this.ignoreNulls = ignoreNulls;
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexProgramBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexProgramBuilder.java
@@ -71,8 +71,8 @@ public class RexProgramBuilder {
   @SuppressWarnings("method.invocation.invalid")
   private RexProgramBuilder(RelDataType inputRowType, RexBuilder rexBuilder,
       @Nullable RexSimplify simplify) {
-    this.inputRowType = requireNonNull(inputRowType);
-    this.rexBuilder = requireNonNull(rexBuilder);
+    this.inputRowType = requireNonNull(inputRowType, "inputRowType");
+    this.rexBuilder = requireNonNull(rexBuilder, "rexBuilder");
     this.simplify = simplify; // may be null
     this.validating = assertionsAreEnabled();
 

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -98,12 +98,12 @@ public class RexSimplify {
   private RexSimplify(RexBuilder rexBuilder, RelOptPredicateList predicates,
       RexUnknownAs defaultUnknownAs, boolean predicateElimination,
       boolean paranoid, RexExecutor executor) {
-    this.rexBuilder = requireNonNull(rexBuilder);
-    this.predicates = requireNonNull(predicates);
-    this.defaultUnknownAs = requireNonNull(defaultUnknownAs);
+    this.rexBuilder = requireNonNull(rexBuilder, "rexBuilder");
+    this.predicates = requireNonNull(predicates, "predicates");
+    this.defaultUnknownAs = requireNonNull(defaultUnknownAs, "defaultUnknownAs");
     this.predicateElimination = predicateElimination;
     this.paranoid = paranoid;
-    this.executor = requireNonNull(executor);
+    this.executor = requireNonNull(executor, "executor");
     this.strong = new Strong();
   }
 
@@ -2446,9 +2446,9 @@ public class RexSimplify {
     final RexLiteral literal;
 
     private Comparison(RexNode ref, SqlKind kind, RexLiteral literal) {
-      this.ref = requireNonNull(ref);
-      this.kind = requireNonNull(kind);
-      this.literal = requireNonNull(literal);
+      this.ref = requireNonNull(ref, "ref");
+      this.kind = requireNonNull(kind, "kind");
+      this.literal = requireNonNull(literal, "literal");
     }
 
     /** Creates a comparison, between a {@link RexInputRef} or {@link RexFieldAccess} or
@@ -2507,8 +2507,8 @@ public class RexSimplify {
     final SqlKind kind;
 
     private IsPredicate(RexNode ref, SqlKind kind) {
-      this.ref = requireNonNull(ref);
-      this.kind = requireNonNull(kind);
+      this.ref = requireNonNull(ref, "ref");
+      this.kind = requireNonNull(kind, "kind");
     }
 
     /** Creates an IS predicate, or returns null. */
@@ -2833,8 +2833,8 @@ public class RexSimplify {
     int nullTermCount;
 
     RexSargBuilder(RexNode ref, RexBuilder rexBuilder, boolean negate) {
-      this.ref = requireNonNull(ref);
-      this.rexBuilder = requireNonNull(rexBuilder);
+      this.ref = requireNonNull(ref, "ref");
+      this.rexBuilder = requireNonNull(rexBuilder, "rexBuilder");
       this.negate = negate;
     }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1205,7 +1205,7 @@ public class RexUtil {
   public static RexNode composeConjunction(RexBuilder rexBuilder,
       Iterable<? extends @Nullable RexNode> nodes) {
     final RexNode e = composeConjunction(rexBuilder, nodes, false);
-    return requireNonNull(e);
+    return requireNonNull(e, "e");
   }
 
   /**
@@ -1279,7 +1279,7 @@ public class RexUtil {
   public static RexNode composeDisjunction(RexBuilder rexBuilder,
       Iterable<? extends RexNode> nodes) {
     final RexNode e = composeDisjunction(rexBuilder, nodes, false);
-    return requireNonNull(e);
+    return requireNonNull(e, "e");
   }
 
   /**
@@ -2952,10 +2952,10 @@ public class RexUtil {
 
     RangeToRex(RexNode ref, List<RexNode> list, RexBuilder rexBuilder,
         RelDataType type) {
-      this.ref = requireNonNull(ref);
-      this.list = requireNonNull(list);
-      this.rexBuilder = requireNonNull(rexBuilder);
-      this.type = requireNonNull(type);
+      this.ref = requireNonNull(ref, "ref");
+      this.list = requireNonNull(list, "list");
+      this.rexBuilder = requireNonNull(rexBuilder, "rexBuilder");
+      this.type = requireNonNull(type, "type");
     }
 
     private void addAnd(RexNode... nodes) {

--- a/core/src/main/java/org/apache/calcite/rex/RexVariable.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexVariable.java
@@ -34,9 +34,9 @@ public abstract class RexVariable extends RexNode {
   protected RexVariable(
       String name,
       RelDataType type) {
-    this.name = Objects.requireNonNull(name);
-    this.digest = Objects.requireNonNull(name);
-    this.type = Objects.requireNonNull(type);
+    this.name = Objects.requireNonNull(name, "name");
+    this.digest = Objects.requireNonNull(name, "name");
+    this.type = Objects.requireNonNull(type, "type");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rex/RexWindow.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexWindow.java
@@ -78,8 +78,8 @@ public class RexWindow {
       boolean isRows) {
     this.partitionKeys = ImmutableList.copyOf(partitionKeys);
     this.orderKeys = ImmutableList.copyOf(orderKeys);
-    this.lowerBound = Objects.requireNonNull(lowerBound);
-    this.upperBound = Objects.requireNonNull(upperBound);
+    this.lowerBound = Objects.requireNonNull(lowerBound, "lowerBound");
+    this.upperBound = Objects.requireNonNull(upperBound, "upperBound");
     this.isRows = isRows;
     this.nodeCount = computeCodeCount();
     this.digest = computeDigest();

--- a/core/src/main/java/org/apache/calcite/runtime/Automaton.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Automaton.java
@@ -46,11 +46,11 @@ public class Automaton {
       ImmutableList<SymbolTransition> transitions,
       ImmutableList<EpsilonTransition> epsilonTransitions,
       ImmutableList<String> symbolNames) {
-    this.startState = Objects.requireNonNull(startState);
-    this.endState = Objects.requireNonNull(endState);
-    this.transitions = Objects.requireNonNull(transitions);
+    this.startState = Objects.requireNonNull(startState, "startState");
+    this.endState = Objects.requireNonNull(endState, "endState");
+    this.transitions = Objects.requireNonNull(transitions, "transitions");
     this.epsilonTransitions = epsilonTransitions;
-    this.symbolNames = Objects.requireNonNull(symbolNames);
+    this.symbolNames = Objects.requireNonNull(symbolNames, "symbolNames");
   }
 
   /** Returns the set of states, represented as a bit set, that the graph is
@@ -122,8 +122,8 @@ public class Automaton {
     final State toState;
 
     Transition(State fromState, State toState) {
-      this.fromState = Objects.requireNonNull(fromState);
-      this.toState = Objects.requireNonNull(toState);
+      this.fromState = Objects.requireNonNull(fromState, "fromState");
+      this.toState = Objects.requireNonNull(toState, "toState");
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/runtime/AutomatonBuilder.java
+++ b/core/src/main/java/org/apache/calcite/runtime/AutomatonBuilder.java
@@ -120,7 +120,7 @@ public class AutomatonBuilder {
   /** Adds a symbol transition. */
   AutomatonBuilder symbol(State fromState, State toState,
       String name) {
-    Objects.requireNonNull(name);
+    Objects.requireNonNull(name, "name");
     final int symbolId =
         symbolIds.computeIfAbsent(name, k -> symbolIds.size());
     transitionList.add(new SymbolTransition(fromState, toState, symbolId));

--- a/core/src/main/java/org/apache/calcite/runtime/DeterministicAutomaton.java
+++ b/core/src/main/java/org/apache/calcite/runtime/DeterministicAutomaton.java
@@ -42,7 +42,7 @@ public class DeterministicAutomaton {
   /** Constructs the DFA from an epsilon-NFA. */
   @SuppressWarnings("method.invocation.invalid")
   DeterministicAutomaton(Automaton automaton) {
-    this.automaton = Objects.requireNonNull(automaton);
+    this.automaton = Objects.requireNonNull(automaton, "automaton");
     // Calculate eps closure of start state
     final Set<MultiState> traversedStates = new HashSet<>();
     // Add transitions
@@ -146,10 +146,10 @@ public class DeterministicAutomaton {
 
     Transition(MultiState fromState, MultiState toState, int symbolId,
         String symbol) {
-      this.fromState = Objects.requireNonNull(fromState);
-      this.toState = Objects.requireNonNull(toState);
+      this.fromState = Objects.requireNonNull(fromState, "fromState");
+      this.toState = Objects.requireNonNull(toState, "toState");
       this.symbolId = symbolId;
-      this.symbol = Objects.requireNonNull(symbol);
+      this.symbol = Objects.requireNonNull(symbol, "symbol");
     }
   }
 
@@ -165,7 +165,7 @@ public class DeterministicAutomaton {
     }
 
     MultiState(ImmutableSet<Automaton.State> states) {
-      this.states = Objects.requireNonNull(states);
+      this.states = Objects.requireNonNull(states, "states");
     }
 
     public boolean contains(Automaton.State state) {

--- a/core/src/main/java/org/apache/calcite/runtime/Enumerables.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Enumerables.java
@@ -97,7 +97,7 @@ public class Enumerables {
           final AtomicInteger matchCounter = new AtomicInteger(1);
 
           @Override public TResult current() {
-            Objects.requireNonNull(resultRow);
+            Objects.requireNonNull(resultRow, "resultRow");
             return resultRow;
           }
 

--- a/core/src/main/java/org/apache/calcite/runtime/GeoFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/GeoFunctions.java
@@ -194,7 +194,7 @@ public class GeoFunctions {
         + xMax + " " + yMax + ", "
         + xMax + " " + yMin + ", "
         + xMin + " " + yMin + "))", srid);
-    return Objects.requireNonNull(geom);
+    return Objects.requireNonNull(geom, "geom");
   }
 
   /** Creates a rectangular Polygon. */

--- a/core/src/main/java/org/apache/calcite/runtime/Geometries.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Geometries.java
@@ -213,7 +213,7 @@ public class Geometries {
     final Geometry g;
 
     SimpleGeom(Geometry g) {
-      this.g = Objects.requireNonNull(g);
+      this.g = Objects.requireNonNull(g, "g");
     }
 
     @Override public String toString() {
@@ -253,7 +253,7 @@ public class Geometries {
     final MapGeometry mg;
 
     MapGeom(MapGeometry mg) {
-      this.mg = Objects.requireNonNull(mg);
+      this.mg = Objects.requireNonNull(mg, "mg");
     }
 
     @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/runtime/Matcher.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Matcher.java
@@ -58,7 +58,7 @@ public class Matcher<E> {
    */
   private Matcher(Automaton automaton,
       ImmutableMap<String, Predicate<MemoryFactory.Memory<E>>> predicates) {
-    this.predicates = Objects.requireNonNull(predicates);
+    this.predicates = Objects.requireNonNull(predicates, "predicates");
     final ImmutableBitSet.Builder startSetBuilder =
         ImmutableBitSet.builder();
     startSetBuilder.set(automaton.startState.id);

--- a/core/src/main/java/org/apache/calcite/runtime/Pattern.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Pattern.java
@@ -152,7 +152,7 @@ public interface Pattern {
     final Op op;
 
     AbstractPattern(Op op) {
-      this.op = Objects.requireNonNull(op);
+      this.op = Objects.requireNonNull(op, "op");
     }
 
     @Override public Automaton toAutomaton() {
@@ -166,7 +166,7 @@ public interface Pattern {
 
     SymbolPattern(String name) {
       super(Op.SYMBOL);
-      this.name = Objects.requireNonNull(name);
+      this.name = Objects.requireNonNull(name, "name");
     }
 
     @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -464,7 +464,7 @@ public final class Schemas {
     final List<CalciteSchema.LatticeEntry> list = getLatticeEntries(schema);
     return Util.transform(list, entry -> {
       final CalciteSchema.TableEntry starTable =
-          requireNonNull(entry).getStarTable();
+          requireNonNull(entry, "entry").getStarTable();
       assert starTable.getTable().getJdbcTableType()
           == Schema.TableType.STAR;
       return entry.getStarTable();
@@ -517,7 +517,7 @@ public final class Schemas {
 
   /** Generates a table name that is unique within the given schema. */
   public static String uniqueTableName(CalciteSchema schema, String base) {
-    String t = requireNonNull(base);
+    String t = requireNonNull(base, "base");
     for (int x = 0; schema.getTable(t, true) != null; x++) {
       t = base + x;
     }

--- a/core/src/main/java/org/apache/calcite/schema/impl/AggregateFunctionImpl.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/AggregateFunctionImpl.java
@@ -72,8 +72,8 @@ public class AggregateFunctionImpl implements AggregateFunction,
     this.parameters = params;
     this.accumulatorType = accumulatorType;
     this.resultType = resultType;
-    this.initMethod = Objects.requireNonNull(initMethod);
-    this.addMethod = Objects.requireNonNull(addMethod);
+    this.initMethod = Objects.requireNonNull(initMethod, "initMethod");
+    this.addMethod = Objects.requireNonNull(addMethod, "addMethod");
     this.mergeMethod = mergeMethod;
     this.resultMethod = resultMethod;
     this.isStatic = Modifier.isStatic(initMethod.getModifiers());

--- a/core/src/main/java/org/apache/calcite/schema/impl/StarTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/StarTable.java
@@ -68,7 +68,7 @@ public class StarTable extends AbstractTable implements TranslatableTable {
 
   /** Creates a StarTable. */
   private StarTable(Lattice lattice, ImmutableList<Table> tables) {
-    this.lattice = Objects.requireNonNull(lattice);
+    this.lattice = Objects.requireNonNull(lattice, "lattice");
     this.tables = tables;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlAbstractDateTimeLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAbstractDateTimeLiteral.java
@@ -57,7 +57,7 @@ public abstract class SqlAbstractDateTimeLiteral extends SqlLiteral {
 
   /** Converts this literal to a {@link TimestampString}. */
   protected TimestampString getTimestamp() {
-    return (TimestampString) requireNonNull(value);
+    return (TimestampString) requireNonNull(value, "value");
   }
 
   public int getPrec() {

--- a/core/src/main/java/org/apache/calcite/sql/SqlAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAggFunction.java
@@ -110,7 +110,7 @@ public abstract class SqlAggFunction extends SqlFunction implements Context {
         operandTypeChecker, funcType);
     this.requiresOrder = requiresOrder;
     this.requiresOver = requiresOver;
-    this.requiresGroupOrder = Objects.requireNonNull(requiresGroupOrder);
+    this.requiresGroupOrder = Objects.requireNonNull(requiresGroupOrder, "requiresGroupOrder");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/SqlBasicCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBasicCall.java
@@ -49,7 +49,7 @@ public class SqlBasicCall extends SqlCall {
       boolean expanded,
       @Nullable SqlLiteral functionQualifier) {
     super(pos);
-    this.operator = Objects.requireNonNull(operator);
+    this.operator = Objects.requireNonNull(operator, "operator");
     this.operands = operands;
     this.expanded = expanded;
     this.functionQuantifier = functionQualifier;
@@ -68,7 +68,7 @@ public class SqlBasicCall extends SqlCall {
   }
 
   public void setOperator(SqlOperator operator) {
-    this.operator = Objects.requireNonNull(operator);
+    this.operator = Objects.requireNonNull(operator, "operator");
   }
 
   @Override public SqlOperator getOperator() {

--- a/core/src/main/java/org/apache/calcite/sql/SqlBinaryOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBinaryOperator.java
@@ -139,7 +139,7 @@ public class SqlBinaryOperator extends SqlOperator {
                 .createTypeWithCharsetAndCollation(
                     type,
                     type.getCharset(),
-                    requireNonNull(resultCol));
+                    requireNonNull(resultCol, "resultCol"));
       }
     }
     return type;

--- a/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
@@ -69,8 +69,8 @@ public class SqlCollectionTypeNameSpec extends SqlTypeNameSpec {
       SqlTypeName collectionTypeName,
       SqlParserPos pos) {
     super(new SqlIdentifier(collectionTypeName.name(), pos), pos);
-    this.elementTypeName = Objects.requireNonNull(elementTypeName);
-    this.collectionTypeName = Objects.requireNonNull(collectionTypeName);
+    this.elementTypeName = Objects.requireNonNull(elementTypeName, "elementTypeName");
+    this.collectionTypeName = Objects.requireNonNull(collectionTypeName, "collectionTypeName");
   }
 
   public SqlTypeNameSpec getElementTypeName() {

--- a/core/src/main/java/org/apache/calcite/sql/SqlDdl.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDdl.java
@@ -31,7 +31,7 @@ public abstract class SqlDdl extends SqlCall {
   /** Creates a SqlDdl. */
   protected SqlDdl(SqlOperator operator, SqlParserPos pos) {
     super(pos);
-    this.operator = Objects.requireNonNull(operator);
+    this.operator = Objects.requireNonNull(operator, "operator");
   }
 
   @Override public SqlOperator getOperator() {

--- a/core/src/main/java/org/apache/calcite/sql/SqlDescribeTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDescribeTable.java
@@ -48,7 +48,7 @@ public class SqlDescribeTable extends SqlCall {
       SqlIdentifier table,
       @Nullable SqlIdentifier column) {
     super(pos);
-    this.table = Objects.requireNonNull(table);
+    this.table = Objects.requireNonNull(table, "table");
     this.column = column;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -1297,8 +1297,8 @@ public class SqlDialect {
     @SuppressWarnings("argument.type.incompatible")
     DatabaseProduct(String databaseProductName, @Nullable String quoteString,
         NullCollation nullCollation) {
-      Objects.requireNonNull(databaseProductName);
-      Objects.requireNonNull(nullCollation);
+      Objects.requireNonNull(databaseProductName, "databaseProductName");
+      Objects.requireNonNull(nullCollation, "nullCollation");
       // Note: below lambda accesses uninitialized DatabaseProduct.this, so it might be
       // worth refactoring
       dialect = Suppliers.memoize(() -> {
@@ -1396,7 +1396,7 @@ public class SqlDialect {
         SqlConformance conformance, NullCollation nullCollation,
         RelDataTypeSystem dataTypeSystem,
         JethroDataSqlDialect.JethroInfo jethroInfo) {
-      this.databaseProduct = Objects.requireNonNull(databaseProduct);
+      this.databaseProduct = Objects.requireNonNull(databaseProduct, "databaseProduct");
       this.databaseProductName = databaseProductName;
       this.databaseVersion = databaseVersion;
       this.databaseMajorVersion = databaseMajorVersion;
@@ -1404,13 +1404,13 @@ public class SqlDialect {
       this.literalQuoteString = literalQuoteString;
       this.literalEscapedQuoteString = literalEscapedQuoteString;
       this.identifierQuoteString = identifierQuoteString;
-      this.quotedCasing = Objects.requireNonNull(quotedCasing);
-      this.unquotedCasing = Objects.requireNonNull(unquotedCasing);
+      this.quotedCasing = Objects.requireNonNull(quotedCasing, "quotedCasing");
+      this.unquotedCasing = Objects.requireNonNull(unquotedCasing, "unquotedCasing");
       this.caseSensitive = caseSensitive;
-      this.conformance = Objects.requireNonNull(conformance);
-      this.nullCollation = Objects.requireNonNull(nullCollation);
-      this.dataTypeSystem = Objects.requireNonNull(dataTypeSystem);
-      this.jethroInfo = Objects.requireNonNull(jethroInfo);
+      this.conformance = Objects.requireNonNull(conformance, "conformance");
+      this.nullCollation = Objects.requireNonNull(nullCollation, "nullCollation");
+      this.dataTypeSystem = Objects.requireNonNull(dataTypeSystem, "dataTypeSystem");
+      this.jethroInfo = Objects.requireNonNull(jethroInfo, "jethroInfo");
     }
 
     @Override public DatabaseProduct databaseProduct() {

--- a/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
@@ -132,7 +132,7 @@ public class SqlFunction extends SqlOperator {
         operandTypeChecker);
 
     this.sqlIdentifier = sqlIdentifier;
-    this.category = Objects.requireNonNull(category);
+    this.category = Objects.requireNonNull(category, "category");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -616,7 +616,7 @@ public class SqlJdbcFunctionCall extends SqlFunction {
      */
     PermutingMakeCall(SqlOperator operator, int[] order) {
       super(operator);
-      this.order = requireNonNull(order);
+      this.order = requireNonNull(order, "order");
     }
 
     @Override public SqlCall createCall(SqlParserPos pos,

--- a/core/src/main/java/org/apache/calcite/sql/SqlJoin.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJoin.java
@@ -64,10 +64,10 @@ public class SqlJoin extends SqlCall {
       @Nullable SqlNode condition) {
     super(pos);
     this.left = left;
-    this.natural = requireNonNull(natural);
-    this.joinType = requireNonNull(joinType);
+    this.natural = requireNonNull(natural, "natural");
+    this.joinType = requireNonNull(joinType, "joinType");
     this.right = right;
-    this.conditionType = requireNonNull(conditionType);
+    this.conditionType = requireNonNull(conditionType, "conditionType");
     this.condition = condition;
 
     Preconditions.checkArgument(natural.getTypeName() == SqlTypeName.BOOLEAN);

--- a/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -654,7 +654,7 @@ public class SqlLiteral extends SqlNode {
     switch (typeName) {
     case DECIMAL:
     case DOUBLE:
-      BigDecimal bd = (BigDecimal) requireNonNull(value);
+      BigDecimal bd = (BigDecimal) requireNonNull(value, "value");
       if (exact) {
         try {
           return bd.intValueExact();
@@ -682,7 +682,7 @@ public class SqlLiteral extends SqlNode {
     switch (typeName) {
     case DECIMAL:
     case DOUBLE:
-      BigDecimal bd = (BigDecimal) requireNonNull(value);
+      BigDecimal bd = (BigDecimal) requireNonNull(value, "value");
       if (exact) {
         try {
           return bd.longValueExact();
@@ -724,7 +724,7 @@ public class SqlLiteral extends SqlNode {
 
   @Deprecated // to be removed before 2.0
   public String getStringValue() {
-    return ((NlsString) requireNonNull(value)).getValue();
+    return ((NlsString) requireNonNull(value, "value")).getValue();
   }
 
   @Override public void unparse(
@@ -763,11 +763,11 @@ public class SqlLiteral extends SqlNode {
       ret = typeFactory.createTypeWithNullability(ret, null == value);
       return ret;
     case BINARY:
-      bitString = (BitString) requireNonNull(value);
+      bitString = (BitString) requireNonNull(value, "value");
       int bitCount = bitString.getBitCount();
       return typeFactory.createSqlType(SqlTypeName.BINARY, bitCount / 8);
     case CHAR:
-      NlsString string = (NlsString) requireNonNull(value);
+      NlsString string = (NlsString) requireNonNull(value, "value");
       Charset charset = string.getCharset();
       if (null == charset) {
         charset = typeFactory.getDefaultCharset();
@@ -801,7 +801,7 @@ public class SqlLiteral extends SqlNode {
     case INTERVAL_MINUTE_SECOND:
     case INTERVAL_SECOND:
       SqlIntervalLiteral.IntervalValue intervalValue =
-          (SqlIntervalLiteral.IntervalValue) requireNonNull(value);
+          (SqlIntervalLiteral.IntervalValue) requireNonNull(value, "value");
       return typeFactory.createSqlIntervalType(
           intervalValue.getIntervalQualifier());
 
@@ -1009,7 +1009,7 @@ public class SqlLiteral extends SqlNode {
       return this;
     }
     assert SqlTypeUtil.inCharFamily(getTypeName());
-    NlsString ns = (NlsString) requireNonNull(value);
+    NlsString ns = (NlsString) requireNonNull(value, "value");
     String s = ns.getValue();
     StringBuilder sb = new StringBuilder();
     int n = s.length();

--- a/core/src/main/java/org/apache/calcite/sql/SqlMatchRecognize.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlMatchRecognize.java
@@ -77,20 +77,20 @@ public class SqlMatchRecognize extends SqlCall {
       @Nullable SqlLiteral rowsPerMatch, SqlNodeList partitionList,
       SqlNodeList orderList, @Nullable SqlLiteral interval) {
     super(pos);
-    this.tableRef = Objects.requireNonNull(tableRef);
-    this.pattern = Objects.requireNonNull(pattern);
+    this.tableRef = Objects.requireNonNull(tableRef, "tableRef");
+    this.pattern = Objects.requireNonNull(pattern, "pattern");
     this.strictStart = strictStart;
     this.strictEnd = strictEnd;
-    this.patternDefList = Objects.requireNonNull(patternDefList);
+    this.patternDefList = Objects.requireNonNull(patternDefList, "patternDefList");
     Preconditions.checkArgument(patternDefList.size() > 0);
-    this.measureList = Objects.requireNonNull(measureList);
+    this.measureList = Objects.requireNonNull(measureList, "measureList");
     this.after = after;
     this.subsetList = subsetList;
     Preconditions.checkArgument(rowsPerMatch == null
         || rowsPerMatch.value instanceof RowsPerMatchOption);
     this.rowsPerMatch = rowsPerMatch;
-    this.partitionList = Objects.requireNonNull(partitionList);
-    this.orderList = Objects.requireNonNull(orderList);
+    this.partitionList = Objects.requireNonNull(partitionList, "partitionList");
+    this.orderList = Objects.requireNonNull(orderList, "orderList");
     this.interval = interval;
   }
 
@@ -124,7 +124,7 @@ public class SqlMatchRecognize extends SqlCall {
   @Override public void setOperand(int i, @Nullable SqlNode operand) {
     switch (i) {
     case OPERAND_TABLE_REF:
-      tableRef = Objects.requireNonNull(operand);
+      tableRef = Objects.requireNonNull(operand, "operand");
       break;
     case OPERAND_PATTERN:
       pattern = operand;

--- a/core/src/main/java/org/apache/calcite/sql/SqlNode.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNode.java
@@ -62,7 +62,7 @@ public abstract class SqlNode implements Cloneable {
    * @param pos Parser position, must not be null.
    */
   SqlNode(SqlParserPos pos) {
-    this.pos = Objects.requireNonNull(pos);
+    this.pos = Objects.requireNonNull(pos, "pos");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/SqlNodeList.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNodeList.java
@@ -78,7 +78,7 @@ public class SqlNodeList extends SqlNode implements List<SqlNode>, RandomAccess 
    * should allow O(1) access to elements. */
   private SqlNodeList(SqlParserPos pos, List<@Nullable SqlNode> list) {
     super(pos);
-    this.list = Objects.requireNonNull(list);
+    this.list = Objects.requireNonNull(list, "list");
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/SqlPivot.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPivot.java
@@ -59,10 +59,10 @@ public class SqlPivot extends SqlCall {
   public SqlPivot(SqlParserPos pos, SqlNode query, SqlNodeList aggList,
       SqlNodeList axisList, SqlNodeList inList) {
     super(pos);
-    this.query = Objects.requireNonNull(query);
-    this.aggList = Objects.requireNonNull(aggList);
-    this.axisList = Objects.requireNonNull(axisList);
-    this.inList = Objects.requireNonNull(inList);
+    this.query = Objects.requireNonNull(query, "query");
+    this.aggList = Objects.requireNonNull(aggList, "aggList");
+    this.axisList = Objects.requireNonNull(axisList, "axisList");
+    this.inList = Objects.requireNonNull(inList, "inList");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/SqlRowTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlRowTypeNameSpec.java
@@ -66,8 +66,8 @@ public class SqlRowTypeNameSpec extends SqlTypeNameSpec {
       List<SqlIdentifier> fieldNames,
       List<SqlDataTypeSpec> fieldTypes) {
     super(new SqlIdentifier(SqlTypeName.ROW.getName(), pos), pos);
-    Objects.requireNonNull(fieldNames);
-    Objects.requireNonNull(fieldTypes);
+    Objects.requireNonNull(fieldNames, "fieldNames");
+    Objects.requireNonNull(fieldTypes, "fieldTypes");
     assert fieldNames.size() > 0; // there must be at least one field.
     this.fieldNames = fieldNames;
     this.fieldTypes = fieldTypes;

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetOption.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetOption.java
@@ -133,7 +133,7 @@ public class SqlSetOption extends SqlAlter {
       }
       break;
     case 1:
-      name = (SqlIdentifier) requireNonNull(operand, "name");
+      name = (SqlIdentifier) requireNonNull(operand, /**/ "name");
       break;
     case 2:
       value = operand;

--- a/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
@@ -41,8 +41,8 @@ public class SqlSnapshot extends SqlCall {
   /** Creates a SqlSnapshot. */
   public SqlSnapshot(SqlParserPos pos, SqlNode tableRef, SqlNode period) {
     super(pos);
-    this.tableRef = Objects.requireNonNull(tableRef);
-    this.period = Objects.requireNonNull(period);
+    this.tableRef = Objects.requireNonNull(tableRef, "tableRef");
+    this.period = Objects.requireNonNull(period, "period");
   }
 
   // ~ Methods
@@ -66,10 +66,10 @@ public class SqlSnapshot extends SqlCall {
   @Override public void setOperand(int i, @Nullable SqlNode operand) {
     switch (i) {
     case OPERAND_TABLE_REF:
-      tableRef = Objects.requireNonNull(operand);
+      tableRef = Objects.requireNonNull(operand, "operand");
       break;
     case OPERAND_PERIOD:
-      period = Objects.requireNonNull(operand);
+      period = Objects.requireNonNull(operand, "operand");
       break;
     default:
       throw new AssertionError(i);

--- a/core/src/main/java/org/apache/calcite/sql/SqlUnpivot.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUnpivot.java
@@ -65,11 +65,11 @@ public class SqlUnpivot extends SqlCall {
   public SqlUnpivot(SqlParserPos pos, SqlNode query, boolean includeNulls,
       SqlNodeList measureList, SqlNodeList axisList, SqlNodeList inList) {
     super(pos);
-    this.query = Objects.requireNonNull(query);
+    this.query = Objects.requireNonNull(query, "query");
     this.includeNulls = includeNulls;
-    this.measureList = Objects.requireNonNull(measureList);
-    this.axisList = Objects.requireNonNull(axisList);
-    this.inList = Objects.requireNonNull(inList);
+    this.measureList = Objects.requireNonNull(measureList, "measureList");
+    this.axisList = Objects.requireNonNull(axisList, "axisList");
+    this.inList = Objects.requireNonNull(inList, "inList");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -497,7 +497,7 @@ public abstract class SqlUtil {
   private static Iterator<SqlOperator> filterOperatorRoutinesByKind(
       Iterator<SqlOperator> routines, final SqlKind sqlKind) {
     return Iterators.filter(routines,
-        operator -> Objects.requireNonNull(operator).getKind() == sqlKind);
+        operator -> Objects.requireNonNull(operator, "operator").getKind() == sqlKind);
   }
 
   /**
@@ -607,7 +607,7 @@ public abstract class SqlUtil {
           Predicates.instanceOf(SqlFunction.class));
     default:
       return Iterators.filter(sqlOperators.iterator(),
-          operator -> Objects.requireNonNull(operator).getSyntax() == syntax);
+          operator -> Objects.requireNonNull(operator, "operator").getSyntax() == syntax);
     }
   }
 
@@ -615,7 +615,7 @@ public abstract class SqlUtil {
       Iterator<SqlOperator> routines,
       final List<RelDataType> argTypes) {
     return Iterators.filter(routines,
-        operator -> Objects.requireNonNull(operator)
+        operator -> Objects.requireNonNull(operator, "operator")
             .getOperandCountRange().isValidCount(argTypes.size()));
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/advise/SqlAdvisor.java
+++ b/core/src/main/java/org/apache/calcite/sql/advise/SqlAdvisor.java
@@ -372,7 +372,7 @@ public class SqlAdvisor {
     List<SqlNode> nodes = SqlUtil.getAncestry(root,
         input -> input instanceof SqlIdentifier
             && ((SqlIdentifier) input).names.contains(hintToken),
-        input -> Objects.requireNonNull(input).getParserPosition()
+        input -> Objects.requireNonNull(input, "input").getParserPosition()
             .startsAt(pos));
     assert nodes.get(0) == root;
     nodes = Lists.reverse(nodes);

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateForeignSchema.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateForeignSchema.java
@@ -57,7 +57,7 @@ public class SqlCreateForeignSchema extends SqlCreate {
       SqlIdentifier name, @Nullable SqlNode type, @Nullable SqlNode library,
       @Nullable SqlNodeList optionList) {
     super(OPERATOR, pos, replace, ifNotExists);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
     this.type = type;
     this.library = library;
     Preconditions.checkArgument((type == null) != (library == null),

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateFunction.java
@@ -51,9 +51,9 @@ public class SqlCreateFunction extends SqlCreate {
       boolean ifNotExists, SqlIdentifier name,
       SqlNode className, SqlNodeList usingList) {
     super(OPERATOR, pos, replace, ifNotExists);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
     this.className = className;
-    this.usingList = Objects.requireNonNull(usingList);
+    this.usingList = Objects.requireNonNull(usingList, "usingList");
     Preconditions.checkArgument(usingList.size() % 2 == 0);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateMaterializedView.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateMaterializedView.java
@@ -49,9 +49,9 @@ public class SqlCreateMaterializedView extends SqlCreate {
       boolean ifNotExists, SqlIdentifier name, @Nullable SqlNodeList columnList,
       SqlNode query) {
     super(OPERATOR, pos, replace, ifNotExists);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
     this.columnList = columnList; // may be null
-    this.query = Objects.requireNonNull(query);
+    this.query = Objects.requireNonNull(query, "query");
   }
 
   @SuppressWarnings("nullness")

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateSchema.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateSchema.java
@@ -42,7 +42,7 @@ public class SqlCreateSchema extends SqlCreate {
   SqlCreateSchema(SqlParserPos pos, boolean replace, boolean ifNotExists,
       SqlIdentifier name) {
     super(OPERATOR, pos, replace, ifNotExists);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
   }
 
   @Override public List<SqlNode> getOperandList() {

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -47,7 +47,7 @@ public class SqlCreateTable extends SqlCreate {
   protected SqlCreateTable(SqlParserPos pos, boolean replace, boolean ifNotExists,
       SqlIdentifier name, @Nullable SqlNodeList columnList, @Nullable SqlNode query) {
     super(OPERATOR, pos, replace, ifNotExists);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
     this.columnList = columnList; // may be null
     this.query = query; // for "CREATE TABLE ... AS query"; may be null
   }

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateType.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateType.java
@@ -48,7 +48,7 @@ public class SqlCreateType extends SqlCreate {
   SqlCreateType(SqlParserPos pos, boolean replace, SqlIdentifier name,
       @Nullable SqlNodeList attributeDefs, @Nullable SqlDataTypeSpec dataType) {
     super(OPERATOR, pos, replace, false);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
     this.attributeDefs = attributeDefs; // may be null
     this.dataType = dataType; // may be null
   }

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateView.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateView.java
@@ -47,9 +47,9 @@ public class SqlCreateView extends SqlCreate {
   SqlCreateView(SqlParserPos pos, boolean replace, SqlIdentifier name,
       @Nullable SqlNodeList columnList, SqlNode query) {
     super(OPERATOR, pos, replace, false);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
     this.columnList = columnList; // may be null
-    this.query = Objects.requireNonNull(query);
+    this.query = Objects.requireNonNull(query, "query");
   }
 
   @SuppressWarnings("nullness")

--- a/core/src/main/java/org/apache/calcite/sql/dialect/JethroDataSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/JethroDataSqlDialect.java
@@ -128,7 +128,7 @@ public class JethroDataSqlDialect extends SqlDialect {
     private final List<SqlTypeName> operandTypes;
 
     JethroSupportedFunction(String name, String operands) {
-      Objects.requireNonNull(name); // not currently used
+      Objects.requireNonNull(name, "name"); // not currently used
       final ImmutableList.Builder<SqlTypeName> b = ImmutableList.builder();
       for (String strType : operands.split(":")) {
         b.add(parse(strType));

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBasicAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBasicAggFunction.java
@@ -62,12 +62,12 @@ public final class SqlBasicAggFunction extends SqlAggFunction {
       Optionality requiresGroupOrder, Optionality distinctOptionality,
       SqlSyntax syntax, boolean allowsNullTreatment, boolean allowsSeparator) {
     super(name, sqlIdentifier, kind,
-        requireNonNull(returnTypeInference), operandTypeInference,
-        requireNonNull(operandTypeChecker),
-        requireNonNull(funcType), requiresOrder, requiresOver,
+        requireNonNull(returnTypeInference, "returnTypeInference"), operandTypeInference,
+        requireNonNull(operandTypeChecker, "operandTypeChecker"),
+        requireNonNull(funcType, "funcType"), requiresOrder, requiresOver,
         requiresGroupOrder);
-    this.distinctOptionality = requireNonNull(distinctOptionality);
-    this.syntax = requireNonNull(syntax);
+    this.distinctOptionality = requireNonNull(distinctOptionality, "distinctOptionality");
+    this.syntax = requireNonNull(syntax, "syntax");
     this.allowsNullTreatment = allowsNullTreatment;
     this.allowsSeparator = allowsSeparator;
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonArrayAggAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonArrayAggAggFunction.java
@@ -50,7 +50,7 @@ public class SqlJsonArrayAggAggFunction extends SqlAggFunction {
     super(kind + "_" + nullClause.name(), null, kind, ReturnTypes.VARCHAR_2000,
         InferTypes.ANY_NULLABLE, OperandTypes.family(SqlTypeFamily.ANY),
         SqlFunctionCategory.SYSTEM, false, false, Optionality.OPTIONAL);
-    this.nullClause = Objects.requireNonNull(nullClause);
+    this.nullClause = Objects.requireNonNull(nullClause, "nullClause");
   }
 
   @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonObjectAggAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonObjectAggAggFunction.java
@@ -54,7 +54,7 @@ public class SqlJsonObjectAggAggFunction extends SqlAggFunction {
         }, OperandTypes.family(SqlTypeFamily.CHARACTER,
             SqlTypeFamily.ANY),
         SqlFunctionCategory.SYSTEM, false, false, Optionality.FORBIDDEN);
-    this.nullClause = Objects.requireNonNull(nullClause);
+    this.nullClause = Objects.requireNonNull(nullClause, "nullClause");
   }
 
   @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
@@ -72,8 +72,8 @@ public enum SqlLibrary {
   public final String fun;
 
   SqlLibrary(String abbrev, String fun) {
-    this.abbrev = Objects.requireNonNull(abbrev);
-    this.fun = Objects.requireNonNull(fun);
+    this.abbrev = Objects.requireNonNull(abbrev, "abbrev");
+    this.fun = Objects.requireNonNull(fun, "fun");
     Preconditions.checkArgument(
         fun.equals(name().toLowerCase(Locale.ROOT).replace("_", "")));
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlQuantifyOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlQuantifyOperator.java
@@ -49,7 +49,7 @@ public class SqlQuantifyOperator extends SqlInOperator {
    */
   SqlQuantifyOperator(SqlKind kind, SqlKind comparisonKind) {
     super(comparisonKind.sql + " " + kind, kind);
-    this.comparisonKind = Objects.requireNonNull(comparisonKind);
+    this.comparisonKind = Objects.requireNonNull(comparisonKind, "comparisonKind");
     Preconditions.checkArgument(comparisonKind == SqlKind.EQUALS
         || comparisonKind == SqlKind.NOT_EQUALS
         || comparisonKind == SqlKind.LESS_THAN_OR_EQUAL

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -352,8 +352,8 @@ public final class SqlParserUtil {
   public static String strip(String s, @Nullable String startQuote,
       @Nullable String endQuote, @Nullable String escape, Casing casing) {
     if (startQuote != null) {
-      return stripQuotes(s, Objects.requireNonNull(startQuote),
-          Objects.requireNonNull(endQuote), Objects.requireNonNull(escape),
+      return stripQuotes(s, Objects.requireNonNull(startQuote, "startQuote"),
+          Objects.requireNonNull(endQuote, "endQuote"), Objects.requireNonNull(escape, "escape"),
           casing);
     } else {
       return toCase(s, casing);
@@ -612,7 +612,7 @@ public final class SqlParserUtil {
       int start,
       int end,
       T o) {
-    requireNonNull(list);
+    requireNonNull(list, "list");
     Preconditions.checkArgument(start < end);
     for (int i = end - 1; i > start; --i) {
       list.remove(i);
@@ -918,7 +918,7 @@ public final class SqlParserUtil {
             throw new AssertionError();
           }
         } else {
-          builder.atom(requireNonNull(o));
+          builder.atom(requireNonNull(o, "o"));
         }
       }
       return builder.build();

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -283,9 +283,9 @@ public class SqlPrettyWriter implements SqlWriter {
   @SuppressWarnings("method.invocation.invalid")
   private SqlPrettyWriter(SqlWriterConfig config,
       StringBuilder buf, @SuppressWarnings("unused") boolean ignore) {
-    this.buf = requireNonNull(buf);
+    this.buf = requireNonNull(buf, "buf");
     this.dialect = requireNonNull(config.dialect());
-    this.config = requireNonNull(config);
+    this.config = requireNonNull(config, "config");
     lineStart = 0;
     reset();
   }
@@ -294,7 +294,7 @@ public class SqlPrettyWriter implements SqlWriter {
    * and a given buffer to write to. */
   public SqlPrettyWriter(SqlWriterConfig config,
       StringBuilder buf) {
-    this(config, requireNonNull(buf), false);
+    this(config, requireNonNull(buf, "buf"), false);
   }
 
   /** Creates a writer with the given configuration and dialect,
@@ -303,14 +303,14 @@ public class SqlPrettyWriter implements SqlWriter {
       SqlDialect dialect,
       SqlWriterConfig config,
       StringBuilder buf) {
-    this(config.withDialect(requireNonNull(dialect)), buf);
+    this(config.withDialect(requireNonNull(dialect, "dialect")), buf);
   }
 
   /** Creates a writer with the given configuration
    * and a private print writer. */
   @Deprecated
   public SqlPrettyWriter(SqlDialect dialect, SqlWriterConfig config) {
-    this(config.withDialect(requireNonNull(dialect)));
+    this(config.withDialect(requireNonNull(dialect, "dialect")));
   }
 
   @Deprecated
@@ -319,7 +319,7 @@ public class SqlPrettyWriter implements SqlWriter {
       boolean alwaysUseParentheses,
       PrintWriter pw) {
     // NOTE that 'pw' is ignored; there is no place for it in the new API
-    this(config().withDialect(requireNonNull(dialect))
+    this(config().withDialect(requireNonNull(dialect, "dialect"))
         .withAlwaysUseParentheses(alwaysUseParentheses));
   }
 
@@ -327,7 +327,7 @@ public class SqlPrettyWriter implements SqlWriter {
   public SqlPrettyWriter(
       SqlDialect dialect,
       boolean alwaysUseParentheses) {
-    this(config().withDialect(requireNonNull(dialect))
+    this(config().withDialect(requireNonNull(dialect, "dialect"))
         .withAlwaysUseParentheses(alwaysUseParentheses));
   }
 
@@ -335,7 +335,7 @@ public class SqlPrettyWriter implements SqlWriter {
    * and a private print writer. */
   @Deprecated
   public SqlPrettyWriter(SqlDialect dialect) {
-    this(config().withDialect(requireNonNull(dialect)));
+    this(config().withDialect(requireNonNull(dialect, "dialect")));
   }
 
   /** Creates a writer with the given configuration,

--- a/core/src/main/java/org/apache/calcite/sql/type/AbstractSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/AbstractSqlType.java
@@ -53,7 +53,7 @@ public abstract class AbstractSqlType
       boolean isNullable,
       @Nullable List<? extends RelDataTypeField> fields) {
     super(fields);
-    this.typeName = Objects.requireNonNull(typeName);
+    this.typeName = Objects.requireNonNull(typeName, "typeName");
     this.isNullable = isNullable || (typeName == SqlTypeName.NULL);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/ArraySqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ArraySqlType.java
@@ -40,7 +40,7 @@ public class ArraySqlType extends AbstractSqlType {
    */
   public ArraySqlType(RelDataType elementType, boolean isNullable) {
     super(SqlTypeName.ARRAY, isNullable, null);
-    this.elementType = requireNonNull(elementType);
+    this.elementType = requireNonNull(elementType, "elementType");
     computeDigest();
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -107,7 +107,7 @@ public class BasicSqlType extends AbstractSqlType {
       @Nullable SqlCollation collation,
       @Nullable SerializableCharset wrappedCharset) {
     super(typeName, nullable, null);
-    this.typeSystem = Objects.requireNonNull(typeSystem);
+    this.typeSystem = Objects.requireNonNull(typeSystem, "typeSystem");
     this.precision = precision;
     this.scale = scale;
     this.collation = collation;

--- a/core/src/main/java/org/apache/calcite/sql/type/ComparableOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ComparableOperandTypeChecker.java
@@ -46,7 +46,7 @@ public class ComparableOperandTypeChecker extends SameOperandTypeChecker {
       RelDataTypeComparability requiredComparability, Consistency consistency) {
     super(nOperands);
     this.requiredComparability = requiredComparability;
-    this.consistency = Objects.requireNonNull(consistency);
+    this.consistency = Objects.requireNonNull(consistency, "consistency");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
@@ -104,8 +104,8 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
       ImmutableList<? extends SqlOperandTypeChecker> allowedRules,
       @Nullable String allowedSignatures,
       @Nullable SqlOperandCountRange range) {
-    this.allowedRules = requireNonNull(allowedRules);
-    this.composition = requireNonNull(composition);
+    this.allowedRules = requireNonNull(allowedRules, "allowedRules");
+    this.composition = requireNonNull(composition, "composition");
     this.allowedSignatures = allowedSignatures;
     this.range = range;
     assert (range != null) == (composition == Composition.REPEAT);

--- a/core/src/main/java/org/apache/calcite/sql/type/ExplicitOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ExplicitOperandTypeChecker.java
@@ -37,7 +37,7 @@ public class ExplicitOperandTypeChecker implements SqlOperandTypeChecker {
   private final RelDataType type;
 
   public ExplicitOperandTypeChecker(RelDataType type) {
-    this.type = Objects.requireNonNull(type);
+    this.type = Objects.requireNonNull(type, "type");
   }
 
   @Override public boolean isOptional(int i) {

--- a/core/src/main/java/org/apache/calcite/sql/type/IntervalSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/IntervalSqlType.java
@@ -49,8 +49,8 @@ public class IntervalSqlType extends AbstractSqlType {
       SqlIntervalQualifier intervalQualifier,
       boolean isNullable) {
     super(intervalQualifier.typeName(), isNullable, null);
-    this.typeSystem = Objects.requireNonNull(typeSystem);
-    this.intervalQualifier = Objects.requireNonNull(intervalQualifier);
+    this.typeSystem = Objects.requireNonNull(typeSystem, "typeSystem");
+    this.intervalQualifier = Objects.requireNonNull(intervalQualifier, "intervalQualifier");
     computeDigest();
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandMetadataImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandMetadataImpl.java
@@ -49,7 +49,7 @@ public class OperandMetadataImpl extends FamilyOperandTypeChecker
       Function<RelDataTypeFactory, List<RelDataType>> paramTypesFactory,
       IntFunction<String> paramNameFn, Predicate<Integer> optional) {
     super(families, optional);
-    this.paramTypesFactory = Objects.requireNonNull(paramTypesFactory);
+    this.paramTypesFactory = Objects.requireNonNull(paramTypesFactory, "paramTypesFactory");
     this.paramNameFn = paramNameFn;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeMappingRule.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeMappingRule.java
@@ -41,8 +41,8 @@ public interface SqlTypeMappingRule {
   /** Returns whether it is valid to apply the defined rules from type {@code from} to
    * type {@code to}. */
   default boolean canApplyFrom(SqlTypeName to, SqlTypeName from) {
-    Objects.requireNonNull(to);
-    Objects.requireNonNull(from);
+    Objects.requireNonNull(to, "to");
+    Objects.requireNonNull(from, "from");
 
     if (to == SqlTypeName.NULL) {
       return false;

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransformCascade.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransformCascade.java
@@ -47,7 +47,7 @@ public class SqlTypeTransformCascade implements SqlReturnTypeInference {
       SqlReturnTypeInference rule,
       SqlTypeTransform... transforms) {
     Preconditions.checkArgument(transforms.length > 0);
-    this.rule = Objects.requireNonNull(rule);
+    this.rule = Objects.requireNonNull(rule, "rule");
     this.transforms = ImmutableList.copyOf(transforms);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
@@ -50,7 +50,7 @@ public abstract class SqlTypeTransforms {
       (opBinding, typeToTransform) ->
           SqlTypeUtil.makeNullableIfOperandsAre(opBinding.getTypeFactory(),
               opBinding.collectOperandTypes(),
-              requireNonNull(typeToTransform));
+              requireNonNull(typeToTransform, "typeToTransform"));
 
   /**
    * Parameter type-inference transform strategy where a derived type is
@@ -70,7 +70,7 @@ public abstract class SqlTypeTransforms {
   public static final SqlTypeTransform TO_NOT_NULLABLE =
       (opBinding, typeToTransform) ->
           opBinding.getTypeFactory().createTypeWithNullability(
-              requireNonNull(typeToTransform), false);
+              requireNonNull(typeToTransform, "typeToTransform"), false);
 
   /**
    * Parameter type-inference transform strategy where a derived type is
@@ -79,7 +79,7 @@ public abstract class SqlTypeTransforms {
   public static final SqlTypeTransform FORCE_NULLABLE =
       (opBinding, typeToTransform) ->
           opBinding.getTypeFactory().createTypeWithNullability(
-              requireNonNull(typeToTransform), true);
+              requireNonNull(typeToTransform, "typeToTransform"), true);
 
   /**
    * Type-inference strategy whereby the result is NOT NULL if any of

--- a/core/src/main/java/org/apache/calcite/sql/util/IdPair.java
+++ b/core/src/main/java/org/apache/calcite/sql/util/IdPair.java
@@ -41,8 +41,8 @@ public class IdPair<L, R> {
   }
 
   protected IdPair(L left, R right) {
-    this.left = Objects.requireNonNull(left);
-    this.right = Objects.requireNonNull(right);
+    this.left = Objects.requireNonNull(left, "left");
+    this.right = Objects.requireNonNull(right, "right");
   }
 
   @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggVisitor.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggVisitor.java
@@ -64,8 +64,8 @@ abstract class AggVisitor extends SqlBasicVisitor<Void> {
     this.over = over;
     this.aggregate = aggregate;
     this.delegate = delegate;
-    this.opTab = Objects.requireNonNull(opTab);
-    this.nameMatcher = Objects.requireNonNull(nameMatcher);
+    this.opTab = Objects.requireNonNull(opTab, "opTab");
+    this.nameMatcher = Objects.requireNonNull(nameMatcher, "nameMatcher");
   }
 
   @Override public Void visit(SqlCall call) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -77,7 +77,7 @@ public class IdentifierNamespace extends AbstractNamespace {
     super(validator, enclosingNode);
     this.id = id;
     this.extendList = extendList;
-    this.parentScope = Objects.requireNonNull(parentScope);
+    this.parentScope = Objects.requireNonNull(parentScope, "parentScope");
   }
 
   IdentifierNamespace(SqlValidatorImpl validator, SqlNode node,

--- a/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
@@ -58,7 +58,7 @@ public abstract class ListScope extends DelegatingScope {
 
   @Override public void addChild(SqlValidatorNamespace ns, String alias,
       boolean nullable) {
-    Objects.requireNonNull(alias);
+    Objects.requireNonNull(alias, "alias");
     children.add(new ScopeChild(children.size(), alias, ns, nullable));
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SchemaNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SchemaNamespace.java
@@ -41,7 +41,7 @@ class SchemaNamespace extends AbstractNamespace {
   /** Creates a SchemaNamespace. */
   SchemaNamespace(SqlValidatorImpl validator, ImmutableList<String> names) {
     super(validator, null);
-    this.names = Objects.requireNonNull(names);
+    this.names = Objects.requireNonNull(names, "names");
   }
 
   @Override protected RelDataType validateImpl(RelDataType targetRowType) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlIdentifierMoniker.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlIdentifierMoniker.java
@@ -36,7 +36,7 @@ public class SqlIdentifierMoniker implements SqlMoniker {
    * Creates an SqlIdentifierMoniker.
    */
   public SqlIdentifierMoniker(SqlIdentifier id) {
-    this.id = Objects.requireNonNull(id);
+    this.id = Objects.requireNonNull(id, "id");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlMonikerImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlMonikerImpl.java
@@ -43,7 +43,7 @@ public class SqlMonikerImpl implements SqlMoniker {
    */
   public SqlMonikerImpl(List<String> names, SqlMonikerType type) {
     this.names = ImmutableList.copyOf(names);
-    this.type = Objects.requireNonNull(type);
+    this.type = Objects.requireNonNull(type, "type");
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -288,10 +288,10 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       SqlValidatorCatalogReader catalogReader,
       RelDataTypeFactory typeFactory,
       Config config) {
-    this.opTab = requireNonNull(opTab);
-    this.catalogReader = requireNonNull(catalogReader);
-    this.typeFactory = requireNonNull(typeFactory);
-    this.config = requireNonNull(config);
+    this.opTab = requireNonNull(opTab, "opTab");
+    this.catalogReader = requireNonNull(catalogReader, "catalogReader");
+    this.typeFactory = requireNonNull(typeFactory, "typeFactory");
+    this.config = requireNonNull(config, "config");
 
     unknownType = typeFactory.createUnknownType();
     booleanType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
@@ -1798,8 +1798,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
    * @param type Its type; must not be null
    */
   @Override public final void setValidatedNodeType(SqlNode node, RelDataType type) {
-    requireNonNull(type);
-    requireNonNull(node);
+    requireNonNull(type, "type");
+    requireNonNull(node, "node");
     if (type.equals(unknownType)) {
       // don't set anything until we know what it is, and don't overwrite
       // a known type with the unknown type
@@ -1834,8 +1834,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   @Override public RelDataType deriveType(
       SqlValidatorScope scope,
       SqlNode expr) {
-    requireNonNull(scope);
-    requireNonNull(expr);
+    requireNonNull(scope, "scope");
+    requireNonNull(expr, "expr");
 
     // if we already know the type, no need to re-derive
     RelDataType type = nodeToTypeMap.get(expr);
@@ -1955,9 +1955,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       RelDataType inferredType,
       SqlValidatorScope scope,
       SqlNode node) {
-    requireNonNull(inferredType);
-    requireNonNull(scope);
-    requireNonNull(node);
+    requireNonNull(inferredType, "inferredType");
+    requireNonNull(scope, "scope");
+    requireNonNull(node, "node");
     final SqlValidatorScope newScope = scopes.get(node);
     if (newScope != null) {
       scope = newScope;
@@ -2704,8 +2704,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       @Nullable String alias,
       boolean forceNullable,
       boolean checkUpdate) {
-    requireNonNull(node);
-    requireNonNull(enclosingNode);
+    requireNonNull(node, "node");
+    requireNonNull(enclosingNode, "enclosingNode");
     Preconditions.checkArgument(usingScope == null || alias != null);
 
     SqlCall call;
@@ -3352,7 +3352,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       SqlNode node,
       RelDataType targetRowType,
       SqlValidatorScope scope) {
-    requireNonNull(targetRowType);
+    requireNonNull(targetRowType, "targetRowType");
     switch (node.getKind()) {
     case AS:
     case TABLE_REF:
@@ -4151,7 +4151,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       }
     }
     final SqlValidatorScope orderScope = getOrderScope(select);
-    requireNonNull(orderScope);
+    requireNonNull(orderScope, "orderScope");
 
     List<SqlNode> expandList = new ArrayList<>();
     for (SqlNode orderItem : orderList) {
@@ -6123,7 +6123,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     InsertNamespace(SqlValidatorImpl validator, SqlInsert node,
         SqlNode enclosingNode, SqlValidatorScope parentScope) {
       super(validator, node.getTargetTable(), enclosingNode, parentScope);
-      this.node = requireNonNull(node);
+      this.node = requireNonNull(node, "node");
     }
 
     @Override public @Nullable SqlNode getNode() {
@@ -6140,7 +6140,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     UpdateNamespace(SqlValidatorImpl validator, SqlUpdate node,
         SqlNode enclosingNode, SqlValidatorScope parentScope) {
       super(validator, node.getTargetTable(), enclosingNode, parentScope);
-      this.node = requireNonNull(node);
+      this.node = requireNonNull(node, "node");
     }
 
     @Override public @Nullable SqlNode getNode() {
@@ -6157,7 +6157,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     DeleteNamespace(SqlValidatorImpl validator, SqlDelete node,
         SqlNode enclosingNode, SqlValidatorScope parentScope) {
       super(validator, node.getTargetTable(), enclosingNode, parentScope);
-      this.node = requireNonNull(node);
+      this.node = requireNonNull(node, "node");
     }
 
     @Override public @Nullable SqlNode getNode() {
@@ -6174,7 +6174,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     MergeNamespace(SqlValidatorImpl validator, SqlMerge node,
         SqlNode enclosingNode, SqlValidatorScope parentScope) {
       super(validator, node.getTargetTable(), enclosingNode, parentScope);
-      this.node = requireNonNull(node);
+      this.node = requireNonNull(node, "node");
     }
 
     @Override public @Nullable SqlNode getNode() {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorScope.java
@@ -269,11 +269,11 @@ public interface SqlValidatorScope {
 
     Step(Path parent, @Nullable RelDataType rowType, int i, String name,
         StructKind kind) {
-      this.parent = Objects.requireNonNull(parent);
+      this.parent = Objects.requireNonNull(parent, "parent");
       this.rowType = rowType; // may be null
       this.i = i;
       this.name = name;
-      this.kind = Objects.requireNonNull(kind);
+      this.kind = Objects.requireNonNull(kind, "kind");
     }
 
     @Override public int stepCount() {
@@ -330,11 +330,11 @@ public interface SqlValidatorScope {
 
     Resolve(SqlValidatorNamespace namespace, boolean nullable,
         @Nullable SqlValidatorScope scope, Path path, @Nullable List<String> remainingNames) {
-      this.namespace = Objects.requireNonNull(namespace);
+      this.namespace = Objects.requireNonNull(namespace, "namespace");
       this.nullable = nullable;
       this.scope = scope;
       assert !(scope instanceof TableScope);
-      this.path = Objects.requireNonNull(path);
+      this.path = Objects.requireNonNull(path, "path");
       this.remainingNames = remainingNames == null ? ImmutableList.of()
           : ImmutableList.copyOf(remainingNames);
     }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -280,7 +280,7 @@ public class SqlValidatorUtil {
   static void checkIdentifierListForDuplicates(List<? extends @Nullable SqlNode> columnList,
       SqlValidatorImpl.ValidationErrorFunction validationErrorFunction) {
     final List<List<String>> names = Util.transform(columnList,
-        o -> ((SqlIdentifier) requireNonNull(o, "sqlNode")).names);
+        sqlNode -> ((SqlIdentifier) requireNonNull(sqlNode, "sqlNode")).names);
     final int i = Util.firstDuplicate(names);
     if (i >= 0) {
       throw validationErrorFunction.apply(
@@ -1331,7 +1331,7 @@ public class SqlValidatorUtil {
     private final RelDataType rowType;
 
     ExplicitRowTypeTable(RelDataType rowType) {
-      this.rowType = requireNonNull(rowType);
+      this.rowType = requireNonNull(rowType, "rowType");
     }
 
     @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
@@ -1346,7 +1346,7 @@ public class SqlValidatorUtil {
     private final Map<String, Table> tableMap;
 
     ExplicitTableSchema(Map<String, Table> tableMap) {
-      this.tableMap = requireNonNull(tableMap);
+      this.tableMap = requireNonNull(tableMap, "tableMap");
     }
 
     @Override protected Map<String, Table> getTableMap() {

--- a/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
@@ -48,7 +48,7 @@ class TableNamespace extends AbstractNamespace {
   private TableNamespace(SqlValidatorImpl validator, SqlValidatorTable table,
       List<RelDataTypeField> fields) {
     super(validator, null);
-    this.table = Objects.requireNonNull(table);
+    this.table = Objects.requireNonNull(table, "table");
     this.extendedFields = ImmutableList.copyOf(fields);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableScope.java
@@ -42,8 +42,8 @@ class TableScope extends ListScope {
    * @param parent  Parent scope
    */
   TableScope(SqlValidatorScope parent, SqlNode node) {
-    super(Objects.requireNonNull(parent));
-    this.node = Objects.requireNonNull(node);
+    super(Objects.requireNonNull(parent, "parent"));
+    this.node = Objects.requireNonNull(node, "node");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
@@ -76,8 +76,8 @@ public abstract class AbstractTypeCoercion implements TypeCoercion {
   //~ Constructors -----------------------------------------------------------
 
   AbstractTypeCoercion(RelDataTypeFactory typeFactory, SqlValidator validator) {
-    this.factory = requireNonNull(typeFactory);
-    this.validator = requireNonNull(validator);
+    this.factory = requireNonNull(typeFactory, "typeFactory");
+    this.validator = requireNonNull(validator, "validator");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -1616,9 +1616,9 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
     private DecorrelateRexShuttle(RelNode currentRel,
         Map<RelNode, Frame> map, CorelMap cm) {
-      this.currentRel = requireNonNull(currentRel);
-      this.map = requireNonNull(map);
-      this.cm = requireNonNull(cm);
+      this.currentRel = requireNonNull(currentRel, "currentRel");
+      this.map = requireNonNull(map, "map");
+      this.cm = requireNonNull(cm, "cm");
     }
 
     @Override public RexNode visitFieldAccess(RexFieldAccess fieldAccess) {
@@ -2968,7 +2968,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
     Frame(RelNode oldRel, RelNode r, NavigableMap<CorDef, Integer> corDefOutputs,
         Map<Integer, Integer> oldToNewOutputs) {
-      this.r = requireNonNull(r);
+      this.r = requireNonNull(r, "r");
       this.corDefOutputs = ImmutableSortedMap.copyOf(corDefOutputs);
       this.oldToNewOutputs = ImmutableSortedMap.copyOf(oldToNewOutputs);
       assert allLessThan(this.corDefOutputs.values(),

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -336,13 +336,13 @@ public class SqlToRelConverter {
     this.typeFactory = rexBuilder.getTypeFactory();
     this.exprConverter = new SqlNodeToRexConverterImpl(convertletTable);
     this.explainParamCount = 0;
-    this.config = requireNonNull(config);
+    this.config = requireNonNull(config, "config");
     this.relBuilder = config.getRelBuilderFactory().create(cluster, null)
         .transform(config.getRelBuilderConfigTransform());
     this.hintStrategies = config.getHintStrategyTable();
 
     cluster.setHintStrategies(this.hintStrategies);
-    this.cluster = requireNonNull(cluster);
+    this.cluster = requireNonNull(cluster, "cluster");
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -5088,7 +5088,7 @@ public class SqlToRelConverter {
 
       // Apply standard conversions.
       rex = expr.accept(this);
-      return requireNonNull(rex);
+      return requireNonNull(rex, "rex");
     }
 
     /**

--- a/core/src/main/java/org/apache/calcite/statistic/QuerySqlStatisticProvider.java
+++ b/core/src/main/java/org/apache/calcite/statistic/QuerySqlStatisticProvider.java
@@ -77,7 +77,7 @@ public class QuerySqlStatisticProvider implements SqlStatisticProvider {
    * @param sqlConsumer Called when each SQL statement is generated
    */
   public QuerySqlStatisticProvider(Consumer<String> sqlConsumer) {
-    this.sqlConsumer = requireNonNull(sqlConsumer);
+    this.sqlConsumer = requireNonNull(sqlConsumer, "sqlConsumer");
   }
 
   @Override public double tableCardinality(RelOptTable table) {

--- a/core/src/main/java/org/apache/calcite/tools/Frameworks.java
+++ b/core/src/main/java/org/apache/calcite/tools/Frameworks.java
@@ -271,23 +271,23 @@ public class Frameworks {
     }
 
     public ConfigBuilder context(Context c) {
-      this.context = Objects.requireNonNull(c);
+      this.context = Objects.requireNonNull(c, "c");
       return this;
     }
 
     public ConfigBuilder executor(RexExecutor executor) {
-      this.executor = Objects.requireNonNull(executor);
+      this.executor = Objects.requireNonNull(executor, "executor");
       return this;
     }
 
     public ConfigBuilder convertletTable(
         SqlRexConvertletTable convertletTable) {
-      this.convertletTable = Objects.requireNonNull(convertletTable);
+      this.convertletTable = Objects.requireNonNull(convertletTable, "convertletTable");
       return this;
     }
 
     public ConfigBuilder operatorTable(SqlOperatorTable operatorTable) {
-      this.operatorTable = Objects.requireNonNull(operatorTable);
+      this.operatorTable = Objects.requireNonNull(operatorTable, "operatorTable");
       return this;
     }
 
@@ -306,19 +306,19 @@ public class Frameworks {
     }
 
     public ConfigBuilder parserConfig(SqlParser.Config parserConfig) {
-      this.parserConfig = Objects.requireNonNull(parserConfig);
+      this.parserConfig = Objects.requireNonNull(parserConfig, "parserConfig");
       return this;
     }
 
     public ConfigBuilder sqlValidatorConfig(SqlValidator.Config sqlValidatorConfig) {
-      this.sqlValidatorConfig = Objects.requireNonNull(sqlValidatorConfig);
+      this.sqlValidatorConfig = Objects.requireNonNull(sqlValidatorConfig, "sqlValidatorConfig");
       return this;
     }
 
     public ConfigBuilder sqlToRelConverterConfig(
         SqlToRelConverter.Config sqlToRelConverterConfig) {
       this.sqlToRelConverterConfig =
-          Objects.requireNonNull(sqlToRelConverterConfig);
+          Objects.requireNonNull(sqlToRelConverterConfig, "sqlToRelConverterConfig");
       return this;
     }
 
@@ -337,7 +337,7 @@ public class Frameworks {
     }
 
     public ConfigBuilder ruleSets(List<RuleSet> ruleSets) {
-      return programs(Programs.listOf(Objects.requireNonNull(ruleSets)));
+      return programs(Programs.listOf(Objects.requireNonNull(ruleSets, "ruleSets")));
     }
 
     public ConfigBuilder programs(List<Program> programs) {
@@ -351,7 +351,7 @@ public class Frameworks {
     }
 
     public ConfigBuilder typeSystem(RelDataTypeSystem typeSystem) {
-      this.typeSystem = Objects.requireNonNull(typeSystem);
+      this.typeSystem = Objects.requireNonNull(typeSystem, "typeSystem");
       return this;
     }
 
@@ -362,7 +362,7 @@ public class Frameworks {
 
     public ConfigBuilder statisticProvider(
         SqlStatisticProvider statisticProvider) {
-      this.statisticProvider = Objects.requireNonNull(statisticProvider);
+      this.statisticProvider = Objects.requireNonNull(statisticProvider, "statisticProvider");
       return this;
     }
 

--- a/core/src/main/java/org/apache/calcite/tools/Hoist.java
+++ b/core/src/main/java/org/apache/calcite/tools/Hoist.java
@@ -77,7 +77,7 @@ public class Hoist {
   }
 
   private Hoist(Config config) {
-    this.config = Objects.requireNonNull(config);
+    this.config = Objects.requireNonNull(config, "config");
   }
 
   /** Converts a {@link Variable} to a string "?N",
@@ -141,9 +141,9 @@ public class Hoist {
     public final int end;
 
     private Variable(String originalSql, int ordinal, SqlNode node) {
-      this.originalSql = Objects.requireNonNull(originalSql);
+      this.originalSql = Objects.requireNonNull(originalSql, "originalSql");
       this.ordinal = ordinal;
-      this.node = Objects.requireNonNull(node);
+      this.node = Objects.requireNonNull(node, "node");
       final SqlParserPos pos = node.getParserPosition();
       start = SqlParserUtil.lineColToIndex(originalSql,
           pos.getLineNum(), pos.getColumnNum());

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -521,8 +521,8 @@ public class RelBuilder {
    * given alias. Searches for the relation starting at the top of the
    * stack. */
   public RexNode field(int inputCount, String alias, String fieldName) {
-    requireNonNull(alias);
-    requireNonNull(fieldName);
+    requireNonNull(alias, "alias");
+    requireNonNull(fieldName, "fieldName");
     final List<String> fields = new ArrayList<>();
     for (int inputOrdinal = 0; inputOrdinal < inputCount; ++inputOrdinal) {
       final Frame frame = peek_(inputOrdinal);
@@ -892,7 +892,7 @@ public class RelBuilder {
     if (groupSet.length() > peek().getRowType().getFieldCount()) {
       throw new IllegalArgumentException("out of bounds: " + groupSet);
     }
-    requireNonNull(groupSets);
+    requireNonNull(groupSets, "groupSets");
     final ImmutableList<RexNode> nodes = fields(groupSet);
     return groupKey_(nodes, Util.transform(groupSets, this::fields));
   }
@@ -1685,7 +1685,7 @@ public class RelBuilder {
             cluster.traitSetOf(Convention.NONE),
             frame.rel,
             withOrdinality,
-            requireNonNull(itemAliases))));
+            requireNonNull(itemAliases, "itemAliases"))));
     return this;
   }
 
@@ -3177,7 +3177,7 @@ public class RelBuilder {
    * {@link org.apache.calcite.rel.hint.Hintable}
    */
   public RelBuilder hints(Iterable<RelHint> hints) {
-    requireNonNull(hints);
+    requireNonNull(hints, "hints");
     final List<RelHint> relHintList = hints instanceof List ? (List<RelHint>) hints
         : Lists.newArrayList(hints);
     if (relHintList.isEmpty()) {
@@ -3276,7 +3276,7 @@ public class RelBuilder {
     GroupKeyImpl(ImmutableList<RexNode> nodes,
         @Nullable ImmutableList<ImmutableList<RexNode>> nodeLists,
         @Nullable String alias) {
-      this.nodes = requireNonNull(nodes);
+      this.nodes = requireNonNull(nodes, "nodes");
       this.nodeLists = nodeLists;
       this.alias = alias;
     }
@@ -3315,7 +3315,7 @@ public class RelBuilder {
         boolean approximate, boolean ignoreNulls, @Nullable RexNode filter,
         @Nullable String alias, ImmutableList<RexNode> operands,
         ImmutableList<RexNode> orderKeys) {
-      this.aggFunction = requireNonNull(aggFunction);
+      this.aggFunction = requireNonNull(aggFunction, "aggFunction");
       // If the aggregate function ignores DISTINCT,
       // make the DISTINCT flag FALSE.
       this.distinct = distinct
@@ -3323,8 +3323,8 @@ public class RelBuilder {
       this.approximate = approximate;
       this.ignoreNulls = ignoreNulls;
       this.alias = alias;
-      this.operands = requireNonNull(operands);
-      this.orderKeys = requireNonNull(orderKeys);
+      this.operands = requireNonNull(operands, "operands");
+      this.orderKeys = requireNonNull(orderKeys, "orderKeys");
       if (filter != null) {
         if (filter.getType().getSqlTypeName() != SqlTypeName.BOOLEAN) {
           throw RESOURCE.filterMustBeBoolean().ex();
@@ -3464,7 +3464,7 @@ public class RelBuilder {
     private final AggregateCall aggregateCall;
 
     AggCallImpl2(AggregateCall aggregateCall) {
-      this.aggregateCall = requireNonNull(aggregateCall);
+      this.aggregateCall = requireNonNull(aggregateCall, "aggregateCall");
     }
 
     @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/util/BitString.java
+++ b/core/src/main/java/org/apache/calcite/util/BitString.java
@@ -208,7 +208,7 @@ public class BitString {
    * @return BitString
    */
   public static BitString createFromBytes(byte[] bytes) {
-    int bitCount = Objects.requireNonNull(bytes).length * 8;
+    int bitCount = Objects.requireNonNull(bytes, "bytes").length * 8;
     StringBuilder sb = new StringBuilder(bitCount);
     for (byte b : bytes) {
       final String s = Integer.toBinaryString(Byte.toUnsignedInt(b));

--- a/core/src/main/java/org/apache/calcite/util/CancelFlag.java
+++ b/core/src/main/java/org/apache/calcite/util/CancelFlag.java
@@ -35,7 +35,7 @@ public class CancelFlag {
   public final AtomicBoolean atomicBoolean;
 
   public CancelFlag(AtomicBoolean atomicBoolean) {
-    this.atomicBoolean = Objects.requireNonNull(atomicBoolean);
+    this.atomicBoolean = Objects.requireNonNull(atomicBoolean, "atomicBoolean");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/util/EquivalenceSet.java
+++ b/core/src/main/java/org/apache/calcite/util/EquivalenceSet.java
@@ -56,7 +56,7 @@ public class EquivalenceSet<E extends Comparable<E>> {
   /** Adds an element, and returns the element (which is its own parent).
    * If already present, returns the element's parent. */
   public E add(E e) {
-    final E parent = parents.get(Objects.requireNonNull(e));
+    final E parent = parents.get(Objects.requireNonNull(e, "e"));
     if (parent == null) {
       // Element is new. Add it to the map, as its own parent.
       parents.put(e, e);

--- a/core/src/main/java/org/apache/calcite/util/ImmutableBeans.java
+++ b/core/src/main/java/org/apache/calcite/util/ImmutableBeans.java
@@ -468,8 +468,8 @@ public class ImmutableBeans {
     private final ImmutableMap<String, Object> map;
 
     BeanImpl(Def<T> def, ImmutableMap<String, Object> map) {
-      this.def = Objects.requireNonNull(def);
-      this.map = Objects.requireNonNull(map);
+      this.def = Objects.requireNonNull(def, "def");
+      this.map = Objects.requireNonNull(map, "map");
     }
 
     @Override public @Nullable Object invoke(Object proxy, Method method, @Nullable Object[] args) {
@@ -502,8 +502,8 @@ public class ImmutableBeans {
     private final ImmutableMap<Method, Handler<T>> handlers;
 
     Def(Class<T> beanClass, ImmutableMap<Method, Handler<T>> handlers) {
-      this.beanClass = Objects.requireNonNull(beanClass);
-      this.handlers = Objects.requireNonNull(handlers);
+      this.beanClass = Objects.requireNonNull(beanClass, "beanClass");
+      this.handlers = Objects.requireNonNull(handlers, "handlers");
     }
 
     private T makeBean(ImmutableMap<String, Object> map) {

--- a/core/src/main/java/org/apache/calcite/util/ImmutableNullableSet.java
+++ b/core/src/main/java/org/apache/calcite/util/ImmutableNullableSet.java
@@ -57,7 +57,7 @@ public class ImmutableNullableSet<E> extends AbstractSet<E> {
   private final ImmutableSet<Object> elements;
 
   private ImmutableNullableSet(ImmutableSet<Object> elements) {
-    this.elements = Objects.requireNonNull(elements);
+    this.elements = Objects.requireNonNull(elements, "elements");
   }
 
   @Override public Iterator<E> iterator() {

--- a/core/src/main/java/org/apache/calcite/util/NlsString.java
+++ b/core/src/main/java/org/apache/calcite/util/NlsString.java
@@ -94,8 +94,8 @@ public class NlsString implements Comparable<NlsString>, Cloneable {
    */
   public NlsString(ByteString bytesValue, String charsetName,
       @Nullable SqlCollation collation) {
-    this(null, Objects.requireNonNull(bytesValue),
-        Objects.requireNonNull(charsetName), collation);
+    this(null, Objects.requireNonNull(bytesValue, "bytesValue"),
+        Objects.requireNonNull(charsetName, "charsetName"), collation);
   }
 
   /**
@@ -113,7 +113,7 @@ public class NlsString implements Comparable<NlsString>, Cloneable {
    */
   public NlsString(String stringValue, @Nullable String charsetName,
       @Nullable SqlCollation collation) {
-    this(Objects.requireNonNull(stringValue), null, charsetName, collation);
+    this(Objects.requireNonNull(stringValue, "stringValue"), null, charsetName, collation);
   }
 
   /** Internal constructor; other constructors must call it. */

--- a/core/src/main/java/org/apache/calcite/util/Pair.java
+++ b/core/src/main/java/org/apache/calcite/util/Pair.java
@@ -382,7 +382,7 @@ public class Pair<T1 extends @Nullable Object, T2 extends @Nullable Object>
     private final E first;
 
     FirstAndIterator(Iterator<? extends E> iterator, E first) {
-      this.iterator = Objects.requireNonNull(iterator);
+      this.iterator = Objects.requireNonNull(iterator, "iterator");
       this.first = first;
     }
 
@@ -409,8 +409,8 @@ public class Pair<T1 extends @Nullable Object, T2 extends @Nullable Object>
 
     ZipIterator(Iterator<? extends L> leftIterator,
         Iterator<? extends R> rightIterator) {
-      this.leftIterator = Objects.requireNonNull(leftIterator);
-      this.rightIterator = Objects.requireNonNull(rightIterator);
+      this.leftIterator = Objects.requireNonNull(leftIterator, "leftIterator");
+      this.rightIterator = Objects.requireNonNull(rightIterator, "rightIterator");
     }
 
     @Override public boolean hasNext() {
@@ -437,7 +437,7 @@ public class Pair<T1 extends @Nullable Object, T2 extends @Nullable Object>
     E previous;
 
     AdjacentIterator(Iterator<? extends E> iterator) {
-      this.iterator = Objects.requireNonNull(iterator);
+      this.iterator = Objects.requireNonNull(iterator, "iterator");
       this.first = iterator.next();
       previous = first;
     }
@@ -500,8 +500,8 @@ public class Pair<T1 extends @Nullable Object, T2 extends @Nullable Object>
     private final List<V> vs;
 
     MutableZipList(List<K> ks, List<V> vs) {
-      this.ks = Objects.requireNonNull(ks);
-      this.vs = Objects.requireNonNull(vs);
+      this.ks = Objects.requireNonNull(ks, "ks");
+      this.vs = Objects.requireNonNull(vs, "vs");
     }
 
     @Override public Pair<K, V> get(int index) {

--- a/core/src/main/java/org/apache/calcite/util/PrecedenceClimbingParser.java
+++ b/core/src/main/java/org/apache/calcite/util/PrecedenceClimbingParser.java
@@ -119,7 +119,7 @@ public class PrecedenceClimbingParser {
       }
       case SPECIAL: {
         Result r = ((SpecialOp) op).special.apply(this, (SpecialOp) op);
-        requireNonNull(r);
+        requireNonNull(r, "r");
         replace(r.replacement, r.first.previous, r.last.next);
         break;
       }

--- a/core/src/main/java/org/apache/calcite/util/Sarg.java
+++ b/core/src/main/java/org/apache/calcite/util/Sarg.java
@@ -70,7 +70,7 @@ public class Sarg<C extends Comparable<C>> implements Comparable<Sarg<C>> {
   public final int pointCount;
 
   private Sarg(ImmutableRangeSet<C> rangeSet, boolean containsNull) {
-    this.rangeSet = Objects.requireNonNull(rangeSet);
+    this.rangeSet = Objects.requireNonNull(rangeSet, "rangeSet");
     this.containsNull = containsNull;
     this.pointCount = RangeSets.countPoints(rangeSet);
   }

--- a/core/src/main/java/org/apache/calcite/util/SourceStringReader.java
+++ b/core/src/main/java/org/apache/calcite/util/SourceStringReader.java
@@ -32,7 +32,7 @@ public class SourceStringReader extends StringReader {
    * @param s String providing the character stream
    */
   public SourceStringReader(String s) {
-    super(Objects.requireNonNull(s));
+    super(Objects.requireNonNull(s, "s"));
     this.s = s;
   }
 

--- a/core/src/main/java/org/apache/calcite/util/Sources.java
+++ b/core/src/main/java/org/apache/calcite/util/Sources.java
@@ -167,13 +167,13 @@ public abstract class Sources {
     private final boolean urlGenerated;
 
     private FileSource(URL url) {
-      this.url = Objects.requireNonNull(url);
+      this.url = Objects.requireNonNull(url, "url");
       this.file = urlToFile(url);
       this.urlGenerated = false;
     }
 
     private FileSource(File file) {
-      this.file = Objects.requireNonNull(file);
+      this.file = Objects.requireNonNull(file, "file");
       this.url = fileToUrl(file);
       this.urlGenerated = true;
     }

--- a/core/src/main/java/org/apache/calcite/util/UnmodifiableArrayList.java
+++ b/core/src/main/java/org/apache/calcite/util/UnmodifiableArrayList.java
@@ -39,7 +39,7 @@ public class UnmodifiableArrayList<E>
   private final E[] elements;
 
   private UnmodifiableArrayList(E[] elements) {
-    this.elements = Objects.requireNonNull(elements);
+    this.elements = Objects.requireNonNull(elements, "elements");
   }
 
   public static <E> UnmodifiableArrayList<E> of(E... elements) {

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -914,7 +914,7 @@ public class Util {
    * but we don't require Guava version 20 yet. */
   public static void throwIfUnchecked(Throwable throwable) {
     Bug.upgrade("Remove when minimum Guava version is 20");
-    Objects.requireNonNull(throwable);
+    Objects.requireNonNull(throwable, "throwable");
     if (throwable instanceof RuntimeException) {
       throw (RuntimeException) throwable;
     }

--- a/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
+++ b/core/src/main/java/org/apache/calcite/util/graph/DefaultEdge.java
@@ -28,8 +28,8 @@ public class DefaultEdge {
   public final Object target;
 
   public DefaultEdge(Object source, Object target) {
-    this.source = Objects.requireNonNull(source);
-    this.target = Objects.requireNonNull(target);
+    this.source = Objects.requireNonNull(source, "source");
+    this.target = Objects.requireNonNull(target, "target");
   }
 
   @Override public int hashCode() {

--- a/core/src/test/java/org/apache/calcite/profile/ProfilerTest.java
+++ b/core/src/test/java/org/apache/calcite/profile/ProfilerTest.java
@@ -468,10 +468,10 @@ class ProfilerTest {
         Predicate<Profiler.Statistic> predicate,
         Comparator<Profiler.Statistic> comparator, int limit,
         List<String> columns) {
-      this.sql = Objects.requireNonNull(sql);
-      this.factory = Objects.requireNonNull(factory);
+      this.sql = Objects.requireNonNull(sql, "sql");
+      this.factory = Objects.requireNonNull(factory, "factory");
       this.columns = ImmutableList.copyOf(columns);
-      this.predicate = Objects.requireNonNull(predicate);
+      this.predicate = Objects.requireNonNull(predicate, "predicate");
       this.comparator = comparator; // null means sort on JSON representation
       this.limit = limit;
       this.config = config;

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
@@ -197,8 +197,8 @@ class RexProgramTestBase extends RexProgramBuilderBase {
     final RexNode node;
 
     Node(RexBuilder rexBuilder, RexNode node) {
-      this.rexBuilder = Objects.requireNonNull(rexBuilder);
-      this.node = Objects.requireNonNull(node);
+      this.rexBuilder = Objects.requireNonNull(rexBuilder, "rexBuilder");
+      this.node = Objects.requireNonNull(node, "node");
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -9926,10 +9926,10 @@ public class SqlParserTest {
 
     Sql(StringAndPos sap, boolean expression, SqlDialect dialect,
         Consumer<SqlParser> parserChecker) {
-      this.sap = Objects.requireNonNull(sap);
+      this.sap = Objects.requireNonNull(sap, "sap");
       this.expression = expression;
       this.dialect = dialect;
-      this.parserChecker = Objects.requireNonNull(parserChecker);
+      this.parserChecker = Objects.requireNonNull(parserChecker, "parserChecker");
     }
 
     public Sql same() {

--- a/core/src/test/java/org/apache/calcite/sql/parser/parserextensiontesting/SqlCreateTable.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/parserextensiontesting/SqlCreateTable.java
@@ -49,7 +49,7 @@ public class SqlCreateTable extends SqlCreate {
   public SqlCreateTable(SqlParserPos pos, SqlIdentifier name,
       SqlNodeList columnList, SqlNode query) {
     super(OPERATOR, pos, false, false);
-    this.name = Objects.requireNonNull(name);
+    this.name = Objects.requireNonNull(name, "name");
     this.columnList = columnList; // may be null
     this.query = query; // for "CREATE TABLE ... AS query"; may be null
   }

--- a/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/AbstractSqlTester.java
@@ -87,8 +87,8 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
 
   public AbstractSqlTester(SqlTestFactory factory,
       UnaryOperator<SqlValidator> validatorTransform) {
-    this.factory = Objects.requireNonNull(factory);
-    this.validatorTransform = Objects.requireNonNull(validatorTransform);
+    this.factory = Objects.requireNonNull(factory, "factory");
+    this.validatorTransform = Objects.requireNonNull(validatorTransform, "validatorTransform");
   }
 
   public final SqlTestFactory getFactory() {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
@@ -73,15 +73,15 @@ class SqlPrettyWriterTest {
 
     Sql(String sql, boolean expr, String desc, String formatted,
         UnaryOperator<SqlWriterConfig> transform) {
-      this.sql = Objects.requireNonNull(sql);
+      this.sql = Objects.requireNonNull(sql, "sql");
       this.expr = expr;
       this.desc = desc;
-      this.formatted = Objects.requireNonNull(formatted);
-      this.transform = Objects.requireNonNull(transform);
+      this.formatted = Objects.requireNonNull(formatted, "formatted");
+      this.transform = Objects.requireNonNull(transform, "transform");
     }
 
     Sql withWriter(UnaryOperator<SqlWriterConfig> transform) {
-      Objects.requireNonNull(transform);
+      Objects.requireNonNull(transform, "transform");
       return new Sql(sql, expr, desc, formatted, w ->
           transform.apply(this.transform.apply(w)));
     }

--- a/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
@@ -1034,7 +1034,7 @@ public class CalciteAssert {
         new AssertThat(EMPTY_CONNECTION_FACTORY);
 
     private AssertThat(ConnectionFactory connectionFactory) {
-      this.connectionFactory = Objects.requireNonNull(connectionFactory);
+      this.connectionFactory = Objects.requireNonNull(connectionFactory, "connectionFactory");
     }
 
     public AssertThat with(Config config) {
@@ -1311,8 +1311,8 @@ public class CalciteAssert {
     private final Schema schema;
 
     public AddSchemaPostProcessor(String name, Schema schema) {
-      this.name = Objects.requireNonNull(name);
-      this.schema = Objects.requireNonNull(schema);
+      this.name = Objects.requireNonNull(name, "name");
+      this.schema = Objects.requireNonNull(schema, "schema");
     }
 
     public Connection apply(Connection connection) throws SQLException {
@@ -1392,8 +1392,8 @@ public class CalciteAssert {
 
     private MapConnectionFactory(ImmutableMap<String, String> map,
         ImmutableList<ConnectionPostProcessor> postProcessors) {
-      this.map = Objects.requireNonNull(map);
-      this.postProcessors = Objects.requireNonNull(postProcessors);
+      this.map = Objects.requireNonNull(map, "map");
+      this.postProcessors = Objects.requireNonNull(postProcessors, "postProcessors");
     }
 
     @Override public boolean equals(Object obj) {
@@ -2164,7 +2164,7 @@ public class CalciteAssert {
     private final String sql;
 
     JavaSql(String java, String sql) {
-      this.java = Objects.requireNonNull(java);
+      this.java = Objects.requireNonNull(java, "java");
       this.sql = sql;
     }
 

--- a/core/src/test/java/org/apache/calcite/test/DiffRepository.java
+++ b/core/src/test/java/org/apache/calcite/test/DiffRepository.java
@@ -794,7 +794,7 @@ public class DiffRepository {
     private final Filter filter;
 
     Key(Class<?> clazz, DiffRepository baseRepository, Filter filter) {
-      this.clazz = Objects.requireNonNull(clazz);
+      this.clazz = Objects.requireNonNull(clazz, "clazz");
       this.baseRepository = baseRepository;
       this.filter = filter;
     }

--- a/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
@@ -160,15 +160,15 @@ abstract class RelOptTestBase extends SqlToRelTestBase {
     Sql(Tester tester, String sql, HepProgram preProgram, RelOptPlanner planner,
         ImmutableMap<Hook, Consumer> hooks,
         ImmutableList<Function<Tester, Tester>> transforms) {
-      this.tester = Objects.requireNonNull(tester);
-      this.sql = Objects.requireNonNull(sql);
+      this.tester = Objects.requireNonNull(tester, "tester");
+      this.sql = Objects.requireNonNull(sql, "sql");
       if (sql.contains(" \n")) {
         throw new AssertionError("trailing whitespace");
       }
       this.preProgram = preProgram;
       this.planner = planner;
-      this.hooks = Objects.requireNonNull(hooks);
-      this.transforms = Objects.requireNonNull(transforms);
+      this.hooks = Objects.requireNonNull(hooks, "hooks");
+      this.transforms = Objects.requireNonNull(transforms, "transforms");
     }
 
     public Sql withTester(UnaryOperator<Tester> transform) {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4201,15 +4201,15 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     Sql(String sql, boolean decorrelate, Tester tester, boolean trim,
         UnaryOperator<SqlToRelConverter.Config> config,
         SqlConformance conformance) {
-      this.sql = Objects.requireNonNull(sql);
+      this.sql = Objects.requireNonNull(sql, "sql");
       if (sql.contains(" \n")) {
         throw new AssertionError("trailing whitespace");
       }
       this.decorrelate = decorrelate;
-      this.tester = Objects.requireNonNull(tester);
+      this.tester = Objects.requireNonNull(tester, "tester");
       this.trim = trim;
-      this.config = Objects.requireNonNull(config);
-      this.conformance = Objects.requireNonNull(conformance);
+      this.config = Objects.requireNonNull(config, "config");
+      this.conformance = Objects.requireNonNull(conformance, "conformance");
     }
 
     public void ok() {
@@ -4226,7 +4226,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
 
     public Sql withConfig(UnaryOperator<SqlToRelConverter.Config> config) {
       final UnaryOperator<SqlToRelConverter.Config> config2 =
-          this.config.andThen(Objects.requireNonNull(config))::apply;
+          this.config.andThen(Objects.requireNonNull(config, "config"))::apply;
       return new Sql(sql, decorrelate, tester, trim, config2, conformance);
     }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
@@ -574,14 +574,14 @@ public abstract class SqlToRelTestBase {
       this.enableTypeCoercion = enableTypeCoercion;
       this.catalogReaderFactory = catalogReaderFactory;
       this.clusterFactory = clusterFactory;
-      this.configTransform = Objects.requireNonNull(configTransform);
-      this.plannerFactory = Objects.requireNonNull(plannerFactory);
-      this.conformance = Objects.requireNonNull(conformance);
-      this.contextTransform = Objects.requireNonNull(contextTransform);
+      this.configTransform = Objects.requireNonNull(configTransform, "configTransform");
+      this.plannerFactory = Objects.requireNonNull(plannerFactory, "plannerFactory");
+      this.conformance = Objects.requireNonNull(conformance, "conformance");
+      this.contextTransform = Objects.requireNonNull(contextTransform, "contextTransform");
     }
 
     public RelRoot convertSqlToRel(String sql) {
-      Objects.requireNonNull(sql);
+      Objects.requireNonNull(sql, "sql");
       final SqlNode sqlQuery;
       try {
         sqlQuery = parseQuery(sql);

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTestCase.java
@@ -324,7 +324,7 @@ public class SqlValidatorTestCase {
      * Checks that a SQL expression gives a particular error.
      */
     Sql fails(String expected) {
-      Objects.requireNonNull(expected);
+      Objects.requireNonNull(expected, "expected");
       tester.assertExceptionIsThrown(toSql(true), expected);
       return this;
     }

--- a/core/src/test/java/org/apache/calcite/util/PartiallyOrderedSetTest.java
+++ b/core/src/test/java/org/apache/calcite/util/PartiallyOrderedSetTest.java
@@ -222,7 +222,7 @@ class PartiallyOrderedSetTest {
     final PartiallyOrderedSet<Integer> poset =
         new PartiallyOrderedSet<>(PartiallyOrderedSetTest::isBitSuperset,
             (Function<Integer, Iterable<Integer>>) i -> {
-              int r = Objects.requireNonNull(i); // bits not yet cleared
+              int r = Objects.requireNonNull(i, "i"); // bits not yet cleared
               final List<Integer> list = new ArrayList<>();
               for (int z = 1; r != 0; z <<= 1) {
                 if ((i & z) != 0) {
@@ -233,7 +233,7 @@ class PartiallyOrderedSetTest {
               return list;
             },
             i -> {
-              Objects.requireNonNull(i);
+              Objects.requireNonNull(i, "i");
               final List<Integer> list = new ArrayList<>();
               for (int z = 1; z <= n; z <<= 1) {
                 if ((i & z) == 0) {

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DefaultDimensionSpec.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DefaultDimensionSpec.java
@@ -34,8 +34,8 @@ public class DefaultDimensionSpec implements DimensionSpec {
   private final DruidType outputType;
 
   public DefaultDimensionSpec(String dimension, String outputName, DruidType outputType) {
-    this.dimension = Objects.requireNonNull(dimension);
-    this.outputName = Objects.requireNonNull(outputName);
+    this.dimension = Objects.requireNonNull(dimension, "dimension");
+    this.outputName = Objects.requireNonNull(outputName, "outputName");
     this.outputType = outputType == null ? DruidType.STRING : outputType;
   }
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidConnectionImpl.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidConnectionImpl.java
@@ -81,8 +81,8 @@ class DruidConnectionImpl implements DruidConnection {
   }
 
   DruidConnectionImpl(String url, String coordinatorUrl) {
-    this.url = Objects.requireNonNull(url);
-    this.coordinatorUrl = Objects.requireNonNull(coordinatorUrl);
+    this.url = Objects.requireNonNull(url, "url");
+    this.coordinatorUrl = Objects.requireNonNull(coordinatorUrl, "coordinatorUrl");
   }
 
   /** Executes a query request.

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidJsonFilter.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidJsonFilter.java
@@ -460,7 +460,7 @@ abstract class DruidJsonFilter implements DruidJson {
 
     JsonExpressionFilter(String expression) {
       super(Type.EXPRESSION);
-      this.expression = Objects.requireNonNull(expression);
+      this.expression = Objects.requireNonNull(expression, "expression");
     }
 
     @Override public void write(JsonGenerator generator) throws IOException {
@@ -627,7 +627,7 @@ abstract class DruidJsonFilter implements DruidJson {
 
   public static DruidJsonFilter getSelectorFilter(String column, String value,
       ExtractionFunction extractionFunction) {
-    Objects.requireNonNull(column);
+    Objects.requireNonNull(column, "column");
     return new JsonSelector(column, value, extractionFunction);
   }
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -1544,8 +1544,8 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
 
     QuerySpec(QueryType queryType, String queryString,
         List<String> fieldNames) {
-      this.queryType = Objects.requireNonNull(queryType);
-      this.queryString = Objects.requireNonNull(queryString);
+      this.queryType = Objects.requireNonNull(queryType, "queryType");
+      this.queryString = Objects.requireNonNull(queryString, "queryString");
       this.fieldNames = ImmutableList.copyOf(fieldNames);
     }
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidSchema.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidSchema.java
@@ -54,8 +54,8 @@ public class DruidSchema extends AbstractSchema {
    */
   public DruidSchema(String url, String coordinatorUrl,
       boolean discoverTables) {
-    this.url = Objects.requireNonNull(url);
-    this.coordinatorUrl = Objects.requireNonNull(coordinatorUrl);
+    this.url = Objects.requireNonNull(url, "url");
+    this.coordinatorUrl = Objects.requireNonNull(coordinatorUrl, "coordinatorUrl");
     this.discoverTables = discoverTables;
   }
 

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTable.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTable.java
@@ -86,9 +86,9 @@ public class DruidTable extends AbstractTable implements TranslatableTable {
       RelProtoDataType protoRowType, Set<String> metricFieldNames,
       String timestampFieldName, List<Interval> intervals,
       Map<String, List<ComplexMetric>> complexMetrics, Map<String, SqlTypeName> allFields) {
-    this.timestampFieldName = Objects.requireNonNull(timestampFieldName);
-    this.schema = Objects.requireNonNull(schema);
-    this.dataSource = Objects.requireNonNull(dataSource);
+    this.timestampFieldName = Objects.requireNonNull(timestampFieldName, "timestampFieldName");
+    this.schema = Objects.requireNonNull(schema, "schema");
+    this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
     this.protoRowType = protoRowType;
     this.metricFieldNames = ImmutableSet.copyOf(metricFieldNames);
     this.intervals = intervals != null ? ImmutableList.copyOf(intervals)

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/ExtractionDimensionSpec.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/ExtractionDimensionSpec.java
@@ -46,8 +46,8 @@ public class ExtractionDimensionSpec implements DimensionSpec {
 
   public ExtractionDimensionSpec(String dimension, ExtractionFunction extractionFunction,
       String outputName, DruidType outputType) {
-    this.dimension = Objects.requireNonNull(dimension);
-    this.extractionFunction = Objects.requireNonNull(extractionFunction);
+    this.dimension = Objects.requireNonNull(dimension, "dimension");
+    this.extractionFunction = Objects.requireNonNull(extractionFunction, "extractionFunction");
     this.outputName = outputName;
     this.outputType = outputType == null ? DruidType.STRING : outputType;
   }

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/Granularities.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/Granularities.java
@@ -87,9 +87,9 @@ public class Granularities {
     private final String timeZone;
 
     private PeriodGranularity(Type type, String period, String timeZone) {
-      this.type = Objects.requireNonNull(type);
-      this.period = Objects.requireNonNull(period);
-      this.timeZone = Objects.requireNonNull(timeZone);
+      this.type = Objects.requireNonNull(type, "type");
+      this.period = Objects.requireNonNull(period, "period");
+      this.timeZone = Objects.requireNonNull(timeZone, "timeZone");
     }
 
     @Override public void write(JsonGenerator generator) throws IOException {

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/NaryOperatorConverter.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/NaryOperatorConverter.java
@@ -35,8 +35,8 @@ public class NaryOperatorConverter implements DruidSqlOperatorConverter {
   private final String druidOperatorName;
 
   public NaryOperatorConverter(SqlOperator operator, String druidOperatorName) {
-    this.operator = Objects.requireNonNull(operator);
-    this.druidOperatorName = Objects.requireNonNull(druidOperatorName);
+    this.operator = Objects.requireNonNull(operator, "operator");
+    this.druidOperatorName = Objects.requireNonNull(druidOperatorName, "druidOperatorName");
   }
 
   @Override public SqlOperator calciteOperator() {

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/VirtualColumn.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/VirtualColumn.java
@@ -36,8 +36,8 @@ public class VirtualColumn implements DruidJson {
   private final DruidType outputType;
 
   public VirtualColumn(String name, String expression, DruidType outputType) {
-    this.name = Objects.requireNonNull(name);
-    this.expression = Objects.requireNonNull(expression);
+    this.name = Objects.requireNonNull(name, "name");
+    this.expression = Objects.requireNonNull(expression, "expression");
     this.outputType = outputType == null ? DruidType.FLOAT : outputType;
   }
 

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSchema.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSchema.java
@@ -39,9 +39,9 @@ public class GeodeSchema extends AbstractSchema {
   private final List<String> regionNames;
   private ImmutableMap<String, Table> tableMap;
 
-  public GeodeSchema(final GemFireCache cache, final Iterable<String> regionNames) {
+  public GeodeSchema(final GemFireCache gemFireCache, final Iterable<String> regionNames) {
     super();
-    this.cache = Objects.requireNonNull(cache, "clientCache");
+    this.cache = Objects.requireNonNull(gemFireCache, "gemFireCache");
     this.regionNames = ImmutableList.copyOf(Objects.requireNonNull(regionNames, "regionNames"));
   }
 

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/IndexCondition.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/IndexCondition.java
@@ -98,8 +98,8 @@ public class IndexCondition {
             : ImmutableList.copyOf(remainderConditions);
     this.queryType = queryType;
     this.pointQueryKey = pointQueryKey;
-    this.rangeQueryLowerOp = Objects.requireNonNull(rangeQueryLowerOp);
-    this.rangeQueryUpperOp = Objects.requireNonNull(rangeQueryUpperOp);
+    this.rangeQueryLowerOp = Objects.requireNonNull(rangeQueryLowerOp, "rangeQueryLowerOp");
+    this.rangeQueryUpperOp = Objects.requireNonNull(rangeQueryUpperOp, "rangeQueryUpperOp");
     this.rangeQueryLowerKey = ImmutableList.copyOf(rangeQueryLowerKey);
     this.rangeQueryUpperKey = ImmutableList.copyOf(rangeQueryUpperKey);
   }

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilter.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilter.java
@@ -48,8 +48,8 @@ public class InnodbFilter extends Filter implements InnodbRel {
       TableDef tableDef, @Nullable String forceIndexName) {
     super(cluster, traitSet, input, condition);
 
-    this.tableDef = Objects.requireNonNull(tableDef);
-    this.indexCondition = Objects.requireNonNull(indexCondition);
+    this.tableDef = Objects.requireNonNull(tableDef, "tableDef");
+    this.indexCondition = Objects.requireNonNull(indexCondition, "indexCondition");
     this.forceIndexName = forceIndexName;
 
     assert getConvention() == InnodbRel.CONVENTION;

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -427,12 +427,12 @@ public abstract class EnumerableDefaults {
           private @Nullable Iterator<TSource> rest;
 
           @Override public boolean hasNext() {
-            return !nonFirst || requireNonNull(rest).hasNext();
+            return !nonFirst || requireNonNull(rest, "rest").hasNext();
           }
 
           @Override public TSource next() {
             if (nonFirst) {
-              return requireNonNull(rest).next();
+              return requireNonNull(rest, "rest").next();
             } else {
               final TSource first = os.current();
               nonFirst = true;
@@ -948,7 +948,7 @@ public abstract class EnumerableDefaults {
 
       if (curResult == null) {
         // current key is the last key.
-        curResult = resultSelector.apply(prevKey, requireNonNull(curAccumulator));
+        curResult = resultSelector.apply(prevKey, requireNonNull(curAccumulator, "curAccumulator"));
         // no need to keep accumulator for the last key.
         curAccumulator = null;
       }
@@ -3801,7 +3801,7 @@ public abstract class EnumerableDefaults {
     return source instanceof OrderedQueryable
         ? ((OrderedQueryable<T>) source)
         : new EnumerableOrderedQueryable<>(
-            source, (Class) Object.class, requireNonNull(null), null);
+            source, (Class) Object.class, requireNonNull(null, "null"), null);
   }
 
   /** Default implementation of {@link ExtendedEnumerable#into(Collection)}. */

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/GroupingImpl.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/GroupingImpl.java
@@ -35,8 +35,8 @@ class GroupingImpl<K extends Object, V> extends AbstractEnumerable<V>
   private final List<V> values;
 
   GroupingImpl(K key, List<V> values) {
-    this.key = Objects.requireNonNull(key);
-    this.values = Objects.requireNonNull(values);
+    this.key = Objects.requireNonNull(key, "key");
+    this.values = Objects.requireNonNull(values, "values");
   }
 
   @Override public String toString() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ArrayLengthRecordField.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ArrayLengthRecordField.java
@@ -55,7 +55,7 @@ public class ArrayLengthRecordField implements Types.RecordField {
   }
 
   @Override public Object get(@Nullable Object o) throws IllegalAccessException {
-    return Array.getLength(requireNonNull(o));
+    return Array.getLength(requireNonNull(o, "o"));
   }
 
   @Override public Type getDeclaringClass() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
@@ -3043,7 +3043,7 @@ public abstract class Expressions {
    * Evaluates an expression and returns the result.
    */
   public static @Nullable Object evaluate(Node node) {
-    requireNonNull(node);
+    requireNonNull(node, "node");
     final Evaluator evaluator = new Evaluator();
     return ((AbstractNode) node).evaluate(evaluator);
   }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ForEachStatement.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ForEachStatement.java
@@ -34,9 +34,9 @@ public class ForEachStatement extends Statement {
   public ForEachStatement(ParameterExpression parameter, Expression iterable,
       Statement body) {
     super(ExpressionType.ForEach, Void.TYPE);
-    this.parameter = Objects.requireNonNull(parameter);
-    this.iterable = Objects.requireNonNull(iterable);
-    this.body = Objects.requireNonNull(body); // may be empty block, not null
+    this.parameter = Objects.requireNonNull(parameter, "parameter");
+    this.iterable = Objects.requireNonNull(iterable, "iterable");
+    this.body = Objects.requireNonNull(body, "body"); // may be empty block, not null
   }
 
   @Override public ForEachStatement accept(Shuttle shuttle) {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/FunctionExpression.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/FunctionExpression.java
@@ -86,7 +86,7 @@ public final class FunctionExpression<F extends Function<?>>
       for (int i = 0; i < args.length; i++) {
         evaluator.push(parameterList.get(i), args[i]);
       }
-      return evaluator.evaluate(requireNonNull(body));
+      return evaluator.evaluate(requireNonNull(body, "body"));
     };
   }
 
@@ -150,7 +150,7 @@ public final class FunctionExpression<F extends Function<?>>
           ? "." + requireNonNull(Primitive.of(parameterType)).primitiveName + "Value()"
           : ""));
     }
-    requireNonNull(body);
+    requireNonNull(body, "body");
     Type bridgeResultType = Functions.FUNCTION_RESULT_TYPES.get(this.type);
     if (bridgeResultType == null) {
       bridgeResultType = body.getType();

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/GotoStatement.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/GotoStatement.java
@@ -98,7 +98,7 @@ public class GotoStatement extends Statement {
     case Sequence:
       // NOTE: We ignore control flow. This is only correct if "return"
       // is the last statement in the block.
-      return requireNonNull(expression).evaluate(evaluator);
+      return requireNonNull(expression, "expression").evaluate(evaluator);
     default:
       throw new AssertionError("evaluate not implemented");
     }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/TryStatement.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/TryStatement.java
@@ -33,8 +33,8 @@ public class TryStatement extends Statement {
   public TryStatement(Statement body, List<CatchBlock> catchBlocks,
       @Nullable Statement fynally) {
     super(ExpressionType.Try, body.getType());
-    this.body = Objects.requireNonNull(body);
-    this.catchBlocks = Objects.requireNonNull(catchBlocks);
+    this.body = Objects.requireNonNull(body, "body");
+    this.catchBlocks = Objects.requireNonNull(catchBlocks, "catchBlocks");
     this.fynally = fynally;
   }
 

--- a/piglet/src/main/java/org/apache/calcite/piglet/Ast.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/Ast.java
@@ -136,8 +136,8 @@ public class Ast {
     public final SqlParserPos pos;
 
     protected Node(SqlParserPos pos, Op op) {
-      this.op = Objects.requireNonNull(op);
-      this.pos = Objects.requireNonNull(pos);
+      this.op = Objects.requireNonNull(op, "op");
+      this.pos = Objects.requireNonNull(pos, "pos");
     }
   }
 
@@ -154,7 +154,7 @@ public class Ast {
 
     protected Assignment(SqlParserPos pos, Op op, Identifier target) {
       super(pos, op);
-      this.target = Objects.requireNonNull(target);
+      this.target = Objects.requireNonNull(target, "target");
     }
   }
 
@@ -164,7 +164,7 @@ public class Ast {
 
     public LoadStmt(SqlParserPos pos, Identifier target, Literal name) {
       super(pos, Op.LOAD, target);
-      this.name = Objects.requireNonNull(name);
+      this.name = Objects.requireNonNull(name, "name");
     }
   }
 
@@ -333,7 +333,7 @@ public class Ast {
 
     public DumpStmt(SqlParserPos pos, Identifier relation) {
       super(pos, Op.DUMP);
-      this.relation = Objects.requireNonNull(relation);
+      this.relation = Objects.requireNonNull(relation, "relation");
     }
   }
 
@@ -343,7 +343,7 @@ public class Ast {
 
     public DescribeStmt(SqlParserPos pos, Identifier relation) {
       super(pos, Op.DESCRIBE);
-      this.relation = Objects.requireNonNull(relation);
+      this.relation = Objects.requireNonNull(relation, "relation");
     }
   }
 
@@ -353,7 +353,7 @@ public class Ast {
 
     public Literal(SqlParserPos pos, Object value) {
       super(pos, Op.LITERAL);
-      this.value = Objects.requireNonNull(value);
+      this.value = Objects.requireNonNull(value, "value");
     }
 
     public static NumericLiteral createExactNumeric(String s,
@@ -408,7 +408,7 @@ public class Ast {
 
     public Identifier(SqlParserPos pos, String value) {
       super(pos, Op.IDENTIFIER);
-      this.value = Objects.requireNonNull(value);
+      this.value = Objects.requireNonNull(value, "value");
     }
 
     public boolean isStar() {
@@ -466,8 +466,8 @@ public class Ast {
 
     public FieldSchema(SqlParserPos pos, Identifier id, Type type) {
       super(pos, Op.FIELD_SCHEMA);
-      this.id = Objects.requireNonNull(id);
-      this.type = Objects.requireNonNull(type);
+      this.id = Objects.requireNonNull(id, "id");
+      this.type = Objects.requireNonNull(type, "type");
     }
   }
 

--- a/plus/src/main/java/org/apache/calcite/adapter/os/SqlShell.java
+++ b/plus/src/main/java/org/apache/calcite/adapter/os/SqlShell.java
@@ -59,9 +59,9 @@ public class SqlShell {
   SqlShell(InputStreamReader in, PrintWriter out,
       PrintWriter err, String... args) {
     this.args = ImmutableList.copyOf(args);
-    this.in = Objects.requireNonNull(in);
-    this.out = Objects.requireNonNull(out);
-    this.err = Objects.requireNonNull(err);
+    this.in = Objects.requireNonNull(in, "in");
+    this.out = Objects.requireNonNull(out, "out");
+    this.err = Objects.requireNonNull(err, "err");
   }
 
   private static String model() {

--- a/server/src/main/java/org/apache/calcite/server/MutableArrayTable.java
+++ b/server/src/main/java/org/apache/calcite/server/MutableArrayTable.java
@@ -59,10 +59,10 @@ class MutableArrayTable extends AbstractModifiableTable
       RelProtoDataType protoRowType,
       InitializerExpressionFactory initializerExpressionFactory) {
     super(name);
-    this.protoStoredRowType = Objects.requireNonNull(protoStoredRowType);
-    this.protoRowType = Objects.requireNonNull(protoRowType);
+    this.protoStoredRowType = Objects.requireNonNull(protoStoredRowType, "protoStoredRowType");
+    this.protoRowType = Objects.requireNonNull(protoRowType, "protoRowType");
     this.initializerExpressionFactory =
-        Objects.requireNonNull(initializerExpressionFactory);
+        Objects.requireNonNull(initializerExpressionFactory, "initializerExpressionFactory");
   }
 
   @Override public Collection getModifiableCollection() {

--- a/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
+++ b/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
@@ -577,7 +577,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
         ColumnStrategy strategy) {
       this.expr = expr;
       this.type = type;
-      this.strategy = Objects.requireNonNull(strategy);
+      this.strategy = Objects.requireNonNull(strategy, "strategy");
       Preconditions.checkArgument(
           strategy == ColumnStrategy.NULLABLE
               || strategy == ColumnStrategy.NOT_NULLABLE


### PR DESCRIPTION
This makes it easier to understand the reason for the failure, especially
when multiple requireNonNull lines go side-by-side.

The added AutoStyle configuration ensures the label does not go out-of-sync