### PR TITLE
[CALCITE-4539] Customization of Metadata Handlers

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
@@ -144,7 +144,7 @@ public class RelOptCluster {
    * @param metadataProvider custom provider
    */
   @EnsuresNonNull({"this.metadataProvider", "this.metadataFactory"})
-  @SuppressWarnings("deprecation")
+  @Deprecated
   public void setMetadataProvider(
       @UnknownInitialization RelOptCluster this,
       RelMetadataProvider metadataProvider) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCluster.java
@@ -20,11 +20,9 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
-import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.MetadataFactory;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
-import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
@@ -136,7 +134,7 @@ public class RelOptCluster {
     return rexBuilder;
   }
 
-  public @Nullable RelMetadataProvider getMetadataProvider() {
+  public RelMetadataProvider getMetadataProvider() {
     return metadataProvider;
   }
 
@@ -153,11 +151,6 @@ public class RelOptCluster {
     this.metadataProvider = metadataProvider;
     this.metadataFactory =
         new org.apache.calcite.rel.metadata.MetadataFactoryImpl(metadataProvider);
-    // Wrap the metadata provider as a JaninoRelMetadataProvider
-    // and set it to the ThreadLocal,
-    // JaninoRelMetadataProvider is required by the RelMetadataQuery.
-    RelMetadataQueryBase.THREAD_PROVIDERS
-        .set(JaninoRelMetadataProvider.of(metadataProvider));
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
@@ -440,7 +440,7 @@ class TopDownRuleDriver implements RuleDriver {
       input.setExplored();
       for (RelSubset subset : input.getSet().subsets) {
         // Clear the LB cache as exploring state has changed.
-        input.getCluster().getMetadataQuery().cache.clear(subset);
+        input.getCluster().getMetadataQuery().clearCache(subset);
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
@@ -440,7 +440,7 @@ class TopDownRuleDriver implements RuleDriver {
       input.setExplored();
       for (RelSubset subset : input.getSet().subsets) {
         // Clear the LB cache as exploring state has changed.
-        input.getCluster().getMetadataQuery().clearCache(subset);
+        input.getCluster().getMetadataQuery().cache.clear(subset);
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoMetadataHandlerProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoMetadataHandlerProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.rel.RelNode;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Proxy;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Provides metadata handlers generated via Janino.
+ */
+public class JaninoMetadataHandlerProvider implements MetadataHandlerProvider {
+
+  public static final JaninoMetadataHandlerProvider INSTANCE = new JaninoMetadataHandlerProvider();
+  private static final ThreadLocal<@Nullable RelMetadataProvider> METADATA_PROVIDER_THREAD_LOCAL =
+      new ThreadLocal<>();
+
+  protected JaninoMetadataHandlerProvider() {
+  }
+
+  @Override public <H extends MetadataHandler<M>, M extends Metadata>
+  H initialHandler(Class<H> handlerClass) {
+    return handlerClass.cast(
+        Proxy.newProxyInstance(RelMetadataQuery.class.getClassLoader(),
+            new Class[] {handlerClass}, (proxy, method, args) -> {
+              final RelNode r = requireNonNull((RelNode) args[0], "(RelNode) args[0]");
+              METADATA_PROVIDER_THREAD_LOCAL.set(r.getCluster().getMetadataProvider());
+              throw new NoHandler(r.getClass());
+            }));
+  }
+
+  @Override public <H extends MetadataHandler<M>, M extends Metadata>
+  H revise(Class<H> handlerClass) {
+    RelMetadataProvider provider = requireNonNull(METADATA_PROVIDER_THREAD_LOCAL.get());
+    return JaninoRelMetadataProvider.revise(provider, handlerClass);
+  }
+
+  @Override public MetadataCache buildCache() {
+    return new TableMetadataCache();
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -20,7 +20,6 @@ import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.interpreter.JaninoRexCompiler;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.janino.RelMetadataHandlerGeneratorUtil;
-import org.apache.calcite.util.ControlFlowException;
 import org.apache.calcite.util.Util;
 
 import com.google.common.cache.CacheBuilder;
@@ -178,7 +177,8 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
     return handlerClass.cast(o);
   }
 
-  synchronized <H extends MetadataHandler<?>> H revise(Class<H> handlerClass) {
+  static synchronized <H extends MetadataHandler<?>> H revise(
+      RelMetadataProvider provider, Class<H> handlerClass) {
     try {
       final Key key = new Key(handlerClass, provider);
       //noinspection unchecked
@@ -197,12 +197,14 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
 
   /** Exception that indicates there there should be a handler for
    * this class but there is not. The action is probably to
-   * re-generate the handler class. */
-  public static class NoHandler extends ControlFlowException {
-    public final Class<? extends RelNode> relClass;
+   * re-generate the handler class.
+   *
+   * Please use MetadataHandlerProvider.NoHandler.*/
+  @Deprecated
+  public static class NoHandler extends MetadataHandlerProvider.NoHandler {
 
     public NoHandler(Class<? extends RelNode> relClass) {
-      this.relClass = relClass;
+      super(relClass);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -16,56 +16,27 @@
  */
 package org.apache.calcite.rel.metadata;
 
-import org.apache.calcite.config.CalciteSystemProperty;
-import org.apache.calcite.interpreter.JaninoRexCompiler;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.metadata.janino.RelMetadataHandlerGeneratorUtil;
-import org.apache.calcite.util.Util;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Multimap;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.codehaus.commons.compiler.CompileException;
-import org.codehaus.commons.compiler.CompilerFactoryFactory;
-import org.codehaus.commons.compiler.ICompilerFactory;
-import org.codehaus.commons.compiler.ISimpleCompiler;
 
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 /**
  * Implementation of the {@link RelMetadataProvider} interface that generates
  * a class that dispatches to the underlying providers.
  */
+@Deprecated
 public class JaninoRelMetadataProvider implements RelMetadataProvider {
   private final RelMetadataProvider provider;
 
   // Constants and static fields
-
+  @Deprecated
   public static final JaninoRelMetadataProvider DEFAULT =
       JaninoRelMetadataProvider.of(DefaultRelMetadataProvider.INSTANCE);
-
-
-  /** Cache of pre-generated handlers by provider and kind of metadata.
-   * For the cache to be effective, providers should implement identity
-   * correctly. */
-  private static final LoadingCache<Key, MetadataHandler<?>> HANDLERS =
-      maxSize(CacheBuilder.newBuilder(),
-          CalciteSystemProperty.METADATA_HANDLER_CACHE_MAXIMUM_SIZE.value())
-          .build(
-              CacheLoader.from(key ->
-                  generateCompileAndInstantiate(key.handlerClass,
-                      key.provider.handlers(key.handlerClass))));
 
   /** Private constructor; use {@link #of}. */
   private JaninoRelMetadataProvider(RelMetadataProvider provider) {
@@ -76,20 +47,12 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
    *
    * @param provider Underlying provider
    */
+  @Deprecated
   public static JaninoRelMetadataProvider of(RelMetadataProvider provider) {
     if (provider instanceof JaninoRelMetadataProvider) {
       return (JaninoRelMetadataProvider) provider;
     }
     return new JaninoRelMetadataProvider(provider);
-  }
-
-  // helper for initialization
-  private static <K, V> CacheBuilder<K, V> maxSize(CacheBuilder<K, V> builder,
-      int size) {
-    if (size >= 0) {
-      builder.maximumSize(size);
-    }
-    return builder;
   }
 
   @Override public boolean equals(@Nullable Object obj) {
@@ -119,75 +82,6 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
     return provider.handlers(handlerClass);
   }
 
-  private static <MH extends MetadataHandler<?>> MH generateCompileAndInstantiate(
-      Class<MH> handlerClass,
-      List<? extends MetadataHandler<? extends Metadata>> handlers) {
-
-    final List<? extends MetadataHandler<? extends Metadata>> uniqueHandlers = handlers.stream()
-        .distinct()
-        .collect(Collectors.toList());
-    RelMetadataHandlerGeneratorUtil.HandlerNameAndGeneratedCode handlerNameAndGeneratedCode =
-        RelMetadataHandlerGeneratorUtil.generateHandler(handlerClass, uniqueHandlers);
-
-    try {
-      return compile(handlerNameAndGeneratedCode.getHandlerName(),
-          handlerNameAndGeneratedCode.getGeneratedCode(), handlerClass, uniqueHandlers);
-    } catch (CompileException | IOException e) {
-      throw new RuntimeException("Error compiling:\n"
-          + handlerNameAndGeneratedCode.getGeneratedCode(), e);
-    }
-  }
-
-
-  static  <MH extends MetadataHandler<?>> MH compile(String className,
-      String generatedCode, Class<MH> handlerClass,
-      List<? extends Object> argList) throws CompileException, IOException {
-    final ICompilerFactory compilerFactory;
-    ClassLoader classLoader =
-        Objects.requireNonNull(JaninoRelMetadataProvider.class.getClassLoader(), "classLoader");
-    try {
-      compilerFactory = CompilerFactoryFactory.getDefaultCompilerFactory(classLoader);
-    } catch (Exception e) {
-      throw new IllegalStateException(
-          "Unable to instantiate java compiler", e);
-    }
-
-    final ISimpleCompiler compiler = compilerFactory.newSimpleCompiler();
-    compiler.setParentClassLoader(JaninoRexCompiler.class.getClassLoader());
-
-    if (CalciteSystemProperty.DEBUG.value()) {
-      // Add line numbers to the generated janino class
-      compiler.setDebuggingInformation(true, true, true);
-      System.out.println(generatedCode);
-    }
-
-    compiler.cook(generatedCode);
-    final Constructor constructor;
-    final Object o;
-    try {
-      constructor = compiler.getClassLoader().loadClass(className)
-          .getDeclaredConstructors()[0];
-      o = constructor.newInstance(argList.toArray());
-    } catch (InstantiationException
-        | IllegalAccessException
-        | InvocationTargetException
-        | ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
-    return handlerClass.cast(o);
-  }
-
-  static synchronized <H extends MetadataHandler<?>> H revise(
-      RelMetadataProvider provider, Class<H> handlerClass) {
-    try {
-      final Key key = new Key(handlerClass, provider);
-      //noinspection unchecked
-      return handlerClass.cast(HANDLERS.get(key));
-    } catch (UncheckedExecutionException | ExecutionException e) {
-      throw Util.throwAsRuntime(Util.causeOrSelf(e));
-    }
-  }
-
   /** Registers some classes. Does not flush the providers, but next time we
    * need to generate a provider, it will handle all of these classes. So,
    * calling this method reduces the number of times we need to re-generate. */
@@ -205,30 +99,6 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider {
 
     public NoHandler(Class<? extends RelNode> relClass) {
       super(relClass);
-    }
-  }
-
-  /** Key for the cache. */
-  private static class Key {
-    final Class<? extends MetadataHandler<? extends Metadata>> handlerClass;
-    final RelMetadataProvider provider;
-
-    private Key(Class<? extends MetadataHandler<?>> handlerClass,
-        RelMetadataProvider provider) {
-      this.handlerClass = handlerClass;
-      this.provider = provider;
-    }
-
-    @Override public int hashCode() {
-      return (handlerClass.hashCode() * 37
-          + provider.hashCode()) * 37;
-    }
-
-    @Override public boolean equals(@Nullable Object obj) {
-      return this == obj
-          || obj instanceof Key
-          && ((Key) obj).handlerClass.equals(handlerClass)
-          && ((Key) obj).provider.equals(provider);
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataCache.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataCache.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.rel.RelNode;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A cache for Rel Nodes Metadata.  {@link NullSentinel} is used for storing nulls and
+ * detecting cyclic metadata calls.
+ */
+public interface MetadataCache {
+  /**
+   * Removes cached metadata values for specified RelNode.
+   *
+   * @param rel RelNode whose cached metadata should be removed
+   * @return true if cache for the provided RelNode was not empty
+   */
+  boolean clear(RelNode rel);
+
+  @Nullable Object remove(RelNode relNode, Object args);
+  @Nullable Object get(RelNode relNode, Object args);
+  @Nullable Object put(RelNode relNode, Object args, Object value);
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandlerProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandlerProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.util.ControlFlowException;
+
+/**
+ * Provides {@link MetadataHandler} call sites and {@link MetadataCache} for
+ * {@link RelMetadataQuery}. The handlers provided are responsible for
+ * updating the cache stored in {@link RelMetadataQuery}.
+ */
+public interface MetadataHandlerProvider {
+
+  <H extends MetadataHandler<M>, M extends Metadata> H initialHandler(Class<H> handlerClass);
+
+  /** Re-generates the handler for a given kind of metadata.. */
+  <H extends MetadataHandler<M>, M extends Metadata> H revise(Class<H> handlerClass);
+
+  /**
+   * Creates a new cache.
+   *
+   * @return A new cache for {@link RelMetadataQuery}
+   */
+  MetadataCache buildCache();
+
+
+  /** Exception that indicates there there should be a handler for
+   * this class but there is not. The action is probably to
+   * re-generate the handler class. */
+  class NoHandler extends ControlFlowException {
+    public final Class<? extends RelNode> relClass;
+
+    public NoHandler(Class<? extends RelNode> relClass) {
+      this.relClass = relClass;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandlerProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandlerProvider.java
@@ -26,10 +26,10 @@ import org.apache.calcite.util.ControlFlowException;
  */
 public interface MetadataHandlerProvider {
 
-  <H extends MetadataHandler<M>, M extends Metadata> H initialHandler(Class<H> handlerClass);
+  <MH extends MetadataHandler<?>> MH initialHandler(Class<MH> handlerClass);
 
   /** Re-generates the handler for a given kind of metadata.. */
-  <H extends MetadataHandler<M>, M extends Metadata> H revise(Class<H> handlerClass);
+  <MH extends MetadataHandler<?>> MH revise(Class<MH> handlerClass);
 
   /**
    * Creates a new cache.

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -201,7 +201,7 @@ public class ReflectiveRelMetadataProvider
                   }
                   key1 = FlatLists.copyOf(args2);
                 }
-                if (mq.map.put(rel, key1, NullSentinel.INSTANCE) != null) {
+                if (mq.cache.put(rel, key1, NullSentinel.INSTANCE) != null) {
                   throw new CyclicMetadataException();
                 }
                 try {
@@ -210,7 +210,7 @@ public class ReflectiveRelMetadataProvider
                     | UndeclaredThrowableException e) {
                   throw Util.throwAsRuntime(Util.causeOrSelf(e));
                 } finally {
-                  mq.map.remove(rel, key1);
+                  mq.cache.remove(rel, key1);
                 }
               });
       methodsMap.put(key, function);

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -41,8 +41,6 @@ import java.util.Set;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * RelMetadataQuery provides a strongly-typed facade on top of
  * {@link RelMetadataProvider} for the set of relational expression metadata
@@ -79,7 +77,8 @@ import static java.util.Objects.requireNonNull;
  * plugin mechanism.
  */
 public class RelMetadataQuery extends RelMetadataQueryBase {
-  private static final RelMetadataQuery EMPTY = new RelMetadataQuery(false);
+  private static final RelMetadataQuery PROTOTYPE =
+      new RelMetadataQuery(JaninoMetadataHandlerProvider.INSTANCE);
 
   private BuiltInMetadata.Collation.Handler collationHandler;
   private BuiltInMetadata.ColumnOrigin.Handler columnOriginHandler;
@@ -107,47 +106,69 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
   private BuiltInMetadata.LowerBoundCost.Handler lowerBoundCostHandler;
 
   /**
-   * Creates the instance with {@link JaninoRelMetadataProvider} instance
-   * from {@link #THREAD_PROVIDERS} and {@link #EMPTY} as a prototype.
+   * Creates the instance using the Handler.classualt prototype.
    */
   protected RelMetadataQuery() {
-    this(castNonNull(THREAD_PROVIDERS.get()), EMPTY);
+    this(PROTOTYPE);
   }
 
   /** Creates and initializes the instance that will serve as a prototype for
    * all other instances. */
-  private RelMetadataQuery(@SuppressWarnings("unused") boolean dummy) {
-    super(null);
-    this.collationHandler = initialHandler(BuiltInMetadata.Collation.Handler.class);
-    this.columnOriginHandler = initialHandler(BuiltInMetadata.ColumnOrigin.Handler.class);
-    this.expressionLineageHandler = initialHandler(BuiltInMetadata.ExpressionLineage.Handler.class);
-    this.tableReferencesHandler = initialHandler(BuiltInMetadata.TableReferences.Handler.class);
-    this.columnUniquenessHandler = initialHandler(BuiltInMetadata.ColumnUniqueness.Handler.class);
-    this.cumulativeCostHandler = initialHandler(BuiltInMetadata.CumulativeCost.Handler.class);
-    this.distinctRowCountHandler = initialHandler(BuiltInMetadata.DistinctRowCount.Handler.class);
-    this.distributionHandler = initialHandler(BuiltInMetadata.Distribution.Handler.class);
-    this.explainVisibilityHandler = initialHandler(BuiltInMetadata.ExplainVisibility.Handler.class);
-    this.maxRowCountHandler = initialHandler(BuiltInMetadata.MaxRowCount.Handler.class);
-    this.minRowCountHandler = initialHandler(BuiltInMetadata.MinRowCount.Handler.class);
-    this.memoryHandler = initialHandler(BuiltInMetadata.Memory.Handler.class);
-    this.nonCumulativeCostHandler = initialHandler(BuiltInMetadata.NonCumulativeCost.Handler.class);
-    this.parallelismHandler = initialHandler(BuiltInMetadata.Parallelism.Handler.class);
+  protected RelMetadataQuery(MetadataHandlerProvider metadataHandlerProvider) {
+    super(metadataHandlerProvider);
+    this.collationHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.Collation.Handler.class);
+    this.columnOriginHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.ColumnOrigin.Handler.class);
+    this.expressionLineageHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.ExpressionLineage.Handler.class);
+    this.tableReferencesHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.TableReferences.Handler.class);
+    this.columnUniquenessHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.ColumnUniqueness.Handler.class);
+    this.cumulativeCostHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.CumulativeCost.Handler.class);
+    this.distinctRowCountHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.DistinctRowCount.Handler.class);
+    this.distributionHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.Distribution.Handler.class);
+    this.explainVisibilityHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.ExplainVisibility.Handler.class);
+    this.maxRowCountHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.MaxRowCount.Handler.class);
+    this.minRowCountHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.MinRowCount.Handler.class);
+    this.memoryHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.Memory.Handler.class);
+    this.nonCumulativeCostHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.NonCumulativeCost.Handler.class);
+    this.parallelismHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.Parallelism.Handler.class);
     this.percentageOriginalRowsHandler =
-        initialHandler(BuiltInMetadata.PercentageOriginalRows.Handler.class);
-    this.populationSizeHandler = initialHandler(BuiltInMetadata.PopulationSize.Handler.class);
-    this.predicatesHandler = initialHandler(BuiltInMetadata.Predicates.Handler.class);
-    this.allPredicatesHandler = initialHandler(BuiltInMetadata.AllPredicates.Handler.class);
-    this.nodeTypesHandler = initialHandler(BuiltInMetadata.NodeTypes.Handler.class);
-    this.rowCountHandler = initialHandler(BuiltInMetadata.RowCount.Handler.class);
-    this.selectivityHandler = initialHandler(BuiltInMetadata.Selectivity.Handler.class);
-    this.sizeHandler = initialHandler(BuiltInMetadata.Size.Handler.class);
-    this.uniqueKeysHandler = initialHandler(BuiltInMetadata.UniqueKeys.Handler.class);
-    this.lowerBoundCostHandler = initialHandler(BuiltInMetadata.LowerBoundCost.Handler.class);
+        metadataHandlerProvider.initialHandler(
+            BuiltInMetadata.PercentageOriginalRows.Handler.class);
+    this.populationSizeHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.PopulationSize.Handler.class);
+    this.predicatesHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.Predicates.Handler.class);
+    this.allPredicatesHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.AllPredicates.Handler.class);
+    this.nodeTypesHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.NodeTypes.Handler.class);
+    this.rowCountHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.RowCount.Handler.class);
+    this.selectivityHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.Selectivity.Handler.class);
+    this.sizeHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.Size.Handler.class);
+    this.uniqueKeysHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.UniqueKeys.Handler.class);
+    this.lowerBoundCostHandler =
+        metadataHandlerProvider.initialHandler(BuiltInMetadata.LowerBoundCost.Handler.class);
   }
 
-  private RelMetadataQuery(JaninoRelMetadataProvider metadataProvider,
-      RelMetadataQuery prototype) {
-    super(requireNonNull(metadataProvider, "metadataProvider"));
+  protected RelMetadataQuery(RelMetadataQuery prototype) {
+    super(prototype.metadataHandlerProvider);
     this.collationHandler = prototype.collationHandler;
     this.columnOriginHandler = prototype.columnOriginHandler;
     this.expressionLineageHandler = prototype.expressionLineageHandler;
@@ -195,8 +216,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return nodeTypesHandler.getNodeTypes(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        nodeTypesHandler = revise(BuiltInMetadata.NodeTypes.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        nodeTypesHandler = metadataHandlerProvider.revise(BuiltInMetadata.NodeTypes.Handler.class);
       } catch (CyclicMetadataException e) {
         return null;
       }
@@ -217,8 +238,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         Double result = rowCountHandler.getRowCount(rel, this);
         return RelMdUtil.validateResult(castNonNull(result));
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        rowCountHandler = revise(BuiltInMetadata.RowCount.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        rowCountHandler = metadataHandlerProvider.revise(BuiltInMetadata.RowCount.Handler.class);
       }
     }
   }
@@ -235,8 +256,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return maxRowCountHandler.getMaxRowCount(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        maxRowCountHandler = revise(BuiltInMetadata.MaxRowCount.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        maxRowCountHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.MaxRowCount.Handler.class);
       }
     }
   }
@@ -253,8 +275,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return minRowCountHandler.getMinRowCount(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        minRowCountHandler = revise(BuiltInMetadata.MinRowCount.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        minRowCountHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.MinRowCount.Handler.class);
       }
     }
   }
@@ -271,8 +294,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return cumulativeCostHandler.getCumulativeCost(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        cumulativeCostHandler = revise(BuiltInMetadata.CumulativeCost.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        cumulativeCostHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.CumulativeCost.Handler.class);
       }
     }
   }
