### PR TITLE
[CALCITE-4515] Do not generate the new join tree from commute/associate rules if there are "always TRUE" conditions (Vladimir Ozerov)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinCommuteRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinCommuteRule.java
@@ -139,7 +139,12 @@ public class JoinCommuteRule
   @Override public boolean matches(RelOptRuleCall call) {
     Join join = call.rel(0);
     // SEMI and ANTI join cannot be swapped.
-    return join.getJoinType().projectsRight();
+    if (!join.getJoinType().projectsRight()) {
+      return false;
+    }
+
+    // Suppress join with "true" condition.
+    return config.isAllowAlwaysTrueCondition() || !join.getCondition().isAlwaysTrue();
   }
 
   @Override public void onMatch(final RelOptRuleCall call) {
@@ -248,5 +253,15 @@ public class JoinCommuteRule
 
     /** Sets {@link #isSwapOuter()}. */
     Config withSwapOuter(boolean swapOuter);
+
+    /**
+     * Whether to emit the new join tree if the join condition is always {@code TRUE}.
+     */
+    @ImmutableBeans.Property
+    @ImmutableBeans.BooleanDefault(true)
+    boolean isAllowAlwaysTrueCondition();
+
+    /** Sets {@link #isAllowAlwaysTrueCondition()}. */
+    Config withAllowAlwaysTrueCondition(boolean allowAlwaysTrueCondition);
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -71,6 +71,8 @@ import org.apache.calcite.rel.rules.DateRangeRules;
 import org.apache.calcite.rel.rules.FilterJoinRule;
 import org.apache.calcite.rel.rules.FilterMultiJoinMergeRule;
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
+import org.apache.calcite.rel.rules.JoinAssociateRule;
+import org.apache.calcite.rel.rules.JoinCommuteRule;
 import org.apache.calcite.rel.rules.MultiJoin;
 import org.apache.calcite.rel.rules.ProjectCorrelateTransposeRule;
 import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
@@ -6958,5 +6960,141 @@ class RelOptRulesTest extends RelOptTestBase {
         .withTester(t -> createDynamicTester())
         .withRule(CoreRules.FILTER_REDUCE_EXPRESSIONS)
         .checkUnchanged();
+  }
+
+  @Test void testJoinCommuteRuleWithAlwaysTrueConditionAllowed() {
+    checkJoinCommuteRuleWithAlwaysTrueConditionDisallowed(true);
+  }
+
+  @Test void testJoinCommuteRuleWithAlwaysTrueConditionDisallowed() {
+    checkJoinCommuteRuleWithAlwaysTrueConditionDisallowed(false);
+  }
+
+  private void checkJoinCommuteRuleWithAlwaysTrueConditionDisallowed(boolean allowAlwaysTrue) {
+    final RelBuilder relBuilder = RelBuilder.create(RelBuilderTest.config().build());
+
+    RelNode left = relBuilder.scan("EMP").build();
+    RelNode right = relBuilder.scan("DEPT").build();
+
+    RelNode relNode = relBuilder.push(left)
+        .push(right)
+        .join(JoinRelType.INNER,
+            relBuilder.literal(true))
+        .build();
+
+    JoinCommuteRule.Config ruleConfig = JoinCommuteRule.Config.DEFAULT;
+    if (!allowAlwaysTrue) {
+      ruleConfig = ruleConfig.withAllowAlwaysTrueCondition(false);
+    }
+
+    HepProgram program = new HepProgramBuilder()
+        .addMatchLimit(1)
+        .addRuleInstance(ruleConfig.toRule())
+        .build();
+
+    HepPlanner hepPlanner = new HepPlanner(program);
+    hepPlanner.setRoot(relNode);
+    RelNode output = hepPlanner.findBestExp();
+
+    final String planAfter = NL + RelOptUtil.toString(output);
+    final DiffRepository diffRepos = getDiffRepos();
+    diffRepos.assertEquals("planAfter", "${planAfter}", planAfter);
+    SqlToRelTestBase.assertValid(output);
+  }
+
+  @Test void testJoinAssociateRuleWithBottomAlwaysTrueConditionAllowed() {
+    checkJoinAssociateRuleWithBottomAlwaysTrueCondition(true);
+  }
+
+  @Test void testJoinAssociateRuleWithBottomAlwaysTrueConditionDisallowed() {
+    checkJoinAssociateRuleWithBottomAlwaysTrueCondition(false);
+  }
+
+  private void checkJoinAssociateRuleWithBottomAlwaysTrueCondition(boolean allowAlwaysTrue) {
+    final RelBuilder relBuilder = RelBuilder.create(RelBuilderTest.config().build());
+
+    RelNode bottomLeft = relBuilder.scan("EMP").build();
+    RelNode bottomRight = relBuilder.scan("DEPT").build();
+    RelNode top = relBuilder.scan("BONUS").build();
+
+    RelNode relNode = relBuilder.push(bottomLeft)
+        .push(bottomRight)
+        .join(JoinRelType.INNER,
+            relBuilder.call(SqlStdOperatorTable.EQUALS,
+                relBuilder.field(2, 0, "DEPTNO"),
+                relBuilder.field(2, 1, "DEPTNO")))
+        .push(top)
+        .join(JoinRelType.INNER,
+            relBuilder.call(SqlStdOperatorTable.EQUALS,
+                relBuilder.field(2, 0, "JOB"),
+                relBuilder.field(2, 1, "JOB")))
+        .build();
+
+    JoinAssociateRule.Config ruleConfig = JoinAssociateRule.Config.DEFAULT;
+    if (!allowAlwaysTrue) {
+      ruleConfig = ruleConfig.withAllowAlwaysTrueCondition(false);
+    }
+
+    HepProgram program = new HepProgramBuilder()
+        .addMatchLimit(1)
+        .addMatchOrder(HepMatchOrder.TOP_DOWN)
+        .addRuleInstance(ruleConfig.toRule())
+        .build();
+
+    HepPlanner hepPlanner = new HepPlanner(program);
+    hepPlanner.setRoot(relNode);
+    RelNode output = hepPlanner.findBestExp();
+
+    final String planAfter = NL + RelOptUtil.toString(output);
+    final DiffRepository diffRepos = getDiffRepos();
+    diffRepos.assertEquals("planAfter", "${planAfter}", planAfter);
+    SqlToRelTestBase.assertValid(output);
+  }
+
+  @Test void testJoinAssociateRuleWithTopAlwaysTrueConditionAllowed() {
+    checkJoinAssociateRuleWithTopAlwaysTrueCondition(true);
+  }
+
+  @Test void testJoinAssociateRuleWithTopAlwaysTrueConditionDisallowed() {
+    checkJoinAssociateRuleWithTopAlwaysTrueCondition(false);
+  }
+
+  private void checkJoinAssociateRuleWithTopAlwaysTrueCondition(boolean allowAlwaysTrue) {
+    final RelBuilder relBuilder = RelBuilder.create(RelBuilderTest.config().build());
+
+    RelNode bottomLeft = relBuilder.scan("EMP").build();
+    RelNode bottomRight = relBuilder.scan("BONUS").build();
+    RelNode top = relBuilder.scan("DEPT").build();
+
+    RelNode relNode = relBuilder.push(bottomLeft)
+        .push(bottomRight)
+        .join(JoinRelType.INNER,
+            relBuilder.literal(true))
+        .push(top)
+        .join(JoinRelType.INNER,
+            relBuilder.call(SqlStdOperatorTable.EQUALS,
+                relBuilder.field(2, 0, "DEPTNO"),
+                relBuilder.field(2, 1, "DEPTNO")))
+        .build();
+
+    JoinAssociateRule.Config ruleConfig = JoinAssociateRule.Config.DEFAULT;
+    if (!allowAlwaysTrue) {
+      ruleConfig = ruleConfig.withAllowAlwaysTrueCondition(false);
+    }
+
+    HepProgram program = new HepProgramBuilder()
+        .addMatchLimit(1)
+        .addMatchOrder(HepMatchOrder.TOP_DOWN)
+        .addRuleInstance(ruleConfig.toRule())
+        .build();
+
+    HepPlanner hepPlanner = new HepPlanner(program);
+    hepPlanner.setRoot(relNode);
+    RelNode output = hepPlanner.findBestExp();
+
+    final String planAfter = NL + RelOptUtil.toString(output);
+    final DiffRepository diffRepos = getDiffRepos();
+    diffRepos.assertEquals("planAfter", "${planAfter}", planAfter);
+    SqlToRelTestBase.assertValid(output);
   }
 }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -13184,4 +13184,85 @@ LogicalProject(DEPTNO=[$0], $f1=[CAST($1):INTEGER NOT NULL], $f2=[$2])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testJoinCommuteRuleWithAlwaysTrueConditionAllowed">
