### PR TITLE
[CALCITE-4917] Add test for 'IS NOT NULL(a) AND a=b' simplification

### DIFF
--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -1710,6 +1710,18 @@ class RexProgramTest extends RexProgramTestBase {
         .expandedSearch(expanded);
   }
 
+  @Test void testSimplifyAndIsNotNullWithEquality() {
+    // "AND(IS NOT NULL(x), =(x, y)) => AND(IS NOT NULL(x), =(x, y)) (unknownAsFalse=false),
+    // "=(x, y)" (unknownAsFalse=true)
+    checkSimplify2(and(isNotNull(vInt(0)), eq(vInt(0), vInt(1))),
+        "AND(IS NOT NULL(?0.int0), =(?0.int0, ?0.int1))",
+        "=(?0.int0, ?0.int1)");
+
+    // "AND(IS NOT NULL(x), =(x, y)) => "=(x, y)"
+    checkSimplify(and(isNotNull(vIntNotNull(0)), eq(vIntNotNull(0), vInt(1))),
+        "=(?0.notNullInt0, ?0.int1)");
+  }
+
   @Test void testSimplifyAndIsNull() {
     final RexNode aRef = input(tInt(true), 0);
     final RexNode bRef = input(tInt(true), 1);


### PR DESCRIPTION
Simplification (from `RexSimplify` class) is mostly covered in `RexProgramTest`, but tests for expressions of the form `IS NOT NULL(a) AND a=b` (with nullable and not nullable types) seem to be missing.

Since I had to write tests to make sure the simplification was as expected, I assume others might end up doing the same, and that the tests will both act as documentation and it will also protect against regressions.