@@ -289,8 +313,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return nonCumulativeCostHandler.getNonCumulativeCost(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        nonCumulativeCostHandler = revise(BuiltInMetadata.NonCumulativeCost.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        nonCumulativeCostHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.NonCumulativeCost.Handler.class);
       }
     }
   }
@@ -310,9 +335,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         Double result =
             percentageOriginalRowsHandler.getPercentageOriginalRows(rel, this);
         return RelMdUtil.validatePercentage(result);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         percentageOriginalRowsHandler =
-            revise(BuiltInMetadata.PercentageOriginalRows.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.PercentageOriginalRows.Handler.class);
       }
     }
   }
@@ -325,16 +350,16 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
    * @param rel           the relational expression
    * @param column 0-based ordinal for output column of interest
    * @return set of origin columns, or null if this information cannot be
-   * determined (whereas empty set indicates definitely no origin columns at
+   * determined (whereas empty set indicates Handler.classinitely no origin columns at
    * all)
    */
   public @Nullable Set<RelColumnOrigin> getColumnOrigins(RelNode rel, int column) {
     for (;;) {
       try {
         return columnOriginHandler.getColumnOrigins(rel, this, column);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         columnOriginHandler =
-            revise(BuiltInMetadata.ColumnOrigin.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.ColumnOrigin.Handler.class);
       }
     }
   }
@@ -366,9 +391,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return expressionLineageHandler.getExpressionLineage(rel, this, expression);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         expressionLineageHandler =
-            revise(BuiltInMetadata.ExpressionLineage.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.ExpressionLineage.Handler.class);
       }
     }
   }