+        <Resource name="sql">
+            <![CDATA[select * from emp join dept ON emp.deptno = dept.deptno]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO=[$10], DEPTNO0=[$0], DNAME=[$1], LOC=[$2])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalTableScan(table=[[scott, DEPT]])
+    LogicalTableScan(table=[[scott, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testJoinCommuteRuleWithAlwaysTrueConditionDisallowed">
+        <Resource name="sql">
+            <![CDATA[select * from emp join dept ON emp.deptno = dept.deptno]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalJoin(condition=[true], joinType=[inner])
+  LogicalTableScan(table=[[scott, EMP]])
+  LogicalTableScan(table=[[scott, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testJoinAssociateRuleWithBottomAlwaysTrueConditionAllowed">
+        <Resource name="sql">
+            <![CDATA[select * from emp join dept ON emp.deptno = dept.deptno join bonus on emp.job = bonus.job]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalJoin(condition=[AND(=($2, $12), =($7, $8))], joinType=[inner])
+  LogicalTableScan(table=[[scott, EMP]])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalTableScan(table=[[scott, DEPT]])
+    LogicalTableScan(table=[[scott, BONUS]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testJoinAssociateRuleWithBottomAlwaysTrueConditionDisallowed">
+        <Resource name="sql">
+            <![CDATA[select * from emp join dept ON emp.deptno = dept.deptno join bonus on emp.job = bonus.job]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalJoin(condition=[=($2, $12)], joinType=[inner])
+  LogicalJoin(condition=[=($7, $8)], joinType=[inner])
+    LogicalTableScan(table=[[scott, EMP]])
+    LogicalTableScan(table=[[scott, DEPT]])
+  LogicalTableScan(table=[[scott, BONUS]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testJoinAssociateRuleWithTopAlwaysTrueConditionAllowed">
+        <Resource name="sql">
+            <![CDATA[select * from emp join bonus ON 1=1 join dept on emp.deptno = dept.deptno]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalJoin(condition=[=($7, $12)], joinType=[inner])
+  LogicalTableScan(table=[[scott, EMP]])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalTableScan(table=[[scott, BONUS]])
+    LogicalTableScan(table=[[scott, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testJoinAssociateRuleWithTopAlwaysTrueConditionDisallowed">
+        <Resource name="sql">
+            <![CDATA[select * from emp join bonus ON 1=1 join dept on emp.deptno = dept.deptno]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalJoin(condition=[=($7, $12)], joinType=[inner])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalTableScan(table=[[scott, EMP]])
+    LogicalTableScan(table=[[scott, BONUS]])
+  LogicalTableScan(table=[[scott, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CALCITE-4515 for the details.

Also, this PR fixes a bug in the `JoinAssociateRule`, that expected a `RelSubset` for one of its operands, which made it impossible to apply the rule in the `HepPlanner`.