### PR TITLE
[CALCITE-5010] Modify RexBuilder to use convertlets to transform the …

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -29,6 +29,8 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.runtime.Geometries;
 import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
@@ -37,12 +39,15 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.fun.SqlCountAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.MultisetSqlType;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql2rel.SqlRexConvertlet;
+import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
@@ -68,6 +73,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -262,7 +268,15 @@ public class RexBuilder {
       SqlOperator op,
       List<? extends RexNode> exprs) {
     final RelDataType type = deriveReturnType(op, exprs);
-    return new RexCall(type, op, exprs);
+    final RexCall rexcall = new RexCall(type, op, exprs);
+    final SqlCall sqlCall = new SqlBasicCall(op, Collections.emptyList(), SqlParserPos.ZERO);
+    final SqlRexConvertlet convertlet = StandardConvertletTable.INSTANCE.get(sqlCall);
+    if (convertlet != null) {
+      final RexNode convertedRexCall = convertlet.convertCall(rexcall, this);
+      return convertedRexCall != null ? convertedRexCall : rexcall;
+    } else {
+      return rexcall;
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlRexConvertlet.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlRexConvertlet.java
@@ -16,9 +16,13 @@
  */
 package org.apache.calcite.sql2rel;
 
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlNode;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Thunk which converts a {@link SqlNode} expression into a {@link RexNode}
@@ -30,4 +34,10 @@ public interface SqlRexConvertlet {
   RexNode convertCall(
       SqlRexContext cx,
       SqlCall call);
+
+  default @Nullable
+      RexNode convertCall(RexCall call, RexBuilder rexBuilder) {
+    return null;
+  }
+
 }

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -1820,16 +1820,13 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
 
   /** Convertlet that handles the {@code TIMESTAMPADD} function. */
   private static class TimestampAddConvertlet implements SqlRexConvertlet {
-    @Override public RexNode convertCall(SqlRexContext cx, SqlCall call) {
+
+    private RexNode convertCall(RexBuilder rexBuilder, TimeUnit unit, RexNode op1, RexNode op2) {
       // TIMESTAMPADD(unit, count, timestamp)
       //  => timestamp + count * INTERVAL '1' UNIT
-      final RexBuilder rexBuilder = cx.getRexBuilder();
-      final SqlLiteral unitLiteral = call.operand(0);
-      final TimeUnit unit = unitLiteral.getValueAs(TimeUnit.class);
       RexNode interval2Add;
       SqlIntervalQualifier qualifier =
-          new SqlIntervalQualifier(unit, null, unitLiteral.getParserPosition());
-      RexNode op1 = cx.convertExpression(call.operand(1));
+          new SqlIntervalQualifier(unit, null, SqlParserPos.ZERO);
       switch (unit) {
       case MICROSECOND:
       case NANOSECOND:
@@ -1846,18 +1843,33 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       }
 
       return rexBuilder.makeCall(SqlStdOperatorTable.DATETIME_PLUS,
-          cx.convertExpression(call.operand(2)), interval2Add);
+          op2, interval2Add);
+    }
+
+    @Override public RexNode convertCall(RexCall call, RexBuilder rexBuilder) {
+      final TimeUnit unit =
+          requireNonNull(((RexLiteral) call.getOperands().get(0)).getValueAs(TimeUnit.class));
+      final RexNode op1 = call.getOperands().get(1);
+      final RexNode op2 = call.getOperands().get(2);
+      return convertCall(rexBuilder, unit, op1, op2);
+    }
+
+    @Override public RexNode convertCall(SqlRexContext cx, SqlCall call) {
+      final SqlLiteral unitLiteral = call.operand(0);
+      final TimeUnit unit = unitLiteral.getValueAs(TimeUnit.class);
+      final RexNode op2 = cx.convertExpression(call.operand(2));
+      final RexNode op1 = cx.convertExpression(call.operand(1));
+      return convertCall(cx.getRexBuilder(), unit, op1, op2);
     }
   }
 
   /** Convertlet that handles the {@code TIMESTAMPDIFF} function. */
   private static class TimestampDiffConvertlet implements SqlRexConvertlet {
-    @Override public RexNode convertCall(SqlRexContext cx, SqlCall call) {
+
+    private RexNode convertCall(RexBuilder rexBuilder, RelDataTypeFactory relDataTypeFactory,
+        TimeUnit unit, RexNode op1, RexNode op2) {
       // TIMESTAMPDIFF(unit, t1, t2)
       //    => (t2 - t1) UNIT
-      final RexBuilder rexBuilder = cx.getRexBuilder();
-      final SqlLiteral unitLiteral = call.operand(0);
-      TimeUnit unit = unitLiteral.getValueAs(TimeUnit.class);
       BigDecimal multiplier = BigDecimal.ONE;
       BigDecimal divider = BigDecimal.ONE;
       SqlTypeName sqlTypeName = unit == TimeUnit.NANOSECOND
@@ -1881,21 +1893,35 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       }
       final SqlIntervalQualifier qualifier =
           new SqlIntervalQualifier(unit, null, SqlParserPos.ZERO);
-      final RexNode op2 = cx.convertExpression(call.operand(2));
-      final RexNode op1 = cx.convertExpression(call.operand(1));
       final RelDataType intervalType =
-          cx.getTypeFactory().createTypeWithNullability(
-              cx.getTypeFactory().createSqlIntervalType(qualifier),
+          relDataTypeFactory.createTypeWithNullability(
+              relDataTypeFactory.createSqlIntervalType(qualifier),
               op1.getType().isNullable() || op2.getType().isNullable());
       final RexCall rexCall = (RexCall) rexBuilder.makeCall(
           intervalType, SqlStdOperatorTable.MINUS_DATE,
           ImmutableList.of(op2, op1));
       final RelDataType intType =
-          cx.getTypeFactory().createTypeWithNullability(
-              cx.getTypeFactory().createSqlType(sqlTypeName),
+          relDataTypeFactory.createTypeWithNullability(
+              relDataTypeFactory.createSqlType(sqlTypeName),
               SqlTypeUtil.containsNullable(rexCall.getType()));
       RexNode e = rexBuilder.makeCast(intType, rexCall);
       return rexBuilder.multiplyDivide(e, multiplier, divider);
+    }
+
+    @Override public RexNode convertCall(RexCall call, RexBuilder rexBuilder) {
+      final TimeUnit unit =
+          requireNonNull(((RexLiteral) call.getOperands().get(0)).getValueAs(TimeUnit.class));
+      final RexNode op1 = call.getOperands().get(1);
+      final RexNode op2 = call.getOperands().get(2);
+      return convertCall(rexBuilder, rexBuilder.getTypeFactory(), unit, op1, op2);
+    }
+
+    @Override public RexNode convertCall(SqlRexContext cx, SqlCall call) {
+      final SqlLiteral unitLiteral = call.operand(0);
+      final TimeUnit unit = unitLiteral.getValueAs(TimeUnit.class);
+      final RexNode op2 = cx.convertExpression(call.operand(2));
+      final RexNode op1 = cx.convertExpression(call.operand(1));
+      return convertCall(cx.getRexBuilder(), cx.getTypeFactory(), unit, op1, op2);
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -18,6 +18,7 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.adapter.enumerable.EnumerableConvention;
 import org.apache.calcite.adapter.java.ReflectiveSchema;
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.Convention;
@@ -4726,4 +4727,51 @@ public class RelBuilderTest {
       };
     }
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5010">[CALCITE-5010]
+   * Modify RexBuilder to use convertlets to transform the RexCall when possible</a>. */
+  @Test void testTimestampAddDiff() throws Exception {
+    // Equivalent SQL:
+    //   SELECT TIMESTAMPDIFF(SECOND, HIREDATE, TIMESTAMP'1970-01-01') FROM EMP
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+            .project(
+                builder.getRexBuilder().makeCall(
+                    SqlStdOperatorTable.TIMESTAMP_DIFF,
+                    builder.getRexBuilder().makeFlag(TimeUnit.SECOND),
+                    builder.getRexBuilder()
+                        .makeTimestampLiteral(TimestampString.fromMillisSinceEpoch(0), 0),
+                    builder.field("HIREDATE")
+                )
+            )
+            .build();
+
+    String expected = "LogicalProject($f0=[CAST(/INT(Reinterpret(-($4, 1970-01-01 00:00:00)), "
+        + "1000)):INTEGER])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(root, hasTree(expected));
+
+    // Equivalent SQL:
+    //   SELECT TIMESTAMPADD(SECOND, 1, HIREDATE) FROM EMP
+    final RelDataType type = builder.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
+    root =
+        builder.scan("EMP")
+            .project(
+                builder.getRexBuilder().makeCall(
+                    SqlStdOperatorTable.TIMESTAMP_ADD,
+                    builder.getRexBuilder().makeFlag(TimeUnit.SECOND),
+                    builder.getRexBuilder().makeLiteral(1, type),
+                    builder.field("HIREDATE")
+                )
+            )
+            .build();
+
+    expected = "LogicalProject($f0=[+($4, *(1000:INTERVAL SECOND, 1))])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(root, hasTree(expected));
+  }
+
+
 }


### PR DESCRIPTION
…RexCall when possible

SqlRexConvertlets are used to transform a SqlCall into a RexCall while parsing a sql string. A RelNode that is created using RelBuilder does not use the same transformations. This causes the following error while trying to use RelBuilder to create a relnode that use  TIMESTAMPDIFF().

Suppressed: java.lang.RuntimeException: cannot translate call TIMESTAMPDIFF($t8, $t4, $t9)
at org.apache.calcite.adapter.enumerable.RexToLixTranslator.visitCall(RexToLixTranslator.java:1157)
at org.apache.calcite.adapter.enumerable.RexToLixTranslator.visitCall(RexToLixTranslator.java:98)

Modify RexBuilder to check if there is a convertlet that exists for the operator being constructed and transform the RexCall using the convertlet.