@@ -380,9 +405,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return tableReferencesHandler.getTableReferences(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         tableReferencesHandler =
-            revise(BuiltInMetadata.TableReferences.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.TableReferences.Handler.class);
       }
     }
   }
@@ -425,9 +450,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         Double result = selectivityHandler.getSelectivity(rel, this, predicate);
         return RelMdUtil.validatePercentage(result);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         selectivityHandler =
-            revise(BuiltInMetadata.Selectivity.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.Selectivity.Handler.class);
       }
     }
   }
@@ -439,7 +464,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
    *
    * @param rel the relational expression
    * @return set of keys, or null if this information cannot be determined
-   * (whereas empty set indicates definitely no keys at all)
+   * (whereas empty set indicates Handler.classinitely no keys at all)
    */
   public @Nullable Set<ImmutableBitSet> getUniqueKeys(RelNode rel) {
     return getUniqueKeys(rel, false);
@@ -455,16 +480,16 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
    *                    whether the keys are unique
    *
    * @return set of keys, or null if this information cannot be determined
-   * (whereas empty set indicates definitely no keys at all)
+   * (whereas empty set indicates Handler.classinitely no keys at all)
    */
   public @Nullable Set<ImmutableBitSet> getUniqueKeys(RelNode rel,
       boolean ignoreNulls) {
     for (;;) {
       try {
         return uniqueKeysHandler.getUniqueKeys(rel, this, ignoreNulls);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         uniqueKeysHandler =
-            revise(BuiltInMetadata.UniqueKeys.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.UniqueKeys.Handler.class);
       }
     }
   }
@@ -546,9 +571,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return columnUniquenessHandler.areColumnsUnique(rel, this, columns,
             ignoreNulls);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         columnUniquenessHandler =
-            revise(BuiltInMetadata.ColumnUniqueness.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.ColumnUniqueness.Handler.class);
       }
     }
   }
