### PR TITLE
[CALCITE-4949] Evaluate if using org.codelibs is appropriate for an Elasticsearch painless dependency

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -118,7 +118,6 @@ dependencies {
         apiv("org.codehaus.janino:commons-compiler", "janino")
         apiv("org.codehaus.janino:janino")
         apiv("org.codelibs.elasticsearch.module:lang-painless", "elasticsearch")
-        apiv("org.codelibs.elasticsearch.module:scripting-painless-spi", "elasticsearch")
         apiv("org.eclipse.jetty:jetty-http", "jetty")
         apiv("org.eclipse.jetty:jetty-security", "jetty")
         apiv("org.eclipse.jetty:jetty-server", "jetty")

--- a/elasticsearch/build.gradle.kts
+++ b/elasticsearch/build.gradle.kts
@@ -37,7 +37,11 @@ dependencies {
 
     testImplementation("org.apache.logging.log4j:log4j-api")
     testImplementation("org.apache.logging.log4j:log4j-core")
-    testImplementation("org.codelibs.elasticsearch.module:lang-painless")
+    // See https://github.com/elastic/elasticsearch/issues/18131.
+    testImplementation("org.codelibs.elasticsearch.module:lang-painless") {
+        because("Elasticsearch doesn't export painless script artifact to maven central, " +
+                "so using 3rd party version (codelibs) only for test.")
+    }
     testImplementation("org.elasticsearch.plugin:transport-netty4-client")
     testImplementation("org.elasticsearch:elasticsearch")
     testImplementation(project(":testkit"))


### PR DESCRIPTION
This PR adds some old comments and removes "scripting-painless-spi" dependency, which is included in "lang-painless".