### PR TITLE
[CALCITE-4456] Allows all the value expressions for explicit row valu…

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3718,7 +3718,7 @@ SqlNode Expression3(ExprContext exprContext) :
     <ROW> {
         s = span();
     }
-    list = ParenthesizedSimpleIdentifierList() {
+    list = ParenthesizedQueryOrCommaList(exprContext) {
         if (exprContext != ExprContext.ACCEPT_ALL
             && exprContext != ExprContext.ACCEPT_CURSOR
             && !this.conformance.allowExplicitRowValueConstructor())

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1287,6 +1287,14 @@ public class SqlParserTest {
     sql(sql)
         .withDialect(MSSQL)
         .ok(expected3);
+
+    conformance = SqlConformanceEnum.DEFAULT;
+    expr("ROW(EMP.EMPNO, EMP.ENAME)").ok("(ROW(`EMP`.`EMPNO`, `EMP`.`ENAME`))");
+    expr("ROW(EMP.EMPNO + 1, EMP.ENAME)").ok("(ROW((`EMP`.`EMPNO` + 1), `EMP`.`ENAME`))");
+    expr("ROW((select deptno from dept where dept.deptno = emp.deptno), EMP.ENAME)")
+        .ok("(ROW((SELECT `DEPTNO`\n"
+            + "FROM `DEPT`\n"
+            + "WHERE (`DEPT`.`DEPTNO` = `EMP`.`DEPTNO`)), `EMP`.`ENAME`))");
   }
 
   /** Whether this is a sub-class that tests un-parsing as well as parsing. */

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -101,6 +101,15 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test void testRowValueConstructorWithSubquery() {
+    final String sql = "select ROW("
+        + "(select deptno\n"
+        + "from dept\n"
+        + "where dept.deptno = emp.deptno), emp.ename)\n"
+        + "from emp";
+    sql(sql).ok();
+  }
+
   @Test void testIntegerLiteral() {
     final String sql = "select 1 from emp";
     sql(sql).ok();

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1641,6 +1641,13 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select t.r.\"EXPR$1\".\"EXPR$2\"\n"
         + "from (select ((1,2),(3,4,5)) r from dept) t")
         .columnType("INTEGER NOT NULL");
+    sql("select row(emp.empno, emp.ename) from emp")
+        .columnType("RecordType(INTEGER NOT NULL EXPR$0, VARCHAR(20) NOT NULL EXPR$1) NOT NULL");
+    sql("select row(emp.empno + 1, emp.ename) from emp")
+        .columnType("RecordType(INTEGER NOT NULL EXPR$0, VARCHAR(20) NOT NULL EXPR$1) NOT NULL");
+    sql("select row((select deptno from dept where dept.deptno = emp.deptno), emp.ename)\n"
+        + "from emp")
+        .columnType("RecordType(INTEGER EXPR$0, VARCHAR(20) NOT NULL EXPR$1) NOT NULL");
   }
 
   @Test void testRowWithValidDot() {

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1064,6 +1064,23 @@ LogicalProject(EXPR$0=[ROW(1, 2).EXPR$1])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testRowValueConstructorWithSubquery">
+        <Resource name="sql">
+            <![CDATA[select ROW((select deptno
+from dept
+where dept.deptno = emp.deptno), emp.ename)
+from emp]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EXPR$0=[ROW($9, $1)])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO9=[$9])
+    LogicalJoin(condition=[=($9, $7)], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testDynamicNestedColumn">
         <Resource name="sql">
             <![CDATA[select t3.fake_q1['fake_col2'] as fake2


### PR DESCRIPTION
…e constructor

As the SQL standard 2011 7.1 <row value constructor> specifies, we
should support all the value expression for explicit row value
constructor.