### PR TITLE
[CALCITE-4936] Generalize FilterCalcMergeRule and ProjectCalcMergeRule

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcMergeRule.java
@@ -28,13 +28,13 @@ import org.immutables.value.Value;
 
 /**
  * Planner rule that merges a
- * {@link org.apache.calcite.rel.logical.LogicalCalc} onto a
- * {@link org.apache.calcite.rel.logical.LogicalCalc}.
+ * {@link org.apache.calcite.rel.core.Calc} onto a
+ * {@link org.apache.calcite.rel.core.Calc}.
  *
- * <p>The resulting {@link org.apache.calcite.rel.logical.LogicalCalc} has the
+ * <p>The resulting {@link org.apache.calcite.rel.core.Calc} has the
  * same project list as the upper
- * {@link org.apache.calcite.rel.logical.LogicalCalc}, but expressed in terms of
- * the lower {@link org.apache.calcite.rel.logical.LogicalCalc}'s inputs.
+ * {@link org.apache.calcite.rel.core.Calc}, but expressed in terms of
+ * the lower {@link org.apache.calcite.rel.core.Calc}'s inputs.
  *
  * @see CoreRules#CALC_MERGE
  */

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterCalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterCalcMergeRule.java
@@ -21,7 +21,6 @@ import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.logical.LogicalCalc;
-import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
@@ -31,9 +30,9 @@ import org.immutables.value.Value;
 
 /**
  * Planner rule that merges a
- * {@link org.apache.calcite.rel.logical.LogicalFilter} and a
- * {@link org.apache.calcite.rel.logical.LogicalCalc}. The
- * result is a {@link org.apache.calcite.rel.logical.LogicalCalc}
+ * {@link org.apache.calcite.rel.core.Filter} and a
+ * {@link org.apache.calcite.rel.core.Calc}. The
+ * result is a {@link org.apache.calcite.rel.core.Calc}
  * whose filter condition is the logical AND of the two.
  *
  * @see FilterMergeRule
@@ -60,8 +59,8 @@ public class FilterCalcMergeRule
   //~ Methods ----------------------------------------------------------------
 
   @Override public void onMatch(RelOptRuleCall call) {
-    final LogicalFilter filter = call.rel(0);
-    final LogicalCalc calc = call.rel(1);
+    final Filter filter = call.rel(0);
+    final Calc calc = call.rel(1);
 
     // Don't merge a filter onto a calc which contains windowed aggregates.
     // That would effectively be pushing a multiset down through a filter.
@@ -87,8 +86,8 @@ public class FilterCalcMergeRule
             topProgram,
             bottomProgram,
             rexBuilder);
-    final LogicalCalc newCalc =
-        LogicalCalc.create(calc.getInput(), mergedProgram);
+    final Calc newCalc =
+        calc.copy(calc.getTraitSet(), calc.getInput(), mergedProgram);
     call.transformTo(newCalc);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectCalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectCalcMergeRule.java
@@ -70,9 +70,7 @@ public class ProjectCalcMergeRule
 
     // Don't merge a project which contains windowed aggregates onto a
     // calc. That would effectively be pushing a windowed aggregate down
-    // through a filter. Transform the project into an identical calc,
-    // which we'll have chance to merge later, after the over is
-    // expanded.
+    // through a filter.
     final RelOptCluster cluster = project.getCluster();
     RexProgram program =
         RexProgram.create(

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectCalcMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectCalcMergeRule.java
@@ -35,13 +35,13 @@ import org.immutables.value.Value;
 
 /**
  * Planner rule that merges a
- * {@link org.apache.calcite.rel.logical.LogicalProject} and a
- * {@link org.apache.calcite.rel.logical.LogicalCalc}.
+ * {@link org.apache.calcite.rel.core.Project} and a
+ * {@link org.apache.calcite.rel.core.Calc}.
  *
- * <p>The resulting {@link org.apache.calcite.rel.logical.LogicalCalc} has the
+ * <p>The resulting {@link org.apache.calcite.rel.core.Calc} has the
  * same project list as the original
- * {@link org.apache.calcite.rel.logical.LogicalProject}, but expressed in terms
- * of the original {@link org.apache.calcite.rel.logical.LogicalCalc}'s inputs.
+ * {@link org.apache.calcite.rel.core.Project}, but expressed in terms
+ * of the original {@link org.apache.calcite.rel.core.Calc}'s inputs.
  *
  * @see FilterCalcMergeRule
  * @see CoreRules#PROJECT_CALC_MERGE
@@ -82,8 +82,6 @@ public class ProjectCalcMergeRule
             project.getRowType(),
             cluster.getRexBuilder());
     if (RexOver.containsOver(program)) {
-      LogicalCalc projectAsCalc = LogicalCalc.create(calc, program);
-      call.transformTo(projectAsCalc);
       return;
     }
 
@@ -105,8 +103,8 @@ public class ProjectCalcMergeRule
             topProgram,
             bottomProgram,
             rexBuilder);
-    final LogicalCalc newCalc =
-        LogicalCalc.create(calc.getInput(), mergedProgram);
+    final Calc newCalc =
+        calc.copy(calc.getTraitSet(), calc.getInput(), mergedProgram);
     call.transformTo(newCalc);
   }
 


### PR DESCRIPTION
[CALCITE-4936] Generalize FilterCalcMergeRule and ProjectCalcMergeRule. Like CalcMergeRule, use only Project, Filter and Calc interfaces, which will expand the range of their applying.