### PR TITLE
[CALCITE-4585] when run RelNode or Queryable directly, Maybe Confusing log information be thrown

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -222,8 +222,16 @@ abstract class CalciteConnectionImpl
       server.getStatement(calcitePreparedStatement.handle).setSignature(signature);
       return calcitePreparedStatement;
     } catch (Exception e) {
-      throw Helper.INSTANCE.createException(
-          "Error while preparing statement [" + query.sql + "]", e);
+      if (null != query.sql) {
+        throw Helper.INSTANCE.createException(
+            "Error while preparing statement [" + query.sql + "]", e);
+      } else if (null != query.queryable) {
+        throw Helper.INSTANCE.createException(
+            "Error while preparing statement [" + query.queryable + "]", e);
+      } else {
+        throw Helper.INSTANCE.createException(
+            "Error while preparing statement [" + RelOptUtil.toString(query.rel) + "]", e);
+      }
     }
   }
 


### PR DESCRIPTION
This code capture the exception,But Only the output of SQL exception is processed.So need to add the procedure to handle extra exception. 