### PR TITLE
[CALCITE-4463] SqlOrderBy should use dialect.unparseOffsetFetch method

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlOrderBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOrderBy.java
@@ -97,26 +97,10 @@ public class SqlOrderBy extends SqlCall {
         writer.list(SqlWriter.FrameTypeEnum.ORDER_BY_LIST, SqlWriter.COMMA,
             orderBy.orderList);
       }
-      if (orderBy.offset != null) {
-        final SqlWriter.Frame frame2 =
-            writer.startList(SqlWriter.FrameTypeEnum.OFFSET);
-        writer.newlineAndIndent();
-        writer.keyword("OFFSET");
-        orderBy.offset.unparse(writer, -1, -1);
-        writer.keyword("ROWS");
-        writer.endList(frame2);
+      if (orderBy.offset != null || orderBy.fetch != null) {
+        writer.getDialect().unparseOffsetFetch(writer, orderBy.offset, orderBy.fetch);
       }
-      if (orderBy.fetch != null) {
-        final SqlWriter.Frame frame3 =
-            writer.startList(SqlWriter.FrameTypeEnum.FETCH);
-        writer.newlineAndIndent();
-        writer.keyword("FETCH");
-        writer.keyword("NEXT");
-        orderBy.fetch.unparse(writer, -1, -1);
-        writer.keyword("ROWS");
-        writer.keyword("ONLY");
-        writer.endList(frame3);
-      }
+
       writer.endList(frame);
     }
   }

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSetOption;
 import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.dialect.SparkSqlDialect;
 import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.test.SqlTests;
@@ -3163,6 +3164,31 @@ public class SqlParserTest {
             + "FROM `FOO`\n"
             + "ORDER BY `B`, `C`\n"
             + "OFFSET 1 ROWS");
+  }
+
+  /**
+   * same as {@link #testLimit} test method but specific spark dialect.
+   */
+  @Test void testLimitWithSparkDialect() {
+    sql("select a from foo order by b, c limit 2 offset 1")
+        .withDialect(SparkSqlDialect.DEFAULT)
+        .ok("SELECT A\n"
+            + "FROM FOO\n"
+            + "ORDER BY B, C\n"
+            + "LIMIT 2\n"
+            + "OFFSET 1");
+    sql("select a from foo order by b, c limit 2")
+        .withDialect(SparkSqlDialect.DEFAULT)
+        .ok("SELECT A\n"
+            + "FROM FOO\n"
+            + "ORDER BY B, C\n"
+            + "LIMIT 2");
+    sql("select a from foo order by b, c offset 1")
+        .withDialect(SparkSqlDialect.DEFAULT)
+        .ok("SELECT A\n"
+            + "FROM FOO\n"
+            + "ORDER BY B, C\n"
+            + "OFFSET 1");
   }
 
   /** Test case that does not reproduce but is related to


### PR DESCRIPTION
related jira: https://issues.apache.org/jira/browse/CALCITE-4463