### PR TITLE
[CALCITE-5040] SqlTypeFactoryTest.testUnknownCreateWithNullabilityTypeConsistency fails

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -93,7 +93,7 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
   }
 
   @Override public RelDataType createUnknownType() {
-    return canonize(new UnknownSqlType(this));
+    return createSqlType(SqlTypeName.UNKNOWN);
   }
 
   @Override public RelDataType createMultisetType(
@@ -550,7 +550,6 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
     return new MapSqlType(keyType, valueType, nullable);
   }
 
-  // override RelDataTypeFactoryImpl
   @Override protected RelDataType canonize(RelDataType type) {
     type = super.canonize(type);
     if (!(type instanceof ObjectSqlType)) {
@@ -566,29 +565,5 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
               false));
     }
     return type;
-  }
-
-  /** The unknown type. Similar to the NULL type, but is only equal to
-   * itself. */
-  static class UnknownSqlType extends BasicSqlType {
-    UnknownSqlType(RelDataTypeFactory typeFactory) {
-      this(typeFactory.getTypeSystem(), false);
-    }
-
-    private UnknownSqlType(RelDataTypeSystem typeSystem, boolean nullable) {
-      super(typeSystem, SqlTypeName.UNKNOWN, nullable);
-    }
-
-    @Override BasicSqlType createWithNullability(boolean nullable) {
-      if (nullable == this.isNullable) {
-        return this;
-      }
-      return new UnknownSqlType(this.typeSystem, nullable);
-    }
-
-    @Override protected void generateTypeString(StringBuilder sb,
-        boolean withDetail) {
-      sb.append("UNKNOWN");
-    }
   }
 }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -21,7 +21,6 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.RelRecordType;
-import org.apache.calcite.sql.type.SqlTypeFactoryImpl.UnknownSqlType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -288,18 +287,30 @@ class SqlTypeFactoryTest {
     assertThat(tsWithPrecision3 == tsWithPrecision8, is(true));
   }
 
-  /** Test that the {code UNKNOWN} type does not does not change class when nullified. */
+  /** Test that the {@code UNKNOWN} type is a {@link BasicSqlType} and remains
+   * so when nullified. */
   @Test void testUnknownCreateWithNullabilityTypeConsistency() {
-    SqlTypeFixture f = new SqlTypeFixture();
+    final SqlTypeFixture f = new SqlTypeFixture();
 
-    RelDataType unknownType  = f.typeFactory.createUnknownType();
-    assertThat(unknownType, isA(UnknownSqlType.class));
+    final RelDataType unknownType = f.typeFactory.createUnknownType();
+    assertThat(unknownType, isA(BasicSqlType.class));
     assertThat(unknownType.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
     assertFalse(unknownType.isNullable());
+    assertThat(unknownType.getFullTypeString(), is("UNKNOWN NOT NULL"));
 
-    RelDataType nullableRelDataType = f.typeFactory.createTypeWithNullability(unknownType, true);
-    assertThat(nullableRelDataType, isA(UnknownSqlType.class));
-    assertThat(nullableRelDataType.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
-    assertTrue(nullableRelDataType.isNullable());
+    final RelDataType nullableType =
+        f.typeFactory.createTypeWithNullability(unknownType, true);
+    assertThat(nullableType, isA(BasicSqlType.class));
+    assertThat(nullableType.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
+    assertTrue(nullableType.isNullable());
+    assertThat(nullableType.getFullTypeString(), is("UNKNOWN"));
+
+    final RelDataType unknownType2 =
+        f.typeFactory.createTypeWithNullability(nullableType, false);
+    assertThat(unknownType2, is(unknownType));
+    assertThat(unknownType2, isA(BasicSqlType.class));
+    assertThat(unknownType2.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
+    assertFalse(unknownType2.isNullable());
+    assertThat(unknownType2.getFullTypeString(), is("UNKNOWN NOT NULL"));
   }
 }


### PR DESCRIPTION
[CALCITE-4872] added an UNKNOWN type that was implemented in some
places by class SqlTypeFactoryImpl.UnknownSqlType, but in others
by BasicSqlType. This would cause
SqlTypeFactoryTest.testUnknownCreateWithNullabilityTypeConsistency
to succeed or fail non-deterministically, depending on which of the
above had made it into the map of canonical type instances.

This commit solves the problem by removing class
SqlTypeFactoryImpl.UnknownSqlType and always using BasicSqlType.