### PR TITLE
Site: Fixed custom table description

### DIFF
--- a/site/_docs/adapter.md
+++ b/site/_docs/adapter.md
@@ -432,7 +432,7 @@ See
 
 To define a custom table, you need to implement
 [<code>interface TableFactory</code>]({{ site.apiRoot }}/org/apache/calcite/schema/TableFactory.html).
-Whereas a schema factory a set of named tables, a table factory produces a
+Whereas a schema factory produces a set of named tables, a table factory produces a
 single table when bound to a schema with a particular name (and optionally a
 set of extra operands).
 


### PR DESCRIPTION
Corrected description (<br/>from <br/><code>Whereas a schema factory a set of named tables...</code> <br/>to <br/> <code>Whereas a schema factory <b>produces</b> a set of named tables...</code><br/>).