### PR TITLE
[CALCITE-4613] OWASP dependency-check tasks fail due to missing resources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ calcite.avatica.version=1.17.0
 com.autonomousapps.dependency-analysis.version=0.71.0
 org.checkerframework.version=0.5.16
 com.github.autostyle.version=3.0
-com.github.burrunan.s3-build-cache.version=1.1
+com.github.burrunan.s3-build-cache.version=1.2
 com.github.johnrengelman.shadow.version=5.1.0
 com.github.spotbugs.version=2.0.0
 com.github.vlsi.vlsi-release-plugins.version=1.72
@@ -57,7 +57,7 @@ net.ltgt.errorprone.version=1.3.0
 me.champeau.gradle.jmh.version=0.5.0
 org.jetbrains.gradle.plugin.idea-ext.version=0.5
 org.nosphere.apache.rat.version=0.7.0
-org.owasp.dependencycheck.version=5.2.2
+org.owasp.dependencycheck.version=6.1.6
 
 # TODO
 # error_prone_core.version=2.3.3


### PR DESCRIPTION
Update org.owasp.dependencycheck.version to 6.1.6 to resolve the problem.