### PR TITLE
[CALCITE-4592] Populate correlation context for Join in RelToSqlConve…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -214,6 +214,7 @@ public class RelToSqlConverter extends SqlImplementor
       break;
     }
     final Result leftResult = visitInput(e, 0).resetAlias();
+    parseCorrelTable(e, leftResult);
     final Result rightResult = visitInput(e, 1).resetAlias();
     final Context leftContext = leftResult.qualifiedContext();
     final Context rightContext = rightResult.qualifiedContext();


### PR DESCRIPTION
…rter

Correlation context is populated in RelToSqlConverter for the followings:
- Project
- Filter
- Calc
- Correlate

But it is not populated for Join. Because of it, using joiner's correlation id causes below exception

Version 1.21 stack-trace
`Caused by:
java.lang.NullPointerException
    at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:506)
    at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:828)
    at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:668)
    at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:828)
    at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:668)
    at org.apache.calcite.rel.rel2sql.RelToSqlConverter.visit(RelToSqlConverter.java:213)
    ... 65 more`

Version 1.26 stack-trace
`java.lang.NullPointerException: variable $cor0 is not found
        at java.util.Objects.requireNonNull(Objects.java:290)
        at org.apache.calcite.rel.rel2sql.SqlImplementor$BaseContext.getAliasContext(SqlImplementor.java:1493)
        at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:709)
        at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:1132)
        at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.callToSql(SqlImplementor.java:851)
        at org.apache.calcite.rel.rel2sql.SqlImplementor$Context.toSql(SqlImplementor.java:827)
        at org.apache.calcite.rel.rel2sql.RelToSqlConverter.visit(RelToSqlConverter.java:338)
`