### PR TITLE
[CALCITE-4894] MV rewriting fails for conjunctive top expressions in SELECT clause

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -493,7 +493,7 @@ public class RelMdExpressionLineage
       Map<RexInputRef, RexNode> singleMapping, Set<RexNode> result) {
     if (mapping.isEmpty()) {
       final RexReplacer replacer = new RexReplacer(singleMapping);
-      final List<RexNode> updatedPreds = new ArrayList<>();
+      final List<RexNode> updatedPreds = new ArrayList<>(1);
       updatedPreds.add(rexBuilder.copy(expr));
       replacer.mutate(updatedPreds);
       result.addAll(updatedPreds);

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -493,9 +493,8 @@ public class RelMdExpressionLineage
       Map<RexInputRef, RexNode> singleMapping, Set<RexNode> result) {
     if (mapping.isEmpty()) {
       final RexReplacer replacer = new RexReplacer(singleMapping);
-      final List<RexNode> updatedPreds = new ArrayList<>(
-          RelOptUtil.conjunctions(
-              rexBuilder.copy(expr)));
+      final List<RexNode> updatedPreds = new ArrayList<>();
+      updatedPreds.add(rexBuilder.copy(expr));
       replacer.mutate(updatedPreds);
       result.addAll(updatedPreds);
     } else {

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewJoinRule.java
@@ -279,8 +279,10 @@ public abstract class MaterializedViewJoinRule<C extends MaterializedViewRule.Co
           exprsLineage.add(RexUtil.composeDisjunction(rexBuilder, rewrittenExprs));
         }
       } else {
-        assert lineages.size() == 1 : "We only support project - filter - join, "
-            + "thus expression lineage should map to a single expression, got: " + lineages;
+        if (lineages.size() != 1) {
+          throw new IllegalStateException("We only support project - filter - join, "
+              + "thus expression lineage should map to a single expression, got: " + lineages);
+        }
         // Rewrite expr. Take first element from the corresponding equivalence class
         // (no need to swap the table references following the table mapping)
         exprsLineage.add(

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewJoinRule.java
@@ -267,7 +267,8 @@ public abstract class MaterializedViewJoinRule<C extends MaterializedViewRule.Co
       }
       if (lineages.size() != 1) {
         throw new IllegalStateException("We only support project - filter - join, "
-            + "thus expression lineage should map to a single expression, got: " + lineages);
+            + "thus expression lineage should map to a single expression, got: '"
+            + lineages + "' for expr '" + expr + "' in node '" + node + "'");
       }
       // Rewrite expr. Take first element from the corresponding equivalence class
       // (no need to swap the table references following the table mapping)

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewJoinRule.java
@@ -279,7 +279,10 @@ public abstract class MaterializedViewJoinRule<C extends MaterializedViewRule.Co
           exprsLineage.add(RexUtil.composeDisjunction(rexBuilder, rewrittenExprs));
         }
       } else {
-        assert lineages.size() == 1;
+        assert lineages.size() == 1 : "We only support project - filter - join, "
+            + "thus expression lineage should map to a single expression, got: " + lineages;
+        // Rewrite expr. Take first element from the corresponding equivalence class
+        // (no need to swap the table references following the table mapping)
         exprsLineage.add(
             RexUtil.swapColumnReferences(rexBuilder,
                 lineages.iterator().next(), queryEC.getEquivalenceClassesMap()));

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
@@ -1035,14 +1035,16 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
     final Map<RexNode, Integer> exprsLineage = new HashMap<>();
     final Map<RexNode, Integer> exprsLineageLosslessCasts = new HashMap<>();
     for (int i = 0; i < nodeExprs.size(); i++) {
-      final Set<RexNode> lineages = mq.getExpressionLineage(node, nodeExprs.get(i));
+      final RexNode expr = nodeExprs.get(i);
+      final Set<RexNode> lineages = mq.getExpressionLineage(node, expr);
       if (lineages == null) {
         // Next expression
         continue;
       }
       if (lineages.size() != 1) {
         throw new IllegalStateException("We only support project - filter - join, "
-            + "thus expression lineage should map to a single expression, got: " + lineages);
+            + "thus expression lineage should map to a single expression, got: '"
+            + lineages + "' for expr '" + expr + "' in node '" + node + "'");
       }
       // Rewrite expr. First we swap the table references following the table
       // mapping, then we take first element from the corresponding equivalence class
@@ -1070,14 +1072,16 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
     final Map<RexNode, Integer> exprsLineage = new HashMap<>();
     final Map<RexNode, Integer> exprsLineageLosslessCasts = new HashMap<>();
     for (int i = 0; i < nodeExprs.size(); i++) {
-      final Set<RexNode> lineages = mq.getExpressionLineage(node, nodeExprs.get(i));
+      final RexNode expr = nodeExprs.get(i);
+      final Set<RexNode> lineages = mq.getExpressionLineage(node, expr);
       if (lineages == null) {
         // Next expression
         continue;
       }
       if (lineages.size() != 1) {
         throw new IllegalStateException("We only support project - filter - join, "
-            + "thus expression lineage should map to a single expression, got: " + lineages);
+            + "thus expression lineage should map to a single expression, got: '"
+            + lineages + "' for expr '" + expr + "' in node '" + node + "'");
       }
       // Rewrite expr. First we take first element from the corresponding equivalence class,
       // then we swap the table references following the table mapping

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
@@ -1055,8 +1055,10 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
           exprsLineage.put(RexUtil.composeDisjunction(rexBuilder, rewrittenExprs), i);
         }
       } else {
-        assert lineages.size() == 1 : "We only support project - filter - join, "
-            + "thus expression lineage should map to a single expression, got: " + lineages;
+        if (lineages.size() != 1) {
+          throw new IllegalStateException("We only support project - filter - join, "
+              + "thus expression lineage should map to a single expression, got: " + lineages);
+        }
         // Rewrite expr. First we swap the table references following the table
         // mapping, then we take first element from the corresponding equivalence class
         final RexNode e = RexUtil.swapTableColumnReferences(rexBuilder,
@@ -1102,8 +1104,10 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
           exprsLineage.put(RexUtil.composeDisjunction(rexBuilder, rewrittenExprs), i);
         }
       } else {
-        assert lineages.size() == 1 : "We only support project - filter - join, "
-            + "thus expression lineage should map to a single expression, got: " + lineages;
+        if (lineages.size() != 1) {
+          throw new IllegalStateException("We only support project - filter - join, "
+              + "thus expression lineage should map to a single expression, got: " + lineages);
+        }
         final RexNode node2 = Iterables.getOnlyElement(lineages);
         // Rewrite expr. First we take first element from the corresponding equivalence class,
         // then we swap the table references following the table mapping

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
@@ -1055,9 +1055,8 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
           exprsLineage.put(RexUtil.composeDisjunction(rexBuilder, rewrittenExprs), i);
         }
       } else {
-        // We only support project - filter - join, thus it should map to
-        // a single expression
-        assert lineages.size() == 1;
+        assert lineages.size() == 1 : "We only support project - filter - join, "
+            + "thus expression lineage should map to a single expression, got: " + lineages;
         // Rewrite expr. First we swap the table references following the table
         // mapping, then we take first element from the corresponding equivalence class
         final RexNode e = RexUtil.swapTableColumnReferences(rexBuilder,
@@ -1103,8 +1102,8 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
           exprsLineage.put(RexUtil.composeDisjunction(rexBuilder, rewrittenExprs), i);
         }
       } else {
-        // We only support project - filter - join, thus it should map to
-        // a single expression
+        assert lineages.size() == 1 : "We only support project - filter - join, "
+            + "thus expression lineage should map to a single expression, got: " + lineages;
         final RexNode node2 = Iterables.getOnlyElement(lineages);
         // Rewrite expr. First we take first element from the corresponding equivalence class,
         // then we swap the table references following the table mapping

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewRelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewRelOptRulesTest.java
@@ -1124,7 +1124,9 @@ class MaterializedViewRelOptRulesTest extends AbstractMaterializedViewTest {
 
   @Test void testViewProjectWithMultifieldExpressions() {
     sql("select s.\"time_id\", s.\"time_id\" >= 1 and s.\"time_id\" < 3,"
-            + " s.\"time_id\" >= 1 or s.\"time_id\" < 3"
+            + " s.\"time_id\" >= 1 or s.\"time_id\" < 3, "
+            + " s.\"time_id\" + s.\"time_id\", "
+            + " s.\"time_id\" * s.\"time_id\""
             + " from \"foodmart\".\"sales_fact_1997\" as s"
             + " where s.\"store_id\" = 1",
         "select s.\"time_id\""
@@ -1133,7 +1135,7 @@ class MaterializedViewRelOptRulesTest extends AbstractMaterializedViewTest {
         .withDefaultSchemaSpec(CalciteAssert.SchemaSpec.JDBC_FOODMART)
         .withChecker(
             resultContains(""
-                + "EnumerableCalc(expr#0..2=[{inputs}], time_id=[$t0])\n"
+                + "EnumerableCalc(expr#0..4=[{inputs}], time_id=[$t0])\n"
                 + "  EnumerableTableScan(table=[[foodmart, MV0]])"))
         .ok();
   }

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -2410,8 +2410,8 @@ public class RelMetadataTest extends SqlToRelTestBase {
     RexNode ref = RexInputRef.of(columnIndex, rel.getRowType().getFieldList());
     Set<RexNode> r = mq.getExpressionLineage(rel, ref);
 
-    assertEquals(expected, String.valueOf(r), "Lineage for expr '" + ref + "' in node '" +
-        rel + "'" + " for query '" + sql + "':\n" + comment);
+    assertEquals(expected, String.valueOf(r), "Lineage for expr '" + ref + "' in node '"
+        + rel + "'" + " for query '" + sql + "':n" + comment);
   }
 
   @Test void testExpressionLineageStar() {

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -2411,7 +2411,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     Set<RexNode> r = mq.getExpressionLineage(rel, ref);
 
     assertEquals(expected, String.valueOf(r), "Lineage for expr '" + ref + "' in node '"
-        + rel + "'" + " for query '" + sql + "':n" + comment);
+        + rel + "'" + " for query '" + sql + "':\n" + comment);
   }
 
   @Test void testExpressionLineageStar() {

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -138,7 +138,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -2489,7 +2488,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
 
     final RexNode ref = RexInputRef.of(0, rel.getRowType().getFieldList());
-    final Set<RexNode> r = Objects.requireNonNull(mq.getExpressionLineage(rel, ref));
+    final Set<RexNode> r = mq.getExpressionLineage(rel, ref);
 
     final String assertionMessage = "Lineage for expr '"
         + ref + "' in node '" + rel + "'" + " for query '" + sql + "':\n"
@@ -2509,7 +2508,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
 
     final RexNode ref = RexInputRef.of(0, rel.getRowType().getFieldList());
-    final Set<RexNode> r = Objects.requireNonNull(mq.getExpressionLineage(rel, ref));
+    final Set<RexNode> r = mq.getExpressionLineage(rel, ref);
 
     final String assertionMessage = "Lineage for expr '"
         + ref + "' in node '" + rel + "'" + " for query '" + sql + "':\n"

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -2411,7 +2411,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     Set<RexNode> r = mq.getExpressionLineage(rel, ref);
 
     assertEquals(expected, String.valueOf(r), "Lineage for expr '" + ref + "' in node '"
-        + rel + "'" + " for query '" + sql + "':\n" + comment);
+        + rel + "'" + " for query '" + sql + "': " + comment);
   }
 
   @Test void testExpressionLineageStar() {

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -189,7 +189,6 @@ public class RelMetadataTest extends SqlToRelTestBase {
   private static final double DEPT_SIZE = 4d;
 
   private static final List<String> EMP_QNAME = ImmutableList.of("CATALOG", "SALES", "EMP");
-  private static final List<String> DEPT_QNAME = ImmutableList.of("CATALOG", "SALES", "DEPT");
 
   /** Ensures that tests that use a lot of memory do not run at the same
    * time. */
@@ -2483,7 +2482,7 @@ public class RelMetadataTest extends SqlToRelTestBase {
     assertThat(inputRef1.getIdentifier(), is(inputRef2.getIdentifier()));
   }
 
-  @Test void testExpressionLineageComplexExpression() {
+  @Test void testExpressionLineageConjuntiveExpression() {
     // empno is column 0 in catalog.sales.emp
     // ename is column 1 in catalog.sales.emp
     // deptno is column 7 in catalog.sales.emp
@@ -2492,48 +2491,15 @@ public class RelMetadataTest extends SqlToRelTestBase {
 
     final RexNode ref = RexInputRef.of(0, rel.getRowType().getFieldList());
     final Set<RexNode> r = mq.getExpressionLineage(rel, ref);
-
-    // check '(empno = 1 or ename = 'abc') and deptno > 1'
     assertThat(r.size(), is(1));
-    final RexNode result = r.iterator().next();
-    assertThat(result.getKind(), is(SqlKind.AND));
-    final RexCall and = (RexCall) result;
 
-    // check '(empno = 1 or ename = 'abc')'
-    assertThat(and.getOperands().size(), is(2));
-    final RexCall or = (RexCall) and.getOperands().get(0);
-    assertThat(or.getKind(), is(SqlKind.OR));
-    assertThat(or.getOperands().size(), is(2));
-
-    // check 'empno = 1'
-    final RexCall eq1 = (RexCall) or.getOperands().get(0);
-    assertThat(eq1.getKind(), is(SqlKind.EQUALS));
-    final RexTableInputRef inputRef1 = (RexTableInputRef) eq1.getOperands().get(0);
-    assertThat(inputRef1.getQualifiedName(), is(EMP_QNAME));
-    assertThat(inputRef1.getIndex(), is(0));
-    final RexLiteral literal1 = (RexLiteral) eq1.getOperands().get(1);
-    assertThat(literal1.getValueAs(Integer.class), is(1));
-
-    // check 'ename = 'abc''
-    final RexCall eq2 = (RexCall) or.getOperands().get(1);
-    assertThat(eq2.getKind(), is(SqlKind.EQUALS));
-    final RexTableInputRef inputRef2 = (RexTableInputRef) eq2.getOperands().get(0);
-    assertThat(inputRef2.getQualifiedName(), is(EMP_QNAME));
-    assertThat(inputRef2.getIndex(), is(1));
-    final RexLiteral literal2 = (RexLiteral) eq2.getOperands().get(1);
-    assertThat(literal2.getValueAs(String.class), is("abc"));
-
-    // check 'deptno > 1'
-    final RexCall gt = (RexCall) and.getOperands().get(1);
-    assertThat(gt.getKind(), is(SqlKind.GREATER_THAN));
-    final RexTableInputRef inputRef3 = (RexTableInputRef) gt.getOperands().get(0);
-    assertThat(inputRef3.getQualifiedName(), is(EMP_QNAME));
-    assertThat(inputRef3.getIndex(), is(7));
-    final RexLiteral literal3 = (RexLiteral) gt.getOperands().get(1);
-    assertThat(literal3.getValueAs(Integer.class), is(1));
+    final String actualExp = r.iterator().next().toString();
+    assertEquals("AND(OR(=([CATALOG, SALES, EMP].#0.$0, 1),"
+        + " =([CATALOG, SALES, EMP].#0.$1, 'abc')),"
+        + " >([CATALOG, SALES, EMP].#0.$7, 1))", actualExp);
   }
 
-  @Test void testExpressionLineageComplexExpressionWithJoin() {
+  @Test void testExpressionLineageBetweenExpressionWithJoin() {
     // empno is column 0 in catalog.sales.emp
     // deptno is column 0 in catalog.sales.dept
     final RelNode rel = convertSql("select dept.deptno + empno between 1 and 2"
@@ -2542,54 +2508,13 @@ public class RelMetadataTest extends SqlToRelTestBase {
 
     final RexNode ref = RexInputRef.of(0, rel.getRowType().getFieldList());
     final Set<RexNode> r = mq.getExpressionLineage(rel, ref);
+    assertThat(r.size(), is(1));
 
     // 'dept.deptno + empno between 1 and 2' is translated into
     // 'dept.deptno + empno >= 1 and dept.deptno + empno <= 2'
-    assertThat(r.size(), is(1));
-    final RexNode result = r.iterator().next();
-    assertThat(result.getKind(), is(SqlKind.AND));
-    final RexCall and = (RexCall) result;
-    assertThat(and.getOperands().size(), is(2));
-
-    // check 'dept.deptno + empno >= 1'
-    final RexCall gt1 = (RexCall) and.getOperands().get(0);
-    assertThat(gt1.getKind(), is(SqlKind.GREATER_THAN_OR_EQUAL));
-    assertThat(gt1.getOperands().size(), is(2));
-    final RexCall plus1 = (RexCall) gt1.getOperands().get(0);
-    // check 'dept.deptno + empno'
-    assertThat(plus1.getKind(), is(SqlKind.PLUS));
-    assertThat(plus1.getOperands().size(), is(2));
-    // check 'dept.deptno'
-    final RexTableInputRef inputRef1 = (RexTableInputRef) plus1.getOperands().get(0);
-    assertThat(inputRef1.getQualifiedName(), is(DEPT_QNAME));
-    assertThat(inputRef1.getIndex(), is(0));
-    // check 'empno'
-    final RexTableInputRef inputRef2 = (RexTableInputRef) plus1.getOperands().get(1);
-    assertThat(inputRef2.getQualifiedName(), is(EMP_QNAME));
-    assertThat(inputRef2.getIndex(), is(0));
-    // check '1'
-    final RexLiteral literal1 = (RexLiteral) gt1.getOperands().get(1);
-    assertThat(literal1.getValueAs(Integer.class), is(1));
-
-    // check 'dept.deptno + empno <= 2'
-    final RexCall lt2 = (RexCall) and.getOperands().get(1);
-    assertThat(lt2.getKind(), is(SqlKind.LESS_THAN_OR_EQUAL));
-    assertThat(lt2.getOperands().size(), is(2));
-    // check 'dept.deptno + empno'
-    final RexCall plus2 = (RexCall) lt2.getOperands().get(0);
-    assertThat(plus2.getKind(), is(SqlKind.PLUS));
-    assertThat(plus2.getOperands().size(), is(2));
-    // check 'dept.deptno'
-    final RexTableInputRef inputRef3 = (RexTableInputRef) plus2.getOperands().get(0);
-    assertThat(inputRef3.getQualifiedName(), is(DEPT_QNAME));
-    assertThat(inputRef3.getIndex(), is(0));
-    // check 'empno'
-    final RexTableInputRef inputRef4 = (RexTableInputRef) plus2.getOperands().get(1);
-    assertThat(inputRef4.getQualifiedName(), is(EMP_QNAME));
-    assertThat(inputRef4.getIndex(), is(0));
-    // check '2'
-    final RexLiteral literal2 = (RexLiteral) lt2.getOperands().get(1);
-    assertThat(literal2.getValueAs(Integer.class), is(2));
+    final String actualExp = r.iterator().next().toString();
+    assertEquals("AND(>=(+([CATALOG, SALES, DEPT].#0.$0, [CATALOG, SALES, EMP].#0.$0), 1),"
+        + " <=(+([CATALOG, SALES, DEPT].#0.$0, [CATALOG, SALES, EMP].#0.$0), 2))", actualExp);
   }
 
   @Test void testExpressionLineageInnerJoinLeft() {

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -2491,15 +2491,15 @@ public class RelMetadataTest extends SqlToRelTestBase {
     final RexNode ref = RexInputRef.of(0, rel.getRowType().getFieldList());
     final Set<RexNode> r = Objects.requireNonNull(mq.getExpressionLineage(rel, ref));
 
-    final String assertionMessage = "For query '" + sql + "':\n"
+    final String assertionMessage = "Lineage for expr '"
+        + ref + "' in node '" + rel + "'" + " for query '" + sql + "':\n"
         + "'empno' is column 0 in 'catalog.sales.emp', "
         + "'ename' is column 1 in 'catalog.sales.emp', and "
         + "'deptno' is column 7 in 'catalog.sales.emp'";
 
-    final String actualExp = Iterables.getOnlyElement(r).toString();
-    assertEquals("AND(OR(=([CATALOG, SALES, EMP].#0.$0, 1),"
-        + " =([CATALOG, SALES, EMP].#0.$1, 'abc')),"
-        + " >([CATALOG, SALES, EMP].#0.$7, 1))", actualExp, assertionMessage);
+    assertEquals("[AND(OR(=([CATALOG, SALES, EMP].#0.$0, 1), "
+        + "=([CATALOG, SALES, EMP].#0.$1, 'abc')), "
+        + ">([CATALOG, SALES, EMP].#0.$7, 1))]", r.toString(), assertionMessage);
   }
 
   @Test void testExpressionLineageBetweenExpressionWithJoin() {
@@ -2511,15 +2511,15 @@ public class RelMetadataTest extends SqlToRelTestBase {
     final RexNode ref = RexInputRef.of(0, rel.getRowType().getFieldList());
     final Set<RexNode> r = Objects.requireNonNull(mq.getExpressionLineage(rel, ref));
 
-    final String assertionMessage = "For query '" + sql + "':\n"
+    final String assertionMessage = "Lineage for expr '"
+        + ref + "' in node '" + rel + "'" + " for query '" + sql + "':\n"
         + "'empno' is column 0 in 'catalog.sales.emp', "
         + "'deptno' is column 0 in 'catalog.sales.dept', and "
         + "'dept.deptno + empno between 1 and 2' is translated into "
         + "'dept.deptno + empno >= 1 and dept.deptno + empno <= 2'";
 
-    final String actualExp = Iterables.getOnlyElement(r).toString();
-    assertEquals("AND(>=(+([CATALOG, SALES, DEPT].#0.$0, [CATALOG, SALES, EMP].#0.$0), 1),"
-        + " <=(+([CATALOG, SALES, DEPT].#0.$0, [CATALOG, SALES, EMP].#0.$0), 2))", actualExp,
+    assertEquals("[AND(>=(+([CATALOG, SALES, DEPT].#0.$0, [CATALOG, SALES, EMP].#0.$0), 1),"
+        + " <=(+([CATALOG, SALES, DEPT].#0.$0, [CATALOG, SALES, EMP].#0.$0), 2))]", r.toString(),
         assertionMessage);
   }
 


### PR DESCRIPTION
### Overview
MV rewrite fails when at least one expression in the project of either the view or the query references, directly or indirectly, to more than one field.

### Changes
- Added unit tests covering such "complex" expressions in both views and queries (highlighting the limitation)
- Improved the implementation to handle such cases as well
- Improved the error message for (possibly remaining) unhandled cases where a single expression can have multiple lineages, turned assertions into exceptions.

Regarding the tests, the generated plans look fine, I was wondering if we could add tests with some actual data to double check that the rewriting is working as expected. So far I could not find the right place to add that, I will keep digging, not sure it's strictly needed, it does not seem to be done for any other case, no matter how complex.