### PR TITLE
[CALCITE-4965] IS NOT NULL failed in Elasticsearch Adapter

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -205,11 +205,6 @@ public abstract class Bug {
    * In Elasticsearch adapter, a range predicate should be translated to a range query</a> is
    * fixed. */
   public static final boolean CALCITE_4645_FIXED = false;
-  /** Whether
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-4965">[CALCITE-4965]
-   * IS NOT NULL failed in Elasticsearch Adapter</a> is
-   * fixed. */
-  public static final boolean CALCITE_4965_FIXED = false;
 
   /**
    * Use this to flag temporary code.

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
@@ -604,6 +604,9 @@ class PredicateAnalyzer {
     public abstract QueryExpression isTrue();
 
     public static QueryExpression create(TerminalExpression expression) {
+      if (expression instanceof CastExpression) {
+        expression = CastExpression.unpack(expression);
+      }
 
       if (expression instanceof NamedFieldExpression) {
         return new SimpleQueryExpression((NamedFieldExpression) expression);

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/BooleanLogicTest.java
@@ -21,7 +21,6 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.test.CalciteAssert;
-import org.apache.calcite.util.Bug;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
@@ -119,10 +118,8 @@ class BooleanLogicTest {
     assertEmpty("select * from view where num > 42 and num < 42 and num = 42");
     assertEmpty("select * from view where num > 42 or num < 42 and num = 42");
     assertSingle("select * from view where num > 42 and num < 42 or num = 42");
-    if (Bug.CALCITE_4965_FIXED) {
-      assertSingle("select * from view where num > 42 or num < 42 or num = 42");
-      assertEmpty("select * from view where num is null");
-    }
+    assertSingle("select * from view where num > 42 or num < 42 or num = 42");
+    assertEmpty("select * from view where num is null");
     assertSingle("select * from view where num >= 42 and num <= 42 and num = 42");
     assertEmpty("select * from view where num >= 42 and num <= 42 and num <> 42");
     assertEmpty("select * from view where num < 42");


### PR DESCRIPTION
NamedFieldExpression is packed in CastExpression while translating bool condition.