### PR TITLE
[CALCITE-4872] Make new UNKNOWN SqlTypeName, distinct from NULL (Will Noble)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -786,6 +786,11 @@ public abstract class SqlImplementor {
           SqlNode fieldOperand = field(ordinal);
           return SqlStdOperatorTable.CURSOR.createCall(SqlParserPos.ZERO, fieldOperand);
         }
+        // Ideally the UNKNOWN type would never exist in a fully-formed, validated rel node, but
+        // it can be useful in certain situations where determining the type of an expression is
+        // infeasible, such as inserting arbitrary user-provided SQL snippets into an otherwise
+        // manually-constructed (as opposed to parsed) rel node.
+        // In such a context, assume that casting anything to UNKNOWN is a no-op.
         if (ignoreCast || call.getType().getSqlTypeName() == SqlTypeName.UNKNOWN) {
           assert nodeList.size() == 1;
           return nodeList.get(0);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -786,7 +786,7 @@ public abstract class SqlImplementor {
           SqlNode fieldOperand = field(ordinal);
           return SqlStdOperatorTable.CURSOR.createCall(SqlParserPos.ZERO, fieldOperand);
         }
-        if (ignoreCast) {
+        if (ignoreCast || SqlTypeName.UNKNOWN.equals(call.getType().getSqlTypeName())) {
           assert nodeList.size() == 1;
           return nodeList.get(0);
         } else {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -786,7 +786,7 @@ public abstract class SqlImplementor {
           SqlNode fieldOperand = field(ordinal);
           return SqlStdOperatorTable.CURSOR.createCall(SqlParserPos.ZERO, fieldOperand);
         }
-        if (ignoreCast || SqlTypeName.UNKNOWN.equals(call.getType().getSqlTypeName())) {
+        if (ignoreCast || call.getType().getSqlTypeName() == SqlTypeName.UNKNOWN) {
           assert nodeList.size() == 1;
           return nodeList.get(0);
         } else {

--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -40,7 +40,7 @@ public class BasicSqlType extends AbstractSqlType {
 
   private final int precision;
   private final int scale;
-  private final RelDataTypeSystem typeSystem;
+  protected final RelDataTypeSystem typeSystem;
   private final @Nullable SqlCollation collation;
   private final @Nullable SerializableCharset wrappedCharset;
 
@@ -54,7 +54,11 @@ public class BasicSqlType extends AbstractSqlType {
    * @param typeName Type name
    */
   public BasicSqlType(RelDataTypeSystem typeSystem, SqlTypeName typeName) {
-    this(typeSystem, typeName, false, PRECISION_NOT_SPECIFIED,
+    this(typeSystem, typeName, false);
+  }
+
+  public BasicSqlType(RelDataTypeSystem typeSystem, SqlTypeName typeName, boolean nullable) {
+    this(typeSystem, typeName, nullable, PRECISION_NOT_SPECIFIED,
         SCALE_NOT_SPECIFIED, null, null);
     checkPrecScale(typeName, false, false);
   }

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -571,8 +571,20 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
   /** The unknown type. Similar to the NULL type, but is only equal to
    * itself. */
   private static class UnknownSqlType extends BasicSqlType {
+
     UnknownSqlType(RelDataTypeFactory typeFactory) {
-      super(typeFactory.getTypeSystem(), SqlTypeName.NULL);
+      this(typeFactory.getTypeSystem(), false);
+    }
+
+    private UnknownSqlType(RelDataTypeSystem typeSystem, boolean nullable) {
+      super(typeSystem, SqlTypeName.UNKNOWN, nullable);
+    }
+
+    @Override BasicSqlType createWithNullability(boolean nullable) {
+      if (nullable == this.isNullable) {
+        return this;
+      }
+      return new UnknownSqlType(this.typeSystem, nullable);
     }
 
     @Override protected void generateTypeString(StringBuilder sb,

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -570,7 +570,7 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
 
   /** The unknown type. Similar to the NULL type, but is only equal to
    * itself. */
-  private static class UnknownSqlType extends BasicSqlType {
+  static class UnknownSqlType extends BasicSqlType {
 
     UnknownSqlType(RelDataTypeFactory typeFactory) {
       this(typeFactory.getTypeSystem(), false);

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeMappingRule.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeMappingRule.java
@@ -44,9 +44,9 @@ public interface SqlTypeMappingRule {
     Objects.requireNonNull(to, "to");
     Objects.requireNonNull(from, "from");
 
-    if (to == SqlTypeName.NULL) {
+    if (to == SqlTypeName.NULL || to == SqlTypeName.UNKNOWN) {
       return false;
-    } else if (from == SqlTypeName.NULL) {
+    } else if (from == SqlTypeName.NULL || from == SqlTypeName.UNKNOWN) {
       return true;
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -106,6 +106,7 @@ public enum SqlTypeName {
   VARBINARY(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARBINARY,
       SqlTypeFamily.BINARY),
   NULL(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
+  UNKNOWN(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
   ANY(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES, true,
       Types.JAVA_OBJECT, SqlTypeFamily.ANY),
   SYMBOL(PrecScale.NO_NO, true, Types.OTHER, null),

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
@@ -145,6 +145,8 @@ public abstract class SqlTypeTransforms {
             return SqlTypeName.ANY;
           case NULL:
             return SqlTypeName.NULL;
+          case UNKNOWN:
+            return SqlTypeName.UNKNOWN;
           default:
             throw Util.unexpected(sqlTypeName);
           }

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -824,6 +824,9 @@ public abstract class SqlTypeUtil {
 
     final SqlTypeName fromTypeName = fromType.getSqlTypeName();
     final SqlTypeName toTypeName = toType.getSqlTypeName();
+    if (toTypeName == SqlTypeName.UNKNOWN) {
+      return true;
+    }
     if (toType.isStruct() || fromType.isStruct()) {
       if (toTypeName == SqlTypeName.DISTINCT) {
         if (fromTypeName == SqlTypeName.DISTINCT) {

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -1036,7 +1036,7 @@ public abstract class SqlTypeUtil {
     assert typeName != null;
 
     final SqlTypeNameSpec typeNameSpec;
-    if (isAtomic(type) || isNull(type)) {
+    if (isAtomic(type) || isNull(type) || type.getSqlTypeName() == SqlTypeName.UNKNOWN) {
       int precision = typeName.allowsPrec() ? type.getPrecision() : -1;
       // fix up the precision.
       if (maxPrecision > 0 && precision > maxPrecision) {

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl.UnknownSqlType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -33,6 +34,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -286,4 +288,18 @@ class SqlTypeFactoryTest {
     assertThat(tsWithPrecision3 == tsWithPrecision8, is(true));
   }
 
+  /** Test that the {code UNKNOWN} type does not does not change class when nullified. */
+  @Test void testUnknownCreateWithNullabiliityTypeConsistency() {
+    SqlTypeFixture f = new SqlTypeFixture();
+
+    RelDataType unknownType  = f.typeFactory.createUnknownType();
+    assertThat(unknownType, isA(UnknownSqlType.class));
+    assertThat(unknownType.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
+    assertFalse(unknownType.isNullable());
+
+    RelDataType nullableRelDataType = f.typeFactory.createTypeWithNullability(unknownType, true);
+    assertThat(nullableRelDataType, isA(UnknownSqlType.class));
+    assertThat(nullableRelDataType.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
+    assertTrue(nullableRelDataType.isNullable());
+  }
 }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -289,7 +289,7 @@ class SqlTypeFactoryTest {
   }
 
   /** Test that the {code UNKNOWN} type does not does not change class when nullified. */
-  @Test void testUnknownCreateWithNullabiliityTypeConsistency() {
+  @Test void testUnknownCreateWithNullabilityTypeConsistency() {
     SqlTypeFixture f = new SqlTypeFixture();
 
     RelDataType unknownType  = f.typeFactory.createUnknownType();

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFixture.java
@@ -44,6 +44,8 @@ class SqlTypeFixture {
       typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
   final RelDataType sqlNull = typeFactory.createTypeWithNullability(
       typeFactory.createSqlType(SqlTypeName.NULL), false);
+  final RelDataType sqlUnknown = typeFactory.createTypeWithNullability(
+      typeFactory.createSqlType(SqlTypeName.UNKNOWN), false);
   final RelDataType sqlAny = typeFactory.createTypeWithNullability(
       typeFactory.createSqlType(SqlTypeName.ANY), false);
   final RelDataType sqlFloat = typeFactory.createTypeWithNullability(

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -38,6 +38,7 @@ import static org.apache.calcite.sql.type.SqlTypeUtil.equalAsMapSansNullability;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of {@link org.apache.calcite.sql.type.SqlTypeUtil}.
@@ -225,5 +226,30 @@ class SqlTypeUtilTest {
 
     compareTypesIgnoringNullability("identical types should return true.",
         bigIntType, bigIntType1, true);
+  }
+
+  @Test public void testCanAlwaysCastToUnknownFromBasic() {
+    RelDataType unknownType = f.typeFactory.createUnknownType();
+    RelDataType nullableUnknownType = f.typeFactory.createTypeWithNullability(unknownType, true);
+
+    for (SqlTypeName fromTypeName : SqlTypeName.values()) {
+      BasicSqlType fromType;
+      try {
+        // This only works for basic types. Ignore the rest.
+        fromType = (BasicSqlType) f.typeFactory.createSqlType(fromTypeName);
+      } catch (AssertionError e) {
+        continue;
+      }
+      BasicSqlType nullableFromType = fromType.createWithNullability(!fromType.isNullable);
+
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, true));
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, true));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, true));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, true));
+    }
   }
 }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static org.apache.calcite.sql.type.SqlTypeUtil.areSameFamily;
@@ -186,7 +187,7 @@ class SqlTypeUtilTest {
     assertThat(fieldTypeNames, is(Arrays.asList("INTEGER", "INTEGER")));
   }
 
-  @Test public void testGetMaxPrecisionScaleDecimal() {
+  @Test void testGetMaxPrecisionScaleDecimal() {
     RelDataType decimal = SqlTypeUtil.getMaxPrecisionScaleDecimal(f.typeFactory);
     assertThat(decimal, is(f.typeFactory.createSqlType(SqlTypeName.DECIMAL, 19, 9)));
   }
@@ -214,7 +215,7 @@ class SqlTypeUtilTest {
         SqlTypeUtil.equalSansNullability(type1, type2), is(expectedResult));
   }
 
-  @Test public void testEqualSansNullability() {
+  @Test void testEqualSansNullability() {
     RelDataType bigIntType = f.sqlBigInt;
     RelDataType nullableBigIntType = f.sqlBigIntNullable;
     RelDataType varCharType = f.sqlVarchar;
@@ -231,7 +232,7 @@ class SqlTypeUtilTest {
         bigIntType, bigIntType1, true);
   }
 
-  @Test public void testCanAlwaysCastToUnknownFromBasic() {
+  @Test void testCanAlwaysCastToUnknownFromBasic() {
     RelDataType unknownType = f.typeFactory.createUnknownType();
     RelDataType nullableUnknownType = f.typeFactory.createTypeWithNullability(unknownType, true);
 
@@ -254,11 +255,11 @@ class SqlTypeUtilTest {
 
   private static void assertCanCast(RelDataType toType, RelDataType fromType) {
     assertThat(
-        String.format(
+        String.format(Locale.ROOT,
             "Expected to be able to cast from %s to %s without coercion.", fromType, toType),
         SqlTypeUtil.canCastFrom(toType, fromType, /* coerce= */ false), is(true));
     assertThat(
-        String.format(
+        String.format(Locale.ROOT,
             "Expected to be able to cast from %s to %s with coercion.", fromType, toType),
         SqlTypeUtil.canCastFrom(toType, fromType, /* coerce= */ true), is(true));
   }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -38,7 +38,6 @@ import static org.apache.calcite.sql.type.SqlTypeUtil.equalAsMapSansNullability;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of {@link org.apache.calcite.sql.type.SqlTypeUtil}.
@@ -156,6 +155,10 @@ class SqlTypeUtilTest {
         (SqlBasicTypeNameSpec) convertTypeToSpec(f.sqlNull).getTypeNameSpec();
     assertThat(nullSpec.getTypeName().getSimple(), is("NULL"));
 
+    SqlBasicTypeNameSpec unknownSpec =
+        (SqlBasicTypeNameSpec) convertTypeToSpec(f.sqlUnknown).getTypeNameSpec();
+    assertThat(unknownSpec.getTypeName().getSimple(), is("UNKNOWN"));
+
     SqlBasicTypeNameSpec basicSpec =
         (SqlBasicTypeNameSpec) convertTypeToSpec(f.sqlBigInt).getTypeNameSpec();
     assertThat(basicSpec.getTypeName().getSimple(), is("BIGINT"));
@@ -242,14 +245,21 @@ class SqlTypeUtilTest {
       }
       BasicSqlType nullableFromType = fromType.createWithNullability(!fromType.isNullable);
 
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, true));
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, true));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, true));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, true));
+      assertCanCast(unknownType, fromType);
+      assertCanCast(unknownType, nullableFromType);
+      assertCanCast(nullableUnknownType, fromType);
+      assertCanCast(nullableUnknownType, nullableFromType);
     }
+  }
+
+  private static void assertCanCast(RelDataType toType, RelDataType fromType) {
+    assertThat(
+        String.format(
+            "Expected to be able to cast from %s to %s without coercion.", fromType, toType),
+        SqlTypeUtil.canCastFrom(toType, fromType, /* coerce= */ false), is(true));
+    assertThat(
+        String.format(
+            "Expected to be able to cast from %s to %s with coercion.", fromType, toType),
+        SqlTypeUtil.canCastFrom(toType, fromType, /* coerce= */ true), is(true));
   }
 }

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1150,8 +1150,8 @@ Note:
 
 | Type     | Description                | Example literals
 |:-------- |:---------------------------|:---------------
-| ANY      | A value of an unknown type, subject to explicit casting to maintain type consistency in expressions |
-| UNKNOWN  | A value of an unknown type, which Calcite assume's will simply work "as is" without any explicit casting |
+| ANY      | The union of all types |
+| UNKNOWN  | A value of an unknown type; used as a placeholder |
 | ROW      | Row with 1 or more columns | Example: Row(f0 int null, f1 varchar)
 | MAP      | Collection of keys mapped to values |
 | MULTISET | Unordered collection that may contain duplicates | Example: int multiset

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1150,7 +1150,8 @@ Note:
 
 | Type     | Description                | Example literals
 |:-------- |:---------------------------|:---------------
-| ANY      | A value of an unknown type |
+| ANY      | A value of an unknown type, subject to explicit casting to maintain type consistency in expressions |
+| UNKNOWN  | A value of an unknown type, which Calcite assume's will simply work "as is" without any explicit casting |
 | ROW      | Row with 1 or more columns | Example: Row(f0 int null, f1 varchar)
 | MAP      | Collection of keys mapped to values |
 | MULTISET | Unordered collection that may contain duplicates | Example: int multiset


### PR DESCRIPTION
Make the unknown `SqlTypeName` and `RelDataType` distinct from the null `SqlTypeName` and `RelDataType`, and make the casting rules logical. See [CALCITE-4872](https://issues.apache.org/jira/browse/CALCITE-4872).