### PR TITLE
[CALCITE-4532] Correct code generated for primitive-object ConstantExpression

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -7762,6 +7762,12 @@ public class JdbcTest {
     assertThat.query(query).returns("id=2008-03-31 12:23:34\nid=2018-02-03 00:00:00\n");
   }
 
+  @Test public void testNestedCastBigInt() {
+    CalciteAssert.AssertThat assertThat = CalciteAssert.that();
+    String query = "SELECT CAST(CAST(4200000000 AS BIGINT) AS ANY) FROM (VALUES(1))";
+    assertThat.query(query).returns("EXPR$0=4200000000\n");
+  }
+
   private static String sums(int n, boolean c) {
     final StringBuilder b = new StringBuilder();
     for (int i = 0; i < n; i++) {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstantExpression.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ConstantExpression.java
@@ -136,6 +136,10 @@ public class ConstantExpression extends Expression {
       write(writer, value, primitive2.primitiveClass);
       return writer.append(")");
     }
+    Primitive primitive3 = Primitive.ofBox(value.getClass());
+    if (Object.class.equals(type) && primitive3 != null) {
+      return write(writer, value, primitive3.primitiveClass);
+    }
     if (value instanceof Enum) {
       return writer.append(((Enum) value).getDeclaringClass())
           .append('.')
@@ -206,6 +210,7 @@ public class ConstantExpression extends Expression {
           "(\n", ",\n", ")");
       return writer;
     }
+
     return writer.append(value);
   }
 

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/ExpressionTest.java
@@ -1357,6 +1357,21 @@ public class ExpressionTest {
         Expressions.toString(Expressions.constant(12.34, BigDecimal.class)));
   }
 
+  @Test void testObjectConstantExpression() {
+    assertEquals("(byte)100",
+        Expressions.toString(Expressions.constant((byte) 100, Object.class)));
+    assertEquals("(char)100",
+        Expressions.toString(Expressions.constant((char) 100, Object.class)));
+    assertEquals("(short)100",
+        Expressions.toString(Expressions.constant((short) 100, Object.class)));
+    assertEquals("100L",
+        Expressions.toString(Expressions.constant(100L, Object.class)));
+    assertEquals("100.0F",
+        Expressions.toString(Expressions.constant(100F, Object.class)));
+    assertEquals("100.0D",
+        Expressions.toString(Expressions.constant(100D, Object.class)));
+  }
+
   @Test void testClassDecl() {
     final NewExpression newExpression =
         Expressions.new_(


### PR DESCRIPTION
[CALCITE-4532](https://issues.apache.org/jira/browse/CALCITE-4532)