@@ -566,8 +591,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return collationHandler.collations(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        collationHandler = revise(BuiltInMetadata.Collation.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        collationHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.Collation.Handler.class);
       }
     }
   }
@@ -590,9 +616,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
           return RelDistributions.ANY;
         }
         return distribution;
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         distributionHandler =
-            revise(BuiltInMetadata.Distribution.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.Distribution.Handler.class);
       }
     }
   }
@@ -616,9 +642,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         Double result =
             populationSizeHandler.getPopulationSize(rel, this, groupKey);
         return RelMdUtil.validateResult(result);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         populationSizeHandler =
-            revise(BuiltInMetadata.PopulationSize.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.PopulationSize.Handler.class);
       }
     }
   }
@@ -635,8 +661,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return sizeHandler.averageRowSize(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        sizeHandler = revise(BuiltInMetadata.Size.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        sizeHandler = metadataHandlerProvider.revise(BuiltInMetadata.Size.Handler.class);
       }
     }
   }
@@ -655,8 +681,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return sizeHandler.averageColumnSizes(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        sizeHandler = revise(BuiltInMetadata.Size.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        sizeHandler = metadataHandlerProvider.revise(BuiltInMetadata.Size.Handler.class);
       }
     }
   }
@@ -684,9 +710,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return parallelismHandler.isPhaseTransition(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         parallelismHandler =
-            revise(BuiltInMetadata.Parallelism.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.Parallelism.Handler.class);
       }
     }
   }
@@ -703,9 +729,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return parallelismHandler.splitCount(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         parallelismHandler =
-            revise(BuiltInMetadata.Parallelism.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.Parallelism.Handler.class);
       }
     }
   }
@@ -724,8 +750,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return memoryHandler.memory(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        memoryHandler = revise(BuiltInMetadata.Memory.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        memoryHandler = metadataHandlerProvider.revise(BuiltInMetadata.Memory.Handler.class);
       }
     }
   }
@@ -744,8 +770,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return memoryHandler.cumulativeMemoryWithinPhase(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        memoryHandler = revise(BuiltInMetadata.Memory.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        memoryHandler = metadataHandlerProvider.revise(BuiltInMetadata.Memory.Handler.class);
       }
     }
   }
@@ -764,8 +790,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return memoryHandler.cumulativeMemoryWithinPhaseSplit(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        memoryHandler = revise(BuiltInMetadata.Memory.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        memoryHandler = metadataHandlerProvider.revise(BuiltInMetadata.Memory.Handler.class);
       }
     }
   }
@@ -791,9 +817,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
             distinctRowCountHandler.getDistinctRowCount(rel, this, groupKey,
                 predicate);
         return RelMdUtil.validateResult(result);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         distinctRowCountHandler =
-            revise(BuiltInMetadata.DistinctRowCount.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.DistinctRowCount.Handler.class);
       }
     }
   }
@@ -811,8 +837,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         RelOptPredicateList result = predicatesHandler.getPredicates(rel, this);
         return result != null ? result : RelOptPredicateList.EMPTY;
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        predicatesHandler = revise(BuiltInMetadata.Predicates.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        predicatesHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.Predicates.Handler.class);
       }
     }
   }
@@ -829,8 +856,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return allPredicatesHandler.getAllPredicates(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        allPredicatesHandler = revise(BuiltInMetadata.AllPredicates.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        allPredicatesHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.AllPredicates.Handler.class);
       }
     }
   }
@@ -843,7 +871,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
    * @param rel          the relational expression
    * @param explainLevel level of detail
    * @return true for visible, false for invisible; if no metadata is available,
-   * defaults to true
+   * Handler.classaults to true
    */
   public Boolean isVisibleInExplain(RelNode rel,
       SqlExplainLevel explainLevel) {
@@ -852,9 +880,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         Boolean b = explainVisibilityHandler.isVisibleInExplain(rel, this,
             explainLevel);
         return b == null || b;
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         explainVisibilityHandler =
-            revise(BuiltInMetadata.ExplainVisibility.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.ExplainVisibility.Handler.class);
       }
     }
   }
@@ -873,8 +901,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return distributionHandler.distribution(rel, this);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
-        distributionHandler = revise(BuiltInMetadata.Distribution.Handler.class);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        distributionHandler =
+            metadataHandlerProvider.revise(BuiltInMetadata.Distribution.Handler.class);
       }
     }
   }
