### PR TITLE
[CALCITE-4888] Unify type inferring logical for Sarg RexLiteral

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -3027,9 +3027,17 @@ public class RexSimplify {
     }
 
     void addRange(Range<Comparable> range, RelDataType type) {
-      types.add(type);
-      rangeSet.add(range);
-      nullAs = nullAs.or(UNKNOWN);
+      try {
+        types.add(type);
+        rangeSet.add(range);
+        nullAs = nullAs.or(UNKNOWN);
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException(
+            String.format("Sarg arguments are not compatible with each other!\n"
+                + "Existed ranges are %s, new range is %s.",
+                rangeSet, range),
+            e);
+      }
     }
 
     @SuppressWarnings({"UnstableApiUsage", "rawtypes", "unchecked"})

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -3027,17 +3027,9 @@ public class RexSimplify {
     }
 
     void addRange(Range<Comparable> range, RelDataType type) {
-      try {
-        types.add(type);
-        rangeSet.add(range);
-        nullAs = nullAs.or(UNKNOWN);
-      } catch (ClassCastException e) {
-        throw new IllegalArgumentException(
-            String.format("Sarg arguments are not compatible with each other!\n"
-                + "Existed ranges are %s, new range is %s.",
-                rangeSet, range),
-            e);
-      }
+      types.add(type);
+      rangeSet.add(range);
+      nullAs = nullAs.or(UNKNOWN);
     }
 
     @SuppressWarnings({"UnstableApiUsage", "rawtypes", "unchecked"})

--- a/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
@@ -642,6 +642,36 @@ class RexBuilderTest {
   }
 
   /**
+   * Tests {@link RexBuilder#makeIn} would generate a disjunction if it is impossible to convert a
+   * list of input expressions to a search argument.
+   */
+  @Test void testMakeInWithNullValueLiteral() {
+    final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    final RelDataType type = typeFactory.createSqlType(SqlTypeName.DATE);
+    RexNode left = rexBuilder.makeInputRef(type, 0);
+    final RexNode literal1 = rexBuilder.makeLiteral(null, type);
+    final RexNode literal2 = rexBuilder.makeLiteral(1, type);
+    RexCall call = (RexCall) rexBuilder.makeIn(left, ImmutableList.of(literal1, literal2));
+    assertThat(call.getOperator(), is(SqlStdOperatorTable.OR));
+  }
+
+  /**
+   * Tests {@link RexBuilder#makeIn} would generate a disjunction if it is impossible to convert a
+   * list of input expressions to a search argument.
+   */
+  @Test void testMakeInWithNonLiteral() {
+    final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    final RelDataType type = typeFactory.createSqlType(SqlTypeName.DATE);
+    RexNode left = rexBuilder.makeInputRef(type, 0);
+    final RexNode literal1 = rexBuilder.makeLiteral(1, type);
+    final RexNode field1 = rexBuilder.makeInputRef(type, 1);
+    RexCall call = (RexCall) rexBuilder.makeIn(left, ImmutableList.of(literal1, field1));
+    assertThat(call.getOperator(), is(SqlStdOperatorTable.OR));
+  }
+
+  /**
    * Tests {@link RexBuilder#makeIn} would generate a search call if types of the ranges are
    * compatible. Type of search argument literal is least restrictive type of ranges.
    */

