### PR TITLE
[CALCITE-4560]: Wrong plan when decorrelating EXISTS subquery with COALESCE in the predicate

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
@@ -33,18 +33,18 @@ import java.util.List;
  * Planner rule that matches a {@link Filter} expression with correlated variables, and rewrites the
  * condition in a simpler form that is more convenient for the decorrelation logic.
  *
- * Uncorrelated calls below a comparison operator are turned into input references by extracting the
- * computation in a {@link org.apache.calcite.rel.core.Project} expression. An additional projection
- * may be added on top of the new filter to retain expression equivalence.
+ * <p>Uncorrelated calls below a comparison operator are turned into input references by extracting
+ * the computation in a {@link org.apache.calcite.rel.core.Project} expression. An additional
+ * projection may be added on top of the new filter to retain expression equivalence.</p>
  *
- * Sub-plan before
+ * <p>Sub-plan before</p>
  * <pre>
  * LogicalProject($f0=[true])
  *   LogicalFilter(condition=[=($cor0.DEPTNO, +($7, 30))])
  *     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
  * </pre>
  *
- * Sub-plan after
+ * <p>Sub-plan after</p>
  * <pre>
  * LogicalProject($f0=[true])
  *   LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2],..., COMM=[$6], DEPTNO=[$7], SLACKER=[$8])

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Planner rule that matches a {@link Filter} expression with correlated variables, and rewrites the
+ * condition in a simpler form that is more convenient for the decorrelation logic.
+ *
+ * Uncorrelated calls below a comparison operator are turned into input references by extracting the
+ * computation in a {@link org.apache.calcite.rel.core.Project} expression. An additional projection
+ * may be added on top of the new filter to retain expression equivalence.
+ *
+ * Sub-plan before
+ * <pre>
+ * LogicalProject($f0=[true])
+ *   LogicalFilter(condition=[=($cor0.DEPTNO, +($7, 30))])
+ *     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+ * </pre>
+ *
+ * Sub-plan after
+ * <pre>
+ * LogicalProject($f0=[true])
+ *   LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2],..., COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+ *     LogicalFilter(condition=[=($cor0.DEPTNO, $9)])
+ *       LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2],..., SLACKER=[$8], $f9=[+($7, 30)])
+ *         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+ * </pre>
+ */
+public final class FilterFlattenCorrelatedConditionRule
+    extends RelRule<FilterFlattenCorrelatedConditionRule.Config> {
+
+  public FilterFlattenCorrelatedConditionRule(final Config config) {
+    super(config);
+  }
+
+  @Override public boolean matches(RelOptRuleCall call) {
+    Filter filter = call.rel(0);
+    return RexUtil.containsCorrelation(filter.getCondition());
+  }
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    Filter filter = call.rel(0);
+    RelBuilder b = call.builder();
+    b.push(filter.getInput());
+    final int proj = b.fields().size();
+    List<RexNode> projOperands = new ArrayList<>();
+    RexNode newCondition = filter.getCondition().accept(new RexShuttle() {
+      @Override public RexNode visitCall(RexCall call) {
+        switch (call.getKind()) {
+        case EQUALS:
+        case NOT_EQUALS:
+        case GREATER_THAN:
+        case GREATER_THAN_OR_EQUAL:
+        case LESS_THAN:
+        case LESS_THAN_OR_EQUAL:
+          RexNode op0 = call.operands.get(0);
+          RexNode op1 = call.operands.get(1);
+          final int replaceIndex;
+          if (RexUtil.containsCorrelation(op1) && isUncorrelatedCall(op0)) {
+            replaceIndex = 0;
+          } else if (RexUtil.containsCorrelation(op0) && isUncorrelatedCall(op1)) {
+            replaceIndex = 1;
+          } else {
+            // Structure does not match, do not replace
+            replaceIndex = -1;
+          }
+          if (replaceIndex != -1) {
+            List<RexNode> copyOperands = new ArrayList<>(call.operands);
+            RexNode oldOp = call.operands.get(replaceIndex);
+            RexNode newOp = b.getRexBuilder()
+                .makeInputRef(oldOp.getType(), proj + projOperands.size());
+            projOperands.add(oldOp);
+            copyOperands.set(replaceIndex, newOp);
+            return call.clone(call.type, copyOperands);
+          }
+          return call;
+        case AND:
+        case OR:
+          return super.visitCall(call);
+        default:
+          return call;
+        }
+      }
+    });
+    if (newCondition.equals(filter.getCondition())) {
+      return;
+    }
+    b.projectPlus(projOperands);
+    b.filter(newCondition);
+    b.project(b.fields(ImmutableBitSet.range(proj).asList()));
+    call.transformTo(b.build());
+  }
+
+  private static boolean isUncorrelatedCall(RexNode node) {
+    return node instanceof RexCall && !RexUtil.containsCorrelation(node);
+  }
+
+  /** Rule configuration. */
+  public interface Config extends RelRule.Config {
+    Config DEFAULT =
+        EMPTY.withOperandSupplier(op -> op.operand(Filter.class).anyInputs()).as(Config.class);
+
+    @Override default FilterFlattenCorrelatedConditionRule toRule() {
+      return new FilterFlattenCorrelatedConditionRule(this);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
@@ -54,7 +54,7 @@ import java.util.List;
  *       LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2],..., SLACKER=[$8], $f9=[+($7, 30)])
  *         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
  * </pre>
- * 
+ *
  * <p>The rule should be used in conjunction with other rules and transformations to have a positive
  * impact on the plan. At the moment it is tightly connected with the decorrelation logic and may
  * not be useful in a broader context. Projects may implement decorrelation differently so they may
@@ -90,6 +90,8 @@ public final class FilterFlattenCorrelatedConditionRule
         case GREATER_THAN_OR_EQUAL:
         case LESS_THAN:
         case LESS_THAN_OR_EQUAL:
+        case IS_DISTINCT_FROM:
+        case IS_NOT_DISTINCT_FROM:
           RexNode op0 = call.operands.get(0);
           RexNode op1 = call.operands.get(1);
           final int replaceIndex;

