### PR TITLE
[CALCITE-4510] RexLiteral can produce wrong digest for some user defined types

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -135,6 +135,8 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.calcite.rel.type.RelDataTypeImpl.NON_NULLABLE_SUFFIX;
+
 /**
  * <code>RelOptUtil</code> defines static utility methods for use in optimizing
  * {@link RelNode}s.
@@ -4315,7 +4317,7 @@ public abstract class RelOptUtil {
         this.indent = prevIndent;
         pw.print(")");
         if (!type.isNullable()) {
-          pw.print(" NOT NULL");
+          pw.print(NON_NULLABLE_SUFFIX);
         }
       } else if (type instanceof MultisetSqlType) {
         // E.g. "INTEGER NOT NULL MULTISET NOT NULL"
@@ -4326,7 +4328,7 @@ public abstract class RelOptUtil {
         accept(componentType);
         pw.print(" MULTISET");
         if (!type.isNullable()) {
-          pw.print(" NOT NULL");
+          pw.print(NON_NULLABLE_SUFFIX);
         }
       } else {
         // E.g. "INTEGER" E.g. "VARCHAR(240) CHARACTER SET "ISO-8859-1"

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -50,6 +50,12 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class RelDataTypeImpl
     implements RelDataType, RelDataTypeFamily {
+
+  /**
+   * Suffix for the digests of non-nullable types.
+   */
+  public static final String NON_NULLABLE_SUFFIX = " NOT NULL";
+
   //~ Instance fields --------------------------------------------------------
 
   protected final @Nullable List<RelDataTypeField> fieldList;
@@ -279,7 +285,7 @@ public abstract class RelDataTypeImpl
     StringBuilder sb = new StringBuilder();
     generateTypeString(sb, true);
     if (!isNullable()) {
-      sb.append(" NOT NULL");
+      sb.append(NON_NULLABLE_SUFFIX);
     }
     digest = sb.toString();
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -65,6 +65,7 @@ import java.util.Objects;
 import java.util.TimeZone;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
+import static org.apache.calcite.rel.type.RelDataTypeImpl.NON_NULLABLE_SUFFIX;
 
 import static java.util.Objects.requireNonNull;
 
@@ -432,11 +433,13 @@ public class RexLiteral extends RexNode {
     if (includeType != RexDigestIncludeType.NO_TYPE) {
       sb.append(':');
       final String fullTypeString = type.getFullTypeString();
-      if (!fullTypeString.endsWith("NOT NULL")) {
+
+      if (!fullTypeString.endsWith(NON_NULLABLE_SUFFIX)) {
         sb.append(fullTypeString);
       } else {
         // Trim " NOT NULL". Apparently, the literal is not null, so we just print the data type.
-        sb.append(fullTypeString, 0, fullTypeString.length() - 9);
+        sb.append(fullTypeString, 0,
+            fullTypeString.length() - NON_NULLABLE_SUFFIX.length());
       }
     }
     return sb.toString();

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.calcite.rel.type.RelDataTypeImpl.NON_NULLABLE_SUFFIX;
 import static org.apache.calcite.sql.type.NonNullableAccessors.getCharset;
 import static org.apache.calcite.sql.type.NonNullableAccessors.getCollation;
 import static org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow;
@@ -1194,8 +1195,8 @@ public abstract class SqlTypeUtil {
     }
 
     return (x.length() == y.length()
-        || x.length() == y.length() + 9 && x.endsWith(" NOT NULL"))
-        && x.startsWith(y);
+        || x.length() == y.length() + NON_NULLABLE_SUFFIX.length()
+        && x.endsWith(NON_NULLABLE_SUFFIX)) && x.startsWith(y);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.Strong;
 import org.apache.calcite.rel.metadata.NullSentinel;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -2509,7 +2510,8 @@ class RexProgramTest extends RexProgramTestBase {
       RexNode rexNode, String representation, String type) {
     assertEquals(representation, rexNode.toString());
     assertEquals(type, rexNode.getType().toString()
-        + (rexNode.getType().isNullable() ? "" : " NOT NULL"), "type of " + rexNode);
+        + (rexNode.getType().isNullable() ? "" : RelDataTypeImpl.NON_NULLABLE_SUFFIX),
+        "type of " + rexNode);
   }
 
   @Test void testIsDeterministic() {

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rex;
 
 import org.apache.calcite.plan.RelOptPredicateList;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.test.Matchers;
@@ -78,7 +79,8 @@ class RexProgramTestBase extends RexProgramBuilderBase {
       // toString contains type (see RexCall.toString)
       actual = node.toString();
     } else {
-      actual = node + ":" + node.getType() + (node.getType().isNullable() ? "" : " NOT NULL");
+      actual = node + ":" + node.getType() + (node.getType().isNullable() ? ""
+          : RelDataTypeImpl.NON_NULLABLE_SUFFIX);
     }
     assertEquals(expected, actual, message);
   }

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -93,6 +93,7 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static org.apache.calcite.rel.type.RelDataTypeImpl.NON_NULLABLE_SUFFIX;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.PI;
 import static org.apache.calcite.util.DateTimeStringUtils.getDateFormatter;
 
@@ -468,7 +469,7 @@ public abstract class SqlOperatorBaseTest {
       double delta) {
     tester.checkScalarApprox(
         getCastString(value, targetType, false),
-        targetType + " NOT NULL",
+        targetType + NON_NULLABLE_SUFFIX,
         expected,
         delta);
   }
@@ -480,7 +481,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkString(
         getCastString(value, targetType, false),
         expected,
-        targetType + " NOT NULL");
+        targetType + NON_NULLABLE_SUFFIX);
   }
 
   private void checkCastToScalarOkay(
@@ -489,7 +490,7 @@ public abstract class SqlOperatorBaseTest {
       String expected) {
     tester.checkScalarExact(
         getCastString(value, targetType, false),
-        targetType + " NOT NULL",
+        targetType + NON_NULLABLE_SUFFIX,
         expected);
   }
 
@@ -7040,7 +7041,7 @@ public abstract class SqlOperatorBaseTest {
         if (binary) {
           expected = DOUBLER.apply(expected);
         }
-        t.checkString(expression, expected, type + " NOT NULL");
+        t.checkString(expression, expected, type + NON_NULLABLE_SUFFIX);
       }
     }
   }

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTests.java
@@ -18,6 +18,7 @@ package org.apache.calcite.sql.test;
 
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParserUtil;
@@ -104,7 +105,7 @@ public abstract class SqlTests {
         actual = actual + "(" + sqlType.getPrecision() + ")";
       }
       if (!sqlType.isNullable()) {
-        actual += " NOT NULL";
+        actual += RelDataTypeImpl.NON_NULLABLE_SUFFIX;
       }
       return actual;
 

--- a/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteAssert.java
@@ -38,6 +38,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.runtime.CalciteException;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.runtime.GeoFunctions;
@@ -487,7 +488,7 @@ public class CalciteAssert {
               + " "
               + metaData.getColumnTypeName(i + 1)
               + (metaData.isNullable(i + 1) == ResultSetMetaData.columnNoNulls
-              ? " NOT NULL"
+              ? RelDataTypeImpl.NON_NULLABLE_SUFFIX
               : ""));
     }
     return list.toString();


### PR DESCRIPTION
We find weird literals for some user defined non-nullable types. Some investigation shows that the problem lies in the `RexLiteral#toJavaString` method.

In particular, it checks the type string suffix with an 8-character string:
```
if (!fullTypeString.endsWith("NOT NULL")) {
```
However, it trims the last 9 characters from the end of the string:
```
sb.append(fullTypeString, 0, fullTypeString.length() - 9);
```
