### PR TITLE
[CALCITE-5029] Babel parser support identifier starting with number

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -548,6 +548,10 @@ data: {
       "< NULL_SAFE_EQUAL: \"<=>\" >"
     ]
 
+    # Custom identifier token.
+    # Example: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >".
+    customIdentifierToken: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >"
+
     # Binary operators initialization.
     # Example: "InfixCast".
     extraBinaryExpressions: [

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -109,6 +109,13 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testIdentifierStartWithNumber() {
+    final String sql = "select 1 as 1_c1 from t";
+    final String expected = "SELECT 1 AS `1_C1`\n"
+        + "FROM `T`";
+    sql(sql).ok(expected);
+  }
+
   /** Tests that there are no reserved keywords. */
   @Disabled
   @Test void testKeywords() {

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -8323,7 +8323,11 @@ MORE :
 
 <DEFAULT, DQID, BTID, BQID> TOKEN :
 {
-    < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >
+    <#if parser.customIdentifierToken??>
+        ${parser.customIdentifierToken}
+    <#else>
+        < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >
+    </#if>
 }
 
 <DEFAULT, DQID, BTID, BQID, BQHID> TOKEN :


### PR DESCRIPTION
Define a plugin in parser.jj for custom identifier token, and rewrite it in babel's parser.