### PR TITLE
[CALCITE-4897] Implicit type conversion is not complete for set operation in DML

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
@@ -121,8 +121,13 @@ public class TypeCoercionImpl extends AbstractTypeCoercion {
       // Set operations are binary for now.
       final SqlCall operand0 = ((SqlCall) query).operand(0);
       final SqlCall operand1 = ((SqlCall) query).operand(1);
-      final boolean coerced = rowTypeCoercion(scope, operand0, columnIndex, targetType)
-          && rowTypeCoercion(scope, operand1, columnIndex, targetType);
+      // Operand1 should be coerced even if operand0 not need to be coerced.
+      // For example, we have one table named t:
+      // INSERT INTO t -- only one column is c(int).
+      // SELECT 1 UNION   -- operand0 not need to be coerced.
+      // SELECT 1.0  -- operand1 should be coerced.
+      boolean coerced = rowTypeCoercion(scope, operand0, columnIndex, targetType);
+      coerced = rowTypeCoercion(scope, operand1, columnIndex, targetType) || coerced;
       // Update the nested SET operator node type.
       if (coerced) {
         updateInferredColumnType(

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
@@ -126,6 +126,24 @@ class TypeCoercionConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4897">[CALCITE-4897]
+   * Set operation in DML, implicit type conversion is not complete</a>. */
+  @Test void testInsertUnionQuerySourceCoercion() {
+    final String sql = "insert into t1 "
+        + "select 'a', 1, 1.0,"
+        + " 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union "
+        + "select 'b', 2, 2,"
+        + " 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union "
+        + "select 'c', CAST(3 AS SMALLINT), 3.0,"
+        + " 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union "
+        + "select 'd', 4, 4.0,"
+        + " 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union "
+        + "select 'e', 5, 5.0,"
+        + " 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false";
+    sql(sql).ok();
+  }
+
   @Test void testUpdateQuerySourceCoercion() {
     final String sql = "update t1 set t1_varchar20=123, "
         + "t1_date=TIMESTAMP '2020-01-03 10:14:34', t1_int=12.3";

--- a/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
@@ -117,6 +117,23 @@ LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testInsertUnionQuerySourceCoercion">
+    <Resource name="sql">insert into t1 select 'a', 1, 1.0, 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union select 'b', 2, 2, 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union select 'c', CAST(3 AS SMALLINT), 3.0, 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union select 'd', 4, 4.0, 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false union select 'e', 5, 5.0, 0, 0, 0, 0, TIMESTAMP '2021-11-28 00:00:00', date '2021-11-28', x'0A', false</Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[false])
+  LogicalUnion(all=[false])
+    LogicalUnion(all=[false])
+      LogicalUnion(all=[false])
+        LogicalUnion(all=[false])
+          LogicalValues(tuples=[[{ 'a', 1, 1, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+          LogicalValues(tuples=[[{ 'b', 2, 2, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+        LogicalValues(tuples=[[{ 'c', 3, 3, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+      LogicalValues(tuples=[[{ 'd', 4, 4, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+    LogicalValues(tuples=[[{ 'e', 5, 5, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNotInOperation">
     <Resource name="sql">
       <![CDATA[select


### PR DESCRIPTION
# insert union case

 Here is the sql:
```
insert into t3 
select 'a', 1.0, 1 union 
select 'b', 2, 2 union 
select 'c', 3.0, CAST(3 AS SMALLINT) union 
select 'd', 4.0, 4 union 
select 'e', 5.0, 5 
```
but the validated sql is :
```
INSERT INTO `CATALOG`.`SALES`.`T3`
SELECT 'a', CAST(1.0 AS INTEGER), CAST(1 AS SMALLINT) UNION 
SELECT 'b', 2, CAST(2 AS SMALLINT) UNION -- Encountered an integer and ended early
SELECT 'c', 3.0, CAST(3 AS SMALLINT) UNION -- Encountered an samlint and ended early
SELECT 'd', 4.0, 4 UNION -- should be cast  
SELECT 'e', 5.0, 5 -- should be cast 
```
This is why CALCITE-4458 changed '&&' to '||', the right validated sql is:
```
INSERT INTO `CATALOG`.`SALES`.`T3`
SELECT 'a', CAST(1.0 AS INTEGER), CAST(1 AS SMALLINT)
UNION
SELECT 'b', 2, CAST(2 AS SMALLINT)
UNION
SELECT 'c', CAST(3.0 AS INTEGER), CAST(3 AS SMALLINT)
UNION
SELECT 'd', CAST(4.0 AS INTEGER), CAST(4 AS SMALLINT)
UNION
SELECT 'e', CAST(5.0 AS INTEGER), CAST(5 AS SMALLINT)
 ```

# insert values case
Here is the sql
```
insert into t3 values ('a', 1.0, 1), ('b', 2, 2), ('c', 3.0, CAST(3 AS SMALLINT)), ('d', 4.0, 4), ('e', 5.0, 5)
```
 the validated sql is :
```
INSERT INTO `CATALOG`.`SALES`.`T3`
VALUES ROW('a', CAST(1.0 AS INTEGER), CAST(1 AS SMALLINT)),
ROW('b', 2, CAST(2 AS SMALLINT)),-- Encountered an integer and ended early
ROW('c', 3.0, CAST(3 AS SMALLINT)),Encountered an samllint and ended early
ROW('d', 4.0, 4),
ROW('e', 5.0, 5) 
```
the right validated sql is:
```
INSERT INTO `CATALOG`.`SALES`.`T3`
VALUES ROW('a', CAST(1.0 AS INTEGER), CAST(1 AS SMALLINT)),
ROW('b', 2, CAST(2 AS SMALLINT)),
ROW('c', CAST(3.0 AS INTEGER), CAST(3 AS SMALLINT)),
ROW('d', CAST(4.0 AS INTEGER), CAST(4 AS SMALLINT)),
ROW('e', CAST(5.0 AS INTEGER), CAST(5 AS SMALLINT))
```