--- a/core/src/main/java/org/apache/calcite/sql2rel/CorrelateProjectExtractor.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/CorrelateProjectExtractor.java
@@ -39,6 +39,7 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
@@ -75,6 +76,7 @@ import java.util.Set;
  * inner loop to the outer loop. It materializes the computation on the left side and flattens
  * expressions on correlated variables on the right side.</p>
  */
+@API(since = "1.27", status = API.Status.EXPERIMENTAL)
 public final class CorrelateProjectExtractor extends RelHomogeneousShuttle {
 
   private final RelBuilderFactory builderFactory;

--- a/core/src/main/java/org/apache/calcite/sql2rel/CorrelateProjectExtractor.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/CorrelateProjectExtractor.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql2rel;
+
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLocalRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexOver;
+import org.apache.calcite.rex.RexPatternFieldRef;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexSubQuery;
+import org.apache.calcite.rex.RexTableInputRef;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A visitor for relational expressions that extracts a {@link org.apache.calcite.rel.core.Project}, with a "simple"
+ * computation over the correlated variables, from the right side of a correlation
+ * ({@link org.apache.calcite.rel.core.Correlate}) and places it on the left side.
+ *
+ * Plan before
+ * <pre>
+ * LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+ *   LogicalTableScan(table=[[scott, EMP]])
+ *   LogicalFilter(condition=[=($0, +(10, $cor0.DEPTNO))])
+ *     LogicalTableScan(table=[[scott, DEPT]])
+ * </pre>
+ *
+ * Plan after
+ * <pre>
+ * LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3],... DNAME=[$10], LOC=[$11])
+ *   LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{8}])
+ *     LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], ... COMM=[$6], DEPTNO=[$7], $f8=[+(10, $7)])
+ *       LogicalTableScan(table=[[scott, EMP]])
+ *     LogicalFilter(condition=[=($0, $cor0.$f8)])
+ *       LogicalTableScan(table=[[scott, DEPT]])
+ * </pre>
+ *
+ * Essentially this transformation moves the computation over a correlated expression from the inner
+ * loop to the outer loop. It materializes the computation on the left side and flattens expressions
+ * on correlated variables on the right side.
+ */
+public final class CorrelateProjectExtractor extends RelHomogeneousShuttle {
+
+  private final RelBuilderFactory builderFactory;
+
+  public CorrelateProjectExtractor(RelBuilderFactory factory) {
+    this.builderFactory = factory;
+  }
+
+  @Override public RelNode visit(LogicalCorrelate correlate) {
+    RelNode left = correlate.getLeft().accept(this);
+    RelNode right = correlate.getRight().accept(this);
+    int oldLeft = left.getRowType().getFieldCount();
+    // Find the correlated expressions from the right side that can be moved to the left
+    Set<RexNode> callsWithCorrelationInRight =
+        findCorrelationDependentCalls(correlate.getCorrelationId(), right);
+    boolean isTrivialCorrelation =
+        callsWithCorrelationInRight.stream().allMatch(exp -> exp instanceof RexFieldAccess);
+    // Early exit condition
+    if (isTrivialCorrelation) {
+      if (correlate.getLeft().equals(left) && correlate.getRight().equals(right)) {
+        return correlate;
+      } else {
+        return correlate.copy(
+            correlate.getTraitSet(),
+            left,
+            right,
+            correlate.getCorrelationId(),
+            correlate.getRequiredColumns(),
+            correlate.getJoinType());
+      }
+    }
+
+    RelBuilder builder = builderFactory.create(correlate.getCluster(), null);
+    // Transform the correlated expression from the right side to an expression over the left side
+    builder.push(left);
+
+    List<RexNode> callsWithCorrelationOverLeft = new ArrayList<>();
+    for (RexNode callInRight : callsWithCorrelationInRight) {
+      callsWithCorrelationOverLeft.add(replaceCorrelationsWithInputRef(callInRight, builder));
+    }
+    builder.projectPlus(callsWithCorrelationOverLeft);
+
+    // Construct the mapping to transform the expressions in the right side based on the new
+    // projection in the left side.
+    Map<RexNode, RexNode> transformMapping = new HashMap<>();
+    for (RexNode callInRight : callsWithCorrelationInRight) {
+      RexBuilder xb = builder.getRexBuilder();
+      RexNode v = xb.makeCorrel(builder.peek().getRowType(), correlate.getCorrelationId());
+      RexNode flatCorrelationInRight = xb.makeFieldAccess(v, oldLeft + transformMapping.size());
+      transformMapping.put(callInRight, flatCorrelationInRight);
+    }
+
+    // Select the required fields/columns from the left side of the correlation. Based on the code
+    // above all these fields should be at the end of the left relational expression.
+    List<RexNode> requiredFields =
+        builder.fields(
+            ImmutableBitSet.range(oldLeft, oldLeft + callsWithCorrelationOverLeft.size()).asList());
+
+    final int newLeft = builder.fields().size();
+    // Transform the expressions in the right side using the mapping constructed earlier.
+    right = replaceExpressionsUsingMap(right, transformMapping);
+    builder.push(right);
+
+    builder.correlate(correlate.getJoinType(), correlate.getCorrelationId(), requiredFields);
+    // Remove the additional fields that were added for the needs of the correlation to keep the old
+    // and new plan equivalent.
+    List<Integer> retainFields;
+    switch (correlate.getJoinType()) {
+    case SEMI:
+    case ANTI:
+      retainFields = ImmutableBitSet.range(0, oldLeft).asList();
+      break;
+    case LEFT:
+    case INNER:
+      retainFields =
+          ImmutableBitSet.builder()
+              .set(0, oldLeft)
+              .set(newLeft, newLeft + right.getRowType().getFieldCount())
+              .build()
+              .asList();
+      break;
+    default:
+      throw new AssertionError(correlate.getJoinType());
+    }
+    builder.project(builder.fields(retainFields));
+    return builder.build();
+  }
+
+  /**
+   * Traverses a plan and finds all simply correlated row expressions with the specified id.
+   */
+  private static Set<RexNode> findCorrelationDependentCalls(CorrelationId corrId, RelNode plan) {
+    SimpleCorrelationCollector finder = new SimpleCorrelationCollector(corrId);
+    plan.accept(new RelHomogeneousShuttle() {
+      @Override public RelNode visit(RelNode other) {
+        if (other instanceof Project || other instanceof Filter) {
+          other.accept(finder);
+        }
+        return super.visit(other);
+      }
+    });
+    return finder.correlations;
+  }
+
+  /**
+   * Replaces all row expressions in the plan using the provided mapping.
+   *
+   * @param plan the relational expression on which we want to perform the replacements.
+   * @param mapping a mapping defining how to replace row expressions in the plan
+   * @return a new relational expression where all expressions present in the mapping are replaced.
+   */
+  private static RelNode replaceExpressionsUsingMap(RelNode plan, Map<RexNode, RexNode> mapping) {
+    CallReplacer replacer = new CallReplacer(mapping);
+    return plan.accept(new RelHomogeneousShuttle() {
+      @Override public RelNode visit(RelNode other) {
+        RelNode mNode = super.visitChildren(other);
+        return mNode.accept(replacer);
+      }
+    });
+  }
+
+  /**
+   * A collector of simply correlated row expressions.
+   *
+   * The shuttle traverses the tree and collects all calls and field accesses that are classified
+   * as simply correlated expressions. Multiple nodes in a call hierarchy may satisfy the criteria
+   * of a simple correlation so we peek the expressions closest to the root.
+   *
+   * @see SimpleCorrelationDetector
+   */
+  private static final class SimpleCorrelationCollector extends RexShuttle {
+    private final CorrelationId correlationId;
+    // Clients are iterating over the collection thus it is better to use LinkedHashSet to keep
+    // plans stable among executions.
+    private final Set<RexNode> correlations = new LinkedHashSet<>();
+
+    SimpleCorrelationCollector(CorrelationId corrId) {
+      this.correlationId = corrId;
+    }
+
+    @Override public RexNode visitCall(RexCall call) {
+      if (isSimpleCorrelatedExpression(call, correlationId)) {
+        correlations.add(call);
+        return call;
+      } else {
+        return super.visitCall(call);
+      }
+    }
+
+    @Override public RexNode visitFieldAccess(RexFieldAccess fieldAccess) {
+      if (isSimpleCorrelatedExpression(fieldAccess, correlationId)) {
+        correlations.add(fieldAccess);
+        return fieldAccess;
+      } else {
+        return super.visitFieldAccess(fieldAccess);
+      }
+    }
+  }
+
+  /**
+   * Returns whether the specified node is a simply correlated expression.
+   */
+  private static boolean isSimpleCorrelatedExpression(RexNode node, CorrelationId id) {
+    Boolean r = node.accept(new SimpleCorrelationDetector(id));
+    return r == null ? Boolean.FALSE : r;
+  }
+
+  /**
+   * A visitor classifying row expressions as simply correlated if they satisfy the conditions
+   * below.
+   * <ul>
+   * <li>all correlated variables have the specified correlation id</li>
+   * <li>all leafs are either correlated variables, dynamic parameters, or literals</li>
+   * <li>intermediate nodes are either calls or field access expressions</li>
+   * </ul>
+   *
+   * Examples:
+   * <pre>{@code
+   * +(10, $cor0.DEPTNO) -> TRUE
+   * /(100,+(10, $cor0.DEPTNO)) -> TRUE
+   * CAST(+(10, $cor0.DEPTNO)):INTEGER NOT NULL -> TRUE
+   * +($0, $cor0.DEPTNO) -> FALSE
+   * }</pre>
+   *
+   */
+  private static class SimpleCorrelationDetector extends RexVisitorImpl<@Nullable Boolean> {
+    private final CorrelationId corrId;
+
+    private SimpleCorrelationDetector(CorrelationId corrId) {
+      super(true);
+      this.corrId = corrId;
+    }
+
+    @Override public Boolean visitOver(RexOver over) {
+      return Boolean.FALSE;
+    }
+
+    @Override public Boolean visitSubQuery(RexSubQuery subQuery) {
+      return Boolean.FALSE;
+    }
+
+    @Override public Boolean visitCall(RexCall call) {
+      Boolean hasSimpleCorrelation = null;
+      for (RexNode op : call.operands) {
+        Boolean b = op.accept(this);
+        if (b != null) {
+          hasSimpleCorrelation = hasSimpleCorrelation == null ? b : hasSimpleCorrelation && b;
+        }
+      }
+      return hasSimpleCorrelation == null ? Boolean.FALSE : hasSimpleCorrelation;
+    }
+
+    @Override public @Nullable Boolean visitFieldAccess(RexFieldAccess fieldAccess) {
+      return fieldAccess.getReferenceExpr().accept(this);
+    }
+
+    @Override public Boolean visitInputRef(RexInputRef inputRef) {
+      return Boolean.FALSE;
+    }
+
+    @Override public Boolean visitCorrelVariable(RexCorrelVariable correlVariable) {
+      return correlVariable.id.equals(corrId);
+    }
+
+    @Override public Boolean visitTableInputRef(RexTableInputRef ref) {
+      return Boolean.FALSE;
+    }
+
+    @Override public Boolean visitLocalRef(RexLocalRef localRef) {
+      return Boolean.FALSE;
+    }
+
+    @Override public Boolean visitPatternFieldRef(RexPatternFieldRef fieldRef) {
+      return Boolean.FALSE;
+    }
+  }
+
+  private static RexNode replaceCorrelationsWithInputRef(RexNode exp, RelBuilder b) {
+    return exp.accept(new RexShuttle() {
+      @Override public RexNode visitFieldAccess(RexFieldAccess fieldAccess) {
+        if (fieldAccess.getReferenceExpr() instanceof RexCorrelVariable) {
+          return b.field(fieldAccess.getField().getIndex());
+        }
+        return super.visitFieldAccess(fieldAccess);
+      }
+    });
+  }
+
+  /**
+   * A visitor traversing row expressions and replacing calls with other expressions according
+   * to the specified mapping.
+   */
+  private static final class CallReplacer extends RexShuttle {
+    private final Map<RexNode, RexNode> mapping;
+
+    CallReplacer(Map<RexNode, RexNode> mapping) {
+      this.mapping = mapping;
+    }
+
+    @Override public RexNode visitCall(RexCall oldCall) {
+      RexNode newCall = mapping.get(oldCall);
+      if (newCall != null) {
+        return newCall;
+      } else {
+        return super.visitCall(oldCall);
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql2rel/CorrelateProjectExtractor.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/CorrelateProjectExtractor.java
@@ -53,7 +53,7 @@ import java.util.Set;
  * computation over the correlated variables, from the right side of a correlation
  * ({@link org.apache.calcite.rel.core.Correlate}) and places it on the left side.
  *
- * Plan before
+ * <p>Plan before</p>
  * <pre>
  * LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
  *   LogicalTableScan(table=[[scott, EMP]])
@@ -61,7 +61,7 @@ import java.util.Set;
  *     LogicalTableScan(table=[[scott, DEPT]])
  * </pre>
  *
- * Plan after
+ * <p>Plan after</p>
  * <pre>
  * LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3],... DNAME=[$10], LOC=[$11])
  *   LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{8}])
