### PR TITLE
[CALCITE-4640] Propagate table scan hints to JDBC

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcImplementor.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcImplementor.java
@@ -22,8 +22,6 @@ import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.util.Util;
 
-import com.google.common.collect.ImmutableList;
-
 /**
  * State for generating a SQL statement.
  */
@@ -31,14 +29,6 @@ public class JdbcImplementor extends RelToSqlConverter {
   public JdbcImplementor(SqlDialect dialect, JavaTypeFactory typeFactory) {
     super(dialect);
     Util.discard(typeFactory);
-  }
-
-  // CHECKSTYLE: IGNORE 1
-  /** @see #dispatch */
-  @SuppressWarnings("MissingSummary")
-  public Result visit(JdbcTableScan scan) {
-    return result(scan.jdbcTable.tableName(),
-        ImmutableList.of(Clause.FROM), scan, null);
   }
 
   public Result implement(RelNode node) {

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -170,7 +170,7 @@ public class JdbcTable extends AbstractQueryableTable
 
   @Override public RelNode toRel(RelOptTable.ToRelContext context,
       RelOptTable relOptTable) {
-    return new JdbcTableScan(context.getCluster(), relOptTable, this,
+    return new JdbcTableScan(context.getCluster(), context.getTableHints(), relOptTable, this,
         jdbcSchema.convention);
   }
 

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTableScan.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTableScan.java
@@ -16,11 +16,13 @@
  */
 package org.apache.calcite.adapter.jdbc;
 
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.hint.RelHint;
 
 import com.google.common.collect.ImmutableList;
 
@@ -28,6 +30,8 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Relational expression representing a scan of a table in a JDBC data source.
@@ -37,21 +41,28 @@ public class JdbcTableScan extends TableScan implements JdbcRel {
 
   protected JdbcTableScan(
       RelOptCluster cluster,
+      List<RelHint> hints,
       RelOptTable table,
       JdbcTable jdbcTable,
       JdbcConvention jdbcConvention) {
-    super(cluster, cluster.traitSetOf(jdbcConvention), ImmutableList.of(), table);
+    super(cluster, cluster.traitSetOf(jdbcConvention), hints, table);
     this.jdbcTable = Objects.requireNonNull(jdbcTable, "jdbcTable");
   }
 
   @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
     assert inputs.isEmpty();
     return new JdbcTableScan(
-        getCluster(), table, jdbcTable, (JdbcConvention) castNonNull(getConvention()));
+        getCluster(), getHints(), table, jdbcTable, (JdbcConvention) castNonNull(getConvention()));
   }
 
   @Override public JdbcImplementor.Result implement(JdbcImplementor implementor) {
     return implementor.result(jdbcTable.tableName(),
         ImmutableList.of(JdbcImplementor.Clause.FROM), this, null);
+  }
+
+  @Override public RelNode withHints(List<RelHint> hintList) {
+    Convention convention = requireNonNull(getConvention(), "getConvention()");
+    return new JdbcTableScan(getCluster(), hintList, getTable(), jdbcTable,
+        (JdbcConvention) convention);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -69,6 +69,7 @@ import org.apache.calcite.sql.SqlOverOperator;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSelectKeyword;
 import org.apache.calcite.sql.SqlSetOperator;
+import org.apache.calcite.sql.SqlTableRef;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.sql.fun.SqlCase;
@@ -505,6 +506,7 @@ public abstract class SqlImplementor {
     assert node instanceof SqlJoin
         || node instanceof SqlIdentifier
         || node instanceof SqlMatchRecognize
+        || node instanceof SqlTableRef
         || node instanceof SqlCall
             && (((SqlCall) node).getOperator() instanceof SqlSetOperator
                 || ((SqlCall) node).getOperator() == SqlStdOperatorTable.AS

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -538,6 +538,11 @@ public class SqlDialect {
         RelDataTypeSystem.DEFAULT);
   }
 
+  /** Converts table scan hints. The default implementation suppresses all hints. */
+  public void unparseTableScanHints(SqlWriter writer,
+      SqlNodeList hints, int leftPrec, int rightPrec) {
+  }
+
   /**
    * Returns whether the string contains any characters outside the
    * comfortable 7-bit ASCII range (32 through 127, plus linefeed (10) and

--- a/core/src/main/java/org/apache/calcite/sql/SqlTableRef.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTableRef.java
@@ -73,10 +73,7 @@ public class SqlTableRef extends SqlCall {
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     tableName.unparse(writer, leftPrec, rightPrec);
     if (this.hints != null && this.hints.size() > 0) {
-      writer.newlineAndIndent();
-      writer.keyword("/*+");
-      this.hints.unparse(writer, 0, 0);
-      writer.keyword("*/");
+      writer.getDialect().unparseTableScanHints(writer, this.hints, leftPrec, rightPrec);
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/AnsiSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/AnsiSqlDialect.java
@@ -17,6 +17,8 @@
 package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlWriter;
 
 /**
  * A <code>SqlDialect</code> implementation for an unknown ANSI compatible database.
@@ -38,4 +40,14 @@ public class AnsiSqlDialect extends SqlDialect {
   public AnsiSqlDialect(Context context) {
     super(context);
   }
+
+  /** Converts table scan hints.*/
+  @Override public void unparseTableScanHints(SqlWriter writer,
+      SqlNodeList hints, int leftPrec, int rightPrec) {
+    writer.newlineAndIndent();
+    writer.keyword("/*+");
+    hints.unparse(writer, 0, 0);
+    writer.keyword("*/");
+  }
+
 }


### PR DESCRIPTION
We would like to use table scan hints to pass [parameters and variables to HANA views](https://help.sap.com/viewer/88fe5f56472e40cca6ef3c3dcab4855b/2.0.04/en-US/fafb3ea432e54fca9eff11648df5bccd.html).

It should be possible to convert the following Calcite SQL 

```SQL
SELECT * FROM VIEW /*+ PLACEHOLDERS("$$PARAMETER_1$$"='Test') */
```

using a special `SqlDialect` to a HANA specific statement

```SQL
SELECT * FROM VIEW ('PLACEHOLDER' = ('$$PARAMETER_1$$', 'Test'))
```

See also my [mail in the mailing list](https://mail-archives.apache.org/mod_mbox/calcite-dev/202105.mbox/%3CD161B82F-5DEC-49A2-A873-4817F4DEB15F%40contoso.com%3E).

Seel also [CALCITE-4640](https://issues.apache.org/jira/browse/CALCITE-4640)
