### PR TITLE
[CALCITE-4784] Ensure Correlate#requiredColumns is subset of columns in left relation

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
@@ -122,7 +122,10 @@ public abstract class Correlate extends BiRel {
   //~ Methods ----------------------------------------------------------------
 
   @Override public boolean isValid(Litmus litmus, @Nullable Context context) {
+    ImmutableBitSet leftColumns = ImmutableBitSet.range(left.getRowType().getFieldCount());
     return super.isValid(litmus, context)
+        && litmus.check(leftColumns.contains(requiredColumns),
+        "Required columns {} not subset of left columns {}", requiredColumns, leftColumns)
         && RelOptUtil.notContainsCorrelation(left, correlationId, litmus);
   }
 


### PR DESCRIPTION
Enforce the implicit class invariant (see Correlate#getRequiredColumns) via assertion to prevent construction of invalid plans and fail fast.