@@ -886,9 +915,9 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     for (;;) {
       try {
         return lowerBoundCostHandler.getLowerBoundCost(rel, this, planner);
-      } catch (JaninoRelMetadataProvider.NoHandler e) {
+      } catch (MetadataHandlerProvider.NoHandler e) {
         lowerBoundCostHandler =
-            revise(BuiltInMetadata.LowerBoundCost.Handler.class);
+            metadataHandlerProvider.revise(BuiltInMetadata.LowerBoundCost.Handler.class);
       }
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQueryBase.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQueryBase.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.RelNode;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
 
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Proxy;
@@ -68,6 +69,7 @@ public class RelMetadataQueryBase {
   @Deprecated // to be removed before 2.0
   public final Table<RelNode, Object, Object> map;
 
+  @API(status = API.Status.INTERNAL)
   public final MetadataCache cache;
   protected final MetadataHandlerProvider metadataHandlerProvider;
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/TableMetadataCache.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/TableMetadataCache.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * Rel Metadata cache back by @see HashBasedTable table.
  */
-public class TableMetadataCache implements MetadataCache {
+class TableMetadataCache implements MetadataCache {
   public final Table<RelNode, Object, Object> map = HashBasedTable.create();
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/metadata/TableMetadataCache.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/TableMetadataCache.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.rel.RelNode;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Map;
+
+/**
+ * Rel Metadata cache back by @see HashBasedTable table.
+ */
+public class TableMetadataCache implements MetadataCache {
+  public final Table<RelNode, Object, Object> map = HashBasedTable.create();
+
+  /**
+   * Removes cached metadata values for specified RelNode.
+   *
+   * @param rel RelNode whose cached metadata should be removed
+   * @return true if cache for the provided RelNode was not empty
+   */
+  @Override public boolean clear(RelNode rel) {
+    Map<Object, Object> row = map.row(rel);
+    if (row.isEmpty()) {
+      return false;
+    }
+
+    row.clear();
+    return true;
+  }
+
+  @Override public @Nullable Object remove(RelNode relNode, Object args) {
+    return map.remove(relNode, args);
+  }
+
+  @Override public @Nullable Object get(RelNode relNode, Object args) {
+    return map.get(relNode, args);
+  }
+
+  @Override public @Nullable Object put(RelNode relNode, Object args, Object value) {
+    return map.put(relNode, args, value);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGeneratorUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGeneratorUtil.java
@@ -66,7 +66,7 @@ class CacheGeneratorUtil {
         .append("    }\n")
         .append("    final Object key;\n");
     selectStrategy(method).cacheKeyBlock(buff, method, methodIndex);
-    buff.append("    final Object v = mq.map.get(r, key);\n")
+    buff.append("    final Object v = mq.cache.get(r, key);\n")
         .append("    if (v != null) {\n")
         .append("      if (v == ")
         .append(NullSentinel.class.getName())
@@ -84,7 +84,7 @@ class CacheGeneratorUtil {
         .append(method.getReturnType().getName())
         .append(") v;\n")
         .append("    }\n")
-        .append("    mq.map.put(r, key,")
+        .append("    mq.cache.put(r, key,")
         .append(NullSentinel.class.getName())
         .append(".ACTIVE);\n")
         .append("    try {\n")
@@ -95,14 +95,14 @@ class CacheGeneratorUtil {
         .append("_(r, mq");
     argList(buff, method)
         .append(");\n")
-        .append("      mq.map.put(r, key, ")
+        .append("      mq.cache.put(r, key, ")
         .append(NullSentinel.class.getName())
         .append(".mask(x));\n")
         .append("      return x;\n")
         .append("    } catch (")
         .append(Exception.class.getName())
         .append(" e) {\n")
-        .append("      mq.map.row(r).clear();\n")
+        .append("      mq.cache.clear(r);\n")
         .append("      throw e;\n")
         .append("    }\n")
         .append("  }\n")
@@ -178,7 +178,7 @@ class CacheGeneratorUtil {
      *     final Object key;
      *     key = org.apache.calcite.runtime.FlatLists.of(method_key_0, org.apache.calcite.rel
      * .metadata.NullSentinel.mask(a2), a3);
-     *     final Object v = mq.map.get(r, key);
+     *     final Object v = mq.cache.get(r, key);
      *     if (v != null) {
      *      ...
      * </code>
@@ -236,7 +236,7 @@ class CacheGeneratorUtil {
      *       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
      *     final Object key;
      *     key = method_key_0;
-     *     final Object v = mq.map.get(r, key);
+     *     final Object v = mq.cache.get(r, key);
      * </code>
      */
     NO_ARG {
@@ -332,7 +332,7 @@ class CacheGeneratorUtil {
      *       boolean a2) {
      *     final Object key;
      *     key = a2 ? method_key_0True : method_key_0False;
-     *     final Object v = mq.map.get(r, key);
+     *     final Object v = mq.cache.get(r, key);
      *     ...
      * </code>
      */

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/JaninoHandlerCompilerAndCacheUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/JaninoHandlerCompilerAndCacheUtil.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 /**
- * Util for {@ref RelMetadataHandler}.
+ * Util for compiling, instantating, caching of {@link RelMetadataHandler}.
  */
 public class JaninoHandlerCompilerAndCacheUtil {
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/JaninoHandlerCompilerAndCacheUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/JaninoHandlerCompilerAndCacheUtil.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata.janino;
+
+import org.apache.calcite.config.CalciteSystemProperty;
+import org.apache.calcite.interpreter.JaninoRexCompiler;
+import org.apache.calcite.rel.metadata.Metadata;
+import org.apache.calcite.rel.metadata.MetadataHandler;
+import org.apache.calcite.rel.metadata.RelMetadataProvider;
+import org.apache.calcite.util.Util;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.codehaus.commons.compiler.CompileException;
+import org.codehaus.commons.compiler.CompilerFactoryFactory;
+import org.codehaus.commons.compiler.ICompilerFactory;
+import org.codehaus.commons.compiler.ISimpleCompiler;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+/**
+ * Util for {@ref RelMetadataHandler}.
+ */
+public class JaninoHandlerCompilerAndCacheUtil {
+
+  private JaninoHandlerCompilerAndCacheUtil() {
+  }
+
+  /**
+   * Cache of pre-generated handlers by provider and kind of metadata.
+   * For the cache to be effective, providers should implement identity
+   * correctly.
+   */
+  private static final LoadingCache<Key, MetadataHandler<?>> HANDLERS =
+      maxSize(CacheBuilder.newBuilder(),
+          CalciteSystemProperty.METADATA_HANDLER_CACHE_MAXIMUM_SIZE.value())
+          .build(
+              CacheLoader.from(key ->
+                  generateCompileAndInstantiate(key.handlerClass,
+                      key.provider.handlers(key.handlerClass))));
+
+  public static <MH extends MetadataHandler<?>> MH getHandler(
+      RelMetadataProvider provider, Class<MH> handlerClass) {
+    try {
+      final Key key =
+          new Key(handlerClass, provider);
+      //noinspection unchecked
+      return handlerClass.cast(HANDLERS.get(key));
+    } catch (UncheckedExecutionException | ExecutionException e) {
+      throw Util.throwAsRuntime(Util.causeOrSelf(e));
+    }
+  }
+
+  private static <MH extends MetadataHandler<?>> MH generateCompileAndInstantiate(
+      Class<MH> handlerClass,
+      List<? extends MetadataHandler<? extends Metadata>> handlers) {
+    final List<? extends MetadataHandler<? extends Metadata>> uniqueHandlers = handlers.stream()
+        .distinct()
+        .collect(Collectors.toList());
+    RelMetadataHandlerGeneratorUtil.HandlerNameAndGeneratedCode handlerNameAndGeneratedCode =
+        RelMetadataHandlerGeneratorUtil.generateHandler(handlerClass, uniqueHandlers);
+    Class<? extends MH> mhImplClazz = compile(handlerNameAndGeneratedCode.getHandlerName(),
+        handlerNameAndGeneratedCode.getGeneratedCode(), handlerClass);
+    return instantiate(mhImplClazz, uniqueHandlers);
+  }
+
+
+  private static <MH extends MetadataHandler<?>> Class<? extends MH> compile(String className,
+      String generatedCode, Class<MH> handlerClass) {
+    final ICompilerFactory compilerFactory;
+    ClassLoader classLoader = Objects.requireNonNull(
+        JaninoHandlerCompilerAndCacheUtil.class.getClassLoader(), "classLoader");
+    try {
+      compilerFactory = CompilerFactoryFactory.getDefaultCompilerFactory(classLoader);
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Unable to instantiate java compiler", e);
+    }
+
+    final ISimpleCompiler compiler = compilerFactory.newSimpleCompiler();
+    compiler.setParentClassLoader(JaninoRexCompiler.class.getClassLoader());
+
+    if (CalciteSystemProperty.DEBUG.value()) {
+      // Add line numbers to the generated janino class
+      compiler.setDebuggingInformation(true, true, true);
+      System.out.println(generatedCode);
+    }
+    try {
+      compiler.cook(generatedCode);
+      Class mhImplClass = compiler.getClassLoader().loadClass(className);
+      assert handlerClass.isAssignableFrom(mhImplClass);
+      //noinspection unchecked
+      return mhImplClass;
+    } catch (CompileException | ClassNotFoundException e) {
+      throw new RuntimeException("Error compiling:\n"
+          + generatedCode, e);
+    }
+  }
+
+  private static <MH extends MetadataHandler<?>> MH instantiate(
+      Class<? extends MH> metadataImpl, List<? extends Object> argList) {
+    try {
+      Constructor<?> constructor = metadataImpl.getConstructors()[0];
+      Object instant = constructor.newInstance(argList.toArray());
+      return metadataImpl.cast(instant);
+    } catch (InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // helper for initialization
+  private static <K, V> CacheBuilder<K, V> maxSize(CacheBuilder<K, V> builder,
+      int size) {
+    if (size >= 0) {
+      builder.maximumSize(size);
+    }
+    return builder;
+  }
+
+  /** Key for the cache. */
+  private static class Key {
+    final Class<? extends MetadataHandler<? extends Metadata>> handlerClass;
+    final RelMetadataProvider provider;
+
+    private Key(Class<? extends MetadataHandler<?>> handlerClass,
+        RelMetadataProvider provider) {
+      this.handlerClass = handlerClass;
+      this.provider = provider;
+    }
+
+    @Override public int hashCode() {
+      return (handlerClass.hashCode() * 37
+          + provider.hashCode()) * 37;
+    }
+
+    @Override public boolean equals(@Nullable Object obj) {
+      return this == obj
+          || obj instanceof Key
+          && ((Key) obj).handlerClass.equals(handlerClass)
+          && ((Key) obj).provider.equals(provider);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -68,10 +68,12 @@ import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.metadata.BuiltInMetadata;
 import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
-import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
+import org.apache.calcite.rel.metadata.JaninoMetadataHandlerProvider;
 import org.apache.calcite.rel.metadata.Metadata;
+import org.apache.calcite.rel.metadata.MetadataCache;
 import org.apache.calcite.rel.metadata.MetadataDef;
 import org.apache.calcite.rel.metadata.MetadataHandler;
+import org.apache.calcite.rel.metadata.MetadataHandlerProvider;
 import org.apache.calcite.rel.metadata.ReflectiveRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelColumnOrigin;
 import org.apache.calcite.rel.metadata.RelMdCollation;
@@ -79,6 +81,7 @@ import org.apache.calcite.rel.metadata.RelMdColumnUniqueness;
 import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.metadata.TableMetadataCache;
 import org.apache.calcite.rel.metadata.UnboundMetadata;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
@@ -1035,7 +1038,10 @@ public class RelMetadataTest extends SqlToRelTestBase {
           return metadataProvider.handlers(handlerClass);
         }
       };
-      RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(wrappedProvider));
+
+      RelOptCluster cluster = rel.getCluster();
+      cluster.setMetadataProvider(wrappedProvider);
+      cluster.invalidateMetadataQuery();
       final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
       final Double result = mq.getRowCount(rel);
       assertThat(result, within(14d, 0.1d));
@@ -1668,6 +1674,101 @@ public class RelMetadataTest extends SqlToRelTestBase {
     assertThat(buf.size(), equalTo(7));
     assertThat(colType(mq, input, 0), equalTo("DEPTNO-agg"));
     assertThat(buf.size(), equalTo(7));
+  }
+
+  /**
+   * Cache for testing supported legacy behavior.
+   *
+   * @see MetadataCache that adds @see RelOptPlanner.getRelMetadataTimestamp()
+   * to the key.
+   */
+  @Deprecated
+  static class LegacyInvalidationMetadataCache implements MetadataCache {
+    private final TableMetadataCache metadataCache = new TableMetadataCache();
+
+    @Deprecated
+    @Override public boolean clear(RelNode rel) {
+      return metadataCache.clear(rel);
+    }
+
+    @Deprecated
+    @Override public @Nullable Object remove(RelNode relNode, Object args) {
+      return metadataCache.remove(relNode, toArgList(relNode, args));
+    }
+
+    @Deprecated
+    @Override public @Nullable Object get(RelNode relNode, Object args) {
+      return metadataCache.get(relNode, toArgList(relNode, args));
+    }
+
+    @Deprecated
+    @Override public @Nullable Object put(RelNode relNode,
+        Object args, Object value) {
+      return metadataCache.put(relNode, toArgList(relNode, args), value);
+    }
+
+    @Deprecated
+    private List<?> toArgList(RelNode relNode, Object args) {
+      return ImmutableList.builder().add(args)
+          .add(relNode.getCluster().getPlanner().getRelMetadataTimestamp(relNode))
+          .build();
+    }
+  }
+
+  @Deprecated
+  @Test void testSupportLegacyCachingBehaviorViaMetadataQuery() {
+    JaninoMetadataHandlerProvider provider = new JaninoMetadataHandlerProvider() {
+      @Override public MetadataCache buildCache() {
+        return new LegacyInvalidationMetadataCache();
+      }
+    };
+    RelMetadataQuery prototype = new CustomMq(provider);
+
+    final List<String> buf = new ArrayList<>();
+    ColTypeImpl.THREAD_LIST.set(buf);
+
+    final String sql = "select deptno, count(*) from emp where deptno > 10 "
+        + "group by deptno having count(*) = 0";
+    final RelRoot root = tester.convertSqlToRel(sql);
+    final RelNode rel = root.rel;
+    rel.getCluster().setMetadataProvider(ColTypeImpl.SOURCE);
+    final RelMetadataQuery mq = new CustomMq(prototype);
+
+    // Top node is a filter. Its metadata uses getColType(RelNode, int).
+    assertThat(rel, instanceOf(LogicalFilter.class));
+
+    // Next node is an aggregate. Its metadata uses
+    // getColType(LogicalAggregate, int).
+    final RelNode input = rel.getInput(0);
+    assertThat(input, instanceOf(LogicalAggregate.class));
+    try {
+      provider.initialHandler(ColType.Handler.class).getColType(input, mq, 0);
+      fail();
+    } catch (MetadataHandlerProvider.NoHandler noHandler) {
+      //ignore
+    }
+    ColType.Handler colTypeHandler = provider.revise(ColType.Handler.class);
+
+    assertThat(colTypeHandler.getColType(input, mq, 0), equalTo("DEPTNO-agg"));
+    assertThat(buf.size(), equalTo(1));
+    assertThat(colTypeHandler.getColType(input, mq, 0), equalTo("DEPTNO-agg"));
+    assertThat(buf.size(), equalTo(1));
+    assertThat(colTypeHandler.getColType(input, mq, 1), equalTo("EXPR$1-agg"));
+    assertThat(buf.size(), equalTo(2));
+    assertThat(colTypeHandler.getColType(input, mq, 1), equalTo("EXPR$1-agg"));
+    assertThat(buf.size(), equalTo(2));
+    assertThat(colTypeHandler.getColType(input, mq, 0), equalTo("DEPTNO-agg"));
+    assertThat(buf.size(), equalTo(2));
+
+    // With a different timestamp, a metadata item is re-computed on first call.
+    final RelOptPlanner planner = rel.getCluster().getPlanner();
+    long timestamp = planner.getRelMetadataTimestamp(rel);
+    assertThat(timestamp, equalTo(0L));
+    ((MockRelOptPlanner) planner).setRelMetadataTimestamp(timestamp + 1);
+    assertThat(colTypeHandler.getColType(input, mq, 0), equalTo("DEPTNO-agg"));
+    assertThat(buf.size(), equalTo(3));
+    assertThat(colTypeHandler.getColType(input, mq, 0), equalTo("DEPTNO-agg"));
+    assertThat(buf.size(), equalTo(3));
   }
 
   @Test void testCustomProviderWithRelMetadataQuery() {
@@ -3344,6 +3445,19 @@ public class RelMetadataTest extends SqlToRelTestBase {
         is(mq.getPopulationSize(rel, ImmutableBitSet.of(0))));
   }
 
+  /**
+   * Custom Metadata Query for using a different MetadataHandlerProvider.
+   */
+  static class CustomMq extends RelMetadataQuery {
+    CustomMq(MetadataHandlerProvider metadataHandlerProvider) {
+      super(metadataHandlerProvider);
+    }
+
+    CustomMq(RelMetadataQuery prototype) {
+      super(prototype);
+    }
+  }
+
   private static final SqlOperator NONDETERMINISTIC_OP = new SqlSpecialOperator(
           "NDC",
           SqlKind.OTHER_FUNCTION,
@@ -3544,15 +3658,16 @@ public class RelMetadataTest extends SqlToRelTestBase {
     private ColType.Handler colTypeHandler;
 
     MyRelMetadataQuery() {
-      colTypeHandler = initialHandler(ColType.Handler.class);
+      colTypeHandler =
+          JaninoMetadataHandlerProvider.INSTANCE.initialHandler(ColType.Handler.class);
     }
 
     public String colType(RelNode rel, int column) {
       for (;;) {
         try {
           return colTypeHandler.getColType(rel, this, column);
-        } catch (JaninoRelMetadataProvider.NoHandler e) {
-          colTypeHandler = revise(ColType.Handler.class);
+        } catch (MetadataHandlerProvider.NoHandler e) {
+          colTypeHandler = metadataHandlerProvider.revise(ColType.Handler.class);
         }
       }
     }

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -81,7 +81,6 @@ import org.apache.calcite.rel.metadata.RelMdColumnUniqueness;
 import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
-import org.apache.calcite.rel.metadata.TableMetadataCache;
 import org.apache.calcite.rel.metadata.UnboundMetadata;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
@@ -115,12 +114,14 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Util;
 
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.CoreMatchers;
@@ -1684,27 +1685,33 @@ public class RelMetadataTest extends SqlToRelTestBase {
    */
   @Deprecated
   static class LegacyInvalidationMetadataCache implements MetadataCache {
-    private final TableMetadataCache metadataCache = new TableMetadataCache();
+    public final Table<RelNode, Object, Object> map = HashBasedTable.create();
 
     @Deprecated
     @Override public boolean clear(RelNode rel) {
-      return metadataCache.clear(rel);
+      Map<Object, Object> row = map.row(rel);
+      if (row.isEmpty()) {
+        return false;
+      }
+
+      row.clear();
+      return true;
     }
 
     @Deprecated
     @Override public @Nullable Object remove(RelNode relNode, Object args) {
-      return metadataCache.remove(relNode, toArgList(relNode, args));
+      return map.remove(relNode, toArgList(relNode, args));
     }
 
     @Deprecated
     @Override public @Nullable Object get(RelNode relNode, Object args) {
-      return metadataCache.get(relNode, toArgList(relNode, args));
+      return map.get(relNode, toArgList(relNode, args));
     }
 
     @Deprecated
     @Override public @Nullable Object put(RelNode relNode,
         Object args, Object value) {
-      return metadataCache.put(relNode, toArgList(relNode, args), value);
+      return map.put(relNode, toArgList(relNode, args), value);
     }
 
     @Deprecated

--- a/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptTestBase.java
@@ -29,9 +29,6 @@ import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
-import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
-import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.test.SqlTestFactory;
@@ -46,8 +43,6 @@ import com.google.common.collect.ImmutableMap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -113,12 +108,7 @@ abstract class RelOptTestBase extends SqlToRelTestBase {
         RelOptPlanner planner, RelNode relInitial, boolean unchanged) {
     assertNotNull(relInitial);
     final DiffRepository diffRepos = getDiffRepos();
-    List<RelMetadataProvider> list = new ArrayList<>();
-    list.add(DefaultRelMetadataProvider.INSTANCE);
-    RelMetadataProvider plannerChain =
-        ChainedRelMetadataProvider.of(list);
     final RelOptCluster cluster = relInitial.getCluster();
-    cluster.setMetadataProvider(plannerChain);
 
     RelNode relBefore;
     if (preProgram == null) {

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_AllPredicatesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_AllPredicatesHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_AllPredicatesHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_AllPredicatesHandler
       }
       return (org.apache.calcite.plan.RelOptPredicateList) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final org.apache.calcite.plan.RelOptPredicateList x = getAllPredicates_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CollationHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CollationHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_CollationHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_CollationHandler
       }
       return (com.google.common.collect.ImmutableList) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final com.google.common.collect.ImmutableList x = collations_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnOriginHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnOriginHandler.java
@@ -43,7 +43,7 @@ public final class GeneratedMetadata_ColumnOriginHandler
     } else {
       key = org.apache.calcite.runtime.FlatLists.of(methodKey0, a2);
     }
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -53,13 +53,13 @@ public final class GeneratedMetadata_ColumnOriginHandler
       }
       return (java.util.Set) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.util.Set x = getColumnOrigins_(r, mq, a2);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnUniquenessHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnUniquenessHandler.java
@@ -38,7 +38,7 @@ public final class GeneratedMetadata_ColumnUniquenessHandler
     }
     final Object key;
     key = org.apache.calcite.runtime.FlatLists.of(methodKey0, org.apache.calcite.rel.metadata.NullSentinel.mask(a2), a3);
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -48,13 +48,13 @@ public final class GeneratedMetadata_ColumnUniquenessHandler
       }
       return (java.lang.Boolean) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Boolean x = areColumnsUnique_(r, mq, a2, a3);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CumulativeCostHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CumulativeCostHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_CumulativeCostHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_CumulativeCostHandler
       }
       return (org.apache.calcite.plan.RelOptCost) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final org.apache.calcite.plan.RelOptCost x = getCumulativeCost_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistinctRowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistinctRowCountHandler.java
@@ -38,7 +38,7 @@ public final class GeneratedMetadata_DistinctRowCountHandler
     }
     final Object key;
     key = org.apache.calcite.runtime.FlatLists.of(methodKey0, org.apache.calcite.rel.metadata.NullSentinel.mask(a2), a3);
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -48,13 +48,13 @@ public final class GeneratedMetadata_DistinctRowCountHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = getDistinctRowCount_(r, mq, a2, a3);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistributionHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistributionHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_DistributionHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_DistributionHandler
       }
       return (org.apache.calcite.rel.RelDistribution) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final org.apache.calcite.rel.RelDistribution x = distribution_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExplainVisibilityHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExplainVisibilityHandler.java
@@ -43,7 +43,7 @@ public final class GeneratedMetadata_ExplainVisibilityHandler
     } else {
       key = methodKey0[a2.ordinal()];
     }
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -53,13 +53,13 @@ public final class GeneratedMetadata_ExplainVisibilityHandler
       }
       return (java.lang.Boolean) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Boolean x = isVisibleInExplain_(r, mq, a2);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExpressionLineageHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExpressionLineageHandler.java
@@ -37,7 +37,7 @@ public final class GeneratedMetadata_ExpressionLineageHandler
     }
     final Object key;
     key = org.apache.calcite.runtime.FlatLists.of(methodKey0, a2);
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -47,13 +47,13 @@ public final class GeneratedMetadata_ExpressionLineageHandler
       }
       return (java.util.Set) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.util.Set x = getExpressionLineage_(r, mq, a2);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_LowerBoundCostHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_LowerBoundCostHandler.java
@@ -37,7 +37,7 @@ public final class GeneratedMetadata_LowerBoundCostHandler
     }
     final Object key;
     key = org.apache.calcite.runtime.FlatLists.of(methodKey0, org.apache.calcite.rel.metadata.NullSentinel.mask(a2));
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -47,13 +47,13 @@ public final class GeneratedMetadata_LowerBoundCostHandler
       }
       return (org.apache.calcite.plan.RelOptCost) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final org.apache.calcite.plan.RelOptCost x = getLowerBoundCost_(r, mq, a2);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MaxRowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MaxRowCountHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_MaxRowCountHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_MaxRowCountHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = getMaxRowCount_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MemoryHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MemoryHandler.java
@@ -40,7 +40,7 @@ public final class GeneratedMetadata_MemoryHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -50,13 +50,13 @@ public final class GeneratedMetadata_MemoryHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = cumulativeMemoryWithinPhase_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }
@@ -78,7 +78,7 @@ public final class GeneratedMetadata_MemoryHandler
     }
     final Object key;
     key = methodKey1;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -88,13 +88,13 @@ public final class GeneratedMetadata_MemoryHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = cumulativeMemoryWithinPhaseSplit_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }
@@ -116,7 +116,7 @@ public final class GeneratedMetadata_MemoryHandler
     }
     final Object key;
     key = methodKey2;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -126,13 +126,13 @@ public final class GeneratedMetadata_MemoryHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = memory_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MinRowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MinRowCountHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_MinRowCountHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_MinRowCountHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = getMinRowCount_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NodeTypesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NodeTypesHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_NodeTypesHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_NodeTypesHandler
       }
       return (com.google.common.collect.Multimap) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final com.google.common.collect.Multimap x = getNodeTypes_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NonCumulativeCostHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NonCumulativeCostHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_NonCumulativeCostHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_NonCumulativeCostHandler
       }
       return (org.apache.calcite.plan.RelOptCost) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final org.apache.calcite.plan.RelOptCost x = getNonCumulativeCost_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ParallelismHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ParallelismHandler.java
@@ -38,7 +38,7 @@ public final class GeneratedMetadata_ParallelismHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -48,13 +48,13 @@ public final class GeneratedMetadata_ParallelismHandler
       }
       return (java.lang.Boolean) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Boolean x = isPhaseTransition_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }
@@ -82,7 +82,7 @@ public final class GeneratedMetadata_ParallelismHandler
     }
     final Object key;
     key = methodKey1;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -92,13 +92,13 @@ public final class GeneratedMetadata_ParallelismHandler
       }
       return (java.lang.Integer) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Integer x = splitCount_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PercentageOriginalRowsHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PercentageOriginalRowsHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_PercentageOriginalRowsHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_PercentageOriginalRowsHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = getPercentageOriginalRows_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PopulationSizeHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PopulationSizeHandler.java
