### PR TITLE
[CALCITE-4618] Refine dependency declarations to better account for type annotations

### DIFF
--- a/cassandra/build.gradle.kts
+++ b/cassandra/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     api("com.datastax.cassandra:cassandra-driver-core")
     api("com.google.guava:guava")
+    api("org.checkerframework:checker-qual")
     api("org.slf4j:slf4j-api")
 
     implementation("org.apache.calcite.avatica:avatica-core")

--- a/elasticsearch/build.gradle.kts
+++ b/elasticsearch/build.gradle.kts
@@ -25,17 +25,17 @@ dependencies {
     api(project(":linq4j"))
 
     api("com.fasterxml.jackson.core:jackson-annotations")
-    api("com.fasterxml.jackson.core:jackson-core")
     api("com.fasterxml.jackson.core:jackson-databind")
+    api("org.checkerframework:checker-qual")
     api("org.elasticsearch.client:elasticsearch-rest-client")
-    api("org.slf4j:slf4j-api")
 
+    implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.google.guava:guava")
     implementation("org.apache.calcite.avatica:avatica-core")
     implementation("org.apache.httpcomponents:httpasyncclient")
     implementation("org.apache.httpcomponents:httpclient")
     implementation("org.apache.httpcomponents:httpcore")
-    implementation("org.checkerframework:checker-qual")
+    implementation("org.slf4j:slf4j-api")
 
     // https://github.com/elastic/elasticsearch/issues/49218
     if (project.props.bool("elasticStrictAsm", default = true)) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ calcite.avatica.version=1.17.0
 # publishGradleMetadata=true
 
 # Plugins
-com.autonomousapps.dependency-analysis.version=0.71.0
+com.autonomousapps.dependency-analysis.version=0.73.0
 org.checkerframework.version=0.5.16
 com.github.autostyle.version=3.0
 com.github.burrunan.s3-build-cache.version=1.1

--- a/innodb/build.gradle.kts
+++ b/innodb/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(project(":core"))
     api(project(":linq4j"))
     api("com.alibaba.database:innodb-java-reader")
+    api("org.checkerframework:checker-qual")
     api("com.google.guava:guava")
 
     implementation("commons-collections:commons-collections")

--- a/mongodb/build.gradle.kts
+++ b/mongodb/build.gradle.kts
@@ -17,6 +17,7 @@
 dependencies {
     api(project(":core"))
     api(project(":linq4j"))
+    api("org.checkerframework:checker-qual")
     api("com.google.guava:guava")
     api("org.slf4j:slf4j-api")
 

--- a/pig/build.gradle.kts
+++ b/pig/build.gradle.kts
@@ -16,9 +16,10 @@
  */
 dependencies {
     api(project(":core"))
-    api(project(":linq4j"))
+    api("org.checkerframework:checker-qual")
     api("com.google.guava:guava")
 
+    implementation(project(":linq4j"))
     implementation("org.apache.calcite.avatica:avatica-core")
     implementation("org.apache.pig:pig::h2")
 

--- a/piglet/build.gradle.kts
+++ b/piglet/build.gradle.kts
@@ -22,12 +22,12 @@ plugins {
 dependencies {
     api(project(":core"))
     api(project(":linq4j"))
+    api("org.checkerframework:checker-qual")
     api("com.google.guava:guava")
     api("org.apache.pig:pig::h2")
 
     implementation("org.apache.calcite.avatica:avatica-core")
     implementation("org.apache.hadoop:hadoop-common")
-    implementation("org.checkerframework:checker-qual")
     implementation("org.slf4j:slf4j-api")
 
     testImplementation(project(":core", "testClasses"))

--- a/plus/build.gradle.kts
+++ b/plus/build.gradle.kts
@@ -16,19 +16,19 @@
  */
 dependencies {
     api(project(":core"))
-    api(project(":linq4j"))
     api("net.hydromatic:quidem")
     api("org.apache.calcite.avatica:avatica-core")
     api("org.checkerframework:checker-qual")
 
+    implementation(project(":linq4j"))
     implementation("com.google.guava:guava")
     implementation("com.teradata.tpcds:tpcds")
     implementation("io.prestosql.tpch:tpch")
     implementation("net.hydromatic:chinook-data-hsqldb")
-    implementation("net.hydromatic:tpcds")
     implementation("org.apache.calcite.avatica:avatica-server")
     implementation("org.hsqldb:hsqldb")
 
     testImplementation(project(":core", "testClasses"))
+    testImplementation("net.hydromatic:tpcds")
     testImplementation("org.incava:java-diff")
 }

--- a/redis/build.gradle.kts
+++ b/redis/build.gradle.kts
@@ -17,6 +17,7 @@
 dependencies {
     api(project(":core"))
     api(project(":linq4j"))
+    api("org.checkerframework:checker-qual")
     api("redis.clients:jedis")
 
     implementation("com.fasterxml.jackson.core:jackson-core")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,9 +22,10 @@ plugins {
 
 dependencies {
     api(project(":core"))
-    api(project(":linq4j"))
     api("org.apache.calcite.avatica:avatica-core")
 
+    implementation(project(":linq4j"))
+    implementation("org.checkerframework:checker-qual")
     implementation("com.google.guava:guava")
     implementation("org.slf4j:slf4j-api")
 

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -17,6 +17,7 @@
 dependencies {
     api(project(":core"))
     api(project(":linq4j"))
+    api("org.checkerframework:checker-qual")
     api("org.apache.spark:spark-core_2.10")
 
     implementation("com.google.guava:guava")


### PR DESCRIPTION
The updated dependency-analysis analyzes type annotations much better.

The command to analyze dependencies is

    ./gradlew -PenableDependencyAnalysis buildHealth

The following warnings are still present (I believe they are false positives, however, the one regarding xerces is weird and we can either skip that dependency or declare it as implementation):

https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/393
```
  Advice for project :core
  Existing dependencies which should be modified to be as indicated:
  - testImplementation("org.apache.commons:commons-dbcp2:2.6.0") (was implementation)
```

https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/392
```
  Plugin advice:
  - java-library: this project has both java-library and org.jetbrains.kotlin.jvm applied, which is redundant. You can remove java-library
```

https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/394
In practice, xerces:xercesImpl is pulled to the `implementation` scope by spark->hadoop anyway, so there's no much sense in declaring xerces explicitly as we don't use it.

```
  Advice for project :spark
  Existing dependencies which should be modified to be as indicated:
  - implementation("xerces:xercesImpl:2.9.1") (was runtimeOnly)
```