--- a/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
@@ -642,8 +642,8 @@ class RexBuilderTest {
   }
 
   /**
-   * Tests {@link RexBuilder#makeIn} would generate a disjunction if it is impossible to convert a
-   * list of input expressions to a search argument.
+   * Tests {@link RexBuilder#makeIn} would generate a disjunction if one or more ranges expressions
+   * are literals with null value.
    */
   @Test void testMakeInWithNullValueLiteral() {
     final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
@@ -657,8 +657,8 @@ class RexBuilderTest {
   }
 
   /**
-   * Tests {@link RexBuilder#makeIn} would generate a disjunction if it is impossible to convert a
-   * list of input expressions to a search argument.
+   * Tests {@link RexBuilder#makeIn} would generate a disjunction if not all ranges expressions are
+   * literals.
    */
   @Test void testMakeInWithNonLiteral() {
     final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
@@ -671,10 +671,11 @@ class RexBuilderTest {
     assertThat(call.getOperator(), is(SqlStdOperatorTable.OR));
   }
 
-  /**
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4888">[CALCITE-4888]
+   * Fix type inferring when call RelBuilder.in with arguments that are different types</a>.
    * Tests {@link RexBuilder#makeIn} would generate a search call if types of the ranges are
-   * compatible. Type of search argument literal is least restrictive type of ranges.
-   */
+   * compatible. Type of search argument literal is least restrictive type of ranges.*/
   @Test void testMakeInWithCompatibleArguments() {
     final Function<RelDataTypeSystem, RexCall> f = t -> {
       final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(t);
@@ -694,6 +695,7 @@ class RexBuilderTest {
     assertThat(sargType1.getSqlTypeName(), is(SqlTypeName.CHAR));
     assertThat(sargType1.getPrecision(), is(5));
 
+    // Type of search argument literal is least restrictive type of char1 and char5.
     RexCall rexCall2 = f.apply(
         new RelDataTypeSystemImpl() {
           @Override public boolean shouldConvertRaggedUnionTypesToVarying() {

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -4042,29 +4042,10 @@ public class RelBuilderTest {
   }
 
   /**
-   * Tests {@link RelBuilder#in} would throw an exception when simplify filter predicates if types
-   * of the ranges are not compatible.
-   */
-  @Test void testFilterInWithNotCompatibleArgumentsSimplification() {
-    try {
-      final RelBuilder b = RelBuilder.create(config().build());
-      final RelNode root = b.scan("EMP")
-          .filter(b.in(b.field(2), b.literal(1), b.literal(true)))
-          .build();
-      fail("expected error, got " + root);
-    } catch (Exception e) {
-      assertThat(
-          e.getMessage(), is(
-          "Sarg arguments are not compatible with each other!\n"
-              + "Existed ranges are [[1..1]], new range is [true..true]."));
-    }
-  }
-
-  /**
    * Tests {@link RelBuilder#in} would generate a disjunction if types of the ranges are not
    * compatible.
    */
-  @Test void testFilterInWithNotCompatibleArgumentsWithoutSimplification() {
+  @Test void testFilterInWithNotCompatibleArguments() {
     final RelBuilder b = createBuilder(c -> c.withSimplify(false));
     final RelNode root = b.scan("EMP")
         .filter(b.in(b.field(2), b.literal(1), b.literal(true)))

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -4041,7 +4041,26 @@ public class RelBuilderTest {
     assertThat(root, hasTree(expected));
   }
 
-  @Test void testFilterInCharWithDiffLength() {
+  /**
+   * Tests {@link RelBuilder#in} would throw exception if types of the ranges are not compatible.
+   */
+  @Test void testFilterInWithNotCompatibleArguments() {
+    try {
+      final RelBuilder b = RelBuilder.create(config().build());
+      final RelNode root = b.scan("EMP")
+          .filter(b.in(b.field(2), b.literal(1), b.literal(true)))
+          .build();
+      fail("expected error, got " + root);
+    } catch (ClassCastException e) {
+      // good
+    }
+  }
+
+  /**
+   * Tests {@link RelBuilder#in} would generate a search call if types of the ranges are
+   * compatible. Type of search argument literal is least restrictive type of ranges.
+   */
+  @Test void testFilterInWithCompatibleArguments() {
     final Function<RelBuilder, RelNode> f = b ->
         b.scan("EMP")
             .filter(b.in(b.field("JOB"), b.literal("CLERK"), b.literal("A")))

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -4056,10 +4056,11 @@ public class RelBuilderTest {
     }
   }
 
-  /**
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4888">[CALCITE-4888]
+   * Fix type inferring when call RelBuilder.in with arguments that are different types</a>.
    * Tests {@link RelBuilder#in} would generate a search call if types of the ranges are
-   * compatible. Type of search argument literal is least restrictive type of ranges.
-   */
+   * compatible. Type of search argument literal is least restrictive type of ranges.*/
   @Test void testFilterInWithCompatibleArguments() {
     final Function<RelBuilder, RelNode> f = b ->
         b.scan("EMP")


### PR DESCRIPTION
## What is the purpose of the change

If `shouldConvertRaggedUnionTypesToVarying` is true, updates `RexBuilder#makeIn` to use less restrictive type based on all ranges types instead of first range type.

## Brief change log

  - Update `RexBuilder#makeIn`

## Verifying this change

  - Add tests in `RexBuilderTest`, `RelBuilderTest`