### PR TITLE
[CALCITE-4470] Add optional bytecode verification with Jandex

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -130,6 +130,7 @@ dependencies {
         apiv("org.hamcrest:hamcrest-library", "hamcrest")
         apiv("org.hsqldb:hsqldb")
         apiv("org.incava:java-diff")
+        apiv("org.jboss:jandex")
         apiv("org.jsoup:jsoup")
         apiv("org.junit.jupiter:junit-jupiter-api", "junit5")
         apiv("org.junit.jupiter:junit-jupiter-params", "junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ plugins {
     id("com.github.spotbugs")
     id("de.thetaphi.forbiddenapis") apply false
     id("net.ltgt.errorprone") apply false
+    id("com.github.vlsi.jandex") apply false
     id("org.owasp.dependencycheck")
     id("com.github.johnrengelman.shadow") apply false
     // IDE configuration
@@ -68,6 +69,7 @@ val lastEditYear by extra(lastEditYear())
 val enableSpotBugs = props.bool("spotbugs")
 val enableCheckerframework by props()
 val enableErrorprone by props()
+val skipJandex by props(true) // It will be enabled by default as Jandex issues are resolved
 val skipCheckstyle by props()
 val skipAutostyle by props()
 val skipJavadoc by props()
@@ -442,6 +444,15 @@ allprojects {
 
         apply(plugin = "de.thetaphi.forbiddenapis")
         apply(plugin = "maven-publish")
+
+        if (!skipJandex) {
+            apply(plugin = "com.github.vlsi.jandex")
+
+            project.configure<com.github.vlsi.jandex.JandexExtension> {
+                toolVersion.set("jandex".v)
+                skipIndexFileGeneration()
+            }
+        }
 
         if (!enableGradleMetadata) {
             tasks.withType<GenerateModuleMetadata> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ org.checkerframework.version=0.5.10
 com.github.autostyle.version=3.0
 com.github.johnrengelman.shadow.version=5.1.0
 com.github.spotbugs.version=2.0.0
-com.github.vlsi.vlsi-release-plugins.version=1.70
+com.github.vlsi.vlsi-release-plugins.version=1.72
 com.google.protobuf.version=0.8.10
 de.thetaphi.forbiddenapis.version=3.1
 kotlin.version=1.3.50
@@ -65,6 +65,7 @@ checkerframework.version=3.7.0
 checkstyle.version=8.28
 spotbugs.version=3.1.11
 errorprone.version=2.4.0
+jandex.version=2.2.2.Final
 
 # We support Guava versions as old as 14.0.1 (the version used by Hive)
 # but prefer more recent versions.
@@ -84,7 +85,6 @@ commons-lang3.version=3.8
 dropwizard-metrics.version=4.0.5
 elasticsearch.version=7.0.1
 embedded-redis.version=0.6
-errorprone.version=2.4.0
 esri-geometry-api.version=2.2.0
 foodmart-data-hsqldb.version=0.3
 foodmart-data-json.version=0.4

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ pluginManagement {
         idv("com.github.vlsi.crlf", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.gradle-extensions", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.ide", "com.github.vlsi.vlsi-release-plugins")
+        idv("com.github.vlsi.jandex", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.license-gather", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.stage-vote-release", "com.github.vlsi.vlsi-release-plugins")
         idv("com.google.protobuf")
@@ -36,6 +37,12 @@ pluginManagement {
         idv("org.nosphere.apache.rat")
         idv("org.owasp.dependencycheck")
         kotlin("jvm") version "kotlin".v()
+    }
+    if (extra.has("enableMavenLocal") && extra["enableMavenLocal"].toString().ifBlank { "true" }.toBoolean()) {
+        repositories {
+            mavenLocal()
+            gradlePluginPortal()
+        }
     }
 }
 


### PR DESCRIPTION
The PR adds optional (disabled by default) verification.

Verification can be performed with `./gradlew -PskipJandex=false jandex`