@@ -71,9 +71,9 @@ import java.util.Set;
  *       LogicalTableScan(table=[[scott, DEPT]])
  * </pre>
  *
- * Essentially this transformation moves the computation over a correlated expression from the inner
- * loop to the outer loop. It materializes the computation on the left side and flattens expressions
- * on correlated variables on the right side.
+ * <p>Essentially this transformation moves the computation over a correlated expression from the
+ * inner loop to the outer loop. It materializes the computation on the left side and flattens
+ * expressions on correlated variables on the right side.</p>
  */
 public final class CorrelateProjectExtractor extends RelHomogeneousShuttle {
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -4927,9 +4927,10 @@ class RelToSqlConverterTest {
         + "                from (values(true)))";
 
     final String expected = "SELECT \"$cor0\".\"department_id\", \"$cor0\".\"D_PLUSONE\"\n"
-        + "FROM \"foodmart\".\"department\" AS \"$cor0\",\n"
-        + "LATERAL (SELECT \"$cor0\".\"department_id\" + 1 AS \"D_PLUSONE\"\n"
-        + "FROM (VALUES (TRUE)) AS \"t\" (\"EXPR$0\")) AS \"t0\"";
+        + "FROM (SELECT \"department_id\", \"department_description\", \"department_id\" + 1 AS \"$f2\"\n"
+        + "FROM \"foodmart\".\"department\") AS \"$cor0\",\n"
+        + "LATERAL (SELECT \"$cor0\".\"$f2\" AS \"D_PLUSONE\"\n"
+        + "FROM (VALUES (TRUE)) AS \"t\" (\"EXPR$0\")) AS \"t1\"";
     sql(sql).ok(expected);
   }
 

--- a/core/src/test/java/org/apache/calcite/sql2rel/CorrelateProjectExtractorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql2rel/CorrelateProjectExtractorTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql2rel;
+
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.Holder;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.apache.calcite.test.Matchers.hasTree;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link CorrelateProjectExtractor}.
+ */
+public class CorrelateProjectExtractorTest {
+  public static Frameworks.ConfigBuilder config() {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(
+            CalciteAssert.addSchema(rootSchema, CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL))
+        .traitDefs((List<RelTraitDef>) null);
+  }
+
+  @Test void testSingleCorrelationCallOverVariableInFilter() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    final Holder<@Nullable RexCorrelVariable> v = Holder.empty();
+    RelNode before = builder.scan("EMP")
+        .variable(v)
+        .scan("DEPT")
+        .filter(
+            builder.equals(builder.field(0),
+                builder.call(
+                    SqlStdOperatorTable.PLUS,
+                    builder.literal(10),
+                    builder.field(v.get(), "DEPTNO"))))
+        .correlate(JoinRelType.LEFT, v.get().id, builder.field(2, 0, "DEPTNO"))
+        .build();
+
+    final String planBefore = ""
+        + "LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n"
+        + "  LogicalFilter(condition=[=($0, +(10, $cor0.DEPTNO))])\n"
+        + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(before, hasTree(planBefore));
+
+    RelNode after = before.accept(new CorrelateProjectExtractor(RelFactories.LOGICAL_BUILDER));
+    final String planAfter = ""
+        + "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], DEPTNO0=[$9], DNAME=[$10], LOC=[$11])\n"
+        + "  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{8}])\n"
+        + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[+(10, $7)])\n"
+        + "      LogicalTableScan(table=[[scott, EMP]])\n"
+        + "    LogicalFilter(condition=[=($0, $cor0.$f8)])\n"
+        + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(after, hasTree(planAfter));
+  }
+
+  @Test void testDoubleCorrelationCallOverVariableInFilters() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    final Holder<@Nullable RexCorrelVariable> v = Holder.empty();
+    RelNode before = builder
+        .scan("EMP").variable(v)
+        .scan("DEPT").filter(
+            builder.equals(
+                builder.field("DEPTNO"),
+                builder.call(SqlStdOperatorTable.PLUS,
+                    builder.literal(10),
+                    builder.field(v.get(), "DEPTNO"))))
+        .correlate(JoinRelType.LEFT, v.get().id, builder.field(2, 0, "DEPTNO"))
+        .variable(v)
+        .scan("DEPT").filter(
+            builder.equals(
+                builder.field("DEPTNO"),
+                builder.call(
+                    SqlStdOperatorTable.MINUS,
+                    builder.literal(50), builder.field(v.get(), "DEPTNO"))))
+        .correlate(JoinRelType.LEFT, v.get().id, builder.field(2, 0, "DEPTNO"))
+        .build();
+
+    final String planBefore = ""
+        + "LogicalCorrelate(correlation=[$cor1], joinType=[left], requiredColumns=[{7}])\n"
+        + "  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])\n"
+        + "    LogicalTableScan(table=[[scott, EMP]])\n"
+        + "    LogicalFilter(condition=[=($0, +(10, $cor0.DEPTNO))])\n"
+        + "      LogicalTableScan(table=[[scott, DEPT]])\n"
+        + "  LogicalFilter(condition=[=($0, -(50, $cor1.DEPTNO))])\n"
+        + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(before, hasTree(planBefore));
+
+    RelNode after = before.accept(new CorrelateProjectExtractor(RelFactories.LOGICAL_BUILDER));
+    final String planAfter = ""
+        + "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], DEPTNO0=[$8], DNAME=[$9], LOC=[$10], DEPTNO1=[$12], DNAME0=[$13], LOC0=[$14])\n"
+        + "  LogicalCorrelate(correlation=[$cor1], joinType=[left], requiredColumns=[{11}])\n"
+        + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], DEPTNO0=[$9], DNAME=[$10], LOC=[$11], $f11=[-(50, $7)])\n"
+        + "      LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{8}])\n"
+        + "        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], $f8=[+(10, $7)])\n"
+        + "          LogicalTableScan(table=[[scott, EMP]])\n"
+        + "        LogicalFilter(condition=[=($0, $cor0.$f8)])\n"
+        + "          LogicalTableScan(table=[[scott, DEPT]])\n"
+        + "    LogicalFilter(condition=[=($0, $cor1.$f11)])\n"
+        + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+    assertThat(after, hasTree(planAfter));
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1518,6 +1518,15 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).decorrelate(true).ok();
   }
 
