### PR TITLE
[CACLITE-5013] Retain parentheses if a setop has an LIMIT clause

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql;
 
+import org.apache.calcite.sql.fun.SqlInternalOperators;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
@@ -249,7 +250,16 @@ public class SqlSelect extends SqlCall {
 
   // Override SqlCall, to introduce a sub-query frame.
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    if (!writer.inQuery()) {
+    if (!writer.inQuery()
+        || getFetch() != null
+            && (leftPrec > SqlInternalOperators.FETCH.getLeftPrec()
+                || rightPrec > SqlInternalOperators.FETCH.getLeftPrec())
+        || getOffset() != null
+            && (leftPrec > SqlInternalOperators.OFFSET.getLeftPrec()
+                || rightPrec > SqlInternalOperators.OFFSET.getLeftPrec())
+        || getOrderList() != null
+            && (leftPrec > SqlOrderBy.OPERATOR.getLeftPrec()
+                || rightPrec > SqlOrderBy.OPERATOR.getRightPrec())) {
       // If this SELECT is the topmost item in a sub-query, introduce a new
       // frame. (The topmost item in the sub-query might be a UNION or
       // ORDER. In this case, we don't need a wrapper frame.)

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlInternalOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlInternalOperators.java
@@ -24,6 +24,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
@@ -119,4 +120,35 @@ public abstract class SqlInternalOperators {
   public static final SqlInternalOperator GROUP_BY_DISTINCT =
       new SqlRollupOperator("GROUP BY DISTINCT", SqlKind.GROUP_BY_DISTINCT);
 
+  /** Fetch operator is ONLY used for its precedence during unparsing. */
+  public static final SqlOperator FETCH =
+      SqlBasicOperator.create("FETCH")
+          .withPrecedence(SqlStdOperatorTable.UNION.getLeftPrec() - 2, true);
+
+  /** Offset operator is ONLY used for its precedence during unparsing. */
+  public static final SqlOperator OFFSET =
+      SqlBasicOperator.create("OFFSET")
+          .withPrecedence(SqlStdOperatorTable.UNION.getLeftPrec() - 2, true);
+
+  /** Subject to change. */
+  private static class SqlBasicOperator extends SqlOperator {
+    @Override public SqlSyntax getSyntax() {
+      return SqlSyntax.SPECIAL;
+    }
+
+    /** Private constructor. Use {@link #create}. */
+    private SqlBasicOperator(String name, int leftPrecedence, int rightPrecedence) {
+      super(name, SqlKind.OTHER, leftPrecedence, rightPrecedence,
+          ReturnTypes.BOOLEAN, InferTypes.RETURN_TYPE, OperandTypes.ANY);
+    }
+
+    static SqlBasicOperator create(String name) {
+      return new SqlBasicOperator(name, 0, 0);
+    }
+
+    SqlBasicOperator withPrecedence(int prec, boolean leftAssoc) {
+      return new SqlBasicOperator(getName(), leftPrec(prec, leftAssoc),
+          rightPrec(prec, leftAssoc));
+    }
+  }
 }


### PR DESCRIPTION
In standard SQL, the operand of union should not have limit  or order by.So parse will fail in SqlParserTetest#testLimitUnion and SqlParserTetest#OrderUnion.
However, when users use parentheses, most engines allow it. We should retain the parentheses written by users.