### PR TITLE
[CALCITE-4443] Add support for ILIKE to core

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -237,6 +237,7 @@ data: {
       "HOUR"
       "IDENTITY"
 #     "IF" # not a keyword in Calcite
+      "ILIKE"
       "IMMEDIATE"
       "IMMEDIATELY"
       "IMPORT"

--- a/core/src/main/codegen/default_config.fmpp
+++ b/core/src/main/codegen/default_config.fmpp
@@ -130,6 +130,7 @@ parser: {
     "HOP"
     "HOURS"
     "IGNORE"
+    "ILIKE"
     "IMMEDIATE"
     "IMMEDIATELY"
     "IMPLEMENTATION"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3588,10 +3588,24 @@ List<Object> Expression2(ExprContext exprContext) :
                         (
                             <LIKE> { op = SqlStdOperatorTable.NOT_LIKE; }
                         |
+                            <ILIKE> {
+                                if (!this.conformance.isIlikeAllowed()) {
+                                    throw SqlUtil.newContextException(getPos(), RESOURCE.ilikeNotAllowed());
+                                }
+                                op = SqlLibraryOperators.NOT_ILIKE;
+                            }
+                        |
                             <SIMILAR> <TO> { op = SqlStdOperatorTable.NOT_SIMILAR_TO; }
                         )
                     |
                         <LIKE> { op = SqlStdOperatorTable.LIKE; }
+                    |
+                        <ILIKE> {
+                            if (!this.conformance.isIlikeAllowed()) {
+                                throw SqlUtil.newContextException(getPos(), RESOURCE.ilikeNotAllowed());
+                            }
+                            op = SqlLibraryOperators.ILIKE;
+                        }
                     |
                         <SIMILAR> <TO> { op = SqlStdOperatorTable.SIMILAR_TO; }
                     )
@@ -7447,6 +7461,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < HOURS: "HOURS" >
 |   < IDENTITY: "IDENTITY" >
 |   < IGNORE: "IGNORE" >
+|   < ILIKE: "ILIKE" >
 |   < IMMEDIATE: "IMMEDIATE" >
 |   < IMMEDIATELY: "IMMEDIATELY" >
 |   < IMPLEMENTATION: "IMPLEMENTATION" >

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -120,6 +120,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.EXISTS_NODE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.EXTRACT_VALUE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.EXTRACT_XML;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FROM_BASE64;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.ILIKE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_DEPTH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_KEYS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_LENGTH;
@@ -469,11 +470,15 @@ public class RexImpTable {
     map.put(IS_FALSE, new IsFalseImplementor());
     map.put(IS_NOT_FALSE, new IsNotFalseImplementor());
 
-    // LIKE and SIMILAR
+    // LIKE, ILIKE and SIMILAR
     final MethodImplementor likeImplementor =
         new MethodImplementor(BuiltInMethod.LIKE.method, NullPolicy.STRICT,
             false);
     map.put(LIKE, likeImplementor);
+    final MethodImplementor ilikeImplementor =
+        new MethodImplementor(BuiltInMethod.ILIKE.method, NullPolicy.STRICT,
+            false);
+    map.put(ILIKE, ilikeImplementor);
     final MethodImplementor similarImplementor =
         new MethodImplementor(BuiltInMethod.SIMILAR.method, NullPolicy.STRICT,
             false);

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -63,6 +63,9 @@ public interface CalciteResource {
   @BaseMessage("Geo-spatial extensions and the GEOMETRY data type are not enabled")
   ExInst<SqlValidatorException> geometryDisabled();
 
+  @BaseMessage("The ''ILIKE'' operator is not allowed under the current SQL conformance level")
+  ExInst<CalciteException> ilikeNotAllowed();
+
   @BaseMessage("Illegal INTERVAL literal {0}; at {1}")
   @Property(name = "SQLSTATE", value = "42000")
   ExInst<CalciteException> illegalIntervalLiteral(String a0, String a1);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -607,6 +607,18 @@ public class SqlFunctions {
     return Pattern.matches(regex, s);
   }
 
+  /** SQL {@code ILIKE} function. */
+  public static boolean ilike(String s, String pattern) {
+    final String regex = Like.sqlToRegexLike(pattern, null);
+    return Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(s).matches();
+  }
+
+  /** SQL {@code ILIKE} function with escape. */
+  public static boolean ilike(String s, String pattern, String escape) {
+    final String regex = Like.sqlToRegexLike(pattern, escape);
+    return Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(s).matches();
+  }
+
   /** SQL {@code SIMILAR} function. */
   public static boolean similar(String s, String pattern) {
     final String regex = Like.sqlToRegexSimilar(pattern, null);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
@@ -27,12 +27,15 @@ import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
 
 /**
  * A <code>SqlDialect</code> implementation for the PostgreSQL database.
@@ -92,6 +95,18 @@ public class PostgresqlSqlDialect extends SqlDialect {
     return new SqlDataTypeSpec(
         new SqlAlienSystemTypeNameSpec(castSpec, type.getSqlTypeName(), SqlParserPos.ZERO),
         SqlParserPos.ZERO);
+  }
+
+  @Override public boolean supportsFunction(
+      final SqlOperator operator, final RelDataType type, final List<RelDataType> paramTypes
+  ) {
+    switch (operator.kind) {
+    case LIKE:
+      // introduces support for ILIKE as well
+      return true;
+    default:
+      return super.supportsFunction(operator, type, paramTypes);
+    }
   }
 
   @Override public boolean requiresAliasForFromItems() {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
@@ -17,7 +17,11 @@
 package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlOperator;
+
+import java.util.List;
 
 /**
  * A <code>SqlDialect</code> implementation for the Vertica database.
@@ -37,5 +41,17 @@ public class VerticaSqlDialect extends SqlDialect {
 
   @Override public boolean supportsNestedAggregations() {
     return false;
+  }
+
+  @Override public boolean supportsFunction(
+      final SqlOperator operator, final RelDataType type, final List<RelDataType> paramTypes
+  ) {
+    switch (operator.kind) {
+    case LIKE:
+      // introduces support for ILIKE as well
+      return true;
+    default:
+      return super.supportsFunction(operator, type, paramTypes);
+    }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
@@ -459,6 +460,16 @@ public abstract class SqlLibraryOperators {
           null,
           OperandTypes.STRING_STRING,
           SqlFunctionCategory.STRING);
+
+  /** The case-insensitive variant of the LIKE operator. */
+  @LibraryOperator(libraries = {POSTGRESQL})
+  public static final SqlSpecialOperator ILIKE =
+      new SqlLikeOperator("ILIKE", SqlKind.LIKE, false, true);
+
+  /** The case-insensitive variant of the NOT LIKE operator. */
+  @LibraryOperator(libraries = {POSTGRESQL})
+  public static final SqlSpecialOperator NOT_ILIKE =
+      new SqlLikeOperator("NOT ILIKE", SqlKind.LIKE, true, true);
 
   /** The "CONCAT(arg, ...)" function that concatenates strings.
    * For example, "CONCAT('a', 'bc', 'd')" returns "abcd". */

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLikeOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLikeOperator.java
@@ -56,20 +56,23 @@ public class SqlLikeOperator extends SqlSpecialOperator {
   //~ Instance fields --------------------------------------------------------
 
   private final boolean negated;
+  private final boolean ignoreCase;
 
   //~ Constructors -----------------------------------------------------------
 
   /**
    * Creates a SqlLikeOperator.
    *
-   * @param name    Operator name
-   * @param kind    Kind
-   * @param negated Whether this is 'NOT LIKE'
+   * @param name        Operator name
+   * @param kind        Kind
+   * @param negated     Whether this is 'NOT LIKE'
+   * @param ignoreCase  Whether it should actually by 'ILIKE'
    */
   SqlLikeOperator(
       String name,
       SqlKind kind,
-      boolean negated) {
+      boolean negated,
+      boolean ignoreCase) {
     // LIKE is right-associative, because that makes it easier to capture
     // dangling ESCAPE clauses: "a like b like c escape d" becomes
     // "a like (b like c escape d)".
@@ -81,7 +84,14 @@ public class SqlLikeOperator extends SqlSpecialOperator {
         ReturnTypes.BOOLEAN_NULLABLE,
         InferTypes.FIRST_KNOWN,
         OperandTypes.STRING_SAME_SAME_SAME);
+    if (ignoreCase && kind != SqlKind.LIKE) {
+      throw new IllegalArgumentException(
+          "Only (possibly negated) " + SqlKind.LIKE + " can be made case-insensitive, not " + kind
+      );
+    }
+
     this.negated = negated;
+    this.ignoreCase = ignoreCase;
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -93,6 +103,15 @@ public class SqlLikeOperator extends SqlSpecialOperator {
    */
   public boolean isNegated() {
     return negated;
+  }
+
+  /**
+   * Returns whether this is the 'ILIKE' operator.
+   *
+   * @return whether this is 'ILIKE'
+   */
+  public boolean isIgnoreCase() {
+    return ignoreCase;
   }
 
   @Override public SqlOperandCountRange getOperandCountRange() {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1399,16 +1399,16 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           true);
 
   public static final SqlSpecialOperator NOT_LIKE =
-      new SqlLikeOperator("NOT LIKE", SqlKind.LIKE, true);
+      new SqlLikeOperator("NOT LIKE", SqlKind.LIKE, true, false);
 
   public static final SqlSpecialOperator LIKE =
-      new SqlLikeOperator("LIKE", SqlKind.LIKE, false);
+      new SqlLikeOperator("LIKE", SqlKind.LIKE, false, false);
 
   public static final SqlSpecialOperator NOT_SIMILAR_TO =
-      new SqlLikeOperator("NOT SIMILAR TO", SqlKind.SIMILAR, true);
+      new SqlLikeOperator("NOT SIMILAR TO", SqlKind.SIMILAR, true, false);
 
   public static final SqlSpecialOperator SIMILAR_TO =
-      new SqlLikeOperator("SIMILAR TO", SqlKind.SIMILAR, false);
+      new SqlLikeOperator("SIMILAR TO", SqlKind.SIMILAR, false, false);
 
   public static final SqlBinaryOperator POSIX_REGEX_CASE_SENSITIVE = new SqlPosixRegexOperator(
       "POSIX REGEX CASE SENSITIVE", SqlKind.POSIX_REGEX_CASE_SENSITIVE, true, false);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -73,6 +73,10 @@ public abstract class SqlAbstractConformance implements SqlConformance {
     return SqlConformanceEnum.DEFAULT.isBangEqualAllowed();
   }
 
+  @Override public boolean isIlikeAllowed() {
+    return SqlConformanceEnum.DEFAULT.isIlikeAllowed();
+  }
+
   @Override public boolean isMinusAllowed() {
     return SqlConformanceEnum.DEFAULT.isMinusAllowed();
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -226,6 +226,16 @@ public interface SqlConformance {
   boolean isBangEqualAllowed();
 
   /**
+   * Whether the "ILIKE" operator is allowed by the parser to provide case-insensitive LIKE.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#BABEL},
+   * {@link SqlConformanceEnum#LENIENT},
+   * false otherwise.
+   */
+  boolean isIlikeAllowed();
+
+  /**
    * Whether the "%" operator is allowed by the parser as an alternative to the
    * {@code mod} function.
    *

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -226,6 +226,16 @@ public enum SqlConformanceEnum implements SqlConformance {
     }
   }
 
+  @Override public boolean isIlikeAllowed() {
+    switch (this) {
+    case LENIENT:
+    case BABEL:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   @Override public boolean isMinusAllowed() {
     switch (this) {
     case BABEL:

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
@@ -63,6 +63,10 @@ public class SqlDelegatingConformance extends SqlAbstractConformance {
     return delegate.isBangEqualAllowed();
   }
 
+  @Override public boolean isIlikeAllowed() {
+    return delegate.isIlikeAllowed();
+  }
+
   @Override public boolean isMinusAllowed() {
     return delegate.isMinusAllowed();
   }

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -172,6 +172,13 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
                 SqlStdOperatorTable.LIKE.createCall(SqlParserPos.ZERO,
                     call.getOperandList()))));
 
+    // Expand "x NOT ILIKE y" into "NOT (x ILIKE y)"
+    registerOp(SqlLibraryOperators.NOT_ILIKE,
+        (cx, call) -> cx.convertExpression(
+            SqlStdOperatorTable.NOT.createCall(SqlParserPos.ZERO,
+                SqlLibraryOperators.ILIKE.createCall(SqlParserPos.ZERO,
+                    call.getOperandList()))));
+
     // Expand "x NOT SIMILAR y" into "NOT (x SIMILAR y)"
     registerOp(SqlStdOperatorTable.NOT_SIMILAR_TO,
         (cx, call) -> cx.convertExpression(

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -82,6 +82,7 @@ import org.apache.calcite.schema.impl.ListTransientTable;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlLikeOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
@@ -641,7 +642,13 @@ public class RelBuilder {
     switch (operator.getKind()) {
     case LIKE:
       if (((SqlLikeOperator) operator).isNegated()) {
-        return (RexCall) not(call(SqlStdOperatorTable.LIKE, operandList));
+        final SqlOperator sqlOperator;
+        if (((SqlLikeOperator) operator).isIgnoreCase()) {
+          sqlOperator = SqlLibraryOperators.ILIKE;
+        } else {
+          sqlOperator = SqlStdOperatorTable.LIKE;
+        }
+        return (RexCall) not(call(sqlOperator, operandList));
       }
       break;
     case SIMILAR:

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -419,6 +419,7 @@ public enum BuiltInMethod {
   LTRIM(SqlFunctions.class, "ltrim", String.class),
   RTRIM(SqlFunctions.class, "rtrim", String.class),
   LIKE(SqlFunctions.class, "like", String.class, String.class),
+  ILIKE(SqlFunctions.class, "ilike", String.class, String.class),
   SIMILAR(SqlFunctions.class, "similar", String.class, String.class),
   POSIX_REGEX(SqlFunctions.class, "posixRegex", String.class, String.class, boolean.class),
   REGEXP_REPLACE3(SqlFunctions.class, "regexpReplace", String.class,

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -29,6 +29,7 @@ IdentifierTooLong=Length of identifier ''{0}'' must be less than or equal to {1,
 BadFormat=not in format ''{0}''
 BetweenWithoutAnd=BETWEEN operator has no terminating AND
 GeometryDisabled=Geo-spatial extensions and the GEOMETRY data type are not enabled
+IlikeNotAllowed=The ''ILIKE'' operator is not allowed under the current SQL conformance level
 IllegalIntervalLiteral=Illegal INTERVAL literal {0}; at {1}
 IllegalMinusDate=Illegal expression. Was expecting "(DATETIME - DATETIME) INTERVALQUALIFIER"
 IllegalOverlaps=Illegal overlaps expression. Was expecting expression on the form "(DATETIME, EXPRESSION) OVERLAPS (DATETIME, EXPRESSION)"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
@@ -165,7 +165,7 @@ class RelToSqlConverterStructsTest {
   private RelToSqlConverterTest.Sql sql(String sql) {
     return new RelToSqlConverterTest.Sql(ROOT_SCHEMA, sql,
         CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT,
-        UnaryOperator.identity(), null, ImmutableList.of());
+        UnaryOperator.identity(), null, ImmutableList.of(), null);
   }
 
   @Test void testNestedSchemaSelectStar() {

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -285,6 +285,7 @@ public class SqlParserTest {
       "HOURS",                                             "2011",
       "IDENTITY",                      "92", "99", "2003", "2011", "2014", "c",
       "IF",                            "92", "99", "2003",
+      "ILIKE",
       "IMMEDIATE",                     "92", "99", "2003",
       "IMMEDIATELY",
       "IMPORT",                                                            "c",
@@ -1796,6 +1797,25 @@ public class SqlParserTest {
         .ok("VALUES (ROW((`A` SIMILAR TO (SELECT *\n"
             + "FROM `T`\n"
             + "WHERE (`A` LIKE `B` ESCAPE `C`)) ESCAPE `D`)))");
+  }
+
+  @Test void testIlike() {
+    conformance = SqlConformanceEnum.LENIENT;
+
+    sql("select * from t where x not ilike '%abc%'")
+        .ok("SELECT *\n"
+            + "FROM `T`\n"
+            + "WHERE (`X` NOT ILIKE '%abc%')");
+
+    sql("select * from t where x ilike '%abc%'")
+        .ok("SELECT *\n"
+            + "FROM `T`\n"
+            + "WHERE (`X` ILIKE '%abc%')");
+
+    conformance = SqlConformanceEnum.DEFAULT;
+
+    sql("select * from t where x ^ilike^ '%abc%'")
+        .fails("The 'ILIKE' operator is not allowed under the current SQL conformance level");
   }
 
   @Test void testFoo() {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -296,6 +296,7 @@ class SqlAdvisorTest extends SqlValidatorTestCase {
           "KEYWORD(CONTAINS)",
           "KEYWORD(EQUALS)",
           "KEYWORD(FORMAT)",
+          "KEYWORD(ILIKE)",
           "KEYWORD(IMMEDIATELY)",
           "KEYWORD(IN)",
           "KEYWORD(IS)",

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -53,6 +53,7 @@ import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.sql.SqlMatchRecognize;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -3970,6 +3971,22 @@ public class RelBuilderTest {
             .build();
     final String expected = ""
         + "LogicalFilter(condition=[NOT(LIKE($1, 'a%b%c'))])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(root, hasTree(expected));
+  }
+
+  @Test void testNotIlike() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+            .filter(
+                builder.call(
+                    SqlLibraryOperators.NOT_ILIKE,
+                    builder.field("ENAME"),
+                    builder.literal("a%b%c")))
+            .build();
+    final String expected = ""
+        + "LogicalFilter(condition=[NOT(ILIKE($1, 'a%b%c'))])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(root, hasTree(expected));
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1005,6 +1005,19 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("'a' similar to 'b' escape 'c'").ok();
   }
 
+  @Test void testIlike() {
+    final Sql s = sql("?")
+        .withOperatorTable(operatorTableFor(SqlLibrary.POSTGRESQL))
+        .withConformance(SqlConformanceEnum.LENIENT);
+    s.expr("'a' ilike 'b'").ok();
+    s.expr("'a' not ilike 'b'").ok();
+  }
+
+  @Test void testIlikeOnDefaultConformance() {
+    expr("'a' ^ilike^ 'b'")
+        .fails("The 'ILIKE' operator is not allowed under the current SQL conformance level");
+  }
+
   public void _testLikeAndSimilarFails() {
     expr("'a' like _UTF16'b'  escape 'c'")
         .fails("(?s).*Operands _ISO-8859-1.a. COLLATE ISO-8859-1.en_US.primary,"

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -632,6 +632,7 @@ HOP,
 HOURS,
 **IDENTITY**,
 IGNORE,
+ILIKE,
 IMMEDIATE,
 IMMEDIATELY,
 IMPLEMENTATION,
@@ -2505,6 +2506,7 @@ semantics.
 | m | EXTRACTVALUE(xml, xpathExpr))                  | Returns the text of the first text node which is a child of the element or elements matched by the XPath expression.
 | o | GREATEST(expr [, expr ]*)                      | Returns the greatest of the expressions
 | b h s | IF(condition, value1, value2)              | Returns *value1* if *condition* is TRUE, *value2* otherwise
+| p | string ILIKE string                            | Behaves like the standard LIKE operator, but without case-sensitivity
 | m | JSON_TYPE(jsonValue)                           | Returns a string value indicating the type of *jsonValue*
 | m | JSON_DEPTH(jsonValue)                          | Returns an integer value indicating the depth of *jsonValue*
 | m | JSON_PRETTY(jsonValue)                         | Returns a pretty-printing of *jsonValue*


### PR DESCRIPTION
Introduce the ILIKE operator with functionality identical to LIKE, but without case-sensitivity.