### PR TITLE
[CALCITE-4877] Enable schema.iq test, with variants depending on Avatica version

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -18,6 +18,8 @@ package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.AvaticaUtils;
 
+import java.util.Objects;
+
 /**
  * Holder for a list of constants describing which bugs which have not been
  * fixed.
@@ -259,9 +261,9 @@ public abstract class Bug {
       // Avatica 1.20 and later gives
       //   Property 'org.apache.calcite.NonExistent' not valid as
       //   'org.apache.calcite.NonExistent' not found in the classpath
-      return e.getMessage().equals("Property 'org.apache.calcite.NonExistent' "
-          + "not valid as 'org.apache.calcite.NonExistent' not found in the "
-          + "classpath");
+      return Objects.equals(e.getMessage(),
+          "Property 'org.apache.calcite.NonExistent' not valid as "
+              + "'org.apache.calcite.NonExistent' not found in the classpath");
     }
     return false;
   }

--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -18,8 +18,6 @@ package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.AvaticaUtils;
 
-import java.math.BigInteger;
-
 /**
  * Holder for a list of constants describing which bugs which have not been
  * fixed.

--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -16,6 +16,10 @@
  */
 package org.apache.calcite.util;
 
+import org.apache.calcite.avatica.AvaticaUtils;
+
+import java.math.BigInteger;
+
 /**
  * Holder for a list of constants describing which bugs which have not been
  * fixed.
@@ -201,6 +205,14 @@ public abstract class Bug {
    * fixed. */
   public static final boolean CALCITE_4213_FIXED = false;
 
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4877">[CALCITE-4877]
+   * Make the exception information of class not found more explicit</a> is
+   * fixed. The actual fix is in Avatica, and we don't know the precise version
+   * of Avatica, so we have to deduce whether it is fixed from Avatica's
+   * behavior. We memoize the result so that we don't generate lots of exceptions.  */
+  public static final boolean CALCITE_4877_FIXED = isCalcite4877Fixed();
+
   /**
    * Use this to flag temporary code.
    */
@@ -235,6 +247,24 @@ public abstract class Bug {
    */
   public static boolean upgrade(String remark) {
     Util.discard(remark);
+    return false;
+  }
+
+  private static boolean isCalcite4877Fixed() {
+    try {
+      AvaticaUtils.instantiatePlugin(Integer.class,
+          "org.apache.calcite.NonExistent");
+    } catch (RuntimeException e) {
+      // Avatica 1.19 and earlier gives
+      //   Property 'org.apache.calcite.NonExistent' not valid for plugin type
+      //   java.lang.Integer
+      // Avatica 1.20 and later gives
+      //   Property 'org.apache.calcite.NonExistent' not valid as
+      //   'org.apache.calcite.NonExistent' not found in the classpath
+      return e.getMessage().equals("Property 'org.apache.calcite.NonExistent' "
+          + "not valid as 'org.apache.calcite.NonExistent' not found in the "
+          + "classpath");
+    }
     return false;
   }
 }

--- a/server/src/test/resources/sql/schema.iq
+++ b/server/src/test/resources/sql/schema.iq
@@ -65,9 +65,16 @@ create schema if not exists s;
 !update
 
 # Bad library
-# create foreign schema fs library 'com.example.BadSchemaFactory';
-# Property 'com.example.BadSchemaFactory' not valid for plugin type org.apache.calcite.schema.SchemaFactory
-# !error
+!if (fixed.calcite4877) {
+create foreign schema fs library 'com.example.BadSchemaFactory';
+Property 'com.example.BadSchemaFactory' not valid as 'com.example.BadSchemaFactory' not found in the classpath
+!error
+!}
+!if (not.fixed.calcite4877) {
+create foreign schema fs library 'com.example.BadSchemaFactory';
+Property 'com.example.BadSchemaFactory' not valid for plugin type org.apache.calcite.schema.SchemaFactory
+!error
+!}
 
 # Bad type
 create foreign schema fs type 'bad';

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -55,8 +55,12 @@ import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -79,6 +83,18 @@ public abstract class QuidemTest {
           return Bug.CALCITE_1045_FIXED;
         case "calcite1048":
           return Bug.CALCITE_1048_FIXED;
+        case "calcite4877":
+          return Bug.CALCITE_4877_FIXED;
+        }
+        return null;
+      };
+    case "not":
+      return (Function<String, Object>) v -> {
+        final Object o = getEnv(v);
+        if (o instanceof Function) {
+          @SuppressWarnings("unchecked") final Function<String, Object> f =
+              (Function<String, Object>) o;
+          return (Function<String, Object>) v2 -> !((Boolean) f.apply(v2));
         }
         return null;
       };

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -55,12 +55,8 @@ import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
-
-import static java.util.Objects.requireNonNull;
 
 import static org.junit.jupiter.api.Assertions.fail;
 


### PR DESCRIPTION
This reverts an earlier commit 84387547cbe718d42ab7d8e609254460a59aa123 and solves the underlying problem. Calcite should now be flexible enough to run on 1.19 and 1.20-SNAPSHOT (and 1.20 when it is released).