### PR TITLE
[CALCITE-4547] Support Java 16 and 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ matrix:
     - jdk: openjdk15
       env:
         - GUAVA=31.0.1-jre # newest supported Guava version
+    - jdk: openjdk16
+      env:
+        - GUAVA=31.0.1-jre
+    - jdk: openjdk17
+      env:
+        - GUAVA=31.0.1-jre
 branches:
   only:
     - master

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -54,7 +54,7 @@ the changes concern custom planner rule configurations, in particular
 Two APIs are deprecated and will be [removed in release 1.29](#to-be-removed-in-1-29-0).
 
 Compatibility: This release is tested on Linux, macOS, Microsoft Windows;
-using JDK/OpenJDK versions 8 to 15;
+using JDK/OpenJDK versions 8 to 17;
 Guava versions 19.0 to 31.0.1-jre;
 other software versions as specified in gradle.properties.
 

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -31,8 +31,8 @@ adapters.
 
 ## Building from a source distribution
 
-Prerequisite is Java (JDK 8, 9, 10, 11, 12, 13, 14 or 15)
-and Gradle (version 7.2) on your path.
+Prerequisite is Java (JDK 8, 9, 10, 11, 12, 13, 14, 15, 16 or 17)
+and Gradle (version 7.3) on your path.
 
 Unpack the source distribution `.tar.gz` file,
 `cd` to the root directory of the unpacked source,
@@ -51,7 +51,7 @@ tests  (but you should use the `gradle` command rather than
 ## Building from Git
 
 Prerequisites are git
-and Java (JDK 8, 9, 10, 11, 12, 13, 14 or 15) on your path.
+and Java (JDK 8, 9, 10, 11, 12, 13, 14, 15, 16 or 17) on your path.
 
 Create a local copy of the GitHub repository,
 `cd` to its root directory,


### PR DESCRIPTION
This PR updates JDK、Gradle version and configures CI tests for JDK 16、 17.