### PR TITLE
[CALCITE-4954] Group TEXT field failed in Elasticsearch Adapter

### DIFF
--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
@@ -190,7 +190,12 @@ class EmbeddedElasticsearchPolicy {
             suffix, type);
       }
     } else {
-      parent.withObject("/" + key).put("type", type);
+      if ("text".equalsIgnoreCase(type)) {
+        // aggregations and sorting are disabled by default for text field type
+        parent.withObject("/" + key).put("type", type).put("fielddata", "true");
+      } else {
+        parent.withObject("/" + key).put("type", type);
+      }
     }
   }
 


### PR DESCRIPTION
Set "**fielddata**" to "**true**" in Elasticsearch mapping, since aggregations and sorting are disabled by default for text type.

It's only set in the test module, which provides instruction for SQL users when they want to group or sort text field.