### PR TITLE
[CALCITE-4617] Wrong offset when SortJoinTransposeRule pushes a sort node with an offset

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
@@ -158,7 +158,7 @@ public class SortJoinTransposeRule
     final RelNode joinCopy = join.copy(join.getTraitSet(), join.getCondition(), newLeftInput,
         newRightInput, join.getJoinType(), join.isSemiJoinDone());
     final RelNode sortCopy = sort.copy(sort.getTraitSet(), joinCopy, sort.getCollation(),
-        sort.offset, sort.fetch);
+        null, sort.fetch);
 
     call.transformTo(sortCopy);
   }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -11751,7 +11751,7 @@ LogicalProject(DEPTNO=[$0], EMPNO=[$2])
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(DEPTNO=[$0], EMPNO=[$2])
-  LogicalSort(offset=[2], fetch=[10])
+  LogicalSort(fetch=[10])
     LogicalJoin(condition=[=($0, $9)], joinType=[right])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
       LogicalSort(offset=[2], fetch=[10])

--- a/core/src/test/resources/sql/join.iq
+++ b/core/src/test/resources/sql/join.iq
@@ -249,4 +249,59 @@ EnumerableCalc(expr#0..10=[{inputs}], expr#11=[COALESCE($t7, $t8)], DEPTNO=[$t11
       EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
+### [CALCITE-4617] Wrong offset when SortJoinTransposeRule pushes a sort node with an offset
+select * from (select * from "scott".emp) e left join (
+  select * from "scott".dept d) using (deptno)
+order by empno limit 3 offset 1;
++--------+-------+-------+----------+------+------------+---------+--------+----------+---------+
+| DEPTNO | EMPNO | ENAME | JOB      | MGR  | HIREDATE   | SAL     | COMM   | DNAME    | LOC     |
++--------+-------+-------+----------+------+------------+---------+--------+----------+---------+
+|     30 |  7499 | ALLEN | SALESMAN | 7698 | 1981-02-20 | 1600.00 | 300.00 | SALES    | CHICAGO |
+|     30 |  7521 | WARD  | SALESMAN | 7698 | 1981-02-22 | 1250.00 | 500.00 | SALES    | CHICAGO |
+|     20 |  7566 | JONES | MANAGER  | 7839 | 1981-02-04 | 2975.00 |        | RESEARCH | DALLAS  |
++--------+-------+-------+----------+------+------------+---------+--------+----------+---------+
+(3 rows)
+
+!ok
+EnumerableCalc(expr#0..10=[{inputs}], expr#11=[COALESCE($t7, $t8)], DEPTNO=[$t11], EMPNO=[$t0], ENAME=[$t1], JOB=[$t2], MGR=[$t3], HIREDATE=[$t4], SAL=[$t5], COMM=[$t6], DNAME=[$t9], LOC=[$t10])
+  EnumerableLimit(fetch=[3])
+    EnumerableHashJoin(condition=[=($7, $8)], joinType=[left])
+      EnumerableLimit(offset=[1], fetch=[3])
+        EnumerableTableScan(table=[[scott, EMP]])
+      EnumerableTableScan(table=[[scott, DEPT]])
+!plan
+
+### [CALCITE-4617] Wrong offset when SortJoinTransposeRule pushes a sort node with an offset
+select d.deptno, empno
+  from "scott".dept d
+  right join "scott".emp e using (deptno)
+  order by empno limit 10 offset 1;
++--------+-------+
+| DEPTNO | EMPNO |
++--------+-------+
+|     30 |  7499 |
+|     30 |  7521 |
+|     20 |  7566 |
+|     30 |  7654 |
+|     30 |  7698 |
+|     10 |  7782 |
+|     20 |  7788 |
+|     10 |  7839 |
+|     30 |  7844 |
+|     20 |  7876 |
++--------+-------+
+(10 rows)
+
+!ok
+EnumerableCalc(expr#0..2=[{inputs}], proj#0..1=[{exprs}])
+  EnumerableLimit(fetch=[10])
+    EnumerableSort(sort0=[$1], dir0=[ASC])
+      EnumerableHashJoin(condition=[=($0, $2)], joinType=[right])
+        EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
+          EnumerableTableScan(table=[[scott, DEPT]])
+        EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], DEPTNO=[$t7])
+          EnumerableLimit(offset=[1], fetch=[10])
+            EnumerableTableScan(table=[[scott, EMP]])
+!plan
+
 # End join.iq


### PR DESCRIPTION
The sort node added on top of the join shouldn't re-apply the offset of the original sort node, otherwise we end up skipping rows twice