### PR TITLE
[CALCITE-4996] in RelJson, add a new public toRex method which can ov…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -689,15 +689,19 @@ public class RelJson {
     BiFunction<Map, RexBuilder, RexNode> inputMapToRex = (map, rexBuilder) -> {
       final Integer input = (Integer) map.get("input");
       int i = input;
-      for (RelNode inputNode : inputNodes) {
-        final RelDataType rowType = inputNode.getRowType();
-        if (i < rowType.getFieldCount()) {
-          final RelDataTypeField field = rowType.getFieldList().get(i);
-          return rexBuilder.makeInputRef(field.getType(), input);
+      if (input != null) {
+        for (RelNode inputNode : inputNodes) {
+          final RelDataType rowType = inputNode.getRowType();
+          if (i < rowType.getFieldCount()) {
+            final RelDataTypeField field = rowType.getFieldList().get(i);
+            return rexBuilder.makeInputRef(field.getType(), input);
+          }
+          i -= rowType.getFieldCount();
         }
-        i -= rowType.getFieldCount();
+        throw new RuntimeException("input field " + input + " is out of range");
+      } else {
+        throw new RuntimeException("input not defined");
       }
-      throw new RuntimeException("input field " + input + " is out of range");
     };
     return toRex(cluster, o, inputMapToRex);
   }

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -554,7 +554,7 @@ public class RelJson {
 
   /**
    * Transforms a RexNode tree defined in a map (from a JSON) into a RexNode
-   * @param cluster: The optimization Environment
+   * @param cluster The optimization Environment
    * @param o the map derived from a RexNode transformed into a JSON
    * @param inputMapToRex is a BiFunction that transform the map representing input references into RexNode.
    *        it has two parameters: the map of the references and the RexBuilder

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -820,7 +820,7 @@ public class RelJson {
    * Containing only a cluster and an empty list of inputs.
    */
   private static class RelInputForCluster implements RelInput {
-    private final @Nullable RelOptCluster cluster;
+    private final RelOptCluster cluster;
 
     RelInputForCluster(RelOptCluster cluster) {
       this.cluster = cluster;

--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -105,11 +105,13 @@ public class RelJson {
     this(jsonBuilder, RelJson::inputTranslatorImpl);
   }
 
-  private static RexNode inputTranslatorImpl(Map<String, Object> stringObjectMap, RexBuilder rexBuilder,
+  private static RexNode inputTranslatorImpl(
+      Map<String, Object> stringObjectMap,
+      RexBuilder rexBuilder,
       List<RelNode> relNodes) {
     final Integer input = (Integer) stringObjectMap.get("input");
-    int i = input;
     if (input != null) {
+      int i = input;
       for (RelNode inputNode : relNodes) {
         final RelDataType rowType = inputNode.getRowType();
         if (i < rowType.getFieldCount()) {
@@ -122,24 +124,26 @@ public class RelJson {
     } else {
       throw new RuntimeException("input not defined");
     }
-
   }
 
-  public RelJson(@Nullable JsonBuilder jsonBuilder, InputTranslator inputTranslator){
+  public RelJson(@Nullable JsonBuilder jsonBuilder, InputTranslator inputTranslator) {
     this.jsonBuilder = jsonBuilder;
     this.inputTranslator = inputTranslator;
   }
 
   /**
-   * Transforms a RexNode tree defined in a map (from a JSON) into a RexNode
-   * Applying a special method to inputs instead of transforming them into inputRef
+   * Transforms a RexNode tree defined in a map (from a JSON) into a RexNode,
+   * applying a special method to inputs instead of transforming them into inputRef.
    * @param cluster The optimization environment
    * @param apply is a InputTranslator lambda that transforms the map representing input
    *               references into a RexNode
    * @param o the map derived from a RexNode transformed into a JSON
    * @return the transformed RexNode
    */
-  public static RexNode readExpression(RelOptCluster cluster, InputTranslator apply, Map<String, Object> o) {
+  public static RexNode readExpression(
+      RelOptCluster cluster,
+      InputTranslator apply,
+      Map<String, Object> o) {
     RelInput relInput = new RelInput() {
       @Override public RelOptCluster getCluster() {
         return cluster;
@@ -904,17 +908,17 @@ public class RelJson {
 
   /**
    *  Functional interface for the "apply" lamdba,
-   *  that defines how to transform the input reference map into RexNode
+   *  that defines how to transform the input reference map into RexNode.
    */
   @FunctionalInterface
-   public interface InputTranslator {
+  public interface InputTranslator {
 
     /**
      * Lambda that defines how to transform the input reference map into RexNode.
      * @param stringObjectMap map representing input references
-     * @param rexBuilder
+     * @param rexBuilder the current builder
      * @param inputs the list of RelNode inputs
-     * @return
+     * @return the new input RexNode
      */
     RexNode apply(Map<String, Object> stringObjectMap,
         RexBuilder rexBuilder, List<RelNode> inputs);

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -734,7 +734,7 @@ class RelWriterTest {
         + "      \"operands\": [\n"
         + "        {\n"
         + "          \"input\": 1,\n"
-        + "          \"sql\": \"column + 1\"\n"
+        + "          \"name\": \"$1\"\n"
         + "        },\n"
         + "        {\n"
         + "          \"literal\": 1,\n"

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -753,7 +753,8 @@ class RelWriterTest {
     final ObjectMapper mapper = new ObjectMapper();
     Map<String, Object> o = mapper
         .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
-        .readValue(jsonString1, new TypeReference<LinkedHashMap<String, Object>>() { } );
+        .readValue(jsonString1, new TypeReference<LinkedHashMap<String, Object>>() {
+        });
     RexNode resRex = RelJson.readExpression(cluster, RelWriterTest::translateInput, o);
     assertThat(resRex.toString(), is(expected));
   }


### PR DESCRIPTION
Creates a new public static method that transforms a RexNode tree defined in a map (from a JSON) into a RexNode, with a way to apply a special method to handle the inputs
```
/**
   * Transforms a RexNode tree defined in a map (from a JSON) into a RexNode
   * Applying a special method to inputs instead of transforming them into inputRef
   * @param cluster The optimization environment
   * @param apply is a InputTranslator lambda that transforms the map representing input
   *               references into a RexNode
   * @param o the map derived from a RexNode transformed into a JSON
   * @return the transformed RexNode
   */
   ```