### PR TITLE
[CALCITE-4668] RelBuilder.join should convert Correlate to Join if correlation variable is unused

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -2409,7 +2409,7 @@ public class RelBuilder {
     Frame right = stack.pop();
     final Frame left = stack.pop();
     final RelNode join;
-    final boolean correlate = variablesSet.size() == 1;
+    final boolean correlate = isCorrelated(variablesSet, joinType, left.rel, right.rel);
     RexNode postCondition = literal(true);
     if (config.simplify()) {
       // Normalize expanded versions IS NOT DISTINCT FROM so that simplifier does not
@@ -2422,10 +2422,6 @@ public class RelBuilder {
     }
     if (correlate) {
       final CorrelationId id = Iterables.getOnlyElement(variablesSet);
-      if (!RelOptUtil.notContainsCorrelation(left.rel, id, Litmus.IGNORE)) {
-        throw new IllegalArgumentException("variable " + id
-            + " must not be used by left input to correlation");
-      }
       // Correlate does not have an ON clause.
       switch (joinType) {
       case LEFT:
@@ -3438,6 +3434,30 @@ public class RelBuilder {
       return nodeLists == null || nodeLists.size() == 1;
     }
   }
+
+  /**Checks for {@link CorrelationId}, then validates the id is not used on left,
+   * and finally checks if id is actually used on right.*/
+  private static boolean isCorrelated(Set<CorrelationId> variablesSet,
+      JoinRelType joinType, RelNode leftNode, RelNode rightRel) {
+    if (variablesSet.size() != 1) {
+      return false;
+    }
+    CorrelationId id = Iterables.getOnlyElement(variablesSet);
+    if (!RelOptUtil.notContainsCorrelation(leftNode, id, Litmus.IGNORE)) {
+      throw new IllegalArgumentException("variable " + id
+          + " must not be used by left input to correlation");
+    }
+    switch (joinType) {
+    case RIGHT:
+    case FULL:
+      throw new IllegalArgumentException("Correlated " + joinType + " join is not supported");
+    default:
+      return !RelOptUtil.correlationColumns(
+          Iterables.getOnlyElement(variablesSet),
+          rightRel).isEmpty();
+    }
+  }
+
 
   /** Implementation of {@link AggCall}. */
   private class AggCallImpl implements AggCallPlus {

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -3435,8 +3435,15 @@ public class RelBuilder {
     }
   }
 
-  /**Checks for {@link CorrelationId}, then validates the id is not used on left,
-   * and finally checks if id is actually used on right.*/
+  /**
+   * Checks for {@link CorrelationId}, then validates the id is not used on left,
+   * and finally checks if id is actually used on right.
+   *
+   * @return true if a correlate id is present and used
+   *
+   * @throws IllegalArgumentException if the {@link CorrelationId} is used by left side or if the a
+   *   {@link CorrelationId} is present and the {@link JoinRelType} is FULL or RIGHT.
+   */
   private static boolean isCorrelated(Set<CorrelationId> variablesSet,
       JoinRelType joinType, RelNode leftNode, RelNode rightRel) {
     if (variablesSet.size() != 1) {

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -2409,7 +2409,7 @@ public class RelBuilder {
     Frame right = stack.pop();
     final Frame left = stack.pop();
     final RelNode join;
-    final boolean correlate = isCorrelated(variablesSet, joinType, left.rel, right.rel);
+    final boolean correlate = checkIfCorrelated(variablesSet, joinType, left.rel, right.rel);
     RexNode postCondition = literal(true);
     if (config.simplify()) {
       // Normalize expanded versions IS NOT DISTINCT FROM so that simplifier does not
@@ -3444,7 +3444,7 @@ public class RelBuilder {
    * @throws IllegalArgumentException if the {@link CorrelationId} is used by left side or if the a
    *   {@link CorrelationId} is present and the {@link JoinRelType} is FULL or RIGHT.
    */
-  private static boolean isCorrelated(Set<CorrelationId> variablesSet,
+  private static boolean checkIfCorrelated(Set<CorrelationId> variablesSet,
       JoinRelType joinType, RelNode leftNode, RelNode rightRel) {
     if (variablesSet.size() != 1) {
       return false;

--- a/core/src/test/java/org/apache/calcite/rel/logical/ToLogicalConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/logical/ToLogicalConverterTest.java
@@ -327,21 +327,25 @@ class ToLogicalConverterTest {
     final RelNode rel = builder.scan("EMP")
         .variable(v)
         .scan("DEPT")
+        .filter(
+            builder.equals(builder.field(0), builder.field(v.get(), "DEPTNO")))
         .join(JoinRelType.LEFT,
             builder.equals(builder.field(2, 0, "SAL"),
                 builder.literal(1000)),
             ImmutableSet.of(v.get().id))
         .build();
     String expectedPhysical = ""
-        + "EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{5}])\n"
+        + "EnumerableCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{5, 7}])\n"
         + "  EnumerableTableScan(table=[[scott, EMP]])\n"
         + "  EnumerableFilter(condition=[=($cor0.SAL, 1000)])\n"
-        + "    EnumerableTableScan(table=[[scott, DEPT]])\n";
+        + "    EnumerableFilter(condition=[=($0, $cor0.DEPTNO)])\n"
+        + "      EnumerableTableScan(table=[[scott, DEPT]])\n";
     String expectedLogical = ""
-        + "LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{5}])\n"
+        + "LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{5, 7}])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalFilter(condition=[=($cor0.SAL, 1000)])\n"
-        + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+        + "    LogicalFilter(condition=[=($0, $cor0.DEPTNO)])\n"
+        + "      LogicalTableScan(table=[[scott, DEPT]])\n";
     verify(rel, expectedPhysical, expectedLogical);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -3905,7 +3905,9 @@ public class RelBuilderTest {
         + "LogicalJoin(condition=[=($7, $8)], joinType=[semi])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
+    assertThat(
+        "Join with correlate id but the id never used should be simplified to a join.",
+        root, hasTree(expected));
   }
 
   @Test void testSemiCorrelatedViaJoin() {
@@ -3916,7 +3918,9 @@ public class RelBuilderTest {
         + "  LogicalFilter(condition=[=($cor0.DEPTNO, $0)])\n"
         + "    LogicalFilter(condition=[=($cor0.EMPNO, 'NaN')])\n"
         + "      LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
+    assertThat(
+        "Correlated semi joins should emmit a correlate with a filter on the right side.",
+        root, hasTree(expected));
   }
 
   @Test void testSimpleAntiCorrelateViaJoin() {
@@ -3925,7 +3929,9 @@ public class RelBuilderTest {
         + "LogicalJoin(condition=[=($7, $8)], joinType=[anti])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
+    assertThat(
+        "Join with correlate id but the id never used should be simplified to a join.",
+        root, hasTree(expected));
   }
 
   @Test void testAntiCorrelateViaJoin() {
@@ -3936,8 +3942,9 @@ public class RelBuilderTest {
         + "  LogicalFilter(condition=[=($cor0.DEPTNO, $0)])\n"
         + "    LogicalFilter(condition=[=($cor0.EMPNO, 'NaN')])\n"
         + "      LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
-  }
+    assertThat(
+        "Correlated anti joins should emmit a correlate with a filter on the right side.",
+        root, hasTree(expected));  }
 
   @Test void testSimpleLeftCorrelateViaJoin() {
     RelNode root = buildSimpleCorrelateWithJoin(JoinRelType.LEFT);
@@ -3945,7 +3952,9 @@ public class RelBuilderTest {
         + "LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
+    assertThat(
+        "Join with correlate id but the id never used should be simplified to a join.",
+        root, hasTree(expected));
   }
 
   @Test void testLeftCorrelateViaJoin() {
@@ -3956,7 +3965,9 @@ public class RelBuilderTest {
         + "  LogicalFilter(condition=[=($cor0.DEPTNO, $0)])\n"
         + "    LogicalFilter(condition=[=($cor0.EMPNO, 'NaN')])\n"
         + "      LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
+    assertThat(
+        "Correlated left joins should emmit a correlate with a filter on the right side.",
+        root, hasTree(expected));
   }
 
   @Test void testSimpleInnerCorrelateViaJoin() {
@@ -3965,7 +3976,8 @@ public class RelBuilderTest {
         + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
+    assertThat("Join with correlate id but never used should be simplified to a join.",
+        root, hasTree(expected));
   }
 
   @Test void testInnerCorrelateViaJoin() {
@@ -3976,27 +3988,33 @@ public class RelBuilderTest {
         + "    LogicalTableScan(table=[[scott, EMP]])\n"
         + "    LogicalFilter(condition=[=($cor0.EMPNO, 'NaN')])\n"
         + "      LogicalTableScan(table=[[scott, DEPT]])\n";
-    assertThat(root, hasTree(expected));
+    assertThat(
+        "Correlated inner joins should emmit a correlate with a filter on top.",
+        root, hasTree(expected));
   }
 
   @Test void testSimpleRightCorrelateViaJoinThrowsException() {
     assertThrows(IllegalArgumentException.class,
-        () -> buildSimpleCorrelateWithJoin(JoinRelType.RIGHT));
+        () -> buildSimpleCorrelateWithJoin(JoinRelType.RIGHT),
+        "Right outer joins with correlated ids are invalid even if id is not used.");
   }
 
   @Test void testSimpleFullCorrelateViaJoinThrowsException() {
     assertThrows(IllegalArgumentException.class,
-        () -> buildSimpleCorrelateWithJoin(JoinRelType.FULL));
+        () -> buildSimpleCorrelateWithJoin(JoinRelType.FULL),
+        "Full outer joins with correlated ids are invalid even if id is not used.");
   }
 
   @Test void testRightCorrelateViaJoinThrowsException() {
     assertThrows(IllegalArgumentException.class,
-        () -> buildCorrelateWithJoin(JoinRelType.RIGHT));
+        () -> buildCorrelateWithJoin(JoinRelType.RIGHT),
+        "Right outer joins with correlated ids are invalid.");
   }
 
   @Test void testFullCorrelateViaJoinThrowsException() {
     assertThrows(IllegalArgumentException.class,
-        () -> buildCorrelateWithJoin(JoinRelType.FULL));
+        () -> buildCorrelateWithJoin(JoinRelType.FULL),
+        "Full outer joins with correlated ids are invalid.");
   }
 
   private static RelNode buildSimpleCorrelateWithJoin(JoinRelType type) {

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -1651,6 +1651,25 @@ select sal from "scott".emp e
 EnumerableValues(tuples=[[]])
 !plan
 
+# Test filter literal IN null liter with query that can not be trivially simplified
+select sal from "scott".emp e
+  where mod(cast(rand() as int), 2) = 3 OR 123 IN (
+    select cast(null as int) from "scott".dept d
+      where d.deptno = e.deptno);
+ SAL
+-----
+(0 rows)
+
+!ok
+EnumerableCalc(expr#0..4=[{inputs}], expr#5=[RAND()], expr#6=[CAST($t5):INTEGER NOT NULL], expr#7=[2], expr#8=[MOD($t6, $t7)], expr#9=[3], expr#10=[=($t8, $t9)], expr#11=[IS NOT NULL($t4)], expr#12=[AND($t4, $t11)], expr#13=[OR($t10, $t12)], SAL=[$t1], $condition=[$t13])
+  EnumerableMergeJoin(condition=[=($2, $3)], joinType=[left])
+    EnumerableSort(sort0=[$2], dir0=[ASC])
+      EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
+        EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], DEPTNO=[$t0], $f1=[$t3])
+      EnumerableTableScan(table=[[scott, DEPT]])
+!plan
+
 # Test filter null IN nullable correlated
 select sal from "scott".emp e
   where cast(null as int) IN (
@@ -2105,13 +2124,13 @@ EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t1, $t2)], expr#8=[IS TRUE($t7)]
 !ok
 
 # [CALCITE-4560] Wrong plan when decorrelating EXISTS subquery with COALESCE in the predicate
-# The employee KING has no manager (NULL) so before the fix the following query was missing 
-# this employee from the result set. 
+# The employee KING has no manager (NULL) so before the fix the following query was missing
+# this employee from the result set.
 select ename
 from "scott".emp as e1
-where exists 
+where exists
     (select 1 from "scott".emp as e2 where coalesce(e1.mgr,0)=coalesce(e2.mgr,0));
-# The plan before the fix was wrong but also inefficient since it required the generation of 
+# The plan before the fix was wrong but also inefficient since it required the generation of
 # a value generator (see RelDecorrelator code). The value generator is not present in the
 # following plan (two scans of EMP table instead of three).
 EnumerableCalc(expr#0..2=[{inputs}], ENAME=[$t1])

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -1601,7 +1601,7 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
 
 # Test filter null IN null correlated
 select sal from "scott".emp e
-  where cast(null as int) IN (
+  where e.sal < 0 OR cast(null as int) IN (
     select cast(null as int)
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1609,12 +1609,17 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableValues(tuples=[[]])
+EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
+  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
+      EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
+      EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter literal IN null correlated
 select sal from "scott".emp e
-  where 123 IN (
+  where e.sal < 0 OR 123 IN (
     select cast(null as int)
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1622,12 +1627,18 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableValues(tuples=[[]])
+EnumerableCalc(expr#0..4=[{inputs}], expr#5=[0], expr#6=[<($t1, $t5)], expr#7=[IS NOT NULL($t4)], expr#8=[AND($t4, $t7)], expr#9=[OR($t6, $t8)], SAL=[$t1], $condition=[$t9])
+  EnumerableMergeJoin(condition=[=($2, $3)], joinType=[left])
+    EnumerableSort(sort0=[$2], dir0=[ASC])
+      EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
+        EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], DEPTNO=[$t0], $f1=[$t3])
+      EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null IN literal correlated
 select sal from "scott".emp e
-  where cast(null as int) IN (
+  where e.sal < 0 OR cast(null as int) IN (
     select 1
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1635,12 +1646,17 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableValues(tuples=[[]])
+EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
+  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
+      EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
+      EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null IN required correlated
 select sal from "scott".emp e
-  where cast(null as int) IN (
+  where e.sal < 0 OR cast(null as int) IN (
     select deptno
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1648,12 +1664,17 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableValues(tuples=[[]])
+EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
+  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
+      EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
+      EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null IN nullable correlated
 select sal from "scott".emp e
-  where cast(null as int) IN (
+  where e.sal < 0 OR cast(null as int) IN (
     select case when true then deptno else null end
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1661,7 +1682,12 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableValues(tuples=[[]])
+EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
+  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
+      EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
+      EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter literal IN required correlated
@@ -2105,13 +2131,13 @@ EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t1, $t2)], expr#8=[IS TRUE($t7)]
 !ok
 
 # [CALCITE-4560] Wrong plan when decorrelating EXISTS subquery with COALESCE in the predicate
-# The employee KING has no manager (NULL) so before the fix the following query was missing 
-# this employee from the result set. 
+# The employee KING has no manager (NULL) so before the fix the following query was missing
+# this employee from the result set.
 select ename
 from "scott".emp as e1
-where exists 
+where exists
     (select 1 from "scott".emp as e2 where coalesce(e1.mgr,0)=coalesce(e2.mgr,0));
-# The plan before the fix was wrong but also inefficient since it required the generation of 
+# The plan before the fix was wrong but also inefficient since it required the generation of
 # a value generator (see RelDecorrelator code). The value generator is not present in the
 # following plan (two scans of EMP table instead of three).
 EnumerableCalc(expr#0..2=[{inputs}], ENAME=[$t1])

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -1609,11 +1609,7 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
-    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableValues(tuples=[[]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter literal IN null correlated
@@ -1639,11 +1635,7 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
-    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableValues(tuples=[[]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter null IN required correlated
@@ -1656,11 +1648,7 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
-    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableValues(tuples=[[]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter null IN nullable correlated
@@ -1673,11 +1661,7 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
-    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableValues(tuples=[[]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter literal IN required correlated

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -1601,7 +1601,7 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
 
 # Test filter null IN null correlated
 select sal from "scott".emp e
-  where e.sal < 0 OR cast(null as int) IN (
+  where cast(null as int) IN (
     select cast(null as int)
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1609,17 +1609,12 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
-    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
-      EnumerableTableScan(table=[[scott, DEPT]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter literal IN null correlated
 select sal from "scott".emp e
-  where e.sal < 0 OR 123 IN (
+  where 123 IN (
     select cast(null as int)
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1627,18 +1622,12 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..4=[{inputs}], expr#5=[0], expr#6=[<($t1, $t5)], expr#7=[IS NOT NULL($t4)], expr#8=[AND($t4, $t7)], expr#9=[OR($t6, $t8)], SAL=[$t1], $condition=[$t9])
-  EnumerableMergeJoin(condition=[=($2, $3)], joinType=[left])
-    EnumerableSort(sort0=[$2], dir0=[ASC])
-      EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
-        EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], DEPTNO=[$t0], $f1=[$t3])
-      EnumerableTableScan(table=[[scott, DEPT]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter null IN literal correlated
 select sal from "scott".emp e
-  where e.sal < 0 OR cast(null as int) IN (
+  where cast(null as int) IN (
     select 1
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1646,17 +1635,12 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
-    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
-      EnumerableTableScan(table=[[scott, DEPT]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter null IN required correlated
 select sal from "scott".emp e
-  where e.sal < 0 OR cast(null as int) IN (
+  where cast(null as int) IN (
     select deptno
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1664,17 +1648,12 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
-    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
-      EnumerableTableScan(table=[[scott, DEPT]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter null IN nullable correlated
 select sal from "scott".emp e
-  where e.sal < 0 OR cast(null as int) IN (
+  where cast(null as int) IN (
     select case when true then deptno else null end
     from "scott".dept d where e.deptno=d.deptno);
  SAL
@@ -1682,12 +1661,7 @@ select sal from "scott".emp e
 (0 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], SAL=[$t1])
-  EnumerableHashJoin(condition=[=($2, $3)], joinType=[left])
-    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[0], expr#9=[<($t5, $t8)], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7], $condition=[$t9])
-      EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
-      EnumerableTableScan(table=[[scott, DEPT]])
+EnumerableValues(tuples=[[]])
 !plan
 
 # Test filter literal IN required correlated
@@ -2131,13 +2105,13 @@ EnumerableCalc(expr#0..6=[{inputs}], expr#7=[>($t1, $t2)], expr#8=[IS TRUE($t7)]
 !ok
 
 # [CALCITE-4560] Wrong plan when decorrelating EXISTS subquery with COALESCE in the predicate
-# The employee KING has no manager (NULL) so before the fix the following query was missing
-# this employee from the result set.
+# The employee KING has no manager (NULL) so before the fix the following query was missing 
+# this employee from the result set. 
 select ename
 from "scott".emp as e1
-where exists
+where exists 
     (select 1 from "scott".emp as e2 where coalesce(e1.mgr,0)=coalesce(e2.mgr,0));
-# The plan before the fix was wrong but also inefficient since it required the generation of
+# The plan before the fix was wrong but also inefficient since it required the generation of 
 # a value generator (see RelDecorrelator code). The value generator is not present in the
 # following plan (two scans of EMP table instead of three).
 EnumerableCalc(expr#0..2=[{inputs}], ENAME=[$t1])


### PR DESCRIPTION
…bles present(James Starr)

Reworking the checking and validating if join is correlated in
RelBuilder.join to check if the correlated id is used on the right
side.If the correlated id is not used on the right side, then the join
is not correlated and a normal Join is emitted.

1.  Updating ToLogicalConverterTest to generate a non trival Correlate
2.  Adding tests for generating non trivial correlate joins to
RelBuilderTest.
3.  Updating plans in sub-query.iq, that are now simplified.