### PR TITLE
[CALCITE-4435] Incorrect logic for validating RexFieldAccess

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexChecker.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexChecker.java
@@ -155,7 +155,7 @@ public class RexChecker extends RexVisitorImpl<@Nullable Boolean> {
     assert refType.isStruct();
     final RelDataTypeField field = fieldAccess.getField();
     final int index = field.getIndex();
-    if ((index < 0) || (index > refType.getFieldList().size())) {
+    if ((index < 0) || (index >= refType.getFieldList().size())) {
       ++failCount;
       return litmus.fail(null);
     }

--- a/core/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
@@ -73,7 +73,7 @@ public class RexFieldAccess extends RexNode {
     RelDataType exprType = expr.getType();
     int fieldIdx = field.getIndex();
     Preconditions.checkArgument(
-        fieldIdx < exprType.getFieldList().size()
+        fieldIdx >= 0 && fieldIdx < exprType.getFieldList().size()
             && exprType.getFieldList().get(fieldIdx).equals(field),
         "Field " + field + " does not exist for expression " + expr);
   }


### PR DESCRIPTION
For the index of a RexFieldAccess, the correct range should be `[0, refType.getFieldList().size())`.
However, according to the current implementation of RexChecker#visitFieldAccess, the valid range is `[0, refType.getFieldList().size()]`