+  /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-4560">[CALCITE-4560]
+   * Wrong plan when decorrelating EXISTS subquery with COALESCE in the predicate</a>. */
+  @Test void testExistsDecorrelateComplexCorrelationPredicate() {
+    final String sql = "select e1.empno from empnullables e1 where exists (\n"
+        + "  select 1 from empnullables e2 where COALESCE(e1.ename,'M')=COALESCE(e2.ename,'M'))";
+    sql(sql).decorrelate(true).ok();
+  }
+
   @Test void testExistsCorrelatedDecorrelateRex() {
     final String sql = "select*from emp where exists (\n"
         + "  select 1 from dept where emp.deptno=dept.deptno)";

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -3840,19 +3840,19 @@ where n1.SAL IN (
         <Resource name="planBefore">
             <![CDATA[
 LogicalProject(SAL=[$5])
-  LogicalJoin(condition=[=($5, $9)], joinType=[inner])
-    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8])
+  LogicalJoin(condition=[AND(=($5, $11), =($9, $12))], joinType=[inner])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8], SAL0=[$5], $f9=[=($5, 4)])
       LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
         LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
     LogicalFilter(condition=[=($1, $0)])
-      LogicalAggregate(group=[{0, 1}])
-        LogicalProject(SAL=[$5], SAL0=[$8])
-          LogicalJoin(condition=[OR(=($8, $5), =($8, 4))], joinType=[inner])
+      LogicalAggregate(group=[{0, 1, 2}])
+        LogicalProject(SAL=[$5], SAL0=[$8], $f9=[$9])
+          LogicalJoin(condition=[OR(=($8, $5), $9)], joinType=[inner])
             LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8])
               LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
                 LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
