### PR TITLE
(CALCITE-5005) Fix broken builds on Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,8 @@
 *.cs     text diff=csharp
 *.java   text diff=java
 *.html   text diff=html
-*.kt     text diff=kotlin
-*.kts    text diff=kotlin
+*.kt     text diff=kotlin eol=crlf
+*.kts    text diff=kotlin eol=crlf
 *.md     text diff=markdown
 *.py     text diff=python executable
 *.pl     text diff=perl executable


### PR DESCRIPTION
Line endings in Kotlin files are CR-LF, breaking the autostyle Gradle task