### PR TITLE
reformat debug log about the plan which after physical tweaks

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -177,7 +177,7 @@ public abstract class Prepare {
     final RelNode rootRel4 = program.run(
         planner, root.rel, desiredTraits, materializationList, latticeList);
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Plan after physical tweaks: {}",
+      LOGGER.debug("Plan after physical tweaks:\n{}",
           RelOptUtil.toString(rootRel4, SqlExplainLevel.ALL_ATTRIBUTES));
     }
 


### PR DESCRIPTION
Before the PR, The Log:
```
Plan after physical tweaks: EnumerableValues(tuples=[[{ 1, 'a' }, { 2, 'b' }]]): rowcount = 2.0, cumulative cost = {2.0 rows, 1.0 cpu, 0.0 io}, id = 30
```

After the PR, The Log:
```
Plan after physical tweaks:
EnumerableValues(tuples=[[{ 1, 'a' }, { 2, 'b' }]]): rowcount = 2.0, cumulative cost = {2.0 rows, 1.0 cpu, 0.0 io}, id = 30
```