### PR TITLE
[CALCITE-4522] Sort cost should account for the number of columns in collation

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Sort.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Sort.java
@@ -29,6 +29,8 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexDynamicParam;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.util.Util;
@@ -124,11 +126,20 @@ public abstract class Sort extends SingleRel {
 
   @Override public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner,
       RelMetadataQuery mq) {
+    final double rowCount = mq.getRowCount(this);
+    double fetchValue = getValue(fetch, rowCount);
+    if (fetchValue <= 0) {
+      return planner.getCostFactory().makeCost(rowCount, 0, 0);
+    }
+    double inCount = mq.getRowCount(input);
     // Higher cost if rows are wider discourages pushing a project through a
     // sort.
-    final double rowCount = mq.getRowCount(this);
     final double bytesPerRow = getRowType().getFieldCount() * 4;
-    final double cpu = Util.nLogN(rowCount) * bytesPerRow;
+    double offsetValue = getValue(offset, 0);
+    assert offsetValue >= 0 : "offset should not be negative:" + offsetValue;
+    double toSort = Math.min(inCount, offsetValue + fetchValue);
+    final double cpu = collation.getFieldCollations().isEmpty() ? toSort * bytesPerRow
+        : Util.nLogM(inCount, toSort) * bytesPerRow;
     return planner.getCostFactory().makeCost(rowCount, cpu, 0);
   }
 
@@ -192,5 +203,13 @@ public abstract class Sort extends SingleRel {
     pw.itemIf("offset", offset, offset != null);
     pw.itemIf("fetch", fetch, fetch != null);
     return pw;
+  }
+
+  private static double getValue(@Nullable RexNode r, double defaultValue) {
+    if (r == null || r instanceof RexDynamicParam) {
+      return defaultValue;
+    }
+    Comparable<?> value = RexLiteral.value(r);
+    return value instanceof Number ? ((Number) value).doubleValue() : defaultValue;
   }
 }

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -370,6 +370,15 @@ public class Util {
   }
 
   /**
+   * Computes <code>nlog(m)</code> using the natural logarithm (or <code>
+   * n</code> if <code>m &lt; {@link Math#E}</code>, so the result is never
+   * negative.
+   */
+  public static double nLogM(double n, double m) {
+    return (m < Math.E) ? n : (n * Math.log(m));
+  }
+
+  /**
    * Prints an object using reflection. We can handle <code>null</code>;
    * arrays of objects and primitive values; for regular objects, we print all
    * public fields.

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -20,6 +20,7 @@ import org.apache.calcite.adapter.enumerable.EnumerableMergeJoin;
 import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptTable;
@@ -28,6 +29,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelCollations;
@@ -91,6 +93,7 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexTableInputRef.RelTableRef;
 import org.apache.calcite.runtime.SqlFunctions;
+import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -107,6 +110,7 @@ import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -3411,5 +3415,50 @@ public class RelMetadataTest extends SqlToRelTestBase {
     assertThat(columnOrigin.getOriginColumnOrdinal(), equalTo(5));
     assertThat(columnOrigin.getOriginTable().getRowType().getFieldNames().get(5),
         equalTo("SAL"));
+  }
+
+  @Test void testSortCpuCostOffsetLimit() {
+    final String sql = "select ename from emp order by ename limit 5 offset 5";
+    double cpuCost = Util.nLogM(EMP_SIZE, 10) * 4;
+    checkCpuCost(sql, cpuCost, "offset + fetch smaller than table size "
+        + "=> cpu cost should be: input_size * log(offset + fetch) * row_bytes");
+  }
+
+  @Test void testSortCpuCostLimit() {
+    final String sql = "select ename from emp limit 10";
+    checkCpuCost(sql, 40d, "no order by clause => "
+        + "cpu cost should be min(fetch + offset, input_size) * row_bytes");
+  }
+
+  @Test void testSortCpuCostLimit0() {
+    final String sql = "select ename from emp order by ename limit 0";
+    checkCpuCost(sql, 0d, "fetch zero => cpu cost should be 0");
+  }
+
+  @Test void testSortCpuCostLimit1() {
+    final String sql = "select ename from emp order by ename limit 1";
+    double cpuCost = EMP_SIZE * 4;
+    checkCpuCost(sql, cpuCost, "fetch 1 => cpu cost should be input_size * row_bytes");
+  }
+
+  @Test void testSortCpuCostLargeLimit() {
+    final String sql = "select ename from emp order by ename limit 10000";
+    double cpuCost = Util.nLogM(EMP_SIZE, EMP_SIZE) * 4;
+    checkCpuCost(sql, cpuCost, "sort limit exceeds table size "
+        + "=> cpu cost should be dominated by table size");
+  }
+
+  private void checkCpuCost(String sql, double expected, String reason) {
+    RelNode rel = convertSql(sql);
+    RelOptCost cost = computeRelSelfCost(rel);
+    final double result = cost.getCpu();
+    assertEquals(expected, result, () -> reason + "\nsql:" + sql + "\nplan:"
+        + RelOptUtil.toString(rel, SqlExplainLevel.ALL_ATTRIBUTES));
+  }
+
+  private static RelOptCost computeRelSelfCost(RelNode rel) {
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    RelOptPlanner planner = new VolcanoPlanner();
+    return rel.computeSelfCost(planner, mq);
   }
 }


### PR DESCRIPTION
The old method to compute the cost of sort has some problem.
1. When the RelCollation is empty, there is no need to sort, but it still compute the cpu cost of sort.
2. use n * log(n) * row_byte to estimate the cpu cost may be inaccurate, where n means the output row count of the sort operator, and row_byte means the average bytes of one row .

Instead, I give follow suggestion.
1. the cpu cost is zero if the RelCollation is empty or the fetch is zero.
2. let heap_size be min(offset + fetch, input_count),  and use input_count * max(1,log(heap_size))* row_byte to compute the cpu cost. 

