### PR TITLE
[CALCITE-4704] Log plan on rule application using explain formatting

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/AbstractRelOptPlanner.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -114,6 +113,7 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
       this.ruleAttemptsListener = new RuleAttemptsListener();
       addListener(this.ruleAttemptsListener);
     }
+    addListener(new RuleEventLogger());
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -324,12 +324,6 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
       return;
     }
 
-    if (LOGGER.isDebugEnabled()) {
-      // Leave this wrapped in a conditional to prevent unnecessarily calling Arrays.toString(...)
-      LOGGER.debug("call#{}: Apply rule [{}] to {}",
-          ruleCall.id, ruleCall.getRule(), Arrays.toString(ruleCall.rels));
-    }
-
     if (listener != null) {
       RelOptListener.RuleAttemptedEvent event =
           new RelOptListener.RuleAttemptedEvent(
@@ -365,11 +359,6 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
       RelOptRuleCall ruleCall,
       RelNode newRel,
       boolean before) {
-    if (before && LOGGER.isDebugEnabled()) {
-      LOGGER.debug("call#{}: Rule {} arguments {} produced {}",
-          ruleCall.id, ruleCall.getRule(), Arrays.toString(ruleCall.rels), newRel);
-    }
-
     if (listener != null) {
       RelOptListener.RuleProductionEvent event =
           new RelOptListener.RuleProductionEvent(

--- a/core/src/main/java/org/apache/calcite/plan/RuleEventLogger.java
+++ b/core/src/main/java/org/apache/calcite/plan/RuleEventLogger.java
@@ -22,6 +22,7 @@ import org.apache.calcite.util.trace.CalciteTrace;
 import org.slf4j.Logger;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -47,7 +48,7 @@ public class RuleEventLogger implements RelOptListener {
   @Override public void ruleProductionSucceeded(RuleProductionEvent event) {
     if (event.isBefore() && LOG.isDebugEnabled()) {
       RelOptRuleCall call = event.getRuleCall();
-      RelNode newRel = event.getRel();
+      RelNode newRel = Objects.requireNonNull(event.getRel());
       String relPlan = RelOptUtil.toString(newRel);
       String relDesc = "rel#" + newRel.getId() + ":" + newRel.getRelTypeName();
       LOG.debug("call#{}: Rule [{}] produced [{}]:\n {}",

--- a/core/src/main/java/org/apache/calcite/plan/RuleEventLogger.java
+++ b/core/src/main/java/org/apache/calcite/plan/RuleEventLogger.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.util.trace.CalciteTrace;
+
+import org.slf4j.Logger;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Listener for logging useful debugging information on certain rule events.
+ */
+public class RuleEventLogger implements RelOptListener {
+  private static final Logger LOG = CalciteTrace.getPlannerTracer();
+
+  @Override public void relEquivalenceFound(final RelEquivalenceEvent event) {
+
+  }
+
+  @Override public void ruleAttempted(final RuleAttemptedEvent event) {
+    if (event.isBefore() && LOG.isDebugEnabled()) {
+      RelOptRuleCall call = event.getRuleCall();
+      String ruleArgs = Arrays.stream(call.rels)
+          .map(rel -> "rel#" + rel.getId() + ":" + rel.getRelTypeName())
+          .collect(Collectors.joining(","));
+      LOG.debug("call#{}: Apply rule [{}] to [{}]", call.id, call.getRule(), ruleArgs);
+    }
+  }
+
+  @Override public void ruleProductionSucceeded(RuleProductionEvent event) {
+    if (event.isBefore() && LOG.isDebugEnabled()) {
+      RelOptRuleCall call = event.getRuleCall();
+      RelNode newRel = event.getRel();
+      String relPlan = RelOptUtil.toString(newRel);
+      String relDesc = "rel#" + newRel.getId() + ":" + newRel.getRelTypeName();
+      LOG.debug("call#{}: Rule [{}] produced [{}]:\n {}",
+          call.id, call.getRule(), relDesc, relPlan);
+    }
+  }
+
+  @Override public void relDiscarded(final RelDiscardedEvent event) {
+
+  }
+
+  @Override public void relChosen(final RelChosenEvent event) {
+
+  }
+}

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRuleCall.java
@@ -117,16 +117,6 @@ public class VolcanoRuleCall extends RelOptRuleCall {
       // It's possible that rel is a subset or is already registered.
       // Is there still a point in continuing? Yes, because we might
       // discover that two sets of expressions are actually equivalent.
-
-      if (LOGGER.isTraceEnabled()) {
-        // Cannot call RelNode.toString() yet, because rel has not
-        // been registered. For now, let's make up something similar.
-        String relDesc =
-            "rel#" + rel.getId() + ":" + rel.getRelTypeName();
-        LOGGER.trace("call#{}: Rule {} arguments {} created {}",
-            id, getRule(), Arrays.toString(rels), relDesc);
-      }
-
       if (volcanoPlanner.getListener() != null) {
         RelOptListener.RuleProductionEvent event =
             new RelOptListener.RuleProductionEvent(
@@ -212,12 +202,6 @@ public class VolcanoRuleCall extends RelOptRuleCall {
               getRule(), i, rel);
           return;
         }
-      }
-
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug(
-            "call#{}: Apply rule [{}] to {}",
-            id, getRule(), Arrays.toString(rels));
       }
 
       if (volcanoPlanner.getListener() != null) {

--- a/core/src/test/java/org/apache/calcite/plan/RuleEventLoggerTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RuleEventLoggerTest.java
@@ -36,12 +36,11 @@ import java.util.Arrays;
  * Class to conveniently print the output of the {@link RuleEventLogger} with Volcano and
  * HepPlanner.
  *
- * The class is not meant to be committed.
+ * <p>The class is not meant to be committed.</p>
  *
- * Add the following line in log4j.properties file and run the test:
- * <pre>
- *  log4j.logger.org.apache.calcite.plan.RelOptPlanner=DEBUG
- * </pre>
+ * <p>Change the level of org.apache.calcite.plan.RelOptPlanner logger in log4j2-test.xml
+ * to DEBUG and run the test. To see the full plan after a rule production switch the
+ * FULL_PLAN marker to ALLOW.</p>
  */
 public class RuleEventLoggerTest {
   public static Frameworks.ConfigBuilder config() {

--- a/core/src/test/java/org/apache/calcite/plan/RuleEventLoggerTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RuleEventLoggerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+/**
+ * Class to conveniently print the output of the {@link RuleEventLogger} with Volcano and
+ * HepPlanner.
+ *
+ * The class is not meant to be committed.
+ *
+ * Add the following line in log4j.properties file and run the test:
+ * <pre>
+ *  log4j.logger.org.apache.calcite.plan.RelOptPlanner=DEBUG
+ * </pre>
+ */
+public class RuleEventLoggerTest {
+  public static Frameworks.ConfigBuilder config() {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(CalciteAssert.addSchema(rootSchema, CalciteAssert.SchemaSpec.SCOTT));
+  }
+
+  private RelNode createRootPlan() {
+    RelBuilder builder = RelBuilder.create(config().build());
+    // Equivalent SQL:
+    //   SELECT e.ename
+    //   FROM emp AS e, dept
+    //   WHERE e.deptno = dept.deptno
+    return builder
+        .scan("EMP").as("e")
+        .scan("DEPT")
+        .join(JoinRelType.LEFT)
+        .filter(
+            builder.equals(
+            builder.field("e", "DEPTNO"),
+            builder.field("DEPT", "DEPTNO")))
+        .project(builder.field("e", "ENAME"))
+        .build();
+  }
+
+  @Test void testWithVolcano() {
+    RelNode initPlan = createRootPlan();
+    VolcanoPlanner planner = (VolcanoPlanner) initPlan.getCluster().getPlanner();
+    planner.clear();
+    planner.setNoneConventionHasInfiniteCost(false);
+    planner.addRule(CoreRules.FILTER_INTO_JOIN);
+    planner.addRule(CoreRules.PROJECT_JOIN_TRANSPOSE);
+    planner.addRule(CoreRules.PROJECT_MERGE);
+    planner.setRoot(initPlan);
+    planner.findBestExp();
+  }
+
+  @Test void testWithHep() {
+    RelNode initPlan = createRootPlan();
+    HepProgram program = HepProgram.builder().addRuleCollection(
+        Arrays.asList(
+        CoreRules.FILTER_INTO_JOIN,
+        CoreRules.PROJECT_JOIN_TRANSPOSE,
+        CoreRules.PROJECT_MERGE
+    )).build();
+    HepPlanner planner = new HepPlanner(program);
+    planner.setRoot(initPlan);
+    planner.findBestExp();
+  }
+}

--- a/core/src/test/resources/log4j2-test.xml
+++ b/core/src/test/resources/log4j2-test.xml
@@ -37,5 +37,8 @@
     <logger name="org.apache.calcite.avatica" level="ERROR"/>
     <logger name="org.eclipse.jetty" level="ERROR"/>
     <logger name="org.apache.calcite.sql.parser" level="ERROR"/>
+    <logger name="org.apache.calcite.plan.RelOptPlanner" level="ERROR">
+      <MarkerFilter marker="FULL_PLAN" onMatch="DENY" onMismatch="NEUTRAL"/>
+    </logger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
1. Add RuleEventLogger for logging events around rule execution.
2. Centralize logs around rule application and production in RuleEventLogger and unify output for volcanoPlanner and HepPlanner
3. Use only id and operator name for displaying rule arguments;remove redundant/not helpful information.
4. Add explain/tree logging on produced expressions.