### PR TITLE
[CALCITE-5035] Define a rule of SortProjectPullUpConstantsRule to pull up constant's project under Sort

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -712,6 +712,10 @@ public class CoreRules {
   public static final SortProjectTransposeRule SORT_PROJECT_TRANSPOSE =
       SortProjectTransposeRule.Config.DEFAULT.toRule();
 
+  /** Rule that pulles up constant literal under an {@link Sort}. */
+  public static final SortProjectPullUpConstantsRule SORT_ANY_PULL_UP_CONSTANTS =
+      SortProjectPullUpConstantsRule.Config.DEFAULT.toRule();
+
   /** Rule that flattens a {@link Union} on a {@code Union}
    * into a single {@code Union}. */
   public static final UnionMergeRule UNION_MERGE =

--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -712,8 +712,8 @@ public class CoreRules {
   public static final SortProjectTransposeRule SORT_PROJECT_TRANSPOSE =
       SortProjectTransposeRule.Config.DEFAULT.toRule();
 
-  /** Rule that pulles up constant literal under an {@link Sort}. */
-  public static final SortProjectPullUpConstantsRule SORT_ANY_PULL_UP_CONSTANTS =
+  /** Rule that pulls up constant literal under a {@link Sort}. */
+  public static final SortProjectPullUpConstantsRule SORT_PULL_UP_CONSTANTS =
       SortProjectPullUpConstantsRule.Config.DEFAULT.toRule();
 
   /** Rule that flattens a {@link Union} on a {@code Union}

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortProjectPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortProjectPullUpConstantsRule.java
@@ -59,7 +59,6 @@ public class SortProjectPullUpConstantsRule
     extends RelRule<SortProjectPullUpConstantsRule.Config>
     implements TransformationRule {
 
-  /** Creates an SortProjectPullUpConstantsRule. */
   protected SortProjectPullUpConstantsRule(Config config) {
     super(config);
   }
@@ -75,7 +74,7 @@ public class SortProjectPullUpConstantsRule
         .stream()
         .map(RelFieldCollation::getFieldIndex)
         .collect(Collectors.toList());
-    if (fieldCollationIndexes.size() <= 0) {
+    if (fieldCollationIndexes.isEmpty()) {
       return;
     }
 
@@ -96,7 +95,7 @@ public class SortProjectPullUpConstantsRule
       }
     }
 
-    // None of the sort field expressions are constant. Nothing to do.
+    // None of the sort field expressions is constant. Nothing to do.
     if (map.isEmpty()) {
       return;
     }
@@ -150,10 +149,9 @@ public class SortProjectPullUpConstantsRule
       }
       projects.add(Pair.of(newExpr, field.getName()));
     }
