### PR TITLE
[CALCITE-4642] Use TypeSystem from Config in Planner

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -76,6 +76,7 @@ public class PlannerImpl implements Planner, ViewExpander {
   private final @Nullable RelOptCostFactory costFactory;
   private final Context context;
   private final CalciteConnectionConfig connectionConfig;
+  private final RelDataTypeSystem typeSystem;
 
   /** Holds the trait definitions to be registered with planner. May be null. */
   private final @Nullable ImmutableList<RelTraitDef> traitDefs;
@@ -118,6 +119,7 @@ public class PlannerImpl implements Planner, ViewExpander {
     this.executor = config.getExecutor();
     this.context = config.getContext();
     this.connectionConfig = connConfig(context, parserConfig);
+    this.typeSystem = config.getTypeSystem();
     reset();
   }
 
@@ -176,9 +178,6 @@ public class PlannerImpl implements Planner, ViewExpander {
     }
     ensure(State.STATE_1_RESET);
 
-    RelDataTypeSystem typeSystem =
-        connectionConfig.typeSystem(RelDataTypeSystem.class,
-            RelDataTypeSystem.DEFAULT);
     typeFactory = new JavaTypeFactoryImpl(typeSystem);
     RelOptPlanner planner = this.planner = new VolcanoPlanner(costFactory, context);
     RelOptUtil.registerDefaultRules(planner,

--- a/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/PlannerTest.java
@@ -1544,16 +1544,9 @@ class PlannerTest {
         + " { 20, 'Marketing' },"
         + " { 30, 'Engineering' },"
         + " { 40, 'Empty' }]])\n";
-    final String expectedDefault = "LogicalProject("
-        + "EXPR$0=["
-        + "CASE(<>($0, 30),"
-        + " 'hi   ', "
-        + "'world')])\n"
-        + "  LogicalValues("
-        + "tuples=[[{ 10, 'Sales      ' },"
-        + " { 20, 'Marketing  ' },"
-        + " { 30, 'Engineering' },"
-        + " { 40, 'Empty      ' }]])\n";
+    final String expectedDefault = ""
+        + "LogicalProject(EXPR$0=[CASE(<>($0, 30), 'hi   ', 'world')])\n"
+        + "  LogicalValues(tuples=[[{ 10, 'Sales      ' }, { 20, 'Marketing  ' }, { 30, 'Engineering' }, { 40, 'Empty      ' }]])\n";
     assertValidPlan(sql, new VaryingTypeSystem(DelegatingTypeSystem.DEFAULT), is(expectedVarying));
     assertValidPlan(sql, DelegatingTypeSystem.DEFAULT, is(expectedDefault));
   }


### PR DESCRIPTION
Fixes a bug in planner where the typeSystem being used wasn't the one provided by the config. Added a test demonstrating the support on typeSystems that have different behavior on unioning chars.