### PR TITLE
[CALCITE-4721] support set hints by `setOperand` in SqlSelect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
@@ -132,6 +132,9 @@ public class SqlSelect extends SqlCall {
     case 9:
       fetch = operand;
       break;
+    case 10:
+      hints = (SqlNodeList) operand;
+      break;
     default:
       throw new AssertionError(i);
     }


### PR DESCRIPTION
add support for set hints in SqlSelect.