@@ -37,7 +37,7 @@ public final class GeneratedMetadata_PopulationSizeHandler
     }
     final Object key;
     key = org.apache.calcite.runtime.FlatLists.of(methodKey0, org.apache.calcite.rel.metadata.NullSentinel.mask(a2));
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -47,13 +47,13 @@ public final class GeneratedMetadata_PopulationSizeHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = getPopulationSize_(r, mq, a2);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PredicatesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PredicatesHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_PredicatesHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_PredicatesHandler
       }
       return (org.apache.calcite.plan.RelOptPredicateList) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final org.apache.calcite.plan.RelOptPredicateList x = getPredicates_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_RowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_RowCountHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_RowCountHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_RowCountHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = getRowCount_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SelectivityHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SelectivityHandler.java
@@ -37,7 +37,7 @@ public final class GeneratedMetadata_SelectivityHandler
     }
     final Object key;
     key = org.apache.calcite.runtime.FlatLists.of(methodKey0, a2);
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -47,13 +47,13 @@ public final class GeneratedMetadata_SelectivityHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = getSelectivity_(r, mq, a2);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SizeHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SizeHandler.java
@@ -38,7 +38,7 @@ public final class GeneratedMetadata_SizeHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -48,13 +48,13 @@ public final class GeneratedMetadata_SizeHandler
       }
       return (java.util.List) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.util.List x = averageColumnSizes_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }
