### PR TITLE
[CALCITE-4796] Travis links in README.md are broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 -->
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.calcite/calcite-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.calcite/calcite-core)
-[![Travis Build Status](https://travis-ci.org/apache/calcite.svg?branch=master)](https://travis-ci.org/apache/calcite)
+[![Travis Build Status](https://app.travis-ci.com/apache/calcite.svg?branch=master)](https://app.travis-ci.com/github/apache/calcite)
 [![CI Status](https://github.com/apache/calcite/workflows/CI/badge.svg?branch=master)](https://github.com/apache/calcite/actions?query=branch%3Amaster)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/apache/calcite?svg=true&branch=master)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/calcite)
 


### PR DESCRIPTION
CALCITE-4796 Travis links in README.md should point to 'app.travis-ci.com' instead of 'travis-ci.org'