### PR TITLE
CALCITE-4571 : Conversion of PIG script with multiple store causing the merging of multiple sql statements (Mahesh Kumar Behera)

### DIFF
--- a/piglet/src/main/java/org/apache/calcite/piglet/PigConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigConverter.java
@@ -254,6 +254,7 @@ public class PigConverter extends PigServer {
       final SqlNode sqlNode = sqlConverter.visitRoot(rel).asStatement();
       sqlNode.unparse(writer, 0, 0);
       sqlStatements.add(writer.toString());
+      writer.reset();
     }
     return sqlStatements;
   }

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -105,6 +105,17 @@ class PigRelOpTest extends PigRelTestBase {
       }
     }
 
+    private Fluent assertSql(Matcher<String> sqlMatcher, int pos) {
+      try {
+        final String sql =
+            converter.pigToSql(script, PigRelSqlDialect.DEFAULT).get(pos);
+        assertThat(sql, sqlMatcher);
+        return this;
+      } catch (IOException e) {
+        throw TestUtil.rethrow(e);
+      }
+    }
+
     private Fluent assertResult(Matcher<String> resultMatcher) {
       final RelNode rel;
       try {
@@ -1642,5 +1653,27 @@ class PigRelOpTest extends PigRelTestBase {
         + "WHERE w0$o0 > 1";
     pig(script).assertRel(hasTree(plan))
         .assertSql(is(sql));
+  }
+
+  @Test void testMultipleStores() {
+    final String script = ""
+        + "A = LOAD 'scott.DEPT' as (DEPTNO:int, DNAME:chararray, LOC:CHARARRAY);\n"
+        + "B = FILTER A BY DEPTNO <= 30;\n"
+        + "STORE B into 'output.csv';\n"
+        + "C = FILTER A BY DEPTNO >= 20;\n"
+        + "STORE C into 'output1.csv';\n";
+    final String plan = ""
+        + "LogicalFilter(condition=[<=($0, 30)])\n"
+        + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    final String sql = ""
+        + "SELECT *\n"
+        + "FROM scott.DEPT\n"
+        + "WHERE DEPTNO <= 30";
+    final String sql1 = ""
+        + "SELECT *\n"
+        + "FROM scott.DEPT\n"
+        + "WHERE DEPTNO >= 20";
+    pig(script).assertRel(hasTree(plan))
+        .assertSql(is(sql1), 1);
   }
 }

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -1674,6 +1674,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "FROM scott.DEPT\n"
         + "WHERE DEPTNO >= 20";
     pig(script).assertRel(hasTree(plan))
+        .assertSql(is(sql), 0)
         .assertSql(is(sql1), 1);
   }
 }


### PR DESCRIPTION
The sql write is not reset after sql statement is converted. This is causing the next sql statements to be merged with the previous one.