### PR TITLE
[CALCITE-4265] Improve error message when CAST to unknown type (Louis…

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -140,6 +140,9 @@ public interface CalciteResource {
   @BaseMessage("Cast function cannot convert value of type {0} to type {1}")
   ExInst<SqlValidatorException> cannotCastValue(String a0, String a1);
 
+  @BaseMessage("Cast function does not support casting to type {0}")
+  ExInst<SqlValidatorException> cannotCastToType(String a0);
+
   @BaseMessage("Unknown datatype name ''{0}''")
   ExInst<SqlValidatorException> unknownDatatypeName(String a0);
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -36,7 +36,9 @@ import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
 
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
@@ -92,6 +94,29 @@ public class SqlCastFunction extends SqlFunction {
   }
 
   //~ Methods ----------------------------------------------------------------
+
+  @Override public void validateCall(final SqlCall call, final SqlValidator validator,
+      final SqlValidatorScope scope,
+      final SqlValidatorScope operandScope) {
+    try {
+      super.validateCall(call, validator, scope, operandScope);
+    } catch (UnsupportedOperationException ex) {
+      assert call.operandCount() == 2;
+      throw validator.newValidationError(call,
+          RESOURCE.cannotCastToType(call.operand(1).toString()));
+    }
+  }
+
+  @Override public RelDataType deriveType(final SqlValidator validator,
+      final SqlValidatorScope scope, final SqlCall call) {
+    try {
+      return super.deriveType(validator, scope, call);
+    } catch (UnsupportedOperationException ex) {
+      assert call.operandCount() == 2;
+      throw validator.newValidationError(call,
+          RESOURCE.cannotCastToType(call.operand(1).toString()));
+    }
+  }
 
   @Override public RelDataType inferReturnType(
       SqlOperatorBinding opBinding) {

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -311,4 +311,5 @@ InvalidInputForExtractValue=Invalid input for EXTRACTVALUE: xml: ''{0}'', xpath 
 InvalidInputForExtractXml=Invalid input for EXTRACT xpath: ''{0}'', namespace: ''{1}''
 InvalidInputForExistsNode=Invalid input for EXISTSNODE xpath: ''{0}'', namespace: ''{1}''
 DifferentLengthForBitwiseOperands=Different length for bitwise operands: the first: {0,number,#}, the second: {1,number,#}
+CannotCastToType=Cast function does not support casting to type {0}
 # End CalciteResource.properties

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1212,8 +1212,8 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test void testCastRegisteredType() {
-    expr("cast(123 as customBigInt)")
-        .fails("class org.apache.calcite.sql.SqlIdentifier: CUSTOMBIGINT");
+    wholeExpr("cast(123 as customBigInt)")
+        .fails("Cast function does not support casting to type `CUSTOMBIGINT`");
     expr("cast(123 as sales.customBigInt)")
         .columnType("BIGINT NOT NULL");
     expr("cast(123 as catalog.sales.customBigInt)")
@@ -1221,8 +1221,6 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test void testCastFails() {
-    expr("cast('foo' as ^bar^)")
-        .fails("class org.apache.calcite.sql.SqlIdentifier: BAR");
     wholeExpr("cast(multiset[1] as integer)")
         .fails("(?s).*Cast function cannot convert value of type "
             + "INTEGER MULTISET to type INTEGER");
@@ -1240,6 +1238,21 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   @Test void testCastBinaryLiteral() {
     expr("cast(^x'0dd'^ as binary(5))")
         .fails("Binary literal string must contain an even number of hexits");
+  }
+
+  @Test void testCastToUnknownType() {
+    // Test validation of SQL expressions.
+    wholeExpr("cast(1 as SIGNED)")
+        .fails("Cast function does not support casting to type `SIGNED`");
+    wholeExpr("cast(1 as UNSIGNED)")
+        .fails("Cast function does not support casting to type `UNSIGNED`");
+    wholeExpr("cast('1' as SIGNED)")
+        .fails("Cast function does not support casting to type `SIGNED`");
+    wholeExpr("cast('foo' as bar)")
+        .fails("Cast function does not support casting to type `BAR`");
+    // Test validation of SQL queries.
+    sql("select ^cast(deptno as SIGNED)^ from emp")
+        .fails("Cast function does not support casting to type `SIGNED`");
   }
 
   /**
@@ -7968,9 +7981,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             + "VARCHAR(5) NOT NULL ARRAY NOT NULL F1) NOT NULL "
             + "ARRAY NOT NULL MULTISET NOT NULL");
     // test UDT collection type.
-    sql("select cast(a as MyUDT array multiset) from COMPLEXTYPES.CTC_T1")
+    sql("select ^cast(a as MyUDT array multiset)^ from COMPLEXTYPES.CTC_T1")
         .withExtendedCatalog()
-        .fails("(?s).*class org\\.apache\\.calcite\\.sql\\.SqlIdentifier: MYUDT.*");
+        .fails("Cast function does not support casting to type `MYUDT` ARRAY MULTISET");
   }
 
   @Test void testCastAsRowType() {


### PR DESCRIPTION
… Kuang)

Override `validateCall` and `deriveType` in `SqlCastFunction` and
wrap `UnsupportedOperationException` thrown from the base class
implementation.