### PR TITLE
[CALCITE-4635] Distinct on aggregate window functions produce wrong r…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
@@ -82,7 +82,8 @@ public class SqlOverOperator extends SqlBinaryOperator {
     if (qualifier != null && qualifier.toString().equals("DISTINCT")
         && window.getKind() == SqlKind.WINDOW) {
       throw validator.newValidationError(aggCall,
-          RESOURCE.functionQuantifierNotAllowed(window.toString())); }
+          RESOURCE.functionQuantifierNotAllowed(window.toString()));
+    }
     validator.validateWindow(window, scope, aggCall);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
@@ -78,6 +78,11 @@ public class SqlOverOperator extends SqlBinaryOperator {
       throw validator.newValidationError(aggCall, RESOURCE.overNonAggregate());
     }
     final SqlNode window = call.operand(1);
+    SqlLiteral qualifier = aggCall.getFunctionQuantifier();
+    if (qualifier != null && qualifier.toString().equals("DISTINCT")
+        && window.getKind() == SqlKind.WINDOW) {
+      throw validator.newValidationError(aggCall,
+          RESOURCE.functionQuantifierNotAllowed(window.toString())); }
     validator.validateWindow(window, scope, aggCall);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
@@ -79,7 +79,7 @@ public class SqlOverOperator extends SqlBinaryOperator {
     }
     final SqlNode window = call.operand(1);
     SqlLiteral qualifier = aggCall.getFunctionQuantifier();
