### PR TITLE
[CALCITE-2339] Add utility to convert datetime_plus to timestampadd

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -56,6 +56,7 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.JoinConditionType;
 import org.apache.calcite.sql.JoinType;
 import org.apache.calcite.sql.SqlBasicCall;
@@ -231,9 +232,10 @@ public class RelToSqlConverter extends SqlImplementor
       sqlCondition = null;
       condType = JoinConditionType.NONE;
     } else {
-      sqlCondition =
-          convertConditionToSqlNode(e.getCondition(), leftContext,
-              rightContext);
+      sqlCondition = convertConditionToSqlNode(
+          simplifyDatetimePlus(e.getCondition(), e.getCluster().getRexBuilder()),
+          leftContext,
+          rightContext);
       condType = JoinConditionType.ON;
     }
     SqlNode join =
@@ -417,15 +419,17 @@ public class RelToSqlConverter extends SqlImplementor
           ImmutableSet.of(Clause.HAVING));
       parseCorrelTable(e, x);
       final Builder builder = x.builder(e);
+      RexNode condition = simplifyDatetimePlus(e.getCondition(), e.getCluster().getRexBuilder());
       x.asSelect().setHaving(
           SqlUtil.andExpressions(x.asSelect().getHaving(),
-              builder.context.toSql(null, e.getCondition())));
+              builder.context.toSql(null, condition)));
       return builder.result();
     } else {
       final Result x = visitInput(e, 0, Clause.WHERE);
       parseCorrelTable(e, x);
       final Builder builder = x.builder(e);
-      builder.setWhere(builder.context.toSql(null, e.getCondition()));
+      RexNode condition = simplifyDatetimePlus(e.getCondition(), e.getCluster().getRexBuilder());
+      builder.setWhere(builder.context.toSql(null, condition));
       return builder.result();
     }
   }
@@ -435,10 +439,17 @@ public class RelToSqlConverter extends SqlImplementor
     final Result x = visitInput(e, 0, Clause.SELECT);
     parseCorrelTable(e, x);
     final Builder builder = x.builder(e);
+
     if (!isStar(e.getProjects(), e.getInput().getRowType(), e.getRowType())) {
       final List<SqlNode> selectList = new ArrayList<>();
       for (RexNode ref : e.getProjects()) {
-        SqlNode sqlExpr = builder.context.toSql(null, ref);
+        SqlNode sqlExpr = builder
+            .context
+            .toSql(
+                null,
+                simplifyDatetimePlus(
+                    ref,
+                    e.getCluster().getRexBuilder()));
         if (SqlUtil.isNullLiteral(sqlExpr, false)) {
           final RelDataTypeField field =
               e.getRowType().getFieldList().get(selectList.size());
@@ -1185,6 +1196,16 @@ public class RelToSqlConverter extends SqlImplementor
     for (CorrelationId id : relNode.getVariablesSet()) {
       correlTableMap.put(id, x.qualifiedContext());
     }
+  }
+
+  private RexNode simplifyDatetimePlus(RexNode node, RexBuilder builder) {
+    if (node != null && dialect.useTimestampAddInsteadOfDatetimePlus()) {
+      RexNode converted = RexUtil.convertDatetimePlusToTimestampAdd(builder, node);
+      if (converted != null) {
+        return converted;
+      }
+    }
+    return node;
   }
 
   /** Stack frame. */

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -535,13 +535,37 @@ public class SqlDialect {
       SqlIntervalLiteral literal, int leftPrec, int rightPrec) {
     SqlIntervalLiteral.IntervalValue interval =
         literal.getValueAs(SqlIntervalLiteral.IntervalValue.class);
+
+    final SqlIntervalQualifier qualifier;
+    final String intervalString = interval.getIntervalLiteral();
+
+    // Correct invalid single-field interval literals, such as those holding weeks or quarters.
+    // These could have been created as part of the TimestampAddConvertlet.
+    if (interval.getIntervalQualifier().isSingleDatetimeField()) {
+      switch (interval.getIntervalQualifier().getStartUnit()) {
+      case WEEK:
+        qualifier = new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO);
+        break;
+
+      case QUARTER:
+        qualifier = new SqlIntervalQualifier(TimeUnit.MONTH, null, SqlParserPos.ZERO);
+        break;
+
+      default:
+        qualifier = interval.getIntervalQualifier();
+        break;
+      }
+    } else {
+      qualifier = interval.getIntervalQualifier();
+    }
+
     writer.keyword("INTERVAL");
     if (interval.getSign() == -1) {
       writer.print("-");
     }
-    writer.literal("'" + interval.getIntervalLiteral() + "'");
-    unparseSqlIntervalQualifier(writer, interval.getIntervalQualifier(),
-        RelDataTypeSystem.DEFAULT);
+
+    writer.literal("'" + intervalString + "'");
+    unparseSqlIntervalQualifier(writer, qualifier, RelDataTypeSystem.DEFAULT);
   }
 
   /** Converts table scan hints. The default implementation suppresses all hints. */
@@ -723,6 +747,14 @@ public class SqlDialect {
     default:
       break;
     }
+    return false;
+  }
+
+  /**
+   * Indicates that datetime_plus operations should be unparsed as timestampadd
+   * when possible.
+   */
+  public boolean useTimestampAddInsteadOfDatetimePlus() {
     return false;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/Db2SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/Db2SqlDialect.java
@@ -16,11 +16,13 @@
  */
 package org.apache.calcite.sql.dialect;
 
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
 
 /**
  * A <code>SqlDialect</code> implementation for the IBM DB2 database.
@@ -85,11 +87,34 @@ public class Db2SqlDialect extends SqlDialect {
 
     SqlIntervalLiteral.IntervalValue interval =
         literal.getValueAs(SqlIntervalLiteral.IntervalValue.class);
+    final SqlIntervalQualifier qualifier;
+
+    // Correct invalid single-field interval literals, such as those holding weeks or quarters.
+    // These could have been created as part of the TimestampAddConvertlet.
+    if (interval.getIntervalQualifier().isSingleDatetimeField()) {
+      switch (interval.getIntervalQualifier().getStartUnit()) {
+      case WEEK:
+        qualifier = new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO);
+        break;
+
+      case QUARTER:
+        qualifier = new SqlIntervalQualifier(TimeUnit.MONTH, null, SqlParserPos.ZERO);
+        break;
+
+      default:
+        qualifier = interval.getIntervalQualifier();
+        break;
+      }
+    } else {
+      qualifier = interval.getIntervalQualifier();
+    }
+
     if (interval.getSign() == -1) {
       writer.print("-");
     }
+
     writer.literal(interval.getIntervalLiteral());
-    unparseSqlIntervalQualifier(writer, interval.getIntervalQualifier(),
+    unparseSqlIntervalQualifier(writer, qualifier,
         RelDataTypeSystem.DEFAULT);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -58,6 +58,13 @@ public class MssqlSqlDialect extends SqlDialect {
           ReturnTypes.ARG0_NULLABLE_VARYING, null, null,
           SqlFunctionCategory.STRING);
 
+  private static final SqlFunction MSSQL_DATEADD =
+      new SqlFunction("DATEADD", SqlStdOperatorTable.TIMESTAMP_ADD.getKind(),
+          SqlStdOperatorTable.TIMESTAMP_ADD.getReturnTypeInference(),
+          SqlStdOperatorTable.TIMESTAMP_ADD.getOperandTypeInference(),
+          SqlStdOperatorTable.TIMESTAMP_ADD.getOperandTypeChecker(),
+          SqlStdOperatorTable.TIMESTAMP_ADD.getFunctionType());
+
   /** Whether to generate "SELECT TOP(fetch)" rather than
    * "SELECT ... FETCH NEXT fetch ROWS ONLY". */
   private final boolean top;
@@ -139,6 +146,10 @@ public class MssqlSqlDialect extends SqlDialect {
     }
   }
 
