### PR TITLE
[CALCITE-4602] Array could contain int and float elements

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -200,6 +200,11 @@ public abstract class Bug {
    * Druid plans with small intervals should be chosen over full interval scan plus filter</a> is
    * fixed. */
   public static final boolean CALCITE_4213_FIXED = false;
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4602">[CALCITE-4602]
+   * ClassCastException for arrays with int and decimal elements within one array</a>
+   * is fixed. */
+  public static final boolean CALCITE_4602_FIXED = false;
 
   /**
    * Use this to flag temporary code.

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -7768,6 +7768,15 @@ public class JdbcTest {
     assertThat.query(query).returns("EXPR$0=4200000000\n");
   }
 
+  @Test public void testIntAndBigDecimalInArray() {
+    if (!Bug.CALCITE_4602_FIXED) {
+      return;
+    }
+    CalciteAssert.that()
+        .query("select array[1, 1.1]")
+        .returns("EXPR$0=[1, 1.1]\n");
+  }
+
   private static String sums(int n, boolean c) {
     final StringBuilder b = new StringBuilder();
     for (int i = 0; i < n; i++) {


### PR DESCRIPTION
The PR adds [[4602]](https://issues.apache.org/jira/browse/CALCITE-4602) bug to JdbcTest.
