### PR TITLE
[CALCITE-5027] Incorrect format for TIMESTAMP literals in SqlDialect#quoteTimestampLiteral

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -682,7 +682,7 @@ public class SqlDialect {
    * @return SQL timestamp literal
    */
   public String quoteTimestampLiteral(Timestamp timestamp) {
-    final SimpleDateFormat format = getDateFormatter("'TIMESTAMP' ''yyyy-MM-DD HH:mm:SS''");
+    final SimpleDateFormat format = getDateFormatter("'TIMESTAMP' ''yyyy-MM-dd HH:mm:ss''");
     return format.format(timestamp);
   }
 

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -745,6 +745,13 @@ class UtilTest {
     buf.literal(new Timestamp(0));
     assertEquals("TIMESTAMP '1970-01-01 00:00:00'", buf.getSqlAndClear());
 
+    buf.literal(new Timestamp(1261053296000L));
+    assertEquals("TIMESTAMP '2009-12-17 12:34:56'", buf.getSqlAndClear());
+
+    buf.append("select ");
+    buf.literal(new Timestamp(1261053296000L));
+    assertEquals("select TIMESTAMP '2009-12-17 12:34:56'", buf.getSqlAndClear());
+
     buf.clear();
     assertEquals(0, buf.length());
 


### PR DESCRIPTION
`Date and Time Patterns` can find in SimpleDateFormat Java Doc.