+  @Override public boolean useTimestampAddInsteadOfDatetimePlus() {
+    return true;
+  }
+
   @Override public void unparseDateTimeLiteral(SqlWriter writer,
       SqlAbstractDateTimeLiteral literal, int leftPrec, int rightPrec) {
     writer.literal("'" + literal.toFormattedString() + "'");
@@ -151,6 +162,8 @@ public class MssqlSqlDialect extends SqlDialect {
         throw new IllegalArgumentException("MSSQL SUBSTRING requires FROM and FOR arguments");
       }
       SqlUtil.unparseFunctionSyntax(MSSQL_SUBSTRING, writer, call, false);
+    } else if (call.getOperator() == SqlStdOperatorTable.TIMESTAMP_ADD) {
+      SqlUtil.unparseFunctionSyntax(MSSQL_DATEADD, writer, call, false);
     } else {
       switch (call.getKind()) {
       case FLOOR:

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -334,11 +334,17 @@ public class MysqlSqlDialect extends SqlDialect {
     case MINUTE:
     case HOUR:
     case DAY:
-    case WEEK:
     case MONTH:
-    case QUARTER:
     case YEAR:
       return timeUnit;
+
+    // Intervals cannot hold WEEK or QUARTERs. This can be the time unit
+    // if a TimestampAdd call was transformed to Datetime_plus through the
+    // TimestampAdd convertlet.
+    case WEEK:
+      return TimeUnit.DAY;
+    case QUARTER:
+      return TimeUnit.MONTH;
     default:
       throw new AssertionError(" Time unit " + timeUnit + "is not supported now.");
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -370,10 +370,10 @@ class RelToSqlConverterTest {
 
   @Test void testSelectQueryWithHiveCube() {
     String query = "select \"product_class_id\", \"product_id\", count(*) "
-            + "from \"product\" group by cube(\"product_class_id\", \"product_id\")";
+        + "from \"product\" group by cube(\"product_class_id\", \"product_id\")";
     String expected = "SELECT product_class_id, product_id, COUNT(*)\n"
-            + "FROM foodmart.product\n"
-            + "GROUP BY product_class_id, product_id WITH CUBE";
+        + "FROM foodmart.product\n"
+        + "GROUP BY product_class_id, product_id WITH CUBE";
     sql(query).withHive().ok(expected);
     SqlDialect sqlDialect = sql(query).withHive().dialect;
     assertTrue(sqlDialect.supportsGroupByWithCube());
@@ -381,10 +381,10 @@ class RelToSqlConverterTest {
 
   @Test void testSelectQueryWithHiveRollup() {
     String query = "select \"product_class_id\", \"product_id\", count(*) "
-            + "from \"product\" group by rollup(\"product_class_id\", \"product_id\")";
+        + "from \"product\" group by rollup(\"product_class_id\", \"product_id\")";
     String expected = "SELECT product_class_id, product_id, COUNT(*)\n"
-            + "FROM foodmart.product\n"
-            + "GROUP BY product_class_id, product_id WITH ROLLUP";
+        + "FROM foodmart.product\n"
+        + "GROUP BY product_class_id, product_id WITH ROLLUP";
     sql(query).withHive().ok(expected);
     SqlDialect sqlDialect = sql(query).withHive().dialect;
     assertTrue(sqlDialect.supportsGroupByWithRollup());
@@ -1025,8 +1025,8 @@ class RelToSqlConverterTest {
         .scan("EMP")
         .join(
             JoinRelType.ANTI, builder.equals(
-              builder.field(2, 1, "DEPTNO"),
-              builder.field(2, 0, "DEPTNO")))
+                builder.field(2, 1, "DEPTNO"),
+                builder.field(2, 0, "DEPTNO")))
         .project(builder.field("DEPTNO"))
         .build();
     final String expectedSql = "SELECT \"DEPTNO\"\n"
@@ -1063,16 +1063,16 @@ class RelToSqlConverterTest {
     // PostgreSQL does not not support nested aggregations
     final String expectedPostgresql =
         "SELECT COUNT(DISTINCT \"rank\") AS \"c\"\n"
-        + "FROM (SELECT RANK() OVER (ORDER BY \"SAL\") AS \"rank\"\n"
-        + "FROM \"scott\".\"EMP\") AS \"t\"\n"
-        + "HAVING COUNT(DISTINCT \"rank\") >= 10";
+            + "FROM (SELECT RANK() OVER (ORDER BY \"SAL\") AS \"rank\"\n"
+            + "FROM \"scott\".\"EMP\") AS \"t\"\n"
+            + "HAVING COUNT(DISTINCT \"rank\") >= 10";
     relFn(relFn).withPostgresql().ok(expectedPostgresql);
 
     // Oracle does support nested aggregations
     final String expectedOracle =
         "SELECT COUNT(DISTINCT RANK() OVER (ORDER BY \"SAL\")) \"c\"\n"
-        + "FROM \"scott\".\"EMP\"\n"
-        + "HAVING COUNT(DISTINCT RANK() OVER (ORDER BY \"SAL\")) >= 10";
+            + "FROM \"scott\".\"EMP\"\n"
+            + "HAVING COUNT(DISTINCT RANK() OVER (ORDER BY \"SAL\")) >= 10";
     relFn(relFn).withOracle().ok(expectedOracle);
   }
 
@@ -1083,8 +1083,8 @@ class RelToSqlConverterTest {
         .scan("EMP")
         .join(
             JoinRelType.SEMI, builder.equals(
-              builder.field(2, 1, "DEPTNO"),
-              builder.field(2, 0, "DEPTNO")))
+                builder.field(2, 1, "DEPTNO"),
+                builder.field(2, 0, "DEPTNO")))
         .project(builder.field("DEPTNO"))
         .build();
     final String expectedSql = "SELECT \"DEPTNO\"\n"
@@ -1102,12 +1102,12 @@ class RelToSqlConverterTest {
         .scan("EMP")
         .filter(
             builder.call(SqlStdOperatorTable.GREATER_THAN,
-              builder.field("EMPNO"),
-              builder.literal((short) 10)))
+                builder.field("EMPNO"),
+                builder.literal((short) 10)))
         .join(
             JoinRelType.SEMI, builder.equals(
-            builder.field(2, 1, "DEPTNO"),
-            builder.field(2, 0, "DEPTNO")))
+                builder.field(2, 1, "DEPTNO"),
+                builder.field(2, 0, "DEPTNO")))
         .project(builder.field("DEPTNO"))
         .build();
     final String expectedSql = "SELECT \"DEPTNO\"\n"
@@ -1130,8 +1130,8 @@ class RelToSqlConverterTest {
             builder.field(builder.peek().getRowType().getField("DEPTNO", false, false).getIndex()))
         .join(
             JoinRelType.SEMI, builder.equals(
-              builder.field(2, 1, "DEPTNO"),
-              builder.field(2, 0, "DEPTNO")))
+                builder.field(2, 1, "DEPTNO"),
+                builder.field(2, 0, "DEPTNO")))
         .project(builder.field("DEPTNO"))
         .build();
     final String expectedSql = "SELECT \"DEPTNO\"\n"
