### PR TITLE
[CALCITE-4584] Using function in partition by list of over window cause converting exception

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2034,6 +2034,7 @@ public class SqlToRelConverter {
     final ImmutableList.Builder<RexNode> partitionKeys =
         ImmutableList.builder();
     for (SqlNode partition : partitionList) {
+      validator().deriveType(bb.scope(), partition);
       partitionKeys.add(bb.convertExpression(partition));
     }
     final RexNode lowerBound = bb.convertExpression(

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4317,10 +4317,20 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).trim(true).ok();
   }
 
-
   @Test public void testInWithConstantList() {
     String expr = "1 in (1,2,3)";
     expr(expr).ok();
+  }
+
+  @Test public void testFunctionExprInOver() {
+    String sql = "select ename, row_number() over(partition by char_length(ename)\n"
+        + " order by deptno desc) as rn\n"
+        + "from emp\n"
+        + "where deptno = 10";
+    Tester newTester = tester.withValidatorTransform(
+        sqlValidator -> sqlValidator.transform(
+            config -> config.withIdentifierExpansion(false)));
+    newTester.assertConvertsTo(sql, "${plan}", false);
   }
 
   /**

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1646,6 +1646,21 @@ LogicalProject(EXPR$0=[ROW(ITEM($3, 1).EMPNO, ITEM($3, 1).ENAME, ROW(ITEM($3, 1)
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFunctionExprInOver">
+    <Resource name="sql">
+      <![CDATA[select ename, row_number() over(partition by char_length(ename)
+order by deptno desc) as rn
+from emp
+where deptno = 10]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ENAME=[$1], RN=[ROW_NUMBER() OVER (PARTITION BY CHAR_LENGTH($1) ORDER BY $7 DESC)])
+  LogicalFilter(condition=[=($7, 10)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFunctionWithStructInput">
     <Resource name="sql">
       <![CDATA[select json_type(skill)


### PR DESCRIPTION
When disable the sql validator to expand identifier, using function expr in the partition by list of over window will cause exception. See [jira:CALCITE-4584](https://issues.apache.org/jira/browse/CALCITE-4584) for mode details.