### PR TITLE
[CALCITE-4987] JDBC adapter generates incorrect query when ORDER BY alias collides with field in SELECT ITEM

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -445,7 +445,8 @@ public class RelToSqlConverter extends SqlImplementor
     final Builder builder = x.builder(e);
     if (!isStar(e.getProjects(), e.getInput().getRowType(), e.getRowType())) {
       //The order by ordinal may be greater than size of the new projects.
-      if (inputIsSort && dialect.getConformance().isSortByOrdinal()) {
+      if (inputIsSort && dialect.getConformance().isSortByOrdinal()
+          && builder.select.hasOrderBy()) {
         int maxOrderKey = e.getProjects().size();
         SqlNodeList orderList = requireNonNull(builder.select.getOrderList());
         final List<SqlNode> newOrderList = new ArrayList<>();

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -445,8 +445,8 @@ public class RelToSqlConverter extends SqlImplementor
     final Builder builder = x.builder(e);
     if (!isStar(e.getProjects(), e.getInput().getRowType(), e.getRowType())) {
       //The order by ordinal may be greater than size of the new projects.
-      if (inputIsSort && dialect.getConformance().isSortByOrdinal()
-          && builder.select.hasOrderBy()) {
+      if (inputIsSort && builder.select.hasOrderBy()
+          && dialect.getConformance().isSortByOrdinal()) {
         int maxOrderKey = e.getProjects().size();
         SqlNodeList orderList = requireNonNull(builder.select.getOrderList());
         final List<SqlNode> newOrderList = new ArrayList<>();

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -95,6 +95,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayDeque;
@@ -113,6 +114,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.calcite.rex.RexLiteral.stringValue;
+import static org.apache.calcite.sql.SqlUtil.stripAs;
 
 import static java.util.Objects.requireNonNull;
 
@@ -433,7 +435,8 @@ public class RelToSqlConverter extends SqlImplementor
   public Result visit(Project e) {
     // If the input is a Sort, wrap SELECT is not required.
     final Result x;
-    if (e.getInput() instanceof Sort) {
+    boolean inputIsSort = e.getInput() instanceof Sort;
+    if (inputIsSort) {
       x = visitInput(e, 0);
     } else {
       x = visitInput(e, 0, Clause.SELECT);
@@ -441,6 +444,31 @@ public class RelToSqlConverter extends SqlImplementor
     parseCorrelTable(e, x);
     final Builder builder = x.builder(e);
     if (!isStar(e.getProjects(), e.getInput().getRowType(), e.getRowType())) {
+      //The order by ordinal may be greater than size of the new projects.
+      if (inputIsSort && dialect.getConformance().isSortByOrdinal()) {
+        int maxOrderKey = e.getProjects().size();
+        SqlNodeList orderList = requireNonNull(builder.select.getOrderList());
+        final List<SqlNode> newOrderList = new ArrayList<>();
+        for (@NonNull SqlNode orderItem : orderList) {
+          int i = SqlUtil.getOrderByOrdinal(orderItem);
+          if (i > maxOrderKey) {
+            SqlNode orderField = stripAs(builder.select.getSelectList().get(i - 1));
+            SqlNode newOrderItem = orderItem.accept(new SqlShuttle() {
+              @Override public @Nullable SqlNode visit(SqlLiteral literal) {
+                if (SqlUtil.getOrderByOrdinal(literal) == i) {
+                  return orderField;
+                }
+                return super.visit(literal);
+              }
+            });
+            newOrderList.add(requireNonNull(newOrderItem, "newOrderItem"));
+          } else {
+            newOrderList.add(orderItem);
+          }
+        }
+        builder.setOrderBy(new SqlNodeList(newOrderList, POS));
+      }
+
       final List<SqlNode> selectList = new ArrayList<>();
       for (RexNode ref : e.getProjects()) {
         SqlNode sqlExpr = builder.context.toSql(null, ref);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -444,7 +444,12 @@ public class RelToSqlConverter extends SqlImplementor
     parseCorrelTable(e, x);
     final Builder builder = x.builder(e);
     if (!isStar(e.getProjects(), e.getInput().getRowType(), e.getRowType())) {
-      //The order by ordinal may be greater than size of the new projects.
+      //The ORDER BY ordinal may be greater than size of the new projects.
+      //For example, given
+      //    SELECT empno FROM emp ORDER BY 2
+      // we generate
+      //    SELECT empno FROM emp ORDER BY ename
+      // "ORDER BY 2" is incorrect because max ordinal is 1.
       if (inputIsSort && builder.select.hasOrderBy()
           && dialect.getConformance().isSortByOrdinal()) {
         int maxOrderKey = e.getProjects().size();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
@@ -27,7 +27,7 @@ public class SqlDelegatingConformance extends SqlAbstractConformance {
   private final SqlConformance delegate;
 
   /** Creates a SqlDelegatingConformance. */
-  protected SqlDelegatingConformance(SqlConformance delegate) {
+  public SqlDelegatingConformance(SqlConformance delegate) {
     this.delegate = delegate;
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -66,6 +66,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.sql.validate.SqlDelegatingConformance;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.MockSqlOperatorTable;
@@ -89,6 +91,7 @@ import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -457,7 +460,7 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY GROUPING SETS((\"product_class_id\", \"brand_name\"),"
         + " \"product_class_id\")\n"
-        + "ORDER BY \"brand_name\", \"product_class_id\"";
+        + "ORDER BY 2, 1";
     sql(query)
         .withPostgresql().ok(expected);
   }
@@ -591,7 +594,7 @@ class RelToSqlConverterTest {
         + "GROUP BY GROUPING SETS((\"EMPNO\", \"ENAME\", \"JOB\"),"
         + " (\"EMPNO\", \"ENAME\"), \"EMPNO\")\n"
         + "HAVING GROUPING(\"EMPNO\", \"ENAME\", \"JOB\") <> 0\n"
-        + "ORDER BY COUNT(*)";
+        + "ORDER BY 4";
     relFn(relFn).ok(expectedSql);
   }
 
@@ -636,14 +639,14 @@ class RelToSqlConverterTest {
     final String expected = "SELECT \"product_class_id\", \"brand_name\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\", \"brand_name\")\n"
-        + "ORDER BY \"product_class_id\", \"brand_name\"";
+        + "ORDER BY 1, 2";
     final String expectedMysql = "SELECT `product_class_id`, `brand_name`\n"
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY `product_class_id`, `brand_name` WITH ROLLUP";
     final String expectedMysql8 = "SELECT `product_class_id`, `brand_name`\n"
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY ROLLUP(`product_class_id`, `brand_name`)\n"
-        + "ORDER BY `product_class_id` NULLS LAST, `brand_name` NULLS LAST";
+        + "ORDER BY 1 NULLS LAST, 2 NULLS LAST";
     sql(query)
         .ok(expected)
         .withMysql().ok(expectedMysql)
@@ -660,7 +663,7 @@ class RelToSqlConverterTest {
     final String expected = "SELECT \"product_class_id\", \"brand_name\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\", \"brand_name\")\n"
-        + "ORDER BY \"brand_name\", \"product_class_id\"";
+        + "ORDER BY 2, 1";
     final String expectedMysql = "SELECT `product_class_id`, `brand_name`\n"
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY `brand_name`, `product_class_id` WITH ROLLUP";
@@ -724,17 +727,17 @@ class RelToSqlConverterTest {
     final String expected = "SELECT \"product_class_id\", COUNT(*) AS \"C\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\")\n"
-        + "ORDER BY \"product_class_id\", COUNT(*)";
+        + "ORDER BY 1, 2";
     final String expectedMysql = "SELECT `product_class_id`, COUNT(*) AS `C`\n"
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY `product_class_id` WITH ROLLUP\n"
-        + "ORDER BY `product_class_id` IS NULL, `product_class_id`,"
-        + " COUNT(*) IS NULL, COUNT(*)";
+        + "ORDER BY `product_class_id` IS NULL, 1,"
+        + " COUNT(*) IS NULL, 2";
     final String expectedPresto = "SELECT \"product_class_id\", COUNT(*) AS \"C\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\")\n"
-        + "ORDER BY \"product_class_id\" IS NULL, \"product_class_id\", "
-        + "COUNT(*) IS NULL, COUNT(*)";
+        + "ORDER BY \"product_class_id\" IS NULL, 1, "
+        + "COUNT(*) IS NULL, 2";
     sql(query)
         .ok(expected)
         .withMysql().ok(expectedMysql)
@@ -774,14 +777,14 @@ class RelToSqlConverterTest {
         + " COUNT(*) AS \"C\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\", \"brand_name\")\n"
-        + "ORDER BY \"product_class_id\", \"brand_name\", COUNT(*)";
+        + "ORDER BY 1, 2, 3";
     final String expectedMysql = "SELECT `product_class_id`, `brand_name`,"
         + " COUNT(*) AS `C`\n"
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY `product_class_id`, `brand_name` WITH ROLLUP\n"
-        + "ORDER BY `product_class_id` IS NULL, `product_class_id`,"
-        + " `brand_name` IS NULL, `brand_name`,"
-        + " COUNT(*) IS NULL, COUNT(*)";
+        + "ORDER BY `product_class_id` IS NULL, 1,"
+        + " `brand_name` IS NULL, 2,"
+        + " COUNT(*) IS NULL, 3";
     sql(query)
         .ok(expected)
         .withMysql().ok(expectedMysql);
@@ -1544,7 +1547,7 @@ class RelToSqlConverterTest {
         "select \"product_id\", \"net_weight\" from \"product\" order by \"net_weight\"";
     final String expected = "SELECT \"product_id\", \"net_weight\"\n"
         + "FROM \"foodmart\".\"product\"\n"
-        + "ORDER BY \"net_weight\"";
+        + "ORDER BY 2";
     sql(query).ok(expected);
   }
 
@@ -2045,10 +2048,10 @@ class RelToSqlConverterTest {
     // Hive and MSSQL do not support NULLS FIRST, so need to emulate
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY product_id IS NULL DESC, product_id DESC";
+        + "ORDER BY product_id IS NULL DESC, 1 DESC";
     final String mssqlExpected = "SELECT [product_id]\n"
         + "FROM [foodmart].[product]\n"
-        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 0 ELSE 1 END, [product_id] DESC";
+        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 0 ELSE 1 END, 1 DESC";
     sql(query)
         .dialect(HiveSqlDialect.DEFAULT).ok(expected)
         .dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected);
@@ -2060,10 +2063,10 @@ class RelToSqlConverterTest {
     // Hive and MSSQL do not support NULLS LAST, so need to emulate
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY product_id IS NULL, product_id";
+        + "ORDER BY product_id IS NULL, 1";
     final String mssqlExpected = "SELECT [product_id]\n"
         + "FROM [foodmart].[product]\n"
-        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 1 ELSE 0 END, [product_id]";
+        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 1 ELSE 0 END, 1";
     sql(query)
         .dialect(HiveSqlDialect.DEFAULT).ok(expected)
         .dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected);
@@ -2076,10 +2079,10 @@ class RelToSqlConverterTest {
     // need to emulate
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY product_id";
+        + "ORDER BY 1";
     final String mssqlExpected = "SELECT [product_id]\n"
         + "FROM [foodmart].[product]\n"
-        + "ORDER BY [product_id]";
+        + "ORDER BY 1";
     sql(query)
         .dialect(HiveSqlDialect.DEFAULT).ok(expected)
         .dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected);
@@ -2092,10 +2095,10 @@ class RelToSqlConverterTest {
     // need to emulate
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY product_id DESC";
+        + "ORDER BY 1 DESC";
     final String mssqlExpected = "SELECT [product_id]\n"
         + "FROM [foodmart].[product]\n"
-        + "ORDER BY [product_id] DESC";
+        + "ORDER BY 1 DESC";
     sql(query)
         .dialect(HiveSqlDialect.DEFAULT).ok(expected)
         .dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected);
@@ -2203,7 +2206,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls first";
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY product_id DESC NULLS FIRST";
+        + "ORDER BY 1 DESC NULLS FIRST";
     sql(query).dialect(hive2_1Dialect).ok(expected);
     sql(query).dialect(hive2_2_Dialect).ok(expected);
   }
@@ -2239,7 +2242,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls first";
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY product_id IS NULL DESC, product_id DESC";
+        + "ORDER BY product_id IS NULL DESC, 1 DESC";
     sql(query).dialect(hive2_1_0_Dialect).ok(expected);
   }
 
@@ -2263,7 +2266,7 @@ class RelToSqlConverterTest {
 
     final String expected = "SELECT \"product_id\"\n"
         + "FROM \"foodmart\".\"product\"\n"
-        + "ORDER BY \"product_id\", \"product_id\" DESC";
+        + "ORDER BY \"product_id\", 1 DESC";
     sql(query).dialect(jethroDataSqlDialect()).ok(expected);
   }
 
@@ -2282,7 +2285,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL DESC, `product_id` DESC";
+        + "ORDER BY `product_id` IS NULL DESC, 1 DESC";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2300,7 +2303,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL, `product_id`";
+        + "ORDER BY `product_id` IS NULL, 1";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2318,7 +2321,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id`";
+        + "ORDER BY 1";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2335,7 +2338,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` DESC";
+        + "ORDER BY 1 DESC";
     sql(query).dialect(MysqlSqlDialect.DEFAULT).ok(expected);
   }
 
@@ -2378,7 +2381,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id`";
+        + "ORDER BY 1";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2395,7 +2398,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL DESC, `product_id`";
+        + "ORDER BY `product_id` IS NULL DESC, 1";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2413,7 +2416,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` DESC";
+        + "ORDER BY 1 DESC";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2430,7 +2433,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL, `product_id` DESC";
+        + "ORDER BY `product_id` IS NULL, 1 DESC";
     sql(query).dialect(mySqlDialect(NullCollation.HIGH)).ok(expected);
   }
 
@@ -2448,7 +2451,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` DESC";
+        + "ORDER BY 1 DESC";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2465,7 +2468,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id`";
+        + "ORDER BY 1";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2482,7 +2485,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL, `product_id` DESC";
+        + "ORDER BY `product_id` IS NULL, 1 DESC";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2500,7 +2503,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL, `product_id`";
+        + "ORDER BY `product_id` IS NULL, 1";
     sql(query).dialect(mySqlDialect(NullCollation.FIRST)).ok(expected);
   }
 
@@ -2518,7 +2521,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL DESC, `product_id` DESC";
+        + "ORDER BY `product_id` IS NULL DESC, 1 DESC";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -2536,7 +2539,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls first";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` IS NULL DESC, `product_id`";
+        + "ORDER BY `product_id` IS NULL DESC, 1";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -2554,7 +2557,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" desc nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id` DESC";
+        + "ORDER BY 1 DESC";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -2571,7 +2574,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" nulls last";
     final String expected = "SELECT `product_id`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY `product_id`";
+        + "ORDER BY 1";
     sql(query).dialect(mySqlDialect(NullCollation.LAST)).ok(expected);
   }
 
@@ -2650,7 +2653,7 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" offset 10 rows fetch next 100 rows only";
     final String expected = "SELECT \"product_id\"\n"
         + "FROM \"foodmart\".\"product\"\n"
-        + "ORDER BY \"product_id\"\n"
+        + "ORDER BY 1\n"
         + "OFFSET 10 ROWS\n"
         + "FETCH NEXT 100 ROWS ONLY";
     sql(query).ok(expected);
@@ -2662,17 +2665,17 @@ class RelToSqlConverterTest {
         + "order by \"product_id\" fetch next 100 rows only";
     final String expected = "SELECT \"product_id\"\n"
         + "FROM \"foodmart\".\"product\"\n"
-        + "ORDER BY \"product_id\"\n"
+        + "ORDER BY 1\n"
         + "FETCH NEXT 100 ROWS ONLY";
     final String expectedMssql10 = "SELECT TOP (100) [product_id]\n"
         + "FROM [foodmart].[product]\n"
-        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 1 ELSE 0 END, [product_id]";
+        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 1 ELSE 0 END, 1";
     final String expectedMssql = "SELECT TOP (100) [product_id]\n"
         + "FROM [foodmart].[product]\n"
-        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 1 ELSE 0 END, [product_id]";
+        + "ORDER BY CASE WHEN [product_id] IS NULL THEN 1 ELSE 0 END, 1";
     final String expectedSybase = "SELECT TOP (100) product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY product_id";
+        + "ORDER BY 1";
     sql(query).ok(expected)
         .withMssql(10).ok(expectedMssql10)
         .withMssql(11).ok(expectedMssql)
@@ -2688,7 +2691,7 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"product\"\n"
         + "WHERE \"cases_per_pallet\" > 100\n"
         + "GROUP BY \"product_id\", \"units_per_case\"\n"
-        + "ORDER BY \"units_per_case\" DESC";
+        + "ORDER BY 2 DESC";
     sql(query).ok(expected);
   }
 
@@ -3034,7 +3037,7 @@ class RelToSqlConverterTest {
         + "FROM foodmart.product AS product\n"
         + "WHERE product.cases_per_pallet > 100\n"
         + "GROUP BY product.product_id, product.units_per_case\n"
-        + "ORDER BY product.units_per_case DESC";
+        + "ORDER BY 2 DESC";
     sql(query).withDb2().ok(expected);
   }
 
@@ -3048,14 +3051,14 @@ class RelToSqlConverterTest {
         + "  from \"product\")\n"
         + "where \"cases_per_pallet\" > 100\n"
         + "group by \"product_id\", \"units_per_case\"\n"
-        + "order by \"units_per_case\" desc";
+        + "order by 2 desc";
     final String expected = "SELECT COUNT(*), t.units_per_case\n"
         + "FROM (SELECT product.units_per_case, product.cases_per_pallet, "
         + "product.product_id, 1 AS FOO\n"
         + "FROM foodmart.product AS product) AS t\n"
         + "WHERE t.cases_per_pallet > 100\n"
         + "GROUP BY t.product_id, t.units_per_case\n"
-        + "ORDER BY t.units_per_case DESC";
+        + "ORDER BY 2 DESC";
     sql(query).withDb2().ok(expected);
   }
 
@@ -3085,7 +3088,7 @@ class RelToSqlConverterTest {
         + "WHERE product0.cases_per_pallet < 100) AS t3\n"
         + "WHERE t3.cases_per_pallet > 100\n"
         + "GROUP BY t3.product_id, t3.units_per_case\n"
-        + "ORDER BY t3.units_per_case DESC";
+        + "ORDER BY 2 DESC";
     sql(query).withDb2().ok(expected);
   }
 
@@ -6232,13 +6235,93 @@ class RelToSqlConverterTest {
         + "FROM SCOTT.EMP\n"
         + "GROUP BY DEPTNO\n"
         + "HAVING COUNT(DISTINCT EMPNO) > 0\n"
-        + "ORDER BY COUNT(DISTINCT EMPNO) IS NULL DESC, COUNT(DISTINCT EMPNO) DESC";
+        + "ORDER BY COUNT(DISTINCT EMPNO) IS NULL DESC, 2 DESC";
 
     // Convert rel node to SQL with BigQuery dialect,
     // in which "isHavingAlias" is true.
     sql(sql)
         .schema(CalciteAssert.SchemaSpec.JDBC_SCOTT)
         .withBigQuery().ok(expected);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4987">[CALCITE-4987]
+   * JDBC adapter generates incorrect query when ORDER BY alias collides with field
+   * in SELECT ITEM</a>. <br>
+   * Also cover <a href="https://issues.apache.org/jira/browse/CALCITE-2552">[CALCITE-2552]
+   * JDBC adapter generates Non-Dialect Specific Order By Field Identifier</a>. <br/>*/
+  @Test void testOrderByClauseWithDialectConformance() {
+    List<String[]> tests = prepareOrderByClauseWithDialectConformanceTests();
+    for (String[] test : tests) {
+      String queryWithAlias = test[0];
+      String expectedWithOrdinal = test[1];
+      String expectedWithSelectItem = test[2];
+      //isSortByOrdinal = true, isSortByAlias = true, resolve to order by ordinal.
+      sql(queryWithAlias).ok(expectedWithOrdinal);
+      //isSortByOrdinal = false, isSortByAlias = true, resolve to order by alias.
+      sql(queryWithAlias)
+          .dialect(new CalciteSqlDialect(CalciteSqlDialect.DEFAULT_CONTEXT) {
+            @Override public SqlConformance getConformance() {
+              return new SqlDelegatingConformance(SqlConformanceEnum.DEFAULT) {
+                @Override public boolean isSortByOrdinal() {
+                  return false;
+                }
+              };
+            }
+          })
+          .ok(queryWithAlias);
+      //isSortByOrdinal = false, isSortByAlias = false, resolve to order by select item.
+      sql(queryWithAlias)
+          .dialect(new CalciteSqlDialect(CalciteSqlDialect.DEFAULT_CONTEXT) {
+            @Override public SqlConformance getConformance() {
+              return new SqlDelegatingConformance(SqlConformanceEnum.DEFAULT) {
+                @Override public boolean isSortByOrdinal() {
+                  return false;
+                }
+
+                @Override public boolean isSortByAlias() {
+                  return false;
+                }
+              };
+            }
+          })
+          .ok(expectedWithSelectItem);
+    }
+  }
+
+  private List<String[]> prepareOrderByClauseWithDialectConformanceTests() {
+    List<String[]> tests = new ArrayList<>();
+    // Before 4987 was fixed, the generated query would prefer "SUM(shelf_width)" in its
+    // ORDER BY clause.Now ORDER BY clause depends on dialect's conformance.
+    // See SqlConformance#isSortByOrdinal, SqlConformance#isSortByAlias
+    //testOrderByAliasCollidingWithFieldInSelect
+    String queryWithAlias = "SELECT SUM(\"shelf_width\") AS \"shelf_width\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "ORDER BY \"shelf_width\"";
+    String expectedWithOrdinal = "SELECT SUM(\"shelf_width\") AS \"shelf_width\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "ORDER BY 1";
+    String expectedWithSelectItem = "SELECT SUM(\"shelf_width\") AS \"shelf_width\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "ORDER BY SUM(\"shelf_width\")";
+    tests.add(new String[]{queryWithAlias, expectedWithOrdinal, expectedWithSelectItem});
+
+    // Before 2552 was fixed, the generated query would prefer "shelf_width" in its
+    // ORDER BY clause.Now ORDER BY clause depends on dialect's conformance.
+    // See SqlConformance#isSortByOrdinal, SqlConformance#isSortByAlias
+    //testOrderByAlias
+    queryWithAlias = "SELECT \"net_weight\" AS \"shelf_width\", \"shelf_width\" AS \"x\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "ORDER BY \"x\""; //equals ORDER BY "product"."shelf_width"
+    expectedWithOrdinal = "SELECT \"net_weight\" AS \"shelf_width\", \"shelf_width\" AS \"x\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "ORDER BY 2";
+    expectedWithSelectItem = "SELECT \"net_weight\" AS \"shelf_width\", \"shelf_width\" AS \"x\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "ORDER BY \"shelf_width\""; //shelf_width doesn't collide because the dialect doesn't
+    // support order by alias.
+    tests.add(new String[]{queryWithAlias, expectedWithOrdinal, expectedWithSelectItem});
+    return tests;
   }
 
   /** Fluid interface to run tests. */

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -190,7 +190,7 @@ class JdbcAdapterTest {
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
         .planHasSql("SELECT \"ENAME\", \"EMPNO\"\n"
             + "FROM \"SCOTT\".\"EMP\"\n"
-            + "ORDER BY \"EMPNO\" NULLS LAST");
+            + "ORDER BY 2 NULLS LAST");
   }
 
   /** Test case for
@@ -209,7 +209,7 @@ class JdbcAdapterTest {
     final String sqlHsqldb = "SELECT \"DEPTNO\", \"JOB\", SUM(\"SAL\")\n"
         + "FROM \"SCOTT\".\"EMP\"\n"
         + "GROUP BY \"JOB\", \"DEPTNO\"\n"
-        + "ORDER BY \"DEPTNO\" NULLS LAST, \"JOB\" NULLS LAST";
+        + "ORDER BY 1 NULLS LAST, 2 NULLS LAST";
     CalciteAssert.model(JdbcTest.SCOTT_MODEL)
         .with(CalciteConnectionProperty.TOPDOWN_OPT.camelName(), false)
         .query(sql)

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -394,7 +394,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "  LATERAL UNNEST (SELECT $cor1.$f2 AS $f0\n"
         + "    FROM (VALUES (0)) AS t (ZERO)) AS t3 (EMPNO, ENAME, JOB,"
         + " MGR, HIREDATE, SAL, COMM, DEPTNO) AS t30\n"
-        + "ORDER BY $cor1.DEPTNO, $cor1.JOB";
+        + "ORDER BY 1, 2";
     pig(script).assertRel(hasTree(plan))
         .assertSql(is(sql));
 
@@ -490,7 +490,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "  LATERAL UNNEST (SELECT $cor5.X AS $f0\n"
         + "    FROM (VALUES (0)) AS t (ZERO)) "
         + "AS t11 (ENAME, JOB, DEPTNO, SAL) AS t110\n"
-        + "ORDER BY $cor5.group";
+        + "ORDER BY 1";
     pig(script).assertRel(hasTree(plan))
         .assertResult(is(result))
         .assertSql(is(sql));
@@ -1362,7 +1362,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "BIGINT) AS $f1, CAST(SUM(SAL) AS DECIMAL(19, 0)) AS salSum\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 3";
     pig(script).assertResult(is(result))
         .assertSql(is(sql));
   }
@@ -1480,7 +1480,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "(19, 0)) AS salAvg\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 3";
     pig(script).assertRel(hasTree(plan))
         .assertOptimizedRel(hasTree(optimizedPlan))
         .assertResult(is(result))
@@ -1501,7 +1501,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "AS A\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 3";
     pig(script2).assertSql(is(sql2));
 
     final String script3 = ""
@@ -1551,7 +1551,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "COLLECT(COMM) AS comArray, CAST(SUM(SAL) AS DECIMAL(19, 0)) AS salSum\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 7";
     pig(script).assertRel(hasTree(plan))
         .assertOptimizedRel(hasTree(optimizedPlan))
         .assertSql(is(sql));
@@ -1610,7 +1610,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "    FROM scott.DEPT\n"
         + "    WHERE DEPTNO >= 20\n"
         + "    GROUP BY CAST(DEPTNO AS INTEGER)) AS t7 ON t4.DEPTNO = t7.DEPTNO\n"
-        + "ORDER BY CASE WHEN t4.DEPTNO IS NOT NULL THEN t4.DEPTNO ELSE t7.DEPTNO END";
+        + "ORDER BY 1";
     pig(script).assertRel(hasTree(plan))
         .assertResult(is(result))
         .assertSql(is(sql));


### PR DESCRIPTION
After this pr, JDBC adapter generates ORDER BY clause with the following preference:
1. if dialect conformance support sort by ordinal, prefer ORDER BY ordinal.
2. if dialect conformance support sort by alias, prefer ORDER BY alias.
3. resolve to ORDER BY SELECT ITEM without as.

Exceptions:
1. if the ORDER BY clause is in WINDOW or WITHIN GROUP, always resolve to ORDER BY SELECT ITEM.
2. if the ORDER BY ordinal is greater than size of SELECT LIST, always resolve to ORDER BY SELECT ITEM.