### PR TITLE
[CALCITE-4603] Least restrictive for collections of collections

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -269,6 +269,11 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
       isNullable |= type.isNullable();
     }
     if (sqlTypeName == SqlTypeName.MAP) {
+      for (RelDataType type: types) {
+        if (type.getKeyType() == null || type.getValueType() == null) {
+          return null;
+        }
+      }
       RelDataType keyType = leastRestrictive(
           Util.transform(types, t -> Objects.requireNonNull(t.getKeyType())));
       RelDataType valueType = leastRestrictive(
@@ -278,6 +283,11 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
       }
       return new MapSqlType(keyType, valueType, isNullable);
     } else {
+      for (RelDataType type: types) {
+        if (type.getComponentType() == null) {
+          return null;
+        }
+      }
       RelDataType type = leastRestrictive(
           Util.transform(types, t -> Objects.requireNonNull(t.getComponentType())));
       if (type == null) {

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -273,12 +273,12 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
         isNullable |= type.isNullable();
       }
       final RelDataType keyType = leastRestrictive(
-          Util.transform(types, t -> Objects.requireNonNull(t.getKeyType())));
+          Util.transform(types, t -> ((MapSqlType) t).getKeyType()));
       if (keyType == null) {
         return null;
       }
       final RelDataType valueType = leastRestrictive(
-          Util.transform(types, t -> Objects.requireNonNull(t.getValueType())));
+          Util.transform(types, t -> ((MapSqlType) t).getValueType()));
       if (valueType == null) {
         return null;
       }
@@ -291,7 +291,10 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
         isNullable |= type.isNullable();
       }
       final RelDataType type = leastRestrictive(
-          Util.transform(types, t -> Objects.requireNonNull(t.getComponentType())));
+          Util.transform(types,
+              t -> t instanceof ArraySqlType
+                  ? ((ArraySqlType) t).getComponentType()
+                  : ((MultisetSqlType) t).getComponentType()));
       if (type == null) {
         return null;
       }

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -265,20 +265,21 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     assert sqlTypeName == SqlTypeName.ARRAY
         || sqlTypeName == SqlTypeName.MULTISET || sqlTypeName == SqlTypeName.MAP;
     boolean isNullable = false;
