### PR TITLE
[CALCITE-4158] Missing whitespace after "*" when converting sqlNode to sql (NobiGo)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -399,6 +399,7 @@ public abstract class SqlUtil {
         final SqlParserPos pos = identifier.getComponentParserPosition(i);
         if (name.equals("")) {
           writer.print("*");
+          writer.setNeedWhitespace(true);
         } else {
           writer.identifier(name, pos.isQuoted());
         }

--- a/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
@@ -173,7 +173,7 @@ ORDER BY
   </TestCase>
   <TestCase name="testClausesNotOnNewLine">
     <Resource name="formatted">
-      <![CDATA[SELECT `X` AS `A`, `B` AS `B`, `C` AS `C`, `D`, 'mixed-Case string', `UNQUOTEDCAMELCASEID`, `quoted id` FROM (SELECT *FROM `T` WHERE `X` = `Y` AND `A` > 5 GROUP BY `Z`, `ZZ` WINDOW `W` AS (PARTITION BY `C`), `W1` AS (PARTITION BY `C`, `D` ORDER BY `A`, `B` RANGE BETWEEN INTERVAL '2:2' HOUR TO MINUTE PRECEDING AND INTERVAL '1' DAY FOLLOWING))
+      <![CDATA[SELECT `X` AS `A`, `B` AS `B`, `C` AS `C`, `D`, 'mixed-Case string', `UNQUOTEDCAMELCASEID`, `quoted id` FROM (SELECT * FROM `T` WHERE `X` = `Y` AND `A` > 5 GROUP BY `Z`, `ZZ` WINDOW `W` AS (PARTITION BY `C`), `W1` AS (PARTITION BY `C`, `D` ORDER BY `A`, `B` RANGE BETWEEN INTERVAL '2:2' HOUR TO MINUTE PRECEDING AND INTERVAL '1' DAY FOLLOWING))
 ORDER BY `GG`]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
When converting a sqlNode to Sql String, Missing space after "*" :

```
select *from tab
```
should be 

```
select * from tab
```
or

```
select column1,column2,*from tab
```

should be 

```
select column1,column2,* from tab
```