### PR TITLE
MINOR: add gradle idea output files to ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@
 !/.idea/icon.png
 !/.idea/vcs.xml
 *.iml
+*.ipr
+*.iws
 
 settings.xml
 .classpath.txt


### PR DESCRIPTION
calcite.ipr and calcite.iws will be generated when running `gradle idea`, add them to ignore files