### PR TITLE
[CALCITE-5032] RelOptUtil#splitJoinCondition returns wrong when there is no equal condition

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -1387,41 +1387,6 @@ public abstract class RelOptUtil {
         }
       }
 
-      if ((rangeOp == null)
-          && ((leftKey == null) || (rightKey == null))) {
-        // no equality join keys found yet:
-        // try transforming the condition to
-        // equality "join" conditions, e.g.
-        //     f(LHS) > 0 ===> ( f(LHS) > 0 ) = TRUE,
-        // and make the RHS produce TRUE, but only if we're strictly
-        // looking for equi-joins
-        final ImmutableBitSet projRefs = InputFinder.bits(condition);
-        leftKey = null;
-        rightKey = null;
-
-        boolean foundInput = false;
-        for (int i = 0; i < inputs.size() && !foundInput; i++) {
-          if (inputsRange[i].contains(projRefs)) {
-            leftInput = i;
-            leftFields = inputs.get(leftInput).getRowType().getFieldList();
-
-            leftKey = condition.accept(
-                new RelOptUtil.RexInputConverter(
-                    rexBuilder,
-                    leftFields,
-                    leftFields,
-                    adjustments));
-
-            rightKey = rexBuilder.makeLiteral(true);
-
-            // effectively performing an equality comparison
-            kind = SqlKind.EQUALS;
-
-            foundInput = true;
-          }
-        }
-      }
-
       if ((leftKey != null) && (rightKey != null)) {
         // found suitable join keys
         // add them to key list, ensuring that if there is a

--- a/core/src/test/java/org/apache/calcite/plan/RelOptUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelOptUtilTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -283,6 +284,27 @@ class RelOptUtilTest {
         Collections.singletonList(rightJoinIndex),
         Collections.singletonList(true),
         relBuilder.literal(true));
+  }
+
+  @Test void testSplitJoinConditionWithoutEqualCondition() {
+    final List<RelDataTypeField> sysFieldList = Collections.emptyList();
+    final List<List<RexNode>> joinKeys = Arrays.asList(new ArrayList<>(), new ArrayList<>());
+    final RexNode joinCondition = relBuilder.equals(
+        RexInputRef.of(0, empDeptJoinRelFields),
+        relBuilder.literal(1));
+    final RexNode result = RelOptUtil.splitJoinCondition(
+        sysFieldList,
+        Arrays.asList(empScan, deptScan),
+        joinCondition,
+        joinKeys,
+        null,
+        null
+    );
+    final List<List<RexNode>> expectedJoinKeys = Arrays.asList(
+        Collections.emptyList(),
+        Collections.emptyList());
+    assertEquals(joinKeys, expectedJoinKeys);
+    assertEquals(result, joinCondition);
   }
 
   /**


### PR DESCRIPTION
Fix the bug for `RelOptUtil#splitJoinCondition`:
```Java
  public static RexNode splitJoinCondition(
      List<RelDataTypeField> sysFieldList,
      List<RelNode> inputs,
      RexNode condition,
      List<List<RexNode>> joinKeys,
      @Nullable List<Integer> filterNulls,
      @Nullable List<SqlOperator> rangeOp) {
```
 for following case:
```SQL
select
 *
from emp left join dept
on emp.empno > 0
```
The expected result is to make `(empno > 0) = true` as the equal join key.