### PR TITLE
[CALCITE-4790] Make Gradle pass the 'user.timezone' to test JVM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -718,6 +718,7 @@ allprojects {
                 passProperty("junit.jupiter.execution.timeout.default", "5 m")
                 passProperty("user.language", "TR")
                 passProperty("user.country", "tr")
+                passProperty("user.timezone", "UTC")
                 val props = System.getProperties()
                 for (e in props.propertyNames() as `java.util`.Enumeration<String>) {
                     if (e.startsWith("calcite.") || e.startsWith("avatica.")) {


### PR DESCRIPTION
[CALCITE-4790] Make Gradle pass the 'user.timezone' property to the test JVM