### PR TITLE
Site: Use openjdk-17 to generate javadoc with docker

### DIFF
--- a/site/docker-compose.yml
+++ b/site/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     volumes:
       - .:/srv/jekyll
   generate-javadoc:
-    image: maven
+    image: maven:3.8.4-openjdk-17-slim
     working_dir: /usr/src/calcite
     command: sh -c "./gradlew javadocAggregate; rm -rf site/target/javadocAggregate; mkdir -p site/target; mv build/docs/javadocAggregate site/target"
     volumes:


### PR DESCRIPTION
Use fixed docker image to avoid spurious changes during the website generation.