### PR TITLE
[CALCITE-4680] Add test case for UNNEST in a subquery with nullable field

### DIFF
--- a/core/src/test/resources/sql/unnest.iq
+++ b/core/src/test/resources/sql/unnest.iq
@@ -223,4 +223,25 @@ FROM UNNEST(array [0, 2, 4, 4, 5]) as x;
 
 !ok
 
+
+WITH tab(field1, field2) AS (VALUES 
+	(1, ARRAY[ ROW(0), ROW(NULL)]), 
+	(2, ARRAY[ ROW(1)])
+)
+SELECT field1 FROM tab
+WHERE field1 IS NOT NULL 
+AND field1 NOT IN (
+ 	SELECT subfield
+	FROM  UNNEST(field2) AS L(subfield)
+);
++--------+
+| FIELD1 |
++--------+
+|      2 |
++--------+
+(1 row)
+
+!ok
+
+
 # End unnest.iq


### PR DESCRIPTION
A small (positive) test case as recommended in [this comment](https://issues.apache.org/jira/browse/CALCITE-4680?focusedCommentId=17375995#comment-17375995). While it does not reproduce the bug, it provides a scenario with NOT IN, correlation variables, and UNNEST.