### PR TITLE
[CALCITE-4562] Improve simplification of "expression IS TRUE"

### DIFF
--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -3084,13 +3084,21 @@ class RexProgramTest extends RexProgramTestBase {
    * RexSimplify should simplify more always true OR expressions</a>. */
   @Test void testSimplifyLike() {
     final RexNode ref = input(tVarchar(true, 10), 0);
-    checkSimplify(like(ref, literal("%")),
-        "OR(null, IS NOT NULL($0))");
-    checkSimplify(like(ref, literal("%"), literal("#")),
-        "OR(null, IS NOT NULL($0))");
+    checkSimplify3(like(ref, literal("%")),
+        "OR(null, IS NOT NULL($0))", "IS NOT NULL($0)", "true");
+    checkSimplify3(like(ref, literal("%"), literal("#")),
+        "OR(null, IS NOT NULL($0))", "IS NOT NULL($0)", "true");
     checkSimplify(or(isNull(ref), like(ref, literal("%"))),
         "true");
     checkSimplify(or(isNull(ref), like(ref, literal("%"), literal("#"))),
+        "true");
+    checkSimplify(isTrue(like(ref, literal("%"))),
+        "IS NOT NULL($0)");
+    checkSimplify(isFalse(like(ref, literal("%"))),
+        "false");
+    checkSimplify(isNotTrue(like(ref, literal("%"))),
+        "IS NULL($0)");
+    checkSimplify(isNotFalse(like(ref, literal("%"))),
         "true");
     checkSimplifyUnchanged(like(ref, literal("%A")));
     checkSimplifyUnchanged(like(ref, literal("%A"), literal("#")));


### PR DESCRIPTION
Add pass of "unknown as" context to simplifyLike.

Add recursive call to simplifyNot in case when underlying expression is
simplified (to cover cases like "NOT (x LIKE '%')" with "unknown as
TRUE" context).

Add "unknown as" context specification for IS_FALSE and IS_NOT_TRUE
expressions.