@@ -102,7 +102,7 @@ public final class GeneratedMetadata_SizeHandler
     }
     final Object key;
     key = methodKey1;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -112,13 +112,13 @@ public final class GeneratedMetadata_SizeHandler
       }
       return (java.lang.Double) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.lang.Double x = averageRowSize_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_TableReferencesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_TableReferencesHandler.java
@@ -36,7 +36,7 @@ public final class GeneratedMetadata_TableReferencesHandler
     }
     final Object key;
     key = methodKey0;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -46,13 +46,13 @@ public final class GeneratedMetadata_TableReferencesHandler
       }
       return (java.util.Set) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.util.Set x = getTableReferences_(r, mq);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_UniqueKeysHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_UniqueKeysHandler.java
@@ -39,7 +39,7 @@ public final class GeneratedMetadata_UniqueKeysHandler
     }
     final Object key;
     key = a2 ? methodKey0True : methodKey0False;
-    final Object v = mq.map.get(r, key);
+    final Object v = mq.cache.get(r, key);
     if (v != null) {
       if (v == org.apache.calcite.rel.metadata.NullSentinel.ACTIVE) {
         throw new org.apache.calcite.rel.metadata.CyclicMetadataException();
@@ -49,13 +49,13 @@ public final class GeneratedMetadata_UniqueKeysHandler
       }
       return (java.util.Set) v;
     }
-    mq.map.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
+    mq.cache.put(r, key,org.apache.calcite.rel.metadata.NullSentinel.ACTIVE);
     try {
       final java.util.Set x = getUniqueKeys_(r, mq, a2);
-      mq.map.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
+      mq.cache.put(r, key, org.apache.calcite.rel.metadata.NullSentinel.mask(x));
       return x;
     } catch (java.lang.Exception e) {
-      mq.map.row(r).clear();
+      mq.cache.clear(r);
       throw e;
     }
   }


### PR DESCRIPTION
Changing RelMetadataQueryBase.map generic from Table<Object, List, Object>
to Table<Object, Object, Object> to support more efficient cache keys.