### PR TITLE
[CALCITE-4777]Casting from DECIMAL to BOOLEAN throws an exception

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeCoercionRule.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeCoercionRule.java
@@ -202,7 +202,7 @@ public class SqlTypeCoercionRule implements SqlTypeMappingRule {
         coerceRules.copyValues(SqlTypeName.BOOLEAN)
             .add(SqlTypeName.CHAR)
             .add(SqlTypeName.VARCHAR)
-            .addAll(SqlTypeName.NUMERIC_TYPES)
+            .addAll(SqlTypeName.INT_TYPES)
             .build());
 
     // DATE, TIME, and TIMESTAMP are castable from

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -202,6 +202,9 @@ public abstract class SqlOperatorBaseTest {
   public static final String INVALID_ARGUMENTS_NUMBER =
       "Invalid number of arguments to function .* Was expecting .* arguments";
 
+  public static final String INVALID_CAST_CONVERSION_ERROR =
+      "Cast function cannot convert value of type .* to type .*";
+
   public static final boolean TODO = false;
 
   /**
@@ -1595,6 +1598,29 @@ public abstract class SqlOperatorBaseTest {
     tester.checkFails(
         "cast(cast('blah' as varchar(10)) as boolean)", INVALID_CHAR_MESSAGE,
         true);
+
+    tester.checkBoolean("cast(0 as boolean)", Boolean.FALSE);
+    tester.checkBoolean("cast(cast(0 as tinyint) as boolean)", Boolean.FALSE);
+    tester.checkBoolean("cast(cast(0 as smallint) as boolean)", Boolean.FALSE);
+    tester.checkBoolean("cast(cast(0 as bigint) as boolean)", Boolean.FALSE);
+
+    //invalid cast conversion
+    //convert from decimal, double, float, real to boolean
+    tester.checkFails(
+        "^cast(0.10915913549909961 as boolean)^", INVALID_CAST_CONVERSION_ERROR,
+        false);
+    tester.checkFails(
+        "^cast(0.2 as boolean)^", INVALID_CAST_CONVERSION_ERROR,
+        false);
+    tester.checkFails(
+        "^cast(cast(0.0 as double) as boolean)^", INVALID_CAST_CONVERSION_ERROR,
+        false);
+    tester.checkFails(
+        "^cast(cast(0.0 as float) as boolean)^", INVALID_CAST_CONVERSION_ERROR,
+        false);
+    tester.checkFails(
+        "^cast(cast(0.0 as real) as boolean)^", INVALID_CAST_CONVERSION_ERROR,
+        false);
   }
 
   @Test void testCase() {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1207,7 +1207,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .columnType("INTEGER NOT NULL MULTISET NOT NULL");
     expr("cast(1 as boolean)")
         .columnType("BOOLEAN NOT NULL");
-    expr("cast(1.0e1 as boolean)")
+    expr("cast(cast(1 as bigint) as boolean)")
+        .columnType("BOOLEAN NOT NULL");
+    expr("cast(cast(1 as smallint) as boolean)")
+        .columnType("BOOLEAN NOT NULL");
+    expr("cast(cast(1 as tinyint) as boolean)")
         .columnType("BOOLEAN NOT NULL");
     expr("cast(true as numeric)")
         .columnType("DECIMAL(19, 0) NOT NULL");
@@ -1267,6 +1271,18 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     wholeExpr("cast(TIME '12:34:01' as DATE)")
         .fails("(?s).*Cast function cannot convert value of type "
             + "TIME\\(0\\) to type DATE.*");
+    wholeExpr("cast(1.0e1 as boolean)")
+        .fails("(?s).*Cast function cannot convert value of type "
+            + "DOUBLE to type BOOLEAN");
+    wholeExpr("cast(cast(1.0 as float) as boolean)")
+        .fails("(?s).*Cast function cannot convert value of type "
+            + "FLOAT to type BOOLEAN");
+    wholeExpr("cast(cast(1.0 as real) as boolean)")
+        .fails("(?s).*Cast function cannot convert value of type "
+            + "REAL to type BOOLEAN");
+    wholeExpr("cast(cast(1.0 as decimal(2,1)) as boolean)")
+        .fails("(?s).*Cast function cannot convert value of type "
+            + "DECIMAL\\(2, 1\\) to type BOOLEAN");
   }
 
   @Test void testCastBinaryLiteral() {

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1510,9 +1510,9 @@ these details follow the table.
 | SMALLINT            | x    | e       | i       | i        | i   | i      | i       | i             | i      | e        | x    | x    | e         | i               | x
 | INT                 | x    | e       | i       | i        | i   | i      | i       | i             | i      | e        | x    | x    | e         | i               | x
 | BIGINT              | x    | e       | i       | i        | i   | i      | i       | i             | i      | e        | x    | x    | e         | i               | x
-| DECIMAL             | x    | e       | i       | i        | i   | i      | i       | i             | i      | e        | x    | x    | e         | i               | x
-| FLOAT/REAL          | x    | e       | i       | i        | i   | i      | i       | i             | i      | x        | x    | x    | e         | i               | x
-| DOUBLE              | x    | e       | i       | i        | i   | i      | i       | i             | i      | x        | x    | x    | e         | i               | x
+| DECIMAL             | x    | x       | i       | i        | i   | i      | i       | i             | i      | e        | x    | x    | e         | i               | x
+| FLOAT/REAL          | x    | x       | i       | i        | i   | i      | i       | i             | i      | x        | x    | x    | e         | i               | x
+| DOUBLE              | x    | x       | i       | i        | i   | i      | i       | i             | i      | x        | x    | x    | e         | i               | x
 | INTERVAL            | x    | x       | e       | e        | e   | e      | e       | x             | x      | i        | x    | x    | x         | e               | x
 | DATE                | x    | x       | x       | x        | x   | x      | x       | x             | x      | x        | i    | x    | i         | i               | x
 | TIME                | x    | x       | x       | x        | x   | x      | x       | x             | x      | x        | x    | i    | e         | i               | x


### PR DESCRIPTION
According to the discussion in [calcite-4777], casting from decimal to boolean is invalid, and an exception like "Cast function cannot convert value of type DECIMAL(2,1) to type BOOLEAN" will be thrown in the period of validating. 
This pr changes:

- remove the coerce rule from decimal to boolean, which will lead to throw a conversion exception and let users know this is an invalid conversion.
- add some test cases in SqlOperatorBaseTest.
- change the reference.md to say this invalid conversion