-    relBuilder.project(Pair.left(projects), Pair.right(projects)); // inverse
-
-    final RelNode newRelNode = relBuilder.build();
-    call.transformTo(newRelNode);
+    // Create a top equal project for origin sort.
+    relBuilder.project(Pair.left(projects), Pair.right(projects));
+    call.transformTo(relBuilder.build());
   }
 
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortProjectPullUpConstantsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortProjectPullUpConstantsRule.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptPredicateList;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.Pair;
+
+import org.immutables.value.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Planner rule that removes constant keys from an
+ * {@link Sort}.
+ *
+ * <p>Constant fields are deduced using
+ * {@link RelMetadataQuery#getPulledUpPredicates(RelNode)}; the input does not
+ * need to be a {@link org.apache.calcite.rel.core.Project}.
+ *
+ * <p>Since the transformed relational expression has to match the original
+ * relational expression, the constants are placed in a projection above the
+ * reduced sort. If those constants are not used, another rule will remove
+ * them from the project.
+ */
+@Value.Enclosing
+public class SortProjectPullUpConstantsRule
+    extends RelRule<SortProjectPullUpConstantsRule.Config>
+    implements TransformationRule {
+
+  /** Creates an SortProjectPullUpConstantsRule. */
+  protected SortProjectPullUpConstantsRule(Config config) {
+    super(config);
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    final Sort sort = call.rel(0);
+    final RelNode input = call.rel(1);
+
+    final RelCollation collation = sort.getCollation();
+    final List<Integer> fieldCollationIndexes = collation.getFieldCollations()
+        .stream()
+        .map(RelFieldCollation::getFieldIndex)
+        .collect(Collectors.toList());
+    if (fieldCollationIndexes.size() <= 0) {
+      return;
+    }
+
+    final RexBuilder rexBuilder = sort.getCluster().getRexBuilder();
+    final RelMetadataQuery mq = call.getMetadataQuery();
+    final RelOptPredicateList predicates =
+        mq.getPulledUpPredicates(input);
+    if (RelOptPredicateList.isEmpty(predicates)) {
+      return;
+    }
+
+    final NavigableMap<Integer, RexNode> map = new TreeMap<>();
+    for (int fieldCollationIndex : fieldCollationIndexes) {
+      final RexInputRef ref =
+          rexBuilder.makeInputRef(input, fieldCollationIndex);
+      if (predicates.constantMap.containsKey(ref)) {
+        map.put(fieldCollationIndex, predicates.constantMap.get(ref));
+      }
+    }
+
+    // None of the sort field expressions are constant. Nothing to do.
+    if (map.isEmpty()) {
+      return;
+    }
+
+    // Input of new top constant project.
+    final RelNode newInputRel;
+    if (map.size() == fieldCollationIndexes.size()) {
+      // All field collations are constants.
+      if (sort.offset == null && sort.fetch == null) {
+        // No any offset or fetch in current sort.
+        // Remove current sort.
+        newInputRel = input;
+      } else {
+        // Some offset or fetch exist in current sort.
+        newInputRel = sort.copy(sort.getTraitSet(), input, RelCollations.EMPTY);
+      }
+    } else {
+      // All field collations are not all constants.
+      final List<RelFieldCollation> newFieldCollations = new ArrayList<>();
+      for (RelFieldCollation fieldCollation : collation.getFieldCollations()) {
+        final int fieldIndex = fieldCollation.getFieldIndex();
+        if (map.containsKey(fieldIndex)) {
+          continue;
+        }
+        newFieldCollations.add(fieldCollation);
+      }
+      final RelCollation newRelCollation = RelCollations.of(newFieldCollations);
+      newInputRel = sort.copy(sort.getTraitSet(), input, newRelCollation);
+    }
+
+    final RelBuilder relBuilder = call.builder();
+    relBuilder.push(newInputRel);
+
+    // Create a projection back again.
+    List<Pair<RexNode, String>> projects = new ArrayList<>();
+    for (RelDataTypeField field : sort.getRowType().getFieldList()) {
+      final int index = field.getIndex();
+      final RexNode constantNode = map.get(index);
+      final RexNode newExpr;
+      if (constantNode == null) {
+        newExpr = rexBuilder.makeInputRef(newInputRel, index);
+      } else {
+        // Re-generate the constant expression in the project.
+        RelDataType originalType =
+            sort.getRowType().getFieldList().get(projects.size()).getType();
+        if (!originalType.equals(constantNode.getType())) {
+          newExpr = rexBuilder.makeCast(originalType, constantNode, true);
+        } else {
+          newExpr = constantNode;
+        }
+      }
+      projects.add(Pair.of(newExpr, field.getName()));
+    }
+    relBuilder.project(Pair.left(projects), Pair.right(projects)); // inverse
+
+    final RelNode newRelNode = relBuilder.build();
+    call.transformTo(newRelNode);
+  }
+
+
+  /** Rule configuration. */
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    Config DEFAULT = ImmutableSortProjectPullUpConstantsRule.Config.of()
+        .withOperandSupplier(b0 ->
+            b0.operand(Sort.class)
+                .oneInput(b1 ->
+                    b1.operand(RelNode.class)
+                        .anyInputs()))
+        .as(Config.class);
+
+    @Override default SortProjectPullUpConstantsRule toRule() {
+      return new SortProjectPullUpConstantsRule(this);
+    }
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5530,6 +5530,58 @@ class RelOptRulesTest extends RelOptTestBase {
         .checkUnchanged();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
+   * Pull up constant project under sort</a>. */
+  @Test void testSortProjectPullUpConstants1() {
+    // The constant's count is more than sort's field, and without any fetch or offset
+    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
+        + "where e.deptno = 123\n"
+        + "order by e.deptno, e.empno";
+    sql(sql)
+        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
+   * Pull up constant project under sort</a>. */
+  @Test void testSortProjectPullUpConstants2() {
+    // Sort with some fetch and offset
+    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
+        + "where e.deptno = 123\n"
+        + "order by e.deptno, e.empno offset 10";
+    sql(sql)
+        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
+   * Pull up constant project under sort</a>. */
+  @Test void testSortProjectPullUpConstants3() {
+    // The constant's count is equal to sort's field
+    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
+        + "where e.deptno = 123\n"
+        + "order by e.deptno offset 10";
+    sql(sql)
+        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
+   * Pull up constant project under sort</a>. */
+  @Test void testSortProjectPullUpConstants4() {
+    // The constant's count is equal to sort's field, and without any fetch or offset
+    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
+        + "where e.deptno = 123\n"
+        + "order by e.deptno";
+    sql(sql)
+        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
+        .check();
+  }
+
   @Test void testSortProjectTranspose1() {
     // This one can be pushed down
     final String sql = "select d.deptno from sales.dept d\n"

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5534,7 +5534,6 @@ class RelOptRulesTest extends RelOptTestBase {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
    * Pull up constant project under sort</a>. */
   @Test void testSortProjectPullUpConstantsNoFetchLimitAndSortEqualFields() {
-    // The count of sort's field is more than constant's, and without any fetch or offset
     final String sql = "select e.empno, e.ename, e.deptno\n"
         + "from sales.emp e\n"
         + "where e.deptno = 123\n"
@@ -5548,7 +5547,6 @@ class RelOptRulesTest extends RelOptTestBase {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
    * Pull up constant project under sort</a>. */
   @Test void testSortProjectPullUpConstantsNoFetchLimitAndSortMoreFields() {
-    // The count of sort's field is more than constant's, and without any fetch or offset
     final String sql = "select e.empno, e.ename, e.deptno\n"
         + "from sales.emp e\n"
         + "where e.deptno = 123\n"
@@ -5562,7 +5560,6 @@ class RelOptRulesTest extends RelOptTestBase {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
    * Pull up constant project under sort</a>. */
   @Test void testSortProjectPullUpConstantsWithFetchLimitAndSortEqualFields() {
-    // The constant's count is equal to sort's field, and sort with some fetch and offset
     final String sql = "select e.empno, e.ename, e.deptno\n"
         + "from sales.emp e\n"
         + "where e.deptno = 123\n"
@@ -5576,7 +5573,6 @@ class RelOptRulesTest extends RelOptTestBase {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
    * Pull up constant project under sort</a>. */
   @Test void testSortProjectPullUpConstantsWithFetchLimitAndSortMoreFields() {
-    // The count of sort's field is more than constant's, and sort with some fetch and offset
     final String sql = "select e.empno, e.ename, e.deptno\n"
         + "from sales.emp e\n"
         + "where e.deptno = 123\n"

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5533,52 +5533,56 @@ class RelOptRulesTest extends RelOptTestBase {
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
    * Pull up constant project under sort</a>. */
-  @Test void testSortProjectPullUpConstants1() {
-    // The constant's count is more than sort's field, and without any fetch or offset
-    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
-        + "where e.deptno = 123\n"
-        + "order by e.deptno, e.empno";
-    sql(sql)
-        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
-        .check();
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
-   * Pull up constant project under sort</a>. */
-  @Test void testSortProjectPullUpConstants2() {
-    // Sort with some fetch and offset
-    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
-        + "where e.deptno = 123\n"
-        + "order by e.deptno, e.empno offset 10";
-    sql(sql)
-        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
-        .check();
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
-   * Pull up constant project under sort</a>. */
-  @Test void testSortProjectPullUpConstants3() {
-    // The constant's count is equal to sort's field
-    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
-        + "where e.deptno = 123\n"
-        + "order by e.deptno offset 10";
-    sql(sql)
-        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
-        .check();
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
-   * Pull up constant project under sort</a>. */
-  @Test void testSortProjectPullUpConstants4() {
-    // The constant's count is equal to sort's field, and without any fetch or offset
-    final String sql = "select e.empno, e.ename, e.deptno from sales.emp e\n"
+  @Test void testSortProjectPullUpConstantsNoFetchLimitAndSortEqualFields() {
+    // The count of sort's field is more than constant's, and without any fetch or offset
+    final String sql = "select e.empno, e.ename, e.deptno\n"
+        + "from sales.emp e\n"
         + "where e.deptno = 123\n"
         + "order by e.deptno";
     sql(sql)
-        .withRule(CoreRules.SORT_ANY_PULL_UP_CONSTANTS)
+        .withRule(CoreRules.SORT_PULL_UP_CONSTANTS)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
+   * Pull up constant project under sort</a>. */
+  @Test void testSortProjectPullUpConstantsNoFetchLimitAndSortMoreFields() {
+    // The count of sort's field is more than constant's, and without any fetch or offset
+    final String sql = "select e.empno, e.ename, e.deptno\n"
+        + "from sales.emp e\n"
+        + "where e.deptno = 123\n"
+        + "order by e.deptno, e.empno";
+    sql(sql)
+        .withRule(CoreRules.SORT_PULL_UP_CONSTANTS)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
+   * Pull up constant project under sort</a>. */
+  @Test void testSortProjectPullUpConstantsWithFetchLimitAndSortEqualFields() {
+    // The constant's count is equal to sort's field, and sort with some fetch and offset
+    final String sql = "select e.empno, e.ename, e.deptno\n"
+        + "from sales.emp e\n"
+        + "where e.deptno = 123\n"
+        + "order by e.deptno offset 10";
+    sql(sql)
+        .withRule(CoreRules.SORT_PULL_UP_CONSTANTS)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5035">[CALCITE-5035]
+   * Pull up constant project under sort</a>. */
+  @Test void testSortProjectPullUpConstantsWithFetchLimitAndSortMoreFields() {
+    // The count of sort's field is more than constant's, and sort with some fetch and offset
+    final String sql = "select e.empno, e.ename, e.deptno\n"
+        + "from sales.emp e\n"
+        + "where e.deptno = 123\n"
+        + "order by e.deptno, e.empno offset 10";
+    sql(sql)
+        .withRule(CoreRules.SORT_PULL_UP_CONSTANTS)
         .check();
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -12222,9 +12222,33 @@ LogicalProject(DEPTNO=[$0], EMPNO=[$2])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSortProjectPullUpConstants1">
+  <TestCase name="testSortProjectPullUpConstantsNoFetchLimitAndSortEqualFields">
     <Resource name="sql">
-      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
+      <![CDATA[select e.empno, e.ename, e.deptno
+from sales.emp e
+where e.deptno = 123
+order by e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$2], dir0=[ASC])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+    LogicalFilter(condition=[=($7, 123)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
+  LogicalFilter(condition=[=($7, 123)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortProjectPullUpConstantsNoFetchLimitAndSortMoreFields">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, e.deptno
+from sales.emp e
 where e.deptno = 123
 order by e.deptno, e.empno]]>
     </Resource>
@@ -12246,33 +12270,10 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSortProjectPullUpConstants2">
+  <TestCase name="testSortProjectPullUpConstantsWithFetchLimitAndSortEqualFields">
     <Resource name="sql">
-      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
-where e.deptno = 123
-order by e.deptno, e.empno offset 10]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalSort(sort0=[$2], sort1=[$0], dir0=[ASC], dir1=[ASC], offset=[10])
-  LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
-    LogicalFilter(condition=[=($7, 123)])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
-  LogicalSort(sort0=[$0], dir0=[ASC], offset=[10])
-    LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
-      LogicalFilter(condition=[=($7, 123)])
-        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testSortProjectPullUpConstants3">
-    <Resource name="sql">
-      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
+      <![CDATA[select e.empno, e.ename, e.deptno
+from sales.emp e
 where e.deptno = 123
 order by e.deptno offset 10]]>
     </Resource>
@@ -12294,15 +12295,16 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSortProjectPullUpConstants4">
+  <TestCase name="testSortProjectPullUpConstantsWithFetchLimitAndSortMoreFields">
     <Resource name="sql">
-      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
+      <![CDATA[select e.empno, e.ename, e.deptno
+from sales.emp e
 where e.deptno = 123
-order by e.deptno]]>
+order by e.deptno, e.empno offset 10]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalSort(sort0=[$2], dir0=[ASC])
+LogicalSort(sort0=[$2], sort1=[$0], dir0=[ASC], dir1=[ASC], offset=[10])
   LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
     LogicalFilter(condition=[=($7, 123)])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -12311,8 +12313,10 @@ LogicalSort(sort0=[$2], dir0=[ASC])
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
-  LogicalFilter(condition=[=($7, 123)])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalSort(sort0=[$0], dir0=[ASC], offset=[10])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+      LogicalFilter(condition=[=($7, 123)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -12222,6 +12222,100 @@ LogicalProject(DEPTNO=[$0], EMPNO=[$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSortProjectPullUpConstants1">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
+where e.deptno = 123
+order by e.deptno, e.empno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$2], sort1=[$0], dir0=[ASC], dir1=[ASC])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+    LogicalFilter(condition=[=($7, 123)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
+  LogicalSort(sort0=[$0], dir0=[ASC])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+      LogicalFilter(condition=[=($7, 123)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortProjectPullUpConstants2">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
+where e.deptno = 123
+order by e.deptno, e.empno offset 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$2], sort1=[$0], dir0=[ASC], dir1=[ASC], offset=[10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+    LogicalFilter(condition=[=($7, 123)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
+  LogicalSort(sort0=[$0], dir0=[ASC], offset=[10])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+      LogicalFilter(condition=[=($7, 123)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortProjectPullUpConstants3">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
+where e.deptno = 123
+order by e.deptno offset 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$2], dir0=[ASC], offset=[10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+    LogicalFilter(condition=[=($7, 123)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
+  LogicalSort(offset=[10])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+      LogicalFilter(condition=[=($7, 123)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortProjectPullUpConstants4">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, e.deptno from sales.emp e
+where e.deptno = 123
+order by e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$2], dir0=[ASC])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
+    LogicalFilter(condition=[=($7, 123)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
+  LogicalFilter(condition=[=($7, 123)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSortProjectTranspose1">
     <Resource name="sql">
       <![CDATA[select d.deptno from sales.dept d


### PR DESCRIPTION
Define a rule to pull up constants project under Sort
Related JIRA: https://issues.apache.org/jira/browse/CALCITE-5035

Just like:
```
===origin rel tree===
LogicalSort(sort0=[$2], sort1=[$0], dir0=[ASC], dir1=[ASC])
  LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
    LogicalFilter(condition=[=($7, 123)])
      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
===optimized rel tree===
LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[123])
|-LogicalSort(sort0=[$0], dir0=[ASC])
  |-LogicalProject(EMPNO=[$0], ENAME=[$1], DEPTNO=[$7])
    |-LogicalFilter(condition=[=($7, 123)])
      |-LogicalTableScan(table=[[CATALOG, SALES, EMP]])
```