### PR TITLE
[CALCITE-5002] SubstitutionVisitor exec mv-match fail, cause by `unused project on aggregate in the mv`

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -195,20 +195,8 @@ public class SubstitutionVisitor {
     this.simplify =
         new RexSimplify(cluster.getRexBuilder(), predicates, executor);
     this.rules = rules;
-    MutableRel queryMutableRel = MutableRels.toMutable(query_);
-    final MutableRel targetMutableRel = MutableRels.toMutable(target_);
-    if (!(queryMutableRel instanceof MutableCalc) && targetMutableRel instanceof MutableCalc) {
-      final RelDataType rowType = queryMutableRel.rowType;
-      final RexProgramBuilder programBuilder =
-          new RexProgramBuilder(rowType, cluster.getRexBuilder());
-      final List<RelDataTypeField> queryFields = rowType.getFieldList();
-      for (int i = 0; i < queryFields.size(); i++) {
-        programBuilder.addProject(RexInputRef.of(i, rowType), queryFields.get(i).getName());
-      }
-      queryMutableRel = MutableCalc.of(queryMutableRel, programBuilder.getProgram());
-    }
-    this.query = Holder.of(queryMutableRel);
-    this.target = targetMutableRel;
+    this.query = Holder.of(MutableRels.toMutable(query_));
+    this.target = MutableRels.toMutable(target_);
     this.relBuilder = relBuilderFactory.create(cluster, null);
     final Set<@Nullable MutableRel> parents = Sets.newIdentityHashSet();
     final List<MutableRel> allNodes = new ArrayList<>();

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -195,8 +195,20 @@ public class SubstitutionVisitor {
     this.simplify =
         new RexSimplify(cluster.getRexBuilder(), predicates, executor);
     this.rules = rules;
-    this.query = Holder.of(MutableRels.toMutable(query_));
-    this.target = MutableRels.toMutable(target_);
+    MutableRel queryMutableRel = MutableRels.toMutable(query_);
+    final MutableRel targetMutableRel = MutableRels.toMutable(target_);
+    if (!(queryMutableRel instanceof MutableCalc) && targetMutableRel instanceof MutableCalc) {
+      final RelDataType rowType = queryMutableRel.rowType;
+      final RexProgramBuilder programBuilder =
+          new RexProgramBuilder(rowType, cluster.getRexBuilder());
+      final List<RelDataTypeField> queryFields = rowType.getFieldList();
+      for (int i = 0; i < queryFields.size(); i++) {
+        programBuilder.addProject(RexInputRef.of(i, rowType), queryFields.get(i).getName());
+      }
+      queryMutableRel = MutableCalc.of(queryMutableRel, programBuilder.getProgram());
+    }
+    this.query = Holder.of(queryMutableRel);
+    this.target = targetMutableRel;
     this.relBuilder = relBuilderFactory.create(cluster, null);
     final Set<@Nullable MutableRel> parents = Sets.newIdentityHashSet();
     final List<MutableRel> allNodes = new ArrayList<>();

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
@@ -450,6 +450,25 @@ public class MaterializedViewSubstitutionVisitorTest {
   }
 
   /**
+   * It's need be matched, unused project on aggregate in the mv, and query's rel-root is aggregate.
+   */
+  @Test void testAggregate7() {
+    String mv = ""
+        + "select \"deptno\", sum(\"salary\"), sum(\"commission\") + 1, sum(\"k\")\n"
+        + "from\n"
+        + "  (select \"deptno\", \"salary\", \"commission\", 100 as \"k\"\n"
+        + "  from \"emps\")\n"
+        + "group by \"deptno\"";
+    String query = ""
+        + "select \"deptno\", sum(\"salary\"), sum(\"k\")\n"
+        + "from\n"
+        + "  (select \"deptno\", \"salary\", 100 as \"k\"\n"
+        + "  from \"emps\")\n"
+        + "group by \"deptno\"";
+    sql(mv, query).ok();
+  }
+
+  /**
    * There will be a compensating Project added after matching of the Aggregate.
    * This rule targets to test if the Calc can be handled.
    */

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
@@ -19,18 +19,22 @@ package org.apache.calcite.test;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.RelOptMaterialization;
 import org.apache.calcite.plan.RelOptPredicateList;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.SubstitutionVisitor;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalCalc;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.rex.RexSimplify;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -80,9 +84,20 @@ public class MaterializedViewSubstitutionVisitorTest {
         @Override protected List<RelNode> optimize(RelNode queryRel,
             List<RelOptMaterialization> materializationList) {
           RelOptMaterialization materialization = materializationList.get(0);
+          RelNode materializedRel = canonicalize(materialization.queryRel);
+          RelNode normalQueryRel = canonicalize(queryRel);
+          if (!(normalQueryRel instanceof LogicalCalc) && materializedRel instanceof LogicalCalc) {
+            final RelDataType rowType = normalQueryRel.getRowType();
+            final RexProgramBuilder programBuilder =
+                new RexProgramBuilder(rowType, normalQueryRel.getCluster().getRexBuilder());
+            final List<RelDataTypeField> queryFields = rowType.getFieldList();
+            for (int i = 0; i < queryFields.size(); i++) {
+              programBuilder.addProject(RexInputRef.of(i, rowType), queryFields.get(i).getName());
+            }
+            normalQueryRel = LogicalCalc.create(normalQueryRel, programBuilder.getProgram());
+          }
           SubstitutionVisitor substitutionVisitor =
-              new SubstitutionVisitor(canonicalize(materialization.queryRel),
-                  canonicalize(queryRel));
+              new SubstitutionVisitor(materializedRel, normalQueryRel);
           return substitutionVisitor
               .go(materialization.tableRel);
         }
@@ -456,6 +471,24 @@ public class MaterializedViewSubstitutionVisitorTest {
   @Test void testAggregateWithCalcTopInMv() {
     String mv = ""
         + "select \"deptno\", sum(\"salary\"), sum(\"commission\") + 1, sum(\"k\")\n"
+        + "from\n"
+        + "  (select \"deptno\", \"salary\", \"commission\", 100 as \"k\"\n"
+        + "  from \"emps\")\n"
+        + "group by \"deptno\"";
+    String query = ""
+        + "select \"deptno\", sum(\"salary\"), sum(\"k\")\n"
+        + "from\n"
+        + "  (select \"deptno\", \"salary\", 100 as \"k\"\n"
+        + "  from \"emps\")\n"
+        + "group by \"deptno\"";
+    sql(mv, query).ok();
+  }
+
+  /** Similar with {@link #testAggregateWithCalcTopInMv()},
+   * but target's fields have no-equal sequence. */
+  @Test void testAggregateWithCalcTopInMv2() {
+    String mv = ""
+        + "select \"deptno\", sum(\"commission\") + 1, sum(\"k\"), sum(\"salary\")\n"
         + "from\n"
         + "  (select \"deptno\", \"salary\", \"commission\", 100 as \"k\"\n"
         + "  from \"emps\")\n"

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
@@ -19,7 +19,6 @@ package org.apache.calcite.test;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.RelOptMaterialization;
 import org.apache.calcite.plan.RelOptPredicateList;
-import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.SubstitutionVisitor;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;


### PR DESCRIPTION
Link to [ISSUE-5002](https://issues.apache.org/jira/browse/CALCITE-5002)
Wrap a top calc to query, when target's top rel is calc.