### PR TITLE
[CALCITE-4773] RelDecorrelator's RemoveSingleAggregateRule can produce result with wrong row type

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -1861,10 +1861,28 @@ public class RelDecorrelator implements ReflectiveVisitor {
   }
 
   /**
-   * Rule to remove single_value rel. For cases like
+   * Rule to remove an Aggregate with SINGLE_VALUE. For cases like:
    *
-   * <blockquote>AggRel single_value proj/filter/agg/ join on unique LHS key
-   * AggRel single group</blockquote>
+   * Aggregate(SINGLE_VALUE)
+   *   Project(single expression)
+   *     Aggregate
+   *
+   * For instance (subtree taken from TPCH query 17):
+   *
+   * LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+   *   LogicalProject(EXPR$0=[*(0.2:DECIMAL(2, 1), $0)])
+   *     LogicalAggregate(group=[{}], agg#0=[AVG($0)])
+   *       LogicalProject(L_QUANTITY=[$4])
+   *         LogicalFilter(condition=[=($1, $cor0.P_PARTKEY)])
+   *           LogicalTableScan(table=[[TPCH_01, LINEITEM]])
+   *
+   * Will be converted into:
+   *
+   * LogicalProject($f0=[*(0.2:DECIMAL(2, 1), $0)])
+   *   LogicalAggregate(group=[{}], agg#0=[AVG($0)])
+   *     LogicalProject(L_QUANTITY=[$4])
+   *       LogicalFilter(condition=[=($1, $cor0.P_PARTKEY)])
+   *         LogicalTableScan(table=[[TPCH_01, LINEITEM]])
    */
   public static final class RemoveSingleAggregateRule
       extends RelRule<RemoveSingleAggregateRule.Config> {
@@ -1883,11 +1901,11 @@ public class RelDecorrelator implements ReflectiveVisitor {
     }
 
     @Override public void onMatch(RelOptRuleCall call) {
-      Aggregate singleAggregate = call.rel(0);
-      Project project = call.rel(1);
-      Aggregate aggregate = call.rel(2);
+      final Aggregate singleAggregate = call.rel(0);
+      final Project project = call.rel(1);
+      final Aggregate aggregate = call.rel(2);
 
-      // check singleAggRel is single_value agg
+      // check the top aggregate is a single value agg function
       if (!singleAggregate.getGroupSet().isEmpty()
           || (singleAggregate.getAggCallList().size() != 1)
           || !(singleAggregate.getAggCallList().get(0).getAggregation()
@@ -1895,10 +1913,8 @@ public class RelDecorrelator implements ReflectiveVisitor {
         return;
       }
 
-      // check projRel only projects one expression
-      // check this project only projects one expression, i.e. scalar
-      // sub-queries.
-      List<RexNode> projExprs = project.getProjects();
+      // check the project only projects one expression, i.e. scalar sub-queries.
+      final List<RexNode> projExprs = project.getProjects();
       if (projExprs.size() != 1) {
         return;
       }
@@ -1908,16 +1924,15 @@ public class RelDecorrelator implements ReflectiveVisitor {
         return;
       }
 
-      // singleAggRel produces a nullable type, so create the new
-      // projection that casts proj expr to a nullable type.
+      // ensure we keep the same type after removing the SINGLE_VALUE Aggregate
       final RelBuilder relBuilder = call.builder();
-      final RelDataType type =
-          relBuilder.getTypeFactory()
-              .createTypeWithNullability(projExprs.get(0).getType(), true);
-      final RexNode cast =
-          relBuilder.getRexBuilder().makeCast(type, projExprs.get(0));
-      relBuilder.push(aggregate)
-          .project(cast);
+      final RelDataType singleAggType =
+          singleAggregate.getRowType().getFieldList().get(0).getType();
+      final RexNode oldProjectExp = projExprs.get(0);
+      final RexNode newProjectExp = singleAggType.equals(oldProjectExp.getType())
+              ? oldProjectExp
+              : relBuilder.getRexBuilder().makeCast(singleAggType, oldProjectExp);
+      relBuilder.push(aggregate).project(newProjectExp);
       call.transformTo(relBuilder.build());
     }
 

--- a/core/src/test/resources/sql/unnest.iq
+++ b/core/src/test/resources/sql/unnest.iq
@@ -223,4 +223,23 @@ FROM UNNEST(array [0, 2, 4, 4, 5]) as x;
 
 !ok
 
+!use bookstore
+
+# [CALCITE-4773] RelDecorrelator's RemoveSingleAggregateRule can produce result with wrong row type
+SELECT au."name"
+FROM "bookstore"."authors" au
+WHERE (
+    SELECT COUNT(*) > 0
+    FROM UNNEST(au."books") AS "unnested"("title", "year", "pages")
+    WHERE "unnested"."year" < 1920
+);
++-------------+
+| name        |
++-------------+
+| Victor Hugo |
++-------------+
+(1 row)
+
+!ok
+
 # End unnest.iq


### PR DESCRIPTION
See Jira: [CALCITE-4773](https://issues.apache.org/jira/browse/CALCITE-4773)