### PR TITLE
[CALCITE-4957] Add HASH_RANDOM in RelDistribution.Type to solve data skew caused by Hash Distribution type

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/RelDistribution.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelDistribution.java
@@ -19,6 +19,8 @@ package org.apache.calcite.rel;
 import org.apache.calcite.plan.RelMultipleTrait;
 import org.apache.calcite.util.mapping.Mappings;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.util.List;
 
 /**
@@ -46,6 +48,12 @@ public interface RelDistribution extends RelMultipleTrait {
    * SINGLETON) never have keys.
    */
   List<Integer> getKeys();
+
+  /** Returns null for type which is not HASH_RANDOM while returns the number of possible instances
+   *  for a record with same keys could appear on for HASH_RANDOM type. */
+  default @Nullable Integer getHashRandomNumber() {
+    return null;
+  }
 
   /**
    * Applies mapping to this distribution trait.
@@ -76,6 +84,20 @@ public interface RelDistribution extends RelMultipleTrait {
      * records whose keys hash to a particular hash value. Instances are
      * disjoint; a given record appears on exactly one stream. */
     HASH_DISTRIBUTED("hash"),
+
+    /** This distribution type could solve data skew problem exists in hash distribution.
+     *
+     * <p>For hash distribution, all record with same key always appear on the same stream.
+     *
+     * <p>For hash random distribution, records with same key could appear on one of the N streams,
+     * chosen at random.
+     *
+     * <p>For example, there are 128 instances of stream and the hash random number is 6. All
+     * records with the same key  would appear on 6 instances of 128 instances. And which a record
+     * would appear on is chosen at random.
+     * <p>In the example, the type is equivalent with hash distribution if N is 1 while the type
+     * is equivalent with random distribution if N is 128. */
+    HASH_RANDOM_DISTRIBUTED("hash_random"),
 
     /** There are multiple instances of the stream, and each instance contains
      * records whose keys fall into a particular range. Instances are disjoint;

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -227,7 +227,8 @@ public class RelJson {
     if (keys != null) {
       list = ImmutableIntList.copyOf(keys);
     }
-    return RelDistributions.of(type, list);
+    Integer hashRandomNumber = (Integer) map.get("number");
+    return RelDistributions.of(type, list, hashRandomNumber);
   }
 
   private Object toJson(RelDistribution relDistribution) {
@@ -235,6 +236,9 @@ public class RelJson {
     map.put("type", relDistribution.getType().name());
     if (!relDistribution.getKeys().isEmpty()) {
       map.put("keys", relDistribution.getKeys());
+    }
+    if (relDistribution.getHashRandomNumber() != null) {
+      map.put("number", relDistribution.getHashRandomNumber());
     }
     return map;
   }

--- a/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/RelDistributionTest.java
@@ -54,6 +54,24 @@ class RelDistributionTest {
     assertThat(distribution2.compareTo(distribution2), is(0));
   }
 
+  @Test void testHashRandomDistributionSatisfy() {
+    RelDistribution distribution1 = RelDistributions.hashRandom(ImmutableList.of(0), 8);
+    RelDistribution distribution2 = RelDistributions.hashRandom(ImmutableList.of(1), 8);
+    RelDistribution distribution3 = RelDistributions.hashRandom(ImmutableList.of(0), 16);
+
+    assertThat(distribution1.satisfies(distribution2), is(false));
+    assertThat(distribution2.satisfies(distribution1), is(false));
+
+    assertThat(distribution1.satisfies(distribution3), is(false));
+    assertThat(distribution3.satisfies(distribution1), is(false));
+
+    assertThat(distribution1.compareTo(distribution2), is(-1));
+    assertThat(distribution2.compareTo(distribution1), is(1));
+    assertThat(distribution3.compareTo(distribution1), is(1));
+    //noinspection EqualsWithItself
+    assertThat(distribution2.compareTo(distribution2), is(0));
+  }
+
   @Test void testRelDistributionMapping() {
     final int n = 10; // Mapping source count.
 
@@ -85,6 +103,16 @@ class RelDistributionTest {
     assertThat(hash9.apply(mapping(n, 1)), is(ANY));
     assertThat(hash9.apply(mapping(n, 2)), is(ANY));
     assertThat(hash9.apply(mapping(n, n - 1)), is(hash(0)));
+
+    // hash_random[0,1]
+    RelDistribution hashRandom01 = RelDistributions.hashRandom(ImmutableIntList.of(0, 1), 8);
+    assertThat(hashRandom01.apply(mapping(n, 0)), is(ANY));
+    assertThat(hashRandom01.apply(mapping(n, 1)), is(ANY));
+    assertThat(hashRandom01.apply(mapping(n, 0, 1)), is(hashRandom01));
+    assertThat(hashRandom01.apply(mapping(n, 1, 2)), is(ANY));
+    assertThat(hashRandom01.apply(mapping(n, 1, 0)), is(hashRandom01));
+    assertThat(hashRandom01.apply(mapping(n, 2, 1, 0)),
+        is(RelDistributions.hashRandom(ImmutableIntList.of(2, 1), 8)));
   }
 
   private static Mapping mapping(int sourceCount, int... sources) {

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -4144,6 +4144,17 @@ public class RelBuilderTest {
     assertThat(root, hasTree(expected));
   }
 
+  @Test void testExchangeWithHashRandom() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    final RelNode root = builder.scan("EMP")
+        .exchange(RelDistributions.hashRandom(Lists.newArrayList(0), 8))
+        .build();
+    final String expected =
+        "LogicalExchange(distribution=[hash_random(keys = [0], number = 8)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(root, hasTree(expected));
+  }
+
   @Test void testSortExchange() {
     final RelBuilder builder = RelBuilder.create(config().build());
     final RelNode root =
@@ -4153,6 +4164,19 @@ public class RelBuilderTest {
             .build();
     final String expected =
         "LogicalSortExchange(distribution=[hash[0]], collation=[[0]])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(root, hasTree(expected));
+  }
+
+  @Test void testSortExchangeWithHashRandom() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    final RelNode root =
+        builder.scan("EMP")
+            .sortExchange(RelDistributions.hashRandom(Lists.newArrayList(0), 8),
+                RelCollations.of(0))
+            .build();
+    final String expected =
+        "LogicalSortExchange(distribution=[hash_random(keys = [0], number = 8)], collation=[[0]])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(root, hasTree(expected));
   }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1034,7 +1034,7 @@ LogicalProject(MGR=[$0], SUM_SAL=[$2])
   <TestCase name="testAggregateUnionTransposeWithAllInputsUnique">
     <Resource name="sql">
       <![CDATA[select deptno, SUM(t) from (
-select deptno, 1 as t from sales.emp e1
+select distinct deptno, 1 as t from sales.emp e1
 union all
 select distinct deptno, 2 as t from sales.emp e2)
 group by deptno]]>
@@ -4024,6 +4024,26 @@ LogicalProject(EXPR$0=[1])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
       LogicalFilter(condition=[>($5, 100)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testHashRandomExchangeRemoveConstantKeysRule">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSortExchange(distribution=[hash_random(keys = [0, 1], number = 8)], collation=[[0, 1]])
+  LogicalProject(EMPNO=[$0], ENAME=[$1])
+    LogicalExchange(distribution=[hash[0]])
+      LogicalFilter(condition=[=($0, 10)])
+        LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalSortExchange(distribution=[hash_random(keys = [1], number = 8)], collation=[[1]])
+  LogicalProject(EMPNO=[$0], ENAME=[$1])
+    LogicalExchange(distribution=[single])
+      LogicalFilter(condition=[=($0, 10)])
+        LogicalTableScan(table=[[scott, EMP]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
## What is the purpose of the change

The pr aims to introduce a new RelDistribution.Type (HASH_RANDOM) to solve data skew caused by Hash type.

## Brief change log

  - Add a value `HASH_RANDOM_DISTRIBUTED` in enum `RelDistribution#Type`
  - Add a method `getHashRandomNumber` in interface `RelDistribution`, which default return null.
  - Update `RelDistributions` to apply for the new enum value in `RelDistribution#Type`
  - Update `ExchangeRemoveConstantKeysRule` to take new enum value in `RelDistribution#Type` into consideration
  - Update `RelJson` to take the hashRandomNumber into consideration when convert to/From Json

## Verifying this change

  - Add tests in `RelWriterTest`, `RelDistributionTest`, `RelBuilderTest`, `RelOptRulesTest`