### PR TITLE
[CALCITE-4570] Always validate preconditions in Filter/Correlate/Snapshot expressions when assertions are enabled

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
@@ -87,6 +87,7 @@ public abstract class Correlate extends BiRel {
    * @param requiredColumns Set of columns that are used by correlation
    * @param joinType Join type
    */
+  @SuppressWarnings("method.invocation.invalid")
   protected Correlate(
       RelOptCluster cluster,
       RelTraitSet traitSet,
@@ -100,6 +101,7 @@ public abstract class Correlate extends BiRel {
     this.joinType = requireNonNull(joinType, "joinType");
     this.correlationId = requireNonNull(correlationId, "correlationId");
     this.requiredColumns = requireNonNull(requiredColumns, "requiredColumns");
+    assert isValid(Litmus.THROW, null);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/core/Filter.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Filter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.rel.core;
 
-import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -79,8 +78,7 @@ public abstract class Filter extends SingleRel {
     super(cluster, traits, child);
     this.condition = requireNonNull(condition, "condition");
     assert RexUtil.isFlat(condition) : "RexUtil.isFlat should be true for condition " + condition;
-    // Too expensive for everyday use:
-    assert !CalciteSystemProperty.DEBUG.value() || isValid(Litmus.THROW, null);
+    assert isValid(Litmus.THROW, null);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/core/Snapshot.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Snapshot.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.rel.core;
 
-import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
@@ -65,8 +64,7 @@ public abstract class Snapshot extends SingleRel  {
       RexNode period) {
     super(cluster, traitSet, input);
     this.period = Objects.requireNonNull(period, "period");
-    // Too expensive for everyday use:
-    assert !CalciteSystemProperty.DEBUG.value() || isValid(Litmus.THROW, null);
+    assert isValid(Litmus.THROW, null);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.rel.logical;
 
-import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -27,7 +26,6 @@ import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.calcite.util.Litmus;
 
 import static java.util.Objects.requireNonNull;
 
@@ -73,7 +71,6 @@ public final class LogicalCorrelate extends Correlate {
         correlationId,
         requiredColumns,
         joinType);
-    assert !CalciteSystemProperty.DEBUG.value() || isValid(Litmus.THROW, null);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -31,7 +31,6 @@ import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMdDistribution;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.util.Litmus;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -69,7 +68,6 @@ public final class LogicalFilter extends Filter {
       ImmutableSet<CorrelationId> variablesSet) {
     super(cluster, traitSet, child, condition);
     this.variablesSet = Objects.requireNonNull(variablesSet, "variablesSet");
-    assert isValid(Litmus.THROW, null);
   }
 
   @Deprecated // to be removed before 2.0


### PR DESCRIPTION
Validate preconditions in the constructor of Filter, Correlate, and
Snapshot regardless if CalciteSystemProperty.DEBUG is enabled or not.
To avoid the performance overhead in production the assertions can be
disabled as it usually happens.