### PR TITLE
[CALCITE-4967] Support SQL hints for temporal table join

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableCorrelate.java
@@ -52,7 +52,7 @@ public class EnumerableCorrelate extends Correlate
       RelNode left, RelNode right,
       CorrelationId correlationId,
       ImmutableBitSet requiredColumns, JoinRelType joinType) {
-    super(cluster, traits, left, right, correlationId, requiredColumns,
+    super(cluster, traits, ImmutableList.of(), left, right, correlationId, requiredColumns,
         joinType);
   }
 

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -127,7 +127,7 @@ public class JdbcRules {
       };
 
   static final RelFactories.CorrelateFactory CORRELATE_FACTORY =
-      (left, right, correlationId, requiredColumns, joinType) -> {
+      (left, right, hints, correlationId, requiredColumns, joinType) -> {
         throw new UnsupportedOperationException("JdbcCorrelate");
       };
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
@@ -25,6 +25,8 @@ import org.apache.calcite.rel.BiRel;
 import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.Hintable;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
@@ -68,12 +70,13 @@ import static java.util.Objects.requireNonNull;
  *
  * @see CorrelationId
  */
-public abstract class Correlate extends BiRel {
+public abstract class Correlate extends BiRel implements Hintable {
   //~ Instance fields --------------------------------------------------------
 
   protected final CorrelationId correlationId;
   protected final ImmutableBitSet requiredColumns;
   protected final JoinRelType joinType;
+  protected final ImmutableList<RelHint> hints;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -91,6 +94,7 @@ public abstract class Correlate extends BiRel {
   protected Correlate(
       RelOptCluster cluster,
       RelTraitSet traitSet,
+      List<RelHint> hints,
       RelNode left,
       RelNode right,
       CorrelationId correlationId,
@@ -101,7 +105,21 @@ public abstract class Correlate extends BiRel {
     this.joinType = requireNonNull(joinType, "joinType");
     this.correlationId = requireNonNull(correlationId, "correlationId");
     this.requiredColumns = requireNonNull(requiredColumns, "requiredColumns");
+    this.hints = ImmutableList.copyOf(hints);
     assert isValid(Litmus.THROW, null);
+  }
+
+  @Deprecated // to be removed before 2.0
+  protected Correlate(
+      RelOptCluster cluster,
+      RelTraitSet traitSet,
+      RelNode left,
+      RelNode right,
+      CorrelationId correlationId,
+      ImmutableBitSet requiredColumns,
+      JoinRelType joinType) {
+    this(cluster, traitSet, ImmutableList.of(), left, right,
+        correlationId, requiredColumns, joinType);
   }
 
   /**
@@ -234,5 +252,9 @@ public abstract class Correlate extends BiRel {
     return planner.getCostFactory().makeCost(
         rowCount /* generate results */ + leftRowCount /* scan left results */,
         0, 0).plus(rescanCost);
+  }
+
+  @Override public ImmutableList<RelHint> getHints() {
+    return hints;
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -406,14 +406,6 @@ public class RelFactories {
     RelNode createCorrelate(RelNode left, RelNode right, List<RelHint> hints,
         CorrelationId correlationId, ImmutableBitSet requiredColumns,
         JoinRelType joinType);
-
-    @Deprecated // to be removed before 1.23
-    default RelNode createCorrelate(RelNode left, RelNode right,
-        CorrelationId correlationId, ImmutableBitSet requiredColumns,
-        JoinRelType joinType) {
-      return createCorrelate(left, right, ImmutableList.of(), correlationId,
-          requiredColumns, joinType);
-    }
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/RelFactories.java
@@ -392,18 +392,28 @@ public class RelFactories {
    * <p>The result is typically a {@link Correlate}.
    */
   public interface CorrelateFactory {
+
     /**
      * Creates a correlate.
      *
      * @param left             Left input
      * @param right            Right input
+     * @param hints            Hints
      * @param correlationId    Variable name for the row of left input
      * @param requiredColumns  Required columns
      * @param joinType         Join type
      */
-    RelNode createCorrelate(RelNode left, RelNode right,
+    RelNode createCorrelate(RelNode left, RelNode right, List<RelHint> hints,
         CorrelationId correlationId, ImmutableBitSet requiredColumns,
         JoinRelType joinType);
+
+    @Deprecated // to be removed before 1.23
+    default RelNode createCorrelate(RelNode left, RelNode right,
+        CorrelationId correlationId, ImmutableBitSet requiredColumns,
+        JoinRelType joinType) {
+      return createCorrelate(left, right, ImmutableList.of(), correlationId,
+          requiredColumns, joinType);
+    }
   }
 
   /**
@@ -411,10 +421,10 @@ public class RelFactories {
    * {@link org.apache.calcite.rel.logical.LogicalCorrelate}.
    */
   private static class CorrelateFactoryImpl implements CorrelateFactory {
-    @Override public RelNode createCorrelate(RelNode left, RelNode right,
-        CorrelationId correlationId, ImmutableBitSet requiredColumns,
-        JoinRelType joinType) {
-      return LogicalCorrelate.create(left, right, correlationId,
+
+    @Override public RelNode createCorrelate(RelNode left, RelNode right, List<RelHint> hints,
+        CorrelationId correlationId, ImmutableBitSet requiredColumns, JoinRelType joinType) {
+      return LogicalCorrelate.create(left, right, hints, correlationId,
           requiredColumns, joinType);
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/hint/HintPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/HintPredicates.java
@@ -50,6 +50,11 @@ public abstract class HintPredicates {
   public static final HintPredicate CALC =
       new NodeTypeHintPredicate(NodeTypeHintPredicate.NodeType.CALC);
 
+  /** A hint predicate that indicates a hint can only be used to
+   * {@link org.apache.calcite.rel.core.Correlate} nodes. */
+  public static final HintPredicate CORRELATE =
+      new NodeTypeHintPredicate(NodeTypeHintPredicate.NodeType.CORRELATE);
+
   /**
    * Returns a composed hint predicate that represents a short-circuiting logical
    * AND of an array of hint predicates {@code hintPredicates}.  When evaluating the composed

--- a/core/src/main/java/org/apache/calcite/rel/hint/NodeTypeHintPredicate.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/NodeTypeHintPredicate.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.hint;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.TableScan;
@@ -63,7 +64,12 @@ public class NodeTypeHintPredicate implements HintPredicate {
     /**
      * The hint would be propagated to the Calc nodes.
      */
-    CALC(Calc.class);
+    CALC(Calc.class),
+
+    /**
+     * The hint would be propagated to the Correlate nodes.
+     */
+    CORRELATE(Correlate.class);
 
     /** Relational expression clazz that the hint can apply to. */
     @SuppressWarnings("ImmutableEnumChecker")

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
@@ -116,7 +116,7 @@ public final class LogicalCorrelate extends Correlate {
         requiredColumns, joinType);
   }
 
-  @Deprecated // to be removed before 1.23
+  @Deprecated // to be removed before 2.0
   public static LogicalCorrelate create(RelNode left, RelNode right,
       CorrelationId correlationId, ImmutableBitSet requiredColumns,
       JoinRelType joinType) {

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalCorrelate.java
@@ -25,7 +25,12 @@ import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.util.ImmutableBitSet;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -58,6 +63,7 @@ public final class LogicalCorrelate extends Correlate {
   public LogicalCorrelate(
       RelOptCluster cluster,
       RelTraitSet traitSet,
+      List<RelHint> hints,
       RelNode left,
       RelNode right,
       CorrelationId correlationId,
@@ -66,6 +72,7 @@ public final class LogicalCorrelate extends Correlate {
     super(
         cluster,
         traitSet,
+        hints,
         left,
         right,
         correlationId,
@@ -73,11 +80,25 @@ public final class LogicalCorrelate extends Correlate {
         joinType);
   }
 
+  @Deprecated // to be removed before 2.0
+  public LogicalCorrelate(
+      RelOptCluster cluster,
+      RelTraitSet traitSet,
+      RelNode left,
+      RelNode right,
+      CorrelationId correlationId,
+      ImmutableBitSet requiredColumns,
+      JoinRelType joinType) {
+    this(cluster, traitSet, ImmutableList.of(), left, right,
+        correlationId, requiredColumns, joinType);
+  }
+
   /**
    * Creates a LogicalCorrelate by parsing serialized output.
    */
   public LogicalCorrelate(RelInput input) {
-    this(input.getCluster(), input.getTraitSet(), input.getInputs().get(0),
+    this(input.getCluster(), input.getTraitSet(), ImmutableList.of(),
+        input.getInputs().get(0),
         input.getInputs().get(1),
         new CorrelationId(
             (Integer) requireNonNull(input.get("correlation"), "correlation")),
@@ -86,13 +107,20 @@ public final class LogicalCorrelate extends Correlate {
   }
 
   /** Creates a LogicalCorrelate. */
-  public static LogicalCorrelate create(RelNode left, RelNode right,
+  public static LogicalCorrelate create(RelNode left, RelNode right, List<RelHint> hints,
       CorrelationId correlationId, ImmutableBitSet requiredColumns,
       JoinRelType joinType) {
     final RelOptCluster cluster = left.getCluster();
     final RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
-    return new LogicalCorrelate(cluster, traitSet, left, right, correlationId,
+    return new LogicalCorrelate(cluster, traitSet, hints, left, right, correlationId,
         requiredColumns, joinType);
+  }
+
+  @Deprecated // to be removed before 1.23
+  public static LogicalCorrelate create(RelNode left, RelNode right,
+      CorrelationId correlationId, ImmutableBitSet requiredColumns,
+      JoinRelType joinType) {
+    return create(left, right, ImmutableList.of(), correlationId, requiredColumns, joinType);
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -101,11 +129,16 @@ public final class LogicalCorrelate extends Correlate {
       RelNode left, RelNode right, CorrelationId correlationId,
       ImmutableBitSet requiredColumns, JoinRelType joinType) {
     assert traitSet.containsIfApplicable(Convention.NONE);
-    return new LogicalCorrelate(getCluster(), traitSet, left, right,
+    return new LogicalCorrelate(getCluster(), traitSet, hints, left, right,
         correlationId, requiredColumns, joinType);
   }
 
   @Override public RelNode accept(RelShuttle shuttle) {
     return shuttle.visit(this);
+  }
+
+  @Override public RelNode withHints(List<RelHint> hintList) {
+    return new LogicalCorrelate(getCluster(), traitSet, hintList, left, right,
+        correlationId, requiredColumns, joinType);
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
+++ b/core/src/main/java/org/apache/calcite/rel/mutable/MutableRels.java
@@ -60,6 +60,8 @@ import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
+import com.google.common.collect.ImmutableList;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.AbstractList;
@@ -297,7 +299,8 @@ public abstract class MutableRels {
     case CORRELATE:
       final MutableCorrelate correlate = (MutableCorrelate) node;
       return LogicalCorrelate.create(fromMutable(correlate.getLeft(), relBuilder),
-          fromMutable(correlate.getRight(), relBuilder), correlate.correlationId,
+          fromMutable(correlate.getRight(), relBuilder),
+          ImmutableList.of(), correlate.correlationId,
           correlate.requiredColumns, correlate.joinType);
     case UNION:
       final MutableUnion union = (MutableUnion) node;

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinToCorrelateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinToCorrelateRule.java
@@ -124,6 +124,7 @@ public class JoinToCorrelateRule
     RelNode newRel =
         LogicalCorrelate.create(left,
             relBuilder.build(),
+            join.getHints(),
             correlationId,
             requiredColumns.build(),
             join.getJoinType());

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -482,6 +482,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
     LogicalCorrelate newRel =
         LogicalCorrelate.create(getNewForOldRel(rel.getLeft()),
             getNewForOldRel(rel.getRight()),
+            rel.getHints(),
             rel.getCorrelationId(),
             newPos.build(),
             rel.getJoinType());

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2756,7 +2756,7 @@ public class SqlToRelConverter {
             .union(p.requiredColumns);
       }
 
-      return LogicalCorrelate.create(leftRel, innerRel,
+      return LogicalCorrelate.create(leftRel, innerRel, ImmutableList.of(),
           p.id, requiredCols, joinType);
     }
 

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -2791,7 +2791,7 @@ public class RelBuilder {
       }
       final ImmutableBitSet requiredColumns = RelOptUtil.correlationColumns(id, right.rel);
       join =
-          struct.correlateFactory.createCorrelate(left.rel, right.rel, id,
+          struct.correlateFactory.createCorrelate(left.rel, right.rel, ImmutableList.of(), id,
               requiredColumns, joinType);
     } else {
       RelNode join0 =
@@ -2836,7 +2836,7 @@ public class RelBuilder {
     Frame left = stack.pop();
 
     final RelNode correlate =
-        struct.correlateFactory.createCorrelate(left.rel, right.rel,
+        struct.correlateFactory.createCorrelate(left.rel, right.rel, ImmutableList.of(),
             correlationId, ImmutableBitSet.of(requiredOrdinals), joinType);
 
     final ImmutableList.Builder<Field> fields = ImmutableList.builder();

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1743,7 +1743,7 @@ class RelOptRulesTest extends RelOptTestBase {
           .project(b.field(0),
               b.getRexBuilder().makeFieldAccess(rexCorrel, 0)).build();
       LogicalCorrelate correlate = new LogicalCorrelate(left.getCluster(),
-          left.getTraitSet(), left, right, correlationId,
+          left.getTraitSet(), ImmutableList.of(), left, right, correlationId,
           ImmutableBitSet.of(0), type);
 
       b.push(correlate);
@@ -4061,6 +4061,7 @@ class RelOptRulesTest extends RelOptTestBase {
     CustomCorrelate customCorrelate = new CustomCorrelate(
         logicalCorrelate.getCluster(),
         logicalCorrelate.getTraitSet(),
+        logicalCorrelate.getHints(),
         logicalCorrelate.getLeft(),
         logicalCorrelate.getRight(),
         logicalCorrelate.getCorrelationId(),

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelTestBase.java
@@ -41,6 +41,7 @@ import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -1078,23 +1079,29 @@ public abstract class SqlToRelTestBase {
     public CustomCorrelate(
         RelOptCluster cluster,
         RelTraitSet traits,
+        List<RelHint> hints,
         RelNode left,
         RelNode right,
         CorrelationId correlationId,
         ImmutableBitSet requiredColumns,
         JoinRelType joinType) {
-      super(cluster, traits, left, right, correlationId, requiredColumns, joinType);
+      super(cluster, traits, hints, left, right, correlationId, requiredColumns, joinType);
     }
 
     @Override public Correlate copy(RelTraitSet traitSet,
         RelNode left, RelNode right, CorrelationId correlationId,
         ImmutableBitSet requiredColumns, JoinRelType joinType) {
-      return new CustomCorrelate(getCluster(), traitSet, left, right,
+      return new CustomCorrelate(getCluster(), traitSet, hints, left, right,
           correlationId, requiredColumns, joinType);
     }
 
     @Override public RelNode accept(RelShuttle shuttle) {
       return shuttle.visit(this);
+    }
+
+    @Override public RelNode withHints(List<RelHint> hintList) {
+      return new CustomCorrelate(getCluster(), traitSet, hintList, left, right,
+          correlationId, requiredColumns, joinType);
     }
   }
 }

--- a/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
@@ -33,6 +33,19 @@ Project:[[RESOURCE inheritPath:[0, 0, 0, 0] options:{MEM=1024}]]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelateHints">
+    <Resource name="sql">
+      <![CDATA[select /*+ use_hash_join (orders, products_temporal) */ stream *
+from orders join products_temporal for system_time as of orders.rowtime
+on orders.productid = products_temporal.productid and orders.orderId is not null]]>
+    </Resource>
+    <Resource name="hints">
+      <![CDATA[
+Project:[[USE_HASH_JOIN inheritPath:[] options:[ORDERS, PRODUCTS_TEMPORAL]]]
+Correlate:[[USE_HASH_JOIN inheritPath:[0] options:[ORDERS, PRODUCTS_TEMPORAL]]]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFourLevelNestedQueryHint">
     <Resource name="sql">
       <![CDATA[select /*+ index(idx1), no_hash_join */ * from emp /*+ index(empno) */

--- a/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
@@ -46,6 +46,19 @@ Correlate:[[USE_HASH_JOIN inheritPath:[0] options:[ORDERS, PRODUCTS_TEMPORAL]]]
 ]]>
     </Resource>
   </TestCase>
+
+  <TestCase name="testCrossCorrelateHints">
+    <Resource name="sql">
+      <![CDATA[select /*+ use_hash_join (orders, products_temporal) */ stream *
+from orders, products_temporal for system_time as of orders.rowtime]]>
+    </Resource>
+    <Resource name="hints">
+      <![CDATA[
+Project:[[USE_HASH_JOIN inheritPath:[] options:[ORDERS, PRODUCTS_TEMPORAL]]]
+Correlate:[[USE_HASH_JOIN inheritPath:[0] options:[ORDERS, PRODUCTS_TEMPORAL]]]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFourLevelNestedQueryHint">
     <Resource name="sql">
       <![CDATA[select /*+ index(idx1), no_hash_join */ * from emp /*+ index(empno) */


### PR DESCRIPTION
## What is the purpose of the change

The pr aims to support SQL hints for temporal table join.

## Brief change log

  - Extends `Correlate` to be a `Hintable`
  - Add a hint predicate in `HintPredicates`

## Verifying this change

  - Add tests in `SqlHintsConverterTest` to validate the hint could be propagated to `Correlate`
  - Add tests in `RelBuilderTest`