### PR TITLE
add specialized code for fetching catalog and schema from ClickHouse

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
@@ -343,6 +343,12 @@ public class JdbcSchema implements Schema {
         }
       }
     }
+    if ((catalog == null || schema == null)
+        && metaData.getDatabaseProductName().equals("ClickHouse")) {
+      // support ClickHouse
+      catalog = connection.getCatalog();
+      schema = connection.getSchema();
+    }
     return Pair.of(catalog, schema);
   }
 


### PR DESCRIPTION
ClickHouse Jdbc Driver Detail：https://github.com/ClickHouse/clickhouse-jdbc

fetch catalog and schema directly from `ru.yandex.clickhouse.ClickHouseConnectionImpl`,  
because of clickhouse jdbc version is before JDBC 4.1. 

clickhouse jdbc driver (`ru.yandex.clickhouse.ClickHouseDatabaseMetadata`) always return MajorVersion: 0 and JDBCMinorVersion: 1 