### PR TITLE
[CALCITE-4491] Aggregations of nested window functions produce invalid SQL

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1825,6 +1825,12 @@ public abstract class SqlImplementor {
       return false;
     }
 
+    /** Checks whether the aggregation node contains nested operands that match the predicate.
+     *
+     * @param rel aggregation node
+     * @param operandPredicate predicate for the nested operands
+     * @return if any of the nested operands passes the predicate test then true, false otherwise.
+     */
     private boolean hasNested(
         @UnknownInitialization Result this,
         Aggregate rel,

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1829,8 +1829,7 @@ public abstract class SqlImplementor {
      *
      * @param rel aggregation node
      * @param operandPredicate predicate for the nested operands
-     * @return if any of the nested operands passes the predicate test then true, false otherwise.
-     */
+     * @return if any of the nested operands passes the predicate test then true, false otherwise.*/
     private boolean hasNested(
         @UnknownInitialization Result this,
         Aggregate rel,

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1833,7 +1833,7 @@ public abstract class SqlImplementor {
     private boolean hasNested(
         @UnknownInitialization Result this,
         Aggregate rel,
-        Predicate<SqlNode> operandPredicate) {
+        Predicate<@Nullable SqlNode> operandPredicate) {
       if (node instanceof SqlSelect) {
         final SqlNodeList selectList = ((SqlSelect) node).getSelectList();
         if (selectList != null) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -828,9 +828,7 @@ class RelToSqlConverterTest {
     final RelBuilder builder = relBuilder();
     final RelNode root = builder
         .scan("EMP")
-        .project(
-            builder.field("SAL")
-        )
+        .project(builder.field("SAL"))
         .project(
             builder.alias(
                 builder.getRexBuilder().makeOver(
@@ -839,35 +837,26 @@ class RelToSqlConverterTest {
                     new ArrayList<>(),
                     new ArrayList<>(),
                     ImmutableList.of(
-                        new RexFieldCollation(builder.field("SAL"), ImmutableSet.of())
-                    ),
+                        new RexFieldCollation(builder.field("SAL"), ImmutableSet.of())),
                     RexWindowBounds.UNBOUNDED_PRECEDING,
                     RexWindowBounds.UNBOUNDED_FOLLOWING,
                     true,
                     true,
                     false,
                     false,
-                    false
-                ),
-                "rank"
-            )
-        )
+                    false),
+                "rank"))
         .as("tmp")
         .aggregate(
             builder.groupKey(),
             builder.count(
                 true,
                 "cnt",
-                builder.field("tmp", "rank")
-            )
-        )
+                builder.field("tmp", "rank")))
         .filter(
-            builder.call(
-                SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            builder.call(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
                 builder.field("cnt"),
-                builder.literal(10)
-            )
-        )
+                builder.literal(10)))
         .build();
 
     // Database not supporting nested aggregations
@@ -876,20 +865,14 @@ class RelToSqlConverterTest {
         + "FROM (SELECT RANK() OVER (ORDER BY \"SAL\") AS \"rank\"\n"
         + "FROM \"scott\".\"EMP\") AS \"t\"\n"
         + "HAVING COUNT(DISTINCT \"rank\") >= 10";
-    assertThat(
-        toSql(root, PostgresqlSqlDialect.DEFAULT),
-        isLinux(expectedPostgreSql)
-    );
+    assertThat(toSql(root, PostgresqlSqlDialect.DEFAULT), isLinux(expectedPostgreSql));
 
     // Database supporting nested aggregations
     final String expectedOracleSql =
         "SELECT COUNT(DISTINCT RANK() OVER (ORDER BY \"SAL\")) \"cnt\"\n"
         + "FROM \"scott\".\"EMP\"\n"
         + "HAVING COUNT(DISTINCT RANK() OVER (ORDER BY \"SAL\")) >= 10";
-    assertThat(
-        toSql(root, OracleSqlDialect.DEFAULT),
-        isLinux(expectedOracleSql)
-    );
+    assertThat(toSql(root, OracleSqlDialect.DEFAULT), isLinux(expectedOracleSql));
   }
 
   @Test void testSemiJoin() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -824,6 +824,11 @@ class RelToSqlConverterTest {
     assertThat(toSql(root), isLinux(expectedSql));
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4491">[CALCITE-4491]
+   * Aggregation of window function produces invalid SQL</a>.
+   */
   @Test void testAggregatedWindowFunction() {
     final RelBuilder builder = relBuilder();
     final RelNode root = builder

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -824,11 +824,9 @@ class RelToSqlConverterTest {
     assertThat(toSql(root), isLinux(expectedSql));
   }
 
-  /**
-   * Test case for
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-4491">[CALCITE-4491]
-   * Aggregation of window function produces invalid SQL</a>.
-   */
+   * Aggregation of window function produces invalid SQL</a>. */
   @Test void testAggregatedWindowFunction() {
     final RelBuilder builder = relBuilder();
     final RelNode root = builder


### PR DESCRIPTION
Dialects which do not support nested aggregations now also don't support
nested window functions.

The added test covers both cases:
- a dialect which supports nested aggregations -> OracleSqlDialect
- a dialect which does not support nested aggregations -> PostgreSqlDialect