### PR TITLE
[CALCITE-4550] Decoupling MetadataDef and JaninoRelMetadataProvider

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -222,6 +222,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
   @Override public void registerSchema(RelOptSchema schema) {
   }
 
+  @Deprecated
   @Override public long getRelMetadataTimestamp(RelNode rel) {
     return 0;
   }
@@ -253,7 +254,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
     return mq.getCumulativeCost(rel);
   }
 
-  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override public @Nullable RelOptCost getCost(RelNode rel) {
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     return getCost(rel, mq);
@@ -268,6 +269,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
     listener.addListener(newListener);
   }
 
+  @Deprecated // to be removed before 2.0
   @Override public void registerMetadataProviders(List<RelMetadataProvider> list) {
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
 import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.MetadataFactory;
-import org.apache.calcite.rel.metadata.MetadataFactoryImpl;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
@@ -56,6 +55,7 @@ public class RelOptCluster {
   private RexNode originalExpression;
   private final RexBuilder rexBuilder;
   private RelMetadataProvider metadataProvider;
+  @Deprecated // to be removed before 2.0
   private MetadataFactory metadataFactory;
   private @Nullable HintStrategyTable hintStrategies;
   private final RelTraitSet emptyTraitSet;
@@ -146,11 +146,13 @@ public class RelOptCluster {
    * @param metadataProvider custom provider
    */
   @EnsuresNonNull({"this.metadataProvider", "this.metadataFactory"})
+  @SuppressWarnings("deprecation")
   public void setMetadataProvider(
       @UnknownInitialization RelOptCluster this,
       RelMetadataProvider metadataProvider) {
     this.metadataProvider = metadataProvider;
-    this.metadataFactory = new MetadataFactoryImpl(metadataProvider);
+    this.metadataFactory =
+        new org.apache.calcite.rel.metadata.MetadataFactoryImpl(metadataProvider);
     // Wrap the metadata provider as a JaninoRelMetadataProvider
     // and set it to the ThreadLocal,
     // JaninoRelMetadataProvider is required by the RelMetadataQuery.
@@ -158,6 +160,7 @@ public class RelOptCluster {
         .set(JaninoRelMetadataProvider.of(metadataProvider));
   }
 
+  @Deprecated // to be removed before 2.0
   public MetadataFactory getMetadataFactory() {
     return metadataFactory;
   }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptPlanner.java
@@ -284,6 +284,7 @@ public interface RelOptPlanner {
    *
    * @param list receives planner's custom providers, if any
    */
+  @Deprecated // to be removed before 2.0
   void registerMetadataProviders(List<RelMetadataProvider> list);
 
   /**
@@ -294,6 +295,7 @@ public interface RelOptPlanner {
    * @param rel rel of interest
    * @return timestamp of last change which might affect metadata derivation
    */
+  @Deprecated // to be removed before 2.0
   long getRelMetadataTimestamp(RelNode rel);
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -1060,11 +1060,13 @@ public class HepPlanner extends AbstractRelOptPlanner {
   }
 
   // implement RelOptPlanner
+  @Deprecated // to be removed before 2.0
   @Override public void registerMetadataProviders(List<RelMetadataProvider> list) {
     list.add(0, new HepRelMetadataProvider());
   }
 
   // implement RelOptPlanner
+  @Deprecated
   @Override public long getRelMetadataTimestamp(RelNode rel) {
     // TODO jvs 20-Apr-2006: This is overly conservative.  Better would be
     // to keep a timestamp per HepRelVertex, and update only affected

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelMetadataProvider.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.UnboundMetadata;
 
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -71,5 +72,10 @@ class HepRelMetadataProvider implements RelMetadataProvider {
   @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
       MetadataDef<M> def) {
     return ImmutableMultimap.of();
+  }
+
+  @Override public <M extends Metadata> ImmutableSet<? extends MetadataHandler<M>> handlers(
+      Class<? extends MetadataHandler<? extends M>> handlerClass) {
+    return ImmutableSet.of();
   }
 }

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelMetadataProvider.java
@@ -36,6 +36,7 @@ import static java.util.Objects.requireNonNull;
  * HepRelMetadataProvider implements the {@link RelMetadataProvider} interface
  * by combining metadata from the rels inside of a {@link HepRelVertex}.
  */
+@Deprecated // to be removed before 2.0
 class HepRelMetadataProvider implements RelMetadataProvider {
   //~ Methods ----------------------------------------------------------------
 
@@ -47,6 +48,7 @@ class HepRelMetadataProvider implements RelMetadataProvider {
     return 107;
   }
 
+  @Deprecated // to be removed before 2.0
   @Override public <@Nullable M extends @Nullable Metadata> UnboundMetadata<M> apply(
       Class<? extends RelNode> relClass,
       final Class<? extends M> metadataClass) {

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.metadata.DelegatingMetadataRel;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 
@@ -33,7 +34,7 @@ import java.util.List;
  * HepRelVertex wraps a real {@link RelNode} as a vertex in a DAG representing
  * the entire query expression.
  */
-public class HepRelVertex extends AbstractRelNode {
+public class HepRelVertex extends AbstractRelNode implements DelegatingMetadataRel {
   //~ Instance fields --------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
@@ -90,7 +90,7 @@ public class HepRelVertex extends AbstractRelNode implements DelegatingMetadataR
   /**
    * Returns current implementation chosen for this vertex.
    */
-  public RelNode getCurrentRel() {
+  @Override public RelNode getCurrentRel() {
     return currentRel;
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -1443,11 +1443,13 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
   }
 
   // implement RelOptPlanner
+  @Deprecated // to be removed before 2.0
   @Override public void registerMetadataProviders(List<RelMetadataProvider> list) {
     list.add(0, new VolcanoRelMetadataProvider());
   }
 
   // implement RelOptPlanner
+  @Deprecated
   @Override public long getRelMetadataTimestamp(RelNode rel) {
     RelSubset subset = getSubset(rel);
     if (subset == null) {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -44,7 +44,6 @@ import org.apache.calcite.rel.convert.Converter;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.externalize.RelWriterImpl;
 import org.apache.calcite.rel.metadata.CyclicMetadataException;
-import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
@@ -271,11 +270,6 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
   }
 
   @Override public void setRoot(RelNode rel) {
-    // We've registered all the rules, and therefore RelNode classes,
-    // we're interested in, and have not yet started calling metadata providers.
-    // So now is a good time to tell the metadata layer what to expect.
-    registerMetadataRels();
-
     this.root = registerImpl(rel, null);
     if (this.originalRoot == null) {
       this.originalRoot = rel;
@@ -552,13 +546,6 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     if (cancelFlag.get()) {
       throw new VolcanoTimeoutException();
     }
-  }
-
-  /** Informs {@link JaninoRelMetadataProvider} about the different kinds of
-   * {@link RelNode} that we will be dealing with. It will reduce the number
-   * of times that we need to re-generate the provider. */
-  private void registerMetadataRels() {
-    JaninoRelMetadataProvider.DEFAULT.register(classOperands.keySet());
   }
 
   /** Ensures that the subset that is the root relational expression contains

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRelMetadataProvider.java
@@ -35,6 +35,7 @@ import java.util.Objects;
  * VolcanoRelMetadataProvider implements the {@link RelMetadataProvider}
  * interface by combining metadata from the rels making up an equivalence class.
  */
+@Deprecated // to be removed before 2.0
 public class VolcanoRelMetadataProvider implements RelMetadataProvider {
   //~ Methods ----------------------------------------------------------------
 
@@ -46,6 +47,7 @@ public class VolcanoRelMetadataProvider implements RelMetadataProvider {
     return 103;
   }
 
+  @Deprecated // to be removed before 2.0
   @Override public <@Nullable M extends @Nullable Metadata> @Nullable UnboundMetadata<M> apply(
       Class<? extends RelNode> relClass,
       final Class<? extends M> metadataClass) {

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRelMetadataProvider.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.UnboundMetadata;
 
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -122,5 +123,10 @@ public class VolcanoRelMetadataProvider implements RelMetadataProvider {
   @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
       MetadataDef<M> def) {
     return ImmutableMultimap.of();
+  }
+
+  @Override public <M extends Metadata> ImmutableSet<? extends MetadataHandler<M>> handlers(
+      Class<? extends MetadataHandler<? extends M>> handlerClass) {
+    return ImmutableSet.of();
   }
 }

--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -363,6 +363,7 @@ public class PlannerImpl implements Planner, ViewExpander {
     return requireNonNull(typeFactory, "typeFactory");
   }
 
+  @SuppressWarnings("deprecation")
   @Override public RelNode transform(int ruleSetIndex, RelTraitSet requiredOutputTraits,
       RelNode rel) {
     ensure(State.STATE_5_CONVERTED);

--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -233,6 +233,7 @@ public abstract class AbstractRelNode implements RelNode {
     return planner.getCostFactory().makeCost(rowCount, rowCount, 0);
   }
 
+  @Deprecated // to be removed before 2.0
   @Override public final <@Nullable M extends @Nullable Metadata> M metadata(Class<M> metadataClass,
       RelMetadataQuery mq) {
     final MetadataFactory factory = cluster.getMetadataFactory();

--- a/core/src/main/java/org/apache/calcite/rel/RelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelNode.java
@@ -213,6 +213,7 @@ public interface RelNode extends RelOptNode, Cloneable {
    *     although if the information is not present the metadata object may
    *     return null from all methods)
    */
+  @Deprecated // to be removed before 2.0
   <@Nullable M extends @Nullable Metadata> M metadata(Class<M> metadataClass, RelMetadataQuery mq);
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.RelNode;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -86,6 +87,11 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
   @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
       MetadataDef<M> def) {
     return underlyingProvider.handlers(def);
+  }
+
+  @Override public <M extends Metadata> ImmutableSet<? extends MetadataHandler<M>> handlers(
+      Class<? extends MetadataHandler<? extends M>> handlerClass) {
+    return underlyingProvider.handlers(handlerClass);
   }
 
   //~ Inner Classes ----------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
@@ -40,6 +40,7 @@ import static java.util.Objects.requireNonNull;
  * Implementation of the {@link RelMetadataProvider}
  * interface that caches results from an underlying provider.
  */
+@Deprecated // to be removed before 2.0
 public class CachingRelMetadataProvider implements RelMetadataProvider {
   //~ Instance fields --------------------------------------------------------
 
@@ -59,7 +60,7 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
   }
 
   //~ Methods ----------------------------------------------------------------
-
+  @Deprecated // to be removed before 2.0
   @Override public <@Nullable M extends @Nullable Metadata> @Nullable UnboundMetadata<M> apply(
       Class<? extends RelNode> relClass,
       final Class<? extends M> metadataClass) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ChainedRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ChainedRelMetadataProvider.java
@@ -70,6 +70,7 @@ public class ChainedRelMetadataProvider implements RelMetadataProvider {
     return providers.hashCode();
   }
 
+  @Deprecated // to be removed before 2.0
   @Override public <@Nullable M extends @Nullable Metadata> @Nullable UnboundMetadata<M> apply(
       Class<? extends RelNode> relClass,
       final Class<? extends M> metadataClass) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ChainedRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ChainedRelMetadataProvider.java
@@ -21,6 +21,7 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -111,6 +112,16 @@ public class ChainedRelMetadataProvider implements RelMetadataProvider {
         ImmutableMultimap.builder();
     for (RelMetadataProvider provider : providers.reverse()) {
       builder.putAll(provider.handlers(def));
+    }
+    return builder.build();
+  }
+
+  @Override public <M extends Metadata> ImmutableSet<? extends MetadataHandler<M>> handlers(
+      Class<? extends MetadataHandler<? extends M>> handlerClass) {
+    final ImmutableSet.Builder<MetadataHandler<M>> builder =
+        ImmutableSet.builder();
+    for (RelMetadataProvider provider : providers.reverse()) {
+      builder.addAll(provider.handlers(handlerClass));
     }
     return builder.build();
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/DelegatingMetadataRel.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/DelegatingMetadataRel.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * Interface for {@link RelNode} where the metadata is derived from another node.
+ */
+public interface DelegatingMetadataRel {
+  RelNode getCurrentRel();
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -169,7 +169,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
     DispatchGenerator dispatchGenerator = new DispatchGenerator(handlerToName);
     for (Ord<Method> method : Ord.zip(map.keySet())) {
       generateCachedMethod(buff, method.e, method.i);
-      dispatchGenerator.generateDispatchMethod(buff, method.e, map.get(method.e));
+      dispatchGenerator.dispatchMethod(buff, method.e, map.get(method.e));
     }
     //buff.append("}");
     final List<Object> argList = new ArrayList<>();

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -16,50 +16,20 @@
  */
 package org.apache.calcite.rel.metadata;
 
-import org.apache.calcite.adapter.enumerable.EnumerableAggregate;
-import org.apache.calcite.adapter.enumerable.EnumerableFilter;
-import org.apache.calcite.adapter.enumerable.EnumerableHashJoin;
-import org.apache.calcite.adapter.enumerable.EnumerableProject;
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.interpreter.JaninoRexCompiler;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.linq4j.tree.Primitive;
-import org.apache.calcite.plan.hep.HepRelVertex;
-import org.apache.calcite.plan.volcano.AbstractConverter;
-import org.apache.calcite.plan.volcano.RelSubset;
-import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.convert.ConverterImpl;
-import org.apache.calcite.rel.logical.LogicalAggregate;
-import org.apache.calcite.rel.logical.LogicalCalc;
-import org.apache.calcite.rel.logical.LogicalCorrelate;
-import org.apache.calcite.rel.logical.LogicalExchange;
-import org.apache.calcite.rel.logical.LogicalFilter;
-import org.apache.calcite.rel.logical.LogicalIntersect;
-import org.apache.calcite.rel.logical.LogicalJoin;
-import org.apache.calcite.rel.logical.LogicalMinus;
-import org.apache.calcite.rel.logical.LogicalProject;
-import org.apache.calcite.rel.logical.LogicalSort;
-import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
-import org.apache.calcite.rel.logical.LogicalTableModify;
-import org.apache.calcite.rel.logical.LogicalTableScan;
-import org.apache.calcite.rel.logical.LogicalUnion;
-import org.apache.calcite.rel.logical.LogicalValues;
-import org.apache.calcite.rel.logical.LogicalWindow;
-import org.apache.calcite.rel.stream.LogicalChi;
-import org.apache.calcite.rel.stream.LogicalDelta;
+import org.apache.calcite.rel.metadata.janino.DispatchGenerator;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ControlFlowException;
-import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
@@ -74,9 +44,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,6 +64,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   public static final JaninoRelMetadataProvider DEFAULT =
       JaninoRelMetadataProvider.of(DefaultRelMetadataProvider.INSTANCE);
 
+  @Deprecated
   private static final Set<Class<? extends RelNode>> ALL_RELS =
       new CopyOnWriteArraySet<>();
 
@@ -107,45 +77,10 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
           CalciteSystemProperty.METADATA_HANDLER_CACHE_MAXIMUM_SIZE.value())
           .build(
               CacheLoader.from(key ->
-                  load3(key.def, key.provider.handlers(key.def),
-                      key.relClasses)));
+                  load3(key.def, key.provider.handlers(key.def))));
 
   // Pre-register the most common relational operators, to reduce the number of
   // times we re-generate.
-  static {
-    DEFAULT.register(
-        Arrays.asList(RelNode.class,
-            AbstractRelNode.class,
-            RelSubset.class,
-            HepRelVertex.class,
-            ConverterImpl.class,
-            AbstractConverter.class,
-
-            LogicalAggregate.class,
-            LogicalCalc.class,
-            LogicalCorrelate.class,
-            LogicalExchange.class,
-            LogicalFilter.class,
-            LogicalIntersect.class,
-            LogicalJoin.class,
-            LogicalMinus.class,
-            LogicalProject.class,
-            LogicalSort.class,
-            LogicalTableFunctionScan.class,
-            LogicalTableModify.class,
-            LogicalTableScan.class,
-            LogicalUnion.class,
-            LogicalValues.class,
-            LogicalWindow.class,
-            LogicalChi.class,
-            LogicalDelta.class,
-
-            EnumerableAggregate.class,
-            EnumerableFilter.class,
-            EnumerableProject.class,
-            EnumerableHashJoin.class,
-            EnumerableTableScan.class));
-  }
 
   /** Private constructor; use {@link #of}. */
   private JaninoRelMetadataProvider(RelMetadataProvider provider) {
@@ -194,44 +129,39 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   }
 
   private static <M extends Metadata> MetadataHandler<M> load3(
-      MetadataDef<M> def, Multimap<Method, MetadataHandler<M>> map,
-      ImmutableList<Class<? extends RelNode>> relClasses) {
+      MetadataDef<M> def, Multimap<Method, ? extends MetadataHandler<?>> map) {
     final StringBuilder buff = new StringBuilder();
     final String name =
         "GeneratedMetadata_" + simpleNameForHandler(def.handlerClass);
-    final Set<MetadataHandler> providerSet = new HashSet<>();
-    final List<Pair<String, MetadataHandler>> providerList = new ArrayList<>();
-    //noinspection unchecked
-    final ReflectiveRelMetadataProvider.Space space =
-        new ReflectiveRelMetadataProvider.Space((Multimap) map);
-    for (MetadataHandler provider : space.providerMap.values()) {
+    final Set<MetadataHandler<?>> providerSet = new HashSet<>();
+
+    final Map<MetadataHandler<?>, String> handlerToName = new LinkedHashMap<>();
+    for (MetadataHandler<?> provider : map.values()) {
       if (providerSet.add(provider)) {
-        providerList.add(
-            Pair.of("provider" + (providerSet.size() - 1), provider));
+        handlerToName.put(provider,
+            "provider" + (providerSet.size() - 1));
       }
     }
 
-    buff.append("  private final java.util.List relClasses;\n")
-        .append("  private final org.apache.calcite.rel.metadata.MetadataDef def;\n");
-    for (Pair<String, MetadataHandler> pair : providerList) {
-      buff.append("  public final ").append(pair.right.getClass().getName())
-          .append(' ').append(pair.left).append(";\n");
+    buff.append("  private final org.apache.calcite.rel.metadata.MetadataDef def;\n");
+    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
+      buff.append("  public final ").append(handlerAndName.getKey().getClass().getName())
+          .append(' ').append(handlerAndName.getValue()).append(";\n");
     }
-    buff.append("  public ").append(name).append("(java.util.List relClasses,\n")
+    buff.append("  public ").append(name).append("(\n")
         .append("      org.apache.calcite.rel.metadata.MetadataDef def");
-    for (Pair<String, MetadataHandler> pair : providerList) {
+    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
       buff.append(",\n")
           .append("      ")
-          .append(pair.right.getClass().getName())
+          .append(handlerAndName.getKey().getClass().getName())
           .append(' ')
-          .append(pair.left);
+          .append(handlerAndName.getValue());
     }
     buff.append(") {\n")
-        .append("    this.relClasses = relClasses;\n")
         .append("    this.def = def;\n");
 
-    for (Pair<String, MetadataHandler> pair : providerList) {
-      buff.append("    this.").append(pair.left).append(" = ").append(pair.left)
+    for (String handlerName : handlerToName.values()) {
+      buff.append("    this.").append(handlerName).append(" = ").append(handlerName)
           .append(";\n");
     }
     buff.append("  }\n")
@@ -240,146 +170,93 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
         .append(" getDef() {\n")
         .append("    return def;")
         .append("  }\n");
-    for (Ord<Method> method : Ord.zip(def.methods)) {
-      buff.append("  public ")
-          .append(method.e.getReturnType().getName())
-          .append(" ")
-          .append(method.e.getName())
-          .append("(\n")
-          .append("      ")
-          .append(RelNode.class.getName())
-          .append(" r,\n")
-          .append("      ")
-          .append(RelMetadataQuery.class.getName())
-          .append(" mq");
-      paramList(buff, method.e)
-          .append(") {\n");
-      buff.append("    final java.util.List key = ")
-          .append(
-              (method.e.getParameterTypes().length < 4
-              ? org.apache.calcite.runtime.FlatLists.class
-              : ImmutableList.class).getName())
-          .append(".of(");
-      if (method.i == 0) {
-        buff.append("def");
-      } else {
-        buff.append("def.methods.get(")
-            .append(method.i)
-            .append(")");
-      }
-      safeArgList(buff, method.e)
-          .append(");\n")
-          .append("    final Object v = mq.map.get(r, key);\n")
-          .append("    if (v != null) {\n")
-          .append("      if (v == ")
-          .append(NullSentinel.class.getName())
-          .append(".ACTIVE) {\n")
-          .append("        throw new ")
-          .append(CyclicMetadataException.class.getName())
-          .append("();\n")
-          .append("      }\n")
-          .append("      if (v == ")
-          .append(NullSentinel.class.getName())
-          .append(".INSTANCE) {\n")
-          .append("        return null;\n")
-          .append("      }\n")
-          .append("      return (")
-          .append(method.e.getReturnType().getName())
-          .append(") v;\n")
-          .append("    }\n")
-          .append("    mq.map.put(r, key,")
-          .append(NullSentinel.class.getName())
-          .append(".ACTIVE);\n")
-          .append("    try {\n")
-          .append("      final ")
-          .append(method.e.getReturnType().getName())
-          .append(" x = ")
-          .append(method.e.getName())
-          .append("_(r, mq");
-      argList(buff, method.e)
-          .append(");\n")
-          .append("      mq.map.put(r, key, ")
-          .append(NullSentinel.class.getName())
-          .append(".mask(x));\n")
-          .append("      return x;\n")
-          .append("    } catch (")
-          .append(Exception.class.getName())
-          .append(" e) {\n")
-          .append("      mq.map.row(r).clear();\n")
-          .append("      throw e;\n")
-          .append("    }\n")
-          .append("  }\n")
-          .append("\n")
-          .append("  private ")
-          .append(method.e.getReturnType().getName())
-          .append(" ")
-          .append(method.e.getName())
-          .append("_(\n")
-          .append("      ")
-          .append(RelNode.class.getName())
-          .append(" r,\n")
-          .append("      ")
-          .append(RelMetadataQuery.class.getName())
-          .append(" mq");
-      paramList(buff, method.e)
-          .append(") {\n");
-      buff.append("    switch (relClasses.indexOf(r.getClass())) {\n");
-
-      // Build a list of clauses, grouping clauses that have the same action.
-      final Multimap<String, Integer> clauses = LinkedHashMultimap.create();
-      final StringBuilder buf2 = new StringBuilder();
-      for (Ord<Class<? extends RelNode>> relClass : Ord.zip(relClasses)) {
-        if (relClass.e == HepRelVertex.class) {
-          buf2.append("      return ")
-              .append(method.e.getName())
-              .append("(((")
-              .append(relClass.e.getName())
-              .append(") r).getCurrentRel(), mq");
-          argList(buf2, method.e)
-              .append(");\n");
-        } else {
-          final Method handler = space.find(relClass.e, method.e);
-          final String v = findProvider(providerList, handler.getDeclaringClass());
-          buf2.append("      return ")
-              .append(v)
-              .append(".")
-              .append(method.e.getName())
-              .append("((")
-              .append(handler.getParameterTypes()[0].getName())
-              .append(") r, mq");
-          argList(buf2, method.e)
-              .append(");\n");
-        }
-        clauses.put(buf2.toString(), relClass.i);
-        buf2.setLength(0);
-      }
-      buf2.append("      throw new ")
-          .append(NoHandler.class.getName())
-          .append("(r.getClass());\n")
-          .append("    }\n")
-          .append("  }\n");
-      clauses.put(buf2.toString(), -1);
-      for (Map.Entry<String, Collection<Integer>> pair : clauses.asMap().entrySet()) {
-        if (pair.getValue().contains(relClasses.indexOf(RelNode.class))) {
-          buff.append("    default:\n");
-        } else {
-          for (Integer integer : pair.getValue()) {
-            buff.append("    case ").append(integer).append(":\n");
-          }
-        }
-        buff.append(pair.getKey());
-      }
+    DispatchGenerator dispatchGenerator = new DispatchGenerator(handlerToName);
+    for (Ord<Method> method : Ord.zip(map.keySet())) {
+      generateCachedMethod(buff, method.e, method.i);
+      dispatchGenerator.generateDispatchMethod(buff, method.e, map.get(method.e));
     }
+    //buff.append("}");
     final List<Object> argList = new ArrayList<>();
-    argList.add(ImmutableList.copyOf(relClasses));
     argList.add(def);
-    argList.addAll(Pair.right(providerList));
+    argList.addAll(handlerToName.keySet());
     try {
       return compile(name, buff.toString(), def, argList);
     } catch (CompileException | IOException e) {
       throw new RuntimeException("Error compiling:\n"
           + buff, e);
     }
+  }
+
+  private static void generateCachedMethod(StringBuilder buff, Method method, int methodIndex) {
+    buff.append("  public ")
+        .append(method.getReturnType().getName())
+        .append(" ")
+        .append(method.getName())
+        .append("(\n")
+        .append("      ")
+        .append(RelNode.class.getName())
+        .append(" r,\n")
+        .append("      ")
+        .append(RelMetadataQuery.class.getName())
+        .append(" mq");
+    paramList(buff, method)
+        .append(") {\n");
+    buff.append("    final java.util.List key = ")
+        .append(
+            (method.getParameterTypes().length < 4
+                ? org.apache.calcite.runtime.FlatLists.class
+                : ImmutableList.class).getName())
+        .append(".of(");
+    if (methodIndex == 0) {
+      buff.append("def");
+    } else {
+      buff.append("def.methods.get(")
+          .append(methodIndex)
+          .append(")");
+    }
+    safeArgList(buff, method)
+        .append(");\n")
+        .append("    final Object v = mq.map.get(r, key);\n")
+        .append("    if (v != null) {\n")
+        .append("      if (v == ")
+        .append(NullSentinel.class.getName())
+        .append(".ACTIVE) {\n")
+        .append("        throw new ")
+        .append(CyclicMetadataException.class.getName())
+        .append("();\n")
+        .append("      }\n")
+        .append("      if (v == ")
+        .append(NullSentinel.class.getName())
+        .append(".INSTANCE) {\n")
+        .append("        return null;\n")
+        .append("      }\n")
+        .append("      return (")
+        .append(method.getReturnType().getName())
+        .append(") v;\n")
+        .append("    }\n")
+        .append("    mq.map.put(r, key,")
+        .append(NullSentinel.class.getName())
+        .append(".ACTIVE);\n")
+        .append("    try {\n")
+        .append("      final ")
+        .append(method.getReturnType().getName())
+        .append(" x = ")
+        .append(method.getName())
+        .append("_(r, mq");
+    argList(buff, method)
+        .append(");\n")
+        .append("      mq.map.put(r, key, ")
+        .append(NullSentinel.class.getName())
+        .append(".mask(x));\n")
+        .append("      return x;\n")
+        .append("    } catch (")
+        .append(Exception.class.getName())
+        .append(" e) {\n")
+        .append("      mq.map.row(r).clear();\n")
+        .append("      throw e;\n")
+        .append("    }\n")
+        .append("  }\n")
+        .append("\n");
   }
 
   private static String simpleNameForHandler(Class<? extends MetadataHandler<?>> clazz) {
@@ -394,16 +271,6 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
     }
   }
 
-  private static String findProvider(
-      List<Pair<String, MetadataHandler>> providerList,
-      Class<?> declaringClass) {
-    for (Pair<String, MetadataHandler> pair : providerList) {
-      if (declaringClass.isInstance(pair.right)) {
-        return pair.left;
-      }
-    }
-    throw new AssertionError("not found: " + declaringClass);
-  }
 
   /** Returns e.g. ", ignoreNulls". */
   private static StringBuilder argList(StringBuilder buff, Method method) {
@@ -479,8 +346,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   synchronized <M extends Metadata, H extends MetadataHandler<M>> H create(
       MetadataDef<M> def) {
     try {
-      final Key key = new Key((MetadataDef) def, provider,
-          ImmutableList.copyOf(ALL_RELS));
+      final Key key = new Key((MetadataDef) def, provider);
       //noinspection unchecked
       return (H) HANDLERS.get(key);
     } catch (UncheckedExecutionException | ExecutionException e) {
@@ -490,9 +356,6 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
 
   synchronized <M extends Metadata, H extends MetadataHandler<M>> H revise(
       Class<? extends RelNode> rClass, MetadataDef<M> def) {
-    if (ALL_RELS.add(rClass)) {
-      HANDLERS.invalidateAll();
-    }
     //noinspection unchecked
     return (H) create(def);
   }
@@ -500,23 +363,8 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   /** Registers some classes. Does not flush the providers, but next time we
    * need to generate a provider, it will handle all of these classes. So,
    * calling this method reduces the number of times we need to re-generate. */
+  @Deprecated
   public void register(Iterable<Class<? extends RelNode>> classes) {
-    // Register the classes and their base classes up to RelNode. Don't bother
-    // to remove duplicates; addAll will do that.
-    final List<Class<? extends RelNode>> list = Lists.newArrayList(classes);
-    for (int i = 0; i < list.size(); i++) {
-      final Class<? extends RelNode> c = list.get(i);
-      final Class s = c.getSuperclass();
-      if (s != null && RelNode.class.isAssignableFrom(s)) {
-        //noinspection unchecked
-        list.add(s);
-      }
-    }
-    synchronized (this) {
-      if (ALL_RELS.addAll(list)) {
-        HANDLERS.invalidateAll();
-      }
-    }
   }
 
   /** Exception that indicates there there should be a handler for
@@ -534,27 +382,22 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   private static class Key {
     public final MetadataDef def;
     public final RelMetadataProvider provider;
-    public final ImmutableList<Class<? extends RelNode>> relClasses;
 
-    private Key(MetadataDef def, RelMetadataProvider provider,
-        ImmutableList<Class<? extends RelNode>> relClassList) {
+    private Key(MetadataDef def, RelMetadataProvider provider) {
       this.def = def;
       this.provider = provider;
-      this.relClasses = relClassList;
     }
 
     @Override public int hashCode() {
       return (def.hashCode() * 37
-          + provider.hashCode()) * 37
-          + relClasses.hashCode();
+          + provider.hashCode()) * 37;
     }
 
     @Override public boolean equals(@Nullable Object obj) {
       return this == obj
           || obj instanceof Key
           && ((Key) obj).def.equals(def)
-          && ((Key) obj).provider.equals(provider)
-          && ((Key) obj).relClasses.equals(relClasses);
+          && ((Key) obj).provider.equals(provider);
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -49,7 +49,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -64,9 +63,6 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   public static final JaninoRelMetadataProvider DEFAULT =
       JaninoRelMetadataProvider.of(DefaultRelMetadataProvider.INSTANCE);
 
-  @Deprecated
-  private static final Set<Class<? extends RelNode>> ALL_RELS =
-      new CopyOnWriteArraySet<>();
 
   /** Cache of pre-generated handlers by provider and kind of metadata.
    * For the cache to be effective, providers should implement identity

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -17,38 +17,21 @@
 package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.config.CalciteSystemProperty;
-import org.apache.calcite.interpreter.JaninoRexCompiler;
-import org.apache.calcite.linq4j.Ord;
-import org.apache.calcite.linq4j.tree.Primitive;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.metadata.janino.DispatchGenerator;
-import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rel.metadata.janino.JaninoMetadataHandlerCreator;
 import org.apache.calcite.util.ControlFlowException;
 import org.apache.calcite.util.Util;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.codehaus.commons.compiler.CompileException;
-import org.codehaus.commons.compiler.CompilerFactoryFactory;
-import org.codehaus.commons.compiler.ICompilerFactory;
-import org.codehaus.commons.compiler.ISimpleCompiler;
 
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -71,9 +54,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   private static final LoadingCache<Key, MetadataHandler> HANDLERS =
       maxSize(CacheBuilder.newBuilder(),
           CalciteSystemProperty.METADATA_HANDLER_CACHE_MAXIMUM_SIZE.value())
-          .build(
-              CacheLoader.from(key ->
-                  load3(key.def, key.provider.handlers(key.def))));
+          .build(cacheLoader());
 
   // Pre-register the most common relational operators, to reduce the number of
   // times we re-generate.
@@ -124,225 +105,15 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
     return provider.handlers(def);
   }
 
-  private static <M extends Metadata> MetadataHandler<M> load3(
-      MetadataDef<M> def, Multimap<Method, ? extends MetadataHandler<?>> map) {
-    final StringBuilder buff = new StringBuilder();
-    final String name =
-        "GeneratedMetadata_" + simpleNameForHandler(def.handlerClass);
-    final Set<MetadataHandler<?>> providerSet = new HashSet<>();
-
-    final Map<MetadataHandler<?>, String> handlerToName = new LinkedHashMap<>();
-    for (MetadataHandler<?> provider : map.values()) {
-      if (providerSet.add(provider)) {
-        handlerToName.put(provider,
-            "provider" + (providerSet.size() - 1));
-      }
-    }
-
-    buff.append("  private final org.apache.calcite.rel.metadata.MetadataDef def;\n");
-    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
-      buff.append("  public final ").append(handlerAndName.getKey().getClass().getName())
-          .append(' ').append(handlerAndName.getValue()).append(";\n");
-    }
-    buff.append("  public ").append(name).append("(\n")
-        .append("      org.apache.calcite.rel.metadata.MetadataDef def");
-    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
-      buff.append(",\n")
-          .append("      ")
-          .append(handlerAndName.getKey().getClass().getName())
-          .append(' ')
-          .append(handlerAndName.getValue());
-    }
-    buff.append(") {\n")
-        .append("    this.def = def;\n");
-
-    for (String handlerName : handlerToName.values()) {
-      buff.append("    this.").append(handlerName).append(" = ").append(handlerName)
-          .append(";\n");
-    }
-    buff.append("  }\n")
-        .append("  public ")
-        .append(MetadataDef.class.getName())
-        .append(" getDef() {\n")
-        .append("    return def;")
-        .append("  }\n");
-    DispatchGenerator dispatchGenerator = new DispatchGenerator(handlerToName);
-    for (Ord<Method> method : Ord.zip(map.keySet())) {
-      generateCachedMethod(buff, method.e, method.i);
-      dispatchGenerator.dispatchMethod(buff, method.e, map.get(method.e));
-    }
-    //buff.append("}");
-    final List<Object> argList = new ArrayList<>();
-    argList.add(def);
-    argList.addAll(handlerToName.keySet());
-    try {
-      return compile(name, buff.toString(), def, argList);
-    } catch (CompileException | IOException e) {
-      throw new RuntimeException("Error compiling:\n"
-          + buff, e);
-    }
-  }
-
-  private static void generateCachedMethod(StringBuilder buff, Method method, int methodIndex) {
-    buff.append("  public ")
-        .append(method.getReturnType().getName())
-        .append(" ")
-        .append(method.getName())
-        .append("(\n")
-        .append("      ")
-        .append(RelNode.class.getName())
-        .append(" r,\n")
-        .append("      ")
-        .append(RelMetadataQuery.class.getName())
-        .append(" mq");
-    paramList(buff, method)
-        .append(") {\n");
-    buff.append("    final java.util.List key = ")
-        .append(
-            (method.getParameterTypes().length < 4
-                ? org.apache.calcite.runtime.FlatLists.class
-                : ImmutableList.class).getName())
-        .append(".of(");
-    if (methodIndex == 0) {
-      buff.append("def");
-    } else {
-      buff.append("def.methods.get(")
-          .append(methodIndex)
-          .append(")");
-    }
-    safeArgList(buff, method)
-        .append(");\n")
-        .append("    final Object v = mq.map.get(r, key);\n")
-        .append("    if (v != null) {\n")
-        .append("      if (v == ")
-        .append(NullSentinel.class.getName())
-        .append(".ACTIVE) {\n")
-        .append("        throw new ")
-        .append(CyclicMetadataException.class.getName())
-        .append("();\n")
-        .append("      }\n")
-        .append("      if (v == ")
-        .append(NullSentinel.class.getName())
-        .append(".INSTANCE) {\n")
-        .append("        return null;\n")
-        .append("      }\n")
-        .append("      return (")
-        .append(method.getReturnType().getName())
-        .append(") v;\n")
-        .append("    }\n")
-        .append("    mq.map.put(r, key,")
-        .append(NullSentinel.class.getName())
-        .append(".ACTIVE);\n")
-        .append("    try {\n")
-        .append("      final ")
-        .append(method.getReturnType().getName())
-        .append(" x = ")
-        .append(method.getName())
-        .append("_(r, mq");
-    argList(buff, method)
-        .append(");\n")
-        .append("      mq.map.put(r, key, ")
-        .append(NullSentinel.class.getName())
-        .append(".mask(x));\n")
-        .append("      return x;\n")
-        .append("    } catch (")
-        .append(Exception.class.getName())
-        .append(" e) {\n")
-        .append("      mq.map.row(r).clear();\n")
-        .append("      throw e;\n")
-        .append("    }\n")
-        .append("  }\n")
-        .append("\n");
-  }
-
-  private static String simpleNameForHandler(Class<? extends MetadataHandler<?>> clazz) {
-    String simpleName = clazz.getSimpleName();
-    //Previously the pattern was to have a nested in class named Handler
-    //So we need to add the parents class to get a unique name
-    if (simpleName.equals("Handler")) {
-      String[] parts = clazz.getName().split("\\.|\\$");
-      return parts[parts.length - 2] + parts[parts.length - 1];
-    } else {
-      return simpleName;
-    }
-  }
-
-
-  /** Returns e.g. ", ignoreNulls". */
-  private static StringBuilder argList(StringBuilder buff, Method method) {
-    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())) {
-      buff.append(", a").append(t.i);
-    }
-    return buff;
-  }
-
-  /** Returns e.g. ", ignoreNulls". */
-  private static StringBuilder safeArgList(StringBuilder buff, Method method) {
-    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())) {
-      if (Primitive.is(t.e) || RexNode.class.isAssignableFrom(t.e)) {
-        buff.append(", a").append(t.i);
-      } else {
-        buff.append(", ") .append(NullSentinel.class.getName())
-            .append(".mask(a").append(t.i).append(")");
-      }
-    }
-    return buff;
-  }
-
-  /** Returns e.g. ",\n boolean ignoreNulls". */
-  private static StringBuilder paramList(StringBuilder buff, Method method) {
-    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())) {
-      buff.append(",\n      ").append(t.e.getName()).append(" a").append(t.i);
-    }
-    return buff;
-  }
-
-  static <M extends Metadata> MetadataHandler<M> compile(String className,
-      String classBody, MetadataDef<M> def,
-      List<Object> argList) throws CompileException, IOException {
-    final ICompilerFactory compilerFactory;
-    try {
-      compilerFactory = CompilerFactoryFactory.getDefaultCompilerFactory();
-    } catch (Exception e) {
-      throw new IllegalStateException(
-          "Unable to instantiate java compiler", e);
-    }
-
-    final ISimpleCompiler compiler = compilerFactory.newSimpleCompiler();
-    compiler.setParentClassLoader(JaninoRexCompiler.class.getClassLoader());
-
-    final String s = "public final class " + className
-        + " implements " + def.handlerClass.getCanonicalName() + " {\n"
-        + classBody
-        + "\n"
-        + "}";
-
-    if (CalciteSystemProperty.DEBUG.value()) {
-      // Add line numbers to the generated janino class
-      compiler.setDebuggingInformation(true, true, true);
-      System.out.println(s);
-    }
-
-    compiler.cook(s);
-    final Constructor constructor;
-    final Object o;
-    try {
-      constructor = compiler.getClassLoader().loadClass(className)
-              .getDeclaredConstructors()[0];
-      o = constructor.newInstance(argList.toArray());
-    } catch (InstantiationException
-        | IllegalAccessException
-        | InvocationTargetException
-        | ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
-    return def.handlerClass.cast(o);
+  @Override public <M extends Metadata> ImmutableSet<? extends MetadataHandler<M>> handlers(
+      Class<? extends MetadataHandler<? extends M>> handlerClass) {
+    return provider.handlers(handlerClass);
   }
 
   synchronized <M extends Metadata, H extends MetadataHandler<M>> H create(
       MetadataDef<M> def) {
     try {
-      final Key key = new Key((MetadataDef) def, provider);
+      final Key key = new Key(def.handlerClass, provider);
       //noinspection unchecked
       return (H) HANDLERS.get(key);
     } catch (UncheckedExecutionException | ExecutionException e) {
@@ -363,6 +134,16 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
   public void register(Iterable<Class<? extends RelNode>> classes) {
   }
 
+  private static <M extends Metadata, MH extends MetadataHandler<M>>
+      CacheLoader<Key, MetadataHandler> cacheLoader() {
+    CacheLoader cacheLoader = CacheLoader.<Key<M, MH>, MH>from(key -> {
+      ImmutableSet<? extends MetadataHandler<Metadata>> handlers =
+          key.provider.handlers(key.handlerClass);
+      return JaninoMetadataHandlerCreator.newInstance(key.handlerClass, handlers);
+    });
+    return cacheLoader;
+  }
+
   /** Exception that indicates there there should be a handler for
    * this class but there is not. The action is probably to
    * re-generate the handler class. */
@@ -374,25 +155,30 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
     }
   }
 
-  /** Key for the cache. */
-  private static class Key {
-    public final MetadataDef def;
+  /**
+   * Key for the cache.
+   * @param <M> Metadata type
+   * @param <MH> Handler type
+   */
+  private static class Key<M extends Metadata, MH extends MetadataHandler<M>> {
+    public final Class<MH> handlerClass;
     public final RelMetadataProvider provider;
 
-    private Key(MetadataDef def, RelMetadataProvider provider) {
-      this.def = def;
+    private Key(Class<MH> handlerClass,
+        RelMetadataProvider provider) {
+      this.handlerClass = handlerClass;
       this.provider = provider;
     }
 
     @Override public int hashCode() {
-      return (def.hashCode() * 37
+      return (handlerClass.hashCode() * 37
           + provider.hashCode()) * 37;
     }
 
     @Override public boolean equals(@Nullable Object obj) {
       return this == obj
           || obj instanceof Key
-          && ((Key) obj).def.equals(def)
+          && ((Key) obj).handlerClass.equals(handlerClass)
           && ((Key) obj).provider.equals(provider);
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataDef.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataDef.java
@@ -31,7 +31,7 @@ import java.util.List;
  * @param <M> Kind of metadata
  */
 public class MetadataDef<M extends Metadata> {
-  public final Class<M> metadataClass;
+  @Deprecated public final Class<M> metadataClass;
   public final Class<? extends MetadataHandler<M>> handlerClass;
   public final ImmutableList<Method> methods;
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataFactoryImpl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutionException;
  * provide which kinds of metadata, for which kinds of relational
  * expressions.</p>
  */
+@Deprecated
 public class MetadataFactoryImpl implements MetadataFactory {
   @SuppressWarnings("unchecked")
   public static final UnboundMetadata<@Nullable Metadata> DUMMY = (rel, mq) -> null;

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandler.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandler.java
@@ -22,5 +22,6 @@ package org.apache.calcite.rel.metadata;
  * @param <M> Kind of metadata
  */
 public interface MetadataHandler<M extends Metadata> {
+  @Deprecated
   MetadataDef<M> getDef();
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -28,6 +28,7 @@ import org.apache.calcite.util.Util;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -68,7 +69,10 @@ public class ReflectiveRelMetadataProvider
   private final ConcurrentMap<Class<RelNode>, UnboundMetadata> map;
   @Deprecated // to be removed before 2.0
   private final Class<? extends Metadata> metadataClass0;
+  @Deprecated
   private final ImmutableMultimap<Method, MetadataHandler> handlerMap;
+  private final Class<? extends MetadataHandler<?>> handlerClass;
+  private final ImmutableSet handlers;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -82,12 +86,15 @@ public class ReflectiveRelMetadataProvider
   protected ReflectiveRelMetadataProvider(
       ConcurrentMap<Class<RelNode>, UnboundMetadata> map,
       Class<? extends Metadata> metadataClass0,
-      Multimap<Method, MetadataHandler> handlerMap) {
+      Multimap<Method, MetadataHandler<?>> handlerMap,
+      Class<? extends MetadataHandler<?>> handlerClass) {
     Preconditions.checkArgument(!map.isEmpty(), "ReflectiveRelMetadataProvider "
         + "methods map is empty; are your methods named wrong?");
     this.map = map;
     this.metadataClass0 = metadataClass0;
     this.handlerMap = ImmutableMultimap.copyOf(handlerMap);
+    this.handlerClass = handlerClass;
+    this.handlers = ImmutableSet.copyOf(handlerMap.values());
   }
 
   /** Returns an implementation of {@link RelMetadataProvider} that scans for
@@ -107,20 +114,30 @@ public class ReflectiveRelMetadataProvider
    * that extend {@link org.apache.calcite.rel.core.Union}
    * or {@link org.apache.calcite.rel.core.Filter}.</p>
    */
+  @Deprecated
   public static RelMetadataProvider reflectiveSource(Method method,
       MetadataHandler target) {
-    return reflectiveSource(target, ImmutableList.of(method));
+    return reflectiveSource(target, ImmutableList.of(method), target.getDef().handlerClass);
   }
 
   /** Returns a reflective metadata provider that implements several
    * methods. */
+  @Deprecated
   public static RelMetadataProvider reflectiveSource(MetadataHandler target,
       Method... methods) {
-    return reflectiveSource(target, ImmutableList.copyOf(methods));
+    return reflectiveSource(target, ImmutableList.copyOf(methods), target.getDef().handlerClass);
+  }
+
+  @SuppressWarnings("deprecation")
+  public static <M extends Metadata> RelMetadataProvider reflectiveSource(
+      MetadataHandler<? extends M> handler, Class<? extends MetadataHandler<M>> handlerClass) {
+    //When deprecated code is removed, handler.getDef().methods will no longer be required
+    return reflectiveSource(handler, handler.getDef().methods, handlerClass);
   }
 
   private static RelMetadataProvider reflectiveSource(
-      final MetadataHandler target, final ImmutableList<Method> methods) {
+      final MetadataHandler target, final ImmutableList<Method> methods,
+      final Class<? extends MetadataHandler<?>> handlerClass) {
     final Space2 space = Space2.create(target, methods);
 
     // This needs to be a concurrent map since RelMetadataProvider are cached in static
@@ -199,7 +216,7 @@ public class ReflectiveRelMetadataProvider
       methodsMap.put(key, function);
     }
     return new ReflectiveRelMetadataProvider(methodsMap, space.metadataClass0,
-        space.providerMap);
+        space.providerMap, handlerClass);
   }
 
   @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
@@ -213,6 +230,16 @@ public class ReflectiveRelMetadataProvider
       }
     }
     return builder.build();
+  }
+
+  @Override public <M extends Metadata> ImmutableSet<? extends MetadataHandler<M>> handlers(
+      Class<? extends MetadataHandler<? extends M>> handlerClass) {
+    if (this.handlerClass.isAssignableFrom(handlerClass)) {
+      //noinspection unchecked
+      return (ImmutableSet<MetadataHandler<M>>) handlers;
+    } else {
+      return ImmutableSet.of();
+    }
   }
 
   private static boolean couldImplement(Method handlerMethod, Method method) {
@@ -281,16 +308,16 @@ public class ReflectiveRelMetadataProvider
   static class Space {
     final Set<Class<RelNode>> classes = new HashSet<>();
     final Map<Pair<Class<RelNode>, Method>, Method> handlerMap = new HashMap<>();
-    final ImmutableMultimap<Method, MetadataHandler> providerMap;
+    final ImmutableMultimap<Method, MetadataHandler<?>> providerMap;
 
-    Space(Multimap<Method, MetadataHandler> providerMap) {
+    Space(Multimap<Method, MetadataHandler<?>> providerMap) {
       this.providerMap = ImmutableMultimap.copyOf(providerMap);
 
       // Find the distinct set of RelNode classes handled by this provider,
       // ordered base-class first.
-      for (Map.Entry<Method, MetadataHandler> entry : providerMap.entries()) {
+      for (Map.Entry<Method, MetadataHandler<?>> entry : providerMap.entries()) {
         final Method method = entry.getKey();
-        final MetadataHandler provider = entry.getValue();
+        final MetadataHandler<?> provider = entry.getValue();
         for (final Method handlerMethod : provider.getClass().getMethods()) {
           if (couldImplement(handlerMethod, method)) {
             @SuppressWarnings("unchecked") final Class<RelNode> relNodeClass =
@@ -336,12 +363,13 @@ public class ReflectiveRelMetadataProvider
     private Class<Metadata> metadataClass0;
 
     Space2(Class<Metadata> metadataClass0,
-        ImmutableMultimap<Method, MetadataHandler> providerMap) {
+        ImmutableMultimap<Method, MetadataHandler<?>> providerMap) {
       super(providerMap);
       this.metadataClass0 = metadataClass0;
     }
 
-    public static Space2 create(MetadataHandler target,
+    public static Space2 create(
+        MetadataHandler<?> target,
         ImmutableList<Method> methods) {
       assert methods.size() > 0;
       final Method method0 = methods.get(0);
@@ -352,7 +380,7 @@ public class ReflectiveRelMetadataProvider
         assert method.getDeclaringClass() == metadataClass0;
       }
 
-      final ImmutableMultimap.Builder<Method, MetadataHandler> providerBuilder =
+      final ImmutableMultimap.Builder<Method, MetadataHandler<?>> providerBuilder =
           ImmutableMultimap.builder();
       for (final Method method : methods) {
         providerBuilder.put(method, target);

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -64,7 +64,9 @@ public class ReflectiveRelMetadataProvider
     implements RelMetadataProvider, ReflectiveVisitor {
 
   //~ Instance fields --------------------------------------------------------
+  @Deprecated // to be removed before 2.0
   private final ConcurrentMap<Class<RelNode>, UnboundMetadata> map;
+  @Deprecated // to be removed before 2.0
   private final Class<? extends Metadata> metadataClass0;
   private final ImmutableMultimap<Method, MetadataHandler> handlerMap;
 
@@ -229,7 +231,7 @@ public class ReflectiveRelMetadataProvider
   }
 
   //~ Methods ----------------------------------------------------------------
-
+  @Deprecated // to be removed before 2.0
   @Override public <@Nullable M extends @Nullable Metadata> @Nullable UnboundMetadata<M> apply(
       Class<? extends RelNode> relClass, Class<? extends M> metadataClass) {
     if (metadataClass == metadataClass0) {
@@ -240,6 +242,7 @@ public class ReflectiveRelMetadataProvider
   }
 
   @SuppressWarnings({ "unchecked", "SuspiciousMethodCalls" })
+  @Deprecated // to be removed before 2.0
   public <@Nullable M extends @Nullable Metadata> @Nullable UnboundMetadata<M> apply(
       Class<? extends RelNode> relClass) {
     List<Class<? extends RelNode>> newSources = new ArrayList<>();

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
@@ -41,7 +41,6 @@ import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexTableInputRef.RelTableRef;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
@@ -78,8 +77,9 @@ import java.util.Set;
  */
 public class RelMdAllPredicates
     implements MetadataHandler<BuiltInMetadata.AllPredicates> {
-  public static final RelMetadataProvider SOURCE = ReflectiveRelMetadataProvider
-      .reflectiveSource(BuiltInMethod.ALL_PREDICATES.method, new RelMdAllPredicates());
+  public static final RelMetadataProvider SOURCE =
+      ReflectiveRelMetadataProvider.reflectiveSource(
+          new RelMdAllPredicates(), BuiltInMetadata.AllPredicates.Handler.class);
 
   @Deprecated
   @Override public MetadataDef<BuiltInMetadata.AllPredicates> getDef() {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
@@ -81,6 +81,7 @@ public class RelMdAllPredicates
   public static final RelMetadataProvider SOURCE = ReflectiveRelMetadataProvider
       .reflectiveSource(BuiltInMethod.ALL_PREDICATES.method, new RelMdAllPredicates());
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.AllPredicates> getDef() {
     return BuiltInMetadata.AllPredicates.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
@@ -51,7 +51,6 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Pair;
@@ -84,7 +83,7 @@ public class RelMdCollation
     implements MetadataHandler<BuiltInMetadata.Collation> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.COLLATIONS.method, new RelMdCollation());
+          new RelMdCollation(), BuiltInMetadata.Collation.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
@@ -92,6 +92,7 @@ public class RelMdCollation
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Collation> getDef() {
     return BuiltInMetadata.Collation.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
@@ -35,7 +35,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.rex.RexVisitor;
 import org.apache.calcite.rex.RexVisitorImpl;
-import org.apache.calcite.util.BuiltInMethod;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
@@ -53,7 +52,7 @@ public class RelMdColumnOrigins
     implements MetadataHandler<BuiltInMetadata.ColumnOrigin> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.COLUMN_ORIGIN.method, new RelMdColumnOrigins());
+          new RelMdColumnOrigins(), BuiltInMetadata.ColumnOrigin.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
@@ -61,6 +61,7 @@ public class RelMdColumnOrigins
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.ColumnOrigin> getDef() {
     return BuiltInMetadata.ColumnOrigin.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -76,6 +76,7 @@ public class RelMdColumnUniqueness
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.ColumnUniqueness> getDef() {
     return BuiltInMetadata.ColumnUniqueness.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -46,7 +46,6 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
@@ -68,7 +67,7 @@ public class RelMdColumnUniqueness
     implements MetadataHandler<BuiltInMetadata.ColumnUniqueness> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.COLUMN_UNIQUENESS.method, new RelMdColumnUniqueness());
+          new RelMdColumnUniqueness(), BuiltInMetadata.ColumnUniqueness.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
@@ -33,7 +33,6 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.util.Bug;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.NumberUtil;
 
@@ -55,7 +54,7 @@ public class RelMdDistinctRowCount
     implements MetadataHandler<BuiltInMetadata.DistinctRowCount> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.DISTINCT_ROW_COUNT.method, new RelMdDistinctRowCount());
+          new RelMdDistinctRowCount(), BuiltInMetadata.DistinctRowCount.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
@@ -63,6 +63,7 @@ public class RelMdDistinctRowCount
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.DistinctRowCount> getDef() {
     return BuiltInMetadata.DistinctRowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistribution.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistribution.java
@@ -36,7 +36,6 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
@@ -54,7 +53,7 @@ public class RelMdDistribution
     implements MetadataHandler<BuiltInMetadata.Distribution> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.DISTRIBUTION.method, new RelMdDistribution());
+          new RelMdDistribution(), BuiltInMetadata.Distribution.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistribution.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistribution.java
@@ -62,6 +62,7 @@ public class RelMdDistribution
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Distribution> getDef() {
     return BuiltInMetadata.Distribution.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExplainVisibility.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExplainVisibility.java
@@ -18,7 +18,6 @@ package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.sql.SqlExplainLevel;
-import org.apache.calcite.util.BuiltInMethod;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -30,8 +29,7 @@ public class RelMdExplainVisibility
     implements MetadataHandler<BuiltInMetadata.ExplainVisibility> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.EXPLAIN_VISIBILITY.method,
-          new RelMdExplainVisibility());
+          new RelMdExplainVisibility(), BuiltInMetadata.ExplainVisibility.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExplainVisibility.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExplainVisibility.java
@@ -38,7 +38,7 @@ public class RelMdExplainVisibility
   private RelMdExplainVisibility() {}
 
   //~ Methods ----------------------------------------------------------------
-
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.ExplainVisibility> getDef() {
     return BuiltInMetadata.ExplainVisibility.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -93,6 +93,7 @@ public class RelMdExpressionLineage
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.ExpressionLineage> getDef() {
     return BuiltInMetadata.ExpressionLineage.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -41,7 +41,6 @@ import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexTableInputRef.RelTableRef;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
@@ -85,7 +84,7 @@ public class RelMdExpressionLineage
     implements MetadataHandler<BuiltInMetadata.ExpressionLineage> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.EXPRESSION_LINEAGE.method, new RelMdExpressionLineage());
+          new RelMdExpressionLineage(), BuiltInMetadata.ExpressionLineage.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdLowerBoundCost.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdLowerBoundCost.java
@@ -21,7 +21,6 @@ import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCost;
-import org.apache.calcite.util.BuiltInMethod;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -34,7 +33,7 @@ public class RelMdLowerBoundCost implements MetadataHandler<LowerBoundCost> {
 
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdLowerBoundCost(), BuiltInMethod.LOWER_BOUND_COST.method);
+          new RelMdLowerBoundCost(), LowerBoundCost.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdLowerBoundCost.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdLowerBoundCost.java
@@ -42,6 +42,7 @@ public class RelMdLowerBoundCost implements MetadataHandler<LowerBoundCost> {
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<LowerBoundCost> getDef() {
     return BuiltInMetadata.LowerBoundCost.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
@@ -36,7 +36,6 @@ import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.util.Bug;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -49,7 +48,7 @@ public class RelMdMaxRowCount
     implements MetadataHandler<BuiltInMetadata.MaxRowCount> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.MAX_ROW_COUNT.method, new RelMdMaxRowCount());
+          new RelMdMaxRowCount(), BuiltInMetadata.MaxRowCount.Handler.class);
 
   //~ Methods ----------------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
@@ -53,6 +53,7 @@ public class RelMdMaxRowCount
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.MaxRowCount> getDef() {
     return BuiltInMetadata.MaxRowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMemory.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMemory.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.util.BuiltInMethod;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -34,9 +33,7 @@ public class RelMdMemory implements MetadataHandler<BuiltInMetadata.Memory> {
    * {@link org.apache.calcite.rel.metadata.BuiltInMetadata.Memory}. */
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(new RelMdMemory(),
-          BuiltInMethod.MEMORY.method,
-          BuiltInMethod.CUMULATIVE_MEMORY_WITHIN_PHASE.method,
-          BuiltInMethod.CUMULATIVE_MEMORY_WITHIN_PHASE_SPLIT.method);
+          BuiltInMetadata.Memory.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMemory.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMemory.java
@@ -44,6 +44,7 @@ public class RelMdMemory implements MetadataHandler<BuiltInMetadata.Memory> {
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Memory> getDef() {
     return BuiltInMetadata.Memory.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
@@ -34,7 +34,6 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.util.Bug;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -47,7 +46,7 @@ public class RelMdMinRowCount
     implements MetadataHandler<BuiltInMetadata.MinRowCount> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.MIN_ROW_COUNT.method, new RelMdMinRowCount());
+          new RelMdMinRowCount(), BuiltInMetadata.MinRowCount.Handler.class);
 
   //~ Methods ----------------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
@@ -51,6 +51,7 @@ public class RelMdMinRowCount
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.MinRowCount> getDef() {
     return BuiltInMetadata.MinRowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
@@ -56,6 +56,7 @@ public class RelMdNodeTypes
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.NodeTypes> getDef() {
     return BuiltInMetadata.NodeTypes.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
@@ -36,7 +36,6 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.core.Window;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -52,7 +51,7 @@ public class RelMdNodeTypes
     implements MetadataHandler<BuiltInMetadata.NodeTypes> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.NODE_TYPES.method, new RelMdNodeTypes());
+          new RelMdNodeTypes(), BuiltInMetadata.NodeTypes.Handler.class);
 
   //~ Methods ----------------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdParallelism.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdParallelism.java
@@ -20,7 +20,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Values;
-import org.apache.calcite.util.BuiltInMethod;
 
 /**
  * Default implementations of the
@@ -36,8 +35,7 @@ public class RelMdParallelism
    * {@link org.apache.calcite.rel.metadata.BuiltInMetadata.Parallelism}. */
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(new RelMdParallelism(),
-          BuiltInMethod.IS_PHASE_TRANSITION.method,
-          BuiltInMethod.SPLIT_COUNT.method);
+          BuiltInMetadata.Parallelism.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdParallelism.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdParallelism.java
@@ -45,6 +45,7 @@ public class RelMdParallelism
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Parallelism> getDef() {
     return BuiltInMetadata.Parallelism.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Union;
-import org.apache.calcite.util.BuiltInMethod;
 
 import com.google.common.collect.ImmutableList;
 
@@ -36,31 +35,25 @@ import java.util.List;
  * {@link RelMetadataQuery#getPercentageOriginalRows} for the standard logical
  * algebra.
  */
-public class RelMdPercentageOriginalRows
-    implements MetadataHandler<BuiltInMetadata.PercentageOriginalRows> {
-  private static final RelMdPercentageOriginalRows INSTANCE =
-      new RelMdPercentageOriginalRows();
-
+public class RelMdPercentageOriginalRows {
   public static final RelMetadataProvider SOURCE =
       ChainedRelMetadataProvider.of(
           ImmutableList.of(
               ReflectiveRelMetadataProvider.reflectiveSource(
-                  BuiltInMethod.PERCENTAGE_ORIGINAL_ROWS.method, INSTANCE),
-
+                  new RelMdPercentageOriginalRowsHandler(),
+                  BuiltInMetadata.PercentageOriginalRows.Handler.class),
               ReflectiveRelMetadataProvider.reflectiveSource(
-                  BuiltInMethod.CUMULATIVE_COST.method, INSTANCE),
-
+                  new RelMdCumulativeCost(),
+                  BuiltInMetadata.CumulativeCost.Handler.class),
               ReflectiveRelMetadataProvider.reflectiveSource(
-                  BuiltInMethod.NON_CUMULATIVE_COST.method, INSTANCE)));
+                  new RelMdNonCumulativeCost(),
+                  BuiltInMetadata.NonCumulativeCost.Handler.class
+              )
+          ));
 
   //~ Methods ----------------------------------------------------------------
 
   private RelMdPercentageOriginalRows() {}
-
-  @Deprecated
-  @Override public MetadataDef<BuiltInMetadata.PercentageOriginalRows> getDef() {
-    return BuiltInMetadata.PercentageOriginalRows.DEF;
-  }
 
   public @Nullable Double getPercentageOriginalRows(Aggregate rel, RelMetadataQuery mq) {
     // REVIEW jvs 28-Mar-2006: The assumption here seems to be that
@@ -198,6 +191,42 @@ public class RelMdPercentageOriginalRows
       return 1.0;
     } else {
       return numerator / denominator;
+    }
+  }
+
+  /**
+   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.CumulativeCost}.
+   */
+  private static final class RelMdCumulativeCost
+      extends RelMdPercentageOriginalRows
+      implements MetadataHandler<BuiltInMetadata.CumulativeCost> {
+    @Deprecated
+    @Override public MetadataDef<BuiltInMetadata.CumulativeCost> getDef() {
+      return BuiltInMetadata.CumulativeCost.DEF;
+    }
+  }
+
+  /**
+   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.NonCumulativeCost}.
+   */
+  private static final class RelMdNonCumulativeCost
+      extends RelMdPercentageOriginalRows
+      implements MetadataHandler<BuiltInMetadata.NonCumulativeCost> {
+    @Deprecated
+    @Override public MetadataDef<BuiltInMetadata.NonCumulativeCost> getDef() {
+      return BuiltInMetadata.NonCumulativeCost.DEF;
+    }
+  }
+
+  /**
+   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.PercentageOriginalRows}.
+   */
+  private static final class RelMdPercentageOriginalRowsHandler
+      extends RelMdPercentageOriginalRows
+      implements MetadataHandler<BuiltInMetadata.PercentageOriginalRows> {
+    @Deprecated
+    @Override public MetadataDef<BuiltInMetadata.PercentageOriginalRows> getDef() {
+      return BuiltInMetadata.PercentageOriginalRows.DEF;
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
@@ -57,6 +57,7 @@ public class RelMdPercentageOriginalRows
 
   private RelMdPercentageOriginalRows() {}
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.PercentageOriginalRows> getDef() {
     return BuiltInMetadata.PercentageOriginalRows.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
@@ -27,7 +27,6 @@ import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -42,7 +41,7 @@ public class RelMdPopulationSize
     implements MetadataHandler<BuiltInMetadata.PopulationSize> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.POPULATION_SIZE.method, new RelMdPopulationSize());
+          new RelMdPopulationSize(), BuiltInMetadata.PopulationSize.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
@@ -50,6 +50,7 @@ public class RelMdPopulationSize
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.PopulationSize> getDef() {
     return BuiltInMetadata.PopulationSize.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -134,6 +134,7 @@ public class RelMdPredicates
 
   private static final List<RexNode> EMPTY_LIST = ImmutableList.of();
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Predicates> getDef() {
     return BuiltInMetadata.Predicates.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -53,7 +53,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.BitSets;
 import org.apache.calcite.util.Bug;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mapping;
@@ -130,7 +129,7 @@ import static java.util.Objects.requireNonNull;
 public class RelMdPredicates
     implements MetadataHandler<BuiltInMetadata.Predicates> {
   public static final RelMetadataProvider SOURCE = ReflectiveRelMetadataProvider
-      .reflectiveSource(BuiltInMethod.PREDICATES.method, new RelMdPredicates());
+      .reflectiveSource(new RelMdPredicates(), BuiltInMetadata.Predicates.Handler.class);
 
   private static final List<RexNode> EMPTY_LIST = ImmutableList.of();
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -36,7 +36,6 @@ import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.util.Bug;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.NumberUtil;
 import org.apache.calcite.util.Util;
@@ -51,7 +50,7 @@ public class RelMdRowCount
     implements MetadataHandler<BuiltInMetadata.RowCount> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.ROW_COUNT.method, new RelMdRowCount());
+          new RelMdRowCount(), BuiltInMetadata.RowCount.Handler.class);
 
   //~ Methods ----------------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -55,6 +55,7 @@ public class RelMdRowCount
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.RowCount> getDef() {
     return BuiltInMetadata.RowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSelectivity.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSelectivity.java
@@ -32,7 +32,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -48,7 +47,7 @@ public class RelMdSelectivity
     implements MetadataHandler<BuiltInMetadata.Selectivity> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.SELECTIVITY.method, new RelMdSelectivity());
+          new RelMdSelectivity(), BuiltInMetadata.Selectivity.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSelectivity.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSelectivity.java
@@ -57,6 +57,7 @@ public class RelMdSelectivity
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Selectivity> getDef() {
     return BuiltInMetadata.Selectivity.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
@@ -38,7 +38,6 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableNullableList;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
@@ -64,8 +63,7 @@ public class RelMdSize implements MetadataHandler<BuiltInMetadata.Size> {
    * {@link org.apache.calcite.rel.metadata.BuiltInMetadata.Size}. */
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(new RelMdSize(),
-          BuiltInMethod.AVERAGE_COLUMN_SIZES.method,
-          BuiltInMethod.AVERAGE_ROW_SIZE.method);
+          BuiltInMetadata.Size.Handler.class);
 
   /** Bytes per character (2). */
   public static final int BYTES_PER_CHARACTER = Character.SIZE / Byte.SIZE;

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
@@ -76,6 +76,7 @@ public class RelMdSize implements MetadataHandler<BuiltInMetadata.Size> {
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Size> getDef() {
     return BuiltInMetadata.Size.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
@@ -73,6 +73,7 @@ public class RelMdTableReferences
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.TableReferences> getDef() {
     return BuiltInMetadata.TableReferences.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
@@ -32,7 +32,6 @@ import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rex.RexTableInputRef.RelTableRef;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.HashMultimap;
@@ -65,7 +64,7 @@ public class RelMdTableReferences
     implements MetadataHandler<BuiltInMetadata.TableReferences> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.TABLE_REFERENCES.method, new RelMdTableReferences());
+          new RelMdTableReferences(), BuiltInMetadata.TableReferences.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
@@ -35,7 +35,6 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
-import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
@@ -60,7 +59,7 @@ public class RelMdUniqueKeys
     implements MetadataHandler<BuiltInMetadata.UniqueKeys> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          BuiltInMethod.UNIQUE_KEYS.method, new RelMdUniqueKeys());
+          new RelMdUniqueKeys(), BuiltInMetadata.UniqueKeys.Handler.class);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
@@ -68,6 +68,7 @@ public class RelMdUniqueKeys
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.UniqueKeys> getDef() {
     return BuiltInMetadata.UniqueKeys.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataProvider.java
@@ -18,6 +18,7 @@ package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.rel.RelNode;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -70,4 +71,7 @@ public interface RelMetadataProvider {
 
   <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
       MetadataDef<M> def);
+
+  <M extends Metadata> ImmutableSet<? extends MetadataHandler<M>> handlers(
+      Class<? extends MetadataHandler<? extends M>> handlerClass);
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataProvider.java
@@ -64,6 +64,7 @@ public interface RelMetadataProvider {
    * @return Function that will field a metadata instance; or null if this
    *     provider cannot supply metadata of this type
    */
+  @Deprecated // to be removed before 2.0
   <@Nullable M extends @Nullable Metadata> @Nullable UnboundMetadata<M> apply(
       Class<? extends RelNode> relClass, Class<? extends M> metadataClass);
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGenerator.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGenerator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata.janino;
+
+import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.linq4j.tree.Primitive;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.CyclicMetadataException;
+import org.apache.calcite.rel.metadata.NullSentinel;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexNode;
+
+import com.google.common.collect.ImmutableList;
+
+import java.lang.reflect.Method;
+
+import static org.apache.calcite.rel.metadata.janino.CodeGeneratorUtil.argList;
+import static org.apache.calcite.rel.metadata.janino.CodeGeneratorUtil.paramList;
+
+/**
+ * Generates caching code for janino backed metadata.
+ */
+class CacheGenerator {
+
+  private CacheGenerator() {
+  }
+
+  static void cacheProperties(StringBuilder buff, Method method, int methodIndex) {
+    buff.append("  private final Object ");
+    appendKeyName(buff, methodIndex);
+    buff.append(" = new ")
+        .append(DescriptiveCacheKey.class.getName())
+        .append("(\"")
+        .append(method.toString())
+        .append("\");\n");
+  }
+
+  public static void cachedMethod(StringBuilder buff, Method method, int methodIndex) {
+    buff.append("  public ")
+        .append(method.getReturnType().getName())
+        .append(" ")
+        .append(method.getName())
+        .append("(\n")
+        .append("      ")
+        .append(RelNode.class.getName())
+        .append(" r,\n")
+        .append("      ")
+        .append(RelMetadataQuery.class.getName())
+        .append(" mq");
+    paramList(buff, method, 2)
+        .append(") {\n");
+    buff.append("    final java.util.List key = ")
+        .append(
+            (method.getParameterTypes().length < 6
+                ? org.apache.calcite.runtime.FlatLists.class
+                : ImmutableList.class).getName())
+        .append(".of(");
+    appendKeyName(buff, methodIndex);
+    safeArgList(buff, method)
+        .append(");\n")
+        .append("    final Object v = mq.map.get(r, key);\n")
+        .append("    if (v != null) {\n")
+        .append("      if (v == ")
+        .append(NullSentinel.class.getName())
+        .append(".ACTIVE) {\n")
+        .append("        throw new ")
+        .append(CyclicMetadataException.class.getName())
+        .append("();\n")
+        .append("      }\n")
+        .append("      if (v == ")
+        .append(NullSentinel.class.getName())
+        .append(".INSTANCE) {\n")
+        .append("        return null;\n")
+        .append("      }\n")
+        .append("      return (")
+        .append(method.getReturnType().getName())
+        .append(") v;\n")
+        .append("    }\n")
+        .append("    mq.map.put(r, key,")
+        .append(NullSentinel.class.getName())
+        .append(".ACTIVE);\n")
+        .append("    try {\n")
+        .append("      final ")
+        .append(method.getReturnType().getName())
+        .append(" x = ")
+        .append(method.getName())
+        .append("_(r, mq");
+    argList(buff, method, 2)
+        .append(");\n")
+        .append("      mq.map.put(r, key, ")
+        .append(NullSentinel.class.getName())
+        .append(".mask(x));\n")
+        .append("      return x;\n")
+        .append("    } catch (")
+        .append(Exception.class.getName())
+        .append(" e) {\n")
+        .append("      mq.map.row(r).clear();\n")
+        .append("      throw e;\n")
+        .append("    }\n")
+        .append("  }\n")
+        .append("\n");
+  }
+
+
+  /** Returns e.g. ", ignoreNulls". */
+  private static StringBuilder safeArgList(StringBuilder buff, Method method) {
+    //We ignore the first 2 arguments since they are included other ways.
+    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())
+        .subList(2, method.getParameterCount())) {
+      if (Primitive.is(t.e) || RexNode.class.isAssignableFrom(t.e)) {
+        buff.append(", a").append(t.i);
+      } else {
+        buff.append(", ").append(NullSentinel.class.getName())
+            .append(".mask(a").append(t.i).append(")");
+      }
+    }
+    return buff;
+  }
+
+  private static void appendKeyName(StringBuilder buff, int methodIndex) {
+    buff.append("methodKey").append(methodIndex);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/CodeGeneratorUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/CodeGeneratorUtil.java
@@ -29,7 +29,7 @@ public class CodeGeneratorUtil {
   }
 
   /** Returns e.g. ",\n boolean ignoreNulls". */
-  static StringBuilder generateParamList(StringBuilder buff, Method method) {
+  static StringBuilder paramList(StringBuilder buff, Method method) {
     for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())) {
       buff.append(",\n      ").append(t.e.getName()).append(" a").append(t.i);
     }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/CodeGeneratorUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/CodeGeneratorUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata.janino;
+
+import org.apache.calcite.linq4j.Ord;
+
+import java.lang.reflect.Method;
+
+/**
+ * Common functions for code generation.
+ */
+public class CodeGeneratorUtil {
+
+  private CodeGeneratorUtil() {
+  }
+
+  /** Returns e.g. ",\n boolean ignoreNulls". */
+  static StringBuilder generateParamList(StringBuilder buff, Method method) {
+    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())) {
+      buff.append(",\n      ").append(t.e.getName()).append(" a").append(t.i);
+    }
+    return buff;
+  }
+
+  /** Returns e.g. ", ignoreNulls". */
+  static StringBuilder argList(StringBuilder buff, Method method) {
+    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())) {
+      buff.append(", a").append(t.i);
+    }
+    return buff;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/DescriptiveCacheKey.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/DescriptiveCacheKey.java
@@ -16,33 +16,19 @@
  */
 package org.apache.calcite.rel.metadata.janino;
 
-import org.apache.calcite.linq4j.Ord;
-
-import java.lang.reflect.Method;
-
 /**
- * Common functions for code generation.
+ * An key used in caching with descriptive to string.  Note the key uses
+ * reference equality for performance.
  */
-class CodeGeneratorUtil {
+public final class DescriptiveCacheKey {
 
-  private CodeGeneratorUtil() {
+  private final String description;
+
+  public DescriptiveCacheKey(String description) {
+    this.description = description;
   }
 
-  /** Returns e.g. ",\n boolean ignoreNulls". */
-  static StringBuilder paramList(StringBuilder buff, Method method, int startIndex) {
-    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())
-        .subList(startIndex, method.getParameterCount())) {
-      buff.append(",\n      ").append(t.e.getName()).append(" a").append(t.i);
-    }
-    return buff;
-  }
-
-  /** Returns e.g. ", ignoreNulls". */
-  static StringBuilder argList(StringBuilder buff, Method method, int startIndex) {
-    for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())
-        .subList(startIndex, method.getParameterCount())) {
-      buff.append(", a").append(t.i);
-    }
-    return buff;
+  @Override public String toString() {
+    return description;
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/DispatchGenerator.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/DispatchGenerator.java
@@ -43,14 +43,14 @@ import static org.apache.calcite.rel.metadata.janino.CodeGeneratorUtil.paramList
 /**
  * Generates the metadata dispatch to handlers.
  */
-public class DispatchGenerator {
+class DispatchGenerator {
   private final Map<MetadataHandler<?>, String> metadataHandlerToName;
 
-  public DispatchGenerator(Map<MetadataHandler<?>, String> metadataHandlerToName) {
+  DispatchGenerator(Map<MetadataHandler<?>, String> metadataHandlerToName) {
     this.metadataHandlerToName = metadataHandlerToName;
   }
 
-  public void dispatchMethod(StringBuilder buff, Method method,
+  void dispatchMethod(StringBuilder buff, Method method,
       Collection<? extends MetadataHandler<?>> metadataHandlers) {
     String delRelClass = DelegatingMetadataRel.class.getName();
     Map<MetadataHandler<?>, Set<Class<? extends RelNode>>> handlersToClasses =
@@ -77,7 +77,7 @@ public class DispatchGenerator {
         .append("      ")
         .append(RelMetadataQuery.class.getName())
         .append(" mq");
-    paramList(buff, method)
+    paramList(buff, method, 2)
         .append(") {\n");
     if (delegateClassList.isEmpty()) {
       throwUnknown(buff.append("    "), method)
@@ -141,7 +141,7 @@ public class DispatchGenerator {
       Class<? extends RelNode> clazz) {
     buff.append(handlerName).append(".").append(method.getName())
         .append("((").append(clazz.getName()).append(") r, mq");
-    argList(buff, method);
+    argList(buff, method, 2);
     buff.append(");\n");
   }
 
@@ -161,7 +161,7 @@ public class DispatchGenerator {
       Method candidate) {
     if (!superMethod.getName().equals(candidate.getName())) {
       return null;
-    } else if (superMethod.getParameterCount() + 2 != candidate.getParameterCount()) {
+    } else if (superMethod.getParameterCount() != candidate.getParameterCount()) {
       return null;
     } else {
       Class<?>[] cpt = candidate.getParameterTypes();
@@ -171,8 +171,8 @@ public class DispatchGenerator {
       } else if (!RelMetadataQuery.class.equals(cpt[1])) {
         return null;
       }
-      for (int i = 0; i < smpt.length; i++) {
-        if (cpt[i + 2] != smpt[i]) {
+      for (int i = 2; i < smpt.length; i++) {
+        if (cpt[i] != smpt[i]) {
           return null;
         }
       }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/DispatchGenerator.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/DispatchGenerator.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata.janino;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.DelegatingMetadataRel;
+import org.apache.calcite.rel.metadata.MetadataHandler;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.calcite.rel.metadata.janino.CodeGeneratorUtil.argList;
+import static org.apache.calcite.rel.metadata.janino.CodeGeneratorUtil.generateParamList;
+
+/**
+ * Generates the metadata dispatch.
+ */
+public class DispatchGenerator {
+  private final Map<MetadataHandler<?>, String> metadataHandlerToName;
+
+  public DispatchGenerator(Map<MetadataHandler<?>, String> metadataHandlerToName) {
+    this.metadataHandlerToName = metadataHandlerToName;
+  }
+
+  public void generateDispatchMethod(StringBuilder sb, Method method,
+      Collection<? extends MetadataHandler<?>> metadataHandlers) {
+    String delRelClass = DelegatingMetadataRel.class.getName();
+    Map<MetadataHandler<?>, Set<Class<? extends RelNode>>> handlersToClasses =
+        metadataHandlers.stream()
+            .distinct()
+            .collect(
+                Collectors.toMap(
+                    Function.identity(),
+                    mh -> methodAndInstanceToImplementingClass(method, mh)));
+
+    Set<Class<? extends RelNode>> delegateClassSet = handlersToClasses.values().stream()
+        .flatMap(Set::stream)
+        .collect(Collectors.toSet());
+    List<Class<? extends RelNode>> delegateClassList = topologicalSort(delegateClassSet);
+    sb
+        .append("  private ")
+        .append(method.getReturnType().getName())
+        .append(" ")
+        .append(method.getName())
+        .append("_(\n")
+        .append("      ")
+        .append(RelNode.class.getName())
+        .append(" r,\n")
+        .append("      ")
+        .append(RelMetadataQuery.class.getName())
+        .append(" mq");
+    generateParamList(sb, method)
+        .append(") {\n");
+    sb
+        .append("    while (r instanceof ").append(delRelClass).append(") {\n")
+        .append("      r = ((").append(delRelClass).append(") r).getCurrentRel();\n")
+        .append("    }\n");
+
+    sb
+        .append(
+            delegateClassList.stream()
+                .map(clazz ->
+                    generateIfInstanceDispatch(method, metadataHandlers, handlersToClasses, clazz))
+                .collect(
+                    Collectors.joining("    } else if ", "    if ", "    } else {\n")))
+        .append("      throw new ")
+        .append(IllegalArgumentException.class.getName())
+        .append("(\"No handler for method [").append(method)
+        .append("] applied to argument of type [\" + r.getClass() + ")
+        .append("\"]; we recommend you create a catch-all (RelNode) handler\"")
+        .append(");\n")
+        .append("    }\n")
+        .append("  }\n");
+  }
+
+  private CharSequence generateIfInstanceDispatch(Method method,
+      Collection<? extends MetadataHandler<?>> metadataHandlers,
+      Map<MetadataHandler<?>, Set<Class<? extends RelNode>>> handlersToClasses,
+
+      Class<? extends RelNode> clazz) {
+    String handlerName = findProvider(metadataHandlers, handlersToClasses, clazz);
+    StringBuilder sb = new StringBuilder()
+        .append("(r instanceof ").append(clazz.getName()).append(") {\n")
+        .append("      return ");
+    generateDispatchedCall(sb, handlerName, method, clazz);
+
+    return sb;
+  }
+
+  private void generateDispatchedCall(StringBuilder sb, String handlerName, Method method,
+      Class<? extends RelNode> clazz) {
+    sb.append(handlerName).append(".").append(method.getName())
+        .append("((").append(clazz.getName()).append(") r, mq");
+    argList(sb, method);
+    sb.append(");\n");
+  }
+
+
+  private static Set<Class<? extends RelNode>> methodAndInstanceToImplementingClass(
+      Method method, MetadataHandler<?> handler) {
+    return Arrays.stream(handler.getClass().getMethods())
+        .map(m -> toRelClass(method, m))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
+  private static @Nullable Class<? extends RelNode> toRelClass(Method superMethod,
+      Method candidate) {
+    if (!superMethod.getName().equals(candidate.getName())) {
+      return null;
+    } else if (superMethod.getParameterCount() + 2 != candidate.getParameterCount()) {
+      return null;
+    } else {
+      Class<?>[] cpt = candidate.getParameterTypes();
+      Class<?>[] smpt = superMethod.getParameterTypes();
+      if (!RelNode.class.isAssignableFrom(cpt[0])) {
+        return null;
+      } else if (!RelMetadataQuery.class.equals(cpt[1])) {
+        return null;
+      }
+      for (int i = 0; i < smpt.length; i++) {
+        if (cpt[i + 2] != smpt[i]) {
+          return null;
+        }
+      }
+      return (Class<? extends RelNode>) cpt[0];
+    }
+  }
+
+
+  private static List<Class<? extends RelNode>> topologicalSort(
+      Collection<Class<? extends RelNode>> list) {
+    //This is currently N squared, wikipedia say it could be better
+    List<Class<? extends RelNode>> l = new ArrayList<>();
+    ArrayDeque<Class<? extends RelNode>> s = new ArrayDeque<>(list);
+
+    while (!s.isEmpty()) {
+      Class<? extends RelNode> n = s.remove();
+
+      boolean found = false;
+      for (Class<? extends RelNode> other : s) {
+        if (n.isAssignableFrom(other)) {
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        s.add(n);
+      } else {
+        l.add(n);
+      }
+    }
+    return l;
+  }
+
+  private String findProvider(Collection<? extends MetadataHandler<?>> metadataHandlers,
+      Map<MetadataHandler<?>, Set<Class<? extends RelNode>>> handlerToClasses,
+      Class<? extends RelNode> clazz) {
+    for (MetadataHandler<?> mh : metadataHandlers) {
+      if (handlerToClasses.getOrDefault(mh, ImmutableSet.of()).contains(clazz)) {
+        return this.metadataHandlerToName.get(mh);
+      }
+    }
+    throw new RuntimeException();
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/JaninoMetadataHandlerCreator.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/JaninoMetadataHandlerCreator.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata.janino;
+
+import org.apache.calcite.config.CalciteSystemProperty;
+import org.apache.calcite.interpreter.JaninoRexCompiler;
+import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.rel.metadata.Metadata;
+import org.apache.calcite.rel.metadata.MetadataDef;
+import org.apache.calcite.rel.metadata.MetadataHandler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.codehaus.commons.compiler.CompileException;
+import org.codehaus.commons.compiler.CompilerFactoryFactory;
+import org.codehaus.commons.compiler.ICompilerFactory;
+import org.codehaus.commons.compiler.ISimpleCompiler;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Generates the {@link MetadataHandler} code, then compiles the code using janino.
+ */
+public class JaninoMetadataHandlerCreator {
+
+  private JaninoMetadataHandlerCreator() {
+  }
+
+  public static <M extends Metadata, MH extends MetadataHandler<M>> MH newInstance(
+      Class<MH> handlerClass,
+      ImmutableSet<? extends MetadataHandler<? extends Metadata>> handlerSet) {
+    final ImmutableList<? extends MetadataHandler<?>> handlers =
+        ImmutableList.copyOf(handlerSet);
+    final StringBuilder buff = new StringBuilder();
+    final String name =
+        "GeneratedMetadata_" + simpleNameForHandler(handlerClass);
+    final Set<MetadataHandler<?>> providerSet = new HashSet<>();
+
+    final Map<MetadataHandler<?>, String> handlerToName = new LinkedHashMap<>();
+    for (MetadataHandler<?> provider : handlers) {
+      if (providerSet.add(provider)) {
+        handlerToName.put(provider,
+            "provider" + (providerSet.size() - 1));
+      }
+    }
+
+    //PROPERTIES
+    for (Ord<Method> method : Ord.zip(handlerClass.getDeclaredMethods())) {
+      CacheGenerator.cacheProperties(buff, method.e, method.i);
+    }
+    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
+      buff.append("  public final ").append(handlerAndName.getKey().getClass().getName())
+          .append(' ').append(handlerAndName.getValue()).append(";\n");
+    }
+
+    //CONSTRUCTOR
+    buff.append("  public ").append(name).append("(\n");
+    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
+      buff.append("      ")
+          .append(handlerAndName.getKey().getClass().getName())
+          .append(' ')
+          .append(handlerAndName.getValue())
+          .append(",\n");
+    }
+    if (!handlerToName.isEmpty()) {
+      buff.setLength(buff.length() - 2);
+    }
+    buff.append(") {\n");
+    for (String handlerName : handlerToName.values()) {
+      buff.append("    this.").append(handlerName).append(" = ").append(handlerName)
+          .append(";\n");
+    }
+    buff.append("  }\n");
+
+    //METHODS
+    getDefMethod(buff,
+        handlerToName.values()
+            .stream()
+            .findFirst()
+            .orElse(null));
+
+    DispatchGenerator dispatchGenerator = new DispatchGenerator(handlerToName);
+    for (Ord<Method> method : Ord.zip(handlerClass.getDeclaredMethods())) {
+      CacheGenerator.cachedMethod(buff, method.e, method.i);
+      dispatchGenerator.dispatchMethod(buff, method.e, handlers);
+    }
+
+    final List<Object> argList = new ArrayList<>(handlerToName.keySet());
+    try {
+      return compile(name, buff.toString(), handlerClass, argList);
+    } catch (CompileException | IOException e) {
+      throw new RuntimeException("Error compiling:\n"
+          + buff, e);
+    }
+  }
+
+  private static void getDefMethod(StringBuilder buff, @Nullable String handlerName) {
+    buff.append("  public ")
+        .append(MetadataDef.class.getName())
+        .append(" getDef() {\n");
+
+    if (handlerName == null) {
+      buff.append("    return null;");
+    } else {
+      buff.append("    return ")
+          .append(handlerName)
+          .append(".getDef();\n");
+    }
+    buff.append("  }\n");
+  }
+
+  private static String simpleNameForHandler(Class<? extends MetadataHandler<?>> clazz) {
+    String simpleName = clazz.getSimpleName();
+    //Previously the pattern was to have a nested in class named Handler
+    //So we need to add the parents class to get a unique name
+    if (simpleName.equals("Handler")) {
+      String[] parts = clazz.getName().split("\\.|\\$");
+      return parts[parts.length - 2] + parts[parts.length - 1];
+    } else {
+      return simpleName;
+    }
+  }
+
+
+  private static <MH extends MetadataHandler<?>> MH compile(String className,
+      String classBody, Class<MH> handlerClass,
+      List<Object> argList) throws CompileException, IOException {
+    final ICompilerFactory compilerFactory;
+    try {
+      compilerFactory = CompilerFactoryFactory.getDefaultCompilerFactory();
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Unable to instantiate java compiler", e);
+    }
+
+    final ISimpleCompiler compiler = compilerFactory.newSimpleCompiler();
+    compiler.setParentClassLoader(JaninoRexCompiler.class.getClassLoader());
+
+    final String s = "public final class " + className
+        + " implements " + handlerClass.getCanonicalName() + " {\n"
+        + classBody
+        + "\n"
+        + "}";
+
+    if (CalciteSystemProperty.DEBUG.value()) {
+      // Add line numbers to the generated janino class
+      compiler.setDebuggingInformation(true, true, true);
+      System.out.println(s);
+    }
+
+    compiler.cook(s);
+    final Constructor constructor;
+    final Object o;
+    try {
+      constructor = compiler.getClassLoader().loadClass(className)
+          .getDeclaredConstructors()[0];
+      o = constructor.newInstance(argList.toArray());
+    } catch (InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException
+        | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    return handlerClass.cast(o);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/package-info.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Defines metadata interfaces and utilities for relational
+ * expressions.
+ */
+
+/**
+ * Code for generating metadata handlers.
+ */
+package org.apache.calcite.rel.metadata.janino;

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -151,6 +151,7 @@ public class Programs {
   }
 
   /** Creates a program that executes a {@link HepProgram}. */
+  @SuppressWarnings("deprecation")
   public static Program of(final HepProgram hepProgram, final boolean noDag,
       final RelMetadataProvider metadataProvider) {
     return (planner, rel, requiredOutputTraits, materializations, lattices) -> {

--- a/core/src/test/java/org/apache/calcite/test/MockRelOptPlanner.java
+++ b/core/src/test/java/org/apache/calcite/test/MockRelOptPlanner.java
@@ -204,10 +204,12 @@ public class MockRelOptPlanner extends AbstractRelOptPlanner {
     return true;
   }
 
+  @Deprecated
   @Override public long getRelMetadataTimestamp(RelNode rel) {
     return metadataTimestamp;
   }
 
+  @Deprecated
   /** Allow tests to tweak the timestamp. */
   public void setRelMetadataTimestamp(long metadataTimestamp) {
     this.metadataTimestamp = metadataTimestamp;

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -64,7 +64,6 @@ import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.metadata.BuiltInMetadata;
-import org.apache.calcite.rel.metadata.CachingRelMetadataProvider;
 import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
 import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
@@ -898,10 +897,6 @@ public class RelMetadataTest extends SqlToRelTestBase {
     RelNode rel =
         convertSql("select deptno, count(*) from emp where deptno > 10 "
             + "group by deptno having count(*) = 0");
-    rel.getCluster().setMetadataProvider(
-        new CachingRelMetadataProvider(
-            rel.getCluster().getMetadataProvider(),
-            rel.getCluster().getPlanner()));
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     Double result = mq.getSelectivity(rel, null);
     assertThat(result,
@@ -914,7 +909,9 @@ public class RelMetadataTest extends SqlToRelTestBase {
    * OutOfMemoryError</a>.
    *
    * Too slow to run every day, and it does not reproduce the issue. */
+  @SuppressWarnings("deprecation")
   @Tag("slow")
+  @Deprecated
   @Test void testMetadataHandlerCacheLimit() {
     assumeTrue(CalciteSystemProperty.METADATA_HANDLER_CACHE_MAXIMUM_SIZE.value() < 10_000,
         "If cache size is too large, this test may fail and the test won't be to blame");
@@ -926,7 +923,8 @@ public class RelMetadataTest extends SqlToRelTestBase {
     for (int i = 0; i < iterationCount; i++) {
       RelMetadataQuery.THREAD_PROVIDERS.set(
           JaninoRelMetadataProvider.of(
-              new CachingRelMetadataProvider(metadataProvider, planner)));
+              new org.apache.calcite.rel.metadata.CachingRelMetadataProvider(
+                  metadataProvider, planner)));
       final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
       final Double result = mq.getRowCount(rel);
       assertThat(result, within(14d, 0.1d));
@@ -1433,6 +1431,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     }
   }
 
+  @Deprecated
   public String colType(RelMetadataQuery mq, RelNode rel, int column) {
     return rel.metadata(ColType.class, mq).getColType(column);
   }
@@ -1441,6 +1440,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     return myRelMetadataQuery.colType(rel, column);
   }
 
+  @Deprecated
   @Test void testCustomProviderWithRelMetadataFactory() {
     final List<String> buf = new ArrayList<>();
     ColTypeImpl.THREAD_LIST.set(buf);
@@ -1483,7 +1483,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     // generates a new call to the provider.
     final RelOptPlanner planner = rel.getCluster().getPlanner();
     rel.getCluster().setMetadataProvider(
-        new CachingRelMetadataProvider(
+        new org.apache.calcite.rel.metadata.CachingRelMetadataProvider(
             rel.getCluster().getMetadataProvider(), planner));
     assertThat(colType(mq, input, 0), equalTo("DEPTNO-agg"));
     assertThat(buf.size(), equalTo(5));
@@ -3292,6 +3292,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
       implements MetadataHandler<ColType> {
     static final ThreadLocal<List<String>> THREAD_LIST = new ThreadLocal<>();
 
+    @Deprecated
     public MetadataDef<ColType> getDef() {
       return ColType.DEF;
     }

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1391,7 +1391,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     } catch (IllegalArgumentException e) {
       final String value = "No handler for method [public abstract java.lang.String "
           + "org.apache.calcite.test.RelMetadataTest$ColType.getColType(int)] "
-          + "applied to argument of type [interface org.apache.calcite.rel.RelNode]; "
+          + "applied to argument of type [class org.apache.calcite.rel.logical.LogicalFilter]; "
           + "we recommend you create a catch-all (RelNode) handler";
       assertThat(e.getMessage(), is(value));
     }
@@ -1425,7 +1425,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     } catch (IllegalArgumentException e) {
       final String value = "No handler for method [public abstract java.lang.String "
           + "org.apache.calcite.test.RelMetadataTest$ColType.getColType(int)] "
-          + "applied to argument of type [interface org.apache.calcite.rel.RelNode]; "
+          + "applied to argument of type [class org.apache.calcite.rel.logical.LogicalFilter]; "
           + "we recommend you create a catch-all (RelNode) handler";
       assertThat(e.getMessage(), is(value));
     }

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1389,8 +1389,9 @@ public class RelMetadataTest extends SqlToRelTestBase {
       assertThat(colType(mq, rel, 0), equalTo("DEPTNO-rel"));
       fail("expected error");
     } catch (IllegalArgumentException e) {
-      final String value = "No handler for method [public abstract java.lang.String "
-          + "org.apache.calcite.test.RelMetadataTest$ColType.getColType(int)] "
+      final String value = "No handler for method [public abstract "
+          + "java.lang.String org.apache.calcite.test.RelMetadataTest$ColType$Handler.getColType("
+          + "org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,int)] "
           + "applied to argument of type [class org.apache.calcite.rel.logical.LogicalFilter]; "
           + "we recommend you create a catch-all (RelNode) handler";
       assertThat(e.getMessage(), is(value));
@@ -1424,9 +1425,10 @@ public class RelMetadataTest extends SqlToRelTestBase {
       fail("expected error");
     } catch (IllegalArgumentException e) {
       final String value = "No handler for method [public abstract java.lang.String "
-          + "org.apache.calcite.test.RelMetadataTest$ColType.getColType(int)] "
-          + "applied to argument of type [class org.apache.calcite.rel.logical.LogicalFilter]; "
-          + "we recommend you create a catch-all (RelNode) handler";
+          + "org.apache.calcite.test.RelMetadataTest$ColType$Handler.getColType("
+          + "org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,int)]"
+          + " applied to argument of type [class org.apache.calcite.rel.logical.LogicalFilter];"
+          + " we recommend you create a catch-all (RelNode) handler";
       assertThat(e.getMessage(), is(value));
     }
   }
@@ -3313,7 +3315,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
    * reflection. */
   public static class ColTypeImpl extends PartialColTypeImpl {
     public static final RelMetadataProvider SOURCE =
-        ReflectiveRelMetadataProvider.reflectiveSource(ColType.METHOD, new ColTypeImpl());
+        ReflectiveRelMetadataProvider.reflectiveSource(new ColTypeImpl(), ColType.Handler.class);
 
     /** Implementation of {@link ColType#getColType(int)} for
      * {@link RelNode}, called via reflection. */
@@ -3329,8 +3331,8 @@ public class RelMetadataTest extends SqlToRelTestBase {
   /** Implementation of {@link ColType} that has no fall-back for {@link RelNode}. */
   public static class BrokenColTypeImpl extends PartialColTypeImpl {
     public static final RelMetadataProvider SOURCE =
-        ReflectiveRelMetadataProvider.reflectiveSource(ColType.METHOD,
-            new BrokenColTypeImpl());
+        ReflectiveRelMetadataProvider.reflectiveSource(
+            new BrokenColTypeImpl(), ColType.Handler.class);
   }
 
   /** Extension to {@link RelMetadataQuery} to support {@link ColType}.

--- a/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
@@ -29,9 +29,6 @@ import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
-import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
-import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.test.SqlTestFactory;
@@ -44,8 +41,6 @@ import org.apache.calcite.util.Closer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -91,13 +86,7 @@ abstract class RelOptTestBase extends SqlToRelTestBase {
 
     assertNotNull(relInitial);
 
-    List<RelMetadataProvider> list = new ArrayList<>();
-    list.add(DefaultRelMetadataProvider.INSTANCE);
-    planner.registerMetadataProviders(list);
-    RelMetadataProvider plannerChain =
-        ChainedRelMetadataProvider.of(list);
     final RelOptCluster cluster = relInitial.getCluster();
-    cluster.setMetadataProvider(plannerChain);
 
     RelNode relBefore;
     if (preProgram == null) {

--- a/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
+++ b/core/src/test/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
@@ -236,6 +236,7 @@ public class MockCatalogReaderExtended extends MockCatalogReaderSimple {
             throw new AssertionError();
           }
 
+          @Deprecated
           public MetadataDef<BuiltInMetadata.AllPredicates> getDef() {
             return BuiltInMetadata.AllPredicates.DEF;
           }


### PR DESCRIPTION
    [CALCITE-4550] Decoupling MetadataDef and JaninoRelMetadataProvider
    
    Reworking binding RelMdPercentageOrignalRows to handlers. Adding
    DescriptiveCacheKey to replace the method in metadata cache list.
    Encapsulating Handler generation in the janino sub package. Adding
    a handlers method to RelMetadataProvider keys on the class of
    MetadataHandler.