### PR TITLE
[CALCITE-2489] Order of fields in JavaTypeFactoryImpl#createStructType is unstable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,10 +71,10 @@ val enableSpotBugs = props.bool("spotbugs")
 val enableCheckerframework by props()
 val enableErrorprone by props()
 val enableDependencyAnalysis by props()
-val enableParameters by props(true)
 val skipJandex by props()
 val skipCheckstyle by props()
 val skipAutostyle by props()
+val skipJavacParameterNames by props()
 val skipJavadoc by props()
 val enableMavenLocal by props()
 val enableGradleMetadata by props()
@@ -699,7 +699,7 @@ allprojects {
                 if (enableCheckerframework) {
                     options.forkOptions.memoryMaximumSize = "2g"
                 }
-                if (enableParameters) {
+                if (!skipJavacParameterNames) {
                     options.compilerArgs.add("-parameters")
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ val enableSpotBugs = props.bool("spotbugs")
 val enableCheckerframework by props()
 val enableErrorprone by props()
 val enableDependencyAnalysis by props()
+val enableParameters by props(true)
 val skipJandex by props()
 val skipCheckstyle by props()
 val skipAutostyle by props()
@@ -697,6 +698,9 @@ allprojects {
                 }
                 if (enableCheckerframework) {
                     options.forkOptions.memoryMaximumSize = "2g"
+                }
+                if (enableParameters) {
+                    options.compilerArgs.add("-parameters")
                 }
             }
             configureEach<Test> {

--- a/core/src/main/java/org/apache/calcite/adapter/java/JavaTypeFactory.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/JavaTypeFactory.java
@@ -19,6 +19,7 @@ package org.apache.calcite.adapter.java;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.List;
 
@@ -33,6 +34,17 @@ public interface JavaTypeFactory extends RelDataTypeFactory {
    * @return Record type that remembers its Java class
    */
   RelDataType createStructType(Class clazz);
+
+  /**
+   * Creates a record type based upon the provided fields of a Java class.
+   *
+   * @param clazz Java class
+   * @param fields fields to use to build the record
+   * @return Record type that remembers its Java class
+   */
+  default RelDataType createStructType(Class clazz, List<Field> fields) {
+    return createStructType(clazz);
+  }
 
   /**
    * Creates a type, deducing whether a record, scalar or primitive type

--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -92,7 +92,7 @@ public class ReflectiveSchema
     super();
     this.clazz = target.getClass();
     this.target = target;
-    this.fieldsOrdering = Types.FieldsOrdering.ALPHABETICAL_AND_HIERARCHY;
+    this.fieldsOrdering = Types.FieldsOrdering.CONSTRUCTOR;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -27,6 +27,7 @@ import org.apache.calcite.linq4j.function.Function1;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.Primitive;
+import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.RelReferentialConstraint;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -61,7 +62,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,6 +78,8 @@ public class ReflectiveSchema
     extends AbstractSchema {
   private final Class clazz;
   private final Object target;
+  private Types.FieldsOrdering fieldsOrdering;
+  private @Nullable Map<Class, List<Field>> classFieldsMap;
   private @MonotonicNonNull Map<String, Table> tableMap;
   private @MonotonicNonNull Multimap<String, Function> functionMap;
 
@@ -87,6 +92,32 @@ public class ReflectiveSchema
     super();
     this.clazz = target.getClass();
     this.target = target;
+    this.fieldsOrdering = Types.FieldsOrdering.ALPHABETICAL_AND_HIERARCHY;
+  }
+
+  /**
+   * Creates a ReflectiveSchema.
+   *
+   * @param target Object whose fields will be sub-objects of the schema
+   * @param fieldsOrdering ordering strategy for SQL type fields from the Object fields
+   */
+  public ReflectiveSchema(Object target, Types.FieldsOrdering fieldsOrdering) {
+    this(target);
+    this.fieldsOrdering = fieldsOrdering;
+  }
+
+  /**
+   * Creates a ReflectiveSchema.
+   *
+   * @param target Object whose fields will be sub-objects of the schema
+   * @param fieldsOrdering ordering strategy for SQL type fields from the Object fields
+   * @param classFieldsMap class to list of fields map for supporting user-provided field ordering
+   */
+  public ReflectiveSchema(Object target,
+      Types.FieldsOrdering fieldsOrdering, @Nullable Map<Class, List<Field>> classFieldsMap) {
+    this(target);
+    this.fieldsOrdering = fieldsOrdering;
+    this.classFieldsMap = classFieldsMap;
   }
 
   @Override public String toString() {
@@ -112,7 +143,7 @@ public class ReflectiveSchema
 
   private Map<String, Table> createTableMap() {
     final ImmutableMap.Builder<String, Table> builder = ImmutableMap.builder();
-    for (Field field : clazz.getFields()) {
+    for (Field field : Types.getClassFields(clazz, true, fieldsOrdering, classFieldsMap)) {
       final String fieldName = field.getName();
       final Table table = fieldRelation(field);
       if (table == null) {
@@ -122,7 +153,7 @@ public class ReflectiveSchema
     }
     Map<String, Table> tableMap = builder.build();
     // Unique-Key - Foreign-Key
-    for (Field field : clazz.getFields()) {
+    for (Field field : Types.getClassFields(clazz, true, fieldsOrdering, classFieldsMap)) {
       if (RelReferentialConstraint.class.isAssignableFrom(field.getType())) {
         RelReferentialConstraint rc;
         try {
@@ -205,7 +236,7 @@ public class ReflectiveSchema
     requireNonNull(o, () -> "field " + field + " is null for " + target);
     @SuppressWarnings("unchecked")
     final Enumerable<T> enumerable = toEnumerable(o);
-    return new FieldTable<>(field, elementType, enumerable);
+    return new FieldTable<>(field, elementType, enumerable, fieldsOrdering, classFieldsMap);
   }
 
   /** Deduces the element type of a collection;
@@ -240,14 +271,27 @@ public class ReflectiveSchema
       extends AbstractQueryableTable
       implements Table, ScannableTable {
     private final Enumerable enumerable;
+    private final Types.FieldsOrdering fieldsOrdering;
+    private final @Nullable Map<Class, List<Field>> classFieldsMap;
 
-    ReflectiveTable(Type elementType, Enumerable enumerable) {
+    ReflectiveTable(Type elementType, Enumerable enumerable,
+        Types.FieldsOrdering fieldsOrdering, @Nullable Map<Class, List<Field>> classFieldsMap) {
       super(elementType);
       this.enumerable = enumerable;
+      this.fieldsOrdering = fieldsOrdering;
+      this.classFieldsMap = classFieldsMap;
     }
 
     @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-      return ((JavaTypeFactory) typeFactory).createType(elementType);
+      if (classFieldsMap == null) {
+        return ((JavaTypeFactory) typeFactory).createType(elementType);
+      }
+      Class clazz = Types.toClass(elementType);
+      List<Field> classFields = classFieldsMap.get(clazz);
+      if (classFields == null) {
+        return ((JavaTypeFactory) typeFactory).createType(elementType);
+      }
+      return ((JavaTypeFactory) typeFactory).createStructType(clazz, classFields);
     }
 
     @Override public Statistic getStatistic() {
@@ -260,7 +304,8 @@ public class ReflectiveSchema
         return enumerable;
       } else {
         //noinspection unchecked
-        return enumerable.select(new FieldSelector((Class) elementType));
+        return enumerable.select(
+            new FieldSelector((Class) elementType, fieldsOrdering, classFieldsMap));
       }
     }
 
@@ -270,7 +315,7 @@ public class ReflectiveSchema
           tableName) {
         @SuppressWarnings("unchecked")
         @Override public Enumerator<T> enumerator() {
-          return (Enumerator<T>) enumerable.enumerator();
+          return enumerable.enumerator();
         }
       };
     }
@@ -281,7 +326,8 @@ public class ReflectiveSchema
    *
    * <p>The following example instantiates a {@code FoodMart} object as a schema
    * that contains tables called {@code EMPS} and {@code DEPTS} based on the
-   * object's fields.
+   * object's fields. The order of the fields in the SQL types, derived from Java
+   * classes, is alphabetical.
    *
    * <blockquote><pre>
    * schemas: [
@@ -291,7 +337,8 @@ public class ReflectiveSchema
    *       factory: "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
    *       operand: {
    *         class: "com.acme.FoodMart",
-   *         staticMethod: "instance"
+   *         staticMethod: "instance",
+   *         fieldsOrdering: "ALPHABETICAL"
    *       }
    *     }
    *   ]
@@ -339,8 +386,61 @@ public class ReflectiveSchema
               e);
         }
       }
+      final Object fieldsOrdering = operand.get("fieldsOrdering");
+      Types.FieldsOrdering fieldsOrderingEnum = null;
+      if (fieldsOrdering != null) {
+        try {
+          fieldsOrderingEnum = Types.FieldsOrdering.valueOf((String) fieldsOrdering);
+        } catch (Exception e) {
+          throw new RuntimeException("Error deriving fields ordering enumeration: "
+              + fieldsOrdering, e);
+        }
+      }
+
+      if (fieldsOrderingEnum != null) {
+        final Object fieldsParam = operand.get("fields");
+
+        if (fieldsParam == null
+            && (fieldsOrderingEnum == Types.FieldsOrdering.EXPLICIT
+            || fieldsOrderingEnum == Types.FieldsOrdering.EXPLICIT_TOLERANT)) {
+          throw new RuntimeException("\"fields\" operand must be provided if fields ordering "
+              + "strategy is either \"" + Types.FieldsOrdering.EXPLICIT.name() + "\" or \""
+              + Types.FieldsOrdering.EXPLICIT_TOLERANT.name() + "\"");
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> fieldsMap = (Map) fieldsParam;
+        Map<Class, List<Field>> classListMap = null;
+
+        if (fieldsMap != null) {
+          classListMap = new HashMap<>(fieldsMap.size());
+          for (Map.Entry<String, List<String>> entry : fieldsMap.entrySet()) {
+            String classString = entry.getKey();
+            try {
+              clazz = Class.forName(classString);
+              classListMap.put(clazz, fieldNamesToFields(clazz, entry.getValue()));
+            } catch (ClassNotFoundException e) {
+              throw new RuntimeException("Error loading class " + classString, e);
+            }
+          }
+        }
+        return new ReflectiveSchema(target, fieldsOrderingEnum, classListMap);
+      }
       return new ReflectiveSchema(target);
     }
+  }
+
+  private static List<Field> fieldNamesToFields(Class clazz, List<String> fieldNames) {
+    List<Field> classFields = new ArrayList<>();
+    for (String fieldName : fieldNames) {
+      try {
+        classFields.add(clazz.getField(fieldName));
+      } catch (NoSuchFieldException e) {
+        throw new RuntimeException("Error resolving field " + fieldName
+            + " in class " + clazz.getName(), e);
+      }
+    }
+    return classFields;
   }
 
   /** Table macro based on a Java method. */
@@ -379,13 +479,15 @@ public class ReflectiveSchema
     private final Field field;
     private Statistic statistic;
 
-    FieldTable(Field field, Type elementType, Enumerable<T> enumerable) {
-      this(field, elementType, enumerable, Statistics.UNKNOWN);
+    FieldTable(Field field, Type elementType, Enumerable<T> enumerable,
+        Types.FieldsOrdering fieldsOrdering, @Nullable Map<Class, List<Field>> classFieldsMap) {
+      this(field, elementType, enumerable, Statistics.UNKNOWN, fieldsOrdering, classFieldsMap);
     }
 
     FieldTable(Field field, Type elementType, Enumerable<T> enumerable,
-        Statistic statistic) {
-      super(elementType, enumerable);
+        Statistic statistic, Types.FieldsOrdering fieldsOrdering,
+        @Nullable Map<Class, List<Field>> classFieldsMap) {
+      super(elementType, enumerable, fieldsOrdering, classFieldsMap);
       this.field = field;
       this.statistic = statistic;
     }
@@ -413,8 +515,11 @@ public class ReflectiveSchema
   private static class FieldSelector implements Function1<Object, @Nullable Object[]> {
     private final Field[] fields;
 
-    FieldSelector(Class elementType) {
-      this.fields = elementType.getFields();
+    FieldSelector(Class elementType, Types.FieldsOrdering fieldsOrdering,
+        @Nullable Map<Class, List<Field>> classFieldsMap) {
+      this.fields =
+          Types.getClassFields(elementType, true, fieldsOrdering, classFieldsMap)
+          .toArray(new Field[0]);
     }
 
     @Override public @Nullable Object[] apply(Object o) {

--- a/core/src/main/java/org/apache/calcite/interpreter/TableScanNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/TableScanNode.java
@@ -20,6 +20,7 @@ import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.function.Function1;
+import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.core.TableScan;
@@ -141,11 +142,8 @@ public class TableScanNode implements Node {
           relOptTable.getQualifiedName());
       ImmutableList.Builder<Field> fieldBuilder = ImmutableList.builder();
       Class type = (Class) elementType;
-      for (Field field : type.getFields()) {
-        if (Modifier.isPublic(field.getModifiers())
-            && !Modifier.isStatic(field.getModifiers())) {
-          fieldBuilder.add(field);
-        }
+      for (Field field : Types.getClassFields(type)) {
+        fieldBuilder.add(field);
       }
       final List<Field> fields = fieldBuilder.build();
       rowEnumerable = queryable.select(o -> {

--- a/core/src/main/java/org/apache/calcite/interpreter/TableScanNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/TableScanNode.java
@@ -48,7 +48,6 @@ import com.google.common.collect.Lists;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.List;
 

--- a/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
@@ -89,6 +89,19 @@ public class JavaTypeFactoryImpl
     return canonize(new JavaRecordType(list, type));
   }
 
+  @Override public RelDataType createStructType(Class type, List<Field> fields) {
+    final List<RelDataTypeField> list = new ArrayList<>();
+    for (Field field : fields) {
+      final Type fieldType = fieldType(field);
+      list.add(
+          new RelDataTypeFieldImpl(
+              field.getName(),
+              list.size(),
+              createType(fieldType)));
+    }
+    return canonize(new JavaRecordType(list, type));
+  }
+
   /** Returns the type of a field.
    *
    * <p>Takes into account {@link org.apache.calcite.adapter.java.Array}

--- a/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/JavaTypeFactoryImpl.java
@@ -75,16 +75,14 @@ public class JavaTypeFactoryImpl
 
   @Override public RelDataType createStructType(Class type) {
     final List<RelDataTypeField> list = new ArrayList<>();
-    for (Field field : type.getFields()) {
-      if (!Modifier.isStatic(field.getModifiers())) {
-        // FIXME: watch out for recursion
-        final Type fieldType = fieldType(field);
-        list.add(
-            new RelDataTypeFieldImpl(
-                field.getName(),
-                list.size(),
-                createType(fieldType)));
-      }
+    for (Field field : Types.getClassFields(type)) {
+      // FIXME: watch out for recursion
+      final Type fieldType = fieldType(field);
+      list.add(
+          new RelDataTypeFieldImpl(
+              field.getName(),
+              list.size(),
+              createType(fieldType)));
     }
     return canonize(new JavaRecordType(list, type));
   }

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.type;
 
 import org.apache.calcite.linq4j.tree.Primitive;
+import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.JavaToSqlTypeConversionRules;
@@ -490,10 +491,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
 
   private @Nullable List<RelDataTypeFieldImpl> fieldsOf(Class clazz) {
     final List<RelDataTypeFieldImpl> list = new ArrayList<>();
-    for (Field field : clazz.getFields()) {
-      if (Modifier.isStatic(field.getModifiers())) {
-        continue;
-      }
+    for (Field field : Types.getClassFields(clazz)) {
       list.add(
           new RelDataTypeFieldImpl(
               field.getName(),

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Interners;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.nio.charset.Charset;
 import java.sql.Time;
 import java.sql.Timestamp;

--- a/core/src/main/java/org/apache/calcite/runtime/RecordEnumeratorCursor.java
+++ b/core/src/main/java/org/apache/calcite/runtime/RecordEnumeratorCursor.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.runtime;
 
 import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.tree.Types;
 
 /**
  * Implementation of {@link org.apache.calcite.avatica.util.Cursor} on top of an
@@ -43,6 +44,6 @@ public class RecordEnumeratorCursor<E> extends EnumeratorCursor<E> {
   }
 
   @Override protected Getter createGetter(int ordinal) {
-    return new FieldGetter(clazz.getFields()[ordinal]);
+    return new FieldGetter(Types.getClassFields(clazz).get(ordinal));
   }
 }

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -20,6 +20,7 @@ import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.avatica.util.Spaces;
 import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.runtime.CalciteException;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlCall;
@@ -471,7 +472,7 @@ public class Util {
     } else {
       pw.print(clazz.getName());
       pw.print(" {");
-      Field[] fields = clazz.getFields();
+      Field[] fields = Types.getClassFields(clazz).toArray(new Field[0]);
       int printed = 0;
       for (Field field : fields) {
         if (Modifier.isStatic(field.getModifiers())) {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -7806,7 +7806,7 @@ public class JdbcTest {
 
   // Disable checkstyle, so it doesn't complain about fields like "customer_id".
   //CHECKSTYLE: OFF
-
+  
   public static class FoodmartJdbcSchema extends JdbcSchema {
     public FoodmartJdbcSchema(DataSource dataSource, SqlDialect dialect,
         JdbcConvention convention, String catalog, String schema) {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -7806,7 +7806,7 @@ public class JdbcTest {
 
   // Disable checkstyle, so it doesn't complain about fields like "customer_id".
   //CHECKSTYLE: OFF
-  
+
   public static class FoodmartJdbcSchema extends JdbcSchema {
     public FoodmartJdbcSchema(DataSource dataSource, SqlDialect dialect,
         JdbcConvention convention, String catalog, String schema) {

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewRelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewRelOptRulesTest.java
@@ -784,8 +784,8 @@ public class MaterializedViewRelOptRulesTest extends AbstractMaterializedViewTes
     String plan = ""
         + "EnumerableAggregate(group=[{8}], num_emps=[$SUM0($1)])\n"
         + "  EnumerableCalc(expr#0..7=[{inputs}], expr#8=[FLAG(YEAR)], "
-        + "expr#9=[FLOOR($t3, $t8)], proj#0..7=[{exprs}], $f8=[$t9])\n"
-        + "    EnumerableHashJoin(condition=[=($0, $4)], joinType=[inner])\n"
+        + "expr#9=[FLOOR($t7, $t8)], proj#0..7=[{exprs}], $f8=[$t9])\n"
+        + "    EnumerableHashJoin(condition=[=($0, $3)], joinType=[inner])\n"
         + "      EnumerableTableScan(table=[[hr, MV0]])\n"
         + "      EnumerableTableScan(table=[[hr, depts2]])\n";
     sql(m, q)

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -308,8 +308,8 @@ public class ReflectiveSchemaTest {
         .withSchema("s", new ReflectiveSchema(new DateColumnSchema()))
         .query("select * from \"s\".\"emps\"")
         .returns(""
-            + "hireDate=1970-01-01; empid=10; deptno=20; name=fred; salary=0.0; commission=null\n"
-            + "hireDate=1970-04-11; empid=10; deptno=20; name=bill; salary=0.0; commission=null\n");
+            + "empid=10; deptno=20; name=fred; salary=0.0; commission=null; hireDate=1970-01-01\n"
+            + "empid=10; deptno=20; name=bill; salary=0.0; commission=null; hireDate=1970-04-11\n");
   }
 
   /** Tests querying an object that has no public fields. */
@@ -727,7 +727,7 @@ public class ReflectiveSchemaTest {
     CalciteAssert.that()
         .withSchema("s", CATCHALL)
         .query("select * from \"s\".\"badTypes\"")
-        .returns("integer=0; bitSet={}\n");
+        .returns("bitSet={}; integer=0\n");
   }
 
   /** Tests that a schema with a field whose type cannot be recognized

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -37,11 +37,14 @@ import org.apache.calcite.test.schemata.catchall.CatchallSchema.EveryType;
 import org.apache.calcite.test.schemata.hr.Employee;
 import org.apache.calcite.test.schemata.hr.HrSchema;
 import org.apache.calcite.util.Smalls;
+import org.apache.calcite.util.Sources;
 import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
+import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -64,6 +67,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -77,6 +81,44 @@ public class ReflectiveSchemaTest {
 
   private static final ReflectiveSchema CATCHALL =
       new ReflectiveSchema(new CatchallSchema());
+
+  private static final ImmutableMap<String, String> HR_MODEL = ImmutableMap.of("model",
+      Sources.of(
+          ReflectiveSchemaTest.class.getResource(
+              "/reflective/hr-reflective-model.json")).file().getAbsolutePath());
+
+  private static final ImmutableMap<String, String> HR_MODEL_JVM = ImmutableMap.of("model",
+      Sources.of(
+          ReflectiveSchemaTest.class.getResource(
+              "/reflective/hr-reflective-model-jvm.json")).file().getAbsolutePath());
+
+  private static final ImmutableMap<String, String> HR_MODEL_EXPLICIT = ImmutableMap.of("model",
+      Sources.of(
+          ReflectiveSchemaTest.class.getResource(
+              "/reflective/hr-reflective-model-explicit.json")).file().getAbsolutePath());
+
+  private static final ImmutableMap<String, String> HR_MODEL_EXPLICIT_INCOMPLETE =
+      ImmutableMap.of(
+          "model", Sources.of(
+              ReflectiveSchemaTest.class.getResource(
+          "/reflective/hr-reflective-model-explicit-incomplete.json")).file().getAbsolutePath());
+
+  private static final ImmutableMap<String, String> HR_MODEL_EXPLICIT_TOLERANT =
+      ImmutableMap.of(
+          "model", Sources.of(
+              ReflectiveSchemaTest.class.getResource(
+          "/reflective/hr-reflective-model-explicit-tolerant.json")).file().getAbsolutePath());
+
+  private static final ImmutableMap<String, String> HR_MODEL_EXPLICIT_TOLERANT_NO_FIELDS =
+      ImmutableMap.of(
+          "model", Sources.of(
+              ReflectiveSchemaTest.class.getResource(
+          "/reflective/hr-reflective-model-explicit-no-fields.json")).file().getAbsolutePath());
+
+  private static final ImmutableMap<String, String> HR_MODEL_INVALID = ImmutableMap.of("model",
+      Sources.of(
+          ReflectiveSchemaTest.class.getResource(
+              "/reflective/hr-reflective-model-invalid.json")).file().getAbsolutePath());
 
   /**
    * Test that uses a JDBC connection as a linq4j
@@ -902,5 +944,112 @@ public class ReflectiveSchemaTest {
         .returnsUnordered(
             "EXPR$0=0",
             "EXPR$0=null");
+  }
+
+  /** Test case for reflective schema with default field ordering. */
+  @Test void testReflectiveDefaultFieldOrdering() {
+    CalciteAssert.that()
+        .with(HR_MODEL)
+        .query("select * from \"hr\".\"emps\"")
+        .returns("empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000\n"
+            + "empid=200; deptno=20; name=Eric; salary=8000.0; commission=500\n"
+            + "empid=150; deptno=10; name=Sebastian; salary=7000.0; commission=null\n"
+            + "empid=110; deptno=10; name=Theodore; salary=11500.0; commission=250\n");
+  }
+
+  /** Test case for reflective schema with JVM-dictated field ordering. */
+  @Test void testReflectiveJVMFieldOrdering() {
+    CalciteAssert.that()
+        .with(HR_MODEL_JVM)
+        .query("select * from \"hr\".\"emps\"")
+        .returns("empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000\n"
+            + "empid=200; deptno=20; name=Eric; salary=8000.0; commission=500\n"
+            + "empid=150; deptno=10; name=Sebastian; salary=7000.0; commission=null\n"
+            + "empid=110; deptno=10; name=Theodore; salary=11500.0; commission=250\n");
+  }
+
+  /** Test case for reflective schema with invalid field ordering. */
+  @Test void testReflectiveInvalidFieldOrdering() {
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> CalciteAssert.that()
+            .with(HR_MODEL_INVALID)
+            .query("select * from \"hr\".\"emps\"")
+            .returns("empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000\n"
+                + "empid=200; deptno=20; name=Eric; salary=8000.0; commission=500\n"
+                + "empid=150; deptno=10; name=Sebastian; salary=7000.0; commission=null\n"
+                + "empid=110; deptno=10; name=Theodore; salary=11500.0; commission=250\n"));
+
+    assertThat(e.getMessage(),
+        Is.is("Error instantiating JsonCustomSchema(name=hr)"));
+    assertThat(e.getCause(), Is.isA(RuntimeException.class));
+    assertThat(e.getCause().getMessage(),
+        Is.is("Error deriving fields ordering enumeration: INVALID"));
+  }
+
+  /** Test case for reflective schema with explicit field ordering. */
+  @Test void testReflectiveExplicitFieldOrdering() {
+    CalciteAssert.that()
+        .with(HR_MODEL_EXPLICIT)
+        .query("select * from \"hr\".\"emps\"")
+        .returns("empid=100; deptno=10; name=Bill; salary=10000.0; commission=1000\n"
+            + "empid=200; deptno=20; name=Eric; salary=8000.0; commission=500\n"
+            + "empid=150; deptno=10; name=Sebastian; salary=7000.0; commission=null\n"
+            + "empid=110; deptno=10; name=Theodore; salary=11500.0; commission=250\n");
+  }
+
+  /** Test case for reflective schema with explicit (incomplete) field ordering. */
+  @Test void testReflectiveExplicitFieldOrderingIncompleteListKO() {
+    SQLException e = assertThrows(SQLException.class,
+        () -> CalciteAssert.that()
+            .with(HR_MODEL_EXPLICIT_INCOMPLETE)
+            .query("select * from \"hr\".\"emps\"")
+            .returns("test throws exception"));
+
+    assertThat(e.getMessage(),
+        Is.is("Error while executing SQL \"select * from \"hr\".\"emps\"\": "
+            + "No list of fields for class org.apache.calcite.test.schemata.hr.Dependent"));
+  }
+
+  /** Test case for reflective schema with explicit (incomplete) field ordering. */
+  @Test void testReflectiveExplicitTolerantFieldOrdering() {
+    CalciteAssert.that()
+        .with(HR_MODEL_EXPLICIT_TOLERANT)
+        .query("select * from \"hr\".\"emps\"")
+        .returns("commission=1000; empid=100\n"
+            + "commission=500; empid=200\n"
+            + "commission=null; empid=150\n"
+            + "commission=250; empid=110\n");
+  }
+
+  /** Test case for reflective schema with explicit (incomplete) field ordering but no fields. */
+  @Test void testReflectiveExplicitTolerantFieldOrderingNoFieldsKO() {
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> CalciteAssert.that()
+            .with(HR_MODEL_EXPLICIT_TOLERANT_NO_FIELDS)
+            .query("select * from \"hr\".\"emps\"")
+            .returns("test throws exception"));
+
+    assertThat(e.getMessage(),
+        Is.is("Error instantiating JsonCustomSchema(name=hr)"));
+    assertThat(e.getCause(), Is.isA(RuntimeException.class));
+    assertThat(e.getCause().getMessage(),
+        Is.is("\"fields\" operand must be provided if fields ordering strategy is either "
+            + "\"EXPLICIT\" or \"EXPLICIT_TOLERANT\""));
+  }
+
+  /** Test case for reflective schema with explicit field ordering but no fields. */
+  @Test void testReflectiveExplicitFieldOrderingNoFieldsKO() {
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> CalciteAssert.that()
+            .with(HR_MODEL_EXPLICIT_TOLERANT_NO_FIELDS)
+            .query("select * from \"hr\".\"emps\"")
+            .returns("test throws exception"));
+
+    assertThat(e.getMessage(),
+        Is.is("Error instantiating JsonCustomSchema(name=hr)"));
+    assertThat(e.getCause(), Is.isA(RuntimeException.class));
+    assertThat(e.getCause().getMessage(),
+        Is.is("\"fields\" operand must be provided if fields ordering strategy is either "
+            + "\"EXPLICIT\" or \"EXPLICIT_TOLERANT\""));
   }
 }

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -114,6 +114,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -2284,7 +2285,7 @@ class UtilTest {
   /** Tests {@link org.apache.calcite.util.ReflectUtil#getParameterName}. */
   @Test void testParameterName() throws NoSuchMethodException {
     final Method method = UtilTest.class.getMethod("foo", int.class, int.class);
-    assertThat(ReflectUtil.getParameterName(method, 0), is("arg0"));
+    assertThat(ReflectUtil.getParameterName(method, 0), anyOf(is("i"), is("arg0")));
     assertThat(ReflectUtil.getParameterName(method, 1), is("j"));
   }
 

--- a/core/src/test/resources/reflective/hr-reflective-model-explicit-incomplete.json
+++ b/core/src/test/resources/reflective/hr-reflective-model-explicit-incomplete.json
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "hr",
+  "schemas": [
+    {
+      "name": "hr",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
+      "operand": {
+        "class": "org.apache.calcite.test.schemata.hr.HrSchema",
+        "fieldsOrdering": "EXPLICIT",
+        "fields": {
+          "org.apache.calcite.test.schemata.hr.HrSchema": [
+            "emps",
+            "depts",
+            "dependents",
+            "locations"
+          ],
+          "org.apache.calcite.test.schemata.hr.Employee": ["deptno", "name", "salary", "commission"]
+        }
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/reflective/hr-reflective-model-explicit-no-fields.json
+++ b/core/src/test/resources/reflective/hr-reflective-model-explicit-no-fields.json
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "hr",
+  "schemas": [
+    {
+      "name": "hr",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
+      "operand": {
+        "class": "org.apache.calcite.test.schemata.hr.HrSchema",
+        "fieldsOrdering": "EXPLICIT_TOLERANT"
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/reflective/hr-reflective-model-explicit-tolerant.json
+++ b/core/src/test/resources/reflective/hr-reflective-model-explicit-tolerant.json
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "hr",
+  "schemas": [
+    {
+      "name": "hr",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
+      "operand": {
+        "class": "org.apache.calcite.test.schemata.hr.HrSchema",
+        "fieldsOrdering": "EXPLICIT_TOLERANT",
+        "fields": {
+          "org.apache.calcite.test.schemata.hr.HrSchema": ["emps", "locations"],
+          "org.apache.calcite.test.schemata.hr.Employee": ["commission", "empid"]
+        }
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/reflective/hr-reflective-model-explicit.json
+++ b/core/src/test/resources/reflective/hr-reflective-model-explicit.json
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "hr",
+  "schemas": [
+    {
+      "name": "hr",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
+      "operand": {
+        "class": "org.apache.calcite.test.schemata.hr.HrSchema",
+        "fieldsOrdering": "EXPLICIT",
+        "fields": {
+          "org.apache.calcite.test.schemata.hr.HrSchema": ["emps", "depts", "dependents", "locations"],
+          "org.apache.calcite.test.schemata.hr.Employee": ["empid", "deptno", "name", "salary", "commission"],
+          "org.apache.calcite.test.schemata.hr.Department": ["deptno", "name", "employees", "location"],
+          "org.apache.calcite.test.schemata.hr.Location": ["x", "y"],
+          "org.apache.calcite.test.schemata.hr.Dependent": ["name", "empid"]
+        }
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/reflective/hr-reflective-model-invalid.json
+++ b/core/src/test/resources/reflective/hr-reflective-model-invalid.json
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "hr",
+  "schemas": [
+    {
+      "name": "hr",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
+      "operand": {
+        "class": "org.apache.calcite.test.schemata.hr.HrSchema",
+        "fieldsOrdering": "INVALID"
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/reflective/hr-reflective-model-jvm.json
+++ b/core/src/test/resources/reflective/hr-reflective-model-jvm.json
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "hr",
+  "schemas": [
+    {
+      "name": "hr",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
+      "operand": {
+        "class": "org.apache.calcite.test.schemata.hr.HrSchema",
+        "fieldsOrdering": "JVM"
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/reflective/hr-reflective-model.json
+++ b/core/src/test/resources/reflective/hr-reflective-model.json
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "hr",
+  "schemas": [
+    {
+      "name": "hr",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.java.ReflectiveSchema$Factory",
+      "operand": {
+        "class": "org.apache.calcite.test.schemata.hr.HrSchema"
+      }
+    }
+  ]
+}

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/util/JavaTypeFactoryExtImpl.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/util/JavaTypeFactoryExtImpl.java
@@ -27,7 +27,6 @@ import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.geode.pdx.PdxInstance;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/util/JavaTypeFactoryExtImpl.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/util/JavaTypeFactoryExtImpl.java
@@ -19,6 +19,7 @@ package org.apache.calcite.adapter.geode.util;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.jdbc.JavaRecordType;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
@@ -41,23 +42,17 @@ import java.util.Map;
 public class JavaTypeFactoryExtImpl
     extends JavaTypeFactoryImpl {
 
-  /**
-   * See <a href="http://stackoverflow.com/questions/16966629/what-is-the-difference-between-getfields-and-getdeclaredfields-in-java-reflectio">
-   *   the difference between fields and declared fields</a>.
-   */
   @Override public RelDataType createStructType(Class type) {
 
     final List<RelDataTypeField> list = new ArrayList<>();
-    for (Field field : type.getDeclaredFields()) {
-      if (!Modifier.isStatic(field.getModifiers())) {
-        // FIXME: watch out for recursion
-        final Type fieldType = field.getType();
-        list.add(
-            new RelDataTypeFieldImpl(
-                field.getName(),
-                list.size(),
-                createType(fieldType)));
-      }
+    for (Field field : Types.getClassFields(type, false)) {
+      // FIXME: watch out for recursion
+      final Type fieldType = field.getType();
+      list.add(
+          new RelDataTypeFieldImpl(
+              field.getName(),
+              list.size(),
+              createType(fieldType)));
     }
     return canonize(new JavaRecordType(list, type));
   }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstantExpression.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstantExpression.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -197,7 +196,7 @@ public class ConstantExpression extends Expression {
     if (constructor != null) {
       writer.append("new ").append(value.getClass());
       list(writer,
-          Arrays.stream(value.getClass().getFields())
+          Types.getClassFields(value.getClass()).stream()
               // <@Nullable Object> is needed for CheckerFramework
               .<@Nullable Object>map(field -> {
                 try {
@@ -281,8 +280,9 @@ public class ConstantExpression extends Expression {
   }
 
   private static @Nullable Constructor matchingConstructor(Object value) {
-    final Field[] fields = value.getClass().getFields();
-    for (Constructor<?> constructor : value.getClass().getConstructors()) {
+    final Class<?> clazz = value.getClass();
+    final Field[] fields = Types.getClassFields(clazz).toArray(new Field[0]);
+    for (Constructor<?> constructor : clazz.getConstructors()) {
       if (argsMatchFields(fields, constructor.getParameterTypes())) {
         return constructor;
       }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
@@ -457,7 +457,7 @@ public abstract class Types {
   }
 
   public static Field nthField(int ordinal, Class clazz) {
-    return clazz.getFields()[ordinal];
+    return getClassFields(clazz).get(ordinal);
   }
 
   public static PseudoField nthField(int ordinal, Type clazz) {
@@ -465,7 +465,7 @@ public abstract class Types {
       RecordType recordType = (RecordType) clazz;
       return recordType.getRecordFields().get(ordinal);
     }
-    return field(toClass(clazz).getFields()[ordinal]);
+    return field(getClassFields(toClass(clazz)).get(ordinal));
   }
 
   public static boolean allAssignable(boolean varArgs, Class[] parameterTypes,

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Types.java
@@ -177,7 +177,7 @@ public abstract class Types {
    * @return the list of fields of a given class.
    */
   public static List<Field> getClassFields(Class type, boolean useHierarchy) {
-    return getClassFields(type, useHierarchy, FieldsOrdering.JVM, null);
+    return getClassFields(type, useHierarchy, FieldsOrdering.CONSTRUCTOR, null);
   }
 
   /**

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/tree/TypeTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/tree/TypeTest.java
@@ -17,13 +17,34 @@
 package org.apache.calcite.linq4j.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 
 /**
  * Test for {@link Types#gcd}.
  */
 class TypeTest {
+
   @Test void testGcd() {
     int i = 0;
     char c = 0;
@@ -62,4 +83,236 @@ class TypeTest {
     assertEquals(Object.class, Types.gcd(String.class, int.class));
     java.io.Serializable o = true ? "x" : 1;
   }
+
+  private static void assertFields(List<Field> expected, List<Field> computed) {
+    assertEquals(expected, computed, "Expected field(s) ["
+        + expected + "] but found [" + computed + "]");
+  }
+
+  @Test void testExcludedStaticFieldsAndViaAnnotation() throws NoSuchFieldException {
+    List<Field> fieldNames = Collections.singletonList(A.class.getField("strField"));
+
+    assertFields(fieldNames, Types.getClassFields(A.class));
+  }
+
+  @Test void testAlphabeticalAndHierarchicalOrder() throws NoSuchFieldException {
+    List<Field> fieldNames = Arrays.asList(AB.class.getField("aField"),
+        A.class.getField("strField"),
+        AB.class.getField("zField"));
+
+    assertFields(
+        fieldNames, Types.getClassFields(AB.class, true,
+        Types.FieldsOrdering.ALPHABETICAL, null));
+  }
+
+  @Test void testOrderViaFieldNamesAndClassHierarchy() throws NoSuchFieldException {
+    List<Field> fieldNames = Arrays.asList(A.class.getField("strField"),
+        AB.class.getField("aField"),
+        AB.class.getField("zField"));
+
+    assertFields(
+        fieldNames, Types.getClassFields(AB.class, true,
+        Types.FieldsOrdering.ALPHABETICAL_AND_HIERARCHY, null));
+  }
+
+  @Test void testNoHierarchyConstructorAlphabetical() throws NoSuchFieldException {
+    List<Field> fieldNames = Arrays.asList(AB.class.getField("aField"),
+        AB.class.getField("zField"));
+
+    assertFields(
+        fieldNames, Types.getClassFields(AB.class, false,
+        Types.FieldsOrdering.CONSTRUCTOR, null));
+  }
+
+  @TestIfParameterNames(clazz = AC.class)
+  void testNoHierarchyConstructorInDeclarationOrder() throws NoSuchFieldException {
+    List<Field> fieldNames = Arrays.asList(AC.class.getField("zField"),
+        AC.class.getField("aField"));
+
+    assertFields(
+        fieldNames, Types.getClassFields(AC.class, false,
+        Types.FieldsOrdering.CONSTRUCTOR, null));
+  }
+
+
+  @TestIfParameterNames(clazz = AB.class)
+  void testHierarchyConstructorAlphabetical() throws NoSuchFieldException {
+    List<Field> fieldNames = Arrays.asList(AB.class.getField("aField"),
+        AB.class.getField("zField"),
+        A.class.getField("strField"));
+
+    assertFields(
+        fieldNames, Types.getClassFields(AB.class, true,
+        Types.FieldsOrdering.CONSTRUCTOR, null));
+  }
+
+  @TestIfParameterNames(clazz = AC.class)
+  void testHierarchyConstructorInDeclarationOrder() throws NoSuchFieldException {
+    List<Field> fieldNames = Arrays.asList(A.class.getField("strField"),
+        AC.class.getField("zField"),
+        AC.class.getField("aField"));
+
+    assertFields(
+        fieldNames, Types.getClassFields(AC.class, true,
+            Types.FieldsOrdering.CONSTRUCTOR, null));
+  }
+
+  @TestIfParameterNames(clazz = AD.class)
+  void testIncompleteConstructors() throws NoSuchFieldException {
+    List<Field> fieldNames = Arrays.asList(A.class.getField("strField"),
+        AD.class.getField("zField"),
+        AD.class.getField("aField"));
+
+    assertFields(
+        fieldNames, Types.getClassFields(AD.class, true,
+            Types.FieldsOrdering.CONSTRUCTOR, null));
+  }
+
+  @Test void testExplicitFieldNames() throws NoSuchFieldException {
+    Map<Class, List<Field>> classFieldsMap = new HashMap<>();
+    List<Field> fieldNames = Arrays.asList(AC.class.getField("zField"),
+        A.class.getField("strField"),
+        AC.class.getField("aField"));
+    classFieldsMap.put(AC.class, fieldNames);
+
+    assertFields(
+        fieldNames, Types.getClassFields(AC.class, true,
+            Types.FieldsOrdering.EXPLICIT, classFieldsMap));
+  }
+
+  @Test void testExplicitFieldNamesIncompleteKO() throws NoSuchFieldException {
+    Map<Class, List<Field>> classFieldsMap = new HashMap<>();
+    List<Field> fieldNames = Arrays.asList(AC.class.getField("zField"),
+        A.class.getField("strField"));
+    classFieldsMap.put(AC.class, fieldNames);
+
+    Types.FieldsOrdering explicitFieldsOrdering = Types.FieldsOrdering.EXPLICIT;
+
+    IllegalArgumentException thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> Types.getClassFields(AC.class, true, explicitFieldsOrdering, classFieldsMap),
+        "Expected 'Types.getClassFields' to throw on incomplete field list"
+    );
+
+    String expectedErrorPrefix = "Incomplete list of fields is not compatible with \""
+        + explicitFieldsOrdering + "\"";
+    assertTrue(thrown.getMessage().contains(expectedErrorPrefix));
+  }
+
+  @Test void testExplicitTolerantFieldNamesIncomplete() throws NoSuchFieldException {
+    Map<Class, List<Field>> classFieldsMap = new HashMap<>();
+    List<Field> fieldNames = Arrays.asList(AC.class.getField("zField"),
+        A.class.getField("strField"));
+    classFieldsMap.put(AC.class, fieldNames);
+
+    assertFields(
+        fieldNames, Types.getClassFields(AC.class, true,
+            Types.FieldsOrdering.EXPLICIT_TOLERANT, classFieldsMap));
+  }
+
+  /** Parent class with ignored (static and private) fields. */
+  @SuppressWarnings({"unused", "NotNullFieldNotInitialized"})
+  private static class A {
+    public String strField;
+    public static Integer staticField;
+    private long privateField;
+
+    A(String strField, long privateField){
+    }
+
+    A(String strField){
+    }
+  }
+
+  /** Second-level derived class, constructor with parameters in different order than
+   * alphabetical order and declaration order. */
+  @SuppressWarnings({"unused", "NotNullFieldNotInitialized"})
+  private static class AA extends A {
+    public Integer aField;
+    public String zField;
+
+    AA(String strField, String zField, String aField) {
+      super(strField);
+    }
+  }
+
+  /** Second level derived class, one constructor in alphabetical order,
+   * different than declaration order, the other one in alphabetical but
+   * respecting the class hierarchy. */
+  @SuppressWarnings({"unused", "NotNullFieldNotInitialized"})
+  private static class AB extends A {
+    public String zField;
+    public Integer aField;
+
+    AB(Integer aField, String zField, String strField) {
+      super(strField);
+    }
+
+    AB(String strField, Integer aField, String zField) {
+      super(strField);
+    }
+  }
+
+  /** Second level derived class, multiple constructors. */
+  @SuppressWarnings({"unused", "NotNullFieldNotInitialized"})
+  private static class AC extends A {
+    public String zField;
+    public Integer aField;
+
+    AC(String strField) {
+      super(strField);
+    }
+
+    AC(String strField, String zField, Integer aField) {
+      super(strField);
+    }
+
+    AC(String strField, Integer aField, String unrelatedField, String unrelatedField2) {
+      super(strField);
+    }
+  }
+
+  /** Second level derived class, constructors do not cover all fields. */
+  @SuppressWarnings({"unused", "NotNullFieldNotInitialized"})
+  private static class AD extends A {
+    public String zField;
+    public Integer aField;
+
+    AD(String strField, String zField) {
+      super(strField);
+    }
+
+    AD(String strField, Integer aField, String unrelatedField, String unrelatedField2) {
+      super(strField);
+    }
+  }
+}
+
+/**
+ * Enables the test conditionally if parameter names are available.
+ */
+class RequiresParameterNamesCondition implements ExecutionCondition {
+  @Override public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    return context.getElement()
+        .flatMap(element ->
+            AnnotationSupport.findAnnotation(element, TestIfParameterNames.class))
+        .map(pnc -> {
+          if (pnc.clazz().getDeclaredConstructors()[0].getParameters()[0].isNamePresent()) {
+            return enabled("Parameter names available for class " + pnc.clazz().getName());
+          }
+          return disabled("Parameter names are not available for class " + pnc.clazz().getName());
+        })
+        .orElseGet(() -> enabled("@RequiresParameterNames not found"));
+  }
+}
+
+/**
+ * Enables the test conditionally if parameter names are available for the given class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@Test
+@ExtendWith(RequiresParameterNamesCondition.class)
+@interface TestIfParameterNames {
+  Class clazz();
 }


### PR DESCRIPTION
### Summary:

The PR follows the approach suggested in the ML [discussion](https://mail-archives.apache.org/mod_mbox/calcite-dev/202102.mbox/%3CCAFtOckKUyaqBHe3q66svZWyX77Zwj0Kc_D4%2B49m75SthuPj%2BGQ%40mail.gmail.com%3E) from several months ago.

In a nutshell, the output of `Class.getFields()` is JVM implementation-specific without any guarantees on the field ordering, the PR aims at providing a deterministic and stable ordering.

`ReflectiveSchema` is where users can define a schema starting from a Java class. Now the schema descriptor has an extra parameter for specifying the sought parameter ordering, among the followings:

- JVM: same as Class.getFields()
- ALPHABETICAL: alphabetical order
- ALPHABETICAL_AND_HIERARCHY: alphabetical order but inherited fields come first
- CONSTRUCTOR: order is taken from the constructor matching the highest number of fields
- EXPLICIT: field ordering is explicitly provided
- EXPLICIT_TOLERANT: field ordering is explicitly provided, but can be incomplete

`CONSTRUCTOR` is being used as default ordering (it generally matches the order of the declared fields, which is what all the JVM implementations I could test use, thus ensuring the least number of diff in existing unit tests), and `ALPHABETICAL_AND_HIERARCHY` as a fallback ordering for classes lacking the name of the parameters in their constructor(s).

This requires adding the `-parameters` compilation parameter to Calcite (see the details in the section below). If this is unwanted, we could switch to another ordering option (e.g., `ALPHABETICAL_AND_HIERARCHY`) and either use the `JVM` option for the existing unit tests, or we could update their expected results.

### Walkthrough of the commits in the PR (from "older" to "newer"):

1.  implementation of the replacement for `Class.getFields()` for `ReflectiveSchema` and the auxiliary methods in `Types` helper class
2. added unit tests covering the aforementioned changes
3. replacing `Class.getFields()` and `Class.getDeclaredFields()` anywhere in the code where the "order" of such fields matters
4. added `-parameters` compilation parameter to enrich Calcite's classes with parameters names for their constructors (more details are in the aforementioned ML discussion) and constructor-based field ordering as default
5. adapted few existing unit tests due to changes in field order coming from (4)

### How the PR was tested:

Several unit tests have been added, covering all the new or changed features, tests are passing locally and in CI.