### PR TITLE
[CALCITE-4960] Enable unit tests in Elasticsearch Adapter

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -200,6 +200,16 @@ public abstract class Bug {
    * Druid plans with small intervals should be chosen over full interval scan plus filter</a> is
    * fixed. */
   public static final boolean CALCITE_4213_FIXED = false;
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4645">[CALCITE-4645]
+   * In Elasticsearch adapter, a range predicate should be translated to a range query</a> is
+   * fixed. */
+  public static final boolean CALCITE_4645_FIXED = false;
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4965">[CALCITE-4965]
+   * IS NOT NULL failed in Elasticsearch Adapter</a> is
+   * fixed. */
+  public static final boolean CALCITE_4965_FIXED = false;
 
   /**
    * Use this to flag temporary code.

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
@@ -121,22 +122,21 @@ class AggregationTest {
    * to rang Query in ES is implemented.
    */
   @Test void searchInRange() {
-    if (Bug.CALCITE_4645_FIXED) {
-      CalciteAssert.that()
-          .with(newConnectionFactory())
-          .query("select count(*) from view where val1 >= 10 and val1 <=20")
-          .returns("EXPR$0=1\n");
+    Assumptions.assumeTrue(Bug.CALCITE_4645_FIXED, "CALCITE-4645");
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select count(*) from view where val1 >= 10 and val1 <=20")
+        .returns("EXPR$0=1\n");
 
-      CalciteAssert.that()
-          .with(newConnectionFactory())
-          .query("select count(*) from view where val1 <= 10 or val1 >=20")
-          .returns("EXPR$0=2\n");
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select count(*) from view where val1 <= 10 or val1 >=20")
+        .returns("EXPR$0=2\n");
 
-      CalciteAssert.that()
-          .with(newConnectionFactory())
-          .query("select count(*) from view where val1 <= 10 or (val1 > 15 and val1 <= 20)")
-          .returns("EXPR$0=2\n");
-    }
+    CalciteAssert.that()
+        .with(newConnectionFactory())
+        .query("select count(*) from view where val1 <= 10 or (val1 > 15 and val1 <= 20)")
+        .returns("EXPR$0=2\n");
   }
 
   @Test void countStar() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/AggregationTest.java
@@ -22,6 +22,7 @@ import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.ElasticsearchChecker;
+import org.apache.calcite.util.Bug;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,7 +30,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -120,22 +120,23 @@ class AggregationTest {
    * So disable this test case until the translation from Search in range
    * to rang Query in ES is implemented.
    */
-  @Disabled
   @Test void searchInRange() {
-    CalciteAssert.that()
-        .with(newConnectionFactory())
-        .query("select count(*) from view where val1 >= 10 and val1 <=20")
-        .returns("EXPR$0=1\n");
+    if (Bug.CALCITE_4645_FIXED) {
+      CalciteAssert.that()
+          .with(newConnectionFactory())
+          .query("select count(*) from view where val1 >= 10 and val1 <=20")
+          .returns("EXPR$0=1\n");
 
-    CalciteAssert.that()
-        .with(newConnectionFactory())
-        .query("select count(*) from view where val1 <= 10 or val1 >=20")
-        .returns("EXPR$0=2\n");
+      CalciteAssert.that()
+          .with(newConnectionFactory())
+          .query("select count(*) from view where val1 <= 10 or val1 >=20")
+          .returns("EXPR$0=2\n");
 
-    CalciteAssert.that()
-        .with(newConnectionFactory())
-        .query("select count(*) from view where val1 <= 10 or (val1 > 15 and val1 <= 20)")
-        .returns("EXPR$0=2\n");
+      CalciteAssert.that()
+          .with(newConnectionFactory())
+          .query("select count(*) from view where val1 <= 10 or (val1 > 15 and val1 <= 20)")
+          .returns("EXPR$0=2\n");
+    }
   }
 
   @Test void countStar() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
@@ -21,6 +21,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.util.Bug;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
@@ -118,6 +119,10 @@ class BooleanLogicTest {
     assertEmpty("select * from view where num > 42 and num < 42 and num = 42");
     assertEmpty("select * from view where num > 42 or num < 42 and num = 42");
     assertSingle("select * from view where num > 42 and num < 42 or num = 42");
+    if (Bug.CALCITE_4965_FIXED) {
+      assertSingle("select * from view where num > 42 or num < 42 or num = 42");
+      assertEmpty("select * from view where num is null");
+    }
     assertSingle("select * from view where num >= 42 and num <= 42 and num = 42");
     assertEmpty("select * from view where num >= 42 and num <= 42 and num <> 42");
     assertEmpty("select * from view where num < 42");

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -42,7 +41,6 @@ import java.util.Map;
 /**
  * Test of different boolean expressions (some more complex than others).
  */
-@Disabled("RestClient often timeout in PR CI")
 @ResourceLock(value = "elasticsearch-scrolls", mode = ResourceAccessMode.READ)
 class BooleanLogicTest {
 
@@ -120,7 +118,6 @@ class BooleanLogicTest {
     assertEmpty("select * from view where num > 42 and num < 42 and num = 42");
     assertEmpty("select * from view where num > 42 or num < 42 and num = 42");
     assertSingle("select * from view where num > 42 and num < 42 or num = 42");
-    assertSingle("select * from view where num > 42 or num < 42 or num = 42");
     assertSingle("select * from view where num >= 42 and num <= 42 and num = 42");
     assertEmpty("select * from view where num >= 42 and num <= 42 and num <> 42");
     assertEmpty("select * from view where num < 42");

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -18,12 +18,12 @@ package org.apache.calcite.adapter.elasticsearch;
 
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.rel.RelFieldCollation;
-import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.ElasticsearchChecker;
+import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.TestUtil;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -32,7 +32,6 @@ import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -462,24 +461,18 @@ class ElasticSearchAdapterTest {
         .explainContains(explain);
   }
 
-  /**
-   * Range query is not supported currently.
-   * @see <a href="https://issues.apache.org/jira/browse/CALCITE-4645">[CALCITE-4645]
-   * In Elasticsearch adapter, a range predicate should be translated to a range query</a>
-   * <p>Description about translating search call to range query
-   * {@link org.apache.calcite.adapter.elasticsearch.PredicateAnalyzer.Visitor#canBeTranslatedToTermsQuery(RexCall)}
-   */
-  @Disabled
   @Test void testFilterSortDesc() {
     final String sql = "select * from zips\n"
         + "where pop BETWEEN 95000 AND 100000\n"
         + "order by state desc, pop";
-    calciteAssert()
-        .query(sql)
-        .limit(4)
-        .returnsOrdered(
-            "city=LOS ANGELES; longitude=-118.258189; latitude=34.007856; pop=96074; state=CA; id=90011",
-            "city=BELL GARDENS; longitude=-118.17205; latitude=33.969177; pop=99568; state=CA; id=90201");
+    if (Bug.CALCITE_4645_FIXED) {
+      calciteAssert()
+          .query(sql)
+          .limit(4)
+          .returnsOrdered(
+              "city=LOS ANGELES; longitude=-118.258189; latitude=34.007856; pop=96074; state=CA; id=90011",
+              "city=BELL GARDENS; longitude=-118.17205; latitude=33.969177; pop=99568; state=CA; id=90201");
+    }
   }
 
   @Test void testInPlan() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
@@ -462,17 +463,16 @@ class ElasticSearchAdapterTest {
   }
 
   @Test void testFilterSortDesc() {
+    Assumptions.assumeTrue(Bug.CALCITE_4645_FIXED, "CALCITE-4645");
     final String sql = "select * from zips\n"
         + "where pop BETWEEN 95000 AND 100000\n"
         + "order by state desc, pop";
-    if (Bug.CALCITE_4645_FIXED) {
-      calciteAssert()
-          .query(sql)
-          .limit(4)
-          .returnsOrdered(
-              "city=LOS ANGELES; longitude=-118.258189; latitude=34.007856; pop=96074; state=CA; id=90011",
-              "city=BELL GARDENS; longitude=-118.17205; latitude=33.969177; pop=99568; state=CA; id=90201");
-    }
+    calciteAssert()
+        .query(sql)
+        .limit(4)
+        .returnsOrdered(
+            "city=LOS ANGELES; longitude=-118.258189; latitude=34.007856; pop=96074; state=CA; id=90011",
+            "city=BELL GARDENS; longitude=-118.17205; latitude=33.969177; pop=99568; state=CA; id=90201");
   }
 
   @Test void testInPlan() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
@@ -197,7 +197,11 @@ class EmbeddedElasticsearchPolicy {
       return client;
     }
 
-    final RestClient client = RestClient.builder(httpHost()).build();
+    final RestClient client = RestClient.builder(httpHost())
+        .setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder
+            .setConnectTimeout(60 * 1000)  // default 1000
+            .setSocketTimeout(3 * 60 * 1000))  // default 30000
+        .build();
     closer.add(client);
     this.client = client;
     return client;

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
@@ -45,7 +45,6 @@ import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -71,7 +70,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Testing Elasticsearch match query.
  */
-@Disabled("RestClient often timeout in PR CI")
 @ResourceLock(value = "elasticsearch-scrolls", mode = ResourceAccessMode.READ)
 class MatchTest {
 
@@ -80,7 +78,6 @@ class MatchTest {
 
   /** Default index/type name. */
   private static final String ZIPS = "match-zips";
-  private static final int ZIPS_SIZE = 149;
 
   /**
    * Used to create {@code zips} index and insert zip data in bulk.

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ProjectionTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ProjectionTest.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -42,7 +41,6 @@ import java.util.Map;
 /**
  * Checks renaming of fields (also upper, lower cases) during projections.
  */
-@Disabled("RestClient often timeout in PR CI")
 @ResourceLock(value = "elasticsearch-scrolls", mode = ResourceAccessMode.READ)
 class ProjectionTest {
 

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ScrollingTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ScrollingTest.java
@@ -46,7 +46,6 @@ import java.util.stream.IntStream;
  * Tests usage of scrolling API like correct results and resource cleanup
  * (delete scroll after scan).
  */
-@Disabled("RestClient often timeout in PR CI")
 @ResourceLock("elasticsearch-scrolls")
 class ScrollingTest {
 


### PR DESCRIPTION
This PR aims at **re-enabling unit tests** in Elasticsearch Adapter. The changes are:

- Increasing SocketTimeout and ConnectionTimeout for RestClient to avoid CI failure

- Remove one case in BooleanLogicTest.java, which is documented at https://issues.apache.org/jira/browse/CALCITE-4965

- Disable testFilterSortDesc() in ElasticSearchAdapterTest.java, which is not supported before CALCITE-4645 merged.

I think re-enabling those tests has higher priorities than fixing bugs in ES Adapter. When other contributors make changes in this module, their codes cannot be guaranteed well without unit tests. Last but not least, the disabled cases mentioned above will be reopened after bug fixing.