### PR TITLE
[CALCITE-4708] Infer list generic type while Table instance is created at ReflectiveSchema class

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/java/Array.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/Array.java
@@ -21,13 +21,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Annotation that indicates that a field is an array type.
+/** Annotation that indicates that a field is an array type.
  *
  * Annotation usage cases:
  * - supply class type at runtime for column in table.
- * - supply class type at runtime for table. Expected that field implements {@link Iterable} interface
- */
+ * - supply class type at runtime for table. Expected that field implements {@link Iterable} interface. */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Array {

--- a/core/src/main/java/org/apache/calcite/adapter/java/Array.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/Array.java
@@ -23,6 +23,10 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation that indicates that a field is an array type.
+ *
+ * Annotation usage cases:
+ * - supply class type at runtime for column in table.
+ * - supply class type at runtime for table. Expected that field implements {@link Iterable} interface
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -188,16 +188,10 @@ public class ReflectiveSchema
         target.getClass());
   }
 
-  /**
-   * Returns a table based on a particular field of this schema.
+  /** Returns a table based on a particular field of this schema.
    * If the field is not of the right type to be a relation, returns null.
-   *
    * Method infer Iterable generic type if the field is annotated with {@link Array}
-   * and Iterable item class is set at {@link Array#component()}
-   *
-   * @param field schema field
-   * @return table instance based on a particular field of this schema
-   */
+   * and Iterable item class is set at {@link Array#component(). */
   private <T> @Nullable Table fieldRelation(final Field field) {
     Array arrayAnnotation = field.getAnnotation(Array.class);
     Class<?> iterableItemClass = arrayAnnotation != null ? arrayAnnotation.component() : null;
@@ -218,17 +212,15 @@ public class ReflectiveSchema
     return new FieldTable<>(field, elementType, enumerable);
   }
 
-  /**
-   * Deduces the element type of a collection;
-   * Collection represent set of rows in table;
-   * Method returns null if class is not collection;
+  /** Deduces the element type of a collection.
+   * Collection represent set of rows in table.
+   * Method returns null if class is not collection.
    *
    * same logic as {@link #toEnumerable}.
    *
    * @param clazz collection class. Parameter is mandatory
    * @param iterableItemClass item's class of iterable collection. Parameter is optional
-   * @return element type of a collection
-   */
+   * @return element type of a collection. */
   private static @Nullable Type getElementType(Class clazz, Class<?> iterableItemClass) {
     if (clazz.isArray()) {
       return clazz.getComponentType();

--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -188,10 +188,20 @@ public class ReflectiveSchema
         target.getClass());
   }
 
-  /** Returns a table based on a particular field of this schema. If the
-   * field is not of the right type to be a relation, returns null. */
+  /**
+   * Returns a table based on a particular field of this schema.
+   * If the field is not of the right type to be a relation, returns null.
+   *
+   * Method infer Iterable generic type if the field is annotated with {@link Array}
+   * and Iterable item class is set at {@link Array#component()}
+   *
+   * @param field schema field
+   * @return table instance based on a particular field of this schema
+   */
   private <T> @Nullable Table fieldRelation(final Field field) {
-    final Type elementType = getElementType(field.getType());
+    Array arrayAnnotation = field.getAnnotation(Array.class);
+    Class<?> iterableItemClass = arrayAnnotation != null ? arrayAnnotation.component() : null;
+    final Type elementType = getElementType(field.getType(), iterableItemClass);
     if (elementType == null) {
       return null;
     }
@@ -208,14 +218,23 @@ public class ReflectiveSchema
     return new FieldTable<>(field, elementType, enumerable);
   }
 
-  /** Deduces the element type of a collection;
-   * same logic as {@link #toEnumerable}. */
-  private static @Nullable Type getElementType(Class clazz) {
+  /**
+   * Deduces the element type of a collection;
+   * Collection represent set of rows in table;
+   * Method returns null if class is not collection;
+   *
+   * same logic as {@link #toEnumerable}.
+   *
+   * @param clazz collection class. Parameter is mandatory
+   * @param iterableItemClass item's class of iterable collection. Parameter is optional
+   * @return element type of a collection
+   */
+  private static @Nullable Type getElementType(Class clazz, Class<?> iterableItemClass) {
     if (clazz.isArray()) {
       return clazz.getComponentType();
     }
     if (Iterable.class.isAssignableFrom(clazz)) {
-      return Object.class;
+      return iterableItemClass != null ? iterableItemClass : Object.class;
     }
     return null; // not a collection/array/iterable
   }

--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -191,7 +191,7 @@ public class ReflectiveSchema
   /** Returns a table based on a particular field of this schema.
    * If the field is not of the right type to be a relation, returns null.
    * Method infer Iterable generic type if the field is annotated with {@link Array}
-   * and Iterable item class is set at {@link Array#component(). */
+   * and Iterable item class is set at {@link Array#component()}. */
   private <T> @Nullable Table fieldRelation(final Field field) {
     Array arrayAnnotation = field.getAnnotation(Array.class);
     Class<?> iterableItemClass = arrayAnnotation != null ? arrayAnnotation.component() : null;

--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -221,7 +221,7 @@ public class ReflectiveSchema
    * @param clazz collection class. Parameter is mandatory
    * @param iterableItemClass item's class of iterable collection. Parameter is optional
    * @return element type of a collection. */
-  private static @Nullable Type getElementType(Class clazz, Class<?> iterableItemClass) {
+  private static @Nullable Type getElementType(Class clazz, @Nullable Class<?> iterableItemClass) {
     if (clazz.isArray()) {
       return clazz.getComponentType();
     }

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -8051,6 +8051,15 @@ public class JdbcTest {
     };
   }
 
+  public static class FoodmartSchemaIterable {
+    @org.apache.calcite.adapter.java.Array(component = SalesFact.class)
+    public final Iterable<SalesFact> sales_fact_1997;
+
+    public FoodmartSchemaIterable(Iterable<SalesFact> sales_fact_1997) {
+      this.sales_fact_1997 = sales_fact_1997;
+    }
+  }
+
   public static class LingualSchema {
     public final LingualEmp[] EMPS = {
       new LingualEmp(1, 10),

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -56,7 +56,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.stream.Stream;
 
@@ -873,10 +879,9 @@ public class ReflectiveSchemaTest {
     }
   }
 
-  /**
-   * Test case for
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-4708">[CALCITE-4708]
-   */
+   * Infer list generic type while Table instance is created at ReflectiveSchema class</a> */
   @ParameterizedTest
   @MethodSource("provideTestTableArrayAnnotation")
   void testTableArrayAnnotation(Iterable<JdbcTest.SalesFact> dataList) throws SQLException {
@@ -910,9 +915,7 @@ public class ReflectiveSchemaTest {
     }
   }
 
-  /**
-   * Test data for test {@link ReflectiveSchemaTest#testTableArrayAnnotation(Iterable)}
-   */
+  /** Test data for test {@link ReflectiveSchemaTest#testTableArrayAnnotation(Iterable)} */
   private static Stream<Arguments> provideTestTableArrayAnnotation() {
     List<JdbcTest.SalesFact> dataList = Arrays.asList(
         new JdbcTest.SalesFact(100, 10),

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -881,13 +881,13 @@ public class ReflectiveSchemaTest {
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-4708">[CALCITE-4708]
-   * Infer list generic type while Table instance is created at ReflectiveSchema class</a> */
+   * Infer list generic type while Table instance is created at ReflectiveSchema class</a>. */
   @ParameterizedTest
   @MethodSource("provideTestTableArrayAnnotation")
   void testTableArrayAnnotation(Iterable<JdbcTest.SalesFact> dataList) throws SQLException {
     Properties properties = new Properties();
     properties.put("lex", "JAVA");
-    try(Connection connection = DriverManager.getConnection("jdbc:calcite:", properties)) {
+    try (Connection connection = DriverManager.getConnection("jdbc:calcite:", properties)) {
       JdbcTest.FoodmartSchemaIterable schemaJava = new JdbcTest.FoodmartSchemaIterable(dataList);
       ReflectiveSchema schema = new ReflectiveSchema(schemaJava);
 
@@ -915,7 +915,7 @@ public class ReflectiveSchemaTest {
     }
   }
 
-  /** Test data for test {@link ReflectiveSchemaTest#testTableArrayAnnotation(Iterable)} */
+  /** Test data for test {@link ReflectiveSchemaTest#testTableArrayAnnotation(Iterable)}. */
   private static Stream<Arguments> provideTestTableArrayAnnotation() {
     List<JdbcTest.SalesFact> dataList = Arrays.asList(
         new JdbcTest.SalesFact(100, 10),

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -41,6 +41,9 @@ import com.google.common.collect.ImmutableList;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -53,11 +56,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.stream.Stream;
 
 import static org.apache.calcite.test.JdbcTest.Employee;
 
@@ -870,6 +871,58 @@ public class ReflectiveSchemaTest {
           + "empid=150; name=Sebastian\n";
       assertThat(CalciteAssert.toString(resultSet), is(expected));
     }
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4708">[CALCITE-4708]
+   */
+  @ParameterizedTest
+  @MethodSource("provideTestTableArrayAnnotation")
+  void testTableArrayAnnotation(Iterable<JdbcTest.SalesFact> dataList) throws SQLException {
+    Properties properties = new Properties();
+    properties.put("lex", "JAVA");
+    try(Connection connection = DriverManager.getConnection("jdbc:calcite:", properties)) {
+      JdbcTest.FoodmartSchemaIterable schemaJava = new JdbcTest.FoodmartSchemaIterable(dataList);
+      ReflectiveSchema schema = new ReflectiveSchema(schemaJava);
+
+      connection
+          .unwrap(CalciteConnection.class)
+          .getRootSchema()
+          .add("test", schema);
+
+      ResultSet resultSet = connection
+          .createStatement()
+          .executeQuery("select t.* from test.sales_fact_1997 t order by cust_id");
+
+      List<JdbcTest.SalesFact> resultList = new ArrayList<>();
+      while (resultSet.next()) {
+        int cust_id = resultSet.getInt("cust_id");
+        int prod_id = resultSet.getInt("prod_id");
+        resultList.add(new JdbcTest.SalesFact(cust_id, prod_id));
+      }
+
+      assertEquals(resultList.size(), 2);
+      assertEquals(resultList.get(0).cust_id, 100);
+      assertEquals(resultList.get(0).prod_id, 10);
+      assertEquals(resultList.get(1).cust_id, 150);
+      assertEquals(resultList.get(1).prod_id, 20);
+    }
+  }
+
+  /**
+   * Test data for test {@link ReflectiveSchemaTest#testTableArrayAnnotation(Iterable)}
+   */
+  private static Stream<Arguments> provideTestTableArrayAnnotation() {
+    List<JdbcTest.SalesFact> dataList = Arrays.asList(
+        new JdbcTest.SalesFact(100, 10),
+        new JdbcTest.SalesFact(150, 20)
+    );
+    return Stream.of(
+        Arguments.of(dataList),
+        Arguments.of(new HashSet<>(dataList)),
+        Arguments.of(new ArrayBlockingQueue<>(2, false, dataList))
+    );
   }
 
   /** Extension to {@link Employee} with a {@code hireDate} column. */


### PR DESCRIPTION
Add reusing `org.apache.calcite.adapter.java.Array` annotation on Iterable field in schema in order to infer Iterable generic type while Table instance is created at ReflectiveSchema class