### PR TITLE
Site: Change the Javadoc title to Apache Calcite API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -437,8 +437,8 @@ allprojects {
                 docEncoding = "UTF-8"
                 charSet = "UTF-8"
                 encoding = "UTF-8"
-                docTitle = "Apache Calcite ${project.name} API"
-                windowTitle = "Apache Calcite ${project.name} API"
+                docTitle = "Apache Calcite API"
+                windowTitle = "Apache Calcite API"
                 header = "<b>Apache Calcite</b>"
                 bottom =
                     "Copyright &copy; 2012-$lastEditYear Apache Software Foundation. All Rights Reserved."


### PR DESCRIPTION
The doc title should be "Apache Calcite API", but is "Apache Calcite calcite API". 