### PR TITLE
[CALCITE-4741] AbstractRelNode#getId can overflow into a negative value causing CompileException in certain Enumerable implement methods

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
@@ -167,7 +167,7 @@ public class EnumerableBatchNestedLoopJoin extends Join implements EnumerableRel
     ParameterExpression corrArg;
     final ParameterExpression corrArgList =
         Expressions.parameter(Modifier.FINAL,
-            List.class, "corrList" + this.getId());
+            List.class, "corrList" + Integer.toUnsignedString(this.getId()));
 
     // Declare batchSize correlation variables
     if (!Primitive.is(corrVarType)) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeUnion.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeUnion.java
@@ -73,7 +73,7 @@ public class EnumerableMergeUnion extends EnumerableUnion {
 
     final ParameterExpression inputListExp = Expressions.parameter(
         List.class,
-        builder.newName("mergeUnionInputs" + getId()));
+        builder.newName("mergeUnionInputs" + Integer.toUnsignedString(this.getId())));
     builder.add(Expressions.declare(0, inputListExp, Expressions.new_(ArrayList.class)));
 
     for (Ord<RelNode> ord : Ord.zip(inputs)) {


### PR DESCRIPTION
See [CALCITE-4741](https://issues.apache.org/jira/browse/CALCITE-4741)