### PR TITLE
[CALCITE-4265] Improve error message when CAST to unknown type (Louis

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1759,6 +1759,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   @Override public RelDataType getValidatedNodeType(SqlNode node) {
     RelDataType type = getValidatedNodeTypeIfKnown(node);
     if (type == null) {
+      if (node.getKind() == SqlKind.IDENTIFIER) {
+        throw newValidationError(node, RESOURCE.unknownIdentifier(node.toString()));
+      }
       throw Util.needToImplement(node);
     } else {
       return type;

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1225,8 +1225,8 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test void testCastRegisteredType() {
-    expr("cast(123 as customBigInt)")
-        .fails("class org.apache.calcite.sql.SqlIdentifier: CUSTOMBIGINT");
+    expr("cast(123 as ^customBigInt^)")
+        .fails("Unknown identifier 'CUSTOMBIGINT'");
     expr("cast(123 as sales.customBigInt)")
         .columnType("BIGINT NOT NULL");
     expr("cast(123 as catalog.sales.customBigInt)")
@@ -1235,7 +1235,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
   @Test void testCastFails() {
     expr("cast('foo' as ^bar^)")
-        .fails("class org.apache.calcite.sql.SqlIdentifier: BAR");
+        .fails("Unknown identifier 'BAR'");
     wholeExpr("cast(multiset[1] as integer)")
         .fails("(?s).*Cast function cannot convert value of type "
             + "INTEGER MULTISET to type INTEGER");
@@ -7988,9 +7988,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             + "VARCHAR(5) NOT NULL ARRAY NOT NULL F1) NOT NULL "
             + "ARRAY NOT NULL MULTISET NOT NULL");
     // test UDT collection type.
-    sql("select cast(a as MyUDT array multiset) from COMPLEXTYPES.CTC_T1")
+    sql("select cast(a as ^MyUDT^ array multiset) from COMPLEXTYPES.CTC_T1")
         .withExtendedCatalog()
-        .fails("(?s).*class org\\.apache\\.calcite\\.sql\\.SqlIdentifier: MYUDT.*");
+        .fails("Unknown identifier 'MYUDT'");
   }
 
   @Test void testCastAsRowType() {


### PR DESCRIPTION
Kuang)

If SqlNode is an Identifier node whose type can not be derived, throws
a validation error instead of an UnsupportedOperationException to improve
error message.