### PR TITLE
[CALCITE-4793] Fix Cassandra and ElasticSearch tests

### DIFF
--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchNode.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchNode.java
@@ -19,7 +19,6 @@ package org.apache.calcite.adapter.elasticsearch;
 import org.apache.calcite.util.TestUtil;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.Files;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -34,6 +33,8 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.Netty4Plugin;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,10 +76,16 @@ class EmbeddedElasticsearchNode implements AutoCloseable {
    * @return instance which needs to be explicitly started (using {@link #start()})
    */
   public static synchronized EmbeddedElasticsearchNode create() {
-    File data = Files.createTempDir();
-    data.deleteOnExit();
-    File home = Files.createTempDir();
-    home.deleteOnExit();
+    File data;
+    File home;
+    try {
+      data = Files.createTempDirectory("es-data").toFile();
+      data.deleteOnExit();
+      home = Files.createTempDirectory("es-home").toFile();
+      home.deleteOnExit();
+    } catch (IOException e) {
+      throw TestUtil.rethrow(e);
+    }
 
     Settings settings = Settings.builder()
         .put("node.name", "fake-elastic")


### PR DESCRIPTION
The PR comprises two commits:

1. ElasticSearch: Replace deprecated `com.google.common.io.Files.createTempDir()` with `java.nio.file.Files.createTempDirectory()` in ElasticSearch tests

2. Cassandra: Finally the test failure for Cassandra was related to retrieving a timestamp, whose result depends on the user timezone (that's why it was failing on different timezones). The solution is to dynamically compute the expected timestamp output value depending on the user timezone.

The changes have been validated locally as follow to cover different guava versions and timezones (for the latter, I have applied the patch from #2534):

```bash
guavas=(19.0 25.0-jre 30.1.1-jre)
timezones=(America/New_York UTC GMT Europe/Paris America/Los_Angeles)

for g in ${guavas[@]}; do
  for tz in ${timezones[@]}; do
    ./gradlew --no-build-cache cleanTest test -Pguava.version=$g -Duser.timezone=$tz -q > /dev/null 2>&1
    if [ $? -eq 1 ]
    then
     echo "guava $g with tz $tz failed"
    else
     echo "guava $g with tz $tz succeeded"
    fi
  done
done

```
Output:
> guava 19.0 with tz America/New_York succeeded
> guava 19.0 with tz UTC succeeded
> guava 19.0 with tz GMT succeeded
> guava 19.0 with tz Europe/Paris succeeded
> guava 19.0 with tz America/Los_Angeles succeeded
> guava 25.0-jre with tz America/New_York succeeded
> guava 25.0-jre with tz UTC succeeded
> guava 25.0-jre with tz GMT succeeded
> guava 25.0-jre with tz Europe/Paris succeeded
> guava 25.0-jre with tz America/Los_Angeles succeeded
> guava 30.1.1-jre with tz America/New_York succeeded
> guava 30.1.1-jre with tz UTC succeeded
> guava 30.1.1-jre with tz GMT succeeded
> guava 30.1.1-jre with tz Europe/Paris succeeded
> guava 30.1.1-jre with tz America/Los_Angeles succeeded
> 