### PR TITLE
[CALCITE-4822] Add functions ARRAY_CONCAT, ARRAY_REVERSE, ARRAY_LENGT…

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -63,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -2786,6 +2787,12 @@ public class SqlFunctions {
     resultCollection.addAll(collection1);
     resultCollection.addAll(collection2);
     return resultCollection;
+  }
+
+  /** Support the ARRAY_REVERSE function. */
+  public static List reverse(List list) {
+    Collections.reverse(list);
+    return list;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -635,6 +635,12 @@ public enum SqlKind {
   /** {@code EXTRACT} function. */
   EXTRACT,
 
+  /** {@code ARRAY_CONCAT} function (BigQuery semantics). */
+  ARRAY_CONCAT,
+
+  /** {@code ARRAY_REVERSE} function (BigQuery semantics). */
+  ARRAY_REVERSE,
+
   /** {@code REVERSE} function (SQL Server, MySQL). */
   REVERSE,
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -525,6 +525,36 @@ public abstract class SqlLibraryOperators {
           OperandTypes.STRING_SAME_SAME,
           SqlFunctionCategory.STRING);
 
+  /** The "ARRAY_LENGTH(array)" function. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction ARRAY_LENGTH =
+      new SqlFunction("ARRAY_LENGTH",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.INTEGER_NULLABLE,
+          null,
+          OperandTypes.ARRAY,
+          SqlFunctionCategory.SYSTEM);
+
+  /** The "ARRAY_REVERSE(array)" function. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction ARRAY_REVERSE =
+      new SqlFunction("ARRAY_REVERSE",
+          SqlKind.ARRAY_REVERSE,
+          ReturnTypes.ARG0_NULLABLE,
+          null,
+          OperandTypes.ARRAY,
+          SqlFunctionCategory.SYSTEM);
+
+  /** The "ARRAY_CONCAT(array [, array]*)" function. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction ARRAY_CONCAT =
+      new SqlFunction("ARRAY_CONCAT",
+          SqlKind.ARRAY_CONCAT,
+          ReturnTypes.LEAST_RESTRICTIVE,
+          null,
+          OperandTypes.AT_LEAST_ONE_SAME_VARIADIC,
+          SqlFunctionCategory.SYSTEM);
+
   @LibraryOperator(libraries = {MYSQL})
   public static final SqlFunction REVERSE =
       new SqlFunction("REVERSE",

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -437,6 +437,18 @@ public abstract class OperandTypes {
       new SameOperandTypeChecker(-1);
 
   /**
+   * Operand type-checking strategy where any positive number of operands must all be
+   * in the same type family.
+   */
+  public static final SqlOperandTypeChecker AT_LEAST_ONE_SAME_VARIADIC =
+      new SameOperandTypeChecker(-1) {
+        @Override public SqlOperandCountRange
+        getOperandCountRange() {
+          return SqlOperandCountRanges.from(1);
+        }
+      };
+
+  /**
    * Operand type-checking strategy where operand types must allow ordered
    * comparisons.
    */

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -569,6 +569,7 @@ public enum BuiltInMethod {
   IS_EMPTY(Collection.class, "isEmpty"),
   SUBMULTISET_OF(SqlFunctions.class, "submultisetOf", Collection.class,
       Collection.class),
+  ARRAY_REVERSE(SqlFunctions.class, "reverse", List.class),
   SELECTIVITY(Selectivity.class, "getSelectivity", RexNode.class),
   UNIQUE_KEYS(UniqueKeys.class, "getUniqueKeys", boolean.class),
   AVERAGE_ROW_SIZE(Size.class, "averageRowSize"),
@@ -633,7 +634,9 @@ public enum BuiltInMethod {
       long.class, long.class),
   SESSIONIZATION(EnumUtils.class, "sessionize", Enumerator.class, int.class, int.class,
       long.class),
-  BIG_DECIMAL_NEGATE(BigDecimal.class, "negate");
+  BIG_DECIMAL_ADD(BigDecimal.class, "add", BigDecimal.class),
+  BIG_DECIMAL_NEGATE(BigDecimal.class, "negate"),
+  COMPARE_TO(Comparable.class, "compareTo", Object.class);
 
   @SuppressWarnings("ImmutableEnumChecker")
   public final Method method;

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5760,6 +5760,44 @@ public abstract class SqlOperatorBaseTest {
     tester.checkScalar("rand_integer(2, 11)", 1, "INTEGER NOT NULL");
   }
 
+  /** Tests {@code ARRAY_CONCAT} function from BigQuery. */
+  @Test void testArrayConcat() {
+    SqlTester tester = libraryTester(SqlLibrary.BIG_QUERY);
+    tester.setFor(SqlLibraryOperators.ARRAY_CONCAT);
+    tester.checkFails("^array_concat()^", INVALID_ARGUMENTS_NUMBER, false);
+    tester.checkScalar("array_concat(array[1, 2], array[2, 3])", "[1, 2, 2, 3]",
+        "INTEGER NOT NULL ARRAY NOT NULL");
+    tester.checkScalar("array_concat(array[1, 2], array[2, null])", "[1, 2, 2, null]",
+        "INTEGER ARRAY NOT NULL");
+    tester.checkScalar(
+        "array_concat(array['hello', 'world'], array['!'], array[cast(null as char)])",
+        "[hello, world, !, null]", "CHAR(5) ARRAY NOT NULL");
+    tester.checkNull("array_concat(cast(null as integer array), array[1])");
+  }
+
+  /** Tests {@code ARRAY_REVERSE} function from BigQuery. */
+  @Test void testArrayReverseFunc() {
+    SqlTester tester = libraryTester(SqlLibrary.BIG_QUERY);
+    tester.setFor(SqlLibraryOperators.ARRAY_REVERSE);
+    tester.checkScalar("array_reverse(array[1])", "[1]",
+        "INTEGER NOT NULL ARRAY NOT NULL");
+    tester.checkScalar("array_reverse(array[1, 2])", "[2, 1]",
+        "INTEGER NOT NULL ARRAY NOT NULL");
+    tester.checkScalar("array_reverse(array[null, 1])", "[1, null]",
+        "INTEGER ARRAY NOT NULL");
+  }
+
+  /** Tests {@code ARRAY_LENGTH} function from BigQuery. */
+  @Test void testArrayLengthFunc() {
+    SqlTester tester = libraryTester(SqlLibrary.BIG_QUERY);
+    tester.setFor(SqlLibraryOperators.ARRAY_LENGTH);
+    tester.checkScalar("array_length(array[1])", "1",
+        "INTEGER NOT NULL");
+    tester.checkScalar("array_length(array[1, 2, null])", "3",
+        "INTEGER NOT NULL");
+    tester.checkNull("array_length(null)");
+  }
+
   /** Tests {@code UNIX_SECONDS} and other datetime functions from BigQuery. */
   @Test void testUnixSecondsFunc() {
     SqlTester tester = libraryTester(SqlLibrary.BIG_QUERY);

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2513,6 +2513,9 @@ semantics.
 | C | Operator syntax                                | Description
 |:- |:-----------------------------------------------|:-----------
 | p | expr :: type                                   | Casts *expr* to *type*
+| b | ARRAY_CONCAT(array [, array ]*)                | Concatenates one or more arrays. If any input argument is `NULL` the function returns `NULL`
+| b | ARRAY_LENGTH(array)                            | Synonym for `CARDINALITY`
+| b | ARRAY_REVERSE(array)                           | Reverses elements of *array*
 | o | CHR(integer) | Returns the character having the binary equivalent to *integer* as a CHAR value
 | o | COSH(numeric)                                  | Returns the hyperbolic cosine of *numeric*
 | o | CONCAT(string, string)                         | Concatenates two strings


### PR DESCRIPTION
The functions follow BigQuery's description 
`ARRAY_CONCAT`: https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_concat
`ARRAY_LENGTH`: https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_length
`ARRAY_REVERSE`: https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_reverse