### PR TITLE
[CALCITE-4512] GROUP BY expression with argument name same with SELEC…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -6601,15 +6601,17 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       this.select = select;
       this.root = root;
       this.havingExpr = havingExpr;
-      addExpandableExpressions();
+      if (!havingExpr) {
+        addExpandableExpressions();
+      }
     }
 
     @Override public @Nullable SqlNode visit(SqlIdentifier id) {
       if (id.isSimple()
-          && aliasOrdinalExpandSet.contains(id)
           && (havingExpr
               ? validator.config().conformance().isHavingAlias()
-              : validator.config().conformance().isGroupByAlias())) {
+              : (validator.config().conformance().isGroupByAlias()
+                  && aliasOrdinalExpandSet.contains(id)))) {
         String name = id.getSimple();
         SqlNode expr = null;
         final SqlNameMatcher nameMatcher =
@@ -6687,6 +6689,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     private void addExpandableExpressions(@UnknownInitialization ExtendedExpander this) {
       switch (root.getKind()) {
       case IDENTIFIER:
+      case LITERAL:
         aliasOrdinalExpandSet.add(root);
         break;
       case GROUPING_SETS:

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4441,9 +4441,8 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
    */
   @Test void testGroupByExprArgFieldSameWithAlias() {
     final String sql = "SELECT floor(deptno / 2) AS deptno\n"
-        + "FROM dept\n"
-        + "GROUP BY floor(deptno / 2)\n"
-        + "HAVING floor(deptno / 2) > 1";
+        + "FROM emp\n"
+        + "GROUP BY floor(deptno / 2)";
     sql(sql)
         .withConformance(SqlConformanceEnum.LENIENT)
         .ok();

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4432,4 +4432,36 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         .withTrim(false)
         .ok();
   }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4512">[CALCITE-4512]
+   * GROUP BY expression with argument name same with SELECT field and alias causes
+   * validation error</a>.
+   */
+  @Test void testGroupByExprArgFieldSameWithAlias() {
+    final String sql = "SELECT floor(deptno / 2) AS deptno\n"
+        + "FROM dept\n"
+        + "GROUP BY floor(deptno / 2)\n"
+        + "HAVING floor(deptno / 2) > 1";
+    sql(sql)
+        .withConformance(SqlConformanceEnum.LENIENT)
+        .ok();
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4512">[CALCITE-4512]
+   * GROUP BY expression with argument name same with SELECT field and alias causes
+   * validation error</a>.
+   */
+  @Test void testGroupByExprArgFieldSameWithAlias2() {
+    final String sql = ""
+        + "SELECT deptno / 2 AS deptno, deptno / 2 as empno, sum(sal)\n"
+        + "FROM emp\n"
+        + "GROUP BY GROUPING SETS ((deptno), (empno, deptno / 2), (2, 1))";
+    sql(sql)
+        .withConformance(SqlConformanceEnum.LENIENT)
+        .ok();
+  }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -6937,6 +6937,10 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select deptno from emp group by ^100^, deptno")
         .withConformance(lenient).fails("Ordinal out of range")
         .withConformance(strict).ok();
+    sql("select floor(e.deptno / 2) AS deptno from emp as e\n"
+        + "join dept as d on e.deptno = d.deptno group by ^deptno^")
+        .withConformance(strict).fails("Column 'DEPTNO' is ambiguous")
+        .withConformance(lenient).ok();
   }
 
   /**

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1921,16 +1921,14 @@ group by
   <TestCase name="testGroupByExprArgFieldSameWithAlias">
     <Resource name="sql">
       <![CDATA[SELECT floor(deptno / 2) AS deptno
-FROM dept
-GROUP BY floor(deptno / 2)
-HAVING floor(deptno / 2) > 1]]>
+FROM emp
+GROUP BY floor(deptno / 2)]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalFilter(condition=[>($0, 1)])
-  LogicalAggregate(group=[{0}])
-    LogicalProject(DEPTNO=[FLOOR(/($0, 2))])
-      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+LogicalAggregate(group=[{0}])
+  LogicalProject(DEPTNO=[FLOOR(/($7, 2))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1918,6 +1918,44 @@ group by
   cube (coord_ne.sub.a, coord.x, coord."unit")]]>
     </Resource>
   </TestCase>
+  <TestCase name="testGroupByExprArgFieldSameWithAlias">
+    <Resource name="sql">
+      <![CDATA[SELECT floor(deptno / 2) AS deptno
+FROM dept
+GROUP BY floor(deptno / 2)
+HAVING floor(deptno / 2) > 1]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalFilter(condition=[>($0, 1)])
+  LogicalAggregate(group=[{0}])
+    LogicalProject(DEPTNO=[FLOOR(/($0, 2))])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupByExprArgFieldSameWithAlias2">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno / 2 AS deptno, deptno / 2 as empno, sum(sal)
+FROM emp
+GROUP BY GROUPING SETS ((deptno), (empno, deptno / 2), (2, 1))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], EMPNO=[$0], EXPR$2=[$1])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{0}], EXPR$2=[SUM($1)])
+      LogicalProject(EMPNO=[/($7, 2)], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0}], EXPR$2=[SUM($1)])
+      LogicalProject(EMPNO=[/($7, 2)], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0}], EXPR$2=[SUM($1)])
+      LogicalProject(EMPNO=[/($7, 2)], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testGroupByExpression">
     <Resource name="sql">
       <![CDATA[select count(*)


### PR DESCRIPTION
…T field and alias causes validation error

This PR restricts the alias/ordinal expanding GROUP BY expr to identifier or CUBE/ROLLUP/GROUPING SETS top level expression.
For example:
select replace(name, 'a', 'b') as name from users group by replace(name, 'a', 'b')
The name in GROUP BY clause will not be replaced by replace(name, 'a', 'b'), it will be resolved as users.name.

SELECT empno + deptno AS x, empno - deptno AS y FROM emp GROUP BY ROLLUP(x, y, empno) 
The x, y in GROUP BY clause will be replaced by empno + deptno, empno - deptno.