### PR TITLE
Set timeout for running Druid tests in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -287,6 +287,7 @@ jobs:
         path: calcite
     - uses: burrunan/gradle-cache-action@v1
       name: 'Run Druid tests'
+      timeout-minutes: 10
       env:
         S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}


### PR DESCRIPTION
When tests run successfully they don't take more than a few minutes.
Sometimes though they get stuck and run forever (till the max GitHub
timeout of 6h) so set a timeout to 10minutes to avoid wasting resources
and fail-fast.