### PR TITLE
[CALCITE-5075] Build fails due to rat check on Gemfile.lock

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -39,6 +39,7 @@ site/_layouts/news.html
 site/_layouts/news_item.html
 site/_layouts/page.html
 site/_sass/**
+site/Gemfile.lock
 site/css/screen.scss
 site/fonts/**
 site/js/**


### PR DESCRIPTION
Add `Gemfile.lock` to `.ratignore` to fix the issue