### PR TITLE
[CALCITE-4826] Set destination directory for core annotation processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - CHECKERFRAMEWORK=Y
       script:
         - export _JAVA_OPTIONS="-XX:GCTimeLimit=90 -XX:GCHeapFreeLimit=35"
-        - ./gradlew --no-parallel --no-daemon --scan -Pguava.version=${GUAVA:-29.0-jre} -PenableCheckerframework :linq4j:classes :core:classes
+        - travis_wait ./gradlew --no-parallel --no-daemon --scan -Pguava.version=${GUAVA:-29.0-jre} -PenableCheckerframework :linq4j:classes :core:classes
     - jdk: openjdk11
       env:
         - ERRORPRONE=Y

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -124,6 +124,8 @@ dependencies {
         apiv("org.elasticsearch.client:elasticsearch-rest-client", "elasticsearch")
         apiv("org.elasticsearch.plugin:transport-netty4-client", "elasticsearch")
         apiv("org.elasticsearch:elasticsearch")
+        apiv("org.immutables:value-annotations", "immutables")
+        apiv("org.immutables:value", "immutables")
         apiv("org.exparity:hamcrest-date")
         apiv("org.hamcrest:hamcrest")
         apiv("org.hamcrest:hamcrest-core", "hamcrest")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -301,7 +301,9 @@ allprojects {
 
     plugins.withId("java-library") {
         dependencies {
+            "annotationProcessor"(platform(project(":bom")))
             "implementation"(platform(project(":bom")))
+            "testAnnotationProcessor"(platform(project(":bom")))
         }
     }
 
@@ -575,6 +577,7 @@ allprojects {
         configure<CheckForbiddenApisExtension> {
             failOnUnsupportedJava = false
             ignoreSignaturesOfMissingClasses = true
+            suppressAnnotations.add("org.immutables.value.Generated")
             bundledSignatures.addAll(
                 listOf(
                     "jdk-unsafe",

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -196,6 +196,7 @@ fun JavaCompile.configureAnnotationSet(sourceSet: SourceSet) {
     classpath = sourceSet.compileClasspath
     options.compilerArgs.add("-proc:only")
     org.gradle.api.plugins.internal.JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, sourceSet.java, options, project)
+    destinationDirectory.set(temporaryDir)
 
     // only if we aren't running compileJava, since doing twice fails (in some places)
     onlyIf { !project.gradle.taskGraph.hasTask(sourceSet.getCompileTaskName("java")) }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,6 +16,8 @@
  */
 import com.github.vlsi.gradle.crlf.CrLfSpec
 import com.github.vlsi.gradle.crlf.LineEndings
+import com.github.vlsi.gradle.ide.dsl.settings
+import com.github.vlsi.gradle.ide.dsl.taskTriggers
 
 plugins {
     kotlin("jvm")
@@ -61,6 +63,8 @@ dependencies {
     implementation("commons-io:commons-io")
     implementation("org.codehaus.janino:commons-compiler")
     implementation("org.codehaus.janino:janino")
+    annotationProcessor("org.immutables:value")
+    compileOnly("org.immutables:value-annotations")
 
     testH2("com.h2database:h2")
     testMysql("mysql:mysql-connector-java")
@@ -185,6 +189,39 @@ ide {
 
     generatedSource(javaCCMain, "main")
     generatedSource(javaCCTest, "test")
+}
+
+fun JavaCompile.configureAnnotationSet(sourceSet: SourceSet) {
+    source = sourceSet.java
+    classpath = sourceSet.compileClasspath
+    options.compilerArgs.add("-proc:only")
+    org.gradle.api.plugins.internal.JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, sourceSet.java, options, project)
+
+    // only if we aren't running compileJava, since doing twice fails (in some places)
+    onlyIf { !project.gradle.taskGraph.hasTask(sourceSet.getCompileTaskName("java")) }
+}
+
+val annotationProcessorMain by tasks.registering(JavaCompile::class) {
+    dependsOn(javaCCMain)
+    configureAnnotationSet(sourceSets.main.get())
+}
+
+ide {
+    // generate annotation processed files on project import/sync.
+    // adds to idea path but skip don't add to SourceSet since that triggers checkstyle
+    fun generatedSource(compile: TaskProvider<JavaCompile>, sourceSetName: String) {
+        project.rootProject.configure<org.gradle.plugins.ide.idea.model.IdeaModel> {
+            project {
+                settings {
+                    taskTriggers {
+                        afterSync(compile.get())
+                    }
+                }
+            }
+        }
+    }
+
+    generatedSource(annotationProcessorMain, "main")
 }
 
 val integTestAll by tasks.registering() {

--- a/core/src/main/java/org/apache/calcite/CalciteImmutable.java
+++ b/core/src/main/java/org/apache/calcite/CalciteImmutable.java
@@ -14,9 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.calcite;
+
+import org.immutables.value.Value;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
 /**
- * Main package for Calcite, the dynamic data management platform.
+ * Annotation to be used to convert interfaces/abstract classes into
+ * Immutable POJO using Immutables package.
  */
-@CalciteImmutable
-package org.apache.calcite;
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Value.Style(
+    visibility = Value.Style.ImplementationVisibility.PACKAGE,
+    defaults = @Value.Immutable(builder = true, singleton = true),
+    get = {"is*", "get*"},
+    init = "with*"
+)
+public @interface CalciteImmutable { }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProjectToCalcRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProjectToCalcRule.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.rules.ProjectToCalcRule;
 import org.apache.calcite.rex.RexProgram;
@@ -53,7 +54,7 @@ public class EnumerableProjectToCalcRule extends ProjectToCalcRule {
 
   /** Rule configuration. */
   public interface Config extends ProjectToCalcRule.Config {
-    Config DEFAULT = ProjectToCalcRule.Config.DEFAULT
+    Config DEFAULT = RelRule.Config.EMPTY
         .withOperandSupplier(b ->
             b.operand(EnumerableProject.class).anyInputs())
         .as(Config.class);

--- a/core/src/main/java/org/apache/calcite/rel/convert/ConverterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/convert/ConverterRule.java
@@ -27,6 +27,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.Locale;
 import java.util.Objects;
@@ -39,6 +40,7 @@ import static org.apache.calcite.linq4j.Nullness.castNonNull;
  * Abstract base class for a rule which converts from one calling convention to
  * another without changing semantics.
  */
+@Value.Enclosing
 public abstract class ConverterRule
     extends RelRule<ConverterRule.Config> {
   //~ Instance fields --------------------------------------------------------
@@ -178,8 +180,16 @@ public abstract class ConverterRule
   //~ Inner Classes ----------------------------------------------------------
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
-    Config INSTANCE = EMPTY.as(Config.class);
+    Config INSTANCE = ImmutableConverterRule.Config.builder()
+        .withInTrait(Convention.NONE)
+        .withOutTrait(Convention.NONE)
+        .withRuleFactory(new Function<Config, ConverterRule>() {
+          @Override public ConverterRule apply(final Config config) {
+            throw new UnsupportedOperationException("A rule factory must be provided");
+          }
+        }).build();
 
     @ImmutableBeans.Property
     RelTrait inTrait();

--- a/core/src/main/java/org/apache/calcite/rel/convert/TraitMatchingRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/convert/TraitMatchingRule.java
@@ -27,6 +27,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 /**
  * TraitMatchingRule adapts a converter rule, restricting it to fire only when
@@ -34,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link org.apache.calcite.plan.hep.HepPlanner} in cases where alternate
  * implementations are available and it is desirable to minimize converters.
  */
+@Value.Enclosing
 public class TraitMatchingRule extends RelRule<TraitMatchingRule.Config> {
   /**
    * Creates a configuration for a TraitMatchingRule.
@@ -46,13 +48,13 @@ public class TraitMatchingRule extends RelRule<TraitMatchingRule.Config> {
       RelBuilderFactory relBuilderFactory) {
     final RelOptRuleOperand operand = converterRule.getOperand();
     assert operand.childPolicy == RelOptRuleOperandChildPolicy.ANY;
-    return Config.EMPTY.withRelBuilderFactory(relBuilderFactory)
+    return ImmutableTraitMatchingRule.Config.builder().withRelBuilderFactory(relBuilderFactory)
         .withDescription("TraitMatchingRule: " + converterRule)
         .withOperandSupplier(b0 ->
             b0.operand(operand.getMatchedClass()).oneInput(b1 ->
                 b1.operand(RelNode.class).anyInputs()))
-        .as(Config.class)
-        .withConverterRule(converterRule);
+        .withConverterRule(converterRule)
+        .build();
   }
 
   //~ Constructors -----------------------------------------------------------
@@ -88,6 +90,7 @@ public class TraitMatchingRule extends RelRule<TraitMatchingRule.Config> {
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
     @Override default TraitMatchingRule toRule() {
       return new TraitMatchingRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelDotWriter.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelDotWriter.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.sql.SqlExplainLevel;
-import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
@@ -30,6 +29,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -42,6 +42,7 @@ import java.util.function.Predicate;
 /**
  * Utility to dump a rel node plan in dot format.
  */
+@Value.Enclosing
 public class RelDotWriter extends RelWriterImpl {
 
   //~ Instance fields --------------------------------------------------------
@@ -262,32 +263,32 @@ public class RelDotWriter extends RelWriterImpl {
   /**
    * Options for displaying the rel node plan in dot format.
    */
+  @Value.Immutable(singleton = true)
   public interface WriteOption {
 
     /** Default configuration. */
-    WriteOption DEFAULT = ImmutableBeans.create(WriteOption.class);
+    WriteOption DEFAULT = ImmutableRelDotWriter.WriteOption.of();
 
     /**
      * The max length of node labels.
      * If the label is too long, the visual display would be messy.
      * -1 means no limit to the label length.
      */
-    @ImmutableBeans.Property
-    @ImmutableBeans.IntDefault(100)
-    int maxNodeLabelLength();
+    @Value.Default default int maxNodeLabelLength() {
+      return 100;
+    }
 
     /**
      * The max length of node label in a line.
      * -1 means no limitation.
      */
-    @ImmutableBeans.Property
-    @ImmutableBeans.IntDefault(20)
-    int maxNodeLabelPerLine();
+    @Value.Default default int maxNodeLabelPerLine() {
+      return 20;
+    }
 
     /**
      * Predicate for nodes that need to be highlighted.
      */
-    @ImmutableBeans.Property
     @Nullable Predicate<RelNode> nodePredicate();
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/rules/AbstractJoinExtractFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AbstractJoinExtractFilterRule.java
@@ -17,13 +17,11 @@
 package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptRuleCall;
-import org.apache.calcite.plan.RelOptRuleOperand;
 import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.tools.RelBuilder;
-import org.apache.calcite.tools.RelBuilderFactory;
 
 /**
  * Rule to convert an
@@ -44,16 +42,6 @@ public abstract class AbstractJoinExtractFilterRule
   /** Creates an AbstractJoinExtractFilterRule. */
   protected AbstractJoinExtractFilterRule(Config config) {
     super(config);
-  }
-
-  @Deprecated // to be removed before 2.0
-  protected AbstractJoinExtractFilterRule(RelOptRuleOperand operand,
-      RelBuilderFactory relBuilderFactory, String description) {
-    this(Config.EMPTY
-        .withOperandSupplier(b -> b.exactly(operand))
-        .withRelBuilderFactory(relBuilderFactory)
-        .withDescription(description)
-        .as(Config.class));
   }
 
   @Override public void onMatch(RelOptRuleCall call) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateCaseToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateCaseToFilterRule.java
@@ -40,6 +40,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -65,6 +66,7 @@ import java.util.List;
  *
  * @see CoreRules#AGGREGATE_CASE_TO_FILTER
  */
+@Value.Enclosing
 public class AggregateCaseToFilterRule
     extends RelRule<AggregateCaseToFilterRule.Config>
     implements TransformationRule {
@@ -275,12 +277,13 @@ public class AggregateCaseToFilterRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableAggregateCaseToFilterRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Aggregate.class).oneInput(b1 ->
-                b1.operand(Project.class).anyInputs()))
-        .as(Config.class);
+                b1.operand(Project.class).anyInputs()));
+
 
     @Override default AggregateCaseToFilterRule toRule() {
       return new AggregateCaseToFilterRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,6 +87,7 @@ import static java.util.Objects.requireNonNull;
  * @see CoreRules#AGGREGATE_EXPAND_DISTINCT_AGGREGATES
  * @see CoreRules#AGGREGATE_EXPAND_DISTINCT_AGGREGATES_TO_JOIN
  */
+@Value.Enclosing
 public final class AggregateExpandDistinctAggregatesRule
     extends RelRule<AggregateExpandDistinctAggregatesRule.Config>
     implements TransformationRule {
@@ -927,12 +929,12 @@ public final class AggregateExpandDistinctAggregatesRule
     return relBuilder;
   }
 
-       /** Rule configuration. */
+  /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableAggregateExpandDistinctAggregatesRule.Config.of()
         .withOperandSupplier(b ->
-            b.operand(LogicalAggregate.class).anyInputs())
-        .as(Config.class);
+            b.operand(LogicalAggregate.class).anyInputs());
 
     Config JOIN = DEFAULT.withUsingGroupingSets(false);
 
@@ -943,7 +945,9 @@ public final class AggregateExpandDistinctAggregatesRule
     /** Whether to use GROUPING SETS, default true. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(true)
-    boolean isUsingGroupingSets();
+    @Value.Default default boolean isUsingGroupingSets() {
+      return true;
+    }
 
     /** Sets {@link #isUsingGroupingSets()}. */
     Config withUsingGroupingSets(boolean usingGroupingSets);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandWithinDistinctRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandWithinDistinctRule.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -100,6 +101,7 @@ import static org.apache.calcite.rel.rules.AggregateExpandDistinctAggregatesRule
  * (e.g. {@code SUM(a) WITHIN DISTINCT (x), SUM(a) WITHIN DISTINCT (y)})
  * the rule creates separate {@code GROUPING SET}s.
  */
+@Value.Enclosing
 public class AggregateExpandWithinDistinctRule
     extends RelRule<AggregateExpandWithinDistinctRule.Config> {
 
@@ -507,12 +509,12 @@ public class AggregateExpandWithinDistinctRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableAggregateExpandWithinDistinctRule.Config.of()
         .withOperandSupplier(b -> b.operand(LogicalAggregate.class)
             .predicate(AggregateExpandWithinDistinctRule::hasWithinDistinct)
-            .anyInputs())
-        .as(AggregateExpandWithinDistinctRule.Config.class);
+            .anyInputs());
 
     @Override default AggregateExpandWithinDistinctRule toRule() {
       return new AggregateExpandWithinDistinctRule(this);
@@ -530,7 +532,9 @@ public class AggregateExpandWithinDistinctRule
      * [100, 120, 150]. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(true)
-    boolean throwIfNotUnique();
+    @Value.Default default boolean throwIfNotUnique() {
+      return true;
+    }
 
     /** Sets {@link #throwIfNotUnique()}. */
     Config withThrowIfNotUnique(boolean throwIfNotUnique);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExtractProjectRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExtractProjectRule.java
@@ -33,6 +33,8 @@ import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,6 +49,7 @@ import java.util.List;
  * <p>To prevent cycles, this rule will not extract a {@code Project} if the
  * {@code Aggregate}s input is already a {@code Project}.
  */
+@Value.Enclosing
 public class AggregateExtractProjectRule
     extends RelRule<AggregateExtractProjectRule.Config>
     implements TransformationRule {
@@ -126,9 +129,9 @@ public class AggregateExtractProjectRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .as(Config.class)
+    Config DEFAULT = ImmutableAggregateExtractProjectRule.Config.of()
         .withOperandFor(Aggregate.class, LogicalTableScan.class);
 
     @Override default AggregateExtractProjectRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
@@ -35,6 +35,8 @@ import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,6 +56,7 @@ import java.util.List;
  * @see org.apache.calcite.rel.rules.FilterAggregateTransposeRule
  * @see CoreRules#AGGREGATE_FILTER_TRANSPOSE
  */
+@Value.Enclosing
 public class AggregateFilterTransposeRule
     extends RelRule<AggregateFilterTransposeRule.Config>
     implements TransformationRule {
@@ -156,8 +159,9 @@ public class AggregateFilterTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateFilterTransposeRule.Config.of()
         .withOperandFor(Aggregate.class, Filter.class);
 
     @Override default AggregateFilterTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinJoinRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinJoinRemoveRule.java
@@ -35,6 +35,8 @@ import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -66,6 +68,7 @@ import java.util.Set;
  *
  * @see CoreRules#AGGREGATE_JOIN_JOIN_REMOVE
  */
+@Value.Enclosing
 public class AggregateJoinJoinRemoveRule
     extends RelRule<AggregateJoinJoinRemoveRule.Config>
     implements TransformationRule {
@@ -156,9 +159,9 @@ public class AggregateJoinJoinRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .as(Config.class)
+    Config DEFAULT = ImmutableAggregateJoinJoinRemoveRule.Config.of()
         .withOperandFor(LogicalAggregate.class, LogicalJoin.class);
 
     @Override default AggregateJoinJoinRemoveRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinRemoveRule.java
@@ -33,6 +33,8 @@ import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -58,6 +60,7 @@ import java.util.Set;
  *
  * @see CoreRules#AGGREGATE_JOIN_REMOVE
  */
+@Value.Enclosing
 public class AggregateJoinRemoveRule
     extends RelRule<AggregateJoinRemoveRule.Config>
     implements TransformationRule {
@@ -125,8 +128,9 @@ public class AggregateJoinRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateJoinRemoveRule.Config.of()
         .withOperandFor(LogicalAggregate.class, LogicalJoin.class);
 
     @Override default AggregateJoinRemoveRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateJoinTransposeRule.java
@@ -49,6 +49,7 @@ import org.apache.calcite.util.mapping.Mappings;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -68,6 +69,7 @@ import static java.util.Objects.requireNonNull;
  * @see CoreRules#AGGREGATE_JOIN_TRANSPOSE
  * @see CoreRules#AGGREGATE_JOIN_TRANSPOSE_EXTENDED
  */
+@Value.Enclosing
 public class AggregateJoinTransposeRule
     extends RelRule<AggregateJoinTransposeRule.Config>
     implements TransformationRule {
@@ -454,12 +456,13 @@ public class AggregateJoinTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateJoinTransposeRule.Config.of()
         .withOperandFor(LogicalAggregate.class, LogicalJoin.class, false);
 
     /** Extended instance that can push down aggregate functions. */
-    Config EXTENDED = EMPTY.as(Config.class)
+    Config EXTENDED = ImmutableAggregateJoinTransposeRule.Config.of()
         .withOperandFor(LogicalAggregate.class, LogicalJoin.class, true);
 
     @Override default AggregateJoinTransposeRule toRule() {
@@ -469,7 +472,10 @@ public class AggregateJoinTransposeRule
     /** Whether to push down aggregate functions, default false. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean isAllowFunctions();
+    @Value.Default
+    default boolean isAllowFunctions() {
+      return false;
+    }
 
     /** Sets {@link #isAllowFunctions()}. */
     Config withAllowFunctions(boolean allowFunctions);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateMergeRule.java
@@ -30,6 +30,8 @@ import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,6 +49,7 @@ import java.util.Map;
  *
  * @see CoreRules#AGGREGATE_MERGE
  */
+@Value.Enclosing
 public class AggregateMergeRule
     extends RelRule<AggregateMergeRule.Config>
     implements TransformationRule {
@@ -149,8 +152,9 @@ public class AggregateMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableAggregateMergeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Aggregate.class)
                 .oneInput(b1 ->

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectMergeRule.java
@@ -35,6 +35,7 @@ import org.apache.calcite.util.mapping.Mappings;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -57,6 +58,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see CoreRules#AGGREGATE_PROJECT_MERGE
  */
+@Value.Enclosing
 public class AggregateProjectMergeRule
     extends RelRule<AggregateProjectMergeRule.Config>
     implements TransformationRule {
@@ -148,8 +150,9 @@ public class AggregateProjectMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateProjectMergeRule.Config.of()
         .withOperandFor(Aggregate.class, Project.class);
 
     @Override default AggregateProjectMergeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectStarTableRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateProjectStarTableRule.java
@@ -22,9 +22,12 @@ import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.schema.impl.StarTable;
 
+import org.immutables.value.Value;
+
 /** Variant of {@link AggregateStarTableRule} that accepts a {@link Project}
  * between the {@link Aggregate} and its {@link StarTable.StarTableScan}
  * input. */
+@Value.Enclosing
 public class AggregateProjectStarTableRule extends AggregateStarTableRule {
   /** Creates an AggregateProjectStarTableRule. */
   protected AggregateProjectStarTableRule(Config config) {
@@ -52,8 +55,10 @@ public class AggregateProjectStarTableRule extends AggregateStarTableRule {
   }
 
   /** Rule configuration. */
+  @Value.Immutable
+  @SuppressWarnings("immutables:subtype")
   public interface Config extends AggregateStarTableRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateProjectStarTableRule.Config.of()
         .withOperandFor(Aggregate.class, Project.class,
             StarTable.StarTableScan.class);
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -96,6 +97,7 @@ import java.util.function.IntPredicate;
  *
  * @see CoreRules#AGGREGATE_REDUCE_FUNCTIONS
  */
+@Value.Enclosing
 public class AggregateReduceFunctionsRule
     extends RelRule<AggregateReduceFunctionsRule.Config>
     implements TransformationRule {
@@ -832,8 +834,9 @@ public class AggregateReduceFunctionsRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateReduceFunctionsRule.Config.of()
         .withOperandFor(LogicalAggregate.class);
 
     Set<SqlKind> DEFAULT_FUNCTIONS_TO_REDUCE =
@@ -851,7 +854,11 @@ public class AggregateReduceFunctionsRule
     @Nullable Set<SqlKind> functionsToReduce();
 
     /** Sets {@link #functionsToReduce}. */
-    Config withFunctionsToReduce(@Nullable Set<SqlKind> functionSet);
+    Config withFunctionsToReduce(@Nullable Iterable<SqlKind> functionSet);
+
+    default Config withFunctionsToReduce(@Nullable Set<SqlKind> functionSet) {
+      return withFunctionsToReduce((Iterable<SqlKind>) functionSet);
+    }
 
     /** Returns the validated set of functions to reduce, or the default set
      * if not specified. */

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
@@ -33,6 +33,8 @@ import org.apache.calcite.sql.SqlSplittableAggFunction;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,6 +48,7 @@ import java.util.List;
  *
  * @see CoreRules#AGGREGATE_REMOVE
  */
+@Value.Enclosing
 public class AggregateRemoveRule
     extends RelRule<AggregateRemoveRule.Config>
     implements SubstitutionRule {
@@ -131,10 +134,10 @@ public class AggregateRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableAggregateRemoveRule.Config.of()
         .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
-        .as(Config.class)
         .withOperandFor(LogicalAggregate.class);
 
     @Override default AggregateRemoveRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
@@ -47,6 +47,7 @@ import org.apache.calcite.util.mapping.AbstractSourceMapping;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,6 +66,7 @@ import static java.util.Objects.requireNonNull;
  * @see CoreRules#AGGREGATE_STAR_TABLE
  * @see CoreRules#AGGREGATE_PROJECT_STAR_TABLE
  */
+@Value.Enclosing
 public class AggregateStarTableRule
     extends RelRule<AggregateStarTableRule.Config>
     implements TransformationRule {
@@ -251,8 +253,10 @@ public class AggregateStarTableRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+
+    Config DEFAULT = ImmutableAggregateStarTableRule.Config.of()
         .withOperandFor(Aggregate.class, StarTable.StarTableScan.class);
 
     @Override default AggregateStarTableRule toRule() {
@@ -270,4 +274,5 @@ public class AggregateStarTableRule
           .as(Config.class);
     }
   }
+
 }

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionAggregateRule.java
@@ -28,6 +28,8 @@ import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that matches
  * {@link org.apache.calcite.rel.core.Aggregate}s beneath a
@@ -43,6 +45,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * @see CoreRules#AGGREGATE_UNION_AGGREGATE_FIRST
  * @see CoreRules#AGGREGATE_UNION_AGGREGATE_SECOND
  */
+@Value.Enclosing
 public class AggregateUnionAggregateRule
     extends RelRule<AggregateUnionAggregateRule.Config>
     implements TransformationRule {
@@ -135,10 +138,10 @@ public class AggregateUnionAggregateRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableAggregateUnionAggregateRule.Config.of()
         .withDescription("AggregateUnionAggregateRule")
-        .as(Config.class)
         .withOperandFor(LogicalAggregate.class, LogicalUnion.class,
             RelNode.class, RelNode.class);
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
@@ -44,6 +44,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
@@ -56,6 +57,7 @@ import java.util.List;
  *
  * @see CoreRules#AGGREGATE_UNION_TRANSPOSE
  */
+@Value.Enclosing
 public class AggregateUnionTransposeRule
     extends RelRule<AggregateUnionTransposeRule.Config>
     implements TransformationRule {
@@ -193,8 +195,9 @@ public class AggregateUnionTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateUnionTransposeRule.Config.of()
         .withOperandFor(LogicalAggregate.class, LogicalUnion.class);
 
     @Override default AggregateUnionTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValuesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValuesRule.java
@@ -29,6 +29,8 @@ import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +55,7 @@ import java.util.List;
  *
  * @see CoreRules#AGGREGATE_VALUES
  */
+@Value.Enclosing
 public class AggregateValuesRule
     extends RelRule<AggregateValuesRule.Config>
     implements SubstitutionRule {
@@ -106,8 +109,9 @@ public class AggregateValuesRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableAggregateValuesRule.Config.of()
         .withOperandFor(Aggregate.class, Values.class);
 
     @Override default AggregateValuesRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
@@ -24,6 +24,8 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that merges a
  * {@link org.apache.calcite.rel.logical.LogicalCalc} onto a
@@ -36,6 +38,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#CALC_MERGE
  */
+@Value.Enclosing
 public class CalcMergeRule extends RelRule<CalcMergeRule.Config>
     implements TransformationRule {
 
@@ -90,8 +93,9 @@ public class CalcMergeRule extends RelRule<CalcMergeRule.Config>
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = Config.EMPTY
+    Config DEFAULT = ImmutableCalcMergeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Calc.class).oneInput(b1 ->
                 b1.operand(Calc.class).anyInputs()))

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcRemoveRule.java
@@ -23,6 +23,8 @@ import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.logical.LogicalCalc;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that removes a trivial
  * {@link org.apache.calcite.rel.logical.LogicalCalc}.
@@ -33,6 +35,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see ProjectRemoveRule
  */
+@Value.Enclosing
 public class CalcRemoveRule extends RelRule<CalcRemoveRule.Config>
     implements SubstitutionRule {
 
@@ -61,8 +64,9 @@ public class CalcRemoveRule extends RelRule<CalcRemoveRule.Config>
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableCalcRemoveRule.Config.of()
         .withOperandSupplier(b ->
             b.operand(LogicalCalc.class)
                 .predicate(calc -> calc.getProgram().isTrivial())

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcSplitRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcSplitRule.java
@@ -27,6 +27,8 @@ import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that converts a {@link Calc}
  * to a {@link org.apache.calcite.rel.core.Project}
@@ -39,6 +41,7 @@ import com.google.common.collect.ImmutableList;
  *
  * @see CoreRules#CALC_SPLIT
  */
+@Value.Enclosing
 public class CalcSplitRule extends RelRule<CalcSplitRule.Config>
     implements TransformationRule {
 
@@ -65,10 +68,10 @@ public class CalcSplitRule extends RelRule<CalcSplitRule.Config>
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(Calc.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableCalcSplitRule.Config.of()
+        .withOperandSupplier(b -> b.operand(Calc.class).anyInputs());
 
     @Override default CalcSplitRule toRule() {
       return new CalcSplitRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/CoerceInputsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoerceInputsRule.java
@@ -26,6 +26,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ import java.util.List;
  *
  * @see CoreRules#COERCE_INPUTS
  */
+@Value.Enclosing
 public class CoerceInputsRule
     extends RelRule<CoerceInputsRule.Config>
     implements TransformationRule {
@@ -109,8 +111,11 @@ public class CoerceInputsRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableCoerceInputsRule.Config.builder()
+        .withConsumerRelClass(RelNode.class)
+        .build()
         .withCoerceNames(false)
         .withOperandFor(RelNode.class);
 
@@ -121,7 +126,9 @@ public class CoerceInputsRule
     /** Whether to coerce names. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean isCoerceNames();
+    @Value.Default default boolean isCoerceNames() {
+      return false;
+    }
 
     /** Sets {@link #isCoerceNames()}. */
     Config withCoerceNames(boolean coerceNames);

--- a/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
@@ -52,6 +52,7 @@ import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -215,13 +216,14 @@ public abstract class DateRangeRules {
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableFilterDateRangeRuleConfig")
     public interface Config extends RelRule.Config {
-      Config DEFAULT = EMPTY
+      Config DEFAULT = ImmutableFilterDateRangeRuleConfig.of()
           .withOperandSupplier(b ->
               b.operand(Filter.class)
                   .predicate(FilterDateRangeRule::containsRoundingExpression)
-                  .anyInputs())
-          .as(Config.class);
+                  .anyInputs());
 
       @Override default FilterDateRangeRule toRule() {
         return new FilterDateRangeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ExchangeRemoveConstantKeysRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ExchangeRemoveConstantKeysRule.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptPredicateList;
-import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.RelCollation;
@@ -33,6 +32,8 @@ import org.apache.calcite.rel.logical.LogicalSortExchange;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.util.ImmutableBeans;
+
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -53,6 +54,7 @@ import java.util.stream.Collectors;
  * @see CoreRules#EXCHANGE_REMOVE_CONSTANT_KEYS
  * @see CoreRules#SORT_EXCHANGE_REMOVE_CONSTANT_KEYS
  */
+@Value.Enclosing
 public class ExchangeRemoveConstantKeysRule
     extends RelRule<ExchangeRemoveConstantKeysRule.Config>
     implements SubstitutionRule {
@@ -170,23 +172,23 @@ public class ExchangeRemoveConstantKeysRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .as(Config.class)
+    Config DEFAULT = ImmutableExchangeRemoveConstantKeysRule.Config
+        .of(ExchangeRemoveConstantKeysRule::matchExchange)
         .withOperandFor(LogicalExchange.class,
             exchange -> exchange.getDistribution().getType()
-                == RelDistribution.Type.HASH_DISTRIBUTED)
-        .withMatchHandler(ExchangeRemoveConstantKeysRule::matchExchange);
+                == RelDistribution.Type.HASH_DISTRIBUTED);
 
-    Config SORT = EMPTY
+    Config SORT = ImmutableExchangeRemoveConstantKeysRule.Config
+        .of(ExchangeRemoveConstantKeysRule::matchSortExchange)
         .withDescription("SortExchangeRemoveConstantKeysRule")
         .as(Config.class)
         .withOperandFor(LogicalSortExchange.class,
             sortExchange -> sortExchange.getDistribution().getType()
                 == RelDistribution.Type.HASH_DISTRIBUTED
                 || !sortExchange.getCollation().getFieldCollations()
-                .isEmpty())
-        .withMatchHandler(ExchangeRemoveConstantKeysRule::matchSortExchange);
+                .isEmpty());
 
     @Override default ExchangeRemoveConstantKeysRule toRule() {
       return new ExchangeRemoveConstantKeysRule(this);
@@ -194,10 +196,11 @@ public class ExchangeRemoveConstantKeysRule
 
     /** Forwards a call to {@link #onMatch(RelOptRuleCall)}. */
     @ImmutableBeans.Property
-    <R extends RelOptRule> MatchHandler<R> matchHandler();
+    @Value.Parameter
+    MatchHandler<ExchangeRemoveConstantKeysRule> matchHandler();
 
     /** Sets {@link #matchHandler()}. */
-    <R extends RelOptRule> Config withMatchHandler(MatchHandler<R> matchHandler);
+    Config withMatchHandler(MatchHandler<ExchangeRemoveConstantKeysRule> matchHandler);
 
     /** Defines an operand tree for the given classes. */
     default <R extends Exchange> Config withOperandFor(Class<R> exchangeClass,

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterAggregateTransposeRule.java
@@ -35,6 +35,8 @@ import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,6 +47,7 @@ import java.util.List;
  * @see org.apache.calcite.rel.rules.AggregateFilterTransposeRule
  * @see CoreRules#FILTER_AGGREGATE_TRANSPOSE
  */
+@Value.Enclosing
 public class FilterAggregateTransposeRule
     extends RelRule<FilterAggregateTransposeRule.Config>
     implements TransformationRule {
@@ -147,8 +150,9 @@ public class FilterAggregateTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableFilterAggregateTransposeRule.Config.of()
         .withOperandFor(Filter.class, Aggregate.class);
 
     @Override default FilterAggregateTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterCalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterCalcMergeRule.java
@@ -27,6 +27,8 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that merges a
  * {@link org.apache.calcite.rel.logical.LogicalFilter} and a
@@ -38,6 +40,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * @see ProjectCalcMergeRule
  * @see CoreRules#FILTER_CALC_MERGE
  */
+@Value.Enclosing
 public class FilterCalcMergeRule
     extends RelRule<FilterCalcMergeRule.Config>
     implements TransformationRule {
@@ -90,8 +93,9 @@ public class FilterCalcMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableFilterCalcMergeRule.Config.of()
         .withOperandFor(Filter.class, LogicalCalc.class);
 
     @Override default FilterCalcMergeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterCorrelateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterCorrelateRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,6 +42,7 @@ import java.util.List;
  *
  * @see CoreRules#FILTER_CORRELATE
  */
+@Value.Enclosing
 public class FilterCorrelateRule
     extends RelRule<FilterCorrelateRule.Config>
     implements TransformationRule {
@@ -124,8 +127,9 @@ public class FilterCorrelateRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableFilterCorrelateRule.Config.of()
         .withOperandFor(Filter.class, Correlate.class);
 
     @Override default FilterCorrelateRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterFlattenCorrelatedConditionRule.java
@@ -27,6 +27,7 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import org.apiguardian.api.API;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +62,7 @@ import java.util.List;
  * choose to use this rule or not.</p>
  */
 @API(since = "1.27", status = API.Status.EXPERIMENTAL)
+@Value.Enclosing
 public final class FilterFlattenCorrelatedConditionRule
     extends RelRule<FilterFlattenCorrelatedConditionRule.Config> {
 
@@ -135,9 +137,10 @@ public final class FilterFlattenCorrelatedConditionRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT =
-        EMPTY.withOperandSupplier(op -> op.operand(Filter.class).anyInputs()).as(Config.class);
+    Config DEFAULT = ImmutableFilterFlattenCorrelatedConditionRule.Config.of()
+        .withOperandSupplier(op -> op.operand(Filter.class).anyInputs());
 
     @Override default FilterFlattenCorrelatedConditionRule toRule() {
       return new FilterFlattenCorrelatedConditionRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterMergeRule.java
@@ -24,10 +24,13 @@ import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that combines two
  * {@link org.apache.calcite.rel.logical.LogicalFilter}s.
  */
+@Value.Enclosing
 public class FilterMergeRule extends RelRule<FilterMergeRule.Config>
     implements SubstitutionRule {
 
@@ -62,8 +65,9 @@ public class FilterMergeRule extends RelRule<FilterMergeRule.Config>
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableFilterMergeRule.Config.of()
         .withOperandFor(Filter.class);
 
     @Override default FilterMergeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterMultiJoinMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterMultiJoinMergeRule.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +38,7 @@ import java.util.List;
  * @see org.apache.calcite.rel.rules.ProjectMultiJoinMergeRule
  * @see CoreRules#FILTER_MULTI_JOIN_MERGE
  */
+@Value.Enclosing
 public class FilterMultiJoinMergeRule
     extends RelRule<FilterMultiJoinMergeRule.Config>
     implements TransformationRule {
@@ -90,8 +92,9 @@ public class FilterMultiJoinMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableFilterMultiJoinMergeRule.Config.of()
         .withOperandFor(Filter.class, MultiJoin.class);
 
     @Override default FilterMultiJoinMergeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
@@ -33,6 +33,8 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
+import org.immutables.value.Value;
+
 import java.util.Collections;
 import java.util.function.Predicate;
 
@@ -43,6 +45,7 @@ import java.util.function.Predicate;
  *
  * @see CoreRules#FILTER_PROJECT_TRANSPOSE
  */
+@Value.Enclosing
 public class FilterProjectTransposeRule
     extends RelRule<FilterProjectTransposeRule.Config>
     implements TransformationRule {
@@ -203,8 +206,9 @@ public class FilterProjectTransposeRule
    * <p>Defining predicates for the Filter (using {@code filterPredicate})
    * and/or the Project (using {@code projectPredicate} allows making the rule
    * more restrictive. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableFilterProjectTransposeRule.Config.of()
         .withOperandFor(Filter.class,
             f -> !RexUtil.containsCorrelation(f.getCondition()),
             Project.class, p -> true)
@@ -219,7 +223,9 @@ public class FilterProjectTransposeRule
      * matched Filter. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(true)
-    boolean isCopyFilter();
+    @Value.Default default boolean isCopyFilter() {
+      return true;
+    }
 
     /** Sets {@link #isCopyFilter()}. */
     Config withCopyFilter(boolean copyFilter);
@@ -228,7 +234,9 @@ public class FilterProjectTransposeRule
      * matched Project. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(true)
-    boolean isCopyProject();
+    @Value.Default default boolean isCopyProject() {
+      return true;
+    }
 
     /** Sets {@link #isCopyProject()}. */
     Config withCopyProject(boolean copyProject);

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterRemoveIsNotDistinctFromRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterRemoveIsNotDistinctFromRule.java
@@ -30,6 +30,8 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that replaces {@code IS NOT DISTINCT FROM}
  * in a {@link Filter} with logically equivalent operations.
@@ -39,6 +41,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * @see RelBuilder#isDistinctFrom
  * @see RelBuilder#isNotDistinctFrom
  */
+@Value.Enclosing
 public final class FilterRemoveIsNotDistinctFromRule
     extends RelRule<FilterRemoveIsNotDistinctFromRule.Config>
     implements TransformationRule {
@@ -116,10 +119,10 @@ public final class FilterRemoveIsNotDistinctFromRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(Filter.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableFilterRemoveIsNotDistinctFromRule.Config.of()
+        .withOperandSupplier(b -> b.operand(Filter.class).anyInputs());
 
     @Override default FilterRemoveIsNotDistinctFromRule toRule() {
       return new FilterRemoveIsNotDistinctFromRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterSetOpTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterSetOpTransposeRule.java
@@ -30,6 +30,8 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,6 +41,7 @@ import java.util.List;
  *
  * @see CoreRules#FILTER_SET_OP_TRANSPOSE
  */
+@Value.Enclosing
 public class FilterSetOpTransposeRule
     extends RelRule<FilterSetOpTransposeRule.Config>
     implements TransformationRule {
@@ -96,12 +99,12 @@ public class FilterSetOpTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableFilterSetOpTransposeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Filter.class).oneInput(b1 ->
-                b1.operand(SetOp.class).anyInputs()))
-        .as(Config.class);
+                b1.operand(SetOp.class).anyInputs()));
 
     @Override default FilterSetOpTransposeRule toRule() {
       return new FilterSetOpTransposeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterTableFunctionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterTableFunctionTransposeRule.java
@@ -29,6 +29,8 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -40,6 +42,7 @@ import java.util.Set;
  *
  * @see CoreRules#FILTER_TABLE_FUNCTION_TRANSPOSE
  */
+@Value.Enclosing
 public class FilterTableFunctionTransposeRule
     extends RelRule<FilterTableFunctionTransposeRule.Config>
     implements TransformationRule {
@@ -118,12 +121,12 @@ public class FilterTableFunctionTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableFilterTableFunctionTransposeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(LogicalFilter.class).oneInput(b1 ->
-                b1.operand(LogicalTableFunctionScan.class).anyInputs()))
-        .as(Config.class);
+                b1.operand(LogicalTableFunctionScan.class).anyInputs()));
 
     @Override default FilterTableFunctionTransposeRule toRule() {
       return new FilterTableFunctionTransposeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterTableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterTableScanRule.java
@@ -35,6 +35,8 @@ import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that converts
  * a {@link org.apache.calcite.rel.core.Filter}
@@ -51,6 +53,7 @@ import com.google.common.collect.ImmutableList;
  * @see CoreRules#FILTER_SCAN
  * @see CoreRules#FILTER_INTERPRETER_SCAN
  */
+@Value.Enclosing
 public class FilterTableScanRule
     extends RelRule<FilterTableScanRule.Config> {
   @SuppressWarnings("Guava")
@@ -65,14 +68,14 @@ public class FilterTableScanRule
 
   @Deprecated // to be removed before 2.0
   protected FilterTableScanRule(RelOptRuleOperand operand, String description) {
-    this(Config.EMPTY.as(Config.class));
+    this(ImmutableFilterTableScanRule.Config.of().as(Config.class));
     throw new UnsupportedOperationException();
   }
 
   @Deprecated // to be removed before 2.0
   protected FilterTableScanRule(RelOptRuleOperand operand,
       RelBuilderFactory relBuilderFactory, String description) {
-    this(Config.EMPTY.as(Config.class));
+    this(ImmutableFilterTableScanRule.Config.of().as(Config.class));
     throw new UnsupportedOperationException();
   }
 
@@ -125,22 +128,21 @@ public class FilterTableScanRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableFilterTableScanRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Filter.class).oneInput(b1 ->
                 b1.operand(TableScan.class)
-                    .predicate(FilterTableScanRule::test).noInputs()))
-        .as(Config.class);
+                    .predicate(FilterTableScanRule::test).noInputs()));
 
-    Config INTERPRETER = EMPTY
+    Config INTERPRETER = ImmutableFilterTableScanRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Filter.class).oneInput(b1 ->
                 b1.operand(EnumerableInterpreter.class).oneInput(b2 ->
                     b2.operand(TableScan.class)
                         .predicate(FilterTableScanRule::test).noInputs())))
-        .withDescription("FilterTableScanRule:interpreter")
-        .as(Config.class);
+        .withDescription("FilterTableScanRule:interpreter");
 
     @Override default FilterTableScanRule toRule() {
       return new FilterTableScanRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterToCalcRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterToCalcRule.java
@@ -27,6 +27,8 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that converts a
  * {@link org.apache.calcite.rel.logical.LogicalFilter} to a
@@ -43,6 +45,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#FILTER_TO_CALC
  */
+@Value.Enclosing
 public class FilterToCalcRule
     extends RelRule<FilterToCalcRule.Config>
     implements TransformationRule {
@@ -78,11 +81,11 @@ public class FilterToCalcRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableFilterToCalcRule.Config.of()
         .withOperandSupplier(b ->
-            b.operand(LogicalFilter.class).anyInputs())
-        .as(Config.class);
+            b.operand(LogicalFilter.class).anyInputs());
 
     @Override default FilterToCalcRule toRule() {
       return new FilterToCalcRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/IntersectToDistinctRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/IntersectToDistinctRule.java
@@ -28,6 +28,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
+import org.immutables.value.Value;
+
 import java.math.BigDecimal;
 
 /**
@@ -66,6 +68,7 @@ import java.math.BigDecimal;
  * @see org.apache.calcite.rel.rules.UnionToDistinctRule
  * @see CoreRules#INTERSECT_TO_DISTINCT
  */
+@Value.Enclosing
 public class IntersectToDistinctRule
     extends RelRule<IntersectToDistinctRule.Config>
     implements TransformationRule {
@@ -130,8 +133,9 @@ public class IntersectToDistinctRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableIntersectToDistinctRule.Config.of()
         .withOperandFor(LogicalIntersect.class);
 
     @Override default IntersectToDistinctRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinAddRedundantSemiJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinAddRedundantSemiJoinRule.java
@@ -28,6 +28,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.immutables.value.Value;
+
 /**
  * Rule to add a semi-join into a join. Transformation is as follows:
  *
@@ -39,6 +41,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @see CoreRules#JOIN_ADD_REDUNDANT_SEMI_JOIN
  */
+@Value.Enclosing
 public class JoinAddRedundantSemiJoinRule
     extends RelRule<JoinAddRedundantSemiJoinRule.Config>
     implements TransformationRule {
@@ -96,8 +99,9 @@ public class JoinAddRedundantSemiJoinRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableJoinAddRedundantSemiJoinRule.Config.of()
         .withOperandFor(LogicalJoin.class);
 
     @Override default JoinAddRedundantSemiJoinRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinAssociateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinAssociateRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.mapping.Mappings;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,6 +48,7 @@ import java.util.List;
  * @see JoinCommuteRule
  * @see CoreRules#JOIN_ASSOCIATE
  */
+@Value.Enclosing
 public class JoinAssociateRule
     extends RelRule<JoinAssociateRule.Config>
     implements TransformationRule {
@@ -163,8 +166,9 @@ public class JoinAssociateRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableJoinAssociateRule.Config.of()
         .withOperandFor(Join.class);
 
     @Override default JoinAssociateRule toRule() {
@@ -177,7 +181,9 @@ public class JoinAssociateRule
      */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(true)
-    boolean isAllowAlwaysTrueCondition();
+    @Value.Default default boolean isAllowAlwaysTrueCondition() {
+      return true;
+    }
 
     /** Sets {@link #isAllowAlwaysTrueCondition()}. */
     Config withAllowAlwaysTrueCondition(boolean allowAlwaysTrueCondition);

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinCommuteRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinCommuteRule.java
@@ -37,6 +37,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.List;
 
@@ -53,6 +54,7 @@ import java.util.List;
  * @see CoreRules#JOIN_COMMUTE
  * @see CoreRules#JOIN_COMMUTE_OUTER
  */
+@Value.Enclosing
 public class JoinCommuteRule
     extends RelRule<JoinCommuteRule.Config>
     implements TransformationRule {
@@ -226,8 +228,9 @@ public class JoinCommuteRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableJoinCommuteRule.Config.of()
         .withOperandFor(LogicalJoin.class)
         .withSwapOuter(false);
 
@@ -250,7 +253,9 @@ public class JoinCommuteRule
     /** Whether to swap outer joins; default false. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean isSwapOuter();
+    @Value.Default default boolean isSwapOuter() {
+      return false;
+    }
 
     /** Sets {@link #isSwapOuter()}. */
     Config withSwapOuter(boolean swapOuter);
@@ -259,7 +264,9 @@ public class JoinCommuteRule
      * (that is, cartesian joins); default true. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(true)
-    boolean isAllowAlwaysTrueCondition();
+    @Value.Default default boolean isAllowAlwaysTrueCondition() {
+      return true;
+    }
 
     /** Sets {@link #isAllowAlwaysTrueCondition()}. */
     Config withAllowAlwaysTrueCondition(boolean allowAlwaysTrueCondition);

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinExtractFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinExtractFilterRule.java
@@ -20,6 +20,8 @@ import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Rule to convert an
  * {@link org.apache.calcite.rel.logical.LogicalJoin inner join} to a
@@ -36,6 +38,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#JOIN_EXTRACT_FILTER
  */
+@Value.Enclosing
 public final class JoinExtractFilterRule extends AbstractJoinExtractFilterRule {
 
   /** Creates a JoinExtractFilterRule. */
@@ -54,10 +57,10 @@ public final class JoinExtractFilterRule extends AbstractJoinExtractFilterRule {
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends AbstractJoinExtractFilterRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(LogicalJoin.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableJoinExtractFilterRule.Config.of()
+        .withOperandSupplier(b -> b.operand(LogicalJoin.class).anyInputs());
 
     @Override default JoinExtractFilterRule toRule() {
       return new JoinExtractFilterRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
@@ -43,6 +43,7 @@ import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.Pair;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,6 +61,7 @@ import static java.util.Objects.requireNonNull;
  * {@link org.apache.calcite.rel.logical.LogicalProject} doesn't originate from
  * a null generating input in an outer join.
  */
+@Value.Enclosing
 public class JoinProjectTransposeRule
     extends RelRule<JoinProjectTransposeRule.Config>
     implements TransformationRule {
@@ -379,14 +381,14 @@ public class JoinProjectTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableJoinProjectTransposeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(LogicalJoin.class).inputs(
                 b1 -> b1.operand(LogicalProject.class).anyInputs(),
                 b2 -> b2.operand(LogicalProject.class).anyInputs()))
-        .withDescription("JoinProjectTransposeRule(Project-Project)")
-        .as(Config.class);
+        .withDescription("JoinProjectTransposeRule(Project-Project)");
 
     Config LEFT = DEFAULT
         .withOperandSupplier(b0 ->
@@ -428,7 +430,9 @@ public class JoinProjectTransposeRule
     /** Whether to include outer joins, default false. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean isIncludeOuter();
+    @Value.Default default boolean isIncludeOuter() {
+      return false;
+    }
 
     /** Sets {@link #isIncludeOuter()}. */
     Config withIncludeOuter(boolean includeOuter);

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinPushExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinPushExpressionsRule.java
@@ -26,6 +26,8 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that pushes down expressions in "equal" join condition.
  *
@@ -37,6 +39,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#JOIN_PUSH_EXPRESSIONS
  */
+@Value.Enclosing
 public class JoinPushExpressionsRule
     extends RelRule<JoinPushExpressionsRule.Config>
     implements TransformationRule {
@@ -80,10 +83,10 @@ public class JoinPushExpressionsRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
-        .withOperandFor(Join.class)
-        .as(Config.class);
+    Config DEFAULT = ImmutableJoinPushExpressionsRule.Config.of()
+        .withOperandFor(Join.class);
 
     @Override default JoinPushExpressionsRule toRule() {
       return new JoinPushExpressionsRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinPushThroughJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinPushThroughJoinRule.java
@@ -35,6 +35,8 @@ import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.mapping.Mappings;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,6 +64,7 @@ import java.util.List;
  * <p>Before the rule, one join has two conditions and the other has none
  * ({@code ON TRUE}). After the rule, each join has one condition.</p>
  */
+@Value.Enclosing
 public class JoinPushThroughJoinRule
     extends RelRule<JoinPushThroughJoinRule.Config>
     implements TransformationRule {
@@ -328,14 +331,15 @@ public class JoinPushThroughJoinRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config RIGHT = EMPTY.withDescription("JoinPushThroughJoinRule:right")
-        .as(Config.class)
+    Config RIGHT = ImmutableJoinPushThroughJoinRule.Config.of()
+        .withDescription("JoinPushThroughJoinRule:right")
         .withOperandFor(LogicalJoin.class)
         .withRight(true);
 
-    Config LEFT = EMPTY.withDescription("JoinPushThroughJoinRule:left")
-        .as(Config.class)
+    Config LEFT = ImmutableJoinPushThroughJoinRule.Config.of()
+        .withDescription("JoinPushThroughJoinRule:left")
         .withOperandFor(LogicalJoin.class)
         .withRight(false);
 
@@ -346,7 +350,9 @@ public class JoinPushThroughJoinRule
     /** Whether to push on the right. If false, push to the left. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean isRight();
+    @Value.Default default boolean isRight() {
+      return false;
+    }
 
     /** Sets {@link #isRight()}. */
     Config withRight(boolean right);

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinPushTransitivePredicatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinPushTransitivePredicatesRule.java
@@ -27,6 +27,8 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that infers predicates from on a
  * {@link org.apache.calcite.rel.core.Join} and creates
@@ -40,6 +42,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#JOIN_PUSH_TRANSITIVE_PREDICATES
  */
+@Value.Enclosing
 public class JoinPushTransitivePredicatesRule
     extends RelRule<JoinPushTransitivePredicatesRule.Config>
     implements TransformationRule {
@@ -102,8 +105,9 @@ public class JoinPushTransitivePredicatesRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableJoinPushTransitivePredicatesRule.Config.of()
         .withOperandFor(Join.class);
 
     @Override default JoinPushTransitivePredicatesRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinToCorrelateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinToCorrelateRule.java
@@ -34,6 +34,8 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import org.immutables.value.Value;
+
 /**
  * Rule that converts a {@link org.apache.calcite.rel.core.Join}
  * into a {@link org.apache.calcite.rel.logical.LogicalCorrelate}, which can
@@ -58,6 +60,7 @@ import org.apache.calcite.util.ImmutableBitSet;
  *
  * @see CoreRules#JOIN_TO_CORRELATE
  */
+@Value.Enclosing
 public class JoinToCorrelateRule
     extends RelRule<JoinToCorrelateRule.Config>
     implements TransformationRule {
@@ -128,8 +131,9 @@ public class JoinToCorrelateRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableJoinToCorrelateRule.Config.of()
         .withOperandFor(LogicalJoin.class);
 
     @Override default JoinToCorrelateRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinToMultiJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinToMultiJoinRule.java
@@ -37,6 +37,7 @@ import org.apache.calcite.util.Pair;
 import com.google.common.collect.ImmutableMap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -106,6 +107,7 @@ import static java.util.Objects.requireNonNull;
  * @see org.apache.calcite.rel.rules.ProjectMultiJoinMergeRule
  * @see CoreRules#JOIN_TO_MULTI_JOIN
  */
+@Value.Enclosing
 public class JoinToMultiJoinRule
     extends RelRule<JoinToMultiJoinRule.Config>
     implements TransformationRule {
@@ -577,8 +579,9 @@ public class JoinToMultiJoinRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableJoinToMultiJoinRule.Config.of()
         .withOperandFor(LogicalJoin.class);
 
     @Override default JoinToMultiJoinRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinUnionTransposeRule.java
@@ -25,6 +25,8 @@ import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +38,7 @@ import java.util.List;
  * @see CoreRules#JOIN_LEFT_UNION_TRANSPOSE
  * @see CoreRules#JOIN_RIGHT_UNION_TRANSPOSE
  */
+@Value.Enclosing
 public class JoinUnionTransposeRule
     extends RelRule<JoinUnionTransposeRule.Config>
     implements TransformationRule {
@@ -114,13 +117,14 @@ public class JoinUnionTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config LEFT = EMPTY.withDescription("JoinUnionTransposeRule(Union-Other)")
-        .as(Config.class)
+    Config LEFT = ImmutableJoinUnionTransposeRule.Config.of()
+        .withDescription("JoinUnionTransposeRule(Union-Other)")
         .withOperandFor(Join.class, Union.class, true);
 
-    Config RIGHT = EMPTY.withDescription("JoinUnionTransposeRule(Other-Union)")
-        .as(Config.class)
+    Config RIGHT = ImmutableJoinUnionTransposeRule.Config.of()
+        .withDescription("JoinUnionTransposeRule(Other-Union)")
         .withOperandFor(Join.class, Union.class, false);
 
     @Override default JoinUnionTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/LoptOptimizeJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/LoptOptimizeJoinRule.java
@@ -49,6 +49,7 @@ import org.apache.calcite.util.mapping.IntPair;
 
 import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -72,6 +73,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see CoreRules#MULTI_JOIN_OPTIMIZE
  */
+@Value.Enclosing
 public class LoptOptimizeJoinRule
     extends RelRule<LoptOptimizeJoinRule.Config>
     implements TransformationRule {
@@ -2086,10 +2088,10 @@ public class LoptOptimizeJoinRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(MultiJoin.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableLoptOptimizeJoinRule.Config.of()
+        .withOperandSupplier(b -> b.operand(MultiJoin.class).anyInputs());
 
     @Override default LoptOptimizeJoinRule toRule() {
       return new LoptOptimizeJoinRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/MatchRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MatchRule.java
@@ -21,6 +21,8 @@ import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalMatch;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that converts a
  * {@link LogicalMatch} to the result
@@ -28,6 +30,7 @@ import org.apache.calcite.rel.logical.LogicalMatch;
  *
  * @see CoreRules#MATCH
  */
+@Value.Enclosing
 public class MatchRule extends RelRule<MatchRule.Config>
     implements TransformationRule {
 
@@ -51,10 +54,10 @@ public class MatchRule extends RelRule<MatchRule.Config>
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(LogicalMatch.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableMatchRule.Config.of()
+        .withOperandSupplier(b -> b.operand(LogicalMatch.class).anyInputs());
 
     @Override default MatchRule toRule() {
       return new MatchRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/MaterializedViewFilterScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MaterializedViewFilterScanRule.java
@@ -33,6 +33,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 
 import com.google.common.base.Suppliers;
 
+import org.immutables.value.Value;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -45,6 +47,7 @@ import java.util.function.Supplier;
  *
  * @see org.apache.calcite.rel.rules.materialize.MaterializedViewRules#FILTER_SCAN
  */
+@Value.Enclosing
 public class MaterializedViewFilterScanRule
     extends RelRule<MaterializedViewFilterScanRule.Config>
     implements TransformationRule {
@@ -104,8 +107,9 @@ public class MaterializedViewFilterScanRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableMaterializedViewFilterScanRule.Config.of()
         .withOperandFor(Filter.class, TableScan.class);
 
     @Override default MaterializedViewFilterScanRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinOptimizeBushyRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinOptimizeBushyRule.java
@@ -39,6 +39,7 @@ import org.apache.calcite.util.mapping.Mappings;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -73,6 +74,7 @@ import static org.apache.calcite.util.mapping.Mappings.TargetMapping;
  *
  * @see CoreRules#MULTI_JOIN_OPTIMIZE_BUSHY
  */
+@Value.Enclosing
 public class MultiJoinOptimizeBushyRule
     extends RelRule<MultiJoinOptimizeBushyRule.Config>
     implements TransformationRule {
@@ -399,10 +401,10 @@ public class MultiJoinOptimizeBushyRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(MultiJoin.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableMultiJoinOptimizeBushyRule.Config.of()
+        .withOperandSupplier(b -> b.operand(MultiJoin.class).anyInputs());
 
     @Override default MultiJoinOptimizeBushyRule toRule() {
       return new MultiJoinOptimizeBushyRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MultiJoinProjectTransposeRule.java
@@ -25,6 +25,8 @@ import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * MultiJoinProjectTransposeRule implements the rule for pulling
  * {@link org.apache.calcite.rel.logical.LogicalProject}s that are on top of a
@@ -60,6 +62,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * @see CoreRules#MULTI_JOIN_LEFT_PROJECT
  * @see CoreRules#MULTI_JOIN_RIGHT_PROJECT
  */
+@Value.Enclosing
 public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
 
   /** Creates a MultiJoinProjectTransposeRule. */
@@ -71,9 +74,8 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
   public MultiJoinProjectTransposeRule(
       RelOptRuleOperand operand,
       String description) {
-    this(Config.DEFAULT.withDescription(description)
-        .withOperandSupplier(b -> b.exactly(operand))
-        .as(Config.class));
+    this(ImmutableMultiJoinProjectTransposeRule.Config.of().withDescription(description)
+        .withOperandSupplier(b -> b.exactly(operand)));
   }
 
   @Deprecated // to be removed before 2.0
@@ -81,10 +83,9 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
       RelOptRuleOperand operand,
       RelBuilderFactory relBuilderFactory,
       String description) {
-    this(Config.DEFAULT.withDescription(description)
+    this(ImmutableMultiJoinProjectTransposeRule.Config.of().withDescription(description)
         .withRelBuilderFactory(relBuilderFactory)
-        .withOperandSupplier(b -> b.exactly(operand))
-        .as(Config.class));
+        .withOperandSupplier(b -> b.exactly(operand)));
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -126,8 +127,10 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
   }
 
   /** Rule configuration. */
+  @Value.Immutable
+  @SuppressWarnings("immutables:subtype")
   public interface Config extends JoinProjectTransposeRule.Config {
-    Config BOTH_PROJECT = EMPTY
+    Config BOTH_PROJECT = ImmutableMultiJoinProjectTransposeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(LogicalJoin.class).inputs(
                 b1 -> b1.operand(LogicalProject.class).oneInput(b2 ->
@@ -135,27 +138,25 @@ public class MultiJoinProjectTransposeRule extends JoinProjectTransposeRule {
                 b3 -> b3.operand(LogicalProject.class).oneInput(b4 ->
                     b4.operand(MultiJoin.class).anyInputs())))
         .withDescription(
-            "MultiJoinProjectTransposeRule: with two LogicalProject children")
-        .as(Config.class);
+            "MultiJoinProjectTransposeRule: with two LogicalProject children");
 
-    Config LEFT_PROJECT = EMPTY
+    Config LEFT_PROJECT = ImmutableMultiJoinProjectTransposeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(LogicalJoin.class).inputs(b1 ->
                 b1.operand(LogicalProject.class).oneInput(b2 ->
                     b2.operand(MultiJoin.class).anyInputs())))
         .withDescription(
-            "MultiJoinProjectTransposeRule: with LogicalProject on left")
-        .as(Config.class);
+            "MultiJoinProjectTransposeRule: with LogicalProject on left");
 
-    Config RIGHT_PROJECT = EMPTY
+    Config RIGHT_PROJECT = ImmutableMultiJoinProjectTransposeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(LogicalJoin.class).inputs(
                 b1 -> b1.operand(RelNode.class).anyInputs(),
                 b2 -> b2.operand(LogicalProject.class).oneInput(b3 ->
                     b3.operand(MultiJoin.class).anyInputs())))
         .withDescription(
-            "MultiJoinProjectTransposeRule: with LogicalProject on right")
-        .as(Config.class);
+            "MultiJoinProjectTransposeRule: with LogicalProject on right");
+
 
     @Override default MultiJoinProjectTransposeRule toRule() {
       return new MultiJoinProjectTransposeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateMergeRule.java
@@ -38,6 +38,8 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
+import org.immutables.value.Value;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @see CoreRules#PROJECT_AGGREGATE_MERGE
  */
+@Value.Enclosing
 public class ProjectAggregateMergeRule
     extends RelRule<ProjectAggregateMergeRule.Config>
     implements TransformationRule {
@@ -189,13 +192,13 @@ public class ProjectAggregateMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableProjectAggregateMergeRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Project.class)
                 .oneInput(b1 ->
-                    b1.operand(Aggregate.class).anyInputs()))
-        .as(Config.class);
+                    b1.operand(Aggregate.class).anyInputs()));
 
     @Override default ProjectAggregateMergeRule toRule() {
       return new ProjectAggregateMergeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectCalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectCalcMergeRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.Pair;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that merges a
  * {@link org.apache.calcite.rel.logical.LogicalProject} and a
@@ -44,6 +46,7 @@ import org.apache.calcite.util.Pair;
  * @see FilterCalcMergeRule
  * @see CoreRules#PROJECT_CALC_MERGE
  */
+@Value.Enclosing
 public class ProjectCalcMergeRule
     extends RelRule<ProjectCalcMergeRule.Config>
     implements TransformationRule {
@@ -108,8 +111,9 @@ public class ProjectCalcMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableProjectCalcMergeRule.Config.of()
         .withOperandFor(LogicalProject.class, LogicalCalc.class);
 
     @Override default ProjectCalcMergeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectCorrelateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectCorrelateTransposeRule.java
@@ -36,6 +36,8 @@ import org.apache.calcite.util.BitSets;
 import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import org.immutables.value.Value;
+
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,6 +50,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see CoreRules#PROJECT_CORRELATE_TRANSPOSE
  */
+@Value.Enclosing
 public class ProjectCorrelateTransposeRule
     extends RelRule<ProjectCorrelateTransposeRule.Config>
     implements TransformationRule {
@@ -204,10 +207,12 @@ public class ProjectCorrelateTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
-        .withOperandFor(Project.class, Correlate.class)
-        .withPreserveExprCondition(expr -> !(expr instanceof RexOver));
+    Config DEFAULT = ImmutableProjectCorrelateTransposeRule.Config.builder()
+        .withPreserveExprCondition(expr -> !(expr instanceof RexOver))
+        .build()
+        .withOperandFor(Project.class, Correlate.class);
 
     @Override default ProjectCorrelateTransposeRule toRule() {
       return new ProjectCorrelateTransposeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectFilterTransposeRule.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -52,6 +53,7 @@ import java.util.Set;
  * @see CoreRules#PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS
  * @see CoreRules#PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS
  */
+@Value.Enclosing
 public class ProjectFilterTransposeRule
     extends RelRule<ProjectFilterTransposeRule.Config>
     implements TransformationRule {
@@ -229,12 +231,9 @@ public class ProjectFilterTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
-        .withOperandFor(LogicalProject.class, LogicalFilter.class)
-        .withPreserveExprCondition(expr -> false)
-        .withWholeProject(false)
-        .withWholeFilter(false);
+    Config DEFAULT = ImmutableProjectFilterTransposeRule.Config.of();
 
     Config PROJECT = DEFAULT.withWholeProject(true);
 
@@ -246,7 +245,9 @@ public class ProjectFilterTransposeRule
 
     /** Expressions that should be preserved in the projection. */
     @ImmutableBeans.Property
-    PushProjector.ExprCondition preserveExprCondition();
+    @Value.Default default PushProjector.ExprCondition preserveExprCondition() {
+      return expr -> false;
+    }
 
     /** Sets {@link #preserveExprCondition()}. */
     Config withPreserveExprCondition(PushProjector.ExprCondition condition);
@@ -255,7 +256,9 @@ public class ProjectFilterTransposeRule
      * if false (the default), only pushes references. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean isWholeProject();
+    @Value.Default default boolean isWholeProject() {
+      return false;
+    }
 
     /** Sets {@link #isWholeProject()}. */
     Config withWholeProject(boolean wholeProject);
@@ -264,7 +267,9 @@ public class ProjectFilterTransposeRule
      * if false (the default), only pushes references. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean isWholeFilter();
+    @Value.Default default boolean isWholeFilter() {
+      return false;
+    }
 
     /** Sets {@link #isWholeFilter()}. */
     Config withWholeFilter(boolean wholeFilter);
@@ -276,6 +281,12 @@ public class ProjectFilterTransposeRule
           b0.operand(projectClass).oneInput(b1 ->
               b1.operand(filterClass).anyInputs()))
           .as(Config.class);
+    }
+
+    @Override @Value.Default default OperandTransform operandSupplier() {
+      return b0 ->
+           b0.operand(LogicalProject.class).oneInput(b1 ->
+               b1.operand(LogicalFilter.class).anyInputs());
     }
 
     /** Defines an operand tree for the given 3 classes. */

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinJoinRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinJoinRemoveRule.java
@@ -32,6 +32,8 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,6 +63,7 @@ import java.util.stream.Collectors;
  *
  * @see CoreRules#PROJECT_JOIN_JOIN_REMOVE
  */
+@Value.Enclosing
 public class ProjectJoinJoinRemoveRule
     extends RelRule<ProjectJoinJoinRemoveRule.Config>
     implements SubstitutionRule {
@@ -139,8 +142,9 @@ public class ProjectJoinJoinRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableProjectJoinJoinRemoveRule.Config.of()
         .withOperandFor(LogicalProject.class, LogicalJoin.class);
 
     @Override default ProjectJoinJoinRemoveRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinRemoveRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,6 +55,7 @@ import java.util.stream.Collectors;
  * <blockquote>
  * <pre>select s.product_id from sales as s</pre></blockquote>
  */
+@Value.Enclosing
 public class ProjectJoinRemoveRule
     extends RelRule<ProjectJoinRemoveRule.Config>
     implements SubstitutionRule {
@@ -124,8 +127,9 @@ public class ProjectJoinRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableProjectJoinRemoveRule.Config.of()
         .withOperandFor(LogicalProject.class, LogicalJoin.class);
 
     @Override default ProjectJoinRemoveRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -32,6 +32,8 @@ import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,6 +47,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see CoreRules#PROJECT_JOIN_TRANSPOSE
  */
+@Value.Enclosing
 public class ProjectJoinTransposeRule
     extends RelRule<ProjectJoinTransposeRule.Config>
     implements TransformationRule {
@@ -152,10 +155,12 @@ public class ProjectJoinTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
-        .withOperandFor(LogicalProject.class, LogicalJoin.class)
-        .withPreserveExprCondition(expr -> !(expr instanceof RexOver));
+    Config DEFAULT = ImmutableProjectJoinTransposeRule.Config.builder()
+        .withPreserveExprCondition(expr -> !(expr instanceof RexOver))
+        .build()
+        .withOperandFor(LogicalProject.class, LogicalJoin.class);
 
     @Override default ProjectJoinTransposeRule toRule() {
       return new ProjectJoinTransposeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectMergeRule.java
@@ -29,6 +29,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.Permutation;
 
+import org.immutables.value.Value;
+
 import java.util.List;
 
 /**
@@ -38,6 +40,7 @@ import java.util.List;
  *
  * @see CoreRules#PROJECT_MERGE
  */
+@Value.Enclosing
 public class ProjectMergeRule
     extends RelRule<ProjectMergeRule.Config>
     implements TransformationRule {
@@ -143,8 +146,9 @@ public class ProjectMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableProjectMergeRule.Config.of()
         .withOperandFor(Project.class);
 
     @Override default ProjectMergeRule toRule() {
@@ -155,7 +159,9 @@ public class ProjectMergeRule
      * Default is {@link #DEFAULT_BLOAT} (100). */
     @ImmutableBeans.Property
     @ImmutableBeans.IntDefault(ProjectMergeRule.DEFAULT_BLOAT)
-    int bloat();
+    @Value.Default default int bloat() {
+      return ProjectMergeRule.DEFAULT_BLOAT;
+    }
 
     /** Sets {@link #bloat()}. */
     Config withBloat(int bloat);
@@ -163,7 +169,9 @@ public class ProjectMergeRule
     /** Whether to always merge projects, default true. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(true)
-    boolean force();
+    @Value.Default default boolean force() {
+      return true;
+    }
 
     /** Sets {@link #force()}. */
     Config withForce(boolean force);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectMultiJoinMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectMultiJoinMergeRule.java
@@ -24,6 +24,8 @@ import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that pushes
  * {@link org.apache.calcite.rel.core.Project}
@@ -33,6 +35,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * @see org.apache.calcite.rel.rules.FilterMultiJoinMergeRule
  * @see CoreRules#PROJECT_MULTI_JOIN_MERGE
  */
+@Value.Enclosing
 public class ProjectMultiJoinMergeRule
     extends RelRule<ProjectMultiJoinMergeRule.Config>
     implements TransformationRule {
@@ -87,8 +90,9 @@ public class ProjectMultiJoinMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableProjectMultiJoinMergeRule.Config.of()
         .withOperandFor(LogicalProject.class, MultiJoin.class);
 
     @Override default ProjectMultiJoinMergeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectRemoveRule.java
@@ -23,6 +23,8 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that,
  * given a {@link org.apache.calcite.rel.core.Project} node that
@@ -35,6 +37,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * @see ProjectMergeRule
  * @see CoreRules#PROJECT_REMOVE
  */
+@Value.Enclosing
 public class ProjectRemoveRule
     extends RelRule<ProjectRemoveRule.Config>
     implements SubstitutionRule {
@@ -85,15 +88,15 @@ public class ProjectRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableProjectRemoveRule.Config.of()
         .withOperandSupplier(b ->
             b.operand(Project.class)
                 // Use a predicate to detect non-matches early.
                 // This keeps the rule queue short.
                 .predicate(ProjectRemoveRule::isTrivial)
-                .anyInputs())
-        .as(Config.class);
+                .anyInputs());
 
     @Override default ProjectRemoveRule toRule() {
       return new ProjectRemoveRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectSetOpTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectSetOpTransposeRule.java
@@ -27,6 +27,8 @@ import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,6 +43,7 @@ import java.util.List;
  *
  * @see CoreRules#PROJECT_SET_OP_TRANSPOSE
  */
+@Value.Enclosing
 public class ProjectSetOpTransposeRule
     extends RelRule<ProjectSetOpTransposeRule.Config>
     implements TransformationRule {
@@ -111,13 +114,14 @@ public class ProjectSetOpTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableProjectSetOpTransposeRule.Config.builder()
+        .withPreserveExprCondition(expr -> !(expr instanceof RexOver))
+        .build()
         .withOperandSupplier(b0 ->
             b0.operand(LogicalProject.class).oneInput(b1 ->
-                b1.operand(SetOp.class).anyInputs()))
-        .as(Config.class)
-        .withPreserveExprCondition(expr -> !(expr instanceof RexOver));
+                b1.operand(SetOp.class).anyInputs()));
 
     @Override default ProjectSetOpTransposeRule toRule() {
       return new ProjectSetOpTransposeRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectTableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectTableScanRule.java
@@ -35,6 +35,8 @@ import org.apache.calcite.util.mapping.Mappings;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,6 +53,7 @@ import java.util.stream.Collectors;
  *
  * @see FilterTableScanRule
  */
+@Value.Enclosing
 public class ProjectTableScanRule
     extends RelRule<ProjectTableScanRule.Config> {
 
@@ -144,15 +147,15 @@ public class ProjectTableScanRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
     /** Config that matches Project on TableScan. */
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableProjectTableScanRule.Config.of()
         .withOperandSupplier(b0 ->
             b0.operand(Project.class).oneInput(b1 ->
                 b1.operand(TableScan.class)
                     .predicate(ProjectTableScanRule::test)
-                    .noInputs()))
-        .as(Config.class);
+                    .noInputs()));
 
     /** Config that matches Project on EnumerableInterpreter on TableScan. */
     Config INTERPRETER = DEFAULT

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToCalcRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToCalcRule.java
@@ -24,6 +24,8 @@ import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Rule to convert a
  * {@link org.apache.calcite.rel.logical.LogicalProject} to a
@@ -39,6 +41,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  * @see FilterToCalcRule
  * @see CoreRules#PROJECT_TO_CALC
  */
+@Value.Enclosing
 public class ProjectToCalcRule extends RelRule<ProjectToCalcRule.Config>
     implements TransformationRule {
 
@@ -70,11 +73,11 @@ public class ProjectToCalcRule extends RelRule<ProjectToCalcRule.Config>
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableProjectToCalcRule.Config.of()
         .withOperandSupplier(b ->
-            b.operand(LogicalProject.class).anyInputs())
-        .as(Config.class);
+            b.operand(LogicalProject.class).anyInputs());
 
     @Override default ProjectToCalcRule toRule() {
       return new ProjectToCalcRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
@@ -48,6 +48,8 @@ import org.apache.calcite.util.graph.TopologicalOrderIterator;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -92,12 +94,6 @@ public abstract class ProjectToWindowRule
       super(config);
     }
 
-    @Deprecated // to be removed before 2.0
-    public CalcToWindowRule(RelBuilderFactory relBuilderFactory) {
-      this(Config.DEFAULT.withRelBuilderFactory(relBuilderFactory)
-          .as(Config.class));
-    }
-
     @Override public void onMatch(RelOptRuleCall call) {
       final Calc calc = call.rel(0);
       assert calc.containsOver();
@@ -108,14 +104,15 @@ public abstract class ProjectToWindowRule
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableCalcToWindowRuleConfig")
     public interface Config extends ProjectToWindowRule.Config {
-      Config DEFAULT = EMPTY
+      Config DEFAULT = ImmutableCalcToWindowRuleConfig.of()
           .withOperandSupplier(b ->
               b.operand(Calc.class)
                   .predicate(Calc::containsOver)
                   .anyInputs())
-          .withDescription("ProjectToWindowRule")
-          .as(Config.class);
+          .withDescription("ProjectToWindowRule");
 
       @Override default CalcToWindowRule toRule() {
         return new CalcToWindowRule(this);
@@ -132,7 +129,7 @@ public abstract class ProjectToWindowRule
    * @see CoreRules#PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW
    */
   public static class ProjectToLogicalProjectAndWindowRule
-      extends ProjectToWindowRule {
+        extends ProjectToWindowRule {
     /** Creates a ProjectToLogicalProjectAndWindowRule. */
     protected ProjectToLogicalProjectAndWindowRule(Config config) {
       super(config);
@@ -141,8 +138,7 @@ public abstract class ProjectToWindowRule
     @Deprecated // to be removed before 2.0
     public ProjectToLogicalProjectAndWindowRule(
         RelBuilderFactory relBuilderFactory) {
-      this(Config.DEFAULT.withRelBuilderFactory(relBuilderFactory)
-          .as(Config.class));
+      this(Config.DEFAULT.withRelBuilderFactory(relBuilderFactory).as(Config.class));
     }
 
     @Override public void onMatch(RelOptRuleCall call) {
@@ -184,14 +180,15 @@ public abstract class ProjectToWindowRule
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableProjectToWindowRule")
     public interface Config extends ProjectToWindowRule.Config {
-      Config DEFAULT = EMPTY
+      Config DEFAULT = ImmutableProjectToWindowRule.of()
           .withOperandSupplier(b ->
               b.operand(Project.class)
                   .predicate(Project::containsOver)
                   .anyInputs())
-          .withDescription("ProjectToWindowRule:project")
-          .as(Config.class);
+          .withDescription("ProjectToWindowRule:project");
 
       @Override default ProjectToLogicalProjectAndWindowRule toRule() {
         return new ProjectToLogicalProjectAndWindowRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectWindowTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectWindowTransposeRule.java
@@ -38,6 +38,8 @@ import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +50,7 @@ import java.util.List;
  *
  * @see CoreRules#PROJECT_WINDOW_TRANSPOSE
  */
+@Value.Enclosing
 public class ProjectWindowTransposeRule
     extends RelRule<ProjectWindowTransposeRule.Config>
     implements TransformationRule {
@@ -238,8 +241,9 @@ public class ProjectWindowTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableProjectWindowTransposeRule.Config.of()
         .withOperandFor(LogicalProject.class, LogicalWindow.class);
 
     @Override default ProjectWindowTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -41,6 +41,8 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -90,13 +92,12 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule UNION_INSTANCE =
-      UnionEmptyPruneRuleConfig.EMPTY
+      ImmutableUnionEmptyPruneRuleConfig.of()
           .withOperandSupplier(b0 ->
               b0.operand(LogicalUnion.class).unorderedInputs(b1 ->
                   b1.operand(Values.class)
                       .predicate(Values::isEmpty).noInputs()))
           .withDescription("Union")
-          .as(UnionEmptyPruneRuleConfig.class)
           .toRule();
 
 
@@ -112,13 +113,12 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule MINUS_INSTANCE =
-      MinusEmptyPruneRuleConfig.EMPTY
+      ImmutableMinusEmptyPruneRuleConfig.of()
           .withOperandSupplier(b0 ->
               b0.operand(LogicalMinus.class).unorderedInputs(b1 ->
                   b1.operand(Values.class).predicate(Values::isEmpty)
                       .noInputs()))
           .withDescription("Minus")
-          .as(MinusEmptyPruneRuleConfig.class)
           .toRule();
 
   /**
@@ -134,13 +134,12 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule INTERSECT_INSTANCE =
-      IntersectEmptyPruneRuleConfig.EMPTY
+      ImmutableIntersectEmptyPruneRuleConfig.of()
           .withOperandSupplier(b0 ->
               b0.operand(LogicalIntersect.class).unorderedInputs(b1 ->
                   b1.operand(Values.class).predicate(Values::isEmpty)
                       .noInputs()))
           .withDescription("Intersect")
-          .as(IntersectEmptyPruneRuleConfig.class)
           .toRule();
 
   private static boolean isEmpty(RelNode node) {
@@ -175,9 +174,8 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule PROJECT_INSTANCE =
-      RemoveEmptySingleRule.Config.EMPTY
+      ImmutablePruneEmptyRuleConfig.of()
           .withDescription("PruneEmptyProject")
-          .as(RemoveEmptySingleRule.Config.class)
           .withOperandFor(Project.class, project -> true)
           .toRule();
 
@@ -192,9 +190,8 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule FILTER_INSTANCE =
-      RemoveEmptySingleRule.Config.EMPTY
+      ImmutablePruneEmptyRuleConfig.of()
           .withDescription("PruneEmptyFilter")
-          .as(RemoveEmptySingleRule.Config.class)
           .withOperandFor(Filter.class, singleRel -> true)
           .toRule();
 
@@ -209,9 +206,8 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule SORT_INSTANCE =
-      RemoveEmptySingleRule.Config.EMPTY
+      ImmutablePruneEmptyRuleConfig.of()
           .withDescription("PruneEmptySort")
-          .as(RemoveEmptySingleRule.Config.class)
           .withOperandFor(Sort.class, singleRel -> true)
           .toRule();
 
@@ -226,11 +222,10 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule SORT_FETCH_ZERO_INSTANCE =
-      SortFetchZeroRuleConfig.EMPTY
+      ImmutableSortFetchZeroRuleConfig.of()
           .withOperandSupplier(b ->
               b.operand(Sort.class).anyInputs())
           .withDescription("PruneSortLimit0")
-          .as(SortFetchZeroRuleConfig.class)
           .toRule();
 
   /**
@@ -249,9 +244,8 @@ public abstract class PruneEmptyRules {
    * @see AggregateValuesRule
    */
   public static final RelOptRule AGGREGATE_INSTANCE =
-      RemoveEmptySingleRule.Config.EMPTY
+      ImmutablePruneEmptyRuleConfig.of()
           .withDescription("PruneEmptyAggregate")
-          .as(RemoveEmptySingleRule.Config.class)
           .withOperandFor(Aggregate.class, Aggregate::isNotGrandTotal)
           .toRule();
 
@@ -269,14 +263,13 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule JOIN_LEFT_INSTANCE =
-      JoinLeftEmptyRuleConfig.EMPTY
+      ImmutableJoinLeftEmptyRuleConfig.of()
           .withOperandSupplier(b0 ->
               b0.operand(Join.class).inputs(
                   b1 -> b1.operand(Values.class)
                       .predicate(Values::isEmpty).noInputs(),
                   b2 -> b2.operand(RelNode.class).anyInputs()))
           .withDescription("PruneEmptyJoin(left)")
-          .as(JoinLeftEmptyRuleConfig.class)
           .toRule();
 
   /**
@@ -293,14 +286,13 @@ public abstract class PruneEmptyRules {
    * </ul>
    */
   public static final RelOptRule JOIN_RIGHT_INSTANCE =
-      JoinRightEmptyRuleConfig.EMPTY
+      ImmutableJoinRightEmptyRuleConfig.of()
           .withOperandSupplier(b0 ->
               b0.operand(Join.class).inputs(
                   b1 -> b1.operand(RelNode.class).anyInputs(),
                   b2 -> b2.operand(Values.class).predicate(Values::isEmpty)
                       .noInputs()))
           .withDescription("PruneEmptyJoin(right)")
-          .as(JoinRightEmptyRuleConfig.class)
           .toRule();
 
   /** Planner rule that converts a single-rel (e.g. project, sort, aggregate or
@@ -353,6 +345,8 @@ public abstract class PruneEmptyRules {
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutablePruneEmptyRuleConfig")
     public interface Config extends PruneEmptyRule.Config {
       @Override default RemoveEmptySingleRule toRule() {
         return new RemoveEmptySingleRule(this);
@@ -370,6 +364,7 @@ public abstract class PruneEmptyRules {
   }
 
   /** Configuration for a rule that prunes empty inputs from a Minus. */
+  @Value.Immutable
   public interface UnionEmptyPruneRuleConfig extends PruneEmptyRule.Config {
     @Override default PruneEmptyRule toRule() {
       return new PruneEmptyRule(this) {
@@ -401,6 +396,7 @@ public abstract class PruneEmptyRules {
   }
 
   /** Configuration for a rule that prunes empty inputs from a Minus. */
+  @Value.Immutable
   public interface MinusEmptyPruneRuleConfig extends PruneEmptyRule.Config {
     @Override default PruneEmptyRule toRule() {
       return new PruneEmptyRule(this) {
@@ -438,6 +434,7 @@ public abstract class PruneEmptyRules {
 
   /** Configuration for a rule that prunes an Intersect if any of its inputs
    * is empty. */
+  @Value.Immutable
   public interface IntersectEmptyPruneRuleConfig extends PruneEmptyRule.Config {
     @Override default PruneEmptyRule toRule() {
       return new PruneEmptyRule(this) {
@@ -452,6 +449,7 @@ public abstract class PruneEmptyRules {
   }
 
   /** Configuration for a rule that prunes a Sort if it has limit 0. */
+  @Value.Immutable
   public interface SortFetchZeroRuleConfig extends PruneEmptyRule.Config {
     @Override default PruneEmptyRule toRule() {
       return new PruneEmptyRule(this) {
@@ -477,6 +475,7 @@ public abstract class PruneEmptyRules {
 
   /** Configuration for rule that prunes a join it its left input is
    * empty. */
+  @Value.Immutable
   public interface JoinLeftEmptyRuleConfig extends PruneEmptyRule.Config {
     @Override default PruneEmptyRule toRule() {
       return new PruneEmptyRule(this) {
@@ -495,6 +494,7 @@ public abstract class PruneEmptyRules {
 
   /** Configuration for rule that prunes a join it its right input is
    * empty. */
+  @Value.Immutable
   public interface JoinRightEmptyRuleConfig extends PruneEmptyRule.Config {
     @Override default PruneEmptyRule toRule() {
       return new PruneEmptyRule(this) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceDecimalsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceDecimalsRule.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -72,6 +73,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see CoreRules#CALC_REDUCE_DECIMALS
  */
+@Value.Enclosing
 public class ReduceDecimalsRule
     extends RelRule<ReduceDecimalsRule.Config>
     implements TransformationRule {
@@ -1323,10 +1325,10 @@ public class ReduceDecimalsRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(LogicalCalc.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableReduceDecimalsRule.Config.of()
+        .withOperandSupplier(b -> b.operand(LogicalCalc.class).anyInputs());
 
     @Override default ReduceDecimalsRule toRule() {
       return new ReduceDecimalsRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
@@ -72,6 +72,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -255,8 +256,10 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableFilterReduceExpressionsRuleConfig")
     public interface Config extends ReduceExpressionsRule.Config {
-      Config DEFAULT = EMPTY.as(Config.class)
+      Config DEFAULT = ImmutableFilterReduceExpressionsRuleConfig.of()
           .withMatchNullability(true)
           .withOperandFor(LogicalFilter.class)
           .withDescription("ReduceExpressionsRule(Filter)")
@@ -321,8 +324,10 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableProjectReduceExpressionsRuleConfig")
     public interface Config extends ReduceExpressionsRule.Config {
-      Config DEFAULT = EMPTY.as(Config.class)
+      Config DEFAULT = ImmutableProjectReduceExpressionsRuleConfig.of()
           .withMatchNullability(true)
           .withOperandFor(LogicalProject.class)
           .withDescription("ReduceExpressionsRule(Project)")
@@ -395,8 +400,10 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableJoinReduceExpressionsRuleConfig")
     public interface Config extends ReduceExpressionsRule.Config {
-      Config DEFAULT = EMPTY.as(Config.class)
+      Config DEFAULT = ImmutableJoinReduceExpressionsRuleConfig.of()
           .withMatchNullability(false)
           .withOperandFor(Join.class)
           .withDescription("ReduceExpressionsRule(Join)")
@@ -509,7 +516,7 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
      *
      * <p>The default implementation of this method is to call
      * {@link RelBuilder#empty}, which for the static schema will be optimized
-     * to an empty
+     * to an Immutable.Config.of()
      * {@link org.apache.calcite.rel.core.Values}.
      *
      * @param input rel to replace, assumes caller has already determined
@@ -522,8 +529,10 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableCalcReduceExpressionsRuleConfig")
     public interface Config extends ReduceExpressionsRule.Config {
-      Config DEFAULT = EMPTY.as(Config.class)
+      Config DEFAULT = ImmutableCalcReduceExpressionsRuleConfig.of()
           .withMatchNullability(true)
           .withOperandFor(LogicalCalc.class)
           .withDescription("ReduceExpressionsRule(Calc)")
@@ -614,8 +623,10 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableWindowReduceExpressionsRuleConfig")
     public interface Config extends ReduceExpressionsRule.Config {
-      Config DEFAULT = EMPTY.as(Config.class)
+      Config DEFAULT = ImmutableWindowReduceExpressionsRuleConfig.of()
           .withMatchNullability(true)
           .withOperandFor(LogicalWindow.class)
           .withDescription("ReduceExpressionsRule(Window)")
@@ -1168,7 +1179,9 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
      * reduces to a NOT NULL literal. */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean matchNullability();
+    @Value.Default default boolean matchNullability() {
+      return false;
+    }
 
     /** Sets {@link #matchNullability()}. */
     Config withMatchNullability(boolean matchNullability);

--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinFilterTransposeRule.java
@@ -30,6 +30,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that pushes {@code SemiJoin}s down in a tree past
  * a {@link org.apache.calcite.rel.core.Filter}.
@@ -42,6 +44,7 @@ import com.google.common.collect.ImmutableSet;
  * @see SemiJoinProjectTransposeRule
  * @see CoreRules#SEMI_JOIN_FILTER_TRANSPOSE
  */
+@Value.Enclosing
 public class SemiJoinFilterTransposeRule
     extends RelRule<SemiJoinFilterTransposeRule.Config>
     implements TransformationRule {
@@ -82,8 +85,9 @@ public class SemiJoinFilterTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSemiJoinFilterTransposeRule.Config.of()
         .withOperandFor(LogicalJoin.class, LogicalFilter.class);
 
     @Override default SemiJoinFilterTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinJoinTransposeRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.util.ImmutableIntList;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +52,7 @@ import java.util.List;
  *
  * @see CoreRules#SEMI_JOIN_JOIN_TRANSPOSE
  */
+@Value.Enclosing
 public class SemiJoinJoinTransposeRule
     extends RelRule<SemiJoinJoinTransposeRule.Config>
     implements TransformationRule {
@@ -221,8 +224,9 @@ public class SemiJoinJoinTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSemiJoinJoinTransposeRule.Config.of()
         .withOperandFor(LogicalJoin.class, Join.class);
 
     @Override default SemiJoinJoinTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinProjectTransposeRule.java
@@ -38,6 +38,8 @@ import org.apache.calcite.util.Pair;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.immutables.value.Value;
+
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -54,6 +56,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see org.apache.calcite.rel.rules.SemiJoinFilterTransposeRule
  */
+@Value.Enclosing
 public class SemiJoinProjectTransposeRule
     extends RelRule<SemiJoinProjectTransposeRule.Config>
     implements TransformationRule {
@@ -178,8 +181,9 @@ public class SemiJoinProjectTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSemiJoinProjectTransposeRule.Config.of()
         .withOperandFor(LogicalJoin.class, LogicalProject.class);
 
     @Override default SemiJoinProjectTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinRemoveRule.java
@@ -22,6 +22,8 @@ import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that removes a {@link Join#isSemiJoin semi-join} from a join
  * tree.
@@ -35,6 +37,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#SEMI_JOIN_REMOVE
  */
+@Value.Enclosing
 public class SemiJoinRemoveRule
     extends RelRule<SemiJoinRemoveRule.Config>
     implements TransformationRule {
@@ -57,8 +60,9 @@ public class SemiJoinRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSemiJoinRemoveRule.Config.of()
         .withOperandFor(LogicalJoin.class);
 
     @Override default SemiJoinRemoveRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinRule.java
@@ -34,6 +34,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -156,9 +157,11 @@ public abstract class SemiJoinRule
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableProjectToSemiJoinRuleConfig")
     public interface Config extends SemiJoinRule.Config {
-      Config DEFAULT = EMPTY.withDescription("SemiJoinRule:project")
-          .as(Config.class)
+      Config DEFAULT = ImmutableProjectToSemiJoinRuleConfig.of()
+          .withDescription("SemiJoinRule:project")
           .withOperandFor(Project.class, Join.class, Aggregate.class);
 
       @Override default ProjectToSemiJoinRule toRule() {
@@ -208,9 +211,11 @@ public abstract class SemiJoinRule
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableJoinToSemiJoinRuleConfig")
     public interface Config extends SemiJoinRule.Config {
-      Config DEFAULT = EMPTY.withDescription("SemiJoinRule:join")
-          .as(Config.class)
+      Config DEFAULT = ImmutableJoinToSemiJoinRuleConfig.of()
+          .withDescription("SemiJoinRule:join")
           .withOperandFor(Join.class, Aggregate.class);
 
       @Override default JoinToSemiJoinRule toRule() {
@@ -229,7 +234,9 @@ public abstract class SemiJoinRule
     }
   }
 
-  /** Rule configuration. */
+  /**
+   * Rule configuration.
+   */
   public interface Config extends RelRule.Config {
     @Override SemiJoinRule toRule();
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortJoinCopyRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortJoinCopyRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +51,7 @@ import java.util.List;
  *
  * @see CoreRules#SORT_JOIN_COPY
  */
+@Value.Enclosing
 public class SortJoinCopyRule
     extends RelRule<SortJoinCopyRule.Config>
     implements TransformationRule {
@@ -165,8 +168,9 @@ public class SortJoinCopyRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSortJoinCopyRule.Config.of()
         .withOperandFor(LogicalSort.class, LogicalJoin.class);
 
     @Override default SortJoinCopyRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortJoinTransposeRule.java
@@ -33,6 +33,8 @@ import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that pushes a {@link org.apache.calcite.rel.core.Sort} past a
  * {@link org.apache.calcite.rel.core.Join}.
@@ -43,6 +45,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#SORT_JOIN_TRANSPOSE
  */
+@Value.Enclosing
 public class SortJoinTransposeRule
     extends RelRule<SortJoinTransposeRule.Config>
     implements TransformationRule {
@@ -164,8 +167,9 @@ public class SortJoinTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSortJoinTransposeRule.Config.of()
         .withOperandFor(LogicalSort.class, LogicalJoin.class);
 
     @Override default SortJoinTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortProjectTransposeRule.java
@@ -41,6 +41,8 @@ import org.apache.calcite.util.mapping.Mappings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import org.immutables.value.Value;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -51,6 +53,7 @@ import java.util.Objects;
  *
  * @see CoreRules#SORT_PROJECT_TRANSPOSE
  */
+@Value.Enclosing
 public class SortProjectTransposeRule
     extends RelRule<SortProjectTransposeRule.Config>
     implements TransformationRule {
@@ -166,8 +169,9 @@ public class SortProjectTransposeRule
     call.transformTo(newProject, equiv);
   }
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSortProjectTransposeRule.Config.of()
         .withOperandFor(Sort.class, LogicalProject.class);
 
     @Override default SortProjectTransposeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveConstantKeysRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveConstantKeysRule.java
@@ -27,6 +27,8 @@ import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexBuilder;
 
+import org.immutables.value.Value;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +39,7 @@ import java.util.stream.Collectors;
  *
  * <p>Requires {@link RelCollationTraitDef}.
  */
+@Value.Enclosing
 public class SortRemoveConstantKeysRule
     extends RelRule<SortRemoveConstantKeysRule.Config>
     implements SubstitutionRule {
@@ -81,10 +84,10 @@ public class SortRemoveConstantKeysRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(Sort.class).anyInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableSortRemoveConstantKeysRule.Config.of()
+        .withOperandSupplier(b -> b.operand(Sort.class).anyInputs());
 
     @Override default SortRemoveConstantKeysRule toRule() {
       return new SortRemoveConstantKeysRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRule.java
@@ -25,6 +25,8 @@ import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that removes
  * a {@link org.apache.calcite.rel.core.Sort} if its input is already sorted.
@@ -33,6 +35,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#SORT_REMOVE
  */
+@Value.Enclosing
 public class SortRemoveRule
     extends RelRule<SortRemoveRule.Config>
     implements TransformationRule {
@@ -71,11 +74,11 @@ public class SortRemoveRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableSortRemoveRule.Config.of()
         .withOperandSupplier(b ->
-            b.operand(Sort.class).anyInputs())
-        .as(Config.class);
+            b.operand(Sort.class).anyInputs());
 
     @Override default SortRemoveRule toRule() {
       return new SortRemoveRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortUnionTransposeRule.java
@@ -26,6 +26,8 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +38,7 @@ import java.util.List;
  * @see CoreRules#SORT_UNION_TRANSPOSE
  * @see CoreRules#SORT_UNION_TRANSPOSE_MATCH_NULL_FETCH
  */
+@Value.Enclosing
 public class SortUnionTransposeRule
     extends RelRule<SortUnionTransposeRule.Config>
     implements TransformationRule {
@@ -104,8 +107,9 @@ public class SortUnionTransposeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableSortUnionTransposeRule.Config.of()
         .withOperandFor(Sort.class, Union.class)
         .withMatchNullFetch(false);
 
@@ -117,7 +121,9 @@ public class SortUnionTransposeRule
      * this only makes sense if the Union preserves order (and merges). */
     @ImmutableBeans.Property
     @ImmutableBeans.BooleanDefault(false)
-    boolean matchNullFetch();
+    @Value.Default default boolean matchNullFetch() {
+      return false;
+    }
 
     /** Sets {@link #matchNullFetch()}. */
     Config withMatchNullFetch(boolean matchNullFetch);

--- a/core/src/main/java/org/apache/calcite/rel/rules/SpatialRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SpatialRules.java
@@ -41,6 +41,7 @@ import com.esri.core.geometry.Point;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -315,8 +316,10 @@ public abstract class SpatialRules {
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = true)
+    @Value.Style(typeImmutable = "ImmutableFilterHilbertRuleConfig")
     public interface Config extends RelRule.Config {
-      Config DEFAULT = EMPTY
+      Config DEFAULT = ImmutableFilterHilbertRuleConfig.of()
           .withOperandSupplier(b ->
               b.operand(Filter.class)
                   .predicate(f -> DWITHIN_FINDER.inFilter(f)

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -47,6 +47,8 @@ import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableList;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -69,6 +71,7 @@ import static org.apache.calcite.util.Util.last;
  * @see CoreRules#PROJECT_SUB_QUERY_TO_CORRELATE
  * @see CoreRules#JOIN_SUB_QUERY_TO_CORRELATE
  */
+@Value.Enclosing
 public class SubQueryRemoveRule
     extends RelRule<SubQueryRemoveRule.Config>
     implements TransformationRule {
@@ -855,31 +858,32 @@ public class SubQueryRemoveRule
     }
   }
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
-    Config PROJECT = EMPTY
+    Config PROJECT = ImmutableSubQueryRemoveRule.Config.builder()
+        .withMatchHandler(SubQueryRemoveRule::matchProject)
+        .build()
         .withOperandSupplier(b ->
             b.operand(Project.class)
                 .predicate(RexUtil.SubQueryFinder::containsSubQuery).anyInputs())
-        .withDescription("SubQueryRemoveRule:Project")
-        .as(Config.class)
-        .withMatchHandler(SubQueryRemoveRule::matchProject);
+        .withDescription("SubQueryRemoveRule:Project");
 
-    Config FILTER = EMPTY
+    Config FILTER = ImmutableSubQueryRemoveRule.Config.builder()
+        .withMatchHandler(SubQueryRemoveRule::matchFilter)
+        .build()
         .withOperandSupplier(b ->
             b.operand(Filter.class)
                 .predicate(RexUtil.SubQueryFinder::containsSubQuery).anyInputs())
-        .withDescription("SubQueryRemoveRule:Filter")
-        .as(Config.class)
-        .withMatchHandler(SubQueryRemoveRule::matchFilter);
+        .withDescription("SubQueryRemoveRule:Filter");
 
-    Config JOIN = EMPTY
+    Config JOIN = ImmutableSubQueryRemoveRule.Config.builder()
+        .withMatchHandler(SubQueryRemoveRule::matchJoin)
+        .build()
         .withOperandSupplier(b ->
             b.operand(Join.class)
                 .predicate(RexUtil.SubQueryFinder::containsSubQuery)
                 .anyInputs())
-        .withDescription("SubQueryRemoveRule:Join")
-        .as(Config.class)
-        .withMatchHandler(SubQueryRemoveRule::matchJoin);
+        .withDescription("SubQueryRemoveRule:Join");
 
     @Override default SubQueryRemoveRule toRule() {
       return new SubQueryRemoveRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/TableScanRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/TableScanRule.java
@@ -24,6 +24,8 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that converts a
  * {@link org.apache.calcite.rel.logical.LogicalTableScan} to the result
@@ -49,8 +51,7 @@ public class TableScanRule extends RelRule<RelRule.Config>
 
   @Deprecated // to be removed before 2.0
   public TableScanRule(RelBuilderFactory relBuilderFactory) {
-    this(Config.DEFAULT.withRelBuilderFactory(relBuilderFactory)
-        .as(Config.class));
+    this(Config.DEFAULT.withRelBuilderFactory(relBuilderFactory));
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -64,10 +65,13 @@ public class TableScanRule extends RelRule<RelRule.Config>
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = true)
+  @Value.Style(typeImmutable = "ImmutableTableScanRuleConfig",
+      passAnnotations = SuppressWarnings.class)
+  @SuppressWarnings("deprecation")
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY
-        .withOperandSupplier(b -> b.operand(LogicalTableScan.class).noInputs())
-        .as(Config.class);
+    Config DEFAULT = ImmutableTableScanRuleConfig.of()
+        .withOperandSupplier(b -> b.operand(LogicalTableScan.class).noInputs());
 
     @Override default TableScanRule toRule() {
       return new TableScanRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionEliminatorRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionEliminatorRule.java
@@ -22,6 +22,8 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * <code>UnionEliminatorRule</code> checks to see if its possible to optimize a
  * Union call by eliminating the Union operator altogether in the case the call
@@ -29,6 +31,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#UNION_REMOVE
  */
+@Value.Enclosing
 public class UnionEliminatorRule
     extends RelRule<UnionEliminatorRule.Config>
     implements SubstitutionRule {
@@ -63,8 +66,9 @@ public class UnionEliminatorRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableUnionEliminatorRule.Config.of()
         .withOperandFor(LogicalUnion.class);
 
     @Override default UnionEliminatorRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionMergeRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.Util;
 
+import org.immutables.value.Value;
+
 /**
  * UnionMergeRule implements the rule for combining two
  * non-distinct {@link org.apache.calcite.rel.core.SetOp}s
@@ -39,6 +41,7 @@ import org.apache.calcite.util.Util;
  * <p>Originally written for {@link Union} (hence the name),
  * but now also applies to {@link Intersect} and {@link Minus}.
  */
+@Value.Enclosing
 public class UnionMergeRule
     extends RelRule<UnionMergeRule.Config>
     implements TransformationRule {
@@ -160,17 +163,18 @@ public class UnionMergeRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.withDescription("UnionMergeRule")
-        .as(Config.class)
+    Config DEFAULT = ImmutableUnionMergeRule.Config.of()
+        .withDescription("UnionMergeRule")
         .withOperandFor(LogicalUnion.class);
 
-    Config INTERSECT = EMPTY.withDescription("IntersectMergeRule")
-        .as(Config.class)
+    Config INTERSECT = ImmutableUnionMergeRule.Config.of()
+        .withDescription("IntersectMergeRule")
         .withOperandFor(LogicalIntersect.class);
 
-    Config MINUS = EMPTY.withDescription("MinusMergeRule")
-        .as(Config.class)
+    Config MINUS = ImmutableUnionMergeRule.Config.of()
+        .withDescription("MinusMergeRule")
         .withOperandFor(LogicalMinus.class);
 
     @Override default UnionMergeRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionPullUpConstantsRule.java
@@ -34,6 +34,8 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.mapping.Mappings;
 
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +46,7 @@ import java.util.Map;
  *
  * @see CoreRules#UNION_PULL_UP_CONSTANTS
  */
+@Value.Enclosing
 public class UnionPullUpConstantsRule
     extends RelRule<UnionPullUpConstantsRule.Config>
     implements TransformationRule {
@@ -136,8 +139,9 @@ public class UnionPullUpConstantsRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableUnionPullUpConstantsRule.Config.of()
         .withOperandFor(Union.class);
 
     @Override default UnionPullUpConstantsRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/UnionToDistinctRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/UnionToDistinctRule.java
@@ -24,6 +24,8 @@ import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /**
  * Planner rule that translates a distinct
  * {@link org.apache.calcite.rel.core.Union}
@@ -34,6 +36,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * @see CoreRules#UNION_TO_DISTINCT
  */
+@Value.Enclosing
 public class UnionToDistinctRule
     extends RelRule<UnionToDistinctRule.Config>
     implements TransformationRule {
@@ -71,8 +74,9 @@ public class UnionToDistinctRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable
   public interface Config extends RelRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableUnionToDistinctRule.Config.of()
         .withOperandFor(LogicalUnion.class);
 
     @Override default UnionToDistinctRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewAggregateRule.java
@@ -35,7 +35,6 @@ import org.apache.calcite.rel.rules.AggregateProjectPullUpConstantsRule;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.rules.FilterAggregateTransposeRule;
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
-import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
@@ -53,7 +52,6 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilder.AggCall;
-import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
@@ -70,6 +68,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -912,66 +911,62 @@ public abstract class MaterializedViewAggregateRule<C extends MaterializedViewAg
     return Pair.of(resultTopViewProject, requireNonNull(resultViewNode, "resultViewNode"));
   }
 
-  /** Rule configuration. */
+  /**
+   * Rule configuration.
+   */
   public interface Config extends MaterializedViewRule.Config {
-    static Config create(RelBuilderFactory relBuilderFactory) {
-      return EMPTY.as(Config.class)
-          .withFilterProjectTransposeRule(
-              CoreRules.FILTER_PROJECT_TRANSPOSE.config
-                  .withRelBuilderFactory(relBuilderFactory)
-                  .as(FilterProjectTransposeRule.Config.class)
-                  .withOperandFor(Filter.class, filter ->
-                          !RexUtil.containsCorrelation(filter.getCondition()),
-                      Project.class, project -> true)
-                  .withCopyFilter(true)
-                  .withCopyProject(true)
-                  .toRule())
-          .withFilterAggregateTransposeRule(
-              CoreRules.FILTER_AGGREGATE_TRANSPOSE.config
-                  .withRelBuilderFactory(relBuilderFactory)
-                  .as(FilterAggregateTransposeRule.Config.class)
-                  .withOperandFor(Filter.class, Aggregate.class)
-                  .toRule())
-          .withAggregateProjectPullUpConstantsRule(
-              AggregateProjectPullUpConstantsRule.Config.DEFAULT
-                  .withRelBuilderFactory(relBuilderFactory)
-                  .withDescription("AggFilterPullUpConstants")
-                  .as(AggregateProjectPullUpConstantsRule.Config.class)
-                  .withOperandFor(Aggregate.class, Filter.class)
-                  .toRule())
-          .withProjectMergeRule(
-              CoreRules.PROJECT_MERGE.config
-                  .withRelBuilderFactory(relBuilderFactory)
-                  .as(ProjectMergeRule.Config.class)
-                  .toRule())
-          .withRelBuilderFactory(relBuilderFactory)
-          .as(Config.class);
-    }
 
     /** Instance of rule to push filter through project. */
     @ImmutableBeans.Property
-    RelOptRule filterProjectTransposeRule();
+    @Value.Default default RelOptRule filterProjectTransposeRule() {
+      return CoreRules.FILTER_PROJECT_TRANSPOSE.config
+          .withRelBuilderFactory(relBuilderFactory())
+          .as(FilterProjectTransposeRule.Config.class)
+          .withOperandFor(Filter.class, filter ->
+                  !RexUtil.containsCorrelation(filter.getCondition()),
+              Project.class, project -> true)
+          .withCopyFilter(true)
+          .withCopyProject(true)
+          .toRule();
+    }
 
     /** Sets {@link #filterProjectTransposeRule()}. */
     Config withFilterProjectTransposeRule(RelOptRule rule);
 
     /** Instance of rule to push filter through aggregate. */
     @ImmutableBeans.Property
-    RelOptRule filterAggregateTransposeRule();
+    @Value.Default default RelOptRule filterAggregateTransposeRule() {
+      return CoreRules.FILTER_AGGREGATE_TRANSPOSE.config
+          .withRelBuilderFactory(relBuilderFactory())
+          .as(FilterAggregateTransposeRule.Config.class)
+          .withOperandFor(Filter.class, Aggregate.class)
+          .toRule();
+    }
 
     /** Sets {@link #filterAggregateTransposeRule()}. */
     Config withFilterAggregateTransposeRule(RelOptRule rule);
 
     /** Instance of rule to pull up constants into aggregate. */
     @ImmutableBeans.Property
-    RelOptRule aggregateProjectPullUpConstantsRule();
+    @Value.Default default RelOptRule aggregateProjectPullUpConstantsRule() {
+      return AggregateProjectPullUpConstantsRule.Config.DEFAULT
+          .withRelBuilderFactory(relBuilderFactory())
+          .withDescription("AggFilterPullUpConstants")
+          .as(AggregateProjectPullUpConstantsRule.Config.class)
+          .withOperandFor(Aggregate.class, Filter.class)
+          .toRule();
+    }
 
     /** Sets {@link #aggregateProjectPullUpConstantsRule()}. */
     Config withAggregateProjectPullUpConstantsRule(RelOptRule rule);
 
     /** Instance of rule to merge project operators. */
     @ImmutableBeans.Property
-    RelOptRule projectMergeRule();
+    @Value.Default default RelOptRule projectMergeRule() {
+      return CoreRules.PROJECT_MERGE.config
+          .withRelBuilderFactory(relBuilderFactory())
+          .toRule();
+    }
 
     /** Sets {@link #projectMergeRule()}. */
     Config withProjectMergeRule(RelOptRule rule);

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewOnlyAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewOnlyAggregateRule.java
@@ -24,7 +24,10 @@ import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /** Rule that matches Aggregate. */
+@Value.Enclosing
 public class MaterializedViewOnlyAggregateRule
     extends MaterializedViewAggregateRule<MaterializedViewOnlyAggregateRule.Config> {
 
@@ -69,18 +72,20 @@ public class MaterializedViewOnlyAggregateRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends MaterializedViewAggregateRule.Config {
     Config DEFAULT = create(RelFactories.LOGICAL_BUILDER);
 
     static Config create(RelBuilderFactory relBuilderFactory) {
-      return MaterializedViewAggregateRule.Config.create(relBuilderFactory)
+
+      return ImmutableMaterializedViewOnlyAggregateRule.Config.builder()
+          .withRelBuilderFactory(relBuilderFactory)
           .withOperandSupplier(b -> b.operand(Aggregate.class).anyInputs())
           .withDescription("MaterializedViewAggregateRule(Aggregate)")
-          .as(MaterializedViewRule.Config.class)
           .withGenerateUnionRewriting(true)
           .withUnionRewritingPullProgram(null)
           .withFastBailOut(false)
-          .as(MaterializedViewOnlyAggregateRule.Config.class);
+          .build();
     }
 
     @Override default MaterializedViewOnlyAggregateRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewOnlyFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewOnlyFilterRule.java
@@ -22,7 +22,10 @@ import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /** Rule that matches Filter. */
+@Value.Enclosing
 public class MaterializedViewOnlyFilterRule
     extends MaterializedViewJoinRule<MaterializedViewOnlyFilterRule.Config> {
 
@@ -48,16 +51,16 @@ public class MaterializedViewOnlyFilterRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends MaterializedViewRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableMaterializedViewOnlyFilterRule.Config.builder()
         .withOperandSupplier(b -> b.operand(Filter.class).anyInputs())
         .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
         .withDescription("MaterializedViewJoinRule(Filter)")
-        .as(MaterializedViewRule.Config.class)
         .withGenerateUnionRewriting(true)
         .withUnionRewritingPullProgram(null)
         .withFastBailOut(true)
-        .as(Config.class);
+        .build();
 
     @Override default MaterializedViewOnlyFilterRule toRule() {
       return new MaterializedViewOnlyFilterRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewOnlyJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewOnlyJoinRule.java
@@ -22,7 +22,10 @@ import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /** Rule that matches Join. */
+@Value.Enclosing
 public class MaterializedViewOnlyJoinRule
     extends MaterializedViewJoinRule<MaterializedViewRule.Config> {
 
@@ -48,16 +51,17 @@ public class MaterializedViewOnlyJoinRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends MaterializedViewRule.Config {
-    Config DEFAULT = EMPTY
+    Config DEFAULT = ImmutableMaterializedViewOnlyJoinRule.Config.builder()
         .withOperandSupplier(b -> b.operand(Join.class).anyInputs())
         .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
         .withDescription("MaterializedViewJoinRule(Join)")
-        .as(MaterializedViewRule.Config.class)
         .withGenerateUnionRewriting(true)
         .withUnionRewritingPullProgram(null)
         .withFastBailOut(true)
-        .as(MaterializedViewOnlyJoinRule.Config.class);
+        .build();
+
 
     @Override default MaterializedViewOnlyJoinRule toRule() {
       return new MaterializedViewOnlyJoinRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewProjectAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewProjectAggregateRule.java
@@ -24,9 +24,12 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /** Rule that matches Project on Aggregate.
  *
  * @see MaterializedViewRules#PROJECT_AGGREGATE */
+@Value.Enclosing
 public class MaterializedViewProjectAggregateRule
     extends MaterializedViewAggregateRule<MaterializedViewProjectAggregateRule.Config> {
 
@@ -69,18 +72,21 @@ public class MaterializedViewProjectAggregateRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends MaterializedViewAggregateRule.Config {
     Config DEFAULT = create(RelFactories.LOGICAL_BUILDER);
 
     static Config create(RelBuilderFactory relBuilderFactory) {
-      return MaterializedViewAggregateRule.Config.create(relBuilderFactory)
+      return ImmutableMaterializedViewProjectAggregateRule.Config.builder()
+          .withRelBuilderFactory(relBuilderFactory)
           .withGenerateUnionRewriting(true)
           .withUnionRewritingPullProgram(null)
+          .withFastBailOut(false)
           .withOperandSupplier(b0 ->
               b0.operand(Project.class).oneInput(b1 ->
                   b1.operand(Aggregate.class).anyInputs()))
           .withDescription("MaterializedViewAggregateRule(Project-Aggregate)")
-          .as(Config.class);
+          .build();
     }
 
     @Override default MaterializedViewProjectAggregateRule toRule() {

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewProjectFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewProjectFilterRule.java
@@ -23,7 +23,10 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /** Rule that matches Project on Filter. */
+@Value.Enclosing
 public class MaterializedViewProjectFilterRule
     extends MaterializedViewJoinRule<MaterializedViewProjectFilterRule.Config> {
 
@@ -51,18 +54,18 @@ public class MaterializedViewProjectFilterRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends MaterializedViewRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableMaterializedViewProjectFilterRule.Config.builder()
         .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
         .withOperandSupplier(b0 ->
             b0.operand(Project.class).oneInput(b1 ->
                 b1.operand(Filter.class).anyInputs()))
         .withDescription("MaterializedViewJoinRule(Project-Filter)")
-        .as(Config.class)
         .withGenerateUnionRewriting(true)
         .withUnionRewritingPullProgram(null)
         .withFastBailOut(true)
-        .as(Config.class);
+        .build();
 
     @Override default MaterializedViewProjectFilterRule toRule() {
       return new MaterializedViewProjectFilterRule(this);

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewProjectJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewProjectJoinRule.java
@@ -23,7 +23,10 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.tools.RelBuilderFactory;
 
+import org.immutables.value.Value;
+
 /** Rule that matches Project on Join. */
+@Value.Enclosing
 public class MaterializedViewProjectJoinRule
     extends MaterializedViewJoinRule<MaterializedViewProjectJoinRule.Config> {
 
@@ -51,18 +54,18 @@ public class MaterializedViewProjectJoinRule
   }
 
   /** Rule configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config extends MaterializedViewRule.Config {
-    Config DEFAULT = EMPTY.as(Config.class)
+    Config DEFAULT = ImmutableMaterializedViewProjectJoinRule.Config.builder()
         .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
         .withOperandSupplier(b0 ->
             b0.operand(Project.class).oneInput(b1 ->
                 b1.operand(Join.class).anyInputs()))
         .withDescription("MaterializedViewJoinRule(Project-Join)")
-        .as(MaterializedViewProjectFilterRule.Config.class)
         .withGenerateUnionRewriting(true)
         .withUnionRewritingPullProgram(null)
         .withFastBailOut(true)
-        .as(Config.class);
+        .build();
 
     @Override default MaterializedViewProjectJoinRule toRule() {
       return new MaterializedViewProjectJoinRule(this);

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriterConfig.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriterConfig.java
@@ -17,14 +17,14 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
-import org.apache.calcite.util.ImmutableBeans;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 /** Configuration for {@link SqlWriter} and {@link SqlPrettyWriter}. */
+@Value.Immutable(singleton = true)
 public interface SqlWriterConfig {
   /** Returns the dialect. */
-  @ImmutableBeans.Property
   @Nullable SqlDialect dialect();
 
   /** Sets {@link #dialect()}. */
@@ -32,9 +32,9 @@ public interface SqlWriterConfig {
 
   /** Returns whether to print keywords (SELECT, AS, etc.) in lower-case.
    * Default is false: keywords are printed in upper-case. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean keywordsLowerCase();
+  @Value.Default default boolean keywordsLowerCase() {
+    return false;
+  }
 
   /** Sets {@link #keywordsLowerCase}. */
   SqlWriterConfig withKeywordsLowerCase(boolean keywordsLowerCase);
@@ -42,17 +42,17 @@ public interface SqlWriterConfig {
   /** Returns whether to quote all identifiers, even those which would be
    * correct according to the rules of the {@link SqlDialect} if quotation
    * marks were omitted. Default is true. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(true)
-  boolean quoteAllIdentifiers();
+  @Value.Default default boolean quoteAllIdentifiers() {
+    return true;
+  }
 
   /** Sets {@link #quoteAllIdentifiers}. */
   SqlWriterConfig withQuoteAllIdentifiers(boolean quoteAllIdentifiers);
 
   /** Returns the number of spaces indentation. Default is 4. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.IntDefault(4)
-  int indentation();
+  @Value.Default default int indentation() {
+    return 4;
+  }
 
   /** Sets {@link #indentation}. */
   SqlWriterConfig withIndentation(int indentation);
@@ -60,18 +60,18 @@ public interface SqlWriterConfig {
   /** Returns whether a clause (FROM, WHERE, GROUP BY, HAVING, WINDOW,
    * ORDER BY) starts a new line. Default is true. SELECT is always at the
    * start of a line. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(true)
-  boolean clauseStartsLine();
+  @Value.Default default boolean clauseStartsLine() {
+    return true;
+  }
 
   /** Sets {@link #clauseStartsLine}. */
   SqlWriterConfig withClauseStartsLine(boolean clauseStartsLine);
 
   /** Returns whether a clause (FROM, WHERE, GROUP BY, HAVING, WINDOW,
    * ORDER BY) is followed by a new line. Default is false. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean clauseEndsLine();
+  @Value.Default default boolean clauseEndsLine() {
+    return false;
+  }
 
   /** Sets {@link #clauseEndsLine()}. */
   SqlWriterConfig withClauseEndsLine(boolean clauseEndsLine);
@@ -82,9 +82,9 @@ public interface SqlWriterConfig {
    * <p>Default is false;
    * this property is superseded by {@link #selectFolding()},
    * {@link #groupByFolding()}, {@link #orderByFolding()}. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean selectListItemsOnSeparateLines();
+  @Value.Default default boolean selectListItemsOnSeparateLines() {
+    return false;
+  }
 
   /** Sets {@link #selectListItemsOnSeparateLines}. */
   SqlWriterConfig withSelectListItemsOnSeparateLines(
@@ -101,7 +101,6 @@ public interface SqlWriterConfig {
    * {@link #valuesListNewline()},
    * {@link #updateSetListNewline()},
    * {@link #windowDeclListNewline()} are used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding lineFolding();
 
   /** Sets {@link #lineFolding()}. */
@@ -109,7 +108,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the SELECT clause.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding selectFolding();
 
   /** Sets {@link #selectFolding()}. */
@@ -117,16 +115,15 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the FROM clause (and JOIN).
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.EnumDefault("TALL")
-  LineFolding fromFolding();
+  @Value.Default default LineFolding fromFolding() {
+    return LineFolding.TALL;
+  }
 
   /** Sets {@link #fromFolding()}. */
   SqlWriterConfig withFromFolding(LineFolding lineFolding);
 
   /** Returns the line-folding policy for the WHERE clause.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding whereFolding();
 
   /** Sets {@link #whereFolding()}. */
@@ -134,7 +131,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the GROUP BY clause.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding groupByFolding();
 
   /** Sets {@link #groupByFolding()}. */
@@ -142,7 +138,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the HAVING clause.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding havingFolding();
 
   /** Sets {@link #havingFolding()}. */
@@ -150,7 +145,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the WINDOW clause.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding windowFolding();
 
   /** Sets {@link #windowFolding()}. */
@@ -158,7 +152,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the MATCH_RECOGNIZE clause.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding matchFolding();
 
   /** Sets {@link #matchFolding()}. */
@@ -166,7 +159,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the ORDER BY clause.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding orderByFolding();
 
   /** Sets {@link #orderByFolding()}. */
@@ -174,7 +166,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the OVER clause or a window
    * declaration. If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding overFolding();
 
   /** Sets {@link #overFolding()}. */
@@ -182,7 +173,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the VALUES expression.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding valuesFolding();
 
   /** Sets {@link #valuesFolding()}. */
@@ -190,7 +180,6 @@ public interface SqlWriterConfig {
 
   /** Returns the line-folding policy for the SET clause of an UPDATE statement.
    * If not set, the value of {@link #lineFolding()} is used. */
-  @ImmutableBeans.Property
   @Nullable LineFolding updateSetFolding();
 
   /** Sets {@link #updateSetFolding()}. */
@@ -221,9 +210,9 @@ public interface SqlWriterConfig {
    * </pre></blockquote>
    * </ul>
    */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(true)
-  boolean selectListExtraIndentFlag();
+  @Value.Default default boolean selectListExtraIndentFlag() {
+    return true;
+  }
 
   /** Sets {@link #selectListExtraIndentFlag}. */
   SqlWriterConfig withSelectListExtraIndentFlag(boolean selectListExtraIndentFlag);
@@ -233,9 +222,9 @@ public interface SqlWriterConfig {
    *
    * <p>Default is true;
    * this property is superseded by {@link #windowFolding()}. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(true)
-  boolean windowDeclListNewline();
+  @Value.Default default boolean windowDeclListNewline() {
+    return true;
+  }
 
   /** Sets {@link #windowDeclListNewline}. */
   SqlWriterConfig withWindowDeclListNewline(boolean windowDeclListNewline);
@@ -245,9 +234,9 @@ public interface SqlWriterConfig {
    *
    * <p>Default is true;
    * this property is superseded by {@link #valuesFolding()}. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(true)
-  boolean valuesListNewline();
+  @Value.Default default boolean valuesListNewline() {
+    return true;
+  }
 
   /** Sets {@link #valuesListNewline}. */
   SqlWriterConfig withValuesListNewline(boolean valuesListNewline);
@@ -257,35 +246,35 @@ public interface SqlWriterConfig {
    *
    * <p>Default is true;
    * this property is superseded by {@link #updateSetFolding()}. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(true)
-  boolean updateSetListNewline();
+  @Value.Default default boolean updateSetListNewline() {
+    return true;
+  }
 
   /** Sets {@link #updateSetListNewline}. */
   SqlWriterConfig withUpdateSetListNewline(boolean updateSetListNewline);
 
   /** Returns whether a WINDOW clause should start its own line. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean windowNewline();
+  @Value.Default default boolean windowNewline() {
+    return false;
+  }
 
   /** Sets {@link #windowNewline}. */
   SqlWriterConfig withWindowNewline(boolean windowNewline);
 
   /** Returns whether commas in SELECT, GROUP BY and ORDER clauses should
    * appear at the start of the line. Default is false. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean leadingComma();
+  @Value.Default default boolean leadingComma() {
+    return false;
+  }
 
   /** Sets {@link #leadingComma()}. */
   SqlWriterConfig withLeadingComma(boolean leadingComma);
 
   /** Returns the sub-query style.
    * Default is {@link SqlWriter.SubQueryStyle#HYDE}. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.EnumDefault("HYDE")
-  SqlWriter.SubQueryStyle subQueryStyle();
+  @Value.Default default SqlWriter.SubQueryStyle subQueryStyle() {
+    return SqlWriter.SubQueryStyle.HYDE;
+  }
 
   /** Sets {@link #subQueryStyle}. */
   SqlWriterConfig withSubQueryStyle(SqlWriter.SubQueryStyle subQueryStyle);
@@ -294,9 +283,9 @@ public interface SqlWriterConfig {
    * higher level) in WHERE clauses.
    *
    * <p>NOTE: Ignored when alwaysUseParentheses is set to true. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean whereListItemsOnSeparateLines();
+  @Value.Default default boolean whereListItemsOnSeparateLines() {
+    return false;
+  }
 
   /** Sets {@link #whereListItemsOnSeparateLines}. */
   SqlWriterConfig withWhereListItemsOnSeparateLines(
@@ -304,18 +293,18 @@ public interface SqlWriterConfig {
 
   /** Returns whether expressions should always be included in parentheses.
    * Default is false. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean alwaysUseParentheses();
+  @Value.Default default boolean alwaysUseParentheses() {
+    return false;
+  }
 
   /** Sets {@link #alwaysUseParentheses}. */
   SqlWriterConfig withAlwaysUseParentheses(boolean alwaysUseParentheses);
 
   /** Returns the maximum line length. Default is zero, which means there is
    * no maximum. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.IntDefault(0)
-  int lineLength();
+  @Value.Default default int lineLength() {
+    return 0;
+  }
 
   /** Sets {@link #lineLength}. */
   SqlWriterConfig withLineLength(int lineLength);
@@ -323,18 +312,18 @@ public interface SqlWriterConfig {
   /** Returns the line length at which items are chopped or folded (for clauses
    * that have chosen {@link LineFolding#CHOP} or {@link LineFolding#FOLD}).
    * Default is 80. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.IntDefault(80)
-  int foldLength();
+  @Value.Default default int foldLength() {
+    return 80;
+  }
 
   /** Sets {@link #foldLength()}. */
   SqlWriterConfig withFoldLength(int lineLength);
 
   /** Returns whether the WHEN, THEN and ELSE clauses of a CASE expression
    * appear at the start of a new line. The default is false. */
-  @ImmutableBeans.Property
-  @ImmutableBeans.BooleanDefault(false)
-  boolean caseClausesOnNewLines();
+  @Value.Default default boolean caseClausesOnNewLines() {
+    return false;
+  }
 
   /** Sets {@link #caseClausesOnNewLines}. */
   SqlWriterConfig withCaseClausesOnNewLines(boolean caseClausesOnNewLines);
@@ -432,5 +421,13 @@ public interface SqlWriterConfig {
 
     /** Wrap always. Items are on separate lines. */
     TALL
+  }
+
+  /**
+   * Create a default SqlWriterConfig object.
+   * @return The config.
+   */
+  static SqlWriterConfig of() {
+    return ImmutableSqlWriterConfig.of();
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParser.java
@@ -27,8 +27,11 @@ import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlDelegatingConformance;
-import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.SourceStringReader;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.immutables.value.Value;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -242,64 +245,71 @@ public class SqlParser {
   /**
    * Interface to define the configuration for a SQL parser.
    */
+  @Value.Immutable(singleton = true)
+  @Value.Style(typeImmutable = "ImmutableSqlParserConfig")
   public interface Config {
     /** Default configuration. */
-    Config DEFAULT = ImmutableBeans.create(Config.class)
-        .withLex(Lex.ORACLE)
-        .withIdentifierMaxLength(DEFAULT_IDENTIFIER_MAX_LENGTH)
-        .withConformance(SqlConformanceEnum.DEFAULT)
-        .withParserFactory(SqlParserImpl.FACTORY);
+    Config DEFAULT = ImmutableSqlParserConfig.of();
 
-    @ImmutableBeans.Property()
-    @ImmutableBeans.IntDefault(DEFAULT_IDENTIFIER_MAX_LENGTH)
-    int identifierMaxLength();
+    @Value.Default default int identifierMaxLength() {
+      return DEFAULT_IDENTIFIER_MAX_LENGTH;
+    }
 
     /** Sets {@link #identifierMaxLength()}. */
     Config withIdentifierMaxLength(int identifierMaxLength);
 
-    @ImmutableBeans.Property
-    Casing quotedCasing();
+    @Value.Default default Casing quotedCasing() {
+      return Casing.UNCHANGED;
+    }
 
     /** Sets {@link #quotedCasing()}. */
     Config withQuotedCasing(Casing casing);
 
-    @ImmutableBeans.Property
-    Casing unquotedCasing();
+    @Value.Default default Casing unquotedCasing() {
+      return Casing.TO_UPPER;
+    }
 
     /** Sets {@link #unquotedCasing()}. */
     Config withUnquotedCasing(Casing casing);
 
-    @ImmutableBeans.Property
-    Quoting quoting();
+    @Value.Default default Quoting quoting() {
+      return Quoting.DOUBLE_QUOTE;
+    }
 
     /** Sets {@link #quoting()}. */
     Config withQuoting(Quoting quoting);
 
-    @ImmutableBeans.Property()
-    @ImmutableBeans.BooleanDefault(true)
-    boolean caseSensitive();
+    @Value.Default default boolean caseSensitive() {
+      return true;
+    }
 
     /** Sets {@link #caseSensitive()}. */
     Config withCaseSensitive(boolean caseSensitive);
 
-    @ImmutableBeans.Property
-    SqlConformance conformance();
+    @Value.Default default SqlConformance conformance() {
+      return SqlConformanceEnum.DEFAULT;
+    }
 
     /** Sets {@link #conformance()}. */
     Config withConformance(SqlConformance conformance);
 
     @Deprecated // to be removed before 2.0
-    boolean allowBangEqual();
+    @SuppressWarnings("deprecation")
+    @Value.Default default boolean allowBangEqual() {
+      return DEFAULT_ALLOW_BANG_EQUAL;
+    }
 
     /** Returns which character literal styles are supported. */
-    @ImmutableBeans.Property
-    Set<CharLiteralStyle> charLiteralStyles();
+    @Value.Default default Set<CharLiteralStyle> charLiteralStyles() {
+      return ImmutableSet.of(CharLiteralStyle.STANDARD);
+    }
 
     /** Sets {@link #charLiteralStyles()}. */
-    Config withCharLiteralStyles(Set<CharLiteralStyle> charLiteralStyles);
+    Config withCharLiteralStyles(Iterable<CharLiteralStyle> charLiteralStyles);
 
-    @ImmutableBeans.Property
-    SqlParserImplFactory parserFactory();
+    @Value.Default default SqlParserImplFactory parserFactory() {
+      return SqlParserImpl.FACTORY;
+    }
 
     /** Sets {@link #parserFactory()}. */
     Config withParserFactory(SqlParserImplFactory factory);

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.util.SqlString;
-import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.trace.CalciteLogger;
 
@@ -259,7 +258,7 @@ public class SqlPrettyWriter implements SqlWriter {
    * Default SqlWriterConfig, reduce the overhead of "ImmutableBeans.create"
    */
   private static final SqlWriterConfig CONFIG =
-      ImmutableBeans.create(SqlWriterConfig.class)
+      SqlWriterConfig.of()
           .withDialect(CalciteSqlDialect.DEFAULT);
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -47,11 +47,11 @@ import org.apache.calcite.sql.type.SqlTypeCoercionRule;
 import org.apache.calcite.sql.validate.implicit.TypeCoercion;
 import org.apache.calcite.sql.validate.implicit.TypeCoercionFactory;
 import org.apache.calcite.sql.validate.implicit.TypeCoercions;
-import org.apache.calcite.util.ImmutableBeans;
 
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
+import org.immutables.value.Value;
 
 import java.util.List;
 import java.util.Map;
@@ -112,6 +112,7 @@ import java.util.function.UnaryOperator;
  * to resolve
  * names in a particular clause of a SQL statement.</p>
  */
+@Value.Enclosing
 public interface SqlValidator {
   //~ Methods ----------------------------------------------------------------
 
@@ -787,17 +788,19 @@ public interface SqlValidator {
    * Interface to define the configuration for a SqlValidator.
    * Provides methods to set each configuration option.
    */
+  @Value.Immutable(singleton = false)
   public interface Config {
     /** Default configuration. */
-    SqlValidator.Config DEFAULT = ImmutableBeans.create(Config.class)
-        .withTypeCoercionFactory(TypeCoercions::createTypeCoercion);
+    SqlValidator.Config DEFAULT = ImmutableSqlValidator.Config.builder()
+        .withTypeCoercionFactory(TypeCoercions::createTypeCoercion)
+        .build();
 
     /**
      * Returns whether to enable rewrite of "macro-like" calls such as COALESCE.
      */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean callRewrite();
+    @Value.Default default boolean callRewrite() {
+      return true;
+    }
 
     /**
      * Sets whether to enable rewrite of "macro-like" calls such as COALESCE.
@@ -806,18 +809,18 @@ public interface SqlValidator {
 
     /** Returns how NULL values should be collated if an ORDER BY item does not
      * contain NULLS FIRST or NULLS LAST. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.EnumDefault("HIGH")
-    NullCollation defaultNullCollation();
+    @Value.Default default NullCollation defaultNullCollation() {
+      return NullCollation.HIGH;
+    }
 
     /** Sets how NULL values should be collated if an ORDER BY item does not
      * contain NULLS FIRST or NULLS LAST. */
     Config withDefaultNullCollation(NullCollation nullCollation);
 
     /** Returns whether column reference expansion is enabled. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean columnReferenceExpansion();
+    @Value.Default default boolean columnReferenceExpansion() {
+      return true;
+    }
 
     /**
      * Sets whether to enable expansion of column references. (Currently this does
@@ -834,9 +837,9 @@ public interface SqlValidator {
      * method and always use this variable (or better, move preferences like
      * this to a separate "parameter" class).
      */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(false)
-    boolean identifierExpansion();
+    @Value.Default default boolean identifierExpansion() {
+      return false;
+    }
 
     /**
      * Sets whether to enable expansion of identifiers other than column
@@ -857,9 +860,9 @@ public interface SqlValidator {
      * <p>If false (the default behavior), an unknown function call causes a
      * validation error to be thrown.
      */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(false)
-    boolean lenientOperatorLookup();
+    @Value.Default default boolean lenientOperatorLookup() {
+      return false;
+    }
 
     /**
      * Sets whether this validator should be lenient upon encountering an unknown
@@ -870,9 +873,9 @@ public interface SqlValidator {
     Config withLenientOperatorLookup(boolean lenient);
 
     /** Returns whether the validator supports implicit type coercion. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean typeCoercionEnabled();
+    @Value.Default default boolean typeCoercionEnabled() {
+      return true;
+    }
 
     /**
      * Sets whether to enable implicit type coercion for validation, default true.
@@ -882,7 +885,6 @@ public interface SqlValidator {
     Config withTypeCoercionEnabled(boolean enabled);
 
     /** Returns the type coercion factory. */
-    @ImmutableBeans.Property
     TypeCoercionFactory typeCoercionFactory();
 
     /**
@@ -895,7 +897,6 @@ public interface SqlValidator {
     Config withTypeCoercionFactory(TypeCoercionFactory factory);
 
     /** Returns the type coercion rules for explicit type coercion. */
-    @ImmutableBeans.Property
     @Nullable SqlTypeCoercionRule typeCoercionRules();
 
     /**
@@ -912,9 +913,10 @@ public interface SqlValidator {
 
     /** Returns the dialect of SQL (SQL:2003, etc.) this validator recognizes.
      * Default is {@link SqlConformanceEnum#DEFAULT}. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.EnumDefault("DEFAULT")
-    SqlConformance sqlConformance();
+    @SuppressWarnings("deprecation")
+    @Value.Default default SqlConformance sqlConformance() {
+      return SqlConformance.DEFAULT;
+    }
 
     /** Sets up the sql conformance of the validator. */
     Config withSqlConformance(SqlConformance conformance);

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -105,6 +105,7 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.SortedSetMultimap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 import org.slf4j.Logger;
 
 import java.math.BigDecimal;
@@ -1886,12 +1887,12 @@ public class RelDecorrelator implements ReflectiveVisitor {
   public static final class RemoveSingleAggregateRule
       extends RelRule<RemoveSingleAggregateRule.Config> {
     static Config config(RelBuilderFactory f) {
-      return Config.EMPTY.withRelBuilderFactory(f)
+      return ImmutableRemoveSingleAggregateRuleConfig.builder().withRelBuilderFactory(f)
           .withOperandSupplier(b0 ->
               b0.operand(Aggregate.class).oneInput(b1 ->
                   b1.operand(Project.class).oneInput(b2 ->
                       b2.operand(Aggregate.class).anyInputs())))
-          .as(Config.class);
+          .build();
     }
 
     /** Creates a RemoveSingleAggregateRule. */
@@ -1936,6 +1937,8 @@ public class RelDecorrelator implements ReflectiveVisitor {
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = false)
+    @Value.Style(typeImmutable = "ImmutableRemoveSingleAggregateRuleConfig", init = "with*")
     public interface Config extends RelRule.Config {
       @Override default RemoveSingleAggregateRule toRule() {
         return new RemoveSingleAggregateRule(this);
@@ -1950,16 +1953,16 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
     static Config config(RelDecorrelator decorrelator,
         RelBuilderFactory relBuilderFactory) {
-      return Config.EMPTY.withRelBuilderFactory(relBuilderFactory)
+      return ImmutableRemoveCorrelationForScalarProjectRuleConfig.builder()
+          .withRelBuilderFactory(relBuilderFactory)
           .withOperandSupplier(b0 ->
                   b0.operand(Correlate.class).inputs(
                       b1 -> b1.operand(RelNode.class).anyInputs(),
                       b2 -> b2.operand(Aggregate.class).oneInput(b3 ->
                           b3.operand(Project.class).oneInput(b4 ->
                               b4.operand(RelNode.class).anyInputs()))))
-          .as(Config.class)
           .withDecorrelator(decorrelator)
-          .as(Config.class);
+          .build();
     }
 
     /** Creates a RemoveCorrelationForScalarProjectRule. */
@@ -2155,6 +2158,9 @@ public class RelDecorrelator implements ReflectiveVisitor {
      *
      * <p>Extends {@link RelDecorrelator.Config} because rule needs a
      * decorrelator instance. */
+    @Value.Immutable(singleton = false)
+    @Value.Style(typeImmutable = "ImmutableRemoveCorrelationForScalarProjectRuleConfig",
+        init = "with*")
     public interface Config extends RelDecorrelator.Config {
       @Override default RemoveCorrelationForScalarProjectRule toRule() {
         return new RemoveCorrelationForScalarProjectRule(this);
@@ -2169,7 +2175,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
     static Config config(RelDecorrelator d,
         RelBuilderFactory relBuilderFactory) {
-      return Config.EMPTY
+      return ImmutableRemoveCorrelationForScalarAggregateRuleConfig.builder()
           .withRelBuilderFactory(relBuilderFactory)
           .withOperandSupplier(b0 ->
               b0.operand(Correlate.class).inputs(
@@ -2179,9 +2185,8 @@ public class RelDecorrelator implements ReflectiveVisitor {
                           .predicate(Aggregate::isSimple).oneInput(b4 ->
                           b4.operand(Project.class).oneInput(b5 ->
                               b5.operand(RelNode.class).anyInputs())))))
-          .as(Config.class)
           .withDecorrelator(d)
-          .as(Config.class);
+          .build();
     }
 
     /** Creates a RemoveCorrelationForScalarAggregateRule. */
@@ -2538,6 +2543,9 @@ public class RelDecorrelator implements ReflectiveVisitor {
      *
      * <p>Extends {@link RelDecorrelator.Config} because rule needs a
      * decorrelator instance. */
+    @Value.Immutable(singleton = false)
+    @Value.Style(typeImmutable = "ImmutableRemoveCorrelationForScalarAggregateRuleConfig",
+        init = "with*")
     public interface Config extends RelDecorrelator.Config {
       @Override default RemoveCorrelationForScalarAggregateRule toRule() {
         return new RemoveCorrelationForScalarAggregateRule(this);
@@ -2560,7 +2568,8 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
     static Config config(boolean flavor, RelDecorrelator decorrelator,
         RelBuilderFactory relBuilderFactory) {
-      return Config.EMPTY.withRelBuilderFactory(relBuilderFactory)
+      return ImmutableAdjustProjectForCountAggregateRuleConfig.builder()
+          .withRelBuilderFactory(relBuilderFactory)
           .withOperandSupplier(b0 ->
               b0.operand(Correlate.class).inputs(
                   b1 -> b1.operand(RelNode.class).anyInputs(),
@@ -2568,10 +2577,9 @@ public class RelDecorrelator implements ReflectiveVisitor {
                       ? b2.operand(Project.class).oneInput(b3 ->
                       b3.operand(Aggregate.class).anyInputs())
                       : b2.operand(Aggregate.class).anyInputs()))
-          .as(Config.class)
           .withFlavor(flavor)
           .withDecorrelator(decorrelator)
-          .as(Config.class);
+          .build();
     }
 
     /** Creates an AdjustProjectForCountAggregateRule. */
@@ -2700,6 +2708,9 @@ public class RelDecorrelator implements ReflectiveVisitor {
     }
 
     /** Rule configuration. */
+    @Value.Immutable(singleton = false)
+    @Value.Style(typeImmutable = "ImmutableAdjustProjectForCountAggregateRuleConfig",
+        init = "with*")
     public interface Config extends RelDecorrelator.Config {
       @Override default AdjustProjectForCountAggregateRule toRule() {
         return new AdjustProjectForCountAggregateRule(this);

--- a/core/src/main/java/org/apache/calcite/tools/Hoist.java
+++ b/core/src/main/java/org/apache/calcite/tools/Hoist.java
@@ -24,13 +24,13 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
-import org.apache.calcite.util.ImmutableBeans;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.sql.PreparedStatement;
 import java.util.ArrayList;
@@ -62,13 +62,15 @@ import java.util.function.Function;
  *
  * <p>Adjust {@link Config} to use a different parser or parsing options.
  */
+@Value.Enclosing
 public class Hoist {
   private final Config config;
 
   /** Creates a Config. */
   public static Config config() {
-    return ImmutableBeans.create(Config.class)
-        .withParserConfig(SqlParser.config());
+    return ImmutableHoist.Config.builder()
+        .withParserConfig(SqlParser.config())
+        .build();
   }
 
   /** Creates a Hoist. */
@@ -118,9 +120,9 @@ public class Hoist {
   }
 
   /** Configuration. */
+  @Value.Immutable(singleton = false)
   public interface Config {
     /** Returns the configuration for the SQL parser. */
-    @ImmutableBeans.Property
     SqlParser.Config parserConfig();
 
     /** Sets {@link #parserConfig()}. */

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -96,7 +96,6 @@ import org.apache.calcite.sql.type.TableFunctionReturnTypeInference;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.util.Holder;
-import org.apache.calcite.util.ImmutableBeans;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -120,6 +119,7 @@ import com.google.common.collect.Sets;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
 import java.math.BigDecimal;
 import java.util.AbstractList;
@@ -166,6 +166,7 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>It is not thread-safe.
  */
+@Value.Enclosing
 public class RelBuilder {
   protected final RelOptCluster cluster;
   protected final @Nullable RelOptSchema relOptSchema;
@@ -4183,19 +4184,10 @@ public class RelBuilder {
    *
    * <p>Start with the {@link #DEFAULT} instance,
    * and call {@code withXxx} methods to set its properties. */
+  @Value.Immutable
   public interface Config {
     /** Default configuration. */
-    Config DEFAULT = ImmutableBeans.create(Config.class);
-
-    @Deprecated // to be removed before 2.0
-    static ConfigBuilder builder() {
-      return DEFAULT.toBuilder();
-    }
-
-    @Deprecated // to be removed before 2.0
-    default ConfigBuilder toBuilder() {
-      return new ConfigBuilder(this);
-    }
+    Config DEFAULT = ImmutableRelBuilder.Config.of();
 
     /** Controls whether to merge two {@link Project} operators when inlining
      * expressions causes complexity to increase.
@@ -4234,104 +4226,73 @@ public class RelBuilder {
      * {@link org.apache.calcite.adapter.enumerable.EnumerableCalc}, will often
      * gather common sub-expressions and compute them only once.
      */
-    @ImmutableBeans.Property
-    @ImmutableBeans.IntDefault(100)
-    int bloat();
+    @Value.Default default int bloat() {
+      return 100;
+    }
 
     /** Sets {@link #bloat}. */
     Config withBloat(int bloat);
 
     /** Whether {@link RelBuilder#aggregate} should eliminate duplicate
      * aggregate calls; default true. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean dedupAggregateCalls();
+    @Value.Default default boolean dedupAggregateCalls() {
+      return true;
+    }
 
     /** Sets {@link #dedupAggregateCalls}. */
     Config withDedupAggregateCalls(boolean dedupAggregateCalls);
 
     /** Whether {@link RelBuilder#aggregate} should prune unused
      * input columns; default true. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean pruneInputOfAggregate();
+    @Value.Default default boolean pruneInputOfAggregate() {
+      return true;
+    }
 
     /** Sets {@link #pruneInputOfAggregate}. */
     Config withPruneInputOfAggregate(boolean pruneInputOfAggregate);
 
     /** Whether to push down join conditions; default false (but
      * {@link SqlToRelConverter#config()} by default sets this to true). */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(false)
-    boolean pushJoinCondition();
+    @Value.Default default boolean pushJoinCondition() {
+      return false;
+    }
 
     /** Sets {@link #pushJoinCondition()}. */
     Config withPushJoinCondition(boolean pushJoinCondition);
 
     /** Whether to simplify expressions; default true. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean simplify();
+    @Value.Default default boolean simplify() {
+      return true;
+    }
 
     /** Sets {@link #simplify}. */
     Config withSimplify(boolean simplify);
 
     /** Whether to simplify LIMIT 0 to an empty relation; default true. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean simplifyLimit();
+    @Value.Default default boolean simplifyLimit() {
+      return true;
+    }
 
     /** Sets {@link #simplifyLimit()}. */
     Config withSimplifyLimit(boolean simplifyLimit);
 
     /** Whether to simplify {@code Union(Values, Values)} or
      * {@code Union(Project(Values))} to {@code Values}; default true. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(true)
-    boolean simplifyValues();
+    @Value.Default default boolean simplifyValues() {
+      return true;
+    }
 
     /** Sets {@link #simplifyValues()}. */
     Config withSimplifyValues(boolean simplifyValues);
 
     /** Whether to create an Aggregate even if we know that the input is
      * already unique; default false. */
-    @ImmutableBeans.Property
-    @ImmutableBeans.BooleanDefault(false)
-    boolean aggregateUnique();
+    @Value.Default default boolean aggregateUnique() {
+      return false;
+    }
 
     /** Sets {@link #aggregateUnique()}. */
     Config withAggregateUnique(boolean aggregateUnique);
   }
 
-  /** Creates a {@link RelBuilder.Config}.
-   *
-   * @deprecated Use the {@code withXxx} methods in
-   * {@link RelBuilder.Config}. */
-  @Deprecated // to be removed before 2.0
-  public static class ConfigBuilder {
-    private Config config;
-
-    private ConfigBuilder(Config config) {
-      this.config = config;
-    }
-
-    /** Creates a {@link RelBuilder.Config}. */
-    public Config build() {
-      return config;
-    }
-
-    /** Sets the value that will become
-     * {@link org.apache.calcite.tools.RelBuilder.Config#dedupAggregateCalls}. */
-    public ConfigBuilder withDedupAggregateCalls(boolean dedupAggregateCalls) {
-      config = config.withDedupAggregateCalls(dedupAggregateCalls);
-      return this;
-    }
-
-    /** Sets the value that will become
-     * {@link org.apache.calcite.tools.RelBuilder.Config#simplify}. */
-    public ConfigBuilder withSimplify(boolean simplify) {
-      config = config.withSimplify(simplify);
-      return this;
-    }
-  }
 }

--- a/core/src/main/java/org/apache/calcite/util/ImmutableBeans.java
+++ b/core/src/main/java/org/apache/calcite/util/ImmutableBeans.java
@@ -180,8 +180,7 @@ public class ImmutableBeans {
     final ImmutableMap<String, Class> propertyNames =
         propertyNameBuilder.build();
     for (Method method : beanClass.getMethods()) {
-      if (!Modifier.isPublic(method.getModifiers())
-          || method.isDefault()) {
+      if (!Modifier.isPublic(method.getModifiers()) || isNonPropertyDefault(method)) {
         continue;
       }
       final Property property = method.getAnnotation(Property.class);
@@ -284,7 +283,7 @@ public class ImmutableBeans {
 
     // Third pass, add default methods.
     for (Method method : beanClass.getMethods()) {
-      if (method.isDefault()) {
+      if (isNonPropertyDefault(method)) {
         final MethodHandle methodHandle;
         try {
           methodHandle = Compatible.INSTANCE.lookupPrivate(beanClass)
@@ -321,6 +320,14 @@ public class ImmutableBeans {
             || args[0] instanceof Map
             && bean.map.equals(args[0]));
     return new Def<>(beanClass, handlers.build());
+  }
+
+  private static boolean isNonPropertyDefault(Method method) {
+    return method.isDefault() && !isImmutableProperty(method);
+  }
+
+  private static boolean isImmutableProperty(Method method) {
+    return method.getAnnotation(ImmutableBeans.Property.class) != null;
   }
 
   /** Returns the value to be stored, optionally copying. */

--- a/core/src/test/java/org/apache/calcite/util/ImmutableBeanTest.java
+++ b/core/src/test/java/org/apache/calcite/util/ImmutableBeanTest.java
@@ -70,6 +70,10 @@ class ImmutableBeanTest {
     assertThat(b4.equals(b), is(false));
     assertThat(b4.equals(b2), is(false));
     assertThat(b4.equals(b3), is(false));
+
+    // assert that we can still set something that happens to have a default method.
+    final MyBean b6 = b.withDef(true);
+    assertThat(b6.getDef(), is(true));
   }
 
   @Test void testDefault() {
@@ -543,6 +547,13 @@ class ImmutableBeanTest {
     @ImmutableBeans.Property
     String getBaz();
     MyBean withBaz(String s);
+
+    @ImmutableBeans.Property
+    default boolean getDef() {
+      return true;
+    }
+    MyBean withDef(boolean def);
+
   }
 
   /** A bean class with just about every combination of default values

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.gradle.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true
@@ -102,6 +102,7 @@ hsqldb.version=2.4.1
 httpclient.version=4.5.9
 httpcore.version=4.4.11
 hydromatic.tpcds.version=0.4
+immutables.version=2.8.8
 innodb-java-reader.version=1.0.10
 jackson-databind.version=2.9.10.1
 jackson.version=2.10.0


### PR DESCRIPTION
Set destination directory for core annotation processing task

This task, used in the IDE, needs the property to be set even though the -proc:only property means no code will be compiled.