### PR TITLE
F481 failing test

### DIFF
--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -2122,6 +2122,12 @@ public abstract class SqlOperatorBaseTest {
 
   @Test void testRow() {
     tester.setFor(SqlStdOperatorTable.ROW, VM_FENNEL);
+    tester.checkBoolean("ROW(null, null) IS NULL", Boolean.TRUE);
+    tester.checkBoolean("ROW(null, null) IS NOT NULL", Boolean.FALSE);
+    tester.checkBoolean("ROW(1, null) IS NULL", Boolean.FALSE);
+    tester.checkBoolean("ROW(1, null) IS NOT NULL", Boolean.FALSE);
+    tester.checkBoolean("ROW(1, 2) IS NULL", Boolean.FALSE);
+    tester.checkBoolean("ROW(1, 2) IS NOT NULL", Boolean.TRUE);
   }
 
   @Test void testAndOperator() {


### PR DESCRIPTION
There is "Expanded NULL predicate" (F481) in SQL 2003 (ISO/IEC 9075-2:2003) feature taxonomy.
Currently the feature is not implemented in Apache Calcite as failing test shows.