### PR TITLE
[CALCITE-4953] Deprecate TableAccessMap class

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/TableAccessMap.java
+++ b/core/src/main/java/org/apache/calcite/plan/TableAccessMap.java
@@ -35,7 +35,12 @@ import java.util.Set;
 /**
  * <code>TableAccessMap</code> represents the tables accessed by a query plan,
  * with READ/WRITE information.
+ *
+ * @deprecated As of 1.30.0, if you need to know how tables in a plan are accessed you are
+ * encouraged to implement your own logic (using a RelNode visitor or other). The class is not used
+ * anywhere in the project and remains untested thus it is deprecated.
  */
+@Deprecated // to be removed before 2.0
 public class TableAccessMap {
   //~ Enums ------------------------------------------------------------------
 


### PR DESCRIPTION
The TableAccessMap class is not used anywhere in the project, it is untested, and hasn't received any real update since its addition in the project in 2012.