### PR TITLE
[CALCITE-4608] Fix NullPointerException in SqlNumericLiteral.isInteger()

### DIFF
--- a/core/src/main/java/org/apache/calcite/schema/SchemaFactory.java
+++ b/core/src/main/java/org/apache/calcite/schema/SchemaFactory.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * <p>A schema factory allows you to include a custom schema in a model file.
  * For example, here is a model that contains a custom schema whose tables
  * read CSV files. (See the
- * <a href="http://calcite.apache.org/apidocs/org/apache/calcite/adapter/csv/package-summary.html">example CSV adapter</a>
+ * <a href="https://calcite.apache.org/javadocAggregate/org/apache/calcite/adapter/csv/package-summary.html">example CSV adapter</a>
  * for more details about this particular adapter.)
  *
  * <blockquote><pre>{

--- a/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -923,7 +923,7 @@ public class SqlLiteral extends SqlNode {
       String s,
       SqlParserPos pos) {
     BigDecimal value = SqlParserUtil.parseDecimal(s);
-    return new SqlNumericLiteral(value, null, null, false, pos);
+    return new SqlNumericLiteral(value, value.precision(), value.scale(), false, pos);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -10161,7 +10161,7 @@ public abstract class SqlOperatorBaseTest {
     SqlNumericLiteral sqlNumericLiteral =
         SqlLiteral.createApproxNumeric(Double.toString(Double.MAX_VALUE), SqlParserPos.ZERO);
     assertThat(sqlNumericLiteral.getPrec(), is(17));
-    assertEquals(sqlNumericLiteral.getScale(), is(-292));
+    assertThat(sqlNumericLiteral.getScale(), is(-292));
   }
 
   private Throwable findMostDescriptiveCause(Throwable ex) {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -100,6 +100,7 @@ import static org.apache.calcite.util.DateTimeStringUtils.getDateFormatter;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -10159,8 +10160,8 @@ public abstract class SqlOperatorBaseTest {
   @Test void testCreateApproxNumericFunction() {
     SqlNumericLiteral sqlNumericLiteral =
         SqlLiteral.createApproxNumeric(Double.toString(Double.MAX_VALUE), SqlParserPos.ZERO);
-    assertEquals(sqlNumericLiteral.getPrec(), 17);
-    assertEquals(sqlNumericLiteral.getScale(), -292);
+    assertThat(sqlNumericLiteral.getPrec(), is(17));
+    assertEquals(sqlNumericLiteral.getScale(), is(-292));
   }
 
   private Throwable findMostDescriptiveCause(Throwable ex) {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -34,6 +34,7 @@ import org.apache.calcite.sql.SqlJdbcFunctionCall;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
@@ -10149,6 +10150,17 @@ public abstract class SqlOperatorBaseTest {
         }
       }
     }
+  }
+
+  /**
+   * Tests that {@link SqlLiteral#createApproxNumeric} function sets scale and precision of the
+   * numeric value.
+   */
+  @Test void testCreateApproxNumericFunction() {
+    SqlNumericLiteral sqlNumericLiteral =
+        SqlLiteral.createApproxNumeric(Double.toString(Double.MAX_VALUE), SqlParserPos.ZERO);
+    assertEquals(sqlNumericLiteral.getPrec(), 17);
+    assertEquals(sqlNumericLiteral.getScale(), -292);
   }
 
   private Throwable findMostDescriptiveCause(Throwable ex) {


### PR DESCRIPTION
A NullPointerException is thrown in SqlNumericLiteral.isInteger(), due to "this.scale" being null. This can be reproduced by compiling SQL statement "SELECT * FROM testTable WHERE floatColumn > 1.7976931348623157E308".

A null check was added through CALCITE-4199 to fix the NullPointerException; however, the root cause is that scale and precision are not being properly set in SqlLiteral.createApproxNumeric function which is called to handle APPROX_NUMERIC_LITERAL token. 