### PR TITLE
[CALCITE-4942] Remove metadata boilerplate

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/hep/HepRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepRelMetadataProvider.java
@@ -18,7 +18,6 @@ package org.apache.calcite.plan.hep;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.Metadata;
-import org.apache.calcite.rel.metadata.MetadataDef;
 import org.apache.calcite.rel.metadata.MetadataHandler;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.UnboundMetadata;
@@ -71,13 +70,13 @@ class HepRelMetadataProvider implements RelMetadataProvider {
   }
 
   @Deprecated // to be removed before 2.0
-  @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
-      MetadataDef<M> def) {
+  @Override public <M extends Metadata> Multimap<Method, MetadataHandler> handlers(
+      org.apache.calcite.rel.metadata.MetadataDef<M> def) {
     return ImmutableMultimap.of();
   }
 
-  @Override public List<MetadataHandler<?>> handlers(
-      Class<? extends MetadataHandler<?>> handlerClass) {
+  @Override public List<MetadataHandler> handlers(
+      Class<? extends MetadataHandler> handlerClass) {
     return ImmutableList.of();
   }
 }

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoRelMetadataProvider.java
@@ -18,7 +18,6 @@ package org.apache.calcite.plan.volcano;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.Metadata;
-import org.apache.calcite.rel.metadata.MetadataDef;
 import org.apache.calcite.rel.metadata.MetadataHandler;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.UnboundMetadata;
@@ -121,14 +120,14 @@ public class VolcanoRelMetadataProvider implements RelMetadataProvider {
     };
   }
 