-            LogicalAggregate(group=[{0}])
-              LogicalProject(SAL=[$5])
+            LogicalAggregate(group=[{0, 1}])
+              LogicalProject(SAL=[$5], $f9=[=($5, 4)])
                 LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
                   LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
 ]]>
@@ -3860,19 +3860,20 @@ LogicalProject(SAL=[$5])
         <Resource name="planAfter">
             <![CDATA[
 LogicalProject(SAL=[$5])
-  LogicalJoin(condition=[=($5, $9)], joinType=[inner])
-    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8])
-      LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
-        LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+  LogicalJoin(condition=[AND(=($5, $11), =($9, $12))], joinType=[inner])
+    LogicalFilter(condition=[>($5, 1000)])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8], SAL0=[$5], $f9=[=($5, 4)])
+        LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
+          LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
     LogicalFilter(condition=[=($1, $0)])
-      LogicalAggregate(group=[{0, 1}])
-        LogicalProject(SAL=[$5], SAL0=[$8])
-          LogicalJoin(condition=[OR(=($8, $5), =($8, 4))], joinType=[inner])
+      LogicalAggregate(group=[{0, 1, 2}])
+        LogicalProject(SAL=[$5], SAL0=[$8], $f9=[$9])
+          LogicalJoin(condition=[OR(=($8, $5), $9)], joinType=[inner])
             LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8])
               LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
                 LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
-            LogicalAggregate(group=[{0}])
-              LogicalProject(SAL=[$5])
+            LogicalAggregate(group=[{0, 1}])
+              LogicalProject(SAL=[$5], $f9=[=($5, 4)])
                 LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
                   LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
 ]]>
@@ -12215,10 +12216,8 @@ LogicalProject(ENAME=[$0])
     LogicalProject(ENAME=[$1], DEPTNO=[$7], SALPLUS=[+($5, 1)])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject(DEPTNO=[$7], $f9=[$9])
