### PR TITLE
[CALCITE-4874] Add recursive digest helper method (Will Noble)

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptNode.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptNode.java
@@ -50,6 +50,15 @@ public interface RelOptNode {
   String getDigest();
 
   /**
+   * Like {@link #getDigest()} but describes this relational expression as well as all of it's
+   * inputs, with each digest separated by newlines and children indented according to depth.
+   * This is mainly useful for visual comparisons of rel node trees while debugging.
+   *
+   * @return Digest string of this {@code RelNode}, with input digests indented recursively underneath
+   */
+  String getDigestRecursive();
+
+  /**
    * Retrieves this RelNode's traits. Note that although the RelTraitSet
    * returned is modifiable, it <b>must not</b> be modified during
    * optimization. It is legal to modify the traits of a RelNode before or

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelVertex.java
@@ -114,4 +114,10 @@ public class HepRelVertex extends AbstractRelNode implements DelegatingMetadataR
   @Override public String getDigest() {
     return "HepRelVertex(" + currentRel + ')';
   }
+
+  @Override public String getDigestRecursive() {
+    // For the purposes of the recursive digest (which is really only intended for debugging),
+    // pretend vertices don't exist.
+    return currentRel.getDigestRecursive();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/rel/RelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelNode.java
@@ -271,6 +271,28 @@ public interface RelNode extends RelOptNode, Cloneable {
   }
 
   /**
+   * Returns a digest string of this {@code RelNode}, as well as the digests of all its input rel
+   * nodes as an indented tree, useful for visual debugging.
+   *
+   * <p>Each call creates many new digest strings,
+   * so don't forget to cache the result if necessary.
+   *
+   * @return Digest string of this {@code RelNode} and all it's direct or indirect inputs.
+   *
+   * @see #getDigest()
+   */
+  @Override default String getDigestRecursive() {
+    final String indentedNewline = "\n  ";
+    final StringBuilder builder = new StringBuilder();
+    builder.append(getDigest());
+    for (RelNode input: getInputs()) {
+      builder.append(indentedNewline);
+      builder.append(input.getDigestRecursive().replace("\n", indentedNewline));
+    }
+    return builder.toString();
+  }
+
+  /**
    * Returns a digest of this {@code RelNode}.
    *
    * <p>INTERNAL USE ONLY. For use by the planner.


### PR DESCRIPTION
I've found myself doing this by hand all the time. Having a method ready to invoke while debugging should save a lot of time in the future.