-  @Deprecated
-  @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
-      MetadataDef<M> def) {
+  @Deprecated // to be removed before 2.0
+  @Override public <M extends Metadata> Multimap<Method, MetadataHandler> handlers(
+      org.apache.calcite.rel.metadata.MetadataDef<M> def) {
     return ImmutableMultimap.of();
   }
 
-  @Override public List<MetadataHandler<?>> handlers(
-      Class<? extends MetadataHandler<?>> handlerClass) {
+  @Override public List<MetadataHandler> handlers(
+      Class<? extends MetadataHandler> handlerClass) {
     return ImmutableList.of();
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
@@ -44,6 +44,7 @@ import java.util.Set;
 public abstract class BuiltInMetadata {
 
   /** Metadata about the selectivity of a predicate. */
+  @Deprecated // to be removed before 2.0
   public interface Selectivity extends Metadata {
     MetadataDef<Selectivity> DEF = MetadataDef.of(Selectivity.class,
         Selectivity.Handler.class, BuiltInMethod.SELECTIVITY.method);
@@ -57,21 +58,52 @@ public abstract class BuiltInMetadata {
      *                  rel's output
      * @return estimated selectivity (between 0.0 and 1.0), or null if no
      * reliable estimate can be determined
+     *
+     * @deprecated use {@link SelectivityHandler#getSelectivity(RelNode, RelMetadataQuery, RexNode)}
      */
+    @Deprecated // to be removed before 2.0
     @Nullable Double getSelectivity(@Nullable RexNode predicate);
 
-    /** Handler API. */
+    /**
+     * Handler API.
+     *
+     * @deprecated use {@link SelectivityHandler}
+     */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<Selectivity> {
-      @Nullable Double getSelectivity(RelNode r, RelMetadataQuery mq, @Nullable RexNode predicate);
-
+    @Deprecated // to be removed before 2.0
+    interface Handler extends SelectivityHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<Selectivity> getDef() {
         return DEF;
       }
     }
   }
 
-  /** Metadata about which combinations of columns are unique identifiers. */
+  /** MetadataHandler about the selectivity of a predicate. */
+  @FunctionalInterface
+  public interface SelectivityHandler extends MetadataHandler {
+    /**
+     * Estimates the percentage of an expression's output rows which satisfy a
+     * given predicate. Returns null to indicate that no reliable estimate can
+     * be produced.
+     *
+     * @param r to find selectivity for
+     * @param mq context
+     * @param predicate predicate whose selectivity is to be estimated against
+     *                  rel's output
+     * @return estimated selectivity (between 0.0 and 1.0), or null if no
+     * reliable estimate can be determined
+     */
+    @Nullable Double getSelectivity(RelNode r, RelMetadataQuery mq, @Nullable RexNode predicate);
+  }
+
+
+  /**
+   * Metadata about which combinations of columns are unique identifiers.
+   *
+   * @deprecated use {@link UniqueKeysHandler}
+   */
+  @Deprecated // to be removed before 2.0
   public interface UniqueKeys extends Metadata {
     MetadataDef<UniqueKeys> DEF = MetadataDef.of(UniqueKeys.class,
         UniqueKeys.Handler.class, BuiltInMethod.UNIQUE_KEYS.method);
@@ -93,17 +125,42 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<UniqueKeys> {
-      @Nullable Set<ImmutableBitSet> getUniqueKeys(RelNode r, RelMetadataQuery mq,
-          boolean ignoreNulls);
-
+    interface Handler extends UniqueKeysHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<UniqueKeys> getDef() {
         return DEF;
       }
     }
   }
 
-  /** Metadata about whether a set of columns uniquely identifies a row. */
+  /** MetadataHandler about which combinations of columns are unique identifiers. */
+  @FunctionalInterface
+  public interface UniqueKeysHandler extends MetadataHandler {
+    /**
+     * Determines the set of unique minimal keys for this expression. A key is
+     * represented as an {@link org.apache.calcite.util.ImmutableBitSet}, where
+     * each bit position represents a 0-based output column ordinal.
+     *
+     * <p>Nulls can be ignored if the relational expression has filtered out
+     * null values.
+     *
+     * @param r to find metadata about
+     * @param mq context
+     * @param ignoreNulls if true, ignore null values when determining
+     *                    whether the keys are unique
+     * @return set of keys, or null if this information cannot be determined
+     * (whereas empty set indicates definitely no keys at all)
+     */
+    @Nullable Set<ImmutableBitSet> getUniqueKeys(RelNode r, RelMetadataQuery mq,
+        boolean ignoreNulls);
+  }
+
+  /**
+   * Metadata about whether a set of columns uniquely identifies a row.
+   *
+   * @deprecated use {@link ColumnUniquenessHandler}
+   */
+  @Deprecated // to be removed before 2.0
   public interface ColumnUniqueness extends Metadata {
     MetadataDef<ColumnUniqueness> DEF = MetadataDef.of(ColumnUniqueness.class,
         ColumnUniqueness.Handler.class, BuiltInMethod.COLUMN_UNIQUENESS.method);
@@ -134,17 +191,51 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<ColumnUniqueness> {
-      Boolean areColumnsUnique(RelNode r, RelMetadataQuery mq,
-          ImmutableBitSet columns, boolean ignoreNulls);
-
+    interface Handler extends ColumnUniquenessHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<ColumnUniqueness> getDef() {
         return DEF;
       }
     }
   }
 
-  /** Metadata about which columns are sorted. */
+  /** MetadataHandler about whether a set of columns uniquely identifies a row. */
+  @FunctionalInterface
+  public interface ColumnUniquenessHandler extends MetadataHandler {
+    /**
+     * Determines whether a specified set of columns from a specified relational
+     * expression are unique.
+     *
+     * <p>For example, if the relational expression is a {@code TableScan} to
+     * T(A, B, C, D) whose key is (A, B), then:
+     * <ul>
+     * <li>{@code areColumnsUnique([0, 1])} yields true,
+     * <li>{@code areColumnsUnique([0])} yields false,
+     * <li>{@code areColumnsUnique([0, 2])} yields false.
+     * </ul>
+     *
+     * <p>Nulls can be ignored if the relational expression has filtered out
+     * null values.
+     *
+     * @param r to find metadata about
+     * @param mq context
+     * @param columns column mask representing the subset of columns for which
+     *                uniqueness will be determined
+     * @param ignoreNulls if true, ignore null values when determining column
+     *                    uniqueness
+     * @return whether the columns are unique, or
+     * null if not enough information is available to make that determination
+     */
+    Boolean areColumnsUnique(RelNode r, RelMetadataQuery mq,
+        ImmutableBitSet columns, boolean ignoreNulls);
+  }
+
+  /**
+   * Metadata about which columns are sorted.
+   *
+   * @deprecated use {@link CollationHandler}
+   */
+  @Deprecated // to be removed before 2.0
   public interface Collation extends Metadata {
     MetadataDef<Collation> DEF = MetadataDef.of(Collation.class,
         Collation.Handler.class, BuiltInMethod.COLLATIONS.method);
@@ -154,13 +245,20 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<Collation> {
+    interface Handler extends CollationHandler {
       ImmutableList<RelCollation> collations(RelNode r, RelMetadataQuery mq);
-
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<Collation> getDef() {
         return DEF;
       }
     }
+  }
+
+  /** MetadataHandler about which columns are sorted. */
+  @FunctionalInterface
+  public interface CollationHandler extends MetadataHandler {
+    /** Determines which columns are sorted. */
+    ImmutableList<RelCollation> collations(RelNode r, RelMetadataQuery mq);
   }
 
   /** Metadata about how a relational expression is distributed.
@@ -174,6 +272,7 @@ public abstract class BuiltInMetadata {
    * <p>When a relational expression is partitioned, it is often partitioned
    * among nodes, but it may be partitioned among threads running on the same
    * node. */
+  @Deprecated // to be removed before 2.0
   public interface Distribution extends Metadata {
     MetadataDef<Distribution> DEF = MetadataDef.of(Distribution.class,
         Distribution.Handler.class, BuiltInMethod.DISTRIBUTION.method);
@@ -183,13 +282,29 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<Distribution> {
-      RelDistribution distribution(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends DistributionHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<Distribution> getDef() {
         return DEF;
       }
     }
+  }
+
+  /** MetadataHandler about how a relational expression is distributed.
+   *
+   * <p>If you are an operator consuming a relational expression, which subset
+   * of the rows are you seeing? You might be seeing all of them (BROADCAST
+   * or SINGLETON), only those whose key column values have a particular hash
+   * code (HASH) or only those whose column values have particular values or
+   * ranges of values (RANGE).
+   *
+   * <p>When a relational expression is partitioned, it is often partitioned
+   * among nodes, but it may be partitioned among threads running on the same
+   * node. */
+  @FunctionalInterface
+  public interface DistributionHandler extends MetadataHandler {
+    /** Determines how the rows are distributed. */
+    RelDistribution distribution(RelNode r, RelMetadataQuery mq);
   }
 
   /**
@@ -199,6 +314,7 @@ public abstract class BuiltInMetadata {
    * to the nodes instantiating that class. Each node will appear in the
    * multimap only once.
    */
+  @Deprecated // to be removed before 2.0
   public interface NodeTypes extends Metadata {
     MetadataDef<NodeTypes> DEF = MetadataDef.of(NodeTypes.class,
         NodeTypes.Handler.class, BuiltInMethod.NODE_TYPES.method);
@@ -212,17 +328,34 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<NodeTypes> {
-      @Nullable Multimap<Class<? extends RelNode>, RelNode> getNodeTypes(RelNode r,
-          RelMetadataQuery mq);
-
+    interface Handler extends NodeTypesHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<NodeTypes> getDef() {
         return DEF;
       }
     }
   }
 
+  /**
+   * MetadataHandler about the node types in a relational expression.
+   *
+   * <p>For each relational expression, it returns a multimap from the class
+   * to the nodes instantiating that class. Each node will appear in the
+   * multimap only once.
+   */
+  @FunctionalInterface
+  public interface NodeTypesHandler extends MetadataHandler {
+    /**
+     * Returns a multimap from the class to the nodes instantiating that
+     * class. The default implementation for a node classifies it as a
+     * {@link RelNode}.
+     */
+    @Nullable Multimap<Class<? extends RelNode>, RelNode> getNodeTypes(RelNode r,
+        RelMetadataQuery mq);
+  }
+
   /** Metadata about the number of rows returned by a relational expression. */
+  @Deprecated // to be removed before 2.0
   public interface RowCount extends Metadata {
     MetadataDef<RowCount> DEF = MetadataDef.of(RowCount.class,
         RowCount.Handler.class, BuiltInMethod.ROW_COUNT.method);
@@ -240,17 +373,34 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<RowCount> {
-      @Nullable Double getRowCount(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends RowCountHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<RowCount> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the number of rows returned by a relational expression. */
+  @FunctionalInterface
+  public interface RowCountHandler extends MetadataHandler {
+
+    /**
+     * Estimates the number of rows which will be returned by a relational
+     * expression. The default implementation for this query asks the rel itself
+     * via {@link RelNode#estimateRowCount}, but metadata providers can override this
+     * with their own cost models.
+     *
+     * @return estimated row count, or null if no reliable estimate can be
+     * determined
+     */
+    @Nullable Double getRowCount(RelNode r, RelMetadataQuery mq);
+
+  }
+
   /** Metadata about the maximum number of rows returned by a relational
    * expression. */
+  @Deprecated // to be removed before 2.0
   public interface MaxRowCount extends Metadata {
     MetadataDef<MaxRowCount> DEF = MetadataDef.of(MaxRowCount.class,
         MaxRowCount.Handler.class, BuiltInMethod.MAX_ROW_COUNT.method);
@@ -269,17 +419,34 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<MaxRowCount> {
-      @Nullable Double getMaxRowCount(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends MaxRowCountHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<MaxRowCount> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the maximum number of rows returned by a
+   * relational expression. */
+  @FunctionalInterface
+  public interface MaxRowCountHandler extends MetadataHandler {
+    /**
+     * Estimates the max number of rows which will be returned by a relational
+     * expression.
+     *
+     * <p>The default implementation for this query returns
+     * {@link Double#POSITIVE_INFINITY},
+     * but metadata providers can override this with their own cost models.
+     *
+     * @return upper bound on the number of rows returned
+     */
+    @Nullable Double getMaxRowCount(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata about the minimum number of rows returned by a relational
    * expression. */
+  @Deprecated // to be removed before 2.0
   public interface MinRowCount extends Metadata {
     MetadataDef<MinRowCount> DEF = MetadataDef.of(MinRowCount.class,
         MinRowCount.Handler.class, BuiltInMethod.MIN_ROW_COUNT.method);
@@ -297,17 +464,33 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<MinRowCount> {
-      @Nullable Double getMinRowCount(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends MinRowCountHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<MinRowCount> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the minimum number of rows returned by a relational
+   * expression. */
+  @FunctionalInterface
+  public interface MinRowCountHandler extends MetadataHandler {
+    /**
+     * Estimates the minimum number of rows which will be returned by a
+     * relational expression.
+     *
+     * <p>The default implementation for this query returns 0,
+     * but metadata providers can override this with their own cost models.
+     *
+     * @return lower bound on the number of rows returned
+     */
+    @Nullable Double getMinRowCount(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata about the number of distinct rows returned by a set of columns
    * in a relational expression. */
+  @Deprecated // to be removed before 2.0
   public interface DistinctRowCount extends Metadata {
     MetadataDef<DistinctRowCount> DEF = MetadataDef.of(DistinctRowCount.class,
         DistinctRowCount.Handler.class, BuiltInMethod.DISTINCT_ROW_COUNT.method);
@@ -328,18 +511,39 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<DistinctRowCount> {
-      @Nullable Double getDistinctRowCount(RelNode r, RelMetadataQuery mq,
-          ImmutableBitSet groupKey, @Nullable RexNode predicate);
-
+    interface Handler extends DistinctRowCountHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<DistinctRowCount> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the number of distinct rows returned by a set of
+   * columns in a relational expression. */
+  @FunctionalInterface
+  public interface DistinctRowCountHandler extends MetadataHandler {
+    /**
+     * Estimates the number of rows which would be produced by a GROUP BY on the
+     * set of columns indicated by groupKey, where the input to the GROUP BY has
+     * been pre-filtered by predicate. This quantity (leaving out predicate) is
+     * often referred to as cardinality (as in gender being a "low-cardinality
+     * column").
+     *
+     * @param r to find metadata about
+     * @param mq context
+     * @param groupKey  column mask representing group by columns
+     * @param predicate pre-filtered predicates
+     * @return distinct row count for groupKey, filtered by predicate, or null
+     * if no reliable estimate can be determined
+     */
+    @Nullable Double getDistinctRowCount(RelNode r, RelMetadataQuery mq,
+        ImmutableBitSet groupKey, @Nullable RexNode predicate);
+  }
+
   /** Metadata about the proportion of original rows that remain in a relational
    * expression. */
+  @Deprecated // to be removed before 2.0
   public interface PercentageOriginalRows extends Metadata {
     MetadataDef<PercentageOriginalRows> DEF =
         MetadataDef.of(PercentageOriginalRows.class,
@@ -358,17 +562,33 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<PercentageOriginalRows> {
-      @Nullable Double getPercentageOriginalRows(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends PercentageOriginalRowsHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<PercentageOriginalRows> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the proportion of original rows that remain in a
+   * relational expression. */
+  @FunctionalInterface
+  public interface PercentageOriginalRowsHandler extends MetadataHandler {
+
+    /**
+     * Estimates the percentage of the number of rows actually produced by a
+     * relational expression out of the number of rows it would produce if all
+     * single-table filter conditions were removed.
+     *
+     * @return estimated percentage (between 0.0 and 1.0), or null if no
+     * reliable estimate can be determined
+     */
+    @Nullable Double getPercentageOriginalRows(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata about the number of distinct values in the original source of a
    * column or set of columns. */
+  @Deprecated // to be removed before 2.0
   public interface PopulationSize extends Metadata {
     MetadataDef<PopulationSize> DEF = MetadataDef.of(PopulationSize.class,
         PopulationSize.Handler.class, BuiltInMethod.POPULATION_SIZE.method);
@@ -388,17 +608,37 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<PopulationSize> {
-      @Nullable Double getPopulationSize(RelNode r, RelMetadataQuery mq,
-          ImmutableBitSet groupKey);
-
+    interface Handler extends PopulationSizeHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<PopulationSize> getDef() {
         return DEF;
       }
     }
   }
 
+  /** Metadata about the number of distinct values in the original source of a
+   * column or set of columns. */
+  @FunctionalInterface
+  public interface PopulationSizeHandler extends MetadataHandler {
+    /**
+     * Estimates the distinct row count in the original source for the given
+     * {@code groupKey}, ignoring any filtering being applied by the expression.
+     * Typically, "original source" means base table, but for derived columns,
+     * the estimate may come from a non-leaf rel such as a LogicalProject.
+     *
+     * @param r to find metadata about
+     * @param mq context
+     * @param groupKey column mask representing the subset of columns for which
+     *                 the row count will be determined
+     * @return distinct row count for the given groupKey, or null if no reliable
+     * estimate can be determined
+     */
+    @Nullable Double getPopulationSize(RelNode r, RelMetadataQuery mq,
+        ImmutableBitSet groupKey);
+  }
+
   /** Metadata about the size of rows and columns. */
+  @Deprecated // to be removed before 2.0
   public interface Size extends Metadata {
     MetadataDef<Size> DEF = MetadataDef.of(Size.class, Size.Handler.class,
         BuiltInMethod.AVERAGE_ROW_SIZE.method,
@@ -430,17 +670,46 @@ public abstract class BuiltInMetadata {
     List<@Nullable Double> averageColumnSizes();
 
     /** Handler API. */
-    interface Handler extends MetadataHandler<Size> {
-      @Nullable Double averageRowSize(RelNode r, RelMetadataQuery mq);
-      @Nullable List<@Nullable Double> averageColumnSizes(RelNode r, RelMetadataQuery mq);
-
+    @Deprecated // to be removed before 2.0
+    interface Handler extends SizeHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<Size> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the size of rows and columns. */
+  public interface SizeHandler extends MetadataHandler {
+
+    /**
+     * Determines the average size (in bytes) of a row from this relational
+     * expression.
+     *
+     * @return average size of a row, in bytes, or null if not known
+     */
+    @Nullable Double averageRowSize(RelNode r, RelMetadataQuery mq);
+
+    /**
+     * Determines the average size (in bytes) of a value of a column in this
+     * relational expression.
+     *
+     * <p>Null values are included (presumably they occupy close to 0 bytes).
+     *
+     * <p>It is left to the caller to decide whether the size is the compressed
+     * size, the uncompressed size, or memory allocation when the value is
+     * wrapped in an object in the Java heap. The uncompressed size is probably
+     * a good compromise.
+     *
+     * @return an immutable list containing, for each column, the average size
+     * of a column value, in bytes. Each value or the entire list may be null if
+     * the metadata is not available
+     */
+    @Nullable List<@Nullable Double> averageColumnSizes(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata about the origins of columns. */
+  @Deprecated // to be removed before 2.0
   public interface ColumnOrigin extends Metadata {
     MetadataDef<ColumnOrigin> DEF = MetadataDef.of(ColumnOrigin.class,
         ColumnOrigin.Handler.class, BuiltInMethod.COLUMN_ORIGIN.method);
@@ -461,17 +730,36 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<ColumnOrigin> {
-      @Nullable Set<RelColumnOrigin> getColumnOrigins(RelNode r, RelMetadataQuery mq,
-          int outputColumn);
-
+    interface Handler extends ColumnOriginHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<ColumnOrigin> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the origins of columns. */
+  public interface ColumnOriginHandler extends MetadataHandler {
+    /**
+     * For a given output column of an expression, determines all columns of
+     * underlying tables which contribute to result values. An output column may
+     * have more than one origin due to expressions such as Union and
+     * LogicalProject. The optimizer may use this information for catalog access
+     * (e.g. index availability).
+     *
+     * @param r to find metadata about
+     * @param mq context
+     * @param outputColumn 0-based ordinal for output column of interest
+     * @return set of origin columns, or null if this information cannot be
+     * determined (whereas empty set indicates definitely no origin columns at
+     * all)
+     */
+    @Nullable Set<RelColumnOrigin> getColumnOrigins(RelNode r, RelMetadataQuery mq,
+        int outputColumn);
+  }
+
   /** Metadata about the origins of expressions. */
+  @Deprecated // to be removed before 2.0
   public interface ExpressionLineage extends Metadata {
     MetadataDef<ExpressionLineage> DEF = MetadataDef.of(ExpressionLineage.class,
         ExpressionLineage.Handler.class, BuiltInMethod.EXPRESSION_LINEAGE.method);
@@ -503,17 +791,48 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<ExpressionLineage> {
-      @Nullable Set<RexNode> getExpressionLineage(RelNode r, RelMetadataQuery mq,
-          RexNode expression);
-
+    interface Handler extends ExpressionLineageHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<ExpressionLineage> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler about the origins of expressions. */
+  @FunctionalInterface
+  public interface ExpressionLineageHandler extends MetadataHandler {
+    /**
+     * Given the input expression applied on the given {@link RelNode}, this
+     * provider returns the expression with its lineage resolved.
+     *
+     * <p>In particular, the result will be a set of nodes which might contain
+     * references to columns in TableScan operators ({@link RexTableInputRef}).
+     * An expression can have more than one lineage expression due to Union
+     * operators. However, we do not check column equality in Filter predicates.
+     * Each TableScan operator below the node is identified uniquely by its
+     * qualified name and its entity number.
+     *
+     * <p>For example, if the expression is {@code $0 + 2} and {@code $0} originated
+     * from column {@code $3} in the {@code 0} occurrence of table {@code A} in the
+     * plan, result will be: {@code A.#0.$3 + 2}. Occurrences are generated in no
+     * particular order, but it is guaranteed that if two expressions referred to the
+     * same table, the qualified name + occurrence will be the same.
+     *
+     * @param r to find metadata about
+     * @param mq context
+     * @param expression expression whose lineage we want to resolve
+     *
+     * @return set of expressions with lineage resolved, or null if this information
+     * cannot be determined (e.g. origin of an expression is an aggregation
+     * in an {@link org.apache.calcite.rel.core.Aggregate} operator)
+     */
+    @Nullable Set<RexNode> getExpressionLineage(RelNode r, RelMetadataQuery mq,
+        RexNode expression);
+  }
+
   /** Metadata to obtain references to tables used by a given expression. */
+  @Deprecated // to be removed before 2.0
   public interface TableReferences extends Metadata {
     MetadataDef<TableReferences> DEF = MetadataDef.of(TableReferences.class,
         TableReferences.Handler.class, BuiltInMethod.TABLE_REFERENCES.method);
@@ -538,17 +857,39 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<TableReferences> {
-      Set<RelTableRef> getTableReferences(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends TableReferencesHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<TableReferences> getDef() {
         return DEF;
       }
     }
   }
 
+  /** MetadataHandler to obtain references to tables used by a given expression. */
+  public interface TableReferencesHandler extends MetadataHandler {
+
+    /**
+     * This provider returns the tables used by a given plan.
+     *
+     * <p>In particular, the result will be a set of unique table references
+     * ({@link RelTableRef}) corresponding to each TableScan operator in the
+     * plan. These table references are composed by the table qualified name
+     * and an entity number.
+     *
+     * <p>Importantly, the table identifiers returned by this metadata provider
+     * will be consistent with the unique identifiers used by the {@link ExpressionLineage}
+     * provider, meaning that it is guaranteed that same table will use same unique
+     * identifiers in both.
+     *
+     * @return set of unique table identifiers, or null if this information
+     * cannot be determined
+     */
+    Set<RelTableRef> getTableReferences(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata about the cost of evaluating a relational expression, including
    * all of its inputs. */
+  @Deprecated // to be removed before 2.0
   public interface CumulativeCost extends Metadata {
     MetadataDef<CumulativeCost> DEF = MetadataDef.of(CumulativeCost.class,
         CumulativeCost.Handler.class, BuiltInMethod.CUMULATIVE_COST.method);
@@ -567,9 +908,8 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<CumulativeCost> {
-      RelOptCost getCumulativeCost(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends CumulativeCostHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<CumulativeCost> getDef() {
         return DEF;
       }
@@ -577,8 +917,26 @@ public abstract class BuiltInMetadata {
     }
   }
 
+  /** MetadataHandler about the cost of evaluating a relational expression,
+   * including all of its inputs. */
+  @FunctionalInterface
+  public interface CumulativeCostHandler extends MetadataHandler {
+    /**
+     * Estimates the cost of executing a relational expression, including the
+     * cost of its inputs. The default implementation for this query adds
+     * {@link NonCumulativeCost#getNonCumulativeCost} to the cumulative cost of
+     * each input, but metadata providers can override this with their own cost
+     * models, e.g. to take into account interactions between expressions.
+     *
+     * @return estimated cost, or null if no reliable estimate can be
+     * determined
+     */
+    RelOptCost getCumulativeCost(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata about the cost of evaluating a relational expression, not
    * including its inputs. */
+  @Deprecated // to be removed before 2.0
   public interface NonCumulativeCost extends Metadata {
     MetadataDef<NonCumulativeCost> DEF = MetadataDef.of(NonCumulativeCost.class,
         NonCumulativeCost.Handler.class,
@@ -600,9 +958,8 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<NonCumulativeCost> {
-      RelOptCost getNonCumulativeCost(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends NonCumulativeCostHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<NonCumulativeCost> getDef() {
         return DEF;
       }
@@ -610,7 +967,29 @@ public abstract class BuiltInMetadata {
     }
   }
 
+  /** MetadataHandler about the cost of evaluating a relational
+   * expression, not including its inputs. */
+  public interface NonCumulativeCostHandler extends MetadataHandler {
+
+    /**
+     * Estimates the cost of executing a relational expression, not counting the
+     * cost of its inputs. (However, the non-cumulative cost is still usually
+     * dependent on the row counts of the inputs.)
+     *
+     * <p>The default implementation for this query asks the rel itself via
+     * {@link RelNode#computeSelfCost(RelOptPlanner, RelMetadataQuery)},
+     * but metadata providers can override this with their own cost models.
+     *
+     * @return estimated cost, or null if no reliable estimate can be
+     * determined
+     */
+    RelOptCost getNonCumulativeCost(RelNode r, RelMetadataQuery mq);
+
+  }
+
+
   /** Metadata about whether a relational expression should appear in a plan. */
+  @Deprecated // to be removed before 2.0
   public interface ExplainVisibility extends Metadata {
     MetadataDef<ExplainVisibility> DEF = MetadataDef.of(ExplainVisibility.class,
         ExplainVisibility.Handler.class,
@@ -627,10 +1006,10 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<ExplainVisibility> {
+    interface Handler extends ExplainVisibilityHandler {
       Boolean isVisibleInExplain(RelNode r, RelMetadataQuery mq,
           SqlExplainLevel explainLevel);
-
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<ExplainVisibility> getDef() {
         return DEF;
       }
@@ -638,8 +1017,22 @@ public abstract class BuiltInMetadata {
     }
   }
 
+  /** Metadata about whether a relational expression should appear in a plan. */
+  public interface ExplainVisibilityHandler extends MetadataHandler {
+    /**
+     * Determines whether a relational expression should be visible in EXPLAIN
+     * PLAN output at a particular level of detail.
+     *
+     * @param explainLevel level of detail
+     * @return true for visible, false for invisible
+     */
+    Boolean isVisibleInExplain(RelNode r, RelMetadataQuery mq,
+        SqlExplainLevel explainLevel);
+  }
+
   /** Metadata about the predicates that hold in the rows emitted from a
    * relational expression. */
+  @Deprecated // to be removed before 2.0
   public interface Predicates extends Metadata {
     MetadataDef<Predicates> DEF = MetadataDef.of(Predicates.class,
         Predicates.Handler.class, BuiltInMethod.PREDICATES.method);
@@ -654,14 +1047,27 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<Predicates> {
+    interface Handler extends PredicatesHandler {
       RelOptPredicateList getPredicates(RelNode r, RelMetadataQuery mq);
-
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<Predicates> getDef() {
         return DEF;
       }
 
     }
+  }
+
+  /** MetadataHandler about the predicates that hold in the rows emitted
+   * from a relational expression. */
+  @FunctionalInterface
+  public interface PredicatesHandler extends MetadataHandler {
+    /**
+     * Derives the predicates that hold on rows emitted from a relational
+     * expression.
+     *
+     * @return Predicate list
+     */
+    RelOptPredicateList getPredicates(RelNode r, RelMetadataQuery mq);
   }
 
   /** Metadata about the predicates that hold in the rows emitted from a
@@ -673,6 +1079,7 @@ public abstract class BuiltInMetadata {
    * on {@link RexTableInputRef} to reference origin columns in
    * {@link org.apache.calcite.rel.core.TableScan} for the result predicates.
    */
+  @Deprecated // to be removed before 2.0
   public interface AllPredicates extends Metadata {
     MetadataDef<AllPredicates> DEF = MetadataDef.of(AllPredicates.class,
             AllPredicates.Handler.class, BuiltInMethod.ALL_PREDICATES.method);
@@ -688,9 +1095,8 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<AllPredicates> {
-      @Nullable RelOptPredicateList getAllPredicates(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends AllPredicatesHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<AllPredicates> getDef() {
         return DEF;
       }
@@ -698,9 +1104,30 @@ public abstract class BuiltInMetadata {
     }
   }
 
+  /** Metadata about the predicates that hold in the rows emitted from a
+   * relational expression.
+   *
+   * <p>The difference with respect to {@link Predicates} provider is that
+   * this provider tries to extract ALL predicates even if they are not
+   * applied on the output expressions of the relational expression; we rely
+   * on {@link RexTableInputRef} to reference origin columns in
+   * {@link org.apache.calcite.rel.core.TableScan} for the result predicates.
+   */
+  public interface AllPredicatesHandler extends MetadataHandler {
+    /**
+     * Derives the predicates that hold on rows emitted from a relational
+     * expression.
+     *
+     * @return predicate list, or null if the provider cannot infer the
+     * lineage for any of the expressions contained in any of the predicates
+     */
+    @Nullable RelOptPredicateList getAllPredicates(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata about the degree of parallelism of a relational expression, and
    * how its operators are assigned to processes with independent resource
    * pools. */
+  @Deprecated // to be removed before 2.0
   public interface Parallelism extends Metadata {
     MetadataDef<Parallelism> DEF = MetadataDef.of(Parallelism.class,
         Parallelism.Handler.class, BuiltInMethod.IS_PHASE_TRANSITION.method,
@@ -728,18 +1155,42 @@ public abstract class BuiltInMetadata {
     Integer splitCount();
 
     /** Handler API. */
-    interface Handler extends MetadataHandler<Parallelism> {
-      Boolean isPhaseTransition(RelNode r, RelMetadataQuery mq);
-      Integer splitCount(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends ParallelismHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<Parallelism> getDef() {
         return DEF;
       }
-
     }
   }
 
+  /** MetadataHandler about the degree of parallelism of a relational expression, and
+   * how its operators are assigned to processes with independent resource
+   * pools. */
+  public interface ParallelismHandler extends MetadataHandler {
+    /** Returns whether each physical operator implementing this relational
+     * expression belongs to a different process than its inputs.
+     *
+     * <p>A collection of operators processing all of the splits of a particular
+     * stage in the query pipeline is called a "phase". A phase starts with
+     * a leaf node such as a {@link org.apache.calcite.rel.core.TableScan},
+     * or with a phase-change node such as an
+     * {@link org.apache.calcite.rel.core.Exchange}. Hadoop's shuffle operator
+     * (a form of sort-exchange) causes data to be sent across the network. */
+    Boolean isPhaseTransition(RelNode r, RelMetadataQuery mq);
+
+    /** Returns the number of distinct splits of the data.
+     *
+     * <p>Note that splits must be distinct. For broadcast, where each copy is
+     * the same, returns 1.
+     *
+     * <p>Thus the split count is the <em>proportion</em> of the data seen by
+     * each operator instance.
+     */
+    Integer splitCount(RelNode r, RelMetadataQuery mq);
+  }
+
   /** Metadata to get the lower bound cost of a RelNode. */
+  @Deprecated // to be removed before 2.0
   public interface LowerBoundCost extends Metadata {
     MetadataDef<LowerBoundCost> DEF = MetadataDef.of(LowerBoundCost.class,
         LowerBoundCost.Handler.class, BuiltInMethod.LOWER_BOUND_COST.method);
@@ -749,10 +1200,10 @@ public abstract class BuiltInMetadata {
 
     /** Handler API. */
     @FunctionalInterface
-    interface Handler extends MetadataHandler<LowerBoundCost> {
+    interface Handler extends LowerBoundCostHandler {
       RelOptCost getLowerBoundCost(
           RelNode r, RelMetadataQuery mq, VolcanoPlanner planner);
-
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<LowerBoundCost> getDef() {
         return DEF;
       }
@@ -760,7 +1211,16 @@ public abstract class BuiltInMetadata {
     }
   }
 
+  /** MetadataHandler to get the lower bound cost of a RelNode. */
+  @FunctionalInterface
+  public interface LowerBoundCostHandler extends MetadataHandler {
+    /** Returns the lower bound cost of a RelNode. */
+    RelOptCost getLowerBoundCost(
+        RelNode r, RelMetadataQuery mq, VolcanoPlanner planner);
+  }
+
   /** Metadata about the memory use of an operator. */
+  @Deprecated // to be removed before 2.0
   public interface Memory extends Metadata {
     MetadataDef<Memory> DEF = MetadataDef.of(Memory.class,
         Memory.Handler.class, BuiltInMethod.MEMORY.method,
@@ -800,11 +1260,8 @@ public abstract class BuiltInMetadata {
     @Nullable Double cumulativeMemoryWithinPhaseSplit();
 
     /** Handler API. */
-    interface Handler extends MetadataHandler<Memory> {
-      @Nullable Double memory(RelNode r, RelMetadataQuery mq);
-      @Nullable Double cumulativeMemoryWithinPhase(RelNode r, RelMetadataQuery mq);
-      @Nullable Double cumulativeMemoryWithinPhaseSplit(RelNode r, RelMetadataQuery mq);
-
+    interface Handler extends MemoryHandler {
+      @Deprecated // to be removed before 2.0
       @Override default MetadataDef<Memory> getDef() {
         return DEF;
       }
@@ -812,7 +1269,44 @@ public abstract class BuiltInMetadata {
     }
   }
 
+  /** MetadataHandler about the memory use of an operator. */
+  public interface MemoryHandler extends MetadataHandler {
+
+    /** Returns the expected amount of memory, in bytes, required by a physical
+     * operator implementing this relational expression, across all splits.
+     *
+     * <p>How much memory is used depends very much on the algorithm; for
+     * example, an implementation of
+     * {@link org.apache.calcite.rel.core.Aggregate} that loads all data into a
+     * hash table requires approximately {@code rowCount * averageRowSize}
+     * bytes, whereas an implementation that assumes that the input is sorted
+     * requires only {@code averageRowSize} bytes to maintain a single
+     * accumulator for each aggregate function.
+     */
+    @Nullable Double memory(RelNode r, RelMetadataQuery mq);
+
+    /** Returns the cumulative amount of memory, in bytes, required by the
+     * physical operator implementing this relational expression, and all other
+     * operators within the same phase, across all splits.
+     *
+     * @see Parallelism#splitCount()
+     */
+    @Nullable Double cumulativeMemoryWithinPhase(RelNode r, RelMetadataQuery mq);
+
+    /** Returns the expected cumulative amount of memory, in bytes, required by
+     * the physical operator implementing this relational expression, and all
+     * operators within the same phase, within each split.
+     *
+     * <p>Basic formula:
+     *
+     * <blockquote>cumulativeMemoryWithinPhaseSplit
+     *     = cumulativeMemoryWithinPhase / Parallelism.splitCount</blockquote>
+     */
+    @Nullable Double cumulativeMemoryWithinPhaseSplit(RelNode r, RelMetadataQuery mq);
+  }
+
   /** The built-in forms of metadata. */
+  @Deprecated // to be removed before 2.0
   interface All extends Selectivity, UniqueKeys, RowCount, DistinctRowCount,
       PercentageOriginalRows, ColumnUniqueness, ColumnOrigin, Predicates,
       Collation, Distribution, Size, Parallelism, Memory, AllPredicates,

--- a/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/CachingRelMetadataProvider.java
@@ -84,13 +84,13 @@ public class CachingRelMetadataProvider implements RelMetadataProvider {
   }
 
   @Deprecated // to be removed before 2.0
-  @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
+  @Override public <M extends Metadata> Multimap<Method, MetadataHandler> handlers(
       MetadataDef<M> def) {
     return underlyingProvider.handlers(def);
   }
 
-  @Override public List<MetadataHandler<?>> handlers(
-      Class<? extends MetadataHandler<?>> handlerClass) {
+  @Override public List<MetadataHandler> handlers(
+      Class<? extends MetadataHandler> handlerClass) {
     return underlyingProvider.handlers(handlerClass);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ChainedRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ChainedRelMetadataProvider.java
@@ -106,9 +106,9 @@ public class ChainedRelMetadataProvider implements RelMetadataProvider {
   }
 
   @Deprecated // to be removed before 2.0
-  @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
+  @Override public <M extends Metadata> Multimap<Method, MetadataHandler> handlers(
       MetadataDef<M> def) {
-    final ImmutableMultimap.Builder<Method, MetadataHandler<M>> builder =
+    final ImmutableMultimap.Builder<Method, MetadataHandler> builder =
         ImmutableMultimap.builder();
     for (RelMetadataProvider provider : providers.reverse()) {
       builder.putAll(provider.handlers(def));
@@ -116,9 +116,9 @@ public class ChainedRelMetadataProvider implements RelMetadataProvider {
     return builder.build();
   }
 
-  @Override public List<MetadataHandler<?>> handlers(
-      Class<? extends MetadataHandler<?>> handlerClass) {
-    final ImmutableList.Builder<MetadataHandler<?>> builder =
+  @Override public List<MetadataHandler> handlers(
+      Class<? extends MetadataHandler> handlerClass) {
+    final ImmutableList.Builder<MetadataHandler> builder =
         ImmutableList.builder();
     for (RelMetadataProvider provider : providers) {
       builder.addAll(provider.handlers(handlerClass));
@@ -133,6 +133,7 @@ public class ChainedRelMetadataProvider implements RelMetadataProvider {
 
   /** Invocation handler that calls a list of {@link Metadata} objects,
    * returning the first non-null value. */
+  @Deprecated // to be removed before 2.0
   private static class ChainedInvocationHandler implements InvocationHandler {
     private final List<Metadata> metadataList;
 
@@ -140,6 +141,7 @@ public class ChainedRelMetadataProvider implements RelMetadataProvider {
       this.metadataList = ImmutableList.copyOf(metadataList);
     }
 
+    @Deprecated // to be removed before 2.0
     @Override public @Nullable Object invoke(Object proxy, Method method, @Nullable Object[] args)
         throws Throwable {
       for (Metadata metadata : metadataList) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/JaninoRelMetadataProvider.java
@@ -62,7 +62,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
   /** Cache of pre-generated handlers by provider and kind of metadata.
    * For the cache to be effective, providers should implement identity
    * correctly. */
-  private static final LoadingCache<Key, MetadataHandler<?>> HANDLERS =
+  private static final LoadingCache<Key, MetadataHandler> HANDLERS =
       maxSize(CacheBuilder.newBuilder(),
           CalciteSystemProperty.METADATA_HANDLER_CACHE_MAXIMUM_SIZE.value())
           .build(
@@ -112,21 +112,21 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
   }
 
   @Deprecated // to be removed before 2.0
-  @Override public <M extends Metadata> Multimap<Method, MetadataHandler<M>>
+  @Override public <M extends Metadata> Multimap<Method, MetadataHandler>
       handlers(MetadataDef<M> def) {
     return provider.handlers(def);
   }
 
-  @Override public List<MetadataHandler<?>> handlers(
-      Class<? extends MetadataHandler<?>> handlerClass) {
+  @Override public List<MetadataHandler> handlers(
+      Class<? extends MetadataHandler> handlerClass) {
     return provider.handlers(handlerClass);
   }
 
-  private static <MH extends MetadataHandler<?>> MH generateCompileAndInstantiate(
+  private static <MH extends MetadataHandler> MH generateCompileAndInstantiate(
       Class<MH> handlerClass,
-      List<? extends MetadataHandler<? extends Metadata>> handlers) {
+      List<? extends MetadataHandler> handlers) {
 
-    final List<? extends MetadataHandler<? extends Metadata>> uniqueHandlers = handlers.stream()
+    final List<? extends MetadataHandler> uniqueHandlers = handlers.stream()
         .distinct()
         .collect(Collectors.toList());
     RelMetadataHandlerGeneratorUtil.HandlerNameAndGeneratedCode handlerNameAndGeneratedCode =
@@ -142,7 +142,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
   }
 
 
-  static  <MH extends MetadataHandler<?>> MH compile(String className,
+  static  <MH extends MetadataHandler> MH compile(String className,
       String generatedCode, Class<MH> handlerClass,
       List<? extends Object> argList) throws CompileException, IOException {
     final ICompilerFactory compilerFactory;
@@ -180,7 +180,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
     return handlerClass.cast(o);
   }
 
-  @Override public synchronized <H extends MetadataHandler<?>> H revise(Class<H> handlerClass) {
+  @Override public synchronized <H extends MetadataHandler> H revise(Class<H> handlerClass) {
     try {
       final Key key = new Key(handlerClass, provider);
       //noinspection unchecked
@@ -193,7 +193,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
   /** Registers some classes. Does not flush the providers, but next time we
    * need to generate a provider, it will handle all of these classes. So,
    * calling this method reduces the number of times we need to re-generate. */
-  @Deprecated
+  @Deprecated // to be removed before 2.0
   public void register(Iterable<Class<? extends RelNode>> classes) {
   }
 
@@ -201,7 +201,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
    * this class but there is not. The action is probably to
    * re-generate the handler class. Use {@link MetadataHandlerProvider.NoHandler} instead.
    * */
-  @Deprecated
+  @Deprecated // to be removed before 2.0
   public static class NoHandler extends MetadataHandlerProvider.NoHandler {
     public NoHandler(Class<? extends RelNode> relClass) {
       super(relClass);
@@ -210,10 +210,10 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
 
   /** Key for the cache. */
   private static class Key {
-    final Class<? extends MetadataHandler<? extends Metadata>> handlerClass;
+    final Class<? extends MetadataHandler> handlerClass;
     final RelMetadataProvider provider;
 
-    private Key(Class<? extends MetadataHandler<?>> handlerClass,
+    private Key(Class<? extends MetadataHandler> handlerClass,
         RelMetadataProvider provider) {
       this.handlerClass = handlerClass;
       this.provider = provider;
@@ -233,7 +233,7 @@ public class JaninoRelMetadataProvider implements RelMetadataProvider, MetadataH
   }
 
   @SuppressWarnings("deprecation")
-  @Override public <MH extends MetadataHandler<?>> MH handler(final Class<MH> handlerClass) {
+  @Override public <MH extends MetadataHandler> MH handler(final Class<MH> handlerClass) {
     return handlerClass.cast(
         Proxy.newProxyInstance(RelMetadataQuery.class.getClassLoader(),
             new Class[] {handlerClass}, (proxy, method, args) -> {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandler.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandler.java
@@ -16,11 +16,10 @@
  */
 package org.apache.calcite.rel.metadata;
 
-/**
- * Marker interface for a handler of metadata.
- *
- * @param <M> Kind of metadata
- */
-public interface MetadataHandler<M extends Metadata> {
-  MetadataDef<M> getDef();
+/** Marker interface for a handler of metadata. */
+public interface MetadataHandler {
+  @Deprecated
+  default MetadataDef<?> getDef() {
+    throw new UnsupportedOperationException();
+  };
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandlerProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/MetadataHandlerProvider.java
@@ -32,7 +32,7 @@ public interface MetadataHandlerProvider {
    * @param <MH> The metadata type the handler relates to.
    * @return The handler implementation.
    */
-  <MH extends MetadataHandler<?>> MH handler(Class<MH> handlerClass);
+  <MH extends MetadataHandler> MH handler(Class<MH> handlerClass);
 
   /** Re-generates the handler for a given kind of metadata.  */
   /**
@@ -44,7 +44,7 @@ public interface MetadataHandlerProvider {
    * @param <MH> The type metadata the handler provides.
    * @return A new handler that should be used instead of any previous handler provided.
    */
-  default <MH extends MetadataHandler<?>> MH revise(Class<MH> handlerClass) {
+  default <MH extends MetadataHandler> MH revise(Class<MH> handlerClass) {
     throw new UnsupportedOperationException("This provider doesn't support handler revision.");
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdAllPredicates.java
@@ -76,11 +76,12 @@ import java.util.Set;
  *
  */
 public class RelMdAllPredicates
-    implements MetadataHandler<BuiltInMetadata.AllPredicates> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdAllPredicates(), BuiltInMetadata.AllPredicates.Handler.class);
+          new RelMdAllPredicates(), BuiltInMetadata.AllPredicatesHandler.class);
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.AllPredicates> getDef() {
     return BuiltInMetadata.AllPredicates.DEF;
   }
@@ -112,8 +113,8 @@ public class RelMdAllPredicates
    * Extracts predicates for a table scan.
    */
   public @Nullable RelOptPredicateList getAllPredicates(TableScan scan, RelMetadataQuery mq) {
-    final BuiltInMetadata.AllPredicates.Handler handler =
-        scan.getTable().unwrap(BuiltInMetadata.AllPredicates.Handler.class);
+    final BuiltInMetadata.AllPredicatesHandler handler =
+        scan.getTable().unwrap(BuiltInMetadata.AllPredicatesHandler.class);
     if (handler != null) {
       return handler.getAllPredicates(scan, mq);
     }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
@@ -80,10 +80,10 @@ import java.util.stream.Collectors;
  * for the standard logical algebra.
  */
 public class RelMdCollation
-    implements MetadataHandler<BuiltInMetadata.Collation> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdCollation(), BuiltInMetadata.Collation.Handler.class);
+          new RelMdCollation(), BuiltInMetadata.CollationHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -91,6 +91,7 @@ public class RelMdCollation
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Collation> getDef() {
     return BuiltInMetadata.Collation.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
@@ -49,10 +49,10 @@ import java.util.Set;
  * {@link RelMetadataQuery#getColumnOrigins} for the standard logical algebra.
  */
 public class RelMdColumnOrigins
-    implements MetadataHandler<BuiltInMetadata.ColumnOrigin> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdColumnOrigins(), BuiltInMetadata.ColumnOrigin.Handler.class);
+          new RelMdColumnOrigins(), BuiltInMetadata.ColumnOriginHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -60,6 +60,7 @@ public class RelMdColumnOrigins
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.ColumnOrigin> getDef() {
     return BuiltInMetadata.ColumnOrigin.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -63,10 +63,10 @@ import java.util.Set;
  * {@link RelMetadataQuery#areColumnsUnique} for the standard logical algebra.
  */
 public class RelMdColumnUniqueness
-    implements MetadataHandler<BuiltInMetadata.ColumnUniqueness> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdColumnUniqueness(), BuiltInMetadata.ColumnUniqueness.Handler.class);
+          new RelMdColumnUniqueness(), BuiltInMetadata.ColumnUniquenessHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -74,6 +74,7 @@ public class RelMdColumnUniqueness
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.ColumnUniqueness> getDef() {
     return BuiltInMetadata.ColumnUniqueness.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistinctRowCount.java
@@ -51,10 +51,10 @@ import java.util.Set;
  * algebra.
  */
 public class RelMdDistinctRowCount
-    implements MetadataHandler<BuiltInMetadata.DistinctRowCount> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdDistinctRowCount(), BuiltInMetadata.DistinctRowCount.Handler.class);
+          new RelMdDistinctRowCount(), BuiltInMetadata.DistinctRowCountHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -62,6 +62,7 @@ public class RelMdDistinctRowCount
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.DistinctRowCount> getDef() {
     return BuiltInMetadata.DistinctRowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistribution.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistribution.java
@@ -49,10 +49,10 @@ import java.util.List;
  * for the standard logical algebra.
  */
 public class RelMdDistribution
-    implements MetadataHandler<BuiltInMetadata.Distribution> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdDistribution(), BuiltInMetadata.Distribution.Handler.class);
+          new RelMdDistribution(), BuiltInMetadata.DistributionHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -60,6 +60,7 @@ public class RelMdDistribution
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Distribution> getDef() {
     return BuiltInMetadata.Distribution.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExplainVisibility.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExplainVisibility.java
@@ -26,10 +26,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link RelMetadataQuery#isVisibleInExplain} for the standard logical algebra.
  */
 public class RelMdExplainVisibility
-    implements MetadataHandler<BuiltInMetadata.ExplainVisibility> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdExplainVisibility(), BuiltInMetadata.ExplainVisibility.Handler.class);
+          new RelMdExplainVisibility(), BuiltInMetadata.ExplainVisibilityHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -37,6 +37,7 @@ public class RelMdExplainVisibility
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.ExplainVisibility> getDef() {
     return BuiltInMetadata.ExplainVisibility.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -80,10 +80,10 @@ import static java.util.Objects.requireNonNull;
  * <p>If the lineage cannot be inferred, we return null.
  */
 public class RelMdExpressionLineage
-    implements MetadataHandler<BuiltInMetadata.ExpressionLineage> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdExpressionLineage(), BuiltInMetadata.ExpressionLineage.Handler.class);
+          new RelMdExpressionLineage(), BuiltInMetadata.ExpressionLineageHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -91,6 +91,7 @@ public class RelMdExpressionLineage
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.ExpressionLineage> getDef() {
     return BuiltInMetadata.ExpressionLineage.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdLowerBoundCost.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdLowerBoundCost.java
@@ -20,7 +20,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCost;
+import org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCostHandler;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -29,11 +29,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link BuiltInMetadata.LowerBoundCost}
  * metadata provider for the standard algebra.
  */
-public class RelMdLowerBoundCost implements MetadataHandler<LowerBoundCost> {
+public class RelMdLowerBoundCost implements MetadataHandler {
 
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdLowerBoundCost(), LowerBoundCost.Handler.class);
+          new RelMdLowerBoundCost(), LowerBoundCostHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -41,7 +41,8 @@ public class RelMdLowerBoundCost implements MetadataHandler<LowerBoundCost> {
 
   //~ Methods ----------------------------------------------------------------
 
-  @Override public MetadataDef<LowerBoundCost> getDef() {
+  @Deprecated
+  @Override public MetadataDef<BuiltInMetadata.LowerBoundCost> getDef() {
     return BuiltInMetadata.LowerBoundCost.DEF;
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
@@ -45,13 +45,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link RelMetadataQuery#getMaxRowCount} for the standard logical algebra.
  */
 public class RelMdMaxRowCount
-    implements MetadataHandler<BuiltInMetadata.MaxRowCount> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdMaxRowCount(), BuiltInMetadata.MaxRowCount.Handler.class);
+          new RelMdMaxRowCount(), BuiltInMetadata.MaxRowCountHandler.class);
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.MaxRowCount> getDef() {
     return BuiltInMetadata.MaxRowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMemory.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMemory.java
@@ -28,12 +28,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @see RelMetadataQuery#isPhaseTransition
  * @see RelMetadataQuery#splitCount
  */
-public class RelMdMemory implements MetadataHandler<BuiltInMetadata.Memory> {
+public class RelMdMemory implements MetadataHandler {
   /** Source for
    * {@link org.apache.calcite.rel.metadata.BuiltInMetadata.Memory}. */
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(new RelMdMemory(),
-          BuiltInMetadata.Memory.Handler.class);
+          BuiltInMetadata.MemoryHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -41,6 +41,7 @@ public class RelMdMemory implements MetadataHandler<BuiltInMetadata.Memory> {
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Memory> getDef() {
     return BuiltInMetadata.Memory.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
@@ -43,13 +43,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link RelMetadataQuery#getMinRowCount} for the standard logical algebra.
  */
 public class RelMdMinRowCount
-    implements MetadataHandler<BuiltInMetadata.MinRowCount> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdMinRowCount(), BuiltInMetadata.MinRowCount.Handler.class);
+          new RelMdMinRowCount(), BuiltInMetadata.MinRowCountHandler.class);
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.MinRowCount> getDef() {
     return BuiltInMetadata.MinRowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdNodeTypes.java
@@ -47,13 +47,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link RelMetadataQuery#getNodeTypes} for the standard logical algebra.
  */
 public class RelMdNodeTypes
-    implements MetadataHandler<BuiltInMetadata.NodeTypes> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdNodeTypes(), BuiltInMetadata.NodeTypes.Handler.class);
+          new RelMdNodeTypes(), BuiltInMetadata.NodeTypesHandler.class);
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.NodeTypes> getDef() {
     return BuiltInMetadata.NodeTypes.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdParallelism.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdParallelism.java
@@ -30,12 +30,12 @@ import org.apache.calcite.rel.core.Values;
  * @see org.apache.calcite.rel.metadata.RelMetadataQuery#splitCount
  */
 public class RelMdParallelism
-    implements MetadataHandler<BuiltInMetadata.Parallelism> {
+    implements MetadataHandler {
   /** Source for
    * {@link org.apache.calcite.rel.metadata.BuiltInMetadata.Parallelism}. */
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(new RelMdParallelism(),
-          BuiltInMetadata.Parallelism.Handler.class);
+          BuiltInMetadata.ParallelismHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -43,6 +43,7 @@ public class RelMdParallelism
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated
   @Override public MetadataDef<BuiltInMetadata.Parallelism> getDef() {
     return BuiltInMetadata.Parallelism.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPercentageOriginalRows.java
@@ -41,13 +41,13 @@ public class RelMdPercentageOriginalRows {
           ImmutableList.of(
               ReflectiveRelMetadataProvider.reflectiveSource(
                   new RelMdPercentageOriginalRowsHandler(),
-                  BuiltInMetadata.PercentageOriginalRows.Handler.class),
+                  BuiltInMetadata.PercentageOriginalRowsHandler.class),
               ReflectiveRelMetadataProvider.reflectiveSource(
                   new RelMdCumulativeCost(),
-                  BuiltInMetadata.CumulativeCost.Handler.class),
+                  BuiltInMetadata.CumulativeCostHandler.class),
               ReflectiveRelMetadataProvider.reflectiveSource(
                   new RelMdNonCumulativeCost(),
-                  BuiltInMetadata.NonCumulativeCost.Handler.class
+                  BuiltInMetadata.NonCumulativeCostHandler.class
               )
           ));
 
@@ -196,11 +196,11 @@ public class RelMdPercentageOriginalRows {
   }
 
   /**
-   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.CumulativeCost}.
+   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.CumulativeCostHandler}.
    */
   private static final class RelMdCumulativeCost
       extends RelMdPercentageOriginalRows
-      implements MetadataHandler<BuiltInMetadata.CumulativeCost> {
+      implements MetadataHandler {
     @Deprecated // to be removed before 2.0
     @Override public MetadataDef<BuiltInMetadata.CumulativeCost> getDef() {
       return BuiltInMetadata.CumulativeCost.DEF;
@@ -208,11 +208,11 @@ public class RelMdPercentageOriginalRows {
   }
 
   /**
-   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.NonCumulativeCost}.
+   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.NonCumulativeCostHandler}.
    */
   private static final class RelMdNonCumulativeCost
       extends RelMdPercentageOriginalRows
-      implements MetadataHandler<BuiltInMetadata.NonCumulativeCost> {
+      implements MetadataHandler {
 
     @Deprecated // to be removed before 2.0
     @Override public MetadataDef<BuiltInMetadata.NonCumulativeCost> getDef() {
@@ -221,11 +221,12 @@ public class RelMdPercentageOriginalRows {
   }
 
   /**
-   * Binds {@link RelMdPercentageOriginalRows} to {@link BuiltInMetadata.PercentageOriginalRows}.
+   * Binds {@link RelMdPercentageOriginalRows} to
+   * {@link BuiltInMetadata.PercentageOriginalRowsHandler}.
    */
   private static final class RelMdPercentageOriginalRowsHandler
       extends RelMdPercentageOriginalRows
-      implements MetadataHandler<BuiltInMetadata.PercentageOriginalRows> {
+      implements MetadataHandler {
     @Deprecated // to be removed before 2.0
     @Override public MetadataDef<BuiltInMetadata.PercentageOriginalRows> getDef() {
       return BuiltInMetadata.PercentageOriginalRows.DEF;

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
@@ -39,10 +39,10 @@ import java.util.List;
  * {@link RelMetadataQuery#getPopulationSize} for the standard logical algebra.
  */
 public class RelMdPopulationSize
-    implements MetadataHandler<BuiltInMetadata.PopulationSize> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdPopulationSize(), BuiltInMetadata.PopulationSize.Handler.class);
+          new RelMdPopulationSize(), BuiltInMetadata.PopulationSizeHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -50,6 +50,7 @@ public class RelMdPopulationSize
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.PopulationSize> getDef() {
     return BuiltInMetadata.PopulationSize.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -126,12 +126,13 @@ import static java.util.Objects.requireNonNull;
  * </ol>
  */
 public class RelMdPredicates
-    implements MetadataHandler<BuiltInMetadata.Predicates> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE = ReflectiveRelMetadataProvider
-      .reflectiveSource(new RelMdPredicates(), BuiltInMetadata.Predicates.Handler.class);
+      .reflectiveSource(new RelMdPredicates(), BuiltInMetadata.PredicatesHandler.class);
 
   private static final List<RexNode> EMPTY_LIST = ImmutableList.of();
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.Predicates> getDef() {
     return BuiltInMetadata.Predicates.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -47,13 +47,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link RelMetadataQuery#getRowCount} for the standard logical algebra.
  */
 public class RelMdRowCount
-    implements MetadataHandler<BuiltInMetadata.RowCount> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdRowCount(), BuiltInMetadata.RowCount.Handler.class);
+          new RelMdRowCount(), BuiltInMetadata.RowCountHandler.class);
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.RowCount> getDef() {
     return BuiltInMetadata.RowCount.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSelectivity.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSelectivity.java
@@ -44,10 +44,10 @@ import java.util.List;
  * {@link RelMetadataQuery#getSelectivity} for the standard logical algebra.
  */
 public class RelMdSelectivity
-    implements MetadataHandler<BuiltInMetadata.Selectivity> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdSelectivity(), BuiltInMetadata.Selectivity.Handler.class);
+          new RelMdSelectivity(), BuiltInMetadata.SelectivityHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -56,6 +56,7 @@ public class RelMdSelectivity
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.Selectivity> getDef() {
     return BuiltInMetadata.Selectivity.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
@@ -58,12 +58,12 @@ import java.util.List;
  * @see RelMetadataQuery#getAverageColumnSizes
  * @see RelMetadataQuery#getAverageColumnSizesNotNull
  */
-public class RelMdSize implements MetadataHandler<BuiltInMetadata.Size> {
+public class RelMdSize implements MetadataHandler {
   /** Source for
    * {@link org.apache.calcite.rel.metadata.BuiltInMetadata.Size}. */
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(new RelMdSize(),
-          BuiltInMetadata.Size.Handler.class);
+          BuiltInMetadata.SizeHandler.class);
 
   /** Bytes per character (2). */
   public static final int BYTES_PER_CHARACTER = Character.SIZE / Byte.SIZE;
@@ -74,6 +74,7 @@ public class RelMdSize implements MetadataHandler<BuiltInMetadata.Size> {
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.Size> getDef() {
     return BuiltInMetadata.Size.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdTableReferences.java
@@ -60,10 +60,10 @@ import java.util.Set;
  * <p>If tables cannot be obtained, we return null.
  */
 public class RelMdTableReferences
-    implements MetadataHandler<BuiltInMetadata.TableReferences> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdTableReferences(), BuiltInMetadata.TableReferences.Handler.class);
+          new RelMdTableReferences(), BuiltInMetadata.TableReferencesHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -71,6 +71,7 @@ public class RelMdTableReferences
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.TableReferences> getDef() {
     return BuiltInMetadata.TableReferences.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUniqueKeys.java
@@ -56,10 +56,10 @@ import static java.util.Objects.requireNonNull;
  * {@link RelMetadataQuery#getUniqueKeys} for the standard logical algebra.
  */
 public class RelMdUniqueKeys
-    implements MetadataHandler<BuiltInMetadata.UniqueKeys> {
+    implements MetadataHandler {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
-          new RelMdUniqueKeys(), BuiltInMetadata.UniqueKeys.Handler.class);
+          new RelMdUniqueKeys(), BuiltInMetadata.UniqueKeysHandler.class);
 
   //~ Constructors -----------------------------------------------------------
 
@@ -67,6 +67,7 @@ public class RelMdUniqueKeys
 
   //~ Methods ----------------------------------------------------------------
 
+  @Deprecated // to be removed before 2.0
   @Override public MetadataDef<BuiltInMetadata.UniqueKeys> getDef() {
     return BuiltInMetadata.UniqueKeys.DEF;
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataProvider.java
@@ -72,7 +72,7 @@ public interface RelMetadataProvider {
       Class<? extends RelNode> relClass, Class<? extends M> metadataClass);
 
   @Deprecated // to be removed before 2.0
-  <M extends Metadata> Multimap<Method, MetadataHandler<M>> handlers(
+  <M extends Metadata> Multimap<Method, MetadataHandler> handlers(
       MetadataDef<M> def);
 
   /**
@@ -90,5 +90,5 @@ public interface RelMetadataProvider {
    *
    * The behavior is undefined if the class hierarchy for dispatching is not a tree.
    */
-  List<MetadataHandler<?>> handlers(Class<? extends MetadataHandler<?>> handlerClass);
+  List<MetadataHandler> handlers(Class<? extends MetadataHandler> handlerClass);
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -83,30 +83,30 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
   private static final Supplier<RelMetadataQuery> EMPTY =
       Suppliers.memoize(() -> new RelMetadataQuery(false));
 
-  private BuiltInMetadata.Collation.Handler collationHandler;
-  private BuiltInMetadata.ColumnOrigin.Handler columnOriginHandler;
-  private BuiltInMetadata.ExpressionLineage.Handler expressionLineageHandler;
-  private BuiltInMetadata.TableReferences.Handler tableReferencesHandler;
-  private BuiltInMetadata.ColumnUniqueness.Handler columnUniquenessHandler;
-  private BuiltInMetadata.CumulativeCost.Handler cumulativeCostHandler;
-  private BuiltInMetadata.DistinctRowCount.Handler distinctRowCountHandler;
-  private BuiltInMetadata.Distribution.Handler distributionHandler;
-  private BuiltInMetadata.ExplainVisibility.Handler explainVisibilityHandler;
-  private BuiltInMetadata.MaxRowCount.Handler maxRowCountHandler;
-  private BuiltInMetadata.MinRowCount.Handler minRowCountHandler;
-  private BuiltInMetadata.Memory.Handler memoryHandler;
-  private BuiltInMetadata.NonCumulativeCost.Handler nonCumulativeCostHandler;
-  private BuiltInMetadata.Parallelism.Handler parallelismHandler;
-  private BuiltInMetadata.PercentageOriginalRows.Handler percentageOriginalRowsHandler;
-  private BuiltInMetadata.PopulationSize.Handler populationSizeHandler;
-  private BuiltInMetadata.Predicates.Handler predicatesHandler;
-  private BuiltInMetadata.AllPredicates.Handler allPredicatesHandler;
-  private BuiltInMetadata.NodeTypes.Handler nodeTypesHandler;
-  private BuiltInMetadata.RowCount.Handler rowCountHandler;
-  private BuiltInMetadata.Selectivity.Handler selectivityHandler;
-  private BuiltInMetadata.Size.Handler sizeHandler;
-  private BuiltInMetadata.UniqueKeys.Handler uniqueKeysHandler;
-  private BuiltInMetadata.LowerBoundCost.Handler lowerBoundCostHandler;
+  private BuiltInMetadata.CollationHandler collationHandler;
+  private BuiltInMetadata.ColumnOriginHandler columnOriginHandler;
+  private BuiltInMetadata.ExpressionLineageHandler expressionLineageHandler;
+  private BuiltInMetadata.TableReferencesHandler tableReferencesHandler;
+  private BuiltInMetadata.ColumnUniquenessHandler columnUniquenessHandler;
+  private BuiltInMetadata.CumulativeCostHandler cumulativeCostHandler;
+  private BuiltInMetadata.DistinctRowCountHandler distinctRowCountHandler;
+  private BuiltInMetadata.DistributionHandler distributionHandler;
+  private BuiltInMetadata.ExplainVisibilityHandler explainVisibilityHandler;
+  private BuiltInMetadata.MaxRowCountHandler maxRowCountHandler;
+  private BuiltInMetadata.MinRowCountHandler minRowCountHandler;
+  private BuiltInMetadata.MemoryHandler memoryHandler;
+  private BuiltInMetadata.NonCumulativeCostHandler nonCumulativeCostHandler;
+  private BuiltInMetadata.ParallelismHandler parallelismHandler;
+  private BuiltInMetadata.PercentageOriginalRowsHandler percentageOriginalRowsHandler;
+  private BuiltInMetadata.PopulationSizeHandler populationSizeHandler;
+  private BuiltInMetadata.PredicatesHandler predicatesHandler;
+  private BuiltInMetadata.AllPredicatesHandler allPredicatesHandler;
+  private BuiltInMetadata.NodeTypesHandler nodeTypesHandler;
+  private BuiltInMetadata.RowCountHandler rowCountHandler;
+  private BuiltInMetadata.SelectivityHandler selectivityHandler;
+  private BuiltInMetadata.SizeHandler sizeHandler;
+  private BuiltInMetadata.UniqueKeysHandler uniqueKeysHandler;
+  private BuiltInMetadata.LowerBoundCostHandler lowerBoundCostHandler;
 
   /**
    * Creates the instance with {@link JaninoRelMetadataProvider} instance
@@ -122,34 +122,34 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
    */
   public RelMetadataQuery(MetadataHandlerProvider provider) {
     super(provider);
-    this.collationHandler = provider.handler(BuiltInMetadata.Collation.Handler.class);
-    this.columnOriginHandler = provider.handler(BuiltInMetadata.ColumnOrigin.Handler.class);
+    this.collationHandler = provider.handler(BuiltInMetadata.CollationHandler.class);
+    this.columnOriginHandler = provider.handler(BuiltInMetadata.ColumnOriginHandler.class);
     this.expressionLineageHandler =
-        provider.handler(BuiltInMetadata.ExpressionLineage.Handler.class);
-    this.tableReferencesHandler = provider.handler(BuiltInMetadata.TableReferences.Handler.class);
-    this.columnUniquenessHandler = provider.handler(BuiltInMetadata.ColumnUniqueness.Handler.class);
-    this.cumulativeCostHandler = provider.handler(BuiltInMetadata.CumulativeCost.Handler.class);
-    this.distinctRowCountHandler = provider.handler(BuiltInMetadata.DistinctRowCount.Handler.class);
-    this.distributionHandler = provider.handler(BuiltInMetadata.Distribution.Handler.class);
+        provider.handler(BuiltInMetadata.ExpressionLineageHandler.class);
+    this.tableReferencesHandler = provider.handler(BuiltInMetadata.TableReferencesHandler.class);
+    this.columnUniquenessHandler = provider.handler(BuiltInMetadata.ColumnUniquenessHandler.class);
+    this.cumulativeCostHandler = provider.handler(BuiltInMetadata.CumulativeCostHandler.class);
+    this.distinctRowCountHandler = provider.handler(BuiltInMetadata.DistinctRowCountHandler.class);
+    this.distributionHandler = provider.handler(BuiltInMetadata.DistributionHandler.class);
     this.explainVisibilityHandler =
-        provider.handler(BuiltInMetadata.ExplainVisibility.Handler.class);
-    this.maxRowCountHandler = provider.handler(BuiltInMetadata.MaxRowCount.Handler.class);
-    this.minRowCountHandler = provider.handler(BuiltInMetadata.MinRowCount.Handler.class);
-    this.memoryHandler = provider.handler(BuiltInMetadata.Memory.Handler.class);
+        provider.handler(BuiltInMetadata.ExplainVisibilityHandler.class);
+    this.maxRowCountHandler = provider.handler(BuiltInMetadata.MaxRowCountHandler.class);
+    this.minRowCountHandler = provider.handler(BuiltInMetadata.MinRowCountHandler.class);
+    this.memoryHandler = provider.handler(BuiltInMetadata.MemoryHandler.class);
     this.nonCumulativeCostHandler =
-        provider.handler(BuiltInMetadata.NonCumulativeCost.Handler.class);
-    this.parallelismHandler = provider.handler(BuiltInMetadata.Parallelism.Handler.class);
+        provider.handler(BuiltInMetadata.NonCumulativeCostHandler.class);
+    this.parallelismHandler = provider.handler(BuiltInMetadata.ParallelismHandler.class);
     this.percentageOriginalRowsHandler =
-        provider.handler(BuiltInMetadata.PercentageOriginalRows.Handler.class);
-    this.populationSizeHandler = provider.handler(BuiltInMetadata.PopulationSize.Handler.class);
-    this.predicatesHandler = provider.handler(BuiltInMetadata.Predicates.Handler.class);
-    this.allPredicatesHandler = provider.handler(BuiltInMetadata.AllPredicates.Handler.class);
-    this.nodeTypesHandler = provider.handler(BuiltInMetadata.NodeTypes.Handler.class);
-    this.rowCountHandler = provider.handler(BuiltInMetadata.RowCount.Handler.class);
-    this.selectivityHandler = provider.handler(BuiltInMetadata.Selectivity.Handler.class);
-    this.sizeHandler = provider.handler(BuiltInMetadata.Size.Handler.class);
-    this.uniqueKeysHandler = provider.handler(BuiltInMetadata.UniqueKeys.Handler.class);
-    this.lowerBoundCostHandler = provider.handler(BuiltInMetadata.LowerBoundCost.Handler.class);
+        provider.handler(BuiltInMetadata.PercentageOriginalRowsHandler.class);
+    this.populationSizeHandler = provider.handler(BuiltInMetadata.PopulationSizeHandler.class);
+    this.predicatesHandler = provider.handler(BuiltInMetadata.PredicatesHandler.class);
+    this.allPredicatesHandler = provider.handler(BuiltInMetadata.AllPredicatesHandler.class);
+    this.nodeTypesHandler = provider.handler(BuiltInMetadata.NodeTypesHandler.class);
+    this.rowCountHandler = provider.handler(BuiltInMetadata.RowCountHandler.class);
+    this.selectivityHandler = provider.handler(BuiltInMetadata.SelectivityHandler.class);
+    this.sizeHandler = provider.handler(BuiltInMetadata.SizeHandler.class);
+    this.uniqueKeysHandler = provider.handler(BuiltInMetadata.UniqueKeysHandler.class);
+    this.lowerBoundCostHandler = provider.handler(BuiltInMetadata.LowerBoundCostHandler.class);
   }
 
   /** Creates and initializes the instance that will serve as a prototype for
@@ -157,31 +157,31 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
   @SuppressWarnings("deprecation")
   private RelMetadataQuery(@SuppressWarnings("unused") boolean dummy) {
     super(null);
-    this.collationHandler = initialHandler(BuiltInMetadata.Collation.Handler.class);
-    this.columnOriginHandler = initialHandler(BuiltInMetadata.ColumnOrigin.Handler.class);
-    this.expressionLineageHandler = initialHandler(BuiltInMetadata.ExpressionLineage.Handler.class);
-    this.tableReferencesHandler = initialHandler(BuiltInMetadata.TableReferences.Handler.class);
-    this.columnUniquenessHandler = initialHandler(BuiltInMetadata.ColumnUniqueness.Handler.class);
-    this.cumulativeCostHandler = initialHandler(BuiltInMetadata.CumulativeCost.Handler.class);
-    this.distinctRowCountHandler = initialHandler(BuiltInMetadata.DistinctRowCount.Handler.class);
-    this.distributionHandler = initialHandler(BuiltInMetadata.Distribution.Handler.class);
-    this.explainVisibilityHandler = initialHandler(BuiltInMetadata.ExplainVisibility.Handler.class);
-    this.maxRowCountHandler = initialHandler(BuiltInMetadata.MaxRowCount.Handler.class);
-    this.minRowCountHandler = initialHandler(BuiltInMetadata.MinRowCount.Handler.class);
-    this.memoryHandler = initialHandler(BuiltInMetadata.Memory.Handler.class);
-    this.nonCumulativeCostHandler = initialHandler(BuiltInMetadata.NonCumulativeCost.Handler.class);
-    this.parallelismHandler = initialHandler(BuiltInMetadata.Parallelism.Handler.class);
+    this.collationHandler = initialHandler(BuiltInMetadata.CollationHandler.class);
+    this.columnOriginHandler = initialHandler(BuiltInMetadata.ColumnOriginHandler.class);
+    this.expressionLineageHandler = initialHandler(BuiltInMetadata.ExpressionLineageHandler.class);
+    this.tableReferencesHandler = initialHandler(BuiltInMetadata.TableReferencesHandler.class);
+    this.columnUniquenessHandler = initialHandler(BuiltInMetadata.ColumnUniquenessHandler.class);
+    this.cumulativeCostHandler = initialHandler(BuiltInMetadata.CumulativeCostHandler.class);
+    this.distinctRowCountHandler = initialHandler(BuiltInMetadata.DistinctRowCountHandler.class);
+    this.distributionHandler = initialHandler(BuiltInMetadata.DistributionHandler.class);
+    this.explainVisibilityHandler = initialHandler(BuiltInMetadata.ExplainVisibilityHandler.class);
+    this.maxRowCountHandler = initialHandler(BuiltInMetadata.MaxRowCountHandler.class);
+    this.minRowCountHandler = initialHandler(BuiltInMetadata.MinRowCountHandler.class);
+    this.memoryHandler = initialHandler(BuiltInMetadata.MemoryHandler.class);
+    this.nonCumulativeCostHandler = initialHandler(BuiltInMetadata.NonCumulativeCostHandler.class);
+    this.parallelismHandler = initialHandler(BuiltInMetadata.ParallelismHandler.class);
     this.percentageOriginalRowsHandler =
-        initialHandler(BuiltInMetadata.PercentageOriginalRows.Handler.class);
-    this.populationSizeHandler = initialHandler(BuiltInMetadata.PopulationSize.Handler.class);
-    this.predicatesHandler = initialHandler(BuiltInMetadata.Predicates.Handler.class);
-    this.allPredicatesHandler = initialHandler(BuiltInMetadata.AllPredicates.Handler.class);
-    this.nodeTypesHandler = initialHandler(BuiltInMetadata.NodeTypes.Handler.class);
-    this.rowCountHandler = initialHandler(BuiltInMetadata.RowCount.Handler.class);
-    this.selectivityHandler = initialHandler(BuiltInMetadata.Selectivity.Handler.class);
-    this.sizeHandler = initialHandler(BuiltInMetadata.Size.Handler.class);
-    this.uniqueKeysHandler = initialHandler(BuiltInMetadata.UniqueKeys.Handler.class);
-    this.lowerBoundCostHandler = initialHandler(BuiltInMetadata.LowerBoundCost.Handler.class);
+        initialHandler(BuiltInMetadata.PercentageOriginalRowsHandler.class);
+    this.populationSizeHandler = initialHandler(BuiltInMetadata.PopulationSizeHandler.class);
+    this.predicatesHandler = initialHandler(BuiltInMetadata.PredicatesHandler.class);
+    this.allPredicatesHandler = initialHandler(BuiltInMetadata.AllPredicatesHandler.class);
+    this.nodeTypesHandler = initialHandler(BuiltInMetadata.NodeTypesHandler.class);
+    this.rowCountHandler = initialHandler(BuiltInMetadata.RowCountHandler.class);
+    this.selectivityHandler = initialHandler(BuiltInMetadata.SelectivityHandler.class);
+    this.sizeHandler = initialHandler(BuiltInMetadata.SizeHandler.class);
+    this.uniqueKeysHandler = initialHandler(BuiltInMetadata.UniqueKeysHandler.class);
+    this.lowerBoundCostHandler = initialHandler(BuiltInMetadata.LowerBoundCostHandler.class);
   }
 
   private RelMetadataQuery(
@@ -236,7 +236,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return nodeTypesHandler.getNodeTypes(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        nodeTypesHandler = revise(BuiltInMetadata.NodeTypes.Handler.class);
+        nodeTypesHandler = revise(BuiltInMetadata.NodeTypesHandler.class);
       } catch (CyclicMetadataException e) {
         return null;
       }
@@ -258,7 +258,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         Double result = rowCountHandler.getRowCount(rel, this);
         return RelMdUtil.validateResult(castNonNull(result));
       } catch (MetadataHandlerProvider.NoHandler e) {
-        rowCountHandler = revise(BuiltInMetadata.RowCount.Handler.class);
+        rowCountHandler = revise(BuiltInMetadata.RowCountHandler.class);
       }
     }
   }
@@ -276,7 +276,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return maxRowCountHandler.getMaxRowCount(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        maxRowCountHandler = revise(BuiltInMetadata.MaxRowCount.Handler.class);
+        maxRowCountHandler = revise(BuiltInMetadata.MaxRowCountHandler.class);
       }
     }
   }
@@ -294,7 +294,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return minRowCountHandler.getMinRowCount(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        minRowCountHandler = revise(BuiltInMetadata.MinRowCount.Handler.class);
+        minRowCountHandler = revise(BuiltInMetadata.MinRowCountHandler.class);
       }
     }
   }
@@ -312,7 +312,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return cumulativeCostHandler.getCumulativeCost(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        cumulativeCostHandler = revise(BuiltInMetadata.CumulativeCost.Handler.class);
+        cumulativeCostHandler = revise(BuiltInMetadata.CumulativeCostHandler.class);
       }
     }
   }
@@ -330,7 +330,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return nonCumulativeCostHandler.getNonCumulativeCost(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        nonCumulativeCostHandler = revise(BuiltInMetadata.NonCumulativeCost.Handler.class);
+        nonCumulativeCostHandler = revise(BuiltInMetadata.NonCumulativeCostHandler.class);
       }
     }
   }
@@ -352,7 +352,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         return RelMdUtil.validatePercentage(result);
       } catch (MetadataHandlerProvider.NoHandler e) {
         percentageOriginalRowsHandler =
-            revise(BuiltInMetadata.PercentageOriginalRows.Handler.class);
+            revise(BuiltInMetadata.PercentageOriginalRowsHandler.class);
       }
     }
   }
@@ -373,7 +373,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return columnOriginHandler.getColumnOrigins(rel, this, column);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        columnOriginHandler = revise(BuiltInMetadata.ColumnOrigin.Handler.class);
+        columnOriginHandler = revise(BuiltInMetadata.ColumnOriginHandler.class);
       }
     }
   }
@@ -406,7 +406,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return expressionLineageHandler.getExpressionLineage(rel, this, expression);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        expressionLineageHandler = revise(BuiltInMetadata.ExpressionLineage.Handler.class);
+        expressionLineageHandler = revise(BuiltInMetadata.ExpressionLineageHandler.class);
       }
     }
   }
@@ -419,7 +419,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return tableReferencesHandler.getTableReferences(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        tableReferencesHandler = revise(BuiltInMetadata.TableReferences.Handler.class);
+        tableReferencesHandler = revise(BuiltInMetadata.TableReferencesHandler.class);
       }
     }
   }
@@ -463,7 +463,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         Double result = selectivityHandler.getSelectivity(rel, this, predicate);
         return RelMdUtil.validatePercentage(result);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        selectivityHandler = revise(BuiltInMetadata.Selectivity.Handler.class);
+        selectivityHandler = revise(BuiltInMetadata.SelectivityHandler.class);
       }
     }
   }
@@ -499,7 +499,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return uniqueKeysHandler.getUniqueKeys(rel, this, ignoreNulls);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        uniqueKeysHandler = revise(BuiltInMetadata.UniqueKeys.Handler.class);
+        uniqueKeysHandler = revise(BuiltInMetadata.UniqueKeysHandler.class);
       }
     }
   }
@@ -582,7 +582,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         return columnUniquenessHandler.areColumnsUnique(rel, this, columns,
             ignoreNulls);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        columnUniquenessHandler = revise(BuiltInMetadata.ColumnUniqueness.Handler.class);
+        columnUniquenessHandler = revise(BuiltInMetadata.ColumnUniquenessHandler.class);
       }
     }
   }
@@ -601,7 +601,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return collationHandler.collations(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        collationHandler = revise(BuiltInMetadata.Collation.Handler.class);
+        collationHandler = revise(BuiltInMetadata.CollationHandler.class);
       }
     }
   }
@@ -625,7 +625,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         }
         return distribution;
       } catch (MetadataHandlerProvider.NoHandler e) {
-        distributionHandler = revise(BuiltInMetadata.Distribution.Handler.class);
+        distributionHandler = revise(BuiltInMetadata.DistributionHandler.class);
       }
     }
   }
@@ -650,7 +650,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
             populationSizeHandler.getPopulationSize(rel, this, groupKey);
         return RelMdUtil.validateResult(result);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        populationSizeHandler = revise(BuiltInMetadata.PopulationSize.Handler.class);
+        populationSizeHandler = revise(BuiltInMetadata.PopulationSizeHandler.class);
       }
     }
   }
@@ -668,7 +668,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return sizeHandler.averageRowSize(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        sizeHandler = revise(BuiltInMetadata.Size.Handler.class);
+        sizeHandler = revise(BuiltInMetadata.SizeHandler.class);
       }
     }
   }
@@ -688,7 +688,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return sizeHandler.averageColumnSizes(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        sizeHandler = revise(BuiltInMetadata.Size.Handler.class);
+        sizeHandler = revise(BuiltInMetadata.SizeHandler.class);
       }
     }
   }
@@ -717,7 +717,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return parallelismHandler.isPhaseTransition(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        parallelismHandler = revise(BuiltInMetadata.Parallelism.Handler.class);
+        parallelismHandler = revise(BuiltInMetadata.ParallelismHandler.class);
       }
     }
   }
@@ -735,7 +735,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return parallelismHandler.splitCount(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        parallelismHandler = revise(BuiltInMetadata.Parallelism.Handler.class);
+        parallelismHandler = revise(BuiltInMetadata.ParallelismHandler.class);
       }
     }
   }
@@ -755,7 +755,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return memoryHandler.memory(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        memoryHandler = revise(BuiltInMetadata.Memory.Handler.class);
+        memoryHandler = revise(BuiltInMetadata.MemoryHandler.class);
       }
     }
   }
@@ -775,7 +775,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return memoryHandler.cumulativeMemoryWithinPhase(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        memoryHandler = revise(BuiltInMetadata.Memory.Handler.class);
+        memoryHandler = revise(BuiltInMetadata.MemoryHandler.class);
       }
     }
   }
@@ -795,7 +795,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return memoryHandler.cumulativeMemoryWithinPhaseSplit(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        memoryHandler = revise(BuiltInMetadata.Memory.Handler.class);
+        memoryHandler = revise(BuiltInMetadata.MemoryHandler.class);
       }
     }
   }
@@ -822,7 +822,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
                 predicate);
         return RelMdUtil.validateResult(result);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        distinctRowCountHandler = revise(BuiltInMetadata.DistinctRowCount.Handler.class);
+        distinctRowCountHandler = revise(BuiltInMetadata.DistinctRowCountHandler.class);
       }
     }
   }
@@ -841,7 +841,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         RelOptPredicateList result = predicatesHandler.getPredicates(rel, this);
         return result != null ? result : RelOptPredicateList.EMPTY;
       } catch (MetadataHandlerProvider.NoHandler e) {
-        predicatesHandler = revise(BuiltInMetadata.Predicates.Handler.class);
+        predicatesHandler = revise(BuiltInMetadata.PredicatesHandler.class);
       }
     }
   }
@@ -859,7 +859,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return allPredicatesHandler.getAllPredicates(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        allPredicatesHandler = revise(BuiltInMetadata.AllPredicates.Handler.class);
+        allPredicatesHandler = revise(BuiltInMetadata.AllPredicatesHandler.class);
       }
     }
   }
@@ -882,7 +882,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
             explainLevel);
         return b == null || b;
       } catch (MetadataHandlerProvider.NoHandler e) {
-        explainVisibilityHandler = revise(BuiltInMetadata.ExplainVisibility.Handler.class);
+        explainVisibilityHandler = revise(BuiltInMetadata.ExplainVisibilityHandler.class);
       }
     }
   }
@@ -902,7 +902,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return distributionHandler.distribution(rel, this);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        distributionHandler = revise(BuiltInMetadata.Distribution.Handler.class);
+        distributionHandler = revise(BuiltInMetadata.DistributionHandler.class);
       }
     }
   }
@@ -915,7 +915,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       try {
         return lowerBoundCostHandler.getLowerBoundCost(rel, this, planner);
       } catch (MetadataHandlerProvider.NoHandler e) {
-        lowerBoundCostHandler = revise(BuiltInMetadata.LowerBoundCost.Handler.class);
+        lowerBoundCostHandler = revise(BuiltInMetadata.LowerBoundCostHandler.class);
       }
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQueryBase.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQueryBase.java
@@ -107,14 +107,14 @@ public class RelMetadataQueryBase {
   /** Re-generates the handler for a given kind of metadata, adding support for
    * {@code class_} if it is not already present. */
   @Deprecated // to be removed before 2.0
-  protected <M extends Metadata, H extends MetadataHandler<M>> H
+  protected <M extends Metadata, H extends MetadataHandler> H
       revise(Class<? extends RelNode> class_, MetadataDef<M> def) {
     return (H) revise(def.handlerClass);
   }
 
   /** Re-generates the handler for a given kind of metadata, adding support for
    * {@code class_} if it is not already present. */
-  protected <H extends MetadataHandler<?>> H revise(Class<H> def) {
+  protected <H extends MetadataHandler> H revise(Class<H> def) {
     return getMetadataHandlerProvider().revise(def);
   }
 
@@ -129,7 +129,7 @@ public class RelMetadataQueryBase {
    * @param <MH> The metadata type the handler relates to.
    * @return The handler implementation.
    */
-  protected <MH extends MetadataHandler<?>> MH handler(Class<MH> handlerClass) {
+  protected <MH extends MetadataHandler> MH handler(Class<MH> handlerClass) {
     return getMetadataHandlerProvider().handler(handlerClass);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/UnboundMetadata.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/UnboundMetadata.java
@@ -28,5 +28,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 @FunctionalInterface
 public interface UnboundMetadata<M extends @Nullable Metadata> {
+  @Deprecated // to be removed before 2.0
   M bind(RelNode rel, RelMetadataQuery mq);
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/DispatchGenerator.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/DispatchGenerator.java
@@ -44,15 +44,15 @@ import static org.apache.calcite.rel.metadata.janino.CodeGeneratorUtil.paramList
  * Generates the metadata dispatch to handlers.
  */
 class DispatchGenerator {
-  private final Map<MetadataHandler<?>, String> metadataHandlerToName;
+  private final Map<MetadataHandler, String> metadataHandlerToName;
 
-  DispatchGenerator(Map<MetadataHandler<?>, String> metadataHandlerToName) {
+  DispatchGenerator(Map<MetadataHandler, String> metadataHandlerToName) {
     this.metadataHandlerToName = metadataHandlerToName;
   }
 
   void dispatchMethod(StringBuilder buff, Method method,
-      Collection<? extends MetadataHandler<?>> metadataHandlers) {
-    Map<MetadataHandler<?>, Set<Class<? extends RelNode>>> handlersToClasses =
+      Collection<? extends MetadataHandler> metadataHandlers) {
+    Map<MetadataHandler, Set<Class<? extends RelNode>>> handlersToClasses =
         metadataHandlers.stream()
             .distinct()
             .collect(
@@ -98,8 +98,8 @@ class DispatchGenerator {
   }
 
   private StringBuilder ifInstanceThenDispatch(Method method,
-      Collection<? extends MetadataHandler<?>> metadataHandlers,
-      Map<MetadataHandler<?>, Set<Class<? extends RelNode>>> handlersToClasses,
+      Collection<? extends MetadataHandler> metadataHandlers,
+      Map<MetadataHandler, Set<Class<? extends RelNode>>> handlersToClasses,
       Class<? extends RelNode> clazz) {
     String handlerName = findProvider(metadataHandlers, handlersToClasses, clazz);
     StringBuilder buff = new StringBuilder()
@@ -110,10 +110,10 @@ class DispatchGenerator {
     return buff;
   }
 
-  private String findProvider(Collection<? extends MetadataHandler<?>> metadataHandlers,
-      Map<MetadataHandler<?>, Set<Class<? extends RelNode>>> handlerToClasses,
+  private String findProvider(Collection<? extends MetadataHandler> metadataHandlers,
+      Map<MetadataHandler, Set<Class<? extends RelNode>>> handlerToClasses,
       Class<? extends RelNode> clazz) {
-    for (MetadataHandler<?> mh : metadataHandlers) {
+    for (MetadataHandler mh : metadataHandlers) {
       if (handlerToClasses.getOrDefault(mh, ImmutableSet.of()).contains(clazz)) {
         return castNonNull(this.metadataHandlerToName.get(mh));
       }
@@ -140,7 +140,7 @@ class DispatchGenerator {
   }
 
   private static Set<Class<? extends RelNode>> methodAndInstanceToImplementingClass(
-      Method method, MetadataHandler<?> handler) {
+      Method method, MetadataHandler handler) {
     Set<Class<? extends RelNode>> set = new HashSet<>();
     for (Method m : handler.getClass().getMethods()) {
       Class<? extends RelNode> aClass = toRelClass(method, m);

--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/RelMetadataHandlerGeneratorUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/RelMetadataHandlerGeneratorUtil.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.rel.metadata.janino;
 
-import org.apache.calcite.rel.metadata.MetadataDef;
 import org.apache.calcite.rel.metadata.MetadataHandler;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -56,8 +55,8 @@ public class RelMetadataHandlerGeneratorUtil {
   }
 
   public static HandlerNameAndGeneratedCode generateHandler(
-      Class<? extends MetadataHandler<?>> handlerClass,
-      List<? extends MetadataHandler<?>> handlers) {
+      Class<? extends MetadataHandler> handlerClass,
+      List<? extends MetadataHandler> handlers) {
     final String classPackage = castNonNull(RelMetadataHandlerGeneratorUtil.class.getPackage())
         .getName();
     final String name =
@@ -66,8 +65,8 @@ public class RelMetadataHandlerGeneratorUtil {
         .filter(m -> !m.getName().equals("getDef")).toArray(i -> new Method[i]);
     Arrays.sort(declaredMethods, Comparator.comparing(Method::getName));
 
-    final Map<MetadataHandler<?>, String> handlerToName = new LinkedHashMap<>();
-    for (MetadataHandler<?> provider : handlers) {
+    final Map<MetadataHandler, String> handlerToName = new LinkedHashMap<>();
+    for (MetadataHandler provider : handlers) {
       handlerToName.put(provider,
           "provider" + handlerToName.size());
     }
@@ -85,14 +84,14 @@ public class RelMetadataHandlerGeneratorUtil {
     for (int i = 0; i < declaredMethods.length; i++) {
       CacheGeneratorUtil.cacheProperties(buff, declaredMethods[i], i);
     }
-    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
+    for (Map.Entry<MetadataHandler, String> handlerAndName : handlerToName.entrySet()) {
       buff.append("  public final ").append(handlerAndName.getKey().getClass().getName())
           .append(' ').append(handlerAndName.getValue()).append(";\n");
     }
 
     //CONSTRUCTOR
     buff.append("  public ").append(name).append("(\n");
-    for (Map.Entry<MetadataHandler<?>, String> handlerAndName : handlerToName.entrySet()) {
+    for (Map.Entry<MetadataHandler, String> handlerAndName : handlerToName.entrySet()) {
       buff.append("      ")
           .append(handlerAndName.getKey().getClass().getName())
           .append(' ')
@@ -129,9 +128,10 @@ public class RelMetadataHandlerGeneratorUtil {
         .build();
   }
 
+  @SuppressWarnings("deprecation")
   private static void getDefMethod(StringBuilder buff, @Nullable String handlerName) {
     buff.append("  public ")
-        .append(MetadataDef.class.getName())
+        .append(org.apache.calcite.rel.metadata.MetadataDef.class.getName())
         .append(" getDef() {\n");
 
     if (handlerName == null) {
@@ -144,7 +144,7 @@ public class RelMetadataHandlerGeneratorUtil {
     buff.append("  }\n");
   }
 
-  private static String simpleNameForHandler(Class<? extends MetadataHandler<?>> clazz) {
+  private static String simpleNameForHandler(Class<? extends MetadataHandler> clazz) {
     String simpleName = clazz.getSimpleName();
     //Previously the pattern was to have a nested in class named Handler
     //So we need to add the parents class to get a unique name

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -53,31 +53,7 @@ import org.apache.calcite.linq4j.tree.FunctionExpression;
 import org.apache.calcite.linq4j.tree.Primitive;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.AllPredicates;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.Collation;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.ColumnOrigin;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.ColumnUniqueness;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.CumulativeCost;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.DistinctRowCount;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.Distribution;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.ExplainVisibility;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.ExpressionLineage;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCost;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.MaxRowCount;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.Memory;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.MinRowCount;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.NodeTypes;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.NonCumulativeCost;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.Parallelism;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.PercentageOriginalRows;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.PopulationSize;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.Predicates;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.RowCount;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.Selectivity;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.Size;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.TableReferences;
-import org.apache.calcite.rel.metadata.BuiltInMetadata.UniqueKeys;
-import org.apache.calcite.rel.metadata.Metadata;
+import org.apache.calcite.rel.metadata.BuiltInMetadata;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.ArrayBindable;
 import org.apache.calcite.runtime.Automaton;
@@ -570,40 +546,42 @@ public enum BuiltInMethod {
   SUBMULTISET_OF(SqlFunctions.class, "submultisetOf", Collection.class,
       Collection.class),
   ARRAY_REVERSE(SqlFunctions.class, "reverse", List.class),
-  SELECTIVITY(Selectivity.class, "getSelectivity", RexNode.class),
-  UNIQUE_KEYS(UniqueKeys.class, "getUniqueKeys", boolean.class),
-  AVERAGE_ROW_SIZE(Size.class, "averageRowSize"),
-  AVERAGE_COLUMN_SIZES(Size.class, "averageColumnSizes"),
-  IS_PHASE_TRANSITION(Parallelism.class, "isPhaseTransition"),
-  SPLIT_COUNT(Parallelism.class, "splitCount"),
-  LOWER_BOUND_COST(LowerBoundCost.class, "getLowerBoundCost",
+  @Deprecated SELECTIVITY(BuiltInMetadata.Selectivity.class, "getSelectivity", RexNode.class),
+  @Deprecated UNIQUE_KEYS(BuiltInMetadata.UniqueKeys.class, "getUniqueKeys", boolean.class),
+  @Deprecated AVERAGE_ROW_SIZE(BuiltInMetadata.Size.class, "averageRowSize"),
+  @Deprecated AVERAGE_COLUMN_SIZES(BuiltInMetadata.Size.class, "averageColumnSizes"),
+  @Deprecated IS_PHASE_TRANSITION(BuiltInMetadata.Parallelism.class, "isPhaseTransition"),
+  @Deprecated SPLIT_COUNT(BuiltInMetadata.Parallelism.class, "splitCount"),
+  @Deprecated LOWER_BOUND_COST(BuiltInMetadata.LowerBoundCost.class, "getLowerBoundCost",
       VolcanoPlanner.class),
-  MEMORY(Memory.class, "memory"),
-  CUMULATIVE_MEMORY_WITHIN_PHASE(Memory.class, "cumulativeMemoryWithinPhase"),
-  CUMULATIVE_MEMORY_WITHIN_PHASE_SPLIT(Memory.class,
+  @Deprecated MEMORY(BuiltInMetadata.Memory.class, "memory"),
+  @Deprecated CUMULATIVE_MEMORY_WITHIN_PHASE(BuiltInMetadata.Memory.class,
+      "cumulativeMemoryWithinPhase"),
+  @Deprecated CUMULATIVE_MEMORY_WITHIN_PHASE_SPLIT(BuiltInMetadata.Memory.class,
       "cumulativeMemoryWithinPhaseSplit"),
-  COLUMN_UNIQUENESS(ColumnUniqueness.class, "areColumnsUnique",
+  @Deprecated COLUMN_UNIQUENESS(BuiltInMetadata.ColumnUniqueness.class, "areColumnsUnique",
       ImmutableBitSet.class, boolean.class),
-  COLLATIONS(Collation.class, "collations"),
-  DISTRIBUTION(Distribution.class, "distribution"),
-  NODE_TYPES(NodeTypes.class, "getNodeTypes"),
-  ROW_COUNT(RowCount.class, "getRowCount"),
-  MAX_ROW_COUNT(MaxRowCount.class, "getMaxRowCount"),
-  MIN_ROW_COUNT(MinRowCount.class, "getMinRowCount"),
-  DISTINCT_ROW_COUNT(DistinctRowCount.class, "getDistinctRowCount",
+  @Deprecated COLLATIONS(BuiltInMetadata.Collation.class, "collations"),
+  @Deprecated DISTRIBUTION(BuiltInMetadata.Distribution.class, "distribution"),
+  @Deprecated NODE_TYPES(BuiltInMetadata.NodeTypes.class, "getNodeTypes"),
+  @Deprecated ROW_COUNT(BuiltInMetadata.RowCount.class, "getRowCount"),
+  @Deprecated MAX_ROW_COUNT(BuiltInMetadata.MaxRowCount.class, "getMaxRowCount"),
+  @Deprecated MIN_ROW_COUNT(BuiltInMetadata.MinRowCount.class, "getMinRowCount"),
+  @Deprecated DISTINCT_ROW_COUNT(BuiltInMetadata.DistinctRowCount.class, "getDistinctRowCount",
       ImmutableBitSet.class, RexNode.class),
-  PERCENTAGE_ORIGINAL_ROWS(PercentageOriginalRows.class,
+  @Deprecated PERCENTAGE_ORIGINAL_ROWS(BuiltInMetadata.PercentageOriginalRows.class,
       "getPercentageOriginalRows"),
-  POPULATION_SIZE(PopulationSize.class, "getPopulationSize",
+  @Deprecated POPULATION_SIZE(BuiltInMetadata.PopulationSize.class, "getPopulationSize",
       ImmutableBitSet.class),
-  COLUMN_ORIGIN(ColumnOrigin.class, "getColumnOrigins", int.class),
-  EXPRESSION_LINEAGE(ExpressionLineage.class, "getExpressionLineage", RexNode.class),
-  TABLE_REFERENCES(TableReferences.class, "getTableReferences"),
-  CUMULATIVE_COST(CumulativeCost.class, "getCumulativeCost"),
-  NON_CUMULATIVE_COST(NonCumulativeCost.class, "getNonCumulativeCost"),
-  PREDICATES(Predicates.class, "getPredicates"),
-  ALL_PREDICATES(AllPredicates.class, "getAllPredicates"),
-  EXPLAIN_VISIBILITY(ExplainVisibility.class, "isVisibleInExplain",
+  @Deprecated COLUMN_ORIGIN(BuiltInMetadata.ColumnOrigin.class, "getColumnOrigins", int.class),
+  @Deprecated EXPRESSION_LINEAGE(BuiltInMetadata.ExpressionLineage.class,
+      "getExpressionLineage", RexNode.class),
+  @Deprecated TABLE_REFERENCES(BuiltInMetadata.TableReferences.class, "getTableReferences"),
+  @Deprecated CUMULATIVE_COST(BuiltInMetadata.CumulativeCost.class, "getCumulativeCost"),
+  @Deprecated NON_CUMULATIVE_COST(BuiltInMetadata.NonCumulativeCost.class, "getNonCumulativeCost"),
+  @Deprecated PREDICATES(BuiltInMetadata.Predicates.class, "getPredicates"),
+  @Deprecated ALL_PREDICATES(BuiltInMetadata.AllPredicates.class, "getAllPredicates"),
+  @Deprecated EXPLAIN_VISIBILITY(BuiltInMetadata.ExplainVisibility.class, "isVisibleInExplain",
       SqlExplainLevel.class),
   SCALAR_EXECUTE1(Scalar.class, "execute", Context.class),
   SCALAR_EXECUTE2(Scalar.class, "execute", Context.class, Object[].class),
@@ -612,7 +590,7 @@ public enum BuiltInMethod {
   FUNCTION_CONTEXTS_OF(FunctionContexts.class, "of", DataContext.class,
       Object[].class),
   DATA_CONTEXT_GET_QUERY_PROVIDER(DataContext.class, "getQueryProvider"),
-  METADATA_REL(Metadata.class, "rel"),
+  @Deprecated METADATA_REL(org.apache.calcite.rel.metadata.Metadata.class, "rel"),
   STRUCT_ACCESS(SqlFunctions.class, "structAccess", Object.class, int.class,
       String.class),
   SOURCE_SORTER(SourceSorter.class, Function2.class, Function1.class,

--- a/core/src/test/java/org/apache/calcite/rel/metadata/janino/RelMetadataHandlerGeneratorUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/metadata/janino/RelMetadataHandlerGeneratorUtilTest.java
@@ -43,105 +43,105 @@ class RelMetadataHandlerGeneratorUtilTest {
   private static final Path RESULT_DIR = Paths.get("build/metadata");
 
   @Test void testAllPredicatesGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.AllPredicates.Handler.class);
+    testGenerateHandler(BuiltInMetadata.AllPredicatesHandler.class);
   }
 
   @Test void testCollationGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.Collation.Handler.class);
+    testGenerateHandler(BuiltInMetadata.CollationHandler.class);
   }
 
   @Test void testColumnOriginGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.ColumnOrigin.Handler.class);
+    testGenerateHandler(BuiltInMetadata.ColumnOriginHandler.class);
   }
 
   @Test void testColumnUniquenessGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.ColumnUniqueness.Handler.class);
+    testGenerateHandler(BuiltInMetadata.ColumnUniquenessHandler.class);
   }
 
   @Test void testCumulativeCostGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.CumulativeCost.Handler.class);
+    testGenerateHandler(BuiltInMetadata.CumulativeCostHandler.class);
   }
 
   @Test void testDistinctRowCountGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.DistinctRowCount.Handler.class);
+    testGenerateHandler(BuiltInMetadata.DistinctRowCountHandler.class);
   }
 
   @Test void testDistributionGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.Distribution.Handler.class);
+    testGenerateHandler(BuiltInMetadata.DistributionHandler.class);
   }
 
   @Test void testExplainVisibilityGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.ExplainVisibility.Handler.class);
+    testGenerateHandler(BuiltInMetadata.ExplainVisibilityHandler.class);
   }
 
   @Test void testExpressionLineageGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.ExpressionLineage.Handler.class);
+    testGenerateHandler(BuiltInMetadata.ExpressionLineageHandler.class);
   }
 
   @Test void testLowerBoundCostGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.LowerBoundCost.Handler.class);
+    testGenerateHandler(BuiltInMetadata.LowerBoundCostHandler.class);
   }
 
   @Test void testMaxRowCountGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.MaxRowCount.Handler.class);
+    testGenerateHandler(BuiltInMetadata.MaxRowCountHandler.class);
   }
 
   @Test void testMemoryGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.Memory.Handler.class);
+    testGenerateHandler(BuiltInMetadata.MemoryHandler.class);
   }
 
   @Test void testMinRowCountGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.MinRowCount.Handler.class);
+    testGenerateHandler(BuiltInMetadata.MinRowCountHandler.class);
   }
 
   @Test void testNodeTypesGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.NodeTypes.Handler.class);
+    testGenerateHandler(BuiltInMetadata.NodeTypesHandler.class);
   }
 
   @Test void testNonCumulativeCostGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.NonCumulativeCost.Handler.class);
+    testGenerateHandler(BuiltInMetadata.NonCumulativeCostHandler.class);
   }
 
   @Test void testParallelismGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.Parallelism.Handler.class);
+    testGenerateHandler(BuiltInMetadata.ParallelismHandler.class);
   }
 
   @Test void testPercentageOriginalRowsGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.PercentageOriginalRows.Handler.class);
+    testGenerateHandler(BuiltInMetadata.PercentageOriginalRowsHandler.class);
   }
 
   @Test void testPopulationSizeGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.PopulationSize.Handler.class);
+    testGenerateHandler(BuiltInMetadata.PopulationSizeHandler.class);
   }
 
   @Test void testPredicatesGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.Predicates.Handler.class);
+    testGenerateHandler(BuiltInMetadata.PredicatesHandler.class);
   }
 
   @Test void testRowCountGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.RowCount.Handler.class);
+    testGenerateHandler(BuiltInMetadata.RowCountHandler.class);
   }
 
   @Test void testSelectivityGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.Selectivity.Handler.class);
+    testGenerateHandler(BuiltInMetadata.SelectivityHandler.class);
   }
 
   @Test void testSizeGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.Size.Handler.class);
+    testGenerateHandler(BuiltInMetadata.SizeHandler.class);
   }
 
   @Test void testTableReferencesGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.TableReferences.Handler.class);
+    testGenerateHandler(BuiltInMetadata.TableReferencesHandler.class);
   }
 
   @Test void testUniqueKeysGenerateHandler() {
-    testGenerateHandler(BuiltInMetadata.UniqueKeys.Handler.class);
+    testGenerateHandler(BuiltInMetadata.UniqueKeysHandler.class);
   }
 
   /**
    * Performance a regression test on the generated code for a given handler.
    */
-  private void testGenerateHandler(Class<? extends MetadataHandler<?>> handlerClass) {
+  private void testGenerateHandler(Class<? extends MetadataHandler> handlerClass) {
     RelMetadataHandlerGeneratorUtil.HandlerNameAndGeneratedCode nameAndGeneratedCode =
         RelMetadataHandlerGeneratorUtil.generateHandler(handlerClass,
             DefaultRelMetadataProvider.INSTANCE.handlers(handlerClass));

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_AllPredicatesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_AllPredicatesHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_AllPredicatesHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.AllPredicates.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.AllPredicatesHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptPredicateList Handler.getAllPredicates()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptPredicateList AllPredicatesHandler.getAllPredicates()");
   public final org.apache.calcite.rel.metadata.RelMdAllPredicates provider0;
   public GeneratedMetadata_AllPredicatesHandler(
       org.apache.calcite.rel.metadata.RelMdAllPredicates provider0) {
@@ -87,7 +87,7 @@ public final class GeneratedMetadata_AllPredicatesHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getAllPredicates((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptPredicateList org.apache.calcite.rel.metadata.BuiltInMetadata$AllPredicates$Handler.getAllPredicates(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptPredicateList org.apache.calcite.rel.metadata.BuiltInMetadata$AllPredicatesHandler.getAllPredicates(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CollationHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CollationHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_CollationHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.Collation.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.CollationHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("ImmutableList Handler.collations()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("ImmutableList CollationHandler.collations()");
   public final org.apache.calcite.rel.metadata.RelMdCollation provider0;
   public GeneratedMetadata_CollationHandler(
       org.apache.calcite.rel.metadata.RelMdCollation provider0) {
@@ -99,7 +99,7 @@ public final class GeneratedMetadata_CollationHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.collations((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract com.google.common.collect.ImmutableList org.apache.calcite.rel.metadata.BuiltInMetadata$Collation$Handler.collations(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract com.google.common.collect.ImmutableList org.apache.calcite.rel.metadata.BuiltInMetadata$CollationHandler.collations(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnOriginHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnOriginHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_ColumnOriginHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ColumnOrigin.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ColumnOriginHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set Handler.getColumnOrigins(RelNode, RelMetadataQuery, int)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set ColumnOriginHandler.getColumnOrigins(RelNode, RelMetadataQuery, int)");
   private final Object[] methodKey0FlyWeight =
       org.apache.calcite.rel.metadata.janino.CacheUtil.generateRange("java.util.Set getColumnOrigins", -256, 256);
   public final org.apache.calcite.rel.metadata.RelMdColumnOrigins provider0;
@@ -91,7 +91,7 @@ public final class GeneratedMetadata_ColumnOriginHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getColumnOrigins((org.apache.calcite.rel.RelNode) r, mq, a2);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnOrigin$Handler.getColumnOrigins(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,int)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnOriginHandler.getColumnOrigins(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,int)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnUniquenessHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnUniquenessHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_ColumnUniquenessHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ColumnUniqueness.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ColumnUniquenessHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Boolean Handler.areColumnsUnique(RelNode, RelMetadataQuery, ImmutableBitSet, boolean)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Boolean ColumnUniquenessHandler.areColumnsUnique(RelNode, RelMetadataQuery, ImmutableBitSet, boolean)");
   public final org.apache.calcite.rel.metadata.RelMdColumnUniqueness provider0;
   public GeneratedMetadata_ColumnUniquenessHandler(
       org.apache.calcite.rel.metadata.RelMdColumnUniqueness provider0) {
@@ -99,7 +99,7 @@ public final class GeneratedMetadata_ColumnUniquenessHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.areColumnsUnique((org.apache.calcite.rel.RelNode) r, mq, a2, a3);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Boolean org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnUniqueness$Handler.areColumnsUnique(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.util.ImmutableBitSet,boolean)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Boolean org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnUniquenessHandler.areColumnsUnique(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.util.ImmutableBitSet,boolean)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CumulativeCostHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_CumulativeCostHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_CumulativeCostHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.CumulativeCost.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.CumulativeCostHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptCost Handler.getCumulativeCost()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptCost CumulativeCostHandler.getCumulativeCost()");
   public final org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows$RelMdCumulativeCost provider0;
   public GeneratedMetadata_CumulativeCostHandler(
       org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows$RelMdCumulativeCost provider0) {
@@ -65,7 +65,7 @@ public final class GeneratedMetadata_CumulativeCostHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getCumulativeCost((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptCost org.apache.calcite.rel.metadata.BuiltInMetadata$CumulativeCost$Handler.getCumulativeCost(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptCost org.apache.calcite.rel.metadata.BuiltInMetadata$CumulativeCostHandler.getCumulativeCost(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistinctRowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistinctRowCountHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_DistinctRowCountHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.DistinctRowCount.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.DistinctRowCountHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.getDistinctRowCount(RelNode, RelMetadataQuery, ImmutableBitSet, RexNode)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double DistinctRowCountHandler.getDistinctRowCount(RelNode, RelMetadataQuery, ImmutableBitSet, RexNode)");
   public final org.apache.calcite.rel.metadata.RelMdDistinctRowCount provider0;
   public GeneratedMetadata_DistinctRowCountHandler(
       org.apache.calcite.rel.metadata.RelMdDistinctRowCount provider0) {
@@ -87,7 +87,7 @@ public final class GeneratedMetadata_DistinctRowCountHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getDistinctRowCount((org.apache.calcite.rel.RelNode) r, mq, a2, a3);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$DistinctRowCount$Handler.getDistinctRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.util.ImmutableBitSet,org.apache.calcite.rex.RexNode)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$DistinctRowCountHandler.getDistinctRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.util.ImmutableBitSet,org.apache.calcite.rex.RexNode)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistributionHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_DistributionHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_DistributionHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.Distribution.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.DistributionHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelDistribution Handler.distribution()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelDistribution DistributionHandler.distribution()");
   public final org.apache.calcite.rel.metadata.RelMdDistribution provider0;
   public GeneratedMetadata_DistributionHandler(
       org.apache.calcite.rel.metadata.RelMdDistribution provider0) {
@@ -79,7 +79,7 @@ public final class GeneratedMetadata_DistributionHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.distribution((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.rel.RelDistribution org.apache.calcite.rel.metadata.BuiltInMetadata$Distribution$Handler.distribution(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.rel.RelDistribution org.apache.calcite.rel.metadata.BuiltInMetadata$DistributionHandler.distribution(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExplainVisibilityHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExplainVisibilityHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_ExplainVisibilityHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ExplainVisibility.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ExplainVisibilityHandler {
   private final Object methodKey0Null =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Boolean Handler.isVisibleInExplain(null)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Boolean ExplainVisibilityHandler.isVisibleInExplain(null)");
   private final Object[] methodKey0 =
       org.apache.calcite.rel.metadata.janino.CacheUtil.generateEnum("Boolean isVisibleInExplain", org.apache.calcite.sql.SqlExplainLevel.values());
   public final org.apache.calcite.rel.metadata.RelMdExplainVisibility provider0;
@@ -71,7 +71,7 @@ public final class GeneratedMetadata_ExplainVisibilityHandler
     if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.isVisibleInExplain((org.apache.calcite.rel.RelNode) r, mq, a2);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Boolean org.apache.calcite.rel.metadata.BuiltInMetadata$ExplainVisibility$Handler.isVisibleInExplain(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.sql.SqlExplainLevel)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Boolean org.apache.calcite.rel.metadata.BuiltInMetadata$ExplainVisibilityHandler.isVisibleInExplain(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.sql.SqlExplainLevel)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExpressionLineageHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ExpressionLineageHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_ExpressionLineageHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ExpressionLineage.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ExpressionLineageHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set Handler.getExpressionLineage(RelNode, RelMetadataQuery, RexNode)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set ExpressionLineageHandler.getExpressionLineage(RelNode, RelMetadataQuery, RexNode)");
   public final org.apache.calcite.rel.metadata.RelMdExpressionLineage provider0;
   public GeneratedMetadata_ExpressionLineageHandler(
       org.apache.calcite.rel.metadata.RelMdExpressionLineage provider0) {
@@ -87,7 +87,7 @@ public final class GeneratedMetadata_ExpressionLineageHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getExpressionLineage((org.apache.calcite.rel.RelNode) r, mq, a2);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$ExpressionLineage$Handler.getExpressionLineage(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.rex.RexNode)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$ExpressionLineageHandler.getExpressionLineage(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.rex.RexNode)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_LowerBoundCostHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_LowerBoundCostHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_LowerBoundCostHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCost.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCostHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptCost Handler.getLowerBoundCost(RelNode, RelMetadataQuery, VolcanoPlanner)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptCost LowerBoundCostHandler.getLowerBoundCost(RelNode, RelMetadataQuery, VolcanoPlanner)");
   public final org.apache.calcite.rel.metadata.RelMdLowerBoundCost provider0;
   public GeneratedMetadata_LowerBoundCostHandler(
       org.apache.calcite.rel.metadata.RelMdLowerBoundCost provider0) {
@@ -67,7 +67,7 @@ public final class GeneratedMetadata_LowerBoundCostHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getLowerBoundCost((org.apache.calcite.rel.RelNode) r, mq, a2);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptCost org.apache.calcite.rel.metadata.BuiltInMetadata$LowerBoundCost$Handler.getLowerBoundCost(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.plan.volcano.VolcanoPlanner)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptCost org.apache.calcite.rel.metadata.BuiltInMetadata$LowerBoundCostHandler.getLowerBoundCost(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.plan.volcano.VolcanoPlanner)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MaxRowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MaxRowCountHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_MaxRowCountHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.MaxRowCount.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.MaxRowCountHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.getMaxRowCount()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double MaxRowCountHandler.getMaxRowCount()");
   public final org.apache.calcite.rel.metadata.RelMdMaxRowCount provider0;
   public GeneratedMetadata_MaxRowCountHandler(
       org.apache.calcite.rel.metadata.RelMdMaxRowCount provider0) {
@@ -93,7 +93,7 @@ public final class GeneratedMetadata_MaxRowCountHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getMaxRowCount((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$MaxRowCount$Handler.getMaxRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$MaxRowCountHandler.getMaxRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MemoryHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MemoryHandler.java
@@ -17,20 +17,20 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_MemoryHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.Memory.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.MemoryHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.cumulativeMemoryWithinPhase()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double MemoryHandler.cumulativeMemoryWithinPhase()");
   private final Object methodKey1 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.cumulativeMemoryWithinPhaseSplit()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double MemoryHandler.cumulativeMemoryWithinPhaseSplit()");
   private final Object methodKey2 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.memory()");
-  public final org.apache.calcite.rel.metadata.RelMdMemory provider1;
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double MemoryHandler.memory()");
+  public final org.apache.calcite.rel.metadata.RelMdMemory provider0;
   public GeneratedMetadata_MemoryHandler(
-      org.apache.calcite.rel.metadata.RelMdMemory provider1) {
-    this.provider1 = provider1;
+      org.apache.calcite.rel.metadata.RelMdMemory provider0) {
+    this.provider0 = provider0;
   }
   public org.apache.calcite.rel.metadata.MetadataDef getDef() {
-    return provider1.getDef();
+    return provider0.getDef();
   }
   public java.lang.Double cumulativeMemoryWithinPhase(
       org.apache.calcite.rel.RelNode r,
@@ -65,9 +65,9 @@ public final class GeneratedMetadata_MemoryHandler
       org.apache.calcite.rel.RelNode r,
       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
     if (r instanceof org.apache.calcite.rel.RelNode) {
-      return provider1.cumulativeMemoryWithinPhase((org.apache.calcite.rel.RelNode) r, mq);
+      return provider0.cumulativeMemoryWithinPhase((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$Memory$Handler.cumulativeMemoryWithinPhase(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$MemoryHandler.cumulativeMemoryWithinPhase(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
   public java.lang.Double cumulativeMemoryWithinPhaseSplit(
@@ -103,9 +103,9 @@ public final class GeneratedMetadata_MemoryHandler
       org.apache.calcite.rel.RelNode r,
       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
     if (r instanceof org.apache.calcite.rel.RelNode) {
-      return provider1.cumulativeMemoryWithinPhaseSplit((org.apache.calcite.rel.RelNode) r, mq);
+      return provider0.cumulativeMemoryWithinPhaseSplit((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$Memory$Handler.cumulativeMemoryWithinPhaseSplit(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$MemoryHandler.cumulativeMemoryWithinPhaseSplit(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
   public java.lang.Double memory(
@@ -141,9 +141,9 @@ public final class GeneratedMetadata_MemoryHandler
       org.apache.calcite.rel.RelNode r,
       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
     if (r instanceof org.apache.calcite.rel.RelNode) {
-      return provider1.memory((org.apache.calcite.rel.RelNode) r, mq);
+      return provider0.memory((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$Memory$Handler.memory(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$MemoryHandler.memory(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MinRowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_MinRowCountHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_MinRowCountHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.MinRowCount.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.MinRowCountHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.getMinRowCount()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double MinRowCountHandler.getMinRowCount()");
   public final org.apache.calcite.rel.metadata.RelMdMinRowCount provider0;
   public GeneratedMetadata_MinRowCountHandler(
       org.apache.calcite.rel.metadata.RelMdMinRowCount provider0) {
@@ -93,7 +93,7 @@ public final class GeneratedMetadata_MinRowCountHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getMinRowCount((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$MinRowCount$Handler.getMinRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$MinRowCountHandler.getMinRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NodeTypesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NodeTypesHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_NodeTypesHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.NodeTypes.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.NodeTypesHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Multimap Handler.getNodeTypes()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Multimap NodeTypesHandler.getNodeTypes()");
   public final org.apache.calcite.rel.metadata.RelMdNodeTypes provider0;
   public GeneratedMetadata_NodeTypesHandler(
       org.apache.calcite.rel.metadata.RelMdNodeTypes provider0) {
@@ -99,7 +99,7 @@ public final class GeneratedMetadata_NodeTypesHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getNodeTypes((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract com.google.common.collect.Multimap org.apache.calcite.rel.metadata.BuiltInMetadata$NodeTypes$Handler.getNodeTypes(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract com.google.common.collect.Multimap org.apache.calcite.rel.metadata.BuiltInMetadata$NodeTypesHandler.getNodeTypes(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NonCumulativeCostHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_NonCumulativeCostHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_NonCumulativeCostHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.NonCumulativeCost.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.NonCumulativeCostHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptCost Handler.getNonCumulativeCost()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptCost NonCumulativeCostHandler.getNonCumulativeCost()");
   public final org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows$RelMdNonCumulativeCost provider0;
   public GeneratedMetadata_NonCumulativeCostHandler(
       org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows$RelMdNonCumulativeCost provider0) {
@@ -63,7 +63,7 @@ public final class GeneratedMetadata_NonCumulativeCostHandler
     if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getNonCumulativeCost((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptCost org.apache.calcite.rel.metadata.BuiltInMetadata$NonCumulativeCost$Handler.getNonCumulativeCost(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptCost org.apache.calcite.rel.metadata.BuiltInMetadata$NonCumulativeCostHandler.getNonCumulativeCost(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ParallelismHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ParallelismHandler.java
@@ -17,18 +17,18 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_ParallelismHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.Parallelism.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.ParallelismHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Boolean Handler.isPhaseTransition()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Boolean ParallelismHandler.isPhaseTransition()");
   private final Object methodKey1 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Integer Handler.splitCount()");
-  public final org.apache.calcite.rel.metadata.RelMdParallelism provider1;
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Integer ParallelismHandler.splitCount()");
+  public final org.apache.calcite.rel.metadata.RelMdParallelism provider0;
   public GeneratedMetadata_ParallelismHandler(
-      org.apache.calcite.rel.metadata.RelMdParallelism provider1) {
-    this.provider1 = provider1;
+      org.apache.calcite.rel.metadata.RelMdParallelism provider0) {
+    this.provider0 = provider0;
   }
   public org.apache.calcite.rel.metadata.MetadataDef getDef() {
-    return provider1.getDef();
+    return provider0.getDef();
   }
   public java.lang.Boolean isPhaseTransition(
       org.apache.calcite.rel.RelNode r,
@@ -63,15 +63,15 @@ public final class GeneratedMetadata_ParallelismHandler
       org.apache.calcite.rel.RelNode r,
       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
     if (r instanceof org.apache.calcite.rel.core.Exchange) {
-      return provider1.isPhaseTransition((org.apache.calcite.rel.core.Exchange) r, mq);
+      return provider0.isPhaseTransition((org.apache.calcite.rel.core.Exchange) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.TableScan) {
-      return provider1.isPhaseTransition((org.apache.calcite.rel.core.TableScan) r, mq);
+      return provider0.isPhaseTransition((org.apache.calcite.rel.core.TableScan) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Values) {
-      return provider1.isPhaseTransition((org.apache.calcite.rel.core.Values) r, mq);
+      return provider0.isPhaseTransition((org.apache.calcite.rel.core.Values) r, mq);
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
-      return provider1.isPhaseTransition((org.apache.calcite.rel.RelNode) r, mq);
+      return provider0.isPhaseTransition((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Boolean org.apache.calcite.rel.metadata.BuiltInMetadata$Parallelism$Handler.isPhaseTransition(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Boolean org.apache.calcite.rel.metadata.BuiltInMetadata$ParallelismHandler.isPhaseTransition(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
   public java.lang.Integer splitCount(
@@ -107,9 +107,9 @@ public final class GeneratedMetadata_ParallelismHandler
       org.apache.calcite.rel.RelNode r,
       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
     if (r instanceof org.apache.calcite.rel.RelNode) {
-      return provider1.splitCount((org.apache.calcite.rel.RelNode) r, mq);
+      return provider0.splitCount((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Integer org.apache.calcite.rel.metadata.BuiltInMetadata$Parallelism$Handler.splitCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Integer org.apache.calcite.rel.metadata.BuiltInMetadata$ParallelismHandler.splitCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PercentageOriginalRowsHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PercentageOriginalRowsHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_PercentageOriginalRowsHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.PercentageOriginalRows.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.PercentageOriginalRowsHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.getPercentageOriginalRows()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double PercentageOriginalRowsHandler.getPercentageOriginalRows()");
   public final org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows$RelMdPercentageOriginalRowsHandler provider0;
   public GeneratedMetadata_PercentageOriginalRowsHandler(
       org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows$RelMdPercentageOriginalRowsHandler provider0) {
@@ -69,7 +69,7 @@ public final class GeneratedMetadata_PercentageOriginalRowsHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getPercentageOriginalRows((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$PercentageOriginalRows$Handler.getPercentageOriginalRows(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$PercentageOriginalRowsHandler.getPercentageOriginalRows(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PopulationSizeHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PopulationSizeHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_PopulationSizeHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.PopulationSize.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.PopulationSizeHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.getPopulationSize(RelNode, RelMetadataQuery, ImmutableBitSet)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double PopulationSizeHandler.getPopulationSize(RelNode, RelMetadataQuery, ImmutableBitSet)");
   public final org.apache.calcite.rel.metadata.RelMdPopulationSize provider0;
   public GeneratedMetadata_PopulationSizeHandler(
       org.apache.calcite.rel.metadata.RelMdPopulationSize provider0) {
@@ -83,7 +83,7 @@ public final class GeneratedMetadata_PopulationSizeHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getPopulationSize((org.apache.calcite.rel.RelNode) r, mq, a2);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$PopulationSize$Handler.getPopulationSize(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.util.ImmutableBitSet)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$PopulationSizeHandler.getPopulationSize(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.util.ImmutableBitSet)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PredicatesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_PredicatesHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_PredicatesHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.Predicates.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.PredicatesHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptPredicateList Handler.getPredicates()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("RelOptPredicateList PredicatesHandler.getPredicates()");
   public final org.apache.calcite.rel.metadata.RelMdPredicates provider0;
   public GeneratedMetadata_PredicatesHandler(
       org.apache.calcite.rel.metadata.RelMdPredicates provider0) {
@@ -87,7 +87,7 @@ public final class GeneratedMetadata_PredicatesHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getPredicates((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptPredicateList org.apache.calcite.rel.metadata.BuiltInMetadata$Predicates$Handler.getPredicates(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract org.apache.calcite.plan.RelOptPredicateList org.apache.calcite.rel.metadata.BuiltInMetadata$PredicatesHandler.getPredicates(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_RowCountHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_RowCountHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_RowCountHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.RowCount.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.RowCountHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.getRowCount()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double RowCountHandler.getRowCount()");
   public final org.apache.calcite.rel.metadata.RelMdRowCount provider0;
   public GeneratedMetadata_RowCountHandler(
       org.apache.calcite.rel.metadata.RelMdRowCount provider0) {
@@ -95,7 +95,7 @@ public final class GeneratedMetadata_RowCountHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getRowCount((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$RowCount$Handler.getRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$RowCountHandler.getRowCount(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SelectivityHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SelectivityHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_SelectivityHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.Selectivity.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.SelectivityHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.getSelectivity(RelNode, RelMetadataQuery, RexNode)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double SelectivityHandler.getSelectivity(RelNode, RelMetadataQuery, RexNode)");
   public final org.apache.calcite.rel.metadata.RelMdSelectivity provider0;
   public GeneratedMetadata_SelectivityHandler(
       org.apache.calcite.rel.metadata.RelMdSelectivity provider0) {
@@ -81,7 +81,7 @@ public final class GeneratedMetadata_SelectivityHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getSelectivity((org.apache.calcite.rel.RelNode) r, mq, a2);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$Selectivity$Handler.getSelectivity(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.rex.RexNode)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$SelectivityHandler.getSelectivity(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,org.apache.calcite.rex.RexNode)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SizeHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_SizeHandler.java
@@ -17,18 +17,18 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_SizeHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.Size.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.SizeHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("List Handler.averageColumnSizes()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("List SizeHandler.averageColumnSizes()");
   private final Object methodKey1 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double Handler.averageRowSize()");
-  public final org.apache.calcite.rel.metadata.RelMdSize provider1;
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Double SizeHandler.averageRowSize()");
+  public final org.apache.calcite.rel.metadata.RelMdSize provider0;
   public GeneratedMetadata_SizeHandler(
-      org.apache.calcite.rel.metadata.RelMdSize provider1) {
-    this.provider1 = provider1;
+      org.apache.calcite.rel.metadata.RelMdSize provider0) {
+    this.provider0 = provider0;
   }
   public org.apache.calcite.rel.metadata.MetadataDef getDef() {
-    return provider1.getDef();
+    return provider0.getDef();
   }
   public java.util.List averageColumnSizes(
       org.apache.calcite.rel.RelNode r,
@@ -63,35 +63,35 @@ public final class GeneratedMetadata_SizeHandler
       org.apache.calcite.rel.RelNode r,
       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
     if (r instanceof org.apache.calcite.rel.core.Aggregate) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Aggregate) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Aggregate) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Calc) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Calc) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Calc) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Exchange) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Exchange) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Exchange) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Filter) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Filter) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Filter) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Intersect) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Intersect) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Intersect) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Join) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Join) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Join) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Minus) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Minus) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Minus) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Project) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Project) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Project) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Sort) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Sort) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Sort) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.TableModify) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.TableModify) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.TableModify) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.TableScan) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.TableScan) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.TableScan) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Union) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Union) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Union) r, mq);
     } else if (r instanceof org.apache.calcite.rel.core.Values) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.core.Values) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.core.Values) r, mq);
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
-      return provider1.averageColumnSizes((org.apache.calcite.rel.RelNode) r, mq);
+      return provider0.averageColumnSizes((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.List org.apache.calcite.rel.metadata.BuiltInMetadata$Size$Handler.averageColumnSizes(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.List org.apache.calcite.rel.metadata.BuiltInMetadata$SizeHandler.averageColumnSizes(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
   public java.lang.Double averageRowSize(
@@ -127,9 +127,9 @@ public final class GeneratedMetadata_SizeHandler
       org.apache.calcite.rel.RelNode r,
       org.apache.calcite.rel.metadata.RelMetadataQuery mq) {
     if (r instanceof org.apache.calcite.rel.RelNode) {
-      return provider1.averageRowSize((org.apache.calcite.rel.RelNode) r, mq);
+      return provider0.averageRowSize((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$Size$Handler.averageRowSize(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.lang.Double org.apache.calcite.rel.metadata.BuiltInMetadata$SizeHandler.averageRowSize(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_TableReferencesHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_TableReferencesHandler.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_TableReferencesHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.TableReferences.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.TableReferencesHandler {
   private final Object methodKey0 =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set Handler.getTableReferences()");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set TableReferencesHandler.getTableReferences()");
   public final org.apache.calcite.rel.metadata.RelMdTableReferences provider0;
   public GeneratedMetadata_TableReferencesHandler(
       org.apache.calcite.rel.metadata.RelMdTableReferences provider0) {
@@ -89,7 +89,7 @@ public final class GeneratedMetadata_TableReferencesHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getTableReferences((org.apache.calcite.rel.RelNode) r, mq);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$TableReferences$Handler.getTableReferences(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$TableReferencesHandler.getTableReferences(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_UniqueKeysHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_UniqueKeysHandler.java
@@ -17,11 +17,11 @@
 package org.apache.calcite.rel.metadata.janino;
 
 public final class GeneratedMetadata_UniqueKeysHandler
-  implements org.apache.calcite.rel.metadata.BuiltInMetadata.UniqueKeys.Handler {
+  implements org.apache.calcite.rel.metadata.BuiltInMetadata.UniqueKeysHandler {
   private final Object methodKey0True =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set Handler.getUniqueKeys(true)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set UniqueKeysHandler.getUniqueKeys(true)");
   private final Object methodKey0False =
-      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set Handler.getUniqueKeys(false)");
+      new org.apache.calcite.rel.metadata.janino.DescriptiveCacheKey("Set UniqueKeysHandler.getUniqueKeys(false)");
   public final org.apache.calcite.rel.metadata.RelMdUniqueKeys provider0;
   public GeneratedMetadata_UniqueKeysHandler(
       org.apache.calcite.rel.metadata.RelMdUniqueKeys provider0) {
@@ -91,7 +91,7 @@ public final class GeneratedMetadata_UniqueKeysHandler
     } else if (r instanceof org.apache.calcite.rel.RelNode) {
       return provider0.getUniqueKeys((org.apache.calcite.rel.RelNode) r, mq, a2);
     } else {
-            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$UniqueKeys$Handler.getUniqueKeys(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,boolean)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
+            throw new java.lang.IllegalArgumentException("No handler for method [public abstract java.util.Set org.apache.calcite.rel.metadata.BuiltInMetadata$UniqueKeysHandler.getUniqueKeys(org.apache.calcite.rel.RelNode,org.apache.calcite.rel.metadata.RelMetadataQuery,boolean)] applied to argument of type [" + r.getClass() + "]; we recommend you create a catch-all (RelNode) handler");
     }
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderExtended.java
@@ -19,7 +19,6 @@ package org.apache.calcite.test.catalog;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.BuiltInMetadata;
-import org.apache.calcite.rel.metadata.MetadataDef;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -206,7 +205,7 @@ public class MockCatalogReaderExtended extends MockCatalogReaderSimple {
     restaurantTable.addColumn("HILBERT", f.bigintType);
     restaurantTable.addMonotonic("HILBERT");
     restaurantTable.addWrap(
-        new BuiltInMetadata.AllPredicates.Handler() {
+        new BuiltInMetadata.AllPredicatesHandler() {
           @Override public RelOptPredicateList getAllPredicates(RelNode r,
               RelMetadataQuery mq) {
             // Return the predicate:
@@ -236,7 +235,9 @@ public class MockCatalogReaderExtended extends MockCatalogReaderSimple {
             throw new AssertionError();
           }
 
-          @Override public MetadataDef<BuiltInMetadata.AllPredicates> getDef() {
+          @Deprecated // to be removed before 2.0
+          @Override public
+          org.apache.calcite.rel.metadata.MetadataDef<BuiltInMetadata.AllPredicates> getDef() {
             return BuiltInMetadata.AllPredicates.DEF;
           }
         });


### PR DESCRIPTION
MetadataHandler's method getDef() and the generic referencing a Metadata
subtype provide no value in current implementation of Metadata.  Removing
them reduces the amount of code to define a Metadata type as well as
clearify the api.  This will require downstream projects that have custom
metadata type to remove the generic from their Handler class.

* Deprecating MetadataDef, BuiltInMetadata.{extends Metadata},
  BuiltInMetadata.{extends Metadata}.Handler, internal methods of
  ChainedRelMetadataProvider, BuiltInMethod referencing Metadata
  methods.
* Reworking BuiltInMetadata to have the Handlers at the top level.
  Extending the new Handlers with the old hanlders to reduces breaking
  downstream projects.
* Adding default implementation to MetadataHandler#getDef
* Removing generic from RelMetadataHandler
* Reworking creation validation in ReflectiveRelMetadataProvider