### PR TITLE
[CALCITE-4827] Move annotation processor configuration to base module

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -191,26 +191,15 @@ ide {
     generatedSource(javaCCTest, "test")
 }
 
-fun JavaCompile.configureAnnotationSet(sourceSet: SourceSet) {
-    source = sourceSet.java
-    classpath = sourceSet.compileClasspath
-    options.compilerArgs.add("-proc:only")
-    org.gradle.api.plugins.internal.JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, sourceSet.java, options, project)
-    destinationDirectory.set(temporaryDir)
 
-    // only if we aren't running compileJava, since doing twice fails (in some places)
-    onlyIf { !project.gradle.taskGraph.hasTask(sourceSet.getCompileTaskName("java")) }
-}
 
 val annotationProcessorMain by tasks.registering(JavaCompile::class) {
     dependsOn(javaCCMain)
-    configureAnnotationSet(sourceSets.main.get())
 }
 
 ide {
     // generate annotation processed files on project import/sync.
-    // adds to idea path but skip don't add to SourceSet since that triggers checkstyle
-    fun generatedSource(compile: TaskProvider<JavaCompile>, sourceSetName: String) {
+    fun generatedSource(compile: TaskProvider<JavaCompile>) {
         project.rootProject.configure<org.gradle.plugins.ide.idea.model.IdeaModel> {
             project {
                 settings {
@@ -222,7 +211,7 @@ ide {
         }
     }
 
-    generatedSource(annotationProcessorMain, "main")
+    generatedSource(annotationProcessorMain)
 }
 
 val integTestAll by tasks.registering() {


### PR DESCRIPTION
This will allow use in multiple modules (not just core) with minimal repetition.