### PR TITLE
[CALCITE-4992] Close the ElasticSearch RestClient in ElasticsearchTransport

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
@@ -67,7 +67,7 @@ public class ElasticsearchSchemaFactory implements SchemaFactory {
       .maximumSize(1000)
       .expireAfterAccess(1, TimeUnit.HOURS)
       .removalListener(new RemovalListener<Integer, RestClient>() {
-        public void onRemoval(RemovalNotification<Integer, RestClient> notice) {
+        @Override public void onRemoval(RemovalNotification<Integer, RestClient> notice) {
           try {
             // Free resources allocated by this RestClient
             notice.getValue().close();

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
@@ -63,7 +63,7 @@ public class ElasticsearchSchemaFactory implements SchemaFactory {
   // RestClient objects allocate system resources and are thread safe. Here, we
   // cache them using a key derived from the hashCode()s of the parameters that
   // define a RestClient.
-  private static Cache<Integer, RestClient> REST_CLIENTS = CacheBuilder.newBuilder()
+  private static Cache<Integer, RestClient> restClients = CacheBuilder.newBuilder()
       .maximumSize(1000)
       .expireAfterAccess(1, TimeUnit.HOURS)
       .removalListener(new RemovalListener<Integer, RestClient>() {
@@ -146,7 +146,7 @@ public class ElasticsearchSchemaFactory implements SchemaFactory {
     Integer cacheKey = Objects.hash(hosts, pathPrefix, username, password);
 
     try {
-      return REST_CLIENTS.get(cacheKey, new Callable<RestClient>() {
+      return restClients.get(cacheKey, new Callable<RestClient>() {
         @Override public RestClient call() {
           RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()]));
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
@@ -72,14 +72,14 @@ public class ElasticsearchSchemaFactory implements SchemaFactory {
       .removalListener(new RemovalListener<Integer, RestClient>() {
         @Override public void onRemoval(RemovalNotification<Integer, RestClient> notice) {
           LOGGER.warn(
-            "Will close an ES REST client to keep the number of open clients under {}",
-            REST_CLIENT_CACHE_SIZE
+              "Will close an ES REST client to keep the number of open clients under {}",
+              REST_CLIENT_CACHE_SIZE
           );
           LOGGER.warn(
-            "Any schema objects created with this client are now broken!\n"
-  +
-            "Do not try to access more than {} distinct ES REST APIs through this adapter.",
-            REST_CLIENT_CACHE_SIZE
+              "Any schema objects created with this client are now broken!\n"
+              +
+              "Do not try to access more than {} distinct ES REST APIs through this adapter.",
+              REST_CLIENT_CACHE_SIZE
           );
 
           try {


### PR DESCRIPTION
## What is the purpose of the change

The change attempts to address a resource leak bug believed to result from no call to RestClient#close() being made.  [Docs describing the need for this call are online here](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low-usage-initialization.html).

~~The call to RestClient#close() is added to a new `finalize()` method in ElasticsearchTransport because no other suitable lifecycle method was evident to me.  Any suggestion of a better place to make this call is welcome.~~

Instead of creating a new RestClient instance every time a new Schema is created, shared RestClient instances are cached and reused. If the cache grows beyond a fixed number, currently 100, of distinct RestClients then evictions begin along with the logging of warnings.  Upon the eviction of a RestClient, a call to its `close()` method is made.

## Verifying this change

File descriptor resource leaks such as we have observed in the context connecting Apache Drill to ElasticSearch (which goes via Calcite) are not easy to unit test.  I'm open to ideas here...