### PR TITLE
[CALCITE-4634] Add a variant to AggregateProjectPullUpConstantsRule to remove all constant keys (Yingyu Wang)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectPullUpConstantsRule.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
@@ -26,14 +27,20 @@ import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,8 +55,12 @@ import java.util.TreeMap;
  * {@link RelMetadataQuery#getPulledUpPredicates(RelNode)}; the input does not
  * need to be a {@link org.apache.calcite.rel.core.Project}.
  *
- * <p>This rule never removes the last column, because {@code Aggregate([])}
+ * <p>By default, this rule never removes the last column, because {@code Aggregate([])}
  * returns 1 row even if its input is empty.
+ *
+ * When {@code config.removeAllConstants()} is true this rule will force removing the last column.
+ * A filter will be added in this case to ensure {@code Aggregate([])} returns 0 row when
+ * its input is empty.
  *
  * <p>Since the transformed relational expression has to match the original
  * relational expression, the constants are placed in a projection above the
@@ -84,9 +95,10 @@ public class AggregateProjectPullUpConstantsRule
     final RelNode input = call.rel(1);
 
     final int groupCount = aggregate.getGroupCount();
-    if (groupCount == 1) {
-      // No room for optimization since we cannot convert from non-empty
-      // GROUP BY list to the empty one.
+    if (groupCount == 1 && !config.removeAllConstants()) {
+      // Default behavior:
+      //   No room for optimization since we cannot convert from non-empty
+      //   GROUP BY list to the empty one.
       return;
     }
 
@@ -111,12 +123,13 @@ public class AggregateProjectPullUpConstantsRule
       return;
     }
 
-    if (groupCount == map.size()) {
-      // At least a single item in group by is required.
-      // Otherwise "GROUP BY 1, 2" might be altered to "GROUP BY ()".
-      // Removing of the first element is not optimal here,
-      // however it will allow us to use fast path below (just trim
-      // groupCount).
+    if (groupCount == map.size() && !config.removeAllConstants()) {
+      // Default behavior:
+      //   At least a single item in group by is required.
+      //   Otherwise "GROUP BY 1, 2" might be altered to "GROUP BY ()".
+      //   Removing of the first element is not optimal here,
+      //   however it will allow us to use fast path below (just trim
+      //   groupCount).
       map.remove(map.navigableKeySet().first());
     }
 
@@ -138,7 +151,28 @@ public class AggregateProjectPullUpConstantsRule
           aggCall.adaptTo(input, aggCall.getArgList(), aggCall.filterArg,
               groupCount, newGroupCount));
     }
+
+    // If all GROUP BY keys have been removed, add "HAVING COUNT(*) > 0" to ensure
+    // "GROUP BY ()" returns 0 row when its input is empty.
+    if (newGroupCount == 0) {
+      // Add "COUNT(*)" aggregate function
+      final RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+      newAggCalls.add(
+          AggregateCall.create(SqlStdOperatorTable.COUNT, false, false,
+          false, ImmutableList.of(),
+          -1, null, RelCollations.EMPTY,
+          typeFactory.createSqlType(SqlTypeName.BIGINT), null));
+    }
+
     relBuilder.aggregate(relBuilder.groupKey(newGroupSet), newAggCalls);
+
+    if (newGroupCount == 0) {
+      // Add filter "> 0" on aggregate function "COUNT(*)"
+      relBuilder.filter(
+          relBuilder.call(SqlStdOperatorTable.GREATER_THAN,
+              relBuilder.field(newAggCalls.size() - 1),
+              relBuilder.literal(0)));
+    }
 
     // Create a projection back again.
     List<Pair<RexNode, String>> projects = new ArrayList<>();
@@ -183,6 +217,14 @@ public class AggregateProjectPullUpConstantsRule
     @Override default AggregateProjectPullUpConstantsRule toRule() {
       return new AggregateProjectPullUpConstantsRule(this);
     }
