### PR TITLE
[CALCITE-4690] Error when executing query with CHARACTER SET in Redshift

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/RedshiftSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/RedshiftSqlDialect.java
@@ -45,4 +45,8 @@ public class RedshiftSqlDialect extends SqlDialect {
       @Nullable SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);
   }
+
+  @Override public boolean supportsCharSet() {
+    return false;
+  }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1599,6 +1599,17 @@ class RelToSqlConverterTest {
     sql(query).withMssql().ok(expected);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4690">[CALCITE-4690]
+   * Error when when executing query with CHARACTER SET in Redshift</a>. */
+  @Test void testRedshiftCharacterSet() {
+    String query = "select \"hire_date\", cast(\"hire_date\" as varchar(10))\n"
+        + "from \"foodmart\".\"reserve_employee\"";
+    final String expected = "SELECT \"hire_date\", CAST(\"hire_date\" AS VARCHAR(10))\n"
+        + "FROM \"foodmart\".\"reserve_employee\"";
+    sql(query).withRedshift().ok(expected);
+  }
+
   @Test void testExasolCharacterSet() {
     String query = "select \"hire_date\", cast(\"hire_date\" as varchar(10))\n"
         + "from \"foodmart\".\"reserve_employee\"";

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1601,7 +1601,7 @@ class RelToSqlConverterTest {
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-4690">[CALCITE-4690]
-   * Error when when executing query with CHARACTER SET in Redshift</a>. */
+   * Error when executing query with CHARACTER SET in Redshift</a>. */
   @Test void testRedshiftCharacterSet() {
     String query = "select \"hire_date\", cast(\"hire_date\" as varchar(10))\n"
         + "from \"foodmart\".\"reserve_employee\"";


### PR DESCRIPTION
Redshift does not support `CHARACTER SET` clause so when it appears in SQL queries it leads to runtime errors. More details in CALCITE-4690.