### PR TITLE
[CALCITE-4585]when run RelNode error,Confuse log info be thrown(xiong duan)

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -225,7 +225,8 @@ abstract class CalciteConnectionImpl
     } catch (Exception e) {
       if (null != query.rel) {
         throw Helper.INSTANCE.createException(
-            "Error while preparing statement [\n" + RelOptUtil.toString(query.rel) + "]", e);
+            "Error while preparing statement [\n"
+                + RelOptUtil.toString(query.rel) + "]", e);
       } else {
         throw Helper.INSTANCE.createException(
             "Error while preparing statement [" + query.sql + "]", e);

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -225,7 +225,7 @@ abstract class CalciteConnectionImpl
     } catch (Exception e) {
       if (null != query.rel) {
         throw Helper.INSTANCE.createException(
-            "Error while preparing statement [" + System.lineSeparator()
+            "Error while preparing plan [" + System.lineSeparator()
                 + RelOptUtil.toString(query.rel) + "]", e);
       } else {
         throw Helper.INSTANCE.createException(

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -225,7 +225,7 @@ abstract class CalciteConnectionImpl
     } catch (Exception e) {
       if (null != query.rel) {
         throw Helper.INSTANCE.createException(
-            "Error while preparing statement [\n"
+            "Error while preparing statement [" + System.lineSeparator()
                 + RelOptUtil.toString(query.rel) + "]", e);
       } else {
         throw Helper.INSTANCE.createException(

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -225,8 +225,7 @@ abstract class CalciteConnectionImpl
     } catch (Exception e) {
       if (null != query.rel) {
         throw Helper.INSTANCE.createException(
-            "Error while preparing plan [" + System.lineSeparator()
-                + RelOptUtil.toString(query.rel) + "]", e);
+            "Error while preparing plan [" + RelOptUtil.toString(query.rel) + "]", e);
       } else {
         throw Helper.INSTANCE.createException(
             "Error while preparing statement [" + query.sql + "]", e);

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -44,6 +44,7 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.materialize.Lattice;
 import org.apache.calcite.materialize.MaterializationService;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.DelegatingTypeSystem;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
@@ -222,8 +223,16 @@ abstract class CalciteConnectionImpl
       server.getStatement(calcitePreparedStatement.handle).setSignature(signature);
       return calcitePreparedStatement;
     } catch (Exception e) {
-      throw Helper.INSTANCE.createException(
-          "Error while preparing statement [" + query.sql + "]", e);
+      if (null != query.sql) {
+        throw Helper.INSTANCE.createException(
+            "Error while preparing statement [" + query.sql + "]", e);
+      } else if (null != query.rel) {
+        throw Helper.INSTANCE.createException(
+            "Error while preparing statement [" + RelOptUtil.toString(query.rel) + "]", e);
+      } else {
+        throw Helper.INSTANCE.createException(
+            "Error while preparing statement [" + query.queryable + "]", e);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -223,15 +223,12 @@ abstract class CalciteConnectionImpl
       server.getStatement(calcitePreparedStatement.handle).setSignature(signature);
       return calcitePreparedStatement;
     } catch (Exception e) {
-      if (null != query.sql) {
+      if (null != query.rel) {
         throw Helper.INSTANCE.createException(
-            "Error while preparing statement [" + query.sql + "]", e);
-      } else if (null != query.rel) {
-        throw Helper.INSTANCE.createException(
-            "Error while preparing statement [" + RelOptUtil.toString(query.rel) + "]", e);
+            "Error while preparing statement [\n" + RelOptUtil.toString(query.rel) + "]", e);
       } else {
         throw Helper.INSTANCE.createException(
-            "Error while preparing statement [" + query.queryable + "]", e);
+            "Error while preparing statement [" + query.sql + "]", e);
       }
     }
   }

--- a/core/src/test/java/org/apache/calcite/test/ExceptionMessageTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ExceptionMessageTest.java
@@ -169,6 +169,7 @@ public class ExceptionMessageTest {
   }
 
   @Test void testValidRelNodeQuery() throws SQLException {
+    // Ensure that the relNode test case runs successfully
     final RelNode relNode = builder
         .scan("test", "entries")
         .project(builder.field("name"))
@@ -177,20 +178,21 @@ public class ExceptionMessageTest {
   }
 
   @Test void testRelNodeQueryException() throws SQLException {
+    // Just by the incorrect function usage to verify exception log
     try {
       final RelNode relNode = builder
           .scan("test", "entries")
           .project(builder.call(SqlStdOperatorTable.ABS, builder.field("name")))
           .build();
       runQuery(relNode);
-      fail("Query badEntries should result in an exception");
+      fail("RelNode query about entries should result in an exception");
     } catch (RuntimeException e) {
       assertThat(
-          e.getMessage(), equalTo("java.sql.SQLException: "
-          + "Error while preparing plan [" + System.lineSeparator()
-          + "LogicalProject($f0=[ABS($1)])" + System.lineSeparator()
-          + "  LogicalTableScan(table=[[test, entries]])" + System.lineSeparator()
-          + "]"));
+          e.getMessage(), Matchers.isLinux("java.sql.SQLException: "
+              + "Error while preparing plan ["
+              + "LogicalProject($f0=[ABS($1)])\n"
+              + "  LogicalTableScan(table=[[test, entries]])\n"
+              + "]"));
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/ExceptionMessageTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ExceptionMessageTest.java
@@ -185,11 +185,12 @@ public class ExceptionMessageTest {
       runQuery(relNode);
       fail("Query badEntries should result in an exception");
     } catch (RuntimeException e) {
-      assertThat(e.getMessage(),
-          equalTo("java.sql.SQLException: Error while preparing statement [\n"
-              + "LogicalProject($f0=[ABS($1)])\n"
-              + "  LogicalTableScan(table=[[test, entries]])\n"
-              + "]"));
+      assertThat(
+          e.getMessage(), equalTo("java.sql.SQLException: "
+          + "Error while preparing statement [" + System.lineSeparator()
+          + "LogicalProject($f0=[ABS($1)])" + System.lineSeparator()
+          + "  LogicalTableScan(table=[[test, entries]])" + System.lineSeparator()
+          + "]"));
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/ExceptionMessageTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ExceptionMessageTest.java
@@ -187,7 +187,7 @@ public class ExceptionMessageTest {
     } catch (RuntimeException e) {
       assertThat(
           e.getMessage(), equalTo("java.sql.SQLException: "
-          + "Error while preparing statement [" + System.lineSeparator()
+          + "Error while preparing plan [" + System.lineSeparator()
           + "LogicalProject($f0=[ABS($1)])" + System.lineSeparator()
           + "  LogicalTableScan(table=[[test, entries]])" + System.lineSeparator()
           + "]"));


### PR DESCRIPTION
This prepareStatement method capture the exception,But Only the output of SQL exception is processed.When run RelNode 
 error, The print log is "Error while preparing statement [null]", There is no useful information in this log So need to add the procedure to handle extra Relnode exception. 
