### PR TITLE
[CALCITE-5048] Optimizer support dynamic parameter in LIMIT/OFFSET

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
@@ -109,16 +109,13 @@ public class RelMdMaxRowCount
     if (rowCount == null) {
       rowCount = Double.POSITIVE_INFINITY;
     }
-    final int offset = rel.offset == null ? 0 : RexLiteral.intValue(rel.offset);
+
+    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
-    if (rel.fetch != null) {
-      final int limit = RexLiteral.intValue(rel.fetch);
-      if (limit < rowCount) {
-        return (double) limit;
-      }
-    }
-    return rowCount;
+    final double limit =
+        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+    return limit < rowCount ? limit : rowCount;
   }
 
   public Double getMaxRowCount(EnumerableLimit rel, RelMetadataQuery mq) {
@@ -126,16 +123,13 @@ public class RelMdMaxRowCount
     if (rowCount == null) {
       rowCount = Double.POSITIVE_INFINITY;
     }
-    final int offset = rel.offset == null ? 0 : RexLiteral.intValue(rel.offset);
+
+    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
-    if (rel.fetch != null) {
-      final int limit = RexLiteral.intValue(rel.fetch);
-      if (limit < rowCount) {
-        return (double) limit;
-      }
-    }
-    return rowCount;
+    final double limit =
+        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+    return limit < rowCount ? limit : rowCount;
   }
 
   public @Nullable Double getMaxRowCount(Aggregate rel, RelMetadataQuery mq) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
@@ -108,16 +108,13 @@ public class RelMdMinRowCount
     if (rowCount == null) {
       rowCount = 0D;
     }
-    final int offset = rel.offset == null ? 0 : RexLiteral.intValue(rel.offset);
+
+    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
-    if (rel.fetch != null) {
-      final int limit = RexLiteral.intValue(rel.fetch);
-      if (limit < rowCount) {
-        return (double) limit;
-      }
-    }
-    return rowCount;
+    final double limit =
+        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+    return limit < rowCount ? limit : rowCount;
   }
 
   public Double getMinRowCount(EnumerableLimit rel, RelMetadataQuery mq) {
@@ -125,16 +122,13 @@ public class RelMdMinRowCount
     if (rowCount == null) {
       rowCount = 0D;
     }
-    final int offset = rel.offset == null ? 0 : RexLiteral.intValue(rel.offset);
+
+    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
-    if (rel.fetch != null) {
-      final int limit = RexLiteral.intValue(rel.fetch);
-      if (limit < rowCount) {
-        return (double) limit;
-      }
-    }
-    return rowCount;
+    final double limit =
+        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+    return limit < rowCount ? limit : rowCount;
   }
 
   public Double getMinRowCount(Aggregate rel, RelMetadataQuery mq) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
@@ -28,6 +28,7 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexLocalRef;
@@ -911,7 +912,7 @@ public class RelMdUtil {
       return true;
     }
     final Double rowCount = mq.getMaxRowCount(input);
-    if (rowCount == null) {
+    if (rowCount == null || offset instanceof RexDynamicParam || fetch instanceof RexDynamicParam) {
       // Cannot be determined
       return false;
     }

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -477,13 +477,10 @@ public class RelDecorrelator implements ReflectiveVisitor {
     RelCollation oldCollation = rel.getCollation();
     RelCollation newCollation = RexUtil.apply(mapping, oldCollation);
 
-    final int offset = rel.offset == null ? -1 : RexLiteral.intValue(rel.offset);
-    final int fetch = rel.fetch == null ? -1 : RexLiteral.intValue(rel.fetch);
-
     final RelNode newSort = relBuilder
-            .push(newInput)
-            .sortLimit(offset, fetch, relBuilder.fields(newCollation))
-            .build();
+        .push(newInput)
+        .sortLimit(rel.offset, rel.fetch, relBuilder.fields(newCollation))
+        .build();
 
     // Sort does not change input ordering
     return register(rel, newSort, frame.oldToNewOutputs, frame.corDefOutputs);

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -70,6 +70,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCallBinding;
 import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.rex.RexFieldCollation;
 import org.apache.calcite.rex.RexInputRef;
@@ -3191,12 +3192,37 @@ public class RelBuilder {
    */
   public RelBuilder sortLimit(int offset, int fetch,
       Iterable<? extends RexNode> nodes) {
+    final @Nullable RexNode offsetNode = offset <= 0 ? null : literal(offset);
+    final @Nullable RexNode fetchNode = fetch < 0 ? null : literal(fetch);
+    return sortLimit(offsetNode, fetchNode, nodes);
+  }
+
+  /** Creates a {@link Sort} by a list of expressions, with limitNode and offsetNode.
+   *
+   * @param offsetNode RexLiteral means number of rows to skip is deterministic,
+   *                   RexDynamicParam means number of rows to skip is dynamic.
+   * @param fetchNode  RexLiteral means maximum number of rows to fetch is deterministic,
+   *                   RexDynamicParam mean maximum number is dynamic.
+   * @param nodes      Sort expressions
+   */
+  public RelBuilder sortLimit(@Nullable RexNode offsetNode, @Nullable RexNode fetchNode,
+      Iterable<? extends RexNode> nodes) {
+    if (offsetNode != null) {
+      if (!(offsetNode instanceof RexLiteral || offsetNode instanceof RexDynamicParam)) {
+        throw new IllegalArgumentException("OFFSET node must be RexLiteral or RexDynamicParam");
+      }
+    }
+    if (fetchNode != null) {
+      if (!(fetchNode instanceof RexLiteral || fetchNode instanceof RexDynamicParam)) {
+        throw new IllegalArgumentException("FETCH node must be RexLiteral or RexDynamicParam");
+      }
+    }
+
     final Registrar registrar = new Registrar(fields(), ImmutableList.of());
     final List<RelFieldCollation> fieldCollations =
         registrar.registerFieldCollations(nodes);
-
-    final RexNode offsetNode = offset <= 0 ? null : literal(offset);
-    final RexNode fetchNode = fetch < 0 ? null : literal(fetch);
+    final int fetch = fetchNode instanceof RexLiteral
+        ? RexLiteral.intValue(fetchNode) : -1;
     if (offsetNode == null && fetch == 0 && config.simplifyLimit()) {
       return empty();
     }

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -644,6 +644,15 @@ public class RelMetadataTest {
     fixture.assertThatRowCount(is(9D), is(0D), is(10d));
   }
 
+  @Test void testRowCountSortLimitOffsetDynamic() {
+    sql("select * from emp order by ename limit ? offset ?")
+        .assertThatRowCount(is(EMP_SIZE), is(0D), is(Double.POSITIVE_INFINITY));
+    sql("select * from emp order by ename limit 1 offset ?")
+        .assertThatRowCount(is(EMP_SIZE), is(0D), is(1D));
+    sql("select * from emp order by ename limit ? offset 1")
+        .assertThatRowCount(is(EMP_SIZE - 1), is(0D), is(Double.POSITIVE_INFINITY));
+  }
+
   @Test void testRowCountSortLimitOffsetOnFinite() {
     final String sql = "select * from (select * from emp limit 12)\n"
         + "order by ename limit 20 offset 5";


### PR DESCRIPTION
I searched the code of `RexLiteral#intValue` in core module. Found that four class failed when LIMIT/OFFSET parameter is Dynamic. 
- RelMdMaxRowCount
- RelMdMinRowCount
- RelMdUtil
- RelDecorrelator

I fixed them, and added corresponding unit tests.