### PR TITLE
[CALCITE-4140] Use Wasabi S3 for remote build cache

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -1,0 +1,33 @@
+name: Seed build cache
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  ubuntu-code-style:
+    strategy:
+      matrix:
+        os: [ubuntu, macos, windows]
+        jdk: [8, 11, 15]
+
+    name: '${{ matrix.os }}, ${{ matrix.jdk }} seed build cache'
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK ${{ matrix.jdk }}'
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+      - uses: burrunan/gradle-cache-action@v1
+        name: Build Calcite
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        with:
+          job-id: jdk${{ matrix.jdk }}
+          remote-build-cache-proxy-enabled: false
+          arguments: --scan --no-parallel --no-daemon build -x test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,12 @@ jobs:
         java-version: 8
     - uses: burrunan/gradle-cache-action@v1
       name: Test
+      env:
+        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         job-id: jdk${{ matrix.jdk }}
+        remote-build-cache-proxy-enabled: false
         arguments: --scan --no-parallel --no-daemon build javadoc
     - name: 'sqlline and sqllsh'
       shell: cmd
@@ -82,8 +86,12 @@ jobs:
         git clone --branch master --depth 100 https://github.com/apache/calcite-avatica.git ../calcite-avatica
     - uses: burrunan/gradle-cache-action@v1
       name: Build Avatica
+      env:
+        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         job-id: avatica-jdk${{ matrix.jdk }}
+        remote-build-cache-proxy-enabled: false
         build-root-directory: ../calcite-avatica
         arguments: publishToMavenLocal
         properties: |
@@ -94,8 +102,12 @@ jobs:
         fetch-depth: 50
     - uses: burrunan/gradle-cache-action@v1
       name: Test
+      env:
+        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         job-id: jdk${{ matrix.jdk }}
+        remote-build-cache-proxy-enabled: false
         execution-only-caches: true
         arguments: --scan --no-parallel --no-daemon build javadoc
         properties: |
@@ -117,8 +129,12 @@ jobs:
           architecture: x64
       - uses: burrunan/gradle-cache-action@v1
         name: Test
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           job-id: jdk8-openj9
+          remote-build-cache-proxy-enabled: false
           arguments: --scan --no-parallel --no-daemon build javadoc
       - name: 'sqlline and sqllsh'
         run: |
@@ -144,8 +160,12 @@ jobs:
           java-version: 15
       - uses: burrunan/gradle-cache-action@v1
         name: Test
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           job-id: jdk15
+          remote-build-cache-proxy-enabled: false
           arguments: --scan --no-parallel --no-daemon build javadoc
       - name: 'sqlline and sqllsh'
         run: |
@@ -171,8 +191,12 @@ jobs:
           java-version: 11
       - uses: burrunan/gradle-cache-action@v1
         name: Test
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           job-id: errprone
+          remote-build-cache-proxy-enabled: false
           arguments: --scan --no-parallel --no-daemon -PenableErrorprone classes
 
   linux-checkerframework:
@@ -188,8 +212,12 @@ jobs:
           java-version: 11
       - name: 'Run CheckerFramework'
         uses: burrunan/gradle-cache-action@v1
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           job-id: checkerframework-jdk11
+          remote-build-cache-proxy-enabled: false
           arguments: --scan --no-parallel --no-daemon -PenableCheckerframework :linq4j:classes :core:classes
 
   linux-slow:
@@ -208,8 +236,12 @@ jobs:
           java-version: 8
       - uses: burrunan/gradle-cache-action@v1
         name: Test
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           job-id: jdk8
+          remote-build-cache-proxy-enabled: false
           arguments: --scan --no-parallel --no-daemon testSlow
 
   linux-druid:
@@ -248,7 +280,11 @@ jobs:
         path: calcite
     - uses: burrunan/gradle-cache-action@v1
       name: 'Run Druid tests'
+      env:
+        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         build-root-directory: ./calcite
         job-id: Druid8
+        remote-build-cache-proxy-enabled: false
         arguments: --scan --no-parallel --no-daemon :druid:test -Dcalcite.test.druid=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true
 #org.gradle.caching.debug=true
+s3.build.cache=true
 # See https://github.com/gradle/gradle/pull/11358 , https://issues.apache.org/jira/browse/INFRA-14923
 # repository.apache.org does not yet support .sha256 and .sha512 checksums
 systemProp.org.gradle.internal.publish.checksums.insecure=true
@@ -44,6 +45,7 @@ calcite.avatica.version=1.17.0
 # Plugins
 org.checkerframework.version=0.5.15
 com.github.autostyle.version=3.0
+com.github.burrunan.s3-build-cache.version=1.1
 com.github.johnrengelman.shadow.version=5.1.0
 com.github.spotbugs.version=2.0.0
 com.github.vlsi.vlsi-release-plugins.version=1.72


### PR DESCRIPTION
Cache build artifacts, so expensive operations (e.g. compileJava, javadoc) do not need to be re-computed
The logic is as follows:
  1. Cache is populated only in CI that has S3_BUILD_CACHE_ACCESS_KEY_ID and S3_BUILD_CACHE_SECRET_KEY (GitHub Actions in the master branch)
  2. Otherwise the cache is read-only (e.g. every day builds and PR builds)