-    if (qualifier != null && qualifier.toString().equals("DISTINCT")
+    if (qualifier != null && qualifier.getValue() == SqlSelectKeyword.DISTINCT
         && window.getKind() == SqlKind.WINDOW) {
       throw validator.newValidationError(aggCall,
           RESOURCE.functionQuantifierNotAllowed(window.toString()));

--- a/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOverOperator.java
@@ -78,12 +78,7 @@ public class SqlOverOperator extends SqlBinaryOperator {
       throw validator.newValidationError(aggCall, RESOURCE.overNonAggregate());
     }
     final SqlNode window = call.operand(1);
-    SqlLiteral qualifier = aggCall.getFunctionQuantifier();
-    if (qualifier != null && qualifier.getValue() == SqlSelectKeyword.DISTINCT
-        && window.getKind() == SqlKind.WINDOW) {
-      throw validator.newValidationError(aggCall,
-          RESOURCE.functionQuantifierNotAllowed(window.toString()));
-    }
+    checkDistinctOnWindowAggregate(validator, aggCall, window);
     validator.validateWindow(window, scope, aggCall);
   }
 
@@ -151,6 +146,15 @@ public class SqlOverOperator extends SqlBinaryOperator {
       }
     } else {
       super.acceptCall(visitor, call, onlyExpressions, argHandler);
+    }
+  }
+
+  private void checkDistinctOnWindowAggregate(SqlValidator validator, SqlCall call, SqlNode node) {
+    SqlLiteral qualifier = call.getFunctionQuantifier();
+    if (qualifier != null && qualifier.getValue() == SqlSelectKeyword.DISTINCT
+        && node.getKind() == SqlKind.WINDOW) {
+      throw validator.newValidationError(call,
+          RESOURCE.functionQuantifierNotAllowed(node.toString()));
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3147,8 +3147,15 @@ class RelToSqlConverterTest {
     sql(query6).optimize(rules, hepPlanner).ok(expected6);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3112">[CALCITE-3112]
+   * Support Window in RelToSqlConverter</a>.
+   * Currently disabled due to
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4635">[CALCITE-4635]
+   * Distinct on aggregate window functions produce wrong result</a>.
+   * Should be enabled again once distinct on window aggregate is properly implemented */
   @Disabled
-  @Test void testConvertWindowToSql2() {
+  @Test void testConvertWindowToSqlWithDistinct() {
     String query7 = "SELECT "
         + "count(distinct \"employee_id\") over (order by \"hire_date\") FROM \"employee\"";
     String expected7 = "SELECT "

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3150,18 +3150,18 @@ class RelToSqlConverterTest {
   @Disabled
   @Test void testConvertWindowToSql2() {
     String query7 = "SELECT "
-        + "count(\"employee_id\") over (order by \"hire_date\") FROM \"employee\"";
+        + "count(distinct \"employee_id\") over (order by \"hire_date\") FROM \"employee\"";
     String expected7 = "SELECT "
-        + "COUNT(\"employee_id\") "
+        + "COUNT(DISTINCT \"employee_id\") "
         + "OVER (ORDER BY \"hire_date\" RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$0\""
         + "\nFROM \"foodmart\".\"employee\"";
 
     String query8 = "SELECT "
-        + "sum(\"position_id\") over (order by \"hire_date\") FROM \"employee\"";
+        + "sum(distinct \"position_id\") over (order by \"hire_date\") FROM \"employee\"";
     String expected8 =
-        "SELECT CASE WHEN (COUNT(\"position_id\") OVER (ORDER BY \"hire_date\" "
+        "SELECT CASE WHEN (COUNT(DISTINCT \"position_id\") OVER (ORDER BY \"hire_date\" "
             + "RANGE"
-            + " BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)) > 0 THEN COALESCE(SUM("
+            + " BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)) > 0 THEN COALESCE(SUM(DISTINCT "
             + "\"position_id\") OVER (ORDER BY \"hire_date\" RANGE BETWEEN UNBOUNDED "
             + "PRECEDING AND CURRENT ROW), 0) ELSE NULL END\n"
             + "FROM \"foodmart\".\"employee\"";

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -658,8 +658,8 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
-  @Disabled
   /** As {@link #testSelectOverDistinct()} but for streaming queries. */
+  @Disabled
   @Test void testSelectStreamPartitionDistinct() {
     final String sql = "select stream\n"
         + "  count(distinct orderId) over (partition by productId\n"

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -645,10 +645,10 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql("select distinct sal + 5 from emp").ok();
   }
 
-  @Disabled
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-476">[CALCITE-476]
    * DISTINCT flag in windowed aggregates</a>. */
+  @Disabled
   @Test void testSelectOverDistinct() {
     // Checks to see if <aggregate>(DISTINCT x) is set and preserved
     // as a flag for the aggregate call.

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -645,6 +645,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql("select distinct sal + 5 from emp").ok();
   }
 
+  @Disabled
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-476">[CALCITE-476]
    * DISTINCT flag in windowed aggregates</a>. */
@@ -657,6 +658,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Disabled
   /** As {@link #testSelectOverDistinct()} but for streaming queries. */
   @Test void testSelectStreamPartitionDistinct() {
     final String sql = "select stream\n"

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7185,6 +7185,18 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + " ^count(distinct empno)^ over(partition by empno)\n"
         + "from emp")
         .fails("DISTINCT/ALL not allowed with \\(PARTITION BY `EMP`\\.`EMPNO`\\) function");
+
+    sql("select ^SUM(DISTINCT deptno)^\n"
+        + "over (ORDER BY empno)\n"
+        + "from emp")
+        .fails("DISTINCT/ALL not allowed with \\(ORDER BY `EMP`\\.`EMPNO`\\) function");
+
+    sql("select ^AVG(DISTINCT deptno)^\n"
+        + "over (ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)\n"
+        + "from emp")
+        .fails("DISTINCT/ALL not allowed with "
+            + "\\(ROWS BETWEEN 10 PRECEDING AND CURRENT ROW\\) function");
+
   }
 
   @Test void testGroupExpressionEquivalenceId() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7180,6 +7180,13 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("Expression 'EMPNO' is not being grouped");
   }
 
+  @Test void testDistinctOnWindowAggregate() {
+    sql("select\n"
+        + " ^count(distinct empno)^ over(partition by empno)\n"
+        + "from emp")
+        .fails("DISTINCT/ALL not allowed with \\(PARTITION BY `EMP`\\.`EMPNO`\\) function");
+  }
+
   @Test void testGroupExpressionEquivalenceId() {
     // identifier equivalence
     sql("select case empno when 10 then deptno else null end from emp "


### PR DESCRIPTION
…esult

Throw with a RESOURCE.functionQuantifierNotAllowed error in SqlOverOperator when distinct is being used with an aggregate window, since currently it'll produce wrong result (James Kim)