### PR TITLE
[CALCITE-4474] SqlSimpleParser inner Tokenizer should not recognize the sql of TokenType.ID or some keywords in some case

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/advise/SqlSimpleParser.java
+++ b/core/src/main/java/org/apache/calcite/sql/advise/SqlSimpleParser.java
@@ -405,9 +405,16 @@ public class SqlSimpleParser {
               case ')':
               case '/':
               case ',':
+              case '\'':
                 break loop;
+              case '-':
+                // possible start of '--' comment
+                if (c == '-' && pos + 1 < sql.length() && sql.charAt(pos + 1) == '-') {
+                  break loop;
+                }
+                // fall through
               default:
-                if (Character.isWhitespace(c)) {
+                if (Character.isWhitespace(c) || c == openQuote) {
                   break loop;
                 } else {
                   ++pos;

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -1584,5 +1586,48 @@ class SqlAdvisorTest extends SqlValidatorTestCase {
         "SELECT * FROM [DEPT] a WHERE _suggest_ and deptno < 5";
     assertSimplify(sql, simplified);
     assertComplete(sql, EXPR_KEYWORDS, Collections.singletonList("TABLE(a)"), DEPT_COLUMNS);
+  }
+
+
+  @Test public void testFilterComment() {
+    // SqlSimpleParser.Tokenizer#nextToken() lines 401 - 423
+    // is used to recognize the sql of TokenType.ID or some keywords
+    // if a certain segment of characters is continuously composed of Token,
+    // the function of this code may be wrong
+    // E.g :
+    // (1)select * from a where price> 10.0--comment
+    // 【10.0--comment】should be recognize as TokenType.ID("10.0") and TokenType.COMMENT
+    // but it recognize as TokenType.ID("10.0--comment")
+    // (2)select * from a where column_b='/* this is not comment */'
+    // 【/* this is not comment */】should be recognize as
+    // TokenType.SQID("/* this is not comment */"), but it was not
+
+    final String baseOriginSql = "select * from a ";
+    final String baseResultSql = "SELECT * FROM a ";
+    String originSql;
+
+    // when SqlSimpleParser.Tokenizer#nextToken() method parse sql,
+    // ignore the  "--" after 10.0, this is a comment,
+    // but Tokenizer#nextToken() does not recognize it
+    originSql = baseOriginSql + "where price > 10.0-- this is comment "
+        + System.lineSeparator() + " -- comment ";
+    filterCommentHelper(originSql, baseResultSql + "WHERE price > 10.0");
+
+    originSql = baseOriginSql + "where column_b='/* this is not comment */'";
+    filterCommentHelper(originSql, baseResultSql + "WHERE column_b= '/* this is not comment */'");
+
+    originSql = baseOriginSql + "where column_b='2021 --this is not comment'";
+    filterCommentHelper(originSql, baseResultSql + "WHERE column_b= '2021 --this is not comment'");
+
+    originSql = baseOriginSql + "where column_b='2021--this is not comment'";
+    filterCommentHelper(originSql, baseResultSql + "WHERE column_b= '2021--this is not comment'");
+  }
+
+  private void filterCommentHelper(String originSql, String expectedSql) {
+    SqlSimpleParser simpleParser =
+        new SqlSimpleParser("_suggest_", SqlParser.Config.DEFAULT);
+
+    String actualSql = simpleParser.simplifySql(originSql);
+    assertThat(originSql, actualSql, equalTo(expectedSql));
   }
 }

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -1611,23 +1611,29 @@ class SqlAdvisorTest extends SqlValidatorTestCase {
     // but Tokenizer#nextToken() does not recognize it
     originSql = baseOriginSql + "where price > 10.0-- this is comment "
         + System.lineSeparator() + " -- comment ";
-    filterCommentHelper(originSql, baseResultSql + "WHERE price > 10.0");
+    assertSimplifySql(originSql, baseResultSql + "WHERE price > 10.0");
 
     originSql = baseOriginSql + "where column_b='/* this is not comment */'";
-    filterCommentHelper(originSql, baseResultSql + "WHERE column_b= '/* this is not comment */'");
+    assertSimplifySql(originSql, baseResultSql + "WHERE column_b= '/* this is not comment */'");
 
     originSql = baseOriginSql + "where column_b='2021 --this is not comment'";
-    filterCommentHelper(originSql, baseResultSql + "WHERE column_b= '2021 --this is not comment'");
+    assertSimplifySql(originSql, baseResultSql + "WHERE column_b= '2021 --this is not comment'");
 
     originSql = baseOriginSql + "where column_b='2021--this is not comment'";
-    filterCommentHelper(originSql, baseResultSql + "WHERE column_b= '2021--this is not comment'");
+    assertSimplifySql(originSql, baseResultSql + "WHERE column_b= '2021--this is not comment'");
   }
 
-  private void filterCommentHelper(String originSql, String expectedSql) {
+  /**
+   * Tests that the simplified originSql is consistent with expectedSql.
+   *
+   * @param originSql   a string sql to simplify.
+   * @param expectedSql Expected result after simplification.
+   */
+  private void assertSimplifySql(String originSql, String expectedSql) {
     SqlSimpleParser simpleParser =
         new SqlSimpleParser("_suggest_", SqlParser.Config.DEFAULT);
 
     String actualSql = simpleParser.simplifySql(originSql);
-    assertThat(originSql, actualSql, equalTo(expectedSql));
+    assertThat("simpleParser.simplifySql(" + originSql + ")", actualSql, equalTo(expectedSql));
   }
 }


### PR DESCRIPTION
Hi, this PR is uesd for solve [CALCITE-4474](https://issues.apache.org/jira/browse/CALCITE-4474)

If you think something is wrong, please comment below, i will keep eye on it.