### PR TITLE
[CALCITE-4725] Between clause operands checker should check all combi…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
@@ -29,7 +29,7 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.parser.SqlParserUtil;
-import org.apache.calcite.sql.type.ComparableOperandTypeChecker;
+import org.apache.calcite.sql.type.FirstWithOthersOperandTypeChecker;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
@@ -79,7 +79,7 @@ public class SqlBetweenOperator extends SqlInfixOperator {
    * Custom operand-type checking strategy.
    */
   private static final SqlOperandTypeChecker OTC_CUSTOM =
-      new ComparableOperandTypeChecker(3, RelDataTypeComparability.ALL,
+      new FirstWithOthersOperandTypeChecker(3, RelDataTypeComparability.ALL,
           SqlOperandTypeChecker.Consistency.COMPARE);
   private static final SqlWriter.FrameType FRAME_TYPE =
       SqlWriter.FrameTypeEnum.create("BETWEEN");

--- a/core/src/main/java/org/apache/calcite/sql/type/FirstWithOthersOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FirstWithOthersOperandTypeChecker.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeComparability;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlOperatorBinding;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Parameter type-checking strategy where the first operand type should be compatible with others.
+ */
+public class FirstWithOthersOperandTypeChecker extends ComparableOperandTypeChecker {
+  public FirstWithOthersOperandTypeChecker(int nOperands,
+      RelDataTypeComparability requiredComparability, Consistency consistency) {
+    super(nOperands, requiredComparability, Consistency.NONE);
+  }
+
+  @Override protected boolean checkOperandTypesImpl(
+      SqlOperatorBinding operatorBinding,
+      boolean throwOnFailure,
+      @Nullable SqlCallBinding callBinding) {
+    if (throwOnFailure && callBinding == null) {
+      throw new IllegalArgumentException(
+          "callBinding must be non-null in case throwOnFailure=true");
+    }
+    int nOperandsActual = nOperands;
+    if (nOperandsActual == -1) {
+      nOperandsActual = operatorBinding.getOperandCount();
+    }
+    RelDataType[] types = new RelDataType[nOperandsActual];
+    final List<Integer> operandList =
+        getOperandList(operatorBinding.getOperandCount());
+    for (int i : operandList) {
+      types[i] = operatorBinding.getOperandType(i);
+    }
+
+    if (!checkOperandTypeComparable(types, operandList)) {
+      if (!throwOnFailure) {
+        return false;
+      }
+
+      // REVIEW jvs 5-June-2005: Why don't we use
+      // newValidationSignatureError() here?  It gives more
+      // specific diagnostics.
+      throw requireNonNull(callBinding, "callBinding").newValidationError(
+          RESOURCE.needSameTypeParameter());
+    }
+
+    return true;
+  }
+
+  private boolean checkOperandTypeComparable(
+      RelDataType[] types,
+      List<Integer> operandList) {
+    final int operandListSize = operandList.size();
+
+    if (operandListSize <= 1) {
+      return true;
+    }
+
+    RelDataType firstOperandType = types[operandList.get(0)];
+    // Here we compare the first operand type with others, so first one is skipped
+    for (int i = 1; i < operandListSize; i++) {
+      if (!SqlTypeUtil.isComparable(firstOperandType, types[operandList.get(i)])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -761,6 +761,49 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("'' between 2 and 3").ok();
     wholeExpr("date '2012-02-03' between 2 and 3")
         .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("1 between '0' and true")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("1 between 0.5 and 20.1")
+        .ok();
+    wholeExpr("1 between '0.5' and 20.1")
+        .ok();
+    wholeExpr("1 between date '2012-02-01' and 15")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("1 between '2012-02-01' and date '2012-03-01'")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("true between true and false")
+        .ok();
+    wholeExpr("true between 'abc' and false")
+        .ok();
+    wholeExpr("false between 'abc' and 1.2345")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("false between 1.2345 and 'abc'")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("date '2012-02-03' between '2012-01-01' and date '2012-05-01'")
+        .ok();
+    wholeExpr("date '2012-02-03' between '2012-01-01' and timestamp '2012-05-01 1:00:00'")
+        .ok();
+    wholeExpr("date '2012-02-03' between timestamp '2012-01-01 16:00:00' "
+        + "and timestamp '2012-05-01 1:00:00'")
+        .ok();
+    wholeExpr("date '2012-02-03' between '1' and 20")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("date '2012-02-03' between '1' and time '4:5:6'")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("timestamp '2012-02-03 13:00:00' between '2012-01-01 12:00:00' "
+        + "and timestamp '2012-05-01 15:00:00'")
+        .ok();
+    wholeExpr("timestamp '2012-02-03 13:00:00' between '2012-01-01 12:00:00' "
+        + "and date '2012-05-01'")
+        .ok();
+    wholeExpr("timestamp '2012-02-03 13:00:00' between date '2012-01-01' and date '2012-05-01'")
+        .ok();
+    wholeExpr("timestamp '2012-02-03 13:00:00' between '2012-01-01' and 123456")
+        .fails("(?s).*Cannot apply 'BETWEEN ASYMMETRIC' to arguments of type.*");
+    wholeExpr("null between 1 and 2")
+        .ok();
+    wholeExpr("null between null and null")
+        .ok();
   }
 
   @Test void testCharsetMismatch() {


### PR DESCRIPTION
…nations of the three operands

## What is the purpose of the change

Fix the issue that between clause operands checker should check all combinations of the three operands, as what has been discuss in CALCITE-4725 in ASF Jira.

## Brief change log

- core/src/main/java/org/apache/calcite/sql/type/SameOperandTypeChecker.java
- core/src/main/java/org/apache/calcite/sql/type/SameOperandTypeExceptLastOperandChecker.java 
