### PR TITLE
[CALCITE-4925] Allow selective application of the reduce-functions rule with arbitrary specificity

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
@@ -126,7 +126,7 @@ public class AggregateReduceFunctionsRule
     super(config);
     this.functionsToReduce =
         ImmutableSet.copyOf(config.actualFunctionsToReduce());
-    this.extraCondition = config.actualExtraCondition();
+    this.extraCondition = config.extraCondition();
   }
 
   @Deprecated // to be removed before 2.0
@@ -854,17 +854,20 @@ public class AggregateReduceFunctionsRule
 
     /** The set of aggregate function types to try to reduce.
      *
-     * Any agg function whose type is omitted from this set, OR which does not pass the
+     * <p>Any agg function whose type is omitted from this set, OR which does not pass the
      * {@link #extraCondition}, will be ignored.
      */
     @Nullable Set<SqlKind> functionsToReduce();
 
     /** A test that must pass before attempting to reduce any aggregate function.
      *
-     * Any agg function which does not pass, OR whose type is omitted from
+     * <p>Any agg function which does not pass, OR whose type is omitted from
      * {@link #functionsToReduce}, will be ignored. The default predicate always passes.
      */
-    @Nullable Predicate<AggregateCall> extraCondition();
+    @Value.Default
+    default Predicate<AggregateCall> extraCondition() {
+      return ignored -> true;
+    }
 
     /** Sets {@link #functionsToReduce}. */
     Config withFunctionsToReduce(@Nullable Iterable<SqlKind> functionSet);
@@ -883,10 +886,6 @@ public class AggregateReduceFunctionsRule
           Util.first(functionsToReduce(), DEFAULT_FUNCTIONS_TO_REDUCE);
       set.forEach(AggregateReduceFunctionsRule::validateFunction);
       return set;
-    }
-
-    default Predicate<AggregateCall> actualExtraCondition() {
-      return Util.first(extraCondition(), ignored -> true);
     }
 
     /** Defines an operand tree for the given classes. */

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -6321,6 +6321,16 @@ class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(rule).check();
   }
 
+  @Test void testReduceWithNonTypePredicate() {
+    // Make sure we can reduce with more specificity than just agg function type.
+    final RelOptRule rule = AggregateReduceFunctionsRule.Config.DEFAULT
+        .withExtraCondition(call -> call.distinctKeys != null)
+        .toRule();
+    final String sql = "select avg(sal), avg(sal) within distinct (deptno)\n"
+        + "from emp";
+    sql(sql).withRule(rule).check();
+  }
+
   /** Test case for
   * <a href="https://issues.apache.org/jira/browse/CALCITE-2803">[CALCITE-2803]
   * Identify expanded IS NOT DISTINCT FROM expression when pushing project past join</a>.

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -9767,6 +9767,28 @@ LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReduceWithNonTypePredicate">
+    <Resource name="sql">
+      <![CDATA[select avg(sal), avg(sal) within distinct (deptno)
+from emp]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($0) WITHIN DISTINCT ($1)])
+  LogicalProject(SAL=[$5], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[$0], EXPR$1=[CAST(/($1, $2)):INTEGER])
+  LogicalProject(EXPR$0=[$0], $f1=[CASE(=($2, 0), null:INTEGER, $1)], $f2=[$2])
+    LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], agg#1=[$SUM0($0) WITHIN DISTINCT ($1)], agg#2=[COUNT() WITHIN DISTINCT ($1)])
+      LogicalProject(SAL=[$5], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testReduceAverage">
     <Resource name="sql">
       <![CDATA[select name, max(name), avg(deptno), min(name)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -9767,28 +9767,6 @@ LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testReduceWithNonTypePredicate">
-    <Resource name="sql">
-      <![CDATA[select avg(sal), avg(sal) within distinct (deptno)
-from emp]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($0) WITHIN DISTINCT ($1)])
-  LogicalProject(SAL=[$5], DEPTNO=[$7])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(EXPR$0=[$0], EXPR$1=[CAST(/($1, $2)):INTEGER])
-  LogicalProject(EXPR$0=[$0], $f1=[CASE(=($2, 0), null:INTEGER, $1)], $f2=[$2])
-    LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], agg#1=[$SUM0($0) WITHIN DISTINCT ($1)], agg#2=[COUNT() WITHIN DISTINCT ($1)])
-      LogicalProject(SAL=[$5], DEPTNO=[$7])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testReduceAverage">
     <Resource name="sql">
       <![CDATA[select name, max(name), avg(deptno), min(name)
@@ -10896,6 +10874,28 @@ LogicalProject(X=[+($0, $1)], B=[$1], A=[$0])
     <Resource name="planAfter">
       <![CDATA[
 LogicalValues(tuples=[[{ 11, 1, 10 }, { 23, 3, 20 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReduceWithNonTypePredicate">
+    <Resource name="sql">
+      <![CDATA[select avg(sal), avg(sal) within distinct (deptno)
+from emp]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($0) WITHIN DISTINCT ($1)])
+  LogicalProject(SAL=[$5], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[$0], EXPR$1=[CAST(/($1, $2)):INTEGER])
+  LogicalProject(EXPR$0=[$0], $f1=[CASE(=($2, 0), null:INTEGER, $1)], $f2=[$2])
+    LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], agg#1=[$SUM0($0) WITHIN DISTINCT ($1)], agg#2=[COUNT() WITHIN DISTINCT ($1)])
+      LogicalProject(SAL=[$5], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
See [CALCITE-4925](https://issues.apache.org/jira/browse/CALCITE-4925).

Add the ability to selectively apply the reduce-functions rule with arbitrary specificity. This ability was added on top of the existing ability to select by function type. It would also be possible to implement the selection by function type as a convenience method that simply wraps the more general predicate setter, meaning there would only ever be 1 predicate, but it seemed like a potential anti-pattern to let 2 methods in the config interfere with each other destructively like that. No strong opinions either way.