### PR TITLE
[CALCITE-4994] SQL-to-RelNode conversion is slow if table contains hundreds of fields

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFieldImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFieldImpl.java
@@ -23,6 +23,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.Serializable;
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Default implementation of {@link RelDataTypeField}.
  */
@@ -42,11 +44,9 @@ public class RelDataTypeFieldImpl implements RelDataTypeField, Serializable {
       String name,
       int index,
       RelDataType type) {
-    assert name != null;
-    assert type != null;
-    this.name = name;
+    this.name = requireNonNull(name, "name");
     this.index = index;
-    this.type = type;
+    this.type = requireNonNull(type, "type");
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -35,6 +35,7 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
@@ -97,9 +98,17 @@ public abstract class RelDataTypeImpl
       throw new IllegalStateException("Trying to access field " + fieldName
           + " in a type with no fields: " + this);
     }
-    for (RelDataTypeField field : fieldList) {
-      if (Util.matches(caseSensitive, field.getName(), fieldName)) {
+    final Map<String, RelDataTypeField> fieldMap = getFieldMap();
+    if (caseSensitive && fieldMap != null) {
+      RelDataTypeField field = fieldMap.get(fieldName);
+      if (field != null) {
         return field;
+      }
+    } else {
+      for (RelDataTypeField field : fieldList) {
+        if (Util.matches(caseSensitive, field.getName(), fieldName)) {
+          return field;
+        }
       }
     }
     if (elideRecord) {
@@ -127,13 +136,32 @@ public abstract class RelDataTypeImpl
     }
 
     // a dynamic * field will match any field name.
-    for (RelDataTypeField field : fieldList) {
-      if (field.isDynamicStar()) {
-        // the requested field could be in the unresolved star
-        return field;
+    if (fieldMap != null) {
+      return fieldMap.get("");
+    } else {
+      for (RelDataTypeField field : fieldList) {
+        if (field.isDynamicStar()) {
+          // the requested field could be in the unresolved star
+          return field;
+        }
       }
     }
 
+    return null;
+  }
+
+  /** Returns a map from field names to fields.
+   *
+   * <p>Matching is case-sensitive.
+   *
+   * <p>If several fields have the same name, the map contains the first.
+   *
+   * <p>A {@link RelDataTypeField#isDynamicStar() dynamic star field} is indexed
+   * under its own name and "" (the empty string).
+   *
+   * <p>If the map is null, the type must do lookup the long way.
+   */
+  protected @Nullable Map<String, RelDataTypeField> getFieldMap() {
     return null;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -4106,8 +4106,9 @@ public class SqlToRelConverter {
     } else {
       qualified = SqlQualified.create(null, 1, null, identifier);
     }
-    final Pair<RexNode, @Nullable BiFunction<RexNode, String, RexNode>> e0 =
-        bb.lookupExp(qualified);
+    final Pair<RexNode, @Nullable BiFunction<RexNode, String, RexNode>> e0 = requireNonNull(
+        bb.lookupExp(qualified),
+        () -> "no expression found for " + qualified);
     RexNode e = e0.left;
     for (String name : qualified.suffix()) {
       if (e == e0.left && e0.right != null) {
@@ -4781,7 +4782,7 @@ public class SqlToRelConverter {
      * @return a {@link RexFieldAccess} or {@link RexRangeRef}, or null if
      * not found
      */
-    Pair<RexNode, @Nullable BiFunction<RexNode, String, RexNode>> lookupExp(
+    @Nullable Pair<RexNode, @Nullable BiFunction<RexNode, String, RexNode>> lookupExp(
         SqlQualified qualified) {
       if (nameToNodeMap != null && qualified.prefixLength == 1) {
         RexNode node = nameToNodeMap.get(qualified.identifier.names.get(0));

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -4106,16 +4106,12 @@ public class SqlToRelConverter {
     } else {
       qualified = SqlQualified.create(null, 1, null, identifier);
     }
-    final Pair<RexNode, @Nullable Map<String, Integer>> e0 = requireNonNull(
-        bb.lookupExp(qualified),
-        () -> "no expression found for " + qualified);
+    final Pair<RexNode, @Nullable BiFunction<RexNode, String, RexNode>> e0 =
+        bb.lookupExp(qualified);
     RexNode e = e0.left;
     for (String name : qualified.suffix()) {
       if (e == e0.left && e0.right != null) {
-        Integer i = requireNonNull(
-            e0.right.get(name),
-            () -> "e0.right.get(name) produced null for " + name);
-        e = rexBuilder.makeFieldAccess(e, i);
+        e = e0.right.apply(e, name);
       } else {
         final boolean caseSensitive = true; // name already fully-qualified
         if (identifier.isStar() && bb.scope instanceof MatchRecognizeScope) {
@@ -4785,7 +4781,8 @@ public class SqlToRelConverter {
      * @return a {@link RexFieldAccess} or {@link RexRangeRef}, or null if
      * not found
      */
-    @Nullable Pair<RexNode, @Nullable Map<String, Integer>> lookupExp(SqlQualified qualified) {
+    Pair<RexNode, @Nullable BiFunction<RexNode, String, RexNode>> lookupExp(
+        SqlQualified qualified) {
       if (nameToNodeMap != null && qualified.prefixLength == 1) {
         RexNode node = nameToNodeMap.get(qualified.identifier.names.get(0));
         if (node == null) {
@@ -4814,18 +4811,13 @@ public class SqlToRelConverter {
         final LookupContext rels =
             new LookupContext(this, inputs, systemFieldList.size());
         final RexNode node = lookup(resolve.path.steps().get(0).i, rels);
-        if (node == null) {
-          return null;
-        } else {
-          final Map<String, Integer> fieldOffsets = new HashMap<>();
-          for (RelDataTypeField f : resolve.rowType().getFieldList()) {
-            if (!fieldOffsets.containsKey(f.getName())) {
-              fieldOffsets.put(f.getName(), f.getIndex());
-            }
-          }
-          final Map<String, Integer> map = ImmutableMap.copyOf(fieldOffsets);
-          return Pair.of(node, map);
-        }
+        assert node != null;
+        return Pair.of(node, (e, fieldName) -> {
+          final RelDataTypeField field =
+              requireNonNull(rowType.getField(fieldName, true, false),
+                  () -> "field " + fieldName);
+          return rexBuilder.makeFieldAccess(e, field.getIndex());
+        });
       } else {
         // We're referencing a relational expression which has not been
         // converted yet. This occurs when from items are correlated,
@@ -4857,7 +4849,11 @@ public class SqlToRelConverter {
           }
           final RexNode c =
               rexBuilder.makeCorrel(builder.uniquify().build(), correlId);
-          return Pair.of(c, fields.build());
+          final ImmutableMap<String, Integer> fieldMap = fields.build();
+          return Pair.of(c, (e, fieldName) -> {
+            final int j = requireNonNull(fieldMap.get(fieldName), "field " + fieldName);
+            return rexBuilder.makeFieldAccess(e, j);
+          });
         }
       }
     }

--- a/ubenchmark/README.md
+++ b/ubenchmark/README.md
@@ -28,27 +28,23 @@ Calcite artifacts. (Besides, jmh's license does not allow that.)
 
 To run all benchmarks:
 
-{noformat}bash
-$ cd calcite
-$ ./gradlew :ubenchmark:jmh
-{noformat}
+    cd calcite
+    ./gradlew :ubenchmark:jmh
 
 ## Running one benchmark from the command line
 
 To run just one benchmark, modify `ubenchmark/build.gradle.kts` and add the
 following task:
 
-{noformat}kotlin
+```kotlin
 jmh {
     include = listOf("removeAllVertices.*Benchmark")
 }
-{noformat}
+```
 
 and run
 
-{noformat}bash
-$ ./gradlew :ubenchmark:jmh
-{noformat}
+    ./gradlew :ubenchmark:jmh
 
 as before. In this case, `removeAllVertices.*Benchmark` is a
 regular expression that matches a few methods -- benchmarks -- in
@@ -74,3 +70,5 @@ case and link them here:
   [3836](https://issues.apache.org/jira/browse/CALCITE-3836)
 * ReflectVisitorDispatcherTest:
   [3873](https://issues.apache.org/jira/browse/CALCITE-3873)
+* RelConversionBenchmark:
+  [4994](https://issues.apache.org/jira/browse/CALCITE-4994)

--- a/ubenchmark/README.md
+++ b/ubenchmark/README.md
@@ -70,5 +70,5 @@ case and link them here:
   [3836](https://issues.apache.org/jira/browse/CALCITE-3836)
 * ReflectVisitorDispatcherTest:
   [3873](https://issues.apache.org/jira/browse/CALCITE-3873)
-* RelConversionBenchmark:
+* RelNodeConversionBenchmark:
   [4994](https://issues.apache.org/jira/browse/CALCITE-4994)

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/RelConversionBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/RelConversionBenchmark.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.benchmarks;
+
+import org.apache.calcite.adapter.java.AbstractQueryableTable;
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Planner;
+import org.apache.calcite.tools.Programs;
+
+import com.google.common.collect.ImmutableList;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks Conversion of Sql To Rel.
+ */
+@Fork(value = 1, jvmArgsPrepend = "-Xmx2048m")
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Threads(1)
+public class RelConversionBenchmark {
+
+  /**
+   * A state holding information needed to parse.
+   */
+  @State(Scope.Thread)
+  public static class SqlToRelBenchmarkState {
+    @Param({"10000"})
+    int length;
+
+    @Param({"10", "100", "1000"})
+    int columnLength;
+    String sql;
+    Planner p;
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+      // Create Sql
+      StringBuilder sb = new StringBuilder();
+      sb.append("select 1 ");
+      Random rnd = new Random();
+      rnd.setSeed(424242);
+      for (int i = 0; i < length; i++) {
+        sb.append(", ");
+        sb.append(
+            String.format(Locale.ROOT, "c%s / CASE WHEN c%s > %d THEN c%s ELSE c%s END ",
+                String.valueOf(rnd.nextInt(columnLength)), String.valueOf(i % columnLength),
+                rnd.nextInt(columnLength), String.valueOf(rnd.nextInt(columnLength)),
+                String.valueOf(rnd.nextInt(columnLength)))
+        );
+      }
+      sb.append(" FROM test1");
+      sql = sb.toString();
+
+      // Create Schema and Table
+
+      AbstractTable t = new AbstractQueryableTable(Integer.class) {
+        List<Integer> items = ImmutableList.of();
+        final Enumerable<Integer> enumerable = Linq4j.asEnumerable(items);
+
+        @Override public <E> Queryable<E> asQueryable(
+            QueryProvider queryProvider, SchemaPlus schema, String tableName) {
+          return (Queryable<E>) enumerable.asQueryable();
+        }
+
+        @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+          RelDataTypeFactory.Builder builder = typeFactory.builder();
+          for (int i = 0; i < columnLength; i++) {
+            builder.add(String.format(Locale.ROOT, "c%d", i), SqlTypeName.INTEGER);
+          }
+          return builder.build();
+        }
+      };
+
+      // Create Planner
+      final SchemaPlus schema = Frameworks.createRootSchema(true);
+      schema.add("test1", t);
+
+      final FrameworkConfig config = Frameworks.newConfigBuilder()
+          .parserConfig(SqlParser.config().withLex(Lex.MYSQL))
+          .defaultSchema(schema)
+          .programs(Programs.ofRules(Programs.RULE_SET))
+          .build();
+      p = Frameworks.getPlanner(config);
+    }
+
+    public RelNode parse() throws Exception {
+      SqlNode n = p.parse(sql);
+      n = p.validate(n);
+      RelNode rel = p.rel(n).project();
+      p.close();
+      p.reset();
+      return rel;
+    }
+  }
+
+  @Benchmark
+  public RelNode parse(SqlToRelBenchmarkState state) throws Exception {
+    return state.parse();
+  }
+
+  /**
+   * A state holding information needed to convert To Rel.
+   */
+  @State(Scope.Thread)
+  public static class SqlNodeToRelBenchmarkState {
+    @Param({"10000"})
+    int length;
+
+    @Param({"10", "100", "1000"})
+    int columnLength;
+    SqlNode sqlNode;
+    Planner p;
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+      String sql;
+      // Create Sql
+      StringBuilder sb = new StringBuilder();
+      sb.append("select 1 ");
+      Random rnd = new Random();
+      rnd.setSeed(424242);
+      for (int i = 0; i < length; i++) {
+        sb.append(", ");
+        sb.append(
+            String.format(Locale.ROOT, "c%s / CASE WHEN c%s > %d THEN c%s ELSE c%s END ",
+                String.valueOf(rnd.nextInt(columnLength)), String.valueOf(i % columnLength),
+                rnd.nextInt(columnLength), String.valueOf(rnd.nextInt(columnLength)),
+                String.valueOf(rnd.nextInt(columnLength)))
+        );
+      }
+      sb.append(" FROM test1");
+      sql = sb.toString();
+
+      // Create Schema and Table
+
+      AbstractTable t = new AbstractQueryableTable(Integer.class) {
+        List<Integer> items = ImmutableList.of();
+        final Enumerable<Integer> enumerable = Linq4j.asEnumerable(items);
+
+        @Override public <E> Queryable<E> asQueryable(
+            QueryProvider queryProvider, SchemaPlus schema, String tableName) {
+          return (Queryable<E>) enumerable.asQueryable();
+        }
+
+        @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+          RelDataTypeFactory.Builder builder = typeFactory.builder();
+          for (int i = 0; i < columnLength; i++) {
+            builder.add(String.format(Locale.ROOT, "c%d", i), SqlTypeName.INTEGER);
+          }
+          return builder.build();
+        }
+      };
+
+      // Create Planner
+      final SchemaPlus schema = Frameworks.createRootSchema(true);
+      schema.add("test1", t);
+
+      final FrameworkConfig config = Frameworks.newConfigBuilder()
+          .parserConfig(SqlParser.config().withLex(Lex.MYSQL))
+          .defaultSchema(schema)
+          .programs(Programs.ofRules(Programs.RULE_SET))
+          .build();
+      p = Frameworks.getPlanner(config);
+
+      try {
+        sqlNode = p.validate(p.parse(sql));
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+
+    }
+
+    public RelNode convertToRel() throws Exception {
+      return p.rel(sqlNode).project();
+    }
+  }
+
+  @Benchmark
+  public RelNode convertToRel(SqlNodeToRelBenchmarkState state) throws Exception {
+    return state.convertToRel();
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(RelConversionBenchmark.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .addProfiler(FlightRecorderProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+}

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/RelNodeConversionBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/RelNodeConversionBenchmark.java
@@ -62,7 +62,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Benchmarks Conversion of Sql To Rel.
+ * Benchmarks Conversion of Sql To RelNode and conversion of SqlNode to RelNode
  */
 @Fork(value = 1, jvmArgsPrepend = "-Xmx2048m")
 @Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
@@ -71,13 +71,13 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Threads(1)
-public class RelConversionBenchmark {
+public class RelNodeConversionBenchmark {
 
   /**
    * A state holding information needed to parse.
    */
   @State(Scope.Thread)
-  public static class SqlToRelBenchmarkState {
+  public static class SqlToRelNodeBenchmarkState {
     @Param({"10000"})
     int length;
 
@@ -148,7 +148,7 @@ public class RelConversionBenchmark {
   }
 
   @Benchmark
-  public RelNode parse(SqlToRelBenchmarkState state) throws Exception {
+  public RelNode parse(SqlToRelNodeBenchmarkState state) throws Exception {
     return state.parse();
   }
 
@@ -156,7 +156,7 @@ public class RelConversionBenchmark {
    * A state holding information needed to convert To Rel.
    */
   @State(Scope.Thread)
-  public static class SqlNodeToRelBenchmarkState {
+  public static class SqlNodeToRelNodeBenchmarkState {
     @Param({"10000"})
     int length;
 
@@ -230,13 +230,13 @@ public class RelConversionBenchmark {
   }
 
   @Benchmark
-  public RelNode convertToRel(SqlNodeToRelBenchmarkState state) throws Exception {
+  public RelNode convertToRel(SqlNodeToRelNodeBenchmarkState state) throws Exception {
     return state.convertToRel();
   }
 
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(RelConversionBenchmark.class.getSimpleName())
+        .include(RelNodeConversionBenchmark.class.getSimpleName())
         .addProfiler(GCProfiler.class)
         .addProfiler(FlightRecorderProfiler.class)
         .detectJvmArgs()


### PR DESCRIPTION
PS-    I am new in calcite so wanted your suggestions if any benchmarking, testing is required .

 fix issue:[ CALCITE-4994](https://issues.apache.org/jira/browse/CALCITE-4994)
This was a bottleneck in In my database, I had observed that for a large table involving 1200 columns and a huge select having multiple expressions and operators, this part was a bottleneck.

I wrote some jmh tests but i could not load this table as I could not find the API to load create tables into catalog for testing

