### PR TITLE
[CALCITE-4461] Do not use `Logical` nodes inside Enumerable rules (Vladimir Ozerov)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAggregateRule.java
@@ -21,13 +21,14 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.InvalidRelException;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Rule to convert a {@link org.apache.calcite.rel.logical.LogicalAggregate}
- * to an {@link EnumerableAggregate}.
+ * Rule to convert a {@link LogicalAggregate} to an {@link EnumerableAggregate}.
+ * You may provide a custom config to convert other nodes that extend {@link Aggregate}.
  *
  * @see EnumerableRules#ENUMERABLE_AGGREGATE_RULE
  */
@@ -44,7 +45,7 @@ class EnumerableAggregateRule extends ConverterRule {
   }
 
   @Override public @Nullable RelNode convert(RelNode rel) {
-    final LogicalAggregate agg = (LogicalAggregate) rel;
+    final Aggregate agg = (Aggregate) rel;
     final RelTraitSet traitSet = rel.getCluster()
         .traitSet().replace(EnumerableConvention.INSTANCE);
     try {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoinRule.java
@@ -39,9 +39,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/** Planner rule that converts a
- * {@link org.apache.calcite.rel.logical.LogicalJoin} into an
- * {@link org.apache.calcite.adapter.enumerable.EnumerableBatchNestedLoopJoin}.
+/** Rule to convert a {@link LogicalJoin} to an {@link EnumerableBatchNestedLoopJoin}.
+ * You may provide a custom config to convert other nodes that extend {@link Join}.
  *
  * @see EnumerableRules#ENUMERABLE_BATCH_NESTED_LOOP_JOIN_RULE
  */

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalcRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCalcRule.java
@@ -20,11 +20,12 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.logical.LogicalCalc;
 
 /**
- * Rule to convert a {@link org.apache.calcite.rel.logical.LogicalCalc} to an
- * {@link EnumerableCalc}.
+ * Rule to convert a {@link LogicalCalc} to an {@link EnumerableCalc}.
+ * You may provide a custom config to convert other nodes that extend {@link Calc}.
  *
  * @see EnumerableRules#ENUMERABLE_CALC_RULE
  */
@@ -44,7 +45,7 @@ class EnumerableCalcRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalCalc calc = (LogicalCalc) rel;
+    final Calc calc = (Calc) rel;
     final RelNode input = calc.getInput();
     return EnumerableCalc.create(
         convert(input,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelateRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelateRule.java
@@ -19,6 +19,7 @@ package org.apache.calcite.adapter.enumerable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.logical.LogicalCorrelate;
 
 /**
@@ -40,7 +41,7 @@ public class EnumerableCorrelateRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalCorrelate c = (LogicalCorrelate) rel;
+    final Correlate c = (Correlate) rel;
     return EnumerableCorrelate.create(
         convert(c.getLeft(), c.getLeft().getTraitSet()
             .replace(EnumerableConvention.INSTANCE)),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilterRule.java
@@ -19,11 +19,12 @@ package org.apache.calcite.adapter.enumerable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.logical.LogicalFilter;
 
 /**
- * Rule to convert a {@link org.apache.calcite.rel.logical.LogicalFilter} to an
- * {@link EnumerableFilter}.
+ * Rule to convert a {@link LogicalFilter} to an {@link EnumerableFilter}.
+ * You may provide a custom config to convert other nodes that extend {@link Filter}.
  *
  * @see EnumerableRules#ENUMERABLE_FILTER_RULE
  */
@@ -41,7 +42,7 @@ class EnumerableFilterRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalFilter filter = (LogicalFilter) rel;
+    final Filter filter = (Filter) rel;
     return new EnumerableFilter(rel.getCluster(),
         rel.getTraitSet().replace(EnumerableConvention.INSTANCE),
         convert(filter.getInput(),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableIntersectRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableIntersectRule.java
@@ -20,12 +20,12 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Intersect;
 import org.apache.calcite.rel.logical.LogicalIntersect;
 
 /**
- * Rule to convert a
- * {@link org.apache.calcite.rel.logical.LogicalIntersect} to an
- * {@link EnumerableIntersect}.
+ * Rule to convert a {@link LogicalIntersect} to an {@link EnumerableIntersect}.
+ * You may provide a custom config to convert other nodes that extend {@link Intersect}.
  *
  * @see EnumerableRules#ENUMERABLE_INTERSECT_RULE
  */
@@ -42,7 +42,7 @@ class EnumerableIntersectRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalIntersect intersect = (LogicalIntersect) rel;
+    final Intersect intersect = (Intersect) rel;
     final EnumerableConvention out = EnumerableConvention.INSTANCE;
     final RelTraitSet traitSet = intersect.getTraitSet().replace(out);
     return new EnumerableIntersect(rel.getCluster(), traitSet,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableJoinRule.java
@@ -19,6 +19,7 @@ package org.apache.calcite.adapter.enumerable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rex.RexBuilder;
@@ -30,8 +31,9 @@ import java.util.Arrays;
 import java.util.List;
 
 /** Planner rule that converts a
- * {@link org.apache.calcite.rel.logical.LogicalJoin} relational expression
+ * {@link LogicalJoin} relational expression
  * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention enumerable calling convention}.
+ * You may provide a custom config to convert other nodes that extend {@link Join}.
  *
  * @see EnumerableRules#ENUMERABLE_JOIN_RULE */
 class EnumerableJoinRule extends ConverterRule {
@@ -47,7 +49,7 @@ class EnumerableJoinRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    LogicalJoin join = (LogicalJoin) rel;
+    Join join = (Join) rel;
     List<RelNode> newInputs = new ArrayList<>();
     for (RelNode input : join.getInputs()) {
       if (!(input.getConvention() instanceof EnumerableConvention)) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitSortRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitSortRule.java
@@ -36,7 +36,7 @@ public class EnumerableLimitSortRule extends RelRule<EnumerableLimitSortRule.Con
   }
 
   @Override public void onMatch(RelOptRuleCall call) {
-    final LogicalSort sort = call.rel(0);
+    final Sort sort = call.rel(0);
     RelNode input = sort.getInput();
     final Sort o = EnumerableLimitSort.create(
         convert(input, input.getTraitSet().replace(EnumerableConvention.INSTANCE)),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMatchRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMatchRule.java
@@ -19,11 +19,12 @@ package org.apache.calcite.adapter.enumerable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Match;
 import org.apache.calcite.rel.logical.LogicalMatch;
 
 /**
- * Rule to convert a {@link LogicalMatch} to an
- * {@link EnumerableMatch}.
+ * Rule to convert a {@link LogicalMatch} to an {@link EnumerableMatch}.
+ * You may provide a custom config to convert other nodes that extend {@link Match}.
  *
  * @see EnumerableRules#ENUMERABLE_MATCH_RULE
  */
@@ -40,7 +41,7 @@ public class EnumerableMatchRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalMatch match = (LogicalMatch) rel;
+    final Match match = (Match) rel;
     return EnumerableMatch.create(
         convert(match.getInput(),
             match.getInput().getTraitSet()

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoinRule.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rex.RexBuilder;
@@ -38,8 +39,9 @@ import java.util.Arrays;
 import java.util.List;
 
 /** Planner rule that converts a
- * {@link org.apache.calcite.rel.logical.LogicalJoin} relational expression
+ * {@link LogicalJoin} relational expression
  * {@link EnumerableConvention enumerable calling convention}.
+ * You may provide a custom config to convert other nodes that extend {@link Join}.
  *
  * @see EnumerableJoinRule
  * @see EnumerableRules#ENUMERABLE_MERGE_JOIN_RULE
@@ -57,7 +59,7 @@ class EnumerableMergeJoinRule extends ConverterRule {
   }
 
   @Override public @Nullable RelNode convert(RelNode rel) {
-    LogicalJoin join = (LogicalJoin) rel;
+    Join join = (Join) rel;
     final JoinInfo info = join.analyzeCondition();
     if (!EnumerableMergeJoin.isMergeJoinSupported(join.getJoinType())) {
       // EnumerableMergeJoin only supports certain join types.

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMinusRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMinusRule.java
@@ -20,11 +20,12 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Minus;
 import org.apache.calcite.rel.logical.LogicalMinus;
 
 /**
- * Rule to convert an {@link org.apache.calcite.rel.logical.LogicalMinus} to an
- * {@link EnumerableMinus}.
+ * Rule to convert an {@link LogicalMinus} to an {@link EnumerableMinus}.
+ * You may provide a custom config to convert other nodes that extend {@link Minus}.
  *
  * @see EnumerableRules#ENUMERABLE_MINUS_RULE
  */
@@ -41,7 +42,7 @@ class EnumerableMinusRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalMinus minus = (LogicalMinus) rel;
+    final Minus minus = (Minus) rel;
     final EnumerableConvention out = EnumerableConvention.INSTANCE;
     final RelTraitSet traitSet =
         rel.getTraitSet().replace(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProjectRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProjectRule.java
@@ -19,11 +19,12 @@ package org.apache.calcite.adapter.enumerable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.logical.LogicalProject;
 
 /**
- * Rule to convert a {@link org.apache.calcite.rel.logical.LogicalProject} to an
- * {@link EnumerableProject}.
+ * Rule to convert a {@link LogicalProject} to an {@link EnumerableProject}.
+ * You may provide a custom config to convert other nodes that extend {@link Project}.
  *
  * @see EnumerableRules#ENUMERABLE_PROJECT_RULE
  */
@@ -42,7 +43,7 @@ class EnumerableProjectRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalProject project = (LogicalProject) rel;
+    final Project project = (Project) rel;
     return EnumerableProject.create(
         convert(project.getInput(),
             project.getInput().getTraitSet()

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRepeatUnionRule.java
@@ -20,11 +20,12 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.RepeatUnion;
 import org.apache.calcite.rel.logical.LogicalRepeatUnion;
 
 /**
- * Rule to convert a {@link LogicalRepeatUnion} into an
- * {@link EnumerableRepeatUnion}.
+ * Rule to convert a {@link LogicalRepeatUnion} into an {@link EnumerableRepeatUnion}.
+ * You may provide a custom config to convert other nodes that extend {@link RepeatUnion}.
  *
  * @see EnumerableRules#ENUMERABLE_REPEAT_UNION_RULE
  */
@@ -41,7 +42,7 @@ public class EnumerableRepeatUnionRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    LogicalRepeatUnion union = (LogicalRepeatUnion) rel;
+    RepeatUnion union = (RepeatUnion) rel;
     EnumerableConvention out = EnumerableConvention.INSTANCE;
     RelTraitSet traitSet = union.getTraitSet().replace(out);
     RelNode seedRel = union.getSeedRel();

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSortedAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSortedAggregateRule.java
@@ -28,8 +28,8 @@ import org.apache.calcite.util.ImmutableIntList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Rule to convert a {@link LogicalAggregate}
- * to an {@link EnumerableSortedAggregate}.
+ * Rule to convert a {@link LogicalAggregate} to an {@link EnumerableSortedAggregate}.
+ * You may provide a custom config to convert other nodes that extend {@link Aggregate}.
  *
  * @see EnumerableRules#ENUMERABLE_SORTED_AGGREGATE_RULE
  */
@@ -46,7 +46,7 @@ class EnumerableSortedAggregateRule extends ConverterRule {
   }
 
   @Override public @Nullable RelNode convert(RelNode rel) {
-    final LogicalAggregate agg = (LogicalAggregate) rel;
+    final Aggregate agg = (Aggregate) rel;
     if (!Aggregate.isSimple(agg)) {
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableFunctionScanRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableFunctionScanRule.java
@@ -20,11 +20,11 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
 
-/** Planner rule that converts a
- * {@link org.apache.calcite.rel.logical.LogicalTableFunctionScan} to
- * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention enumerable calling convention}.
+/** Rule to convert a {@link LogicalTableFunctionScan} to an {@link EnumerableTableFunctionScan}.
+ * You may provide a custom config to convert other nodes that extend {@link TableFunctionScan}.
  *
  * @see EnumerableRules#ENUMERABLE_TABLE_FUNCTION_SCAN_RULE */
 public class EnumerableTableFunctionScanRule extends ConverterRule {
@@ -43,7 +43,7 @@ public class EnumerableTableFunctionScanRule extends ConverterRule {
   @Override public RelNode convert(RelNode rel) {
     final RelTraitSet traitSet =
         rel.getTraitSet().replace(EnumerableConvention.INSTANCE);
-    LogicalTableFunctionScan scan = (LogicalTableFunctionScan) rel;
+    TableFunctionScan scan = (TableFunctionScan) rel;
     return new EnumerableTableFunctionScan(rel.getCluster(), traitSet,
         convertList(scan.getInputs(), traitSet.getTrait(0)),
         scan.getElementType(), scan.getRowType(),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModifyRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModifyRule.java
@@ -20,14 +20,14 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.logical.LogicalTableModify;
 import org.apache.calcite.schema.ModifiableTable;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** Planner rule that converts a
- * {@link org.apache.calcite.rel.logical.LogicalTableModify} to
- * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention enumerable calling convention}.
+/** Planner rule that converts a {@link LogicalTableModify} to an {@link EnumerableTableModify}.
+ * You may provide a custom config to convert other nodes that extend {@link TableModify}.
  *
  * @see EnumerableRules#ENUMERABLE_TABLE_MODIFICATION_RULE */
 public class EnumerableTableModifyRule extends ConverterRule {
@@ -43,8 +43,7 @@ public class EnumerableTableModifyRule extends ConverterRule {
   }
 
   @Override public @Nullable RelNode convert(RelNode rel) {
-    final LogicalTableModify modify =
-        (LogicalTableModify) rel;
+    final TableModify modify = (TableModify) rel;
     final ModifiableTable modifiableTable =
         modify.getTable().unwrap(ModifiableTable.class);
     if (modifiableTable == null) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableScanRule.java
@@ -20,15 +20,15 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.schema.QueryableTable;
 import org.apache.calcite.schema.Table;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** Planner rule that converts a
- * {@link org.apache.calcite.rel.logical.LogicalTableScan} to
- * {@link EnumerableConvention enumerable calling convention}.
+/** Planner rule that converts a {@link LogicalTableScan} to an {@link EnumerableTableScan}.
+ * You may provide a custom config to convert other nodes that extend {@link TableScan}.
  *
  * @see EnumerableRules#ENUMERABLE_TABLE_SCAN_RULE */
 public class EnumerableTableScanRule extends ConverterRule {
@@ -46,7 +46,7 @@ public class EnumerableTableScanRule extends ConverterRule {
   }
 
   @Override public @Nullable RelNode convert(RelNode rel) {
-    LogicalTableScan scan = (LogicalTableScan) rel;
+    TableScan scan = (TableScan) rel;
     final RelOptTable relOptTable = scan.getTable();
     final Table table = relOptTable.unwrap(Table.class);
     // The QueryableTable can only be implemented as ENUMERABLE convention,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableSpoolRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableSpoolRule.java
@@ -20,11 +20,12 @@ import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.TableSpool;
 import org.apache.calcite.rel.logical.LogicalTableSpool;
 
 /**
- * Rule to convert a {@link LogicalTableSpool} into an
- * {@link EnumerableTableSpool}.
+ * Rule to convert a {@link LogicalTableSpool} into an {@link EnumerableTableSpool}.
+ * You may provide a custom config to convert other nodes that extend {@link TableSpool}.
  *
  * <p>NOTE: The current API is experimental and subject to change without
  * notice.
@@ -45,7 +46,7 @@ public class EnumerableTableSpoolRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    LogicalTableSpool spool = (LogicalTableSpool) rel;
+    TableSpool spool = (TableSpool) rel;
     return EnumerableTableSpool.create(
         convert(spool.getInput(),
             spool.getInput().getTraitSet().replace(EnumerableConvention.INSTANCE)),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableUnionRule.java
@@ -20,14 +20,15 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.util.Util;
 
 import java.util.List;
 
 /**
- * Rule to convert an {@link org.apache.calcite.rel.logical.LogicalUnion} to an
- * {@link EnumerableUnion}.
+ * Rule to convert an {@link LogicalUnion} to an {@link EnumerableUnion}.
+ * You may provide a custom config to convert other nodes that extend {@link Union}.
  *
  * @see EnumerableRules#ENUMERABLE_UNION_RULE
  */
@@ -44,7 +45,7 @@ class EnumerableUnionRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalUnion union = (LogicalUnion) rel;
+    final Union union = (Union) rel;
     final EnumerableConvention out = EnumerableConvention.INSTANCE;
     final RelTraitSet traitSet = rel.getCluster().traitSet().replace(out);
     final List<RelNode> newInputs = Util.transform(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableValuesRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableValuesRule.java
@@ -19,12 +19,11 @@ package org.apache.calcite.adapter.enumerable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.logical.LogicalValues;
 
-/** Planner rule that converts a
- * {@link org.apache.calcite.rel.logical.LogicalValues}
- * relational expression
- * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention enumerable calling convention}.
+/** Planner rule that converts a {@link LogicalValues} to an {@link EnumerableValues}.
+ * You may provide a custom config to convert other nodes that extend {@link Values}.
  *
  * @see EnumerableRules#ENUMERABLE_VALUES_RULE */
 public class EnumerableValuesRule extends ConverterRule {
@@ -40,7 +39,7 @@ public class EnumerableValuesRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalValues logicalValues = (LogicalValues) rel;
+    final Values logicalValues = (Values) rel;
     final EnumerableValues enumerableValues = EnumerableValues.create(
         logicalValues.getCluster(), logicalValues.getRowType(), logicalValues.getTuples());
     return enumerableValues.copy(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindowRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindowRule.java
@@ -20,11 +20,12 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.logical.LogicalWindow;
 
 /**
- * Rule to convert a {@link org.apache.calcite.rel.logical.LogicalWindow} to
- * an {@link org.apache.calcite.adapter.enumerable.EnumerableWindow}.
+ * Rule to convert a {@link LogicalWindow} to an {@link EnumerableWindow}.
+ * You may provide a custom config to convert other nodes that extend {@link Window}.
  *
  * @see EnumerableRules#ENUMERABLE_WINDOW_RULE
  */
@@ -41,7 +42,7 @@ class EnumerableWindowRule extends ConverterRule {
   }
 
   @Override public RelNode convert(RelNode rel) {
-    final LogicalWindow winAgg = (LogicalWindow) rel;
+    final Window winAgg = (Window) rel;
     final RelTraitSet traitSet =
         winAgg.getTraitSet().replace(EnumerableConvention.INSTANCE);
     final RelNode child = winAgg.getInput();


### PR DESCRIPTION
This PR removes casts to `Logical` operators in `Enumerable` rules.