### PR TITLE
[CALCITE-4526] Fixup the unparse's output of SqlSnapshot,when tableRel is a SqlAsOperator (jibiyr)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
@@ -31,6 +31,7 @@ import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Util;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.apache.calcite.util.Static.RESOURCE;
 
@@ -69,6 +70,15 @@ public class SqlAsOperator extends SqlSpecialOperator {
       SqlCall call,
       int leftPrec,
       int rightPrec) {
+    unparse(writer, call, leftPrec, rightPrec, null);
+  }
+
+  public void unparse(
+      SqlWriter writer,
+      SqlCall call,
+      int leftPrec,
+      int rightPrec,
+      Consumer<Object> beforeWriteAlias) {
     assert call.operandCount() >= 2;
     final SqlWriter.Frame frame =
         writer.startList(
@@ -76,6 +86,9 @@ public class SqlAsOperator extends SqlSpecialOperator {
     call.operand(0).unparse(writer, leftPrec, getLeftPrec());
     final boolean needsSpace = true;
     writer.setNeedWhitespace(needsSpace);
+    if (beforeWriteAlias != null) {
+      beforeWriteAlias.accept(null);
+    }
     if (writer.getDialect().allowsAs()) {
       writer.sep("AS");
       writer.setNeedWhitespace(needsSpace);

--- a/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAsOperator.java
@@ -31,7 +31,6 @@ import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Util;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import static org.apache.calcite.util.Static.RESOURCE;
 
@@ -70,15 +69,6 @@ public class SqlAsOperator extends SqlSpecialOperator {
       SqlCall call,
       int leftPrec,
       int rightPrec) {
-    unparse(writer, call, leftPrec, rightPrec, null);
-  }
-
-  public void unparse(
-      SqlWriter writer,
-      SqlCall call,
-      int leftPrec,
-      int rightPrec,
-      Consumer<Object> beforeWriteAlias) {
     assert call.operandCount() >= 2;
     final SqlWriter.Frame frame =
         writer.startList(
@@ -86,9 +76,6 @@ public class SqlAsOperator extends SqlSpecialOperator {
     call.operand(0).unparse(writer, leftPrec, getLeftPrec());
     final boolean needsSpace = true;
     writer.setNeedWhitespace(needsSpace);
-    if (beforeWriteAlias != null) {
-      beforeWriteAlias.accept(null);
-    }
     if (writer.getDialect().allowsAs()) {
       writer.sep("AS");
       writer.setNeedWhitespace(needsSpace);

--- a/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
@@ -38,7 +38,9 @@ public class SqlSnapshot extends SqlCall {
   private SqlNode tableRef;
   private SqlNode period;
 
-  /** Creates a SqlSnapshot. */
+  /**
+   * Creates a SqlSnapshot.
+   */
   public SqlSnapshot(SqlParserPos pos, SqlNode tableRef, SqlNode period) {
     super(pos);
     this.tableRef = Objects.requireNonNull(tableRef, "tableRef");
@@ -127,10 +129,23 @@ public class SqlSnapshot extends SqlCall {
         int leftPrec,
         int rightPrec) {
       final SqlSnapshot snapshot = (SqlSnapshot) call;
+      SqlNode tableRef = snapshot.tableRef;
 
-      snapshot.tableRef.unparse(writer, 0, 0);
-      writer.keyword("FOR SYSTEM_TIME AS OF");
-      snapshot.period.unparse(writer, 0, 0);
+      if (tableRef instanceof SqlBasicCall
+          && ((SqlBasicCall) tableRef).getOperator() instanceof SqlAsOperator) {
+        SqlBasicCall basicCall = (SqlBasicCall) tableRef;
+        SqlAsOperator operator = (SqlAsOperator) ((SqlBasicCall) tableRef).getOperator();
+        operator.unparse(
+            writer, basicCall, 0, 0, ignore -> writeKeywordAndPeriod(writer, snapshot));
+      } else {
+        tableRef.unparse(writer, 0, 0);
+        writeKeywordAndPeriod(writer, snapshot);
+      }
     }
+  }
+
+  private static void writeKeywordAndPeriod(SqlWriter writer, SqlSnapshot snapshot) {
+    writer.keyword("FOR SYSTEM_TIME AS OF");
+    snapshot.period.unparse(writer, 0, 0);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
@@ -134,9 +134,11 @@ public class SqlSnapshot extends SqlCall {
       if (tableRef instanceof SqlBasicCall
           && ((SqlBasicCall) tableRef).getOperator() instanceof SqlAsOperator) {
         SqlBasicCall basicCall = (SqlBasicCall) tableRef;
-        SqlAsOperator operator = (SqlAsOperator) ((SqlBasicCall) tableRef).getOperator();
-        operator.unparse(
-            writer, basicCall, 0, 0, ignore -> writeKeywordAndPeriod(writer, snapshot));
+        basicCall.operand(0).unparse(writer, 0, 0);
+        writer.setNeedWhitespace(true);
+        writeKeywordAndPeriod(writer, snapshot);
+        writer.keyword("AS");
+        basicCall.operand(1).unparse(writer, 0, 0);
       } else {
         tableRef.unparse(writer, 0, 0);
         writeKeywordAndPeriod(writer, snapshot);

--- a/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
@@ -136,17 +136,17 @@ public class SqlSnapshot extends SqlCall {
         SqlBasicCall basicCall = (SqlBasicCall) tableRef;
         basicCall.operand(0).unparse(writer, 0, 0);
         writer.setNeedWhitespace(true);
-        writeKeywordAndPeriod(writer, snapshot);
+        writeForSystemTimeAsOf(writer, snapshot);
         writer.keyword("AS");
         basicCall.operand(1).unparse(writer, 0, 0);
       } else {
         tableRef.unparse(writer, 0, 0);
-        writeKeywordAndPeriod(writer, snapshot);
+        writeForSystemTimeAsOf(writer, snapshot);
       }
     }
   }
 
-  private static void writeKeywordAndPeriod(SqlWriter writer, SqlSnapshot snapshot) {
+  private static void writeForSystemTimeAsOf(SqlWriter writer, SqlSnapshot snapshot) {
     writer.keyword("FOR SYSTEM_TIME AS OF");
     snapshot.period.unparse(writer, 0, 0);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSnapshot.java
@@ -144,10 +144,12 @@ public class SqlSnapshot extends SqlCall {
         writeForSystemTimeAsOf(writer, snapshot);
       }
     }
+
+    private static void writeForSystemTimeAsOf(SqlWriter writer, SqlSnapshot snapshot) {
+      writer.keyword("FOR SYSTEM_TIME AS OF");
+      snapshot.period.unparse(writer, 0, 0);
+    }
+
   }
 
-  private static void writeForSystemTimeAsOf(SqlWriter writer, SqlSnapshot snapshot) {
-    writer.keyword("FOR SYSTEM_TIME AS OF");
-    snapshot.period.unparse(writer, 0, 0);
-  }
 }

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -7766,7 +7766,7 @@ public class SqlParserTest {
         SqlParserUtil.addCarets("abcdef", 1, 7, 1, 7));
   }
 
-  @Test void testSnapshot() {
+  @Test void testSnapshotForSystemTimeWithAlias() {
     sql("SELECT * FROM orders LEFT JOIN products FOR SYSTEM_TIME AS OF "
         + "orders.proctime as products ON orders.product_id = products.pro_id")
         .ok("SELECT *\n"

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -18,8 +18,6 @@ package org.apache.calcite.sql.parser;
 
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.avatica.util.Quoting;
-import org.apache.calcite.sql.SqlAsOperator;
-import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlExplain;
@@ -30,8 +28,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSetOption;
-import org.apache.calcite.sql.SqlSnapshot;
-import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.sql.dialect.SparkSqlDialect;
@@ -7771,28 +7767,11 @@ public class SqlParserTest {
   }
 
   @Test void testSnapshot() {
-    SqlNode tableRef = new SqlBasicCall(
-        new SqlAsOperator(),
-        new SqlNode[]{
-            new SqlIdentifier("default_db.products", new SqlParserPos(8, 11)),
-            new SqlIdentifier("products1", new SqlParserPos(8, 11))
-        },
-        new SqlParserPos(8, 11)
-    );
-    SqlNode period = new SqlIdentifier("orders.proctime", new SqlParserPos(8, 42));
-    SqlSnapshot sqlSnapshot = new SqlSnapshot(new SqlParserPos(8, 11), tableRef, period);
-
-    SqlWriter sqlWriter = new SqlPrettyWriter();
-    sqlSnapshot.unparse(sqlWriter, 0, 0);
-
-    assertEquals(sqlWriter.toSqlString().getSql(), "\"default_db.products\" "
-        + "FOR SYSTEM_TIME AS OF \"orders.proctime\" AS \"products1\"");
-
     sql("SELECT * FROM orders LEFT JOIN products FOR SYSTEM_TIME AS OF "
-        + "orders.proctime ON orders.product_id = products.pro_id")
+        + "orders.proctime as products ON orders.product_id = products.pro_id")
         .ok("SELECT *\n"
             + "FROM `ORDERS`\n"
-            + "LEFT JOIN `PRODUCTS` FOR SYSTEM_TIME AS OF `ORDERS`.`PROCTIME` ON (`ORDERS`"
+            + "LEFT JOIN `PRODUCTS` FOR SYSTEM_TIME AS OF `ORDERS`.`PROCTIME` AS `PRODUCTS` ON (`ORDERS`"
             + ".`PRODUCT_ID` = `PRODUCTS`.`PRO_ID`)");
   }
 


### PR DESCRIPTION

before this change when the sqlSnapshot' tableRel is a alias. the unparse result is wrong.
add test for sqlSnapshot and fix it.