### PR TITLE
[CALCITE-4753] Extend FunctionContext with a DataContext getter

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/FunctionContexts.java
+++ b/core/src/main/java/org/apache/calcite/runtime/FunctionContexts.java
@@ -49,6 +49,10 @@ public class FunctionContexts {
       return root.getTypeFactory();
     }
 
+    @Override public DataContext getDataContext() {
+      return root;
+    }
+
     @Override public int getParameterCount() {
       return argumentValues.length;
     }

--- a/core/src/main/java/org/apache/calcite/schema/FunctionContext.java
+++ b/core/src/main/java/org/apache/calcite/schema/FunctionContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.schema;
 
+import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 
@@ -87,6 +88,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public interface FunctionContext {
   /** Returns the type factory. */
   RelDataTypeFactory getTypeFactory();
+
+  /** Returns the data context of execution. */
+  DataContext getDataContext();
 
   /** Returns the number of parameters. */
   int getParameterCount();

--- a/testkit/src/main/java/org/apache/calcite/util/Smalls.java
+++ b/testkit/src/main/java/org/apache/calcite/util/Smalls.java
@@ -509,6 +509,7 @@ public class Smalls {
     private final int initY;
 
     public MyPlusInitFunction(FunctionContext fx) {
+      // it is expected that the FunctionContext has a populated DataContext
       if (fx.getDataContext() == null) {
         throw new IllegalStateException("Data context is not set in function context");
       }
@@ -874,6 +875,10 @@ public class Smalls {
    * The constructor has an initialization parameter. */
   public static class MyTwoParamsSumFunctionFilter1 {
     public MyTwoParamsSumFunctionFilter1(FunctionContext fx) {
+      // it is expected that the FunctionContext has a populated DataContext
+      if (fx.getDataContext() == null) {
+        throw new IllegalStateException("Data context is not set in function context");
+      }
       Objects.requireNonNull(fx, "fx");
       assert fx.getParameterCount() == 2;
     }

--- a/testkit/src/main/java/org/apache/calcite/util/Smalls.java
+++ b/testkit/src/main/java/org/apache/calcite/util/Smalls.java
@@ -509,6 +509,9 @@ public class Smalls {
     private final int initY;
 
     public MyPlusInitFunction(FunctionContext fx) {
+      if (fx.getDataContext() == null) {
+        throw new IllegalStateException("Data context is not set in function context");
+      }
       INSTANCE_COUNT.get().incrementAndGet();
       final StringBuilder b = new StringBuilder();
       final int parameterCount = fx.getParameterCount();


### PR DESCRIPTION
Refreshed PR #2505 - exposing DataContext in FunctionContext.