### PR TITLE
[CALCITE-4459] Verify the bytecode with Jandex by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ val lastEditYear by extra(lastEditYear())
 val enableSpotBugs = props.bool("spotbugs")
 val enableCheckerframework by props()
 val enableErrorprone by props()
-val skipJandex by props(true) // It will be enabled by default as Jandex issues are resolved
+val skipJandex by props()
 val skipCheckstyle by props()
 val skipAutostyle by props()
 val skipJavadoc by props()

--- a/gradle.properties
+++ b/gradle.properties
@@ -65,7 +65,8 @@ checkerframework.version=3.7.0
 checkstyle.version=8.28
 spotbugs.version=3.1.11
 errorprone.version=2.4.0
-jandex.version=2.2.2.Final
+# The property is used in https://github.com/wildfly/jandex regression testing, so avoid renaming
+jandex.version=2.2.3.Final
 
 # We support Guava versions as old as 14.0.1 (the version used by Hive)
 # but prefer more recent versions.


### PR DESCRIPTION
Here's the relevant jandex release notice: https://github.com/wildfly/jandex/pull/104#issuecomment-765690070