@@ -1150,16 +1150,16 @@ class RelToSqlConverterTest {
         .scan("EMP")
         .join(
             JoinRelType.INNER, builder.equals(
-              builder.field(2, 0, "EMPNO"),
-              builder.field(2, 1, "EMPNO")))
+                builder.field(2, 0, "EMPNO"),
+                builder.field(2, 1, "EMPNO")))
         .build();
     final RelNode root = builder
         .scan("DEPT")
         .push(base)
         .join(
             JoinRelType.SEMI, builder.equals(
-              builder.field(2, 1, "DEPTNO"),
-              builder.field(2, 0, "DEPTNO")))
+                builder.field(2, 1, "DEPTNO"),
+                builder.field(2, 0, "DEPTNO")))
         .project(builder.field("DEPTNO"))
         .build();
     final String expectedSql = "SELECT \"DEPTNO\"\n"
@@ -1480,10 +1480,10 @@ class RelToSqlConverterTest {
     // BigQuery has isHavingAlias=true, case-sensitive=false
     final String expectedBigQuery = upperAlias
         ? "SELECT product_id + 1, GROSS_WEIGHT\n"
-            + "FROM (SELECT product_id, SUM(gross_weight) AS GROSS_WEIGHT\n"
-            + "FROM foodmart.product\n"
-            + "GROUP BY product_id\n"
-            + "HAVING GROSS_WEIGHT < 200) AS t1"
+        + "FROM (SELECT product_id, SUM(gross_weight) AS GROSS_WEIGHT\n"
+        + "FROM foodmart.product\n"
+        + "GROUP BY product_id\n"
+        + "HAVING GROSS_WEIGHT < 200) AS t1"
         // Before [CALCITE-3896] was fixed, we got
         // "HAVING SUM(gross_weight) < 200) AS t1"
         // which on BigQuery gives you an error about aggregating aggregates
@@ -1613,35 +1613,35 @@ class RelToSqlConverterTest {
 
   @Test void testBigQueryCast() {
     String query = "select cast(cast(\"employee_id\" as varchar) as bigint), "
-            + "cast(cast(\"employee_id\" as varchar) as smallint), "
-            + "cast(cast(\"employee_id\" as varchar) as tinyint), "
-            + "cast(cast(\"employee_id\" as varchar) as integer), "
-            + "cast(cast(\"employee_id\" as varchar) as float), "
-            + "cast(cast(\"employee_id\" as varchar) as char), "
-            + "cast(cast(\"employee_id\" as varchar) as binary), "
-            + "cast(cast(\"employee_id\" as varchar) as varbinary), "
-            + "cast(cast(\"employee_id\" as varchar) as timestamp), "
-            + "cast(cast(\"employee_id\" as varchar) as double), "
-            + "cast(cast(\"employee_id\" as varchar) as decimal), "
-            + "cast(cast(\"employee_id\" as varchar) as date), "
-            + "cast(cast(\"employee_id\" as varchar) as time), "
-            + "cast(cast(\"employee_id\" as varchar) as boolean) "
-            + "from \"foodmart\".\"reserve_employee\" ";
+        + "cast(cast(\"employee_id\" as varchar) as smallint), "
+        + "cast(cast(\"employee_id\" as varchar) as tinyint), "
+        + "cast(cast(\"employee_id\" as varchar) as integer), "
+        + "cast(cast(\"employee_id\" as varchar) as float), "
+        + "cast(cast(\"employee_id\" as varchar) as char), "
+        + "cast(cast(\"employee_id\" as varchar) as binary), "
+        + "cast(cast(\"employee_id\" as varchar) as varbinary), "
+        + "cast(cast(\"employee_id\" as varchar) as timestamp), "
+        + "cast(cast(\"employee_id\" as varchar) as double), "
+        + "cast(cast(\"employee_id\" as varchar) as decimal), "
+        + "cast(cast(\"employee_id\" as varchar) as date), "
+        + "cast(cast(\"employee_id\" as varchar) as time), "
+        + "cast(cast(\"employee_id\" as varchar) as boolean) "
+        + "from \"foodmart\".\"reserve_employee\" ";
     final String expected = "SELECT CAST(CAST(employee_id AS STRING) AS INT64), "
-            + "CAST(CAST(employee_id AS STRING) AS INT64), "
-            + "CAST(CAST(employee_id AS STRING) AS INT64), "
-            + "CAST(CAST(employee_id AS STRING) AS INT64), "
-            + "CAST(CAST(employee_id AS STRING) AS FLOAT64), "
-            + "CAST(CAST(employee_id AS STRING) AS STRING), "
-            + "CAST(CAST(employee_id AS STRING) AS BYTES), "
-            + "CAST(CAST(employee_id AS STRING) AS BYTES), "
-            + "CAST(CAST(employee_id AS STRING) AS TIMESTAMP), "
-            + "CAST(CAST(employee_id AS STRING) AS FLOAT64), "
-            + "CAST(CAST(employee_id AS STRING) AS NUMERIC), "
-            + "CAST(CAST(employee_id AS STRING) AS DATE), "
-            + "CAST(CAST(employee_id AS STRING) AS TIME), "
-            + "CAST(CAST(employee_id AS STRING) AS BOOL)\n"
-            + "FROM foodmart.reserve_employee";
+        + "CAST(CAST(employee_id AS STRING) AS INT64), "
+        + "CAST(CAST(employee_id AS STRING) AS INT64), "
+        + "CAST(CAST(employee_id AS STRING) AS INT64), "
+        + "CAST(CAST(employee_id AS STRING) AS FLOAT64), "
+        + "CAST(CAST(employee_id AS STRING) AS STRING), "
+        + "CAST(CAST(employee_id AS STRING) AS BYTES), "
+        + "CAST(CAST(employee_id AS STRING) AS BYTES), "
+        + "CAST(CAST(employee_id AS STRING) AS TIMESTAMP), "
+        + "CAST(CAST(employee_id AS STRING) AS FLOAT64), "
+        + "CAST(CAST(employee_id AS STRING) AS NUMERIC), "
+        + "CAST(CAST(employee_id AS STRING) AS DATE), "
+        + "CAST(CAST(employee_id AS STRING) AS TIME), "
+        + "CAST(CAST(employee_id AS STRING) AS BOOL)\n"
+        + "FROM foodmart.reserve_employee";
     sql(query).withBigQuery().ok(expected);
   }
 
@@ -1770,8 +1770,8 @@ class RelToSqlConverterTest {
     final String expected = "SELECT TRIM('$@*AABC$@*AADCAA$@*A', '$@*A')\n"
         + "FROM foodmart.reserve_employee";
     sql(query)
-      .withBigQuery()
-      .ok(expected);
+        .withBigQuery()
+        .ok(expected);
   }
 
   @Test void testHiveAndSparkTrimWithBothSpecialCharacter() {
@@ -2094,41 +2094,41 @@ class RelToSqlConverterTest {
 
   @Test void testHiveSubstring() {
     String query = "SELECT SUBSTRING('ABC', 2)"
-            + "from \"foodmart\".\"reserve_employee\"";
+        + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT SUBSTRING('ABC', 2)\n"
-            + "FROM foodmart.reserve_employee";
+        + "FROM foodmart.reserve_employee";
     sql(query).withHive().ok(expected);
   }
 
   @Test void testHiveSubstringWithLength() {
     String query = "SELECT SUBSTRING('ABC', 2, 3)"
-            + "from \"foodmart\".\"reserve_employee\"";
+        + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT SUBSTRING('ABC', 2, 3)\n"
-            + "FROM foodmart.reserve_employee";
+        + "FROM foodmart.reserve_employee";
     sql(query).withHive().ok(expected);
   }
 
   @Test void testHiveSubstringWithANSI() {
     String query = "SELECT SUBSTRING('ABC' FROM 2)"
-            + "from \"foodmart\".\"reserve_employee\"";
+        + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT SUBSTRING('ABC', 2)\n"
-            + "FROM foodmart.reserve_employee";
+        + "FROM foodmart.reserve_employee";
     sql(query).withHive().ok(expected);
   }
 
   @Test void testHiveSubstringWithANSIAndLength() {
     String query = "SELECT SUBSTRING('ABC' FROM 2 FOR 3)"
-            + "from \"foodmart\".\"reserve_employee\"";
+        + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT SUBSTRING('ABC', 2, 3)\n"
-            + "FROM foodmart.reserve_employee";
+        + "FROM foodmart.reserve_employee";
     sql(query).withHive().ok(expected);
   }
 
   @Test void testHiveSelectQueryWithOverDescNullsLastShouldNotAddNullEmulation() {
     final String query = "SELECT row_number() over "
-            + "(order by \"hire_date\" desc nulls last) FROM \"employee\"";
+        + "(order by \"hire_date\" desc nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY hire_date DESC)\n"
-            + "FROM foodmart.employee";
+        + "FROM foodmart.employee";
     sql(query).dialect(HiveSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2235,11 +2235,11 @@ class RelToSqlConverterTest {
 
   @Test void testJethroDataSelectQueryWithOverDescAndNullsFirstShouldBeEmulated() {
     final String query = "SELECT row_number() over "
-            + "(order by \"hire_date\" desc nulls first) FROM \"employee\"";
+        + "(order by \"hire_date\" desc nulls first) FROM \"employee\"";
 
     final String expected = "SELECT ROW_NUMBER() OVER "
-            + "(ORDER BY \"hire_date\", \"hire_date\" DESC)\n"
-            + "FROM \"foodmart\".\"employee\"";
+        + "(ORDER BY \"hire_date\", \"hire_date\" DESC)\n"
+        + "FROM \"foodmart\".\"employee\"";
     sql(query).dialect(jethroDataSqlDialect()).ok(expected);
   }
 
@@ -2254,10 +2254,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlSelectQueryWithOverDescAndNullsFirstShouldBeEmulated() {
     final String query = "SELECT row_number() over "
-            + "(order by \"hire_date\" desc nulls first) FROM \"employee\"";
+        + "(order by \"hire_date\" desc nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER "
-            + "(ORDER BY `hire_date` IS NULL DESC, `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "(ORDER BY `hire_date` IS NULL DESC, `hire_date` DESC)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2272,10 +2272,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlSelectQueryWithOverAscAndNullsLastShouldBeEmulated() {
     final String query = "SELECT row_number() over "
-            + "(order by \"hire_date\" nulls last) FROM \"employee\"";
+        + "(order by \"hire_date\" nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER "
-            + "(ORDER BY `hire_date` IS NULL, `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "(ORDER BY `hire_date` IS NULL, `hire_date`)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2290,9 +2290,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlSelectQueryWithOverAscNullsFirstShouldNotAddNullEmulation() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
+        + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2307,9 +2307,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlSelectQueryWithOverDescNullsLastShouldNotAddNullEmulation() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
+        + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2350,9 +2350,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithHighNullsSelectWithOverAscNullsLastAndNoEmulation() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" nulls last) FROM \"employee\"";
+        + "over (order by \"hire_date\" nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2367,10 +2367,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithHighNullsSelectWithOverAscNullsFirstAndNullEmulation() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
+        + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() "
-            + "OVER (ORDER BY `hire_date` IS NULL DESC, `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "OVER (ORDER BY `hire_date` IS NULL DESC, `hire_date`)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2385,9 +2385,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithHighNullsSelectWithOverDescNullsFirstAndNoEmulation() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" desc nulls first) FROM \"employee\"";
+        + "over (order by \"hire_date\" desc nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2402,10 +2402,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithHighNullsSelectWithOverDescNullsLastAndNullEmulation() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
+        + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() "
-            + "OVER (ORDER BY `hire_date` IS NULL, `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "OVER (ORDER BY `hire_date` IS NULL, `hire_date` DESC)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2420,9 +2420,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithFirstNullsSelectWithOverDescAndNullsFirstShouldNotBeEmulated() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" desc nulls first) FROM \"employee\"";
+        + "over (order by \"hire_date\" desc nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2437,9 +2437,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithFirstNullsSelectWithOverAscAndNullsFirstShouldNotBeEmulated() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
+        + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2454,10 +2454,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithFirstNullsSelectWithOverDescAndNullsLastShouldBeEmulated() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
+        + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() "
-            + "OVER (ORDER BY `hire_date` IS NULL, `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "OVER (ORDER BY `hire_date` IS NULL, `hire_date` DESC)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2472,10 +2472,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithFirstNullsSelectWithOverAscAndNullsLastShouldBeEmulated() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" nulls last) FROM \"employee\"";
+        + "over (order by \"hire_date\" nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() "
-            + "OVER (ORDER BY `hire_date` IS NULL, `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "OVER (ORDER BY `hire_date` IS NULL, `hire_date`)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2490,10 +2490,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithLastNullsSelectWithOverDescAndNullsFirstShouldBeEmulated() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" desc nulls first) FROM \"employee\"";
+        + "over (order by \"hire_date\" desc nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() "
-            + "OVER (ORDER BY `hire_date` IS NULL DESC, `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "OVER (ORDER BY `hire_date` IS NULL DESC, `hire_date` DESC)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -2508,10 +2508,10 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithLastNullsSelectWithOverAscAndNullsFirstShouldBeEmulated() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
+        + "over (order by \"hire_date\" nulls first) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() "
-            + "OVER (ORDER BY `hire_date` IS NULL DESC, `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "OVER (ORDER BY `hire_date` IS NULL DESC, `hire_date`)\n"
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -2526,9 +2526,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithLastNullsSelectWithOverDescAndNullsLastShouldNotBeEmulated() {
     final String query = "SELECT row_number() "
-            + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
+        + "over (order by \"hire_date\" desc nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date` DESC)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -2543,9 +2543,9 @@ class RelToSqlConverterTest {
 
   @Test void testMySqlWithLastNullsSelectWithOverAscAndNullsLastShouldNotBeEmulated() {
     final String query = "SELECT row_number() over "
-            + "(order by \"hire_date\" nulls last) FROM \"employee\"";
+        + "(order by \"hire_date\" nulls last) FROM \"employee\"";
     final String expected = "SELECT ROW_NUMBER() OVER (ORDER BY `hire_date`)\n"
-            + "FROM `foodmart`.`employee`";
+        + "FROM `foodmart`.`employee`";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -3315,6 +3315,453 @@ class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-2339">[CALCITE-2339]
+   * Conversion of datetime_plus to timestampadd for dialects that only
+   * support timestampadd</a>. */
+  @Test void testTimestampAddToTimestampAddMssql() {
+    String query = "SELECT TIMESTAMPADD(MONTH, 10, \"hire_date\") FROM \"employee\"";
+    String expected = "SELECT DATEADD(MONTH, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(YEAR, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(YEAR, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(YEAR, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(YEAR, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(YEAR, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(YEAR, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(DAY, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(DAY, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(DAY, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(DAY, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(HOUR, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(HOUR, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(MINUTE, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(MINUTE, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(MINUTE, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(MINUTE, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(SECOND, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(SECOND, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(QUARTER, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(QUARTER, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(QUARTER, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(QUARTER, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(WEEK, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(WEEK, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(WEEK, [employee_id], [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(QUARTER, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT DATEADD(QUARTER, [employee_id], [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+  }
+
+  @Test void testDatetimePlusToTimestampAddMssql() {
+    String query = "SELECT \"hire_date\" + INTERVAL '10' MONTH FROM \"employee\"";
+    String expected = "SELECT DATEADD(MONTH, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" - INTERVAL '10' MONTH FROM \"employee\"";
+    expected = "SELECT DATEADD(MONTH, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '-10' MONTH FROM \"employee\"";
+    expected = "SELECT DATEADD(MONTH, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL -'10' MONTH FROM \"employee\"";
+    expected = "SELECT DATEADD(MONTH, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '10' SECOND FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, 10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" - INTERVAL '10' SECOND FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '-10' SECOND FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL -'10' SECOND FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, -10, [hire_date])\nFROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + \"employee_id\" * INTERVAL -'10' SECOND FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, -10 * [employee_id], [hire_date])\n"
+        + "FROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL -'10' SECOND * \"employee_id\" FROM \"employee\"";
+    expected = "SELECT DATEADD(SECOND, -10 * [employee_id], [hire_date])\n"
+        + "FROM [foodmart].[employee]";
+    sql(query)
+        .withMssql()
+        .ok(expected);
+  }
+
+  @Test void testDatetimePlusToDatetimePlusDb2() {
+    String query = "SELECT \"hire_date\" + INTERVAL '10' MONTH FROM \"employee\"";
+    String expected = "SELECT (employee.hire_date + 10 MONTH)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" - INTERVAL '10' MONTH FROM \"employee\"";
+    expected = "SELECT (employee.hire_date - 10 MONTH)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '-10' MONTH FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + -10 MONTH)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL -'10' MONTH FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + -10 MONTH)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '10' YEAR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 10 YEAR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '-10' YEAR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + -10 YEAR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL -'10' YEAR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + -10 YEAR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" - INTERVAL '10' YEAR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date - 10 YEAR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '10' HOUR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 10 HOUR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL '-10' HOUR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + -10 HOUR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL -'10' HOUR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + -10 HOUR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" - INTERVAL '10' HOUR FROM \"employee\"";
+    expected = "SELECT (employee.hire_date - 10 HOUR)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + \"employee_id\" * INTERVAL -'10' SECOND FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + employee.employee_id * -10 SECOND)\n"
+        + "FROM foodmart.employee AS employee";
+
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT \"hire_date\" + INTERVAL -'10' SECOND * \"employee_id\" FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + -10 SECOND * employee.employee_id)\n"
+        + "FROM foodmart.employee AS employee";
+
+    sql(query)
+        .withDb2()
+        .ok(expected);
+  }
+
+  @Test void testTimestampAddToDatetimePlusDb2() {
+    String query = "SELECT TIMESTAMPADD(MONTH, 10, \"hire_date\") FROM \"employee\"";
+    String expected = "SELECT (employee.hire_date + 1 MONTH * 10)\n"
+        + "FROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(MONTH, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 1 MONTH * -10)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 1 HOUR * -10)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 1 HOUR * 10)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 7 DAY * 10)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 7 DAY * -10)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+
+    query = "SELECT TIMESTAMPADD(QUARTER, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 3 MONTH * 10)\nFROM foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 7 DAY * employee.employee_id)\nFROM "
+        + "foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(QUARTER, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (employee.hire_date + 3 MONTH * employee.employee_id)\nFROM "
+        + "foodmart.employee AS employee";
+    sql(query)
+        .withDb2()
+        .ok(expected);
+  }
+
+  @Test void testTimestampAddToDatetimePlusMySql() {
+    String query = "SELECT TIMESTAMPADD(MONTH, 10, \"hire_date\") FROM \"employee\"";
+    String expected = "SELECT (`hire_date` + INTERVAL '1' MONTH * 10)\nFROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(MONTH, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '1' MONTH * -10)\nFROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '1' HOUR * -10)\nFROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '1' HOUR * 10)\nFROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '7' DAY * 10)\nFROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '7' DAY * -10)\nFROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+
+    query = "SELECT TIMESTAMPADD(QUARTER, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '3' MONTH * 10)\nFROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '7' DAY * `employee_id`)\n"
+        + "FROM `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(QUARTER, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (`hire_date` + INTERVAL '3' MONTH * `employee_id`)\nFROM"
+        + " `foodmart`.`employee`";
+    sql(query)
+        .withMysql()
+        .ok(expected);
+  }
+
+  @Test public void testTimestampAddToDatetimePlusPostgresql() {
+    String query = "SELECT TIMESTAMPADD(MONTH, 10, \"hire_date\") FROM \"employee\"";
+    String expected = "SELECT (\"hire_date\" + INTERVAL '1' MONTH * 10)\n"
+        + "FROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(MONTH, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '1' MONTH * -10)\nFROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '1' HOUR * -10)\nFROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(HOUR, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '1' HOUR * 10)\nFROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '7' DAY * 10)\nFROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, -10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '7' DAY * -10)\nFROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+
+    query = "SELECT TIMESTAMPADD(QUARTER, 10, \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '3' MONTH * 10)\nFROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(WEEK, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '7' DAY * \"employee_id\")\n"
+        + "FROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+
+    query = "SELECT TIMESTAMPADD(QUARTER, \"employee_id\", \"hire_date\") FROM \"employee\"";
+    expected = "SELECT (\"hire_date\" + INTERVAL '3' MONTH * \"employee_id\")\n"
+        + "FROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPostgresql()
+        .ok(expected);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2625">[CALCITE-2625]
    * Removing Window Boundaries from SqlWindow of Aggregate Function which do
    * not allow Framing</a>. */
@@ -3331,70 +3778,70 @@ class RelToSqlConverterTest {
   @Test void testConvertWindowToSql() {
     String query0 = "SELECT row_number() over (order by \"hire_date\") FROM \"employee\"";
     String expected0 = "SELECT ROW_NUMBER() OVER (ORDER BY \"hire_date\") AS \"$0\"\n"
-            + "FROM \"foodmart\".\"employee\"";
+        + "FROM \"foodmart\".\"employee\"";
 
     String query1 = "SELECT rank() over (order by \"hire_date\") FROM \"employee\"";
     String expected1 = "SELECT RANK() OVER (ORDER BY \"hire_date\") AS \"$0\"\n"
-            + "FROM \"foodmart\".\"employee\"";
+        + "FROM \"foodmart\".\"employee\"";
 
     String query2 = "SELECT lead(\"employee_id\",1,'NA') over "
-            + "(partition by \"hire_date\" order by \"employee_id\")\n"
-            + "FROM \"employee\"";
+        + "(partition by \"hire_date\" order by \"employee_id\")\n"
+        + "FROM \"employee\"";
     String expected2 = "SELECT LEAD(\"employee_id\", 1, 'NA') OVER "
-            + "(PARTITION BY \"hire_date\" "
-            + "ORDER BY \"employee_id\") AS \"$0\"\n"
-            + "FROM \"foodmart\".\"employee\"";
+        + "(PARTITION BY \"hire_date\" "
+        + "ORDER BY \"employee_id\") AS \"$0\"\n"
+        + "FROM \"foodmart\".\"employee\"";
 
     String query3 = "SELECT lag(\"employee_id\",1,'NA') over "
-            + "(partition by \"hire_date\" order by \"employee_id\")\n"
-            + "FROM \"employee\"";
+        + "(partition by \"hire_date\" order by \"employee_id\")\n"
+        + "FROM \"employee\"";
     String expected3 = "SELECT LAG(\"employee_id\", 1, 'NA') OVER "
-            + "(PARTITION BY \"hire_date\" ORDER BY \"employee_id\") AS \"$0\"\n"
-            + "FROM \"foodmart\".\"employee\"";
+        + "(PARTITION BY \"hire_date\" ORDER BY \"employee_id\") AS \"$0\"\n"
+        + "FROM \"foodmart\".\"employee\"";
 
     String query4 = "SELECT lag(\"employee_id\",1,'NA') "
-            + "over (partition by \"hire_date\" order by \"employee_id\") as lag1, "
-            + "lag(\"employee_id\",1,'NA') "
-            + "over (partition by \"birth_date\" order by \"employee_id\") as lag2, "
-            + "count(*) over (partition by \"hire_date\" order by \"employee_id\") as count1, "
-            + "count(*) over (partition by \"birth_date\" order by \"employee_id\") as count2\n"
-            + "FROM \"employee\"";
+        + "over (partition by \"hire_date\" order by \"employee_id\") as lag1, "
+        + "lag(\"employee_id\",1,'NA') "
+        + "over (partition by \"birth_date\" order by \"employee_id\") as lag2, "
+        + "count(*) over (partition by \"hire_date\" order by \"employee_id\") as count1, "
+        + "count(*) over (partition by \"birth_date\" order by \"employee_id\") as count2\n"
+        + "FROM \"employee\"";
     String expected4 = "SELECT LAG(\"employee_id\", 1, 'NA') OVER "
-            + "(PARTITION BY \"hire_date\" ORDER BY \"employee_id\") AS \"$0\", "
-            + "LAG(\"employee_id\", 1, 'NA') OVER "
-            + "(PARTITION BY \"birth_date\" ORDER BY \"employee_id\") AS \"$1\", "
-            + "COUNT(*) OVER (PARTITION BY \"hire_date\" ORDER BY \"employee_id\" "
-            + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$2\", "
-            + "COUNT(*) OVER (PARTITION BY \"birth_date\" ORDER BY \"employee_id\" "
-            + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$3\"\n"
-            + "FROM \"foodmart\".\"employee\"";
+        + "(PARTITION BY \"hire_date\" ORDER BY \"employee_id\") AS \"$0\", "
+        + "LAG(\"employee_id\", 1, 'NA') OVER "
+        + "(PARTITION BY \"birth_date\" ORDER BY \"employee_id\") AS \"$1\", "
+        + "COUNT(*) OVER (PARTITION BY \"hire_date\" ORDER BY \"employee_id\" "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$2\", "
+        + "COUNT(*) OVER (PARTITION BY \"birth_date\" ORDER BY \"employee_id\" "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$3\"\n"
+        + "FROM \"foodmart\".\"employee\"";
 
     String query5 = "SELECT lag(\"employee_id\",1,'NA') "
-            + "over (partition by \"hire_date\" order by \"employee_id\") as lag1, "
-            + "lag(\"employee_id\",1,'NA') "
-            + "over (partition by \"birth_date\" order by \"employee_id\") as lag2, "
-            + "max(sum(\"employee_id\")) over (partition by \"hire_date\" order by \"employee_id\") as count1, "
-            + "max(sum(\"employee_id\")) over (partition by \"birth_date\" order by \"employee_id\") as count2\n"
-            + "FROM \"employee\" group by \"employee_id\", \"hire_date\", \"birth_date\"";
+        + "over (partition by \"hire_date\" order by \"employee_id\") as lag1, "
+        + "lag(\"employee_id\",1,'NA') "
+        + "over (partition by \"birth_date\" order by \"employee_id\") as lag2, "
+        + "max(sum(\"employee_id\")) over (partition by \"hire_date\" order by \"employee_id\") as count1, "
+        + "max(sum(\"employee_id\")) over (partition by \"birth_date\" order by \"employee_id\") as count2\n"
+        + "FROM \"employee\" group by \"employee_id\", \"hire_date\", \"birth_date\"";
     String expected5 = "SELECT LAG(\"employee_id\", 1, 'NA') OVER "
-            + "(PARTITION BY \"hire_date\" ORDER BY \"employee_id\") AS \"$0\", "
-            + "LAG(\"employee_id\", 1, 'NA') OVER "
-            + "(PARTITION BY \"birth_date\" ORDER BY \"employee_id\") AS \"$1\", "
-            + "MAX(SUM(\"employee_id\")) OVER (PARTITION BY \"hire_date\" ORDER BY \"employee_id\" "
-            + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$2\", "
-            + "MAX(SUM(\"employee_id\")) OVER (PARTITION BY \"birth_date\" ORDER BY \"employee_id\" "
-            + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$3\"\n"
-            + "FROM \"foodmart\".\"employee\"\n"
-            + "GROUP BY \"employee_id\", \"hire_date\", \"birth_date\"";
+        + "(PARTITION BY \"hire_date\" ORDER BY \"employee_id\") AS \"$0\", "
+        + "LAG(\"employee_id\", 1, 'NA') OVER "
+        + "(PARTITION BY \"birth_date\" ORDER BY \"employee_id\") AS \"$1\", "
+        + "MAX(SUM(\"employee_id\")) OVER (PARTITION BY \"hire_date\" ORDER BY \"employee_id\" "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$2\", "
+        + "MAX(SUM(\"employee_id\")) OVER (PARTITION BY \"birth_date\" ORDER BY \"employee_id\" "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"$3\"\n"
+        + "FROM \"foodmart\".\"employee\"\n"
+        + "GROUP BY \"employee_id\", \"hire_date\", \"birth_date\"";
 
     String query6 = "SELECT lag(\"employee_id\",1,'NA') over "
-            + "(partition by \"hire_date\" order by \"employee_id\"), \"hire_date\"\n"
-            + "FROM \"employee\"\n"
-            + "group by \"hire_date\", \"employee_id\"";
+        + "(partition by \"hire_date\" order by \"employee_id\"), \"hire_date\"\n"
+        + "FROM \"employee\"\n"
+        + "group by \"hire_date\", \"employee_id\"";
     String expected6 = "SELECT LAG(\"employee_id\", 1, 'NA') "
-            + "OVER (PARTITION BY \"hire_date\" ORDER BY \"employee_id\"), \"hire_date\"\n"
-            + "FROM \"foodmart\".\"employee\"\n"
-            + "GROUP BY \"hire_date\", \"employee_id\"";
+        + "OVER (PARTITION BY \"hire_date\" ORDER BY \"employee_id\"), \"hire_date\"\n"
+        + "FROM \"foodmart\".\"employee\"\n"
+        + "GROUP BY \"hire_date\", \"employee_id\"";
     String query7 = "SELECT "
         + "count(distinct \"employee_id\") over (order by \"hire_date\") FROM \"employee\"";
     String expected7 = "SELECT "
@@ -3690,23 +4137,23 @@ class RelToSqlConverterTest {
 
   @Test void testUnparseSqlIntervalQualifierBigQuery() {
     final String sql0 = "select  * from \"employee\" where  \"hire_date\" - "
-            + "INTERVAL '19800' SECOND(5) > TIMESTAMP '2005-10-17 00:00:00' ";
+        + "INTERVAL '19800' SECOND(5) > TIMESTAMP '2005-10-17 00:00:00' ";
     final String expect0 = "SELECT *\n"
-            + "FROM foodmart.employee\n"
-            + "WHERE (hire_date - INTERVAL 19800 SECOND)"
-            + " > TIMESTAMP '2005-10-17 00:00:00'";
+        + "FROM foodmart.employee\n"
+        + "WHERE (hire_date - INTERVAL 19800 SECOND)"
+        + " > TIMESTAMP '2005-10-17 00:00:00'";
     sql(sql0).withBigQuery().ok(expect0);
 
     final String sql1 = "select  * from \"employee\" where  \"hire_date\" + "
-            + "INTERVAL '10' HOUR > TIMESTAMP '2005-10-17 00:00:00' ";
+        + "INTERVAL '10' HOUR > TIMESTAMP '2005-10-17 00:00:00' ";
     final String expect1 = "SELECT *\n"
-            + "FROM foodmart.employee\n"
-            + "WHERE (hire_date + INTERVAL 10 HOUR)"
-            + " > TIMESTAMP '2005-10-17 00:00:00'";
+        + "FROM foodmart.employee\n"
+        + "WHERE (hire_date + INTERVAL 10 HOUR)"
+        + " > TIMESTAMP '2005-10-17 00:00:00'";
     sql(sql1).withBigQuery().ok(expect1);
 
     final String sql2 = "select  * from \"employee\" where  \"hire_date\" + "
-            + "INTERVAL '1 2:34:56.78' DAY TO SECOND > TIMESTAMP '2005-10-17 00:00:00' ";
+        + "INTERVAL '1 2:34:56.78' DAY TO SECOND > TIMESTAMP '2005-10-17 00:00:00' ";
     sql(sql2).withBigQuery().throws_("Only INT64 is supported as the interval value for BigQuery.");
   }
 
@@ -5678,7 +6125,7 @@ class RelToSqlConverterTest {
   @Test void testJsonRemove() {
     String query = "select json_remove(\"product_name\", '$[0]') from \"product\"";
     final String expected = "SELECT JSON_REMOVE(\"product_name\", '$[0]')\n"
-           + "FROM \"foodmart\".\"product\"";
+        + "FROM \"foodmart\".\"product\"";
     sql(query).ok(expected);
   }
 
@@ -5966,7 +6413,7 @@ class RelToSqlConverterTest {
   @Test void testSelectCountStar() {
     final String query = "select count(*) from \"product\"";
     final String expected = "SELECT COUNT(*)\n"
-            + "FROM \"foodmart\".\"product\"";
+        + "FROM \"foodmart\".\"product\"";
     Sql sql = sql(query);
     sql.ok(expected);
   }
@@ -6301,10 +6748,10 @@ class RelToSqlConverterTest {
               .withDataTypeSystem(new RelDataTypeSystemImpl() {
                 @Override public int getMaxPrecision(SqlTypeName typeName) {
                   switch (typeName) {
-                    case VARCHAR:
-                      return 512;
-                    default:
-                      return super.getMaxPrecision(typeName);
+                  case VARCHAR:
+                    return 512;
+                  default:
+                    return super.getMaxPrecision(typeName);
                   }
                 }
               }));


### PR DESCRIPTION
This PR is just bringing back up:

#721

And here is the description:

Canonicalize the representation of adding a single time unit
to a datetime type under the datetime_plus operator. Add a RexUtil
method for converting back to timestampadd.
Add a hook that lets a SqlDialect request datetime_plus to be
exposed as timestampadd.
This work duplicates some of the work in [CALCITE-2188],
however it allows for this conversion to happen outside of
SqlDialect. It also handles the case where an interval is not
just a literal, but a multiplication of an interval literal by an
integer (the TimestampAddConvertlet does this when
converting TIMESTAMPADD to DATETIME_PLUS initially)