### PR TITLE
Cancel stale workflows in GitHub Actions CI

### DIFF
--- a/.github/workflows/cancel-duplicates.yml
+++ b/.github/workflows/cancel-duplicates.yml
@@ -1,0 +1,20 @@
+name: Cancelling Duplicates
+on:
+  workflow_run:
+    workflows:
+      - 'CI'
+    types: ['requested']
+
+# See https://github.com/potiuk/cancel-workflow-runs#most-often-used-canceling-example
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel duplicate workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738 # 2020-10-01
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
It should reduce CI load when PR or branch is updated often

See https://github.com/potiuk/cancel-workflow-runs#most-often-used-canceling-example