-        LogicalFilter(condition=[=(+($5, 1), $9)])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[+($5, 1)])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(DEPTNO=[$7], $f9=[+($5, 1)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -12262,10 +12261,8 @@ LogicalProject(NAME=[$0])
     LogicalProject(NAME=[$1], DEPTNO=[$0], DEPTNOMINUS=[-($0, 10)])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
     LogicalAggregate(group=[{0, 1}])
-      LogicalProject(DEPTNO=[$7], $f9=[$9])
-        LogicalFilter(condition=[=(+($5, 1), $9)])
-          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[+($5, 1)])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(DEPTNO=[$7], $f9=[+($5, 1)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>
@@ -12357,6 +12354,143 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
         LogicalProject(DEPTNO=[$0], i=[true])
           LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testFlattenUncorrelatedCallBelowEquals">
+        <Resource name="sql">
+            <![CDATA[select * from sales.emp
+where EXISTS (select * from emp e where emp.deptno = coalesce(e.deptno,30))
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalFilter(condition=[=($cor0.DEPTNO, +($7, 30))])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+            LogicalFilter(condition=[=($cor0.DEPTNO, $9)])
+              LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[+($7, 30)])
+                LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testCallOverCorrelationVariableIsNotFlattened">
+        <Resource name="sql">
+            <![CDATA[select * from emp e1 where exists (
+select * from emp e2 where (e1.deptno+30) = e2.deptno)
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalFilter(condition=[=(+($cor0.DEPTNO, 30), $7)])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testFlattenUncorrelatedTwoLevelCallBelowEqualsSucceeds">
+        <Resource name="sql">
+            <![CDATA[select * from emp e1 where exists (
+select * from emp e2 where e1.deptno = (2 * e2.deptno+30))
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalFilter(condition=[=($cor0.DEPTNO, +(*(2, $7), 30))])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+            LogicalFilter(condition=[=($cor0.DEPTNO, $9)])
+              LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[+(*(2, $7), 30)])
+                LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testUncorrelatedCallBelowNonComparisonOpIsNotFlattened">
+        <Resource name="sql">
+            <![CDATA[select * from emp e1 where exists (
+select * from emp e2 where (e1.deptno + (e2.deptno+30)) > 0)
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalFilter(condition=[>(+($cor0.DEPTNO, +($7, 30)), 0)])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testUncorrelatedCallInConjunctionIsFlattenedOnlyIfSiblingOfCorrelation">
+        <Resource name="sql">
+            <![CDATA[select * from emp e1 where exists (
+select * from emp e2 where (e2.empno+50) < 20 and e1.deptno >= (30+e2.deptno))
+]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalFilter(condition=[AND(<(+($0, 50), 20), >=($cor0.DEPTNO, +(30, $7)))])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{7}])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[MIN($0)])
+        LogicalProject($f0=[true])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+            LogicalFilter(condition=[AND(<(+($0, 50), 20), >=($cor0.DEPTNO, $9))])
+              LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[+(30, $7)])
+                LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
         </Resource>
     </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2580,6 +2580,25 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testExistsDecorrelateComplexCorrelationPredicate">
+        <Resource name="sql">
+            <![CDATA[select e1.empno from empnullables e1 where exists (
+  select 1 from empnullables e2 where COALESCE(e1.ename,'M')=COALESCE(e2.ename,'M'))]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[IS NOT NULL($9)])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f0=[$11])
+      LogicalJoin(condition=[=($9, $10)], joinType=[left])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[CASE(IS NOT NULL($1), $1, 'M':VARCHAR(20))])
+          LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+        LogicalAggregate(group=[{0}], agg#0=[MIN($1)])
+          LogicalProject($f9=[CASE(IS NOT NULL($1), CAST($1):VARCHAR(20) NOT NULL, 'M':VARCHAR(20))], $f0=[true])
+            LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testExistsCorrelatedLimit">
         <Resource name="sql">
             <![CDATA[select*from emp where exists (
@@ -2628,14 +2647,16 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
         <Resource name="plan">
             <![CDATA[
 LogicalProject(DEPTNO=[$0], NAME=[$1], EXPR$0=[$2])
-  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-    Uncollect
-      LogicalProject(EXPR$0=[$SLICE($0)])
-        Collect(field=[EXPR$0])
-          LogicalUnion(all=[true])
-            LogicalProject(EXPR$0=[*($cor0.DEPTNO, 2)])
-              LogicalValues(tuples=[[{ 0 }]])
+  LogicalProject(DEPTNO=[$0], NAME=[$1], EXPR$0=[$3])
+    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+      LogicalProject(DEPTNO=[$0], NAME=[$1], $f2=[*($0, 2)])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      Uncollect
+        LogicalProject(EXPR$0=[$SLICE($0)])
+          Collect(field=[EXPR$0])
+            LogicalUnion(all=[true])
+              LogicalProject(EXPR$0=[$cor0.$f2])
+                LogicalValues(tuples=[[{ 0 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -6121,14 +6142,16 @@ LogicalProject(D2=[$0], D3=[$1])
         <Resource name="plan">
             <![CDATA[
 LogicalProject(DEPTNO=[$0], NAME=[$1], EXPR$0=[$2])
-  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-    Uncollect
-      LogicalProject(EXPR$0=[$SLICE($0)])
-        Collect(field=[EXPR$0])
-          LogicalUnion(all=[true])
-            LogicalProject(EXPR$0=[*($cor0.DEPTNO, 2)])
-              LogicalValues(tuples=[[{ 0 }]])
+  LogicalProject(DEPTNO=[$0], NAME=[$1], EXPR$0=[$3])
+    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+      LogicalProject(DEPTNO=[$0], NAME=[$1], $f2=[*($0, 2)])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      Uncollect
+        LogicalProject(EXPR$0=[$SLICE($0)])
+          Collect(field=[EXPR$0])
+            LogicalUnion(all=[true])
+              LogicalProject(EXPR$0=[$cor0.$f2])
+                LogicalValues(tuples=[[{ 0 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -6571,13 +6594,14 @@ unnest(t1.fake_col) as t2(c1)]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(C1=[$1])
-  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
-    LogicalProject(**=[$0])
-      LogicalTableScan(table=[[CATALOG, SALES, CUSTOMER]])
-    LogicalProject(C1=[$0])
-      Uncollect
-        LogicalProject(EXPR$0=[ITEM($cor0.**, 'FAKE_COL')])
-          LogicalValues(tuples=[[{ 0 }]])
+  LogicalProject(**=[$0], C1=[$2])
+    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      LogicalProject(**=[$0], $f1=[ITEM($0, 'FAKE_COL')])
+        LogicalTableScan(table=[[CATALOG, SALES, CUSTOMER]])
+      LogicalProject(C1=[$0])
+        Uncollect
+          LogicalProject(EXPR$0=[$cor0.$f1])
+            LogicalValues(tuples=[[{ 0 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -7032,11 +7056,13 @@ LogicalProject(C=[$0], D=[$1], C0=[$2])
         <Resource name="plan">
             <![CDATA[
 LogicalProject(C=[$0], D=[$1], D0=[$2], C0=[$3])
-  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 1}])
-    LogicalValues(tuples=[[{ 4, 5 }]])
-    LogicalFilter(condition=[=(+($cor0.C, $cor0.D), $1)])
-      LogicalProject(C=[$cor0.C], EXPR$1=[*($0, $cor0.C)])
-        LogicalValues(tuples=[[{ 2 }]])
+  LogicalProject(C=[$0], D=[$1], C0=[$4], EXPR$1=[$5])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{2, 3}])
+      LogicalProject(C=[$0], D=[$1], $f2=[+($0, $1)], C0=[$0])
+        LogicalValues(tuples=[[{ 4, 5 }]])
+      LogicalFilter(condition=[=($cor0.$f2, $1)])
+        LogicalProject(C=[$cor0.C], EXPR$1=[*($0, $cor0.C)])
+          LogicalValues(tuples=[[{ 2 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -7053,14 +7079,16 @@ as r(n) on c=n]]>
         <Resource name="plan">
             <![CDATA[
 LogicalProject(C=[$0], N=[$1])
-  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
-    LogicalValues(tuples=[[{ 4 }]])
-    LogicalFilter(condition=[=($cor0.C, $0)])
-      LogicalProject(EXPR$0=[+($0, $1)])
-        LogicalJoin(condition=[=($0, $1)], joinType=[inner])
-          LogicalValues(tuples=[[{ 2 }]])
-          LogicalProject(EXPR$0=[+($cor0.C, 1)])
-            LogicalValues(tuples=[[{ 3 }]])
+  LogicalProject(C=[$0], EXPR$0=[$3])
+    LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1, 2}])
+      LogicalProject(C=[$0], C0=[$0], $f2=[+($0, 1)])
+        LogicalValues(tuples=[[{ 4 }]])
+      LogicalFilter(condition=[=($cor0.C, $0)])
+        LogicalProject(EXPR$0=[+($0, $1)])
+          LogicalJoin(condition=[=($0, $1)], joinType=[inner])
+            LogicalValues(tuples=[[{ 2 }]])
+            LogicalProject(EXPR$0=[$cor0.$f2])
+              LogicalValues(tuples=[[{ 3 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -7074,11 +7102,13 @@ LogicalProject(C=[$0], N=[$1])
         <Resource name="plan">
             <![CDATA[
 LogicalProject(C=[$0], D=[$1], C0=[$2], F=[$3])
-  LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{0, 1}])
-    LogicalValues(tuples=[[{ 4, 5 }]])
-    LogicalProject(C=[$cor3.C], F=[*($0, $cor3.C)])
-      LogicalFilter(condition=[=(+($cor3.C, $cor3.D), *($0, $cor3.C))])
-        LogicalValues(tuples=[[{ 2 }]])
+  LogicalProject(C=[$0], D=[$1], C0=[$4], F=[$5])
+    LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{2, 3}])
+      LogicalProject(C=[$0], D=[$1], C0=[$0], $f3=[+($0, $1)])
+        LogicalValues(tuples=[[{ 4, 5 }]])
+      LogicalProject(C=[$cor3.C], F=[*($0, $cor3.C)])
+        LogicalFilter(condition=[=($cor3.$f3, *($0, $cor3.C))])
+          LogicalValues(tuples=[[{ 2 }]])
 ]]>
         </Resource>
     </TestCase>
@@ -7096,15 +7126,17 @@ cross join lateral
         <Resource name="plan">
             <![CDATA[
 LogicalProject(C=[$0], N=[$1])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
-    LogicalValues(tuples=[[{ 4 }]])
-    LogicalProject(N=[$0])
-      LogicalFilter(condition=[=($cor1.C, $0)])
-        LogicalProject(EXPR$0=[+($0, $1)])
-          LogicalJoin(condition=[=($0, $1)], joinType=[inner])
-            LogicalValues(tuples=[[{ 2 }]])
-            LogicalProject(EXPR$0=[+($cor1.C, 1)])
-              LogicalValues(tuples=[[{ 3 }]])
+  LogicalProject(C=[$0], N=[$3])
+    LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 2}])
+      LogicalProject(C=[$0], C0=[$0], $f2=[+($0, 1)])
+        LogicalValues(tuples=[[{ 4 }]])
+      LogicalProject(N=[$0])
+        LogicalFilter(condition=[=($cor1.C, $0)])
+          LogicalProject(EXPR$0=[+($0, $1)])
+            LogicalJoin(condition=[=($0, $1)], joinType=[inner])
+              LogicalValues(tuples=[[{ 2 }]])
+              LogicalProject(EXPR$0=[$cor1.$f2])
+                LogicalValues(tuples=[[{ 3 }]])
 ]]>
         </Resource>
     </TestCase>

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -492,10 +492,10 @@ or not exists (
 (3 rows)
 
 !ok
-EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NULL($t5)], expr#9=[IS NULL($t7)], expr#10=[OR($t8, $t9)], proj#0..4=[{exprs}], $condition=[$t10])
-  EnumerableMergeJoin(condition=[=($0, $6)], joinType=[left])
-    EnumerableSort(sort0=[$0], dir0=[ASC])
-      EnumerableCalc(expr#0..6=[{inputs}], proj#0..4=[{exprs}], $f0=[$t6])
+EnumerableCalc(expr#0..8=[{inputs}], expr#9=[IS NULL($t5)], expr#10=[IS NULL($t8)], expr#11=[OR($t9, $t10)], proj#0..4=[{exprs}], $condition=[$t11])
+  EnumerableMergeJoin(condition=[=($6, $7)], joinType=[left])
+    EnumerableSort(sort0=[$6], dir0=[ASC])
+      EnumerableCalc(expr#0..6=[{inputs}], expr#7=[CAST($t0):INTEGER NOT NULL], proj#0..4=[{exprs}], $f0=[$t6], empid0=[$t7])
         EnumerableMergeJoin(condition=[=($1, $5)], joinType=[left])
           EnumerableSort(sort0=[$1], dir0=[ASC])
             EnumerableTableScan(table=[[hr, emps]])

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -2120,5 +2120,42 @@ EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t1, $t2)], expr#8=[IS TRUE($t7)]
 
 !ok
 
+# [CALCITE-4560] Wrong plan when decorrelating EXISTS subquery with COALESCE in the predicate
+# The employee KING has no manager (NULL) so before the fix the following query was missing 
+# this employee from the result set. 
+select ename
+from "scott".emp as e1
+where exists 
+    (select 1 from "scott".emp as e2 where coalesce(e1.mgr,0)=coalesce(e2.mgr,0));
+# The plan before the fix was wrong but also inefficient since it required the generation of 
+# a value generator (see RelDecorrelator code). The value generator is not present in the
+# following plan (two scans of EMP table instead of three).
+EnumerableCalc(expr#0..2=[{inputs}], ENAME=[$t1])
+  EnumerableHashJoin(condition=[=($2, $3)], joinType=[semi])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NOT NULL($t3)], expr#9=[CAST($t3):INTEGER], expr#10=[0], expr#11=[CASE($t8, $t9, $t10)], proj#0..1=[{exprs}], $f3=[$t11])
+      EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NOT NULL($t3)], expr#9=[CAST($t3):INTEGER NOT NULL], expr#10=[0], expr#11=[CASE($t8, $t9, $t10)], $f8=[$t11])
+      EnumerableTableScan(table=[[scott, EMP]])
+!plan
+
+ ENAME
+--------
+ ADAMS
+ ALLEN
+ BLAKE
+ CLARK
+ FORD
+ JAMES
+ JONES
+ KING
+ MARTIN
+ MILLER
+ SCOTT
+ SMITH
+ TURNER
+ WARD
+(14 rows)
+
+!ok
 
 # End sub-query.iq

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -583,11 +583,11 @@ where empno IN (
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..4=[{inputs}], SAL=[$t4])
-  EnumerableHashJoin(condition=[AND(=($1, $3), =($0, $2))], joinType=[inner])
+EnumerableCalc(expr#0..4=[{inputs}], SAL=[$t3])
+  EnumerableHashJoin(condition=[AND(=($1, $4), =($0, $2))], joinType=[inner])
     EnumerableCalc(expr#0..2=[{inputs}], expr#3=[IS NOT NULL($t1)], proj#0..1=[{exprs}], $condition=[$t3])
       EnumerableTableScan(table=[[scott, DEPT]])
-    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], JOB=[$t2], SAL=[$t5])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t2):VARCHAR(14)], EMPNO=[$t0], SAL=[$t5], JOB0=[$t8])
       EnumerableTableScan(table=[[scott, EMP]])
 !plan
 
@@ -2037,24 +2037,20 @@ where sal + 100 not in (
 
 !ok
 EnumerableAggregate(group=[{}], C=[COUNT()])
-  EnumerableCalc(expr#0..9=[{inputs}], expr#10=[0], expr#11=[=($t3, $t10)], expr#12=[IS NULL($t2)], expr#13=[IS NOT NULL($t7)], expr#14=[<($t4, $t3)], expr#15=[OR($t12, $t13, $t14)], expr#16=[IS NOT TRUE($t15)], expr#17=[OR($t11, $t16)], proj#0..9=[{exprs}], $condition=[$t17])
-    EnumerableMergeJoin(condition=[AND(=($1, $8), =($2, $9))], joinType=[left])
-      EnumerableSort(sort0=[$1], sort1=[$2], dir0=[ASC], dir1=[ASC])
-        EnumerableMergeJoin(condition=[=($1, $5)], joinType=[left])
-          EnumerableSort(sort0=[$1], dir0=[ASC])
-            EnumerableCalc(expr#0..7=[{inputs}], proj#0..1=[{exprs}], SAL=[$t5])
-              EnumerableTableScan(table=[[scott, EMP]])
-          EnumerableSort(sort0=[$2], dir0=[ASC])
-            EnumerableCalc(expr#0..2=[{inputs}], expr#3=[1:BIGINT], expr#4=[IS NOT NULL($t1)], c=[$t3], ck=[$t3], DNAME=[$t1], $condition=[$t4])
-              EnumerableTableScan(table=[[scott, DEPT]])
-      EnumerableSort(sort0=[$2], sort1=[$3], dir0=[ASC], dir1=[ASC])
-        EnumerableCalc(expr#0..4=[{inputs}], DEPTNO=[$t2], i=[$t3], DNAME=[$t4], SAL=[$t0])
-          EnumerableHashJoin(condition=[=($1, $2)], joinType=[inner])
-            EnumerableCalc(expr#0=[{inputs}], expr#1=[100], expr#2=[+($t0, $t1)], SAL=[$t0], $f1=[$t2])
-              EnumerableAggregate(group=[{5}])
+  EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[=($t1, $t8)], expr#10=[IS NULL($t0)], expr#11=[IS NOT NULL($t6)], expr#12=[<($t2, $t1)], expr#13=[OR($t10, $t11, $t12)], expr#14=[IS NOT TRUE($t13)], expr#15=[OR($t9, $t14)], proj#0..7=[{exprs}], $condition=[$t15])
+    EnumerableMergeJoin(condition=[AND(=($3, $5), =($4, $7))], joinType=[left])
+      EnumerableSort(sort0=[$3], sort1=[$4], dir0=[ASC], dir1=[ASC])
+        EnumerableCalc(expr#0..6=[{inputs}], expr#7=[100], expr#8=[+($t2, $t7)], expr#9=[CAST($t1):VARCHAR(14)], SAL=[$t2], c=[$t4], ck=[$t5], $f5=[$t8], ENAME0=[$t9])
+          EnumerableMergeJoin(condition=[=($3, $6)], joinType=[left])
+            EnumerableSort(sort0=[$3], dir0=[ASC])
+              EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t1):VARCHAR(14)], proj#0..1=[{exprs}], SAL=[$t5], ENAME0=[$t8])
                 EnumerableTableScan(table=[[scott, EMP]])
-            EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[IS NOT NULL($t1)], DEPTNO=[$t0], i=[$t3], DNAME=[$t1], $condition=[$t4])
-              EnumerableTableScan(table=[[scott, DEPT]])
+            EnumerableSort(sort0=[$2], dir0=[ASC])
+              EnumerableCalc(expr#0..2=[{inputs}], expr#3=[1:BIGINT], expr#4=[IS NOT NULL($t1)], c=[$t3], ck=[$t3], DNAME=[$t1], $condition=[$t4])
+                EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableSort(sort0=[$0], sort1=[$2], dir0=[ASC], dir1=[ASC])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[IS NOT NULL($t1)], DEPTNO=[$t0], i=[$t3], DNAME=[$t1], $condition=[$t4])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Correlated ANY sub-query


### PR DESCRIPTION
1. Add plan transformations before starting the core RelDecorrelator logic
to bring the plan into an equivalent but more convenient form that can be
decorrelated into more efficient and correct plans.

2. Based on the changes above many plans with subqueries become more
efficient since the value generator is no longer necessary and it is dropped.

3. Add test case in SqlToRelConverter reproducing the problem (bad plan)
and update existing tests based on the changes.