### PR TITLE
[CALCITE-4808] Throwing exception for multiple ids in Relbuilder.join

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -4385,7 +4385,7 @@ public abstract class RelOptUtil {
         final RexCorrelVariable v =
             (RexCorrelVariable) fieldAccess.getReferenceExpr();
         assert variables.contains(v.id) || !variableFields.containsKey(v.id)
-            : "Correlate Id used out of scope";
+            : "correlate id used out of scope";
         variableFields.put(v.id, fieldAccess.getField().getIndex());
       }
       return super.visitFieldAccess(fieldAccess);
@@ -4703,7 +4703,7 @@ public abstract class RelOptUtil {
 
     @Override public RelNode visit(RelNode other) {
       assert Sets.intersection(other.getVariablesSet(), vuv.variables).isEmpty()
-          : "Correlate Id used out of scope";
+          : "correlate id used out of scope";
       other.collectVariablesUsed(vuv.variables);
       other.accept(vuv);
       RelNode result = super.visit(other);

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -279,6 +279,22 @@ public abstract class RelOptUtil {
     return visitor.vuv.variables;
   }
 
+  /**
+   * Returns a set of variables used by a relational expression or its
+   * descendants.
+   *
+   * <p>The set may contain "duplicates" (variables with different ids that,
+   * when resolved, will reference the same source relational expression).
+   *
+   * <p>The item type is the same as
+   * {@link org.apache.calcite.rex.RexCorrelVariable#id}.
+   */
+  public static Set<CorrelationId> getVariablesUsed(RexNode rex) {
+    CorrelationCollector visitor = new CorrelationCollector();
+    rex.accept(visitor.vuv);
+    return visitor.vuv.variables;
+  }
+
   /** Finds which columns of a correlation variable are used within a
    * relational expression. */
   public static ImmutableBitSet correlationColumns(CorrelationId id,

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -107,6 +107,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 
 import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
@@ -4383,6 +4384,8 @@ public abstract class RelOptUtil {
       if (fieldAccess.getReferenceExpr() instanceof RexCorrelVariable) {
         final RexCorrelVariable v =
             (RexCorrelVariable) fieldAccess.getReferenceExpr();
+        assert variables.contains(v.id) || !variableFields.containsKey(v.id)
+            : "Correlate Id used out of scope";
         variableFields.put(v.id, fieldAccess.getField().getIndex());
       }
       return super.visitFieldAccess(fieldAccess);
@@ -4699,6 +4702,8 @@ public abstract class RelOptUtil {
     private final VariableUsedVisitor vuv = new VariableUsedVisitor(this);
 
     @Override public RelNode visit(RelNode other) {
+      assert Sets.intersection(other.getVariablesSet(), vuv.variables).isEmpty()
+          : "Correlate Id used out of scope";
       other.collectVariablesUsed(vuv.variables);
       other.accept(vuv);
       RelNode result = super.visit(other);

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -3494,12 +3494,17 @@ public class RelBuilder {
    *   {@link CorrelationId} is present and the {@link JoinRelType} is FULL or RIGHT.
    */
   private static boolean checkIfCorrelated(Set<CorrelationId> variablesSet,
-      JoinRelType joinType, RelNode leftNode, RelNode rightRel) {
-    if (variablesSet.size() != 1) {
+      JoinRelType joinType, RelNode leftRel, RelNode rightRel) {
+    if (variablesSet.isEmpty()) {
       return false;
+    } else if (variablesSet.size() != 1) {
+      String idsString = variablesSet.stream()
+          .map(Object::toString)
+          .collect(Collectors.joining(", "));
+      throw new IllegalArgumentException("multiple correlate ids not supported: " + idsString);
     }
     CorrelationId id = Iterables.getOnlyElement(variablesSet);
-    if (!RelOptUtil.notContainsCorrelation(leftNode, id, Litmus.IGNORE)) {
+    if (!RelOptUtil.notContainsCorrelation(leftRel, id, Litmus.IGNORE)) {
       throw new IllegalArgumentException("variable " + id
           + " must not be used by left input to correlation");
     }

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -71,12 +71,14 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCallBinding;
 import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexExecutor;
+import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexFieldCollation;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.rex.RexSimplify;
+import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.rex.RexWindowBounds;
@@ -454,6 +456,20 @@ public class RelBuilder {
   public RelBuilder variable(Holder<RexCorrelVariable> v) {
     v.set((RexCorrelVariable)
         getRexBuilder().makeCorrel(peek().getRowType(),
+            cluster.createCorrel()));
+    return this;
+  }
+
+  /** Creates a correlation variable for the current top 2 inputs, and writes it into
+   * a Holder. */
+  public RelBuilder joinVariable(Holder<RexCorrelVariable> v) {
+    RelDataType leftType = peek(1).getRowType();
+    RelDataType rightType = peek().getRowType();
+    //inner join is used because the nullabiltiy of the join type should not be considered
+    v.set((RexCorrelVariable)
+        getRexBuilder().makeCorrel(
+            SqlValidatorUtil.deriveJoinRowType(leftType, rightType, JoinRelType.INNER,
+                getTypeFactory(), null, ImmutableList.of()),
             cluster.createCorrel()));
     return this;
   }
@@ -2460,7 +2476,6 @@ public class RelBuilder {
     Frame right = stack.pop();
     final Frame left = stack.pop();
     final RelNode join;
-    final boolean correlate = checkIfCorrelated(variablesSet, joinType, left.rel, right.rel);
     RexNode postCondition = literal(true);
     if (config.simplify()) {
       // Normalize expanded versions IS NOT DISTINCT FROM so that simplifier does not
@@ -2471,21 +2486,29 @@ public class RelBuilder {
       }
       condition = simplifier.simplifyUnknownAsFalse(condition);
     }
-    if (correlate) {
+    if (checkIfCorrelated(joinType, condition, left.rel, right.rel, variablesSet)) {
       final CorrelationId id = Iterables.getOnlyElement(variablesSet);
       // Correlate does not have an ON clause.
       switch (joinType) {
+      case INNER:
+        // For INNER, we can defer if condition is not correlated.
+        if(RelOptUtil.getVariablesUsed(condition).contains(id)) {
+          postCondition = condition;
+          break;
+        }
       case LEFT:
       case SEMI:
       case ANTI:
         // For a LEFT/SEMI/ANTI, predicate must be evaluated first.
         stack.push(right);
-        filter(condition.accept(new Shifter(left.rel, id, right.rel)));
+        Shifter shifter = new Shifter(left.rel, id, right.rel);
+        RexNode shiftedCondition = condition.accept(shifter);
+        if (RelOptUtil.getVariablesUsed(shiftedCondition).contains(shifter.rightId)) {
+          filter(ImmutableSet.of(shifter.rightId), shiftedCondition);
+        } else {
+          filter(shiftedCondition);
+        }
         right = stack.pop();
-        break;
-      case INNER:
-        // For INNER, we can defer.
-        postCondition = condition;
         break;
       default:
         throw new IllegalArgumentException("Correlated " + joinType + " join is not supported");
@@ -3493,8 +3516,8 @@ public class RelBuilder {
    * @throws IllegalArgumentException if the {@link CorrelationId} is used by left side or if the a
    *   {@link CorrelationId} is present and the {@link JoinRelType} is FULL or RIGHT.
    */
-  private static boolean checkIfCorrelated(Set<CorrelationId> variablesSet,
-      JoinRelType joinType, RelNode leftRel, RelNode rightRel) {
+  private static boolean checkIfCorrelated(JoinRelType joinType, RexNode condition,
+      RelNode leftRel, RelNode rightRel, Set<CorrelationId> variablesSet) {
     if (variablesSet.isEmpty()) {
       return false;
     } else if (variablesSet.size() != 1) {
@@ -3513,9 +3536,8 @@ public class RelBuilder {
     case FULL:
       throw new IllegalArgumentException("Correlated " + joinType + " join is not supported");
     default:
-      return !RelOptUtil.correlationColumns(
-          Iterables.getOnlyElement(variablesSet),
-          rightRel).isEmpty();
+      return RelOptUtil.getVariablesUsed(rightRel).contains(id)
+          || RelOptUtil.getVariablesUsed(condition).contains(id);
     }
   }
 
@@ -4160,24 +4182,84 @@ public class RelBuilder {
    * {@link RexCorrelVariable}. */
   private class Shifter extends RexShuttle {
     private final RelNode left;
-    private final CorrelationId id;
+    private final int leftCount;
+    private final CorrelationId leftId;
+    private final CorrelationId rightId;
     private final RelNode right;
+    private final RexShuttle subQueryRexShifter = new RexShuttle() {
+
+      @Override public RexNode visitSubQuery(RexSubQuery subQuery) {
+        RelNode relNode = subQuery.rel.accept(subQueryRelShuttle);
+        RexSubQuery subQueryWithNewNode;
+        if (subQuery.rel == relNode) {
+          subQueryWithNewNode = subQuery;
+        } else {
+          subQueryWithNewNode = subQuery.clone(relNode);
+        }
+        return super.visitSubQuery(subQueryWithNewNode);
+      }
+
+      @Override public RexNode visitFieldAccess(RexFieldAccess fieldAccess) {
+        if (fieldAccess.getReferenceExpr() instanceof RexCorrelVariable
+            && ((RexCorrelVariable) fieldAccess.getReferenceExpr()).id == leftId) {
+          int index = fieldAccess.getField().getIndex();
+          if (index < leftCount) {
+            final RexNode leftCorrel = getRexBuilder().makeCorrel(left.getRowType(), leftId);
+            return getRexBuilder().makeFieldAccess(leftCorrel, index);
+          } else {
+            final RexNode rightCorrel = getRexBuilder().makeCorrel(right.getRowType(), rightId);
+            return getRexBuilder().makeFieldAccess(rightCorrel, index - leftCount);
+          }
+        } else {
+          return super.visitFieldAccess(fieldAccess);
+        }
+      }
+    };
+
+    private final RelHomogeneousShuttle subQueryRelShuttle = new RelHomogeneousShuttle() {
+      @Override public RelNode visit(RelNode other) {
+        return super.visit(other.accept(subQueryRexShifter));
+      }
+    };
 
     Shifter(RelNode left, CorrelationId id, RelNode right) {
       this.left = left;
-      this.id = id;
+      this.leftId = id;
+      this.leftCount = left.getRowType().getFieldCount();
       this.right = right;
+      this.rightId = left.getCluster().createCorrel();
     }
 
     @Override public RexNode visitInputRef(RexInputRef inputRef) {
-      final RelDataType leftRowType = left.getRowType();
-      final RexBuilder rexBuilder = getRexBuilder();
-      final int leftCount = leftRowType.getFieldCount();
-      if (inputRef.getIndex() < leftCount) {
-        final RexNode v = rexBuilder.makeCorrel(leftRowType, id);
-        return rexBuilder.makeFieldAccess(v, inputRef.getIndex());
+      return rewriteField(inputRef.getIndex());
+    }
+
+    @Override public RexNode visitSubQuery(RexSubQuery subQuery) {
+      RelNode relNode = subQuery.rel.accept(subQueryRelShuttle);
+      RexSubQuery subQueryWithNewNode;
+      if (subQuery.rel == relNode) {
+        subQueryWithNewNode = subQuery;
       } else {
-        return rexBuilder.makeInputRef(right, inputRef.getIndex() - leftCount);
+        subQueryWithNewNode = subQuery.clone(relNode);
+      }
+      return super.visitSubQuery(subQueryWithNewNode);
+    }
+
+    @Override public RexNode visitFieldAccess(RexFieldAccess fieldAccess) {
+      if (fieldAccess.getReferenceExpr() instanceof RexCorrelVariable
+          && ((RexCorrelVariable) fieldAccess.getReferenceExpr()).id == leftId) {
+        return rewriteField(fieldAccess.getField().getIndex());
+      } else {
+        return super.visitFieldAccess(fieldAccess);
+      }
+    }
+
+    private RexNode rewriteField(int index) {
+      if (index < leftCount) {
+        final RexNode leftCorrel = getRexBuilder().makeCorrel(left.getRowType(), leftId);
+        return getRexBuilder().makeFieldAccess(leftCorrel, index);
+      } else {
+        return getRexBuilder().makeInputRef(right, index - leftCount);
       }
     }
   }

--- a/core/src/test/java/org/apache/calcite/plan/RelOptUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelOptUtilTest.java
@@ -719,7 +719,7 @@ class RelOptUtilTest {
                   relBuilder.field(1, 0, "DEPTNO")))
           .build();
       RelOptUtil.getVariablesUsed(relNode);
-    }, "Correlate Id used out of scope");
+    }, "correlate id used out of scope");
   }
 
   @Test void testGetVariablesUsedVaribleUsedBefore() {
@@ -743,7 +743,7 @@ class RelOptUtilTest {
           .join(JoinRelType.INNER)
           .build();
       RelOptUtil.getVariablesUsed(relNode);
-    }, "Correlate Id used out of scope");
+    }, "correlate id used out of scope");
   }
 
   /** Dummy sub-class of ConverterRule, to check whether generated descriptions

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -3713,7 +3713,7 @@ public class RelBuilderTest {
     RelNode root = builder.scan("EMP")
         .variable(v)
         .scan("DEPT")
-        .filter(Collections.singletonList(v.get().id),
+        .filter(
             builder.or(
                 builder.and(
                     builder.lessThan(builder.field(v.get(), "DEPTNO"),
@@ -3732,9 +3732,7 @@ public class RelBuilderTest {
         + "requiredColumns=[{5, 7}])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalFilter(condition=[=($cor0.SAL, 1000)])\n"
-        + "    LogicalFilter(condition=[OR("
-        + "SEARCH($cor0.DEPTNO, Sarg[(20..30)]), "
-        + "IS NULL($2))], variablesSet=[[$cor0]])\n"
+        + "    LogicalFilter(condition=[OR(SEARCH($cor0.DEPTNO, Sarg[(20..30)]), IS NULL($2))])\n"
         + "      LogicalTableScan(table=[[scott, DEPT]])\n";
 
     assertThat(root, hasTree(expected));


### PR DESCRIPTION
Throwing an IllegalArgumentException when multiple correlate ids are
passed into Relbuilder.join.
