### PR TITLE
Clarify why squash commits option in GitHub PR merge is disabled

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,7 +22,10 @@ github:
     issues: false
     projects: false
   enabled_merge_buttons:
+    # "squash and merge" replaces committer with noreply@github, and we don't want that
+    # See https://lists.apache.org/thread/vxxpt1x316kjryb4dptsbs95p66d9xrv
     squash:  false
+    # We prefer linear history, so creating merge commits is disabled in UI
     merge:   false
     rebase:  true
 notifications:


### PR DESCRIPTION
See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits

Unfortunately, the button loses `committer` info as follows (it uses GitHub noreply for committer):

```
commit a8e50734e0460e506f1762fbe0f628bcb444b8f5
Author: Denys Kuzmenko <dk...@cloudera.com>
AuthorDate: Tue Nov 30 10:09:06 2021 +0200
Commit: GitHub <no...@github.com>
CommitDate: Tue Nov 30 09:09:06 2021 +0100
```