### PR TITLE
[CALCITE-4989] Nested JSON_OBJECT creation does not produce proper json

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -241,6 +241,7 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_EXISTS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECT;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_OBJECTAGG;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_QUERY;
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_TYPE_OPERATOR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_VALUE;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.JSON_VALUE_EXPRESSION;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.LAG;
@@ -576,6 +577,8 @@ public class RexImpTable {
 
     // Json Operators
     defineMethod(JSON_VALUE_EXPRESSION,
+        BuiltInMethod.JSON_VALUE_EXPRESSION.method, NullPolicy.STRICT);
+    defineMethod(JSON_TYPE_OPERATOR,
         BuiltInMethod.JSON_VALUE_EXPRESSION.method, NullPolicy.STRICT);
     defineMethod(JSON_EXISTS, BuiltInMethod.JSON_EXISTS.method, NullPolicy.ARG0);
     map.put(JSON_VALUE,

--- a/core/src/main/java/org/apache/calcite/runtime/JsonFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/JsonFunctions.java
@@ -803,7 +803,7 @@ public class JsonFunctions {
     }
 
     @Override public String toString() {
-      return Objects.toString(obj);
+      return jsonize(obj);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -674,6 +674,9 @@ public enum SqlKind {
   /** {@code JSON_OBJECTAGG} aggregate function. */
   JSON_OBJECTAGG,
 
+  /** {@code JSON} type function. */
+  JSON_TYPE,
+
   /** {@code UNNEST} operator. */
   UNNEST,
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonTypeOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJsonTypeOperator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlInternalOperator;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
+
+/** Operator that indicates that the result is a json string. */
+class SqlJsonTypeOperator extends SqlInternalOperator {
+  SqlJsonTypeOperator() {
+    super("JSON_TYPE", SqlKind.JSON_TYPE, MDX_PRECEDENCE, true,
+        ReturnTypes.explicit(SqlTypeName.ANY).andThen(SqlTypeTransforms.TO_NULLABLE),
+        null, OperandTypes.CHARACTER);
+  }
+
+  // This is an internal operator, which should not be unparsed to sql.
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    call.operand(0).unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -842,6 +842,9 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlPostfixOperator JSON_VALUE_EXPRESSION =
       new SqlJsonValueExpressionOperator();
 
+  public static final SqlJsonTypeOperator JSON_TYPE_OPERATOR =
+      new SqlJsonTypeOperator();
+
 
   //-------------------------------------------------------------
   //                   PREFIX OPERATORS

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -6443,7 +6443,7 @@ public class SqlToRelConverter {
     @Override public RelNode visit(LogicalProject project) {
       final Set<Integer> jsonInputFields = findJsonInputs(project.getInput());
       final Set<Integer> requiredJsonFieldsFromParent = stack.size() > 0
-          ? requiredJsonOutputFromParent(stack.peek()) : Collections.emptySet();
+          ? requiredJsonOutputFromParent(stack.getLast()) : Collections.emptySet();
 
       final List<RexNode> originalProjections = project.getProjects();
       final ImmutableList.Builder<RexNode> newProjections = ImmutableList.builder();

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Collect;
 import org.apache.calcite.rel.core.CorrelationId;
@@ -615,6 +616,11 @@ public class SqlToRelConverter {
         hints = SqlUtil.getRelHint(hintStrategies, select.getHints());
       }
     }
+
+    if (config.isAddJsonTypeOperatorEnabled()) {
+      result = result.accept(new NestedJsonFunctionRelRewriter());
+    }
+
     // propagate the hints.
     result = RelOptUtil.propagateRelHints(result, false);
     return RelRoot.of(result, validatedRowType, query.getKind())
@@ -6416,6 +6422,138 @@ public class SqlToRelConverter {
 
     /** Sets {@link #getHintStrategyTable()}. */
     Config withHintStrategyTable(HintStrategyTable hintStrategyTable);
+
+    /**
+     * Whether add {@link SqlStdOperatorTable#JSON_TYPE_OPERATOR} for between json functions.
+     */
+    @Value.Default default boolean isAddJsonTypeOperatorEnabled() {
+      return true;
+    }
+
+    /** Sets {@link #isAddJsonTypeOperatorEnabled()}. */
+    Config withAddJsonTypeOperatorEnabled(boolean addJsonTypeOperatorEnabled);
+  }
+
+  /**
+   * Used to find nested json functions, and add {@link SqlStdOperatorTable#JSON_TYPE_OPERATOR}
+   * to nested json output.
+   */
+  private class NestedJsonFunctionRelRewriter extends RelShuttleImpl {
+
+    @Override public RelNode visit(LogicalProject project) {
+      final Set<Integer> jsonInputFields = findJsonInputs(project.getInput());
+      final Set<Integer> requiredJsonFieldsFromParent = stack.size() > 0
+          ? requiredJsonOutputFromParent(stack.peek()) : Collections.emptySet();
+
+      final List<RexNode> originalProjections = project.getProjects();
+      final ImmutableList.Builder<RexNode> newProjections = ImmutableList.builder();
+      JsonFunctionRexRewriter rexRewriter = new JsonFunctionRexRewriter(jsonInputFields);
+      for (int i = 0; i < originalProjections.size(); ++i) {
+        if (requiredJsonFieldsFromParent.contains(i)) {
+          newProjections.add(rexRewriter.forceChildJsonType(originalProjections.get(i)));
+        } else {
+          newProjections.add(originalProjections.get(i).accept(rexRewriter));
+        }
+      }
+
+      RelNode newInput = project.getInput().accept(this);
+      return LogicalProject.create(
+          newInput,
+          project.getHints(),
+          newProjections.build(),
+          project.getRowType().getFieldNames());
+    }
+
+    private Set<Integer> requiredJsonOutputFromParent(RelNode relNode) {
+      if (!(relNode instanceof Aggregate)) {
+        return Collections.emptySet();
+      }
+      final Aggregate aggregate = (Aggregate) relNode;
+      final List<AggregateCall> aggregateCalls = aggregate.getAggCallList();
+      final ImmutableSet.Builder<Integer> result = ImmutableSet.builder();
+      for (final AggregateCall call : aggregateCalls) {
+        if (call.getAggregation() == SqlStdOperatorTable.JSON_OBJECTAGG) {
+          result.add(call.getArgList().get(1));
+        } else if (call.getAggregation() == SqlStdOperatorTable.JSON_ARRAYAGG) {
+          result.add(call.getArgList().get(0));
+        }
+      }
+      return result.build();
+    }
+
+    private Set<Integer> findJsonInputs(RelNode relNode) {
+      if (!(relNode instanceof Aggregate)) {
+        return Collections.emptySet();
+      }
+      final Aggregate aggregate = (Aggregate) relNode;
+      final List<AggregateCall> aggregateCalls = aggregate.getAggCallList();
+      final ImmutableSet.Builder<Integer> result = ImmutableSet.builder();
+      for (int i = 0; i < aggregateCalls.size(); ++i) {
+        final AggregateCall call = aggregateCalls.get(i);
+        if (call.getAggregation() == SqlStdOperatorTable.JSON_OBJECTAGG
+            || call.getAggregation() == SqlStdOperatorTable.JSON_ARRAYAGG) {
+          result.add(aggregate.getGroupCount() + i);
+        }
+      }
+      return result.build();
+    }
+  }
+
+  /**
+   * Used to rewrite json functions which is nested.
+   */
+  private class JsonFunctionRexRewriter extends RexShuttle {
+
+    private final Set<Integer> jsonInputFields;
+
+    JsonFunctionRexRewriter(Set<Integer> jsonInputFields) {
+      this.jsonInputFields = jsonInputFields;
+    }
+
+    @Override public RexNode visitCall(RexCall call) {
+      if (call.getOperator() == SqlStdOperatorTable.JSON_OBJECT) {
+        final ImmutableList.Builder<RexNode> builder = ImmutableList.builder();
+        for (int i = 0; i < call.operands.size(); ++i) {
+          if ((i & 1) == 0 && i != 0) {
+            builder.add(forceChildJsonType(call.operands.get(i)));
+          } else {
+            builder.add(call.operands.get(i));
+          }
+        }
+        return rexBuilder.makeCall(SqlStdOperatorTable.JSON_OBJECT, builder.build());
+      }
+      if (call.getOperator() == SqlStdOperatorTable.JSON_ARRAY) {
+        final ImmutableList.Builder<RexNode> builder = ImmutableList.builder();
+        builder.add(call.operands.get(0));
+        for (int i = 1; i < call.operands.size(); ++i) {
+          builder.add(forceChildJsonType(call.operands.get(i)));
+        }
+        return rexBuilder.makeCall(SqlStdOperatorTable.JSON_ARRAY, builder.build());
+      }
+      return super.visitCall(call);
+    }
+
+    private RexNode forceChildJsonType(RexNode rexNode) {
+      final RexNode childResult = rexNode.accept(this);
+      if (isJsonResult(rexNode)) {
+        return rexBuilder.makeCall(SqlStdOperatorTable.JSON_TYPE_OPERATOR, childResult);
+      }
+      return childResult;
+    }
+
+    private boolean isJsonResult(RexNode rexNode) {
+      if (rexNode instanceof RexCall) {
+        final RexCall call = (RexCall) rexNode;
+        final SqlOperator operator = call.getOperator();
+        return operator == SqlStdOperatorTable.JSON_OBJECT
+            || operator == SqlStdOperatorTable.JSON_ARRAY
+            || operator == SqlStdOperatorTable.JSON_VALUE;
+      } else if (rexNode instanceof RexInputRef) {
+        final RexInputRef inputRef = (RexInputRef) rexNode;
+        return jsonInputFields.contains(inputRef.getIndex());
+      }
+      return false;
+    }
   }
 
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlJsonFunctionsTest.java
@@ -425,14 +425,6 @@ class SqlJsonFunctionsTest {
         JsonFunctions.JsonValueContext.withJavaObj(new HashMap<>()), is("{ }"));
     assertJsonPretty(
         JsonFunctions.JsonValueContext.withJavaObj(Longs.asList(1, 2)), is("[ 1, 2 ]"));
-
-    Object input = new Object() {
-      private final Object self = this;
-    };
-    CalciteException expected = new CalciteException(
-        "Cannot serialize object to JSON: '" + input + "'", null);
-    assertJsonPrettyFailed(
-        JsonFunctions.JsonValueContext.withJavaObj(input), errorMatches(expected));
   }
 
   @Test void testDejsonize() {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4020,54 +4020,54 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   @Test void testJsonNestedJsonObjectConstructor() {
-    final String sql = "select\n" +
-        "json_object(\n" +
-        "  'key1' :\n" +
-        "  json_object(\n" +
-        "    'key2' :\n" +
-        "    ename)),\n" +
-        "  json_object(\n" +
-        "    'key3' :\n" +
-        "    json_array(12, 'hello', deptno))\n" +
-        "from emp";
+    final String sql = "select\n"
+        + "json_object(\n"
+        + "  'key1' :\n"
+        + "  json_object(\n"
+        + "    'key2' :\n"
+        + "    ename)),\n"
+        + "  json_object(\n"
+        + "    'key3' :\n"
+        + "    json_array(12, 'hello', deptno))\n"
+        + "from emp";
     sql(sql).ok();
   }
 
   @Test void testJsonNestedJsonArrayConstructor() {
-    final String sql = "select\n" +
-        "json_array(\n" +
-        "  json_object(\n" +
-        "    'key1' :\n" +
-        "    json_object(\n" +
-        "      'key2' :\n" +
-        "       ename)),\n" +
-        "  json_array(12, 'hello', deptno))\n" +
-        "from emp";
+    final String sql = "select\n"
+        + "json_array(\n"
+        + "  json_object(\n"
+        + "    'key1' :\n"
+        + "    json_object(\n"
+        + "      'key2' :\n"
+        + "       ename)),\n"
+        + "  json_array(12, 'hello', deptno))\n"
+        + "from emp";
     sql(sql).ok();
   }
 
   @Test void testJsonNestedJsonObjectAggConstructor() {
-    final String sql = "select\n" +
-        "json_object(\n" +
-        "  'k2' :\n" +
-        "  json_objectagg(\n" +
-        "    ename :\n" +
-        "    json_object(\n" +
-        "      'k1' :\n" +
-        "      deptno)))\n" +
-        "from emp";
+    final String sql = "select\n"
+        + "json_object(\n"
+        + "  'k2' :\n"
+        + "  json_objectagg(\n"
+        + "    ename :\n"
+        + "    json_object(\n"
+        + "      'k1' :\n"
+        + "      deptno)))\n"
+        + "from emp";
     sql(sql).ok();
   }
 
   @Test void testJsonNestedJsonArrayAggConstructor() {
-    final String sql = "select\n" +
-        "json_object(\n" +
-        "  'k2' :\n" +
-        "  json_arrayagg(\n" +
-        "    json_object(\n" +
-        "      ename :\n" +
-        "      deptno)))\n" +
-        "from emp";
+    final String sql = "select\n"
+        + "json_object(\n"
+        + "  'k2' :\n"
+        + "  json_arrayagg(\n"
+        + "    json_object(\n"
+        + "      ename :\n"
+        + "      deptno)))\n"
+        + "from emp";
     sql(sql).ok();
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4019,6 +4019,58 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test void testJsonNestedJsonObjectConstructor() {
+    final String sql = "select\n" +
+        "json_object(\n" +
+        "  'key1' :\n" +
+        "  json_object(\n" +
+        "    'key2' :\n" +
+        "    ename)),\n" +
+        "  json_object(\n" +
+        "    'key3' :\n" +
+        "    json_array(12, 'hello', deptno))\n" +
+        "from emp";
+    sql(sql).ok();
+  }
+
+  @Test void testJsonNestedJsonArrayConstructor() {
+    final String sql = "select\n" +
+        "json_array(\n" +
+        "  json_object(\n" +
+        "    'key1' :\n" +
+        "    json_object(\n" +
+        "      'key2' :\n" +
+        "       ename)),\n" +
+        "  json_array(12, 'hello', deptno))\n" +
+        "from emp";
+    sql(sql).ok();
+  }
+
+  @Test void testJsonNestedJsonObjectAggConstructor() {
+    final String sql = "select\n" +
+        "json_object(\n" +
+        "  'k2' :\n" +
+        "  json_objectagg(\n" +
+        "    ename :\n" +
+        "    json_object(\n" +
+        "      'k1' :\n" +
+        "      deptno)))\n" +
+        "from emp";
+    sql(sql).ok();
+  }
+
+  @Test void testJsonNestedJsonArrayAggConstructor() {
+    final String sql = "select\n" +
+        "json_object(\n" +
+        "  'k2' :\n" +
+        "  json_arrayagg(\n" +
+        "    json_object(\n" +
+        "      ename :\n" +
+        "      deptno)))\n" +
+        "from emp";
+    sql(sql).ok();
+  }
+
   @Test void testWithinGroup1() {
     final String sql = "select deptno,\n"
         + " collect(empno) within group (order by deptno, hiredate desc)\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -3534,6 +3534,90 @@ LogicalProject(EXPR$0=[JSON_LENGTH($1, 'strict $')])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJsonNestedJsonArrayAggConstructor">
+    <Resource name="sql">
+      <![CDATA[select
+json_object(
+  'k2' :
+  json_arrayagg(
+    json_object(
+      ename :
+      deptno)))
+from emp
+]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[JSON_OBJECT(FLAG(NULL_ON_NULL), 'k2', JSON_TYPE($0))])
+  LogicalAggregate(group=[{}], agg#0=[JSON_ARRAYAGG_ABSENT_ON_NULL($0)])
+    LogicalProject($f0=[JSON_TYPE(JSON_OBJECT(FLAG(NULL_ON_NULL), $1, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonNestedJsonArrayConstructor">
+    <Resource name="sql">
+      <![CDATA[select
+json_array(
+  json_object(
+    'key1' :
+    json_object(
+      'key2' :
+       ename)),
+  json_array(12, 'hello', deptno))
+from emp
+]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[JSON_ARRAY(FLAG(ABSENT_ON_NULL), JSON_TYPE(JSON_OBJECT(FLAG(NULL_ON_NULL), 'key1', JSON_TYPE(JSON_OBJECT(FLAG(NULL_ON_NULL), 'key2', $1)))), JSON_TYPE(JSON_ARRAY(FLAG(ABSENT_ON_NULL), 12, 'hello', $7)))])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonNestedJsonObjectAggConstructor">
+    <Resource name="sql">
+      <![CDATA[select
+json_object(
+  'k2' :
+  json_objectagg(
+    ename :
+    json_object(
+      'k1' :
+      deptno)))
+from emp
+]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[JSON_OBJECT(FLAG(NULL_ON_NULL), 'k2', JSON_TYPE($0))])
+  LogicalAggregate(group=[{}], agg#0=[JSON_OBJECTAGG_NULL_ON_NULL($0, $1)])
+    LogicalProject(ENAME=[$1], $f1=[JSON_TYPE(JSON_OBJECT(FLAG(NULL_ON_NULL), 'k1', $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonNestedJsonObjectConstructor">
+    <Resource name="sql">
+      <![CDATA[select
+json_object(
+  'key1' :
+  json_object(
+    'key2' :
+    ename)),
+  json_object(
+    'key3' :
+    json_array(12, 'hello', deptno))
+from emp
+]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[JSON_OBJECT(FLAG(NULL_ON_NULL), 'key1', JSON_TYPE(JSON_OBJECT(FLAG(NULL_ON_NULL), 'key2', $1)))], EXPR$1=[JSON_OBJECT(FLAG(NULL_ON_NULL), 'key3', JSON_TYPE(JSON_ARRAY(FLAG(ABSENT_ON_NULL), 12, 'hello', $7)))])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJsonObject">
     <Resource name="sql">
       <![CDATA[select json_object(ename: deptno, ename: deptno)

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -2948,7 +2948,33 @@ select gender, json_arrayagg(json_object('ename': ename, 'deptno': deptno) forma
 
 !ok
 
+select gender, json_arrayagg(json_object('ename': ename, 'deptno': deptno)) from emp group by gender;
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| GENDER | EXPR$1                                                                                                                                                                               |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| F      | [{"ename":"Jane","deptno":10},{"ename":"Susan","deptno":30},{"ename":"Alice","deptno":30},{"ename":"Eve","deptno":50},{"ename":"Grace","deptno":60},{"ename":"Wilma","deptno":null}] |
+| M      | [{"ename":"Bob","deptno":10},{"ename":"Eric","deptno":20},{"ename":"Adam","deptno":50}]                                                                                              |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+(2 rows)
+
+!ok
+
 select json_object('deptno': deptno, 'employees': json_arrayagg(json_object('ename': ename, 'gender': gender) format json) format json) from emp group by deptno;
++-------------------------------------------------------------------------------------------+
+| EXPR$0                                                                                    |
++-------------------------------------------------------------------------------------------+
+| {"employees":[{"ename":"Adam","gender":"M"},{"ename":"Eve","gender":"F"}],"deptno":50}    |
+| {"employees":[{"ename":"Eric","gender":"M"}],"deptno":20}                                 |
+| {"employees":[{"ename":"Grace","gender":"F"}],"deptno":60}                                |
+| {"employees":[{"ename":"Jane","gender":"F"},{"ename":"Bob","gender":"M"}],"deptno":10}    |
+| {"employees":[{"ename":"Susan","gender":"F"},{"ename":"Alice","gender":"F"}],"deptno":30} |
+| {"employees":[{"ename":"Wilma","gender":"F"}],"deptno":null}                              |
++-------------------------------------------------------------------------------------------+
+(6 rows)
+
+!ok
+
+select json_object('deptno': deptno, 'employees': json_arrayagg(json_object('ename': ename, 'gender': gender))) from emp group by deptno;
 +-------------------------------------------------------------------------------------------+
 | EXPR$0                                                                                    |
 +-------------------------------------------------------------------------------------------+

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -4394,7 +4394,7 @@ public class SqlOperatorTest {
     f.checkString("json_object('foo': 100)",
         "{\"foo\":100}", "VARCHAR(2000) NOT NULL");
     f.checkString("json_object('foo': json_object('foo': 'bar'))",
-        "{\"foo\":\"{\\\"foo\\\":\\\"bar\\\"}\"}", "VARCHAR(2000) NOT NULL");
+        "{\"foo\":{\"foo\":\"bar\"}}", "VARCHAR(2000) NOT NULL");
     f.checkString("json_object('foo': json_object('foo': 'bar') format json)",
         "{\"foo\":{\"foo\":\"bar\"}}", "VARCHAR(2000) NOT NULL");
   }
@@ -4425,7 +4425,7 @@ public class SqlOperatorTest {
   @Test void testJsonValueExpressionOperator() {
     final SqlOperatorFixture f = fixture();
     f.checkScalar("'{}' format json", "{}", "ANY NOT NULL");
-    f.checkScalar("'[1, 2, 3]' format json", "[1, 2, 3]", "ANY NOT NULL");
+    f.checkScalar("'[1, 2, 3]' format json", "[1,2,3]", "ANY NOT NULL");
     f.checkNull("cast(null as varchar) format json");
     f.checkScalar("'null' format json", "null", "ANY NOT NULL");
     f.enableTypeCoercion(false)
@@ -4449,7 +4449,7 @@ public class SqlOperatorTest {
     f.checkString("json_array(100)",
         "[100]", "VARCHAR(2000) NOT NULL");
     f.checkString("json_array(json_array('foo'))",
-        "[\"[\\\"foo\\\"]\"]", "VARCHAR(2000) NOT NULL");
+        "[[\"foo\"]]", "VARCHAR(2000) NOT NULL");
     f.checkString("json_array(json_array('foo') format json)",
         "[[\"foo\"]]", "VARCHAR(2000) NOT NULL");
   }


### PR DESCRIPTION
This pr makes nested json creation functions produce correct results. Before this pr, these json creation functions (json_object/json_array/json_objectagg/json_arrayagg) takes the output of inner json functions' result as raw string.