-    for (RelDataType type : types) {
-      isNullable |= type.isNullable();
-    }
     if (sqlTypeName == SqlTypeName.MAP) {
       for (RelDataType type: types) {
         if (type.getKeyType() == null || type.getValueType() == null) {
           return null;
         }
+        isNullable |= type.isNullable();
       }
-      RelDataType keyType = leastRestrictive(
+      final RelDataType keyType = leastRestrictive(
           Util.transform(types, t -> Objects.requireNonNull(t.getKeyType())));
-      RelDataType valueType = leastRestrictive(
+      if (keyType == null) {
+        return null;
+      }
+      final RelDataType valueType = leastRestrictive(
           Util.transform(types, t -> Objects.requireNonNull(t.getValueType())));
-      if (keyType == null || valueType == null) {
+      if (valueType == null) {
         return null;
       }
       return new MapSqlType(keyType, valueType, isNullable);
@@ -287,8 +288,9 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
         if (type.getComponentType() == null) {
           return null;
         }
+        isNullable |= type.isNullable();
       }
-      RelDataType type = leastRestrictive(
+      final RelDataType type = leastRestrictive(
           Util.transform(types, t -> Objects.requireNonNull(t.getComponentType())));
       if (type == null) {
         return null;

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -270,17 +270,16 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     }
     if (sqlTypeName == SqlTypeName.MAP) {
       RelDataType keyType = leastRestrictive(
-          Util.transform(types, RelDataType::getKeyType));
+          Util.transform(types, t -> Objects.requireNonNull(t.getKeyType())));
       RelDataType valueType = leastRestrictive(
-          Util.transform(types, RelDataType::getValueType));
+          Util.transform(types, t -> Objects.requireNonNull(t.getValueType())));
       if (keyType == null || valueType == null) {
         return null;
       }
       return new MapSqlType(keyType, valueType, isNullable);
     } else {
       RelDataType type = leastRestrictive(
-          Util.transform(types, RelDataType::getComponentType)
-      );
+          Util.transform(types, t -> Objects.requireNonNull(t.getComponentType())));
       if (type == null) {
         return null;
       }

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -288,7 +288,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     assert sqlTypeName == SqlTypeName.MAP;
     boolean isNullable = false;
     for (RelDataType type: types) {
-      if (type.getKeyType() == null || type.getValueType() == null) {
+      if (!(type instanceof MapSqlType)) {
         return null;
       }
       isNullable |= type.isNullable();

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -292,9 +292,11 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
           return leastRestrictiveStructuredType(types);
         }
         if (sqlTypeName == SqlTypeName.ARRAY
-            || sqlTypeName == SqlTypeName.MAP
             || sqlTypeName == SqlTypeName.MULTISET) {
-          return leastRestrictiveCollectionType(types, sqlTypeName);
+          return leastRestrictiveArrayMultisetType(types, sqlTypeName);
+        }
+        if (sqlTypeName == SqlTypeName.MAP) {
+          return leastRestrictiveMapType(types, sqlTypeName);
         }
       }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -287,8 +287,14 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
 
       if (resultType == null) {
         resultType = type;
-        if (resultType.getSqlTypeName() == SqlTypeName.ROW) {
+        SqlTypeName sqlTypeName = resultType.getSqlTypeName();
+        if (sqlTypeName == SqlTypeName.ROW) {
           return leastRestrictiveStructuredType(types);
+        }
+        if (sqlTypeName == SqlTypeName.ARRAY
+            || sqlTypeName == SqlTypeName.MAP
+            || sqlTypeName == SqlTypeName.MULTISET) {
+          return leastRestrictiveCollectionType(types, sqlTypeName);
         }
       }
 

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -83,6 +83,37 @@ class SqlTypeFactoryTest {
     assertThat(leastRestrictive.isNullable(), is(true));
   }
 
+  @Test void testLeastRestrictiveForArrays() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(
+            Lists.newArrayList(f.sqlCharArray10, f.sqlCharArray1));
+    assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.ARRAY));
+    assertThat(leastRestrictive.isNullable(), is(false));
+    assertThat(leastRestrictive.getComponentType().getPrecision(), is(10));
+  }
+
+  @Test void testLeastRestrictiveForMultisets() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(
+            Lists.newArrayList(f.sqlCharMultiset10Nullable, f.sqlCharMultiset1));
+    assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.MULTISET));
+    assertThat(leastRestrictive.isNullable(), is(true));
+    assertThat(leastRestrictive.getComponentType().getPrecision(), is(10));
+  }
+
+  @Test void testLeastRestrictiveForMaps() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(
+            Lists.newArrayList(f.sqlCharMap10Nullable, f.sqlCharMap1));
+    assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.MAP));
+    assertThat(leastRestrictive.isNullable(), is(true));
+    assertThat(leastRestrictive.getKeyType().getPrecision(), is(10));
+    assertThat(leastRestrictive.getValueType().getPrecision(), is(10));
+  }
+
   /** Unit test for {@link SqlTypeUtil#comparePrecision(int, int)}
    * and  {@link SqlTypeUtil#maxPrecision(int, int)}. */
   @Test void testMaxPrecision() {

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -83,6 +84,14 @@ class SqlTypeFactoryTest {
     assertThat(leastRestrictive.isNullable(), is(true));
   }
 
+  @Test void testLeastRestrictiveForImpossibleWithArray() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(
+            Lists.newArrayList(f.sqlCharArray10, f.sqlChar));
+    assertNull(leastRestrictive);
+  }
+
   @Test void testLeastRestrictiveForArrays() {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
@@ -103,6 +112,24 @@ class SqlTypeFactoryTest {
     assertThat(leastRestrictive.getComponentType().getPrecision(), is(10));
   }
 
+  @Test void testLeastRestrictiveForMultisetsAndArrays() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(
+            Lists.newArrayList(f.sqlCharMultiset10Nullable, f.sqlCharArray1));
+    assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.MULTISET));
+    assertThat(leastRestrictive.isNullable(), is(true));
+    assertThat(leastRestrictive.getComponentType().getPrecision(), is(10));
+  }
+
+  @Test void testLeastRestrictiveForImpossibleWithMultisets() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(
+            Lists.newArrayList(f.sqlCharMultiset10Nullable, f.sqlCharMap1));
+    assertNull(leastRestrictive);
+  }
+
   @Test void testLeastRestrictiveForMaps() {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
@@ -112,6 +139,14 @@ class SqlTypeFactoryTest {
     assertThat(leastRestrictive.isNullable(), is(true));
     assertThat(leastRestrictive.getKeyType().getPrecision(), is(10));
     assertThat(leastRestrictive.getValueType().getPrecision(), is(10));
+  }
+
+  @Test void testLeastRestrictiveForImpossibleWithMaps() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(
+            Lists.newArrayList(f.sqlCharMap10Nullable, f.sqlCharArray1));
+    assertNull(leastRestrictive);
   }
 
   /** Unit test for {@link SqlTypeUtil#comparePrecision(int, int)}

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -88,7 +88,7 @@ class SqlTypeFactoryTest {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(
-            Lists.newArrayList(f.sqlCharArray10, f.sqlChar));
+            Lists.newArrayList(f.arraySqlChar10, f.sqlChar));
     assertNull(leastRestrictive);
   }
 
@@ -96,7 +96,7 @@ class SqlTypeFactoryTest {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(
-            Lists.newArrayList(f.sqlCharArray10, f.sqlCharArray1));
+            Lists.newArrayList(f.arraySqlChar10, f.arraySqlChar1));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.ARRAY));
     assertThat(leastRestrictive.isNullable(), is(false));
     assertThat(leastRestrictive.getComponentType().getPrecision(), is(10));
@@ -106,7 +106,7 @@ class SqlTypeFactoryTest {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(
-            Lists.newArrayList(f.sqlCharMultiset10Nullable, f.sqlCharMultiset1));
+            Lists.newArrayList(f.multisetSqlChar10Nullable, f.multisetSqlChar1));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.MULTISET));
     assertThat(leastRestrictive.isNullable(), is(true));
     assertThat(leastRestrictive.getComponentType().getPrecision(), is(10));
@@ -116,7 +116,7 @@ class SqlTypeFactoryTest {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(
-            Lists.newArrayList(f.sqlCharMultiset10Nullable, f.sqlCharArray1));
+            Lists.newArrayList(f.multisetSqlChar10Nullable, f.arraySqlChar1));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.MULTISET));
     assertThat(leastRestrictive.isNullable(), is(true));
     assertThat(leastRestrictive.getComponentType().getPrecision(), is(10));
@@ -126,7 +126,7 @@ class SqlTypeFactoryTest {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(
-            Lists.newArrayList(f.sqlCharMultiset10Nullable, f.sqlCharMap1));
+            Lists.newArrayList(f.multisetSqlChar10Nullable, f.mapSqlChar1));
     assertNull(leastRestrictive);
   }
 
@@ -134,7 +134,7 @@ class SqlTypeFactoryTest {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(
-            Lists.newArrayList(f.sqlCharMap10Nullable, f.sqlCharMap1));
+            Lists.newArrayList(f.mapSqlChar10Nullable, f.mapSqlChar1));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.MAP));
     assertThat(leastRestrictive.isNullable(), is(true));
     assertThat(leastRestrictive.getKeyType().getPrecision(), is(10));
@@ -145,7 +145,7 @@ class SqlTypeFactoryTest {
     SqlTypeFixture f = new SqlTypeFixture();
     RelDataType leastRestrictive =
         f.typeFactory.leastRestrictive(
-            Lists.newArrayList(f.sqlCharMap10Nullable, f.sqlCharArray1));
+            Lists.newArrayList(f.mapSqlChar10Nullable, f.arraySqlChar1));
     assertNull(leastRestrictive);
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
@@ -78,4 +78,20 @@ class SqlTypeFixture {
       typeFactory.createMapType(sqlInt, sqlInt), false);
   final RelDataType mapOfIntNullable = typeFactory.createTypeWithNullability(
       typeFactory.createMapType(sqlInt, sqlInt), true);
+  final RelDataType sqlChar1 = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.CHAR, 1), false);
+  final RelDataType sqlChar10 = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.CHAR, 10), false);
+  final RelDataType sqlCharArray10 = typeFactory.createTypeWithNullability(
+      typeFactory.createArrayType(sqlChar10, -1), false);
+  final RelDataType sqlCharArray1 = typeFactory.createTypeWithNullability(
+      typeFactory.createArrayType(sqlChar1, -1), false);
+  final RelDataType sqlCharMultiset10Nullable = typeFactory.createTypeWithNullability(
+      typeFactory.createMultisetType(sqlChar10, -1), true);
+  final RelDataType sqlCharMultiset1 = typeFactory.createTypeWithNullability(
+      typeFactory.createMultisetType(sqlChar1, -1), false);
+  final RelDataType sqlCharMap10Nullable = typeFactory.createTypeWithNullability(
+      typeFactory.createMapType(sqlChar10, sqlChar10), true);
+  final RelDataType sqlCharMap1 = typeFactory.createTypeWithNullability(
+      typeFactory.createMapType(sqlChar1, sqlChar1), false);
 }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
@@ -82,16 +82,16 @@ class SqlTypeFixture {
       typeFactory.createSqlType(SqlTypeName.CHAR, 1), false);
   final RelDataType sqlChar10 = typeFactory.createTypeWithNullability(
       typeFactory.createSqlType(SqlTypeName.CHAR, 10), false);
-  final RelDataType sqlCharArray10 = typeFactory.createTypeWithNullability(
+  final RelDataType arraySqlChar10 = typeFactory.createTypeWithNullability(
       typeFactory.createArrayType(sqlChar10, -1), false);
-  final RelDataType sqlCharArray1 = typeFactory.createTypeWithNullability(
+  final RelDataType arraySqlChar1 = typeFactory.createTypeWithNullability(
       typeFactory.createArrayType(sqlChar1, -1), false);
-  final RelDataType sqlCharMultiset10Nullable = typeFactory.createTypeWithNullability(
+  final RelDataType multisetSqlChar10Nullable = typeFactory.createTypeWithNullability(
       typeFactory.createMultisetType(sqlChar10, -1), true);
-  final RelDataType sqlCharMultiset1 = typeFactory.createTypeWithNullability(
+  final RelDataType multisetSqlChar1 = typeFactory.createTypeWithNullability(
       typeFactory.createMultisetType(sqlChar1, -1), false);
-  final RelDataType sqlCharMap10Nullable = typeFactory.createTypeWithNullability(
+  final RelDataType mapSqlChar10Nullable = typeFactory.createTypeWithNullability(
       typeFactory.createMapType(sqlChar10, sqlChar10), true);
-  final RelDataType sqlCharMap1 = typeFactory.createTypeWithNullability(
+  final RelDataType mapSqlChar1 = typeFactory.createTypeWithNullability(
       typeFactory.createMapType(sqlChar1, sqlChar1), false);
 }


### PR DESCRIPTION
The PR implements least restrictive for collection of collections for instance
```sql
 select array[array['hello'], array['world'], array['!']] as "array"
```
and others mentioned in CALCITE-4603