### PR TITLE
[CALCITE-5050] Correct rowcount of aggregate without group keys

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -199,7 +199,10 @@ public class RelMdRowCount
 
   public Double getRowCount(Aggregate rel, RelMetadataQuery mq) {
     ImmutableBitSet groupKey = rel.getGroupSet();
-
+    if (groupKey.isEmpty()) {
+      // Aggregate with no GROUP BY always returns 1 row (even on empty table).
+      return 1D;
+    }
     // rowCount is the cardinality of the group by columns
     Double distinctRowCount =
         mq.getDistinctRowCount(rel.getInput(), groupKey, null);

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -674,6 +674,35 @@ public class RelMetadataTest {
     sql(sql).assertThatRowCount(is(1D), is(1D), is(1D));
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5050">[CALCITE-5050]
+   * Aggregate with no GROUP BY always returns 1 row. </a>. */
+  @Test void testRowCountAggregateEmptyGroupKey() {
+    fixture()
+        .withRelFn(b ->
+            b.scan("EMP")
+                .aggregate(
+                    b.groupKey(),
+                    b.count(false, "C"))
+                .build())
+        .assertThatRowCount(is(1D), is(1D), is(1D));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5050">[CALCITE-5050]
+   * Aggregate with no GROUP BY always returns 1 row (even on empty table). </a>. */
+  @Test void testRowCountAggregateEmptyGroupKeyWithEmptyTable() {
+    fixture()
+        .withRelFn(b ->
+            b.scan("EMP")
+                .filter(b.literal(false))
+                .aggregate(
+                    b.groupKey(),
+                    b.count(false, "C"))
+                .build())
+        .assertThatRowCount(is(1D), is(1D), is(1D));
+  }
+
   @Test void testRowCountAggregateConstantKey() {
     final String sql = "select count(*) from emp where deptno=2 and ename='emp1' "
         + "group by deptno, ename";


### PR DESCRIPTION
## What is the purpose of the change

This pr is to fix a minor bug: the row count of an aggregate is wrong if it is without group keys.

## Brief change log

  - Update `RelMdRowCount#getRowCount(Aggregate rel, RelMetadataQuery mq)`

## Verifying this change

  - Add tests in `RelMetadataTest`