### PR TITLE
[MINOR] Update javacc official website

### DIFF
--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -18,8 +18,8 @@
 # SQL statements, literals or data types.
 #
 # Calcite's parser grammar file (Parser.jj) is written in javacc
-# (http://javacc.java.net/) with Freemarker (http://freemarker.org/) variables
-# to allow clients to:
+# (https://javacc.github.io/javacc/) with Freemarker (http://freemarker.org/)
+# variables to allow clients to:
 #   1. have custom parser implementation class and package name.
 #   2. insert new parser method implementations written in javacc to parse
 #      custom:


### PR DESCRIPTION
The java.net site has closed. Update javacc official website. Help make it easier for newcomers to view the javacc documentation.