### PR TITLE
Improve debug message in IterativeRuleDriver

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/IterativeRuleDriver.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/IterativeRuleDriver.java
@@ -21,8 +21,6 @@ import org.apache.calcite.util.trace.CalciteTrace;
 
 import org.slf4j.Logger;
 
-import static java.util.Objects.requireNonNull;
-
 /***
  * <p>The algorithm executes repeatedly. The exact rules
  * that may be fired varies.
@@ -48,8 +46,8 @@ class IterativeRuleDriver implements RuleDriver {
 
   @Override public void drive() {
     while (true) {
-      LOGGER.debug("PLANNER = {}; COST = {}", this,
-          requireNonNull(planner.root, "planner.root").bestCost);
+      assert planner.root != null : "RelSubset must not be null at this point";
+      LOGGER.debug("Best cost before rule match: {}", planner.root.bestCost);
 
       VolcanoRuleMatch match = ruleQueue.popMatch();
       if (match == null) {


### PR DESCRIPTION
Remove PLANNER logging from the message and better formulate at which point during the rule matching the cost is printed.

The original message is misleading cause it is not the planner that is printed but the queue. Moreover, `IterativeRuleDriver#toString` just prints the class name and hashcode of the instance which is useless. 
Class name might be useful but can be obtained by changing the logger configuration (pattern layout).

### Before
```
PLANNER = org.apache.calcite.plan.volcano.IterativeRuleDriver@3f3065ea; COST = {inf}
...
PLANNER = org.apache.calcite.plan.volcano.IterativeRuleDriver@3f3065ea; COST = {11.0 rows, 42.0 cpu, 0.0 io}
```

### After
```
Best cost before rule match: {inf}
...
Best cost before rule match: {11.0 rows, 42.0 cpu, 0.0 io}
```

