### PR TITLE
Updated to clarify DB value in system property setting

### DIFF
--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -109,7 +109,7 @@ You can use `./gradlew assemble` to build the artifacts and skip all tests and v
 There are other options that control which tests are run, and in what
 environment, as follows.
 
-* `-Dcalcite.test.db=DB` (where db is `h2`, `hsqldb`, `mysql`, or `postgresql`) allows you
+* `-Dcalcite.test.db=DB` (where DB is `h2`, `hsqldb`, `mysql`, or `postgresql`) allows you
   to change the JDBC data source for the test suite. Calcite's test
   suite requires a JDBC data source populated with the foodmart data
   set.


### PR DESCRIPTION
Update to clarify system property value **DB** which can be `h2`, `hsqldb` etc (updated <pre>-Dcalcite.test.db=DB (where <b>db</b> is...</pre> to <pre>-Dcalcite.test.db=DB (where <b>DB</b> is...</pre>).