+
+    /** Whether to remove all constant keys, default false. */
+    @ImmutableBeans.Property
+    @ImmutableBeans.BooleanDefault(false)
+    boolean removeAllConstants();
+
+    /** Sets {@link #removeAllConstants()}. */
+    Config withRemoveAllConstants(boolean removeAllConstants);
 
     /** Defines an operand tree for the given classes.
      *

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5781,6 +5781,39 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4634">[CALCITE-4634]
+   * Improve AggregateProjectPullUpConstantsRule to remove all constant keys</a>
+   * Tests with {@code config.withRemoveAllConstants(true)}
+   * constant key is removed even if "deptno" is the only key. */
+  @Test void testAggregateConstantKeyRuleWithRemoveAll() {
+    final String sql = "select count(*) as c\n"
+        + "from sales.emp\n"
+        + "where deptno = 10\n"
+        + "group by deptno";
+    sql(sql).withRule(AggregateProjectPullUpConstantsRule.Config.DEFAULT
+        .withRemoveAllConstants(true)
+        .toRule())
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4634">[CALCITE-4634]
+   * Improve AggregateProjectPullUpConstantsRule to remove all constant keys</a>
+   * Tests with {@code config.withRemoveAllConstants(true)}
+   * Both keys are constant and both can be removed. */
+  @Test void testAggregateConstantKeyRuleWithRemoveAll1() {
+    final String sql = "select job\n"
+        + "from sales.emp\n"
+        + "where deptno = 10 and job = 'Clerk'\n"
+        + "group by deptno, job\n"
+        + "having count(*) > 3";
+    sql(sql).withRule(AggregateProjectPullUpConstantsRule.Config.DEFAULT
+        .withRemoveAllConstants(true)
+        .toRule())
+        .check();
+  }
+
   @Test void testReduceExpressionsNot() {
     final String sql = "select * from (values (false),(true)) as q (col1) where not(col1)";
     sql(sql).withRule(CoreRules.FILTER_REDUCE_EXPRESSIONS)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -156,6 +156,65 @@ LogicalProject(JOB=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAggregateConstantKeyRuleWithRemoveAll">
+    <Resource name="sql">
+      <![CDATA[select count(*) as c
+from sales.emp
+where deptno = 10
+group by deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(C=[$1])
+  LogicalAggregate(group=[{0}], C=[COUNT()])
+    LogicalProject(DEPTNO=[$7])
+      LogicalFilter(condition=[=($7, 10)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(C=[$1])
+  LogicalProject(DEPTNO=[10], C=[$0])
+    LogicalFilter(condition=[>($1, 0)])
+      LogicalProject(C=[$0], C0=[$0])
+        LogicalAggregate(group=[{}], C=[COUNT()])
+          LogicalFilter(condition=[=($7, 10)])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateConstantKeyRuleWithRemoveAll1">
+    <Resource name="sql">
+      <![CDATA[select job
+from sales.emp
+where deptno = 10 and job = 'Clerk'
+group by deptno, job
+having count(*) > 3]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(JOB=[$1])
+  LogicalFilter(condition=[>($2, 3)])
+    LogicalAggregate(group=[{0, 1}], agg#0=[COUNT()])
+      LogicalProject(DEPTNO=[$7], JOB=[$2])
+        LogicalFilter(condition=[AND(=($7, 10), =($2, 'Clerk'))])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(JOB=[$1])
+  LogicalFilter(condition=[>($2, 3)])
+    LogicalProject(DEPTNO=[10], JOB=['Clerk':VARCHAR(10)], $f2=[$0])
+      LogicalFilter(condition=[>($1, 0)])
+        LogicalProject($f0=[$0], $f00=[$0])
+          LogicalAggregate(group=[{}], agg#0=[COUNT()])
+            LogicalFilter(condition=[AND(=($7, 10), =($2, 'Clerk'))])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAggregateDynamicFunction">
     <Resource name="sql">
       <![CDATA[select hiredate


### PR DESCRIPTION
This is the first part of the change for https://issues.apache.org/jira/browse/CALCITE-4634.
A variant is added to `AggregateProjectPullUpConstantsRule` to remove all constant keys.

By default, this rule never removes the last column, because `Aggregate([])` returns 1 row even if its input is empty.
When `config.removeAllConstants()` is true this rule will force removing the last column.  A filter will be added in this case to ensure `Aggregate([])` returns 0 row when its input is empty.