### PR TITLE
[CALCITE-4547] Support JDK 16 (and bump Gradle to 7.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - jdk: openjdk11
       env:
         - TZ=Pacific/Chatham # flips between +12:45 and +13:45
-    - jdk: openjdk15
+    - jdk: openjdk16
 branches:
   only:
     - master

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 #
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionSha256Sum=2e6b95b41001bd9f099b17a772c3308fe59356f8b7f995ffd7bf74400db0f13c
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-milestone-3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 #
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=2e6b95b41001bd9f099b17a772c3308fe59356f8b7f995ffd7bf74400db0f13c
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-milestone-3-bin.zip
+distributionSha256Sum=12b807b5d6b065f05e0e47d8d00e9d55fe26d3cfc6cdb22d6825a93940edec90
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -27,8 +27,15 @@ For a full list of releases, see
 <a href="https://github.com/apache/calcite/releases">github</a>.
 Downloads are available on the
 [downloads page]({{ site.baseurl }}/downloads/).
+
 ## <a href="https://github.com/apache/calcite/releases/tag/calcite-1.27.0">1.27.0</a> / under development
 {: #v1-27-0}
+
+Compatibility: This release is tested on Linux, macOS, Microsoft Windows;
+using JDK/OpenJDK versions 8 to 16;
+Guava versions 19.0 to 29.0-jre;
+other software versions as specified in gradle.properties.
+
 #### Breaking Changes
 * [<a href="https://issues.apache.org/jira/browse/CALCITE-4521">CALCITE-4251</a>]
 Get the origin column, even if it is derived


### PR DESCRIPTION
Not complete - gradle complains about missing "testRuntime" configuration.