### PR TITLE
[CALCITE-4982] NonNull field shouldn't be pushed down into leaf of outer-join in 'ProjectJoinTransposeRule'

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/Strong.java
+++ b/core/src/main/java/org/apache/calcite/plan/Strong.java
@@ -101,6 +101,10 @@ public class Strong {
    * given whether its arguments are null.
    */
   public static Policy policy(RexNode rexNode) {
+    // If cast not null, return NOT_NULL directly.
+    if (rexNode.getKind() == SqlKind.CAST && !rexNode.getType().isNullable()) {
+      return Policy.NOT_NULL;
+    }
     if (rexNode instanceof RexCall) {
       return policy(((RexCall) rexNode).getOperator());
     }

--- a/core/src/main/java/org/apache/calcite/plan/Strong.java
+++ b/core/src/main/java/org/apache/calcite/plan/Strong.java
@@ -101,10 +101,6 @@ public class Strong {
    * given whether its arguments are null.
    */
   public static Policy policy(RexNode rexNode) {
-    // If cast not null, return NOT_NULL directly.
-    if (rexNode.getKind() == SqlKind.CAST && !rexNode.getType().isNullable()) {
-      return Policy.NOT_NULL;
-    }
     if (rexNode instanceof RexCall) {
       return policy(((RexCall) rexNode).getOperator());
     }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -169,8 +169,8 @@ public class ProjectJoinTransposeRule
             final RexCall castCall = (RexCall) expr;
             final RelDataType operand0Type = castCall.getOperands().get(0).getType();
             if (relType.getSqlTypeName() == operand0Type.getSqlTypeName()
-                && relType.isNullable() != operand0Type.isNullable()) {
-              // Non push down cast's expression with the same type by default
+                && operand0Type.isNullable() && !relType.isNullable()) {
+              // Do not push down not nullable cast's expression with the same type by default
               // eg: CAST($1):VARCHAR(10) NOT NULL, and type of $1 is nullable VARCHAR(10)
               return false;
             }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -31,15 +31,12 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -24,17 +24,22 @@ import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 import org.immutables.value.Value;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 
@@ -157,7 +162,24 @@ public class ProjectJoinTransposeRule
   @Value.Immutable(singleton = false)
   public interface Config extends RelRule.Config {
     Config DEFAULT = ImmutableProjectJoinTransposeRule.Config.builder()
-        .withPreserveExprCondition(expr -> !(expr instanceof RexOver))
+        .withPreserveExprCondition(expr -> {
+          // Non push down over's expression by default
+          if (expr instanceof RexOver) {
+            return false;
+          }
+          final RelDataType relType = expr.getType();
+          if (SqlKind.CAST == expr.getKind()) {
+            final RexCall castCall = (RexCall) expr;
+            final RelDataType operand0Type = castCall.getOperands().get(0).getType();
+            if (relType.getSqlTypeName() == operand0Type.getSqlTypeName()
+                && relType.isNullable() != operand0Type.isNullable()) {
+              // Non push down cast's expression with the same type by default
+              // eg: CAST($1):VARCHAR(10) NOT NULL, and type of $1 is nullable VARCHAR(10)
+              return false;
+            }
+          }
+          return true;
+        })
         .build()
         .withOperandFor(LogicalProject.class, LogicalJoin.class);
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -163,19 +163,20 @@ public class ProjectJoinTransposeRule
           // Do not push down over's expression by default
           if (expr instanceof RexOver) {
             return false;
-          }
-          final RelDataType relType = expr.getType();
-          if (SqlKind.CAST == expr.getKind()) {
-            final RexCall castCall = (RexCall) expr;
-            final RelDataType operand0Type = castCall.getOperands().get(0).getType();
-            if (relType.getSqlTypeName() == operand0Type.getSqlTypeName()
-                && operand0Type.isNullable() && !relType.isNullable()) {
-              // Do not push down not nullable cast's expression with the same type by default
-              // eg: CAST($1):VARCHAR(10) NOT NULL, and type of $1 is nullable VARCHAR(10)
-              return false;
+          } else {
+            final RelDataType relType = expr.getType();
+            if (SqlKind.CAST == expr.getKind()) {
+              final RexCall castCall = (RexCall) expr;
+              final RelDataType operand0Type = castCall.getOperands().get(0).getType();
+              if (relType.getSqlTypeName() == operand0Type.getSqlTypeName()
+                  && operand0Type.isNullable() && !relType.isNullable()) {
+                // Do not push down not nullable cast's expression with the same type by default
+                // eg: CAST($1):VARCHAR(10) NOT NULL, and type of $1 is nullable VARCHAR(10)
+                return false;
+              }
             }
+            return true;
           }
-          return true;
         })
         .build()
         .withOperandFor(LogicalProject.class, LogicalJoin.class);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -163,20 +163,19 @@ public class ProjectJoinTransposeRule
           // Do not push down over's expression by default
           if (expr instanceof RexOver) {
             return false;
-          } else {
-            final RelDataType relType = expr.getType();
-            if (SqlKind.CAST == expr.getKind()) {
-              final RexCall castCall = (RexCall) expr;
-              final RelDataType operand0Type = castCall.getOperands().get(0).getType();
-              if (relType.getSqlTypeName() == operand0Type.getSqlTypeName()
-                  && operand0Type.isNullable() && !relType.isNullable()) {
-                // Do not push down not nullable cast's expression with the same type by default
-                // eg: CAST($1):VARCHAR(10) NOT NULL, and type of $1 is nullable VARCHAR(10)
-                return false;
-              }
-            }
-            return true;
           }
+          if (SqlKind.CAST == expr.getKind()) {
+            final RelDataType relType = expr.getType();
+            final RexCall castCall = (RexCall) expr;
+            final RelDataType operand0Type = castCall.getOperands().get(0).getType();
+            if (relType.getSqlTypeName() == operand0Type.getSqlTypeName()
+                && operand0Type.isNullable() && !relType.isNullable()) {
+              // Do not push down not nullable cast's expression with the same type by default
+              // eg: CAST($1):VARCHAR(10) NOT NULL, and type of $1 is nullable VARCHAR(10)
+              return false;
+            }
+          }
+          return true;
         })
         .build()
         .withOperandFor(LogicalProject.class, LogicalJoin.class);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectJoinTransposeRule.java
@@ -160,7 +160,7 @@ public class ProjectJoinTransposeRule
   public interface Config extends RelRule.Config {
     Config DEFAULT = ImmutableProjectJoinTransposeRule.Config.builder()
         .withPreserveExprCondition(expr -> {
-          // Non push down over's expression by default
+          // Do not push down over's expression by default
           if (expr instanceof RexOver) {
             return false;
           }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2039,6 +2039,14 @@ class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
   }
 
+  @Test void testPushProjectPastLeftJoin2() {
+    final String sql = "select coalesce(d.name, b.job, '')\n"
+        + "from emp e\n"
+        + "left join bonus b on e.ename = b.ename\n"
+        + "left join dept d on e.deptno = d.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
+  }
+
   @Test void testPushProjectPastLeftJoinSwap() {
     final String sql = "select count(*), " + NOT_STRONG_EXPR + "\n"
         + "from bonus b left outer join emp e on e.ename = b.ename\n"

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2039,14 +2039,6 @@ class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
   }
 
-  @Test void testPushProjectPastLeftJoin2() {
-    final String sql = "select coalesce(d.name, b.job, '')\n"
-        + "from emp e\n"
-        + "left join bonus b on e.ename = b.ename\n"
-        + "left join dept d on e.deptno = d.deptno";
-    sql(sql).withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
-  }
-
   @Test void testPushProjectPastLeftJoinSwap() {
     final String sql = "select count(*), " + NOT_STRONG_EXPR + "\n"
         + "from bonus b left outer join emp e on e.ename = b.ename\n"
@@ -2135,6 +2127,18 @@ class RelOptRulesTest extends RelOptTestBase {
         + "sum(b.sal + b.sal + 100) over (partition by b.job)\n"
         + "from emp e join bonus b\n"
         + "on e.ename = b.ename and e.deptno = 10";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4982">[CALCITE-4982]
+   * NonNull field shouldn't be pushed down into leaf of outer-join
+   * in 'ProjectJoinTransposeRule'</a>. */
+  @Test void testPushProjectPastOutJoinWithCastNonNullExpr() {
+    final String sql = "select e.empno + 1 as c1, coalesce(d.name, b.job, '') as c2\n"
+        + "from emp e\n"
+        + "left join bonus b on e.ename = b.ename\n"
+        + "left join dept d on e.deptno = d.deptno";
     sql(sql).withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -9685,38 +9685,6 @@ LogicalProject(EXPR$0=[$1], EXPR$1=[$0])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testPushProjectPastLeftJoin2">
-    <Resource name="sql">
-      <![CDATA[select coalesce(d.name, b.job, '')
-from emp e
-left join bonus b on e.ename = b.ename
-left join dept d on e.deptno = d.deptno]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[CASE(IS NOT NULL($14), CAST($14):VARCHAR(10) NOT NULL, IS NOT NULL($10), CAST($10):VARCHAR(10) NOT NULL, '':VARCHAR(10))])
-  LogicalJoin(condition=[=($7, $13)], joinType=[left])
-    LogicalJoin(condition=[=($1, $9)], joinType=[left])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-      LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(EXPR$0=[CASE(IS NOT NULL($4), CAST($4):VARCHAR(10) NOT NULL, $1, $2, '':VARCHAR(10))])
-  LogicalJoin(condition=[=($0, $3)], joinType=[left])
-    LogicalProject(DEPTNO=[$1], EXPR$0=[IS NOT NULL($3)], EXPR$1=[CAST($3):VARCHAR(10) NOT NULL])
-      LogicalJoin(condition=[=($0, $2)], joinType=[left])
-        LogicalProject(ENAME=[$1], DEPTNO=[$7])
-          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-        LogicalProject(ENAME=[$0], JOB=[$1])
-          LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
-    LogicalProject(DEPTNO=[$0], NAME=[$1])
-      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testPushProjectPastLeftJoinStrong">
     <Resource name="sql">
       <![CDATA[select count(*), case when e.sal < 11 then -1 * e.sal else e.sal end
@@ -9801,6 +9769,38 @@ LogicalProject(EXPR$0=[$1], EXPR$1=[$0])
           LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
         LogicalProject(ENAME=[$1], EXPR$1=[CASE(<($5, 11), *(-1, $5), $5)])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushProjectPastOutJoinWithCastNonNullExpr">
+    <Resource name="sql">
+      <![CDATA[select e.empno + 1 as c1, coalesce(d.name, b.job, '') as c2
+from emp e
+left join bonus b on e.ename = b.ename
+left join dept d on e.deptno = d.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(C1=[+($0, 1)], C2=[CASE(IS NOT NULL($14), CAST($14):VARCHAR(10) NOT NULL, IS NOT NULL($10), CAST($10):VARCHAR(10) NOT NULL, '':VARCHAR(10))])
+  LogicalJoin(condition=[=($7, $13)], joinType=[left])
+    LogicalJoin(condition=[=($1, $9)], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(C1=[$2], C2=[CASE(IS NOT NULL($5), CAST($5):VARCHAR(10) NOT NULL, $3, CAST($1):VARCHAR(10) NOT NULL, '':VARCHAR(10))])
+  LogicalJoin(condition=[=($0, $4)], joinType=[left])
+    LogicalProject(DEPTNO=[$1], JOB0=[$4], C1=[$2], EXPR$1=[IS NOT NULL($4)])
+      LogicalJoin(condition=[=($0, $3)], joinType=[left])
+        LogicalProject(ENAME=[$1], DEPTNO=[$7], C1=[+($0, 1)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalProject(ENAME=[$0], JOB=[$1])
+          LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -9685,6 +9685,38 @@ LogicalProject(EXPR$0=[$1], EXPR$1=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPushProjectPastLeftJoin2">
+    <Resource name="sql">
+      <![CDATA[select coalesce(d.name, b.job, '')
+from emp e
+left join bonus b on e.ename = b.ename
+left join dept d on e.deptno = d.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[CASE(IS NOT NULL($14), CAST($14):VARCHAR(10) NOT NULL, IS NOT NULL($10), CAST($10):VARCHAR(10) NOT NULL, '':VARCHAR(10))])
+  LogicalJoin(condition=[=($7, $13)], joinType=[left])
+    LogicalJoin(condition=[=($1, $9)], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[CASE(IS NOT NULL($4), CAST($4):VARCHAR(10) NOT NULL, $1, $2, '':VARCHAR(10))])
+  LogicalJoin(condition=[=($0, $3)], joinType=[left])
+    LogicalProject(DEPTNO=[$1], EXPR$0=[IS NOT NULL($3)], EXPR$1=[CAST($3):VARCHAR(10) NOT NULL])
+      LogicalJoin(condition=[=($0, $2)], joinType=[left])
+        LogicalProject(ENAME=[$1], DEPTNO=[$7])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalProject(ENAME=[$0], JOB=[$1])
+          LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPushProjectPastLeftJoinStrong">
     <Resource name="sql">
       <![CDATA[select count(*), case when e.sal < 11 then -1 * e.sal else e.sal end


### PR DESCRIPTION
This pr is prepared for [ISSUE-4982](https://issues.apache.org/jira/browse/CALCITE-4982)