### PR TITLE
[CALCITE-4511] The distinct row count and population size for constant columns should be 1

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -40,6 +40,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.ControlFlowException;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.RangeSets;
@@ -2289,6 +2290,28 @@ public class RexUtil {
       }
     }.visitEach(nodes);
     return occurrences;
+  }
+
+  /**
+   * Given some expressions, gets the indices of the non-constant ones.
+   */
+  public static ImmutableBitSet getNonConstColumns(List<RexNode> expressions) {
+    ImmutableBitSet cols = ImmutableBitSet.range(0, expressions.size());
+    return getNonConstColumns(cols, expressions);
+  }
+
+  /**
+   * Given some expressions and columns, gets the indices of the non-constant ones.
+   */
+  public static ImmutableBitSet getNonConstColumns(
+      ImmutableBitSet columns, List<RexNode> expressions) {
+    ImmutableBitSet.Builder nonConstCols = ImmutableBitSet.builder();
+    for (int col : columns) {
+      if (!isLiteral(expressions.get(col), true)) {
+        nonConstCols.set(col);
+      }
+    }
+    return nonConstCols.build();
   }
 
   //~ Inner Classes ----------------------------------------------------------


### PR DESCRIPTION
Suppose we have a relation with 3 columns: `(a, '1', '2')`. The first column comes from an underlying table, while the other two columns are constants.

For this relation, we should have `NDV({1}) = 1`, since column 1 is a constant (`NDV({1})` denotes the number of distinct values for column 1), which have only one possible value (suppose the column index starts from 0).

Similarly, we should have `NDV({1, 2}) = 1`, since both columns are constants.

We should also have `NDV({0, 1}) == NDV({0})`, because the number of distinct values depends on the non-const column, which is `a` from the underlying table.