### PR TITLE
[CALCITE-5086] Core parser should allow "OFFSET" to occur before "LIMIT"

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -644,7 +644,11 @@ SqlNode OrderedQueryOrExpr(ExprContext exprContext) :
     [
         OffsetClause(startCount)
         [
-            LimitClause(startCount)
+            LimitClause(startCount) {
+                if (!this.conformance.isOffsetStartLimitCountAllowed()) {
+                    throw SqlUtil.newContextException(getPos(), RESOURCE.offsetStartLimitCountNotAllowed());
+                }
+            }
         ]
         |
         LimitClause(startCount)

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -606,6 +606,13 @@ JAVACODE boolean matchesPrefix(int[] seq, int[][] prefixes)
  *    [ OFFSET start ]</pre>
  * </blockquote>
  *
+ * <p>Trino syntax for limit:
+ *
+ * <blockquote><pre>
+ *    [ OFFSET start ]
+ *    [ LIMIT { count | ALL } ]</pre>
+ * </blockquote>
+ *
  * <p>MySQL syntax for limit:
  *
  * <blockquote><pre>
@@ -623,8 +630,7 @@ SqlNode OrderedQueryOrExpr(ExprContext exprContext) :
 {
     SqlNode e;
     SqlNodeList orderBy = null;
-    SqlNode start = null;
-    SqlNode count = null;
+    SqlNode[] startCount = {null, null};
 }
 {
     (
@@ -636,45 +642,69 @@ SqlNode OrderedQueryOrExpr(ExprContext exprContext) :
         orderBy = OrderBy(e.isA(SqlKind.QUERY))
     ]
     [
-        // Postgres-style syntax. "LIMIT ... OFFSET ..."
-        <LIMIT>
-        (
-            // MySQL-style syntax. "LIMIT start, count"
-            LOOKAHEAD(2)
-            start = UnsignedNumericLiteralOrParam()
-            <COMMA> count = UnsignedNumericLiteralOrParam() {
-                if (!this.conformance.isLimitStartCountAllowed()) {
-                    throw SqlUtil.newContextException(getPos(), RESOURCE.limitStartCountNotAllowed());
-                }
-            }
+        OffsetClause(startCount)
+        [
+            LimitClause(startCount)
+        ]
         |
-            count = UnsignedNumericLiteralOrParam()
-        |
-            <ALL>
-        )
-    ]
-    [
-        // ROW or ROWS is required in SQL:2008 but we make it optional
-        // because it is not present in Postgres-style syntax.
-        // If you specify both LIMIT start and OFFSET, OFFSET wins.
-        <OFFSET> start = UnsignedNumericLiteralOrParam() [ <ROW> | <ROWS> ]
+        LimitClause(startCount)
+        [
+            OffsetClause(startCount)
+        ]
     ]
     [
         // SQL:2008-style syntax. "OFFSET ... FETCH ...".
         // If you specify both LIMIT and FETCH, FETCH wins.
-        <FETCH> ( <FIRST> | <NEXT> ) count = UnsignedNumericLiteralOrParam()
+        <FETCH> ( <FIRST> | <NEXT> ) startCount[1] = UnsignedNumericLiteralOrParam()
         ( <ROW> | <ROWS> ) <ONLY>
     ]
     {
-        if (orderBy != null || start != null || count != null) {
+        if (orderBy != null || startCount[0] != null || startCount[1] != null) {
             if (orderBy == null) {
                 orderBy = SqlNodeList.EMPTY;
             }
-            e = new SqlOrderBy(getPos(), e, orderBy, start, count);
-
+            e = new SqlOrderBy(getPos(), e, orderBy, startCount[0], startCount[1]);
         }
         return e;
     }
+}
+
+/**
+ * Parses an offset clause in an order by expression.
+ */
+void OffsetClause(SqlNode[] startCount) :
+{
+}
+{
+    // ROW or ROWS is required in SQL:2008 but we make it optional
+    // because it is not present in Postgres-style syntax.
+    // If you specify both LIMIT start and OFFSET, OFFSET wins.
+    <OFFSET> startCount[0] = UnsignedNumericLiteralOrParam() [ <ROW> | <ROWS> ]
+}
+
+/**
+ * Parses a limit clause in an order by expression.
+ */
+void LimitClause(SqlNode[] startCount) :
+{
+}
+{
+    // Postgres-style syntax. "LIMIT ... OFFSET ..."
+    <LIMIT>
+    (
+        // MySQL-style syntax. "LIMIT start, count"
+        LOOKAHEAD(2)
+        startCount[0] = UnsignedNumericLiteralOrParam()
+        <COMMA> startCount[1] = UnsignedNumericLiteralOrParam() {
+            if (!this.conformance.isLimitStartCountAllowed()) {
+                throw SqlUtil.newContextException(getPos(), RESOURCE.limitStartCountNotAllowed());
+            }
+        }
+    |
+        startCount[1] = UnsignedNumericLiteralOrParam()
+    |
+        <ALL>
+    )
 }
 
 /**

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -42,6 +42,9 @@ public interface CalciteResource {
   @BaseMessage("''LIMIT start, count'' is not allowed under the current SQL conformance level")
   ExInst<CalciteException> limitStartCountNotAllowed();
 
+  @BaseMessage("''OFFSET start LIMIT count'' is not allowed under the current SQL conformance level")
+  ExInst<CalciteException> offsetStartLimitCountNotAllowed();
+
   @BaseMessage("APPLY operator is not allowed under the current SQL conformance level")
   ExInst<CalciteException> applyNotAllowed();
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -101,6 +101,11 @@ public abstract class SqlAbstractConformance implements SqlConformance {
     return SqlConformanceEnum.DEFAULT.isLimitStartCountAllowed();
   }
 
+  @Override
+  public boolean isOffsetStartLimitCountAllowed() {
+    return SqlConformanceEnum.DEFAULT.isOffsetStartLimitCountAllowed();
+  }
+
   @Override public boolean isPercentRemainderAllowed() {
     return SqlConformanceEnum.DEFAULT.isPercentRemainderAllowed();
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -101,8 +101,7 @@ public abstract class SqlAbstractConformance implements SqlConformance {
     return SqlConformanceEnum.DEFAULT.isLimitStartCountAllowed();
   }
 
-  @Override
-  public boolean isOffsetStartLimitCountAllowed() {
+  @Override public boolean isOffsetStartLimitCountAllowed() {
     return SqlConformanceEnum.DEFAULT.isOffsetStartLimitCountAllowed();
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -402,6 +402,22 @@ public interface SqlConformance {
   boolean isLimitStartCountAllowed();
 
   /**
+   * Whether to allow the SQL syntax "{@code OFFSET start LIMIT count}".
+   *
+   * <p>The equivalent syntax in standard SQL is
+   * "{@code OFFSET start ROW FETCH FIRST count ROWS ONLY}",
+   * and in TrinoSQL "{@code OFFSET start LIMIT count}".
+   *
+   * <p>Trino allows this behavior.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#BABEL},
+   * {@link SqlConformanceEnum#LENIENT};
+   * false otherwise.
+   */
+  boolean isOffsetStartLimitCountAllowed();
+
+  /**
    * Whether to allow geo-spatial extensions, including the GEOMETRY type.
    *
    * <p>Among the built-in conformance levels, true in

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -319,8 +319,7 @@ public enum SqlConformanceEnum implements SqlConformance {
     }
   }
 
-  @Override
-  public boolean isOffsetStartLimitCountAllowed() {
+  @Override public boolean isOffsetStartLimitCountAllowed() {
     switch (this) {
     case BABEL:
     case LENIENT:

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -319,6 +319,17 @@ public enum SqlConformanceEnum implements SqlConformance {
     }
   }
 
+  @Override
+  public boolean isOffsetStartLimitCountAllowed() {
+    switch (this) {
+    case BABEL:
+    case LENIENT:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   @Override public boolean allowGeometry() {
     switch (this) {
     case BABEL:

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -22,6 +22,7 @@ ParserContext=line {0,number,#}, column {1,number,#}
 BangEqualNotAllowed=Bang equal ''!='' is not allowed under the current SQL conformance level
 PercentRemainderNotAllowed=Percent remainder ''%'' is not allowed under the current SQL conformance level
 LimitStartCountNotAllowed=''LIMIT start, count'' is not allowed under the current SQL conformance level
+OffsetStartLimitCountNotAllowed=''OFFSET start LIMIT count'' is not allowed under the current SQL conformance level
 ApplyNotAllowed=APPLY operator is not allowed under the current SQL conformance level
 JsonPathMustBeSpecified=JSON path expression must be specified after the JSON value expression
 IllegalLiteral=Illegal {0} literal {1}: {2}

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -186,8 +186,7 @@ query:
       |   query INTERSECT [ ALL | DISTINCT ] query
       }
       [ ORDER BY orderItem [, orderItem ]* ]
-      [ LIMIT [ start, ] { count | ALL } ]
-      [ OFFSET start { ROW | ROWS } ]
+      [ OFFSET start { ROW | ROWS } [ LIMIT [ start, ] { count | ALL } ] | LIMIT [ start, ] { count | ALL } [ OFFSET start { ROW | ROWS } ] ]
       [ FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } ONLY ]
 
 withItem:
@@ -384,6 +383,10 @@ CROSS APPLY and OUTER APPLY are only allowed in certain
 "LIMIT start, count" is equivalent to "LIMIT count OFFSET start"
 but is only allowed in certain
 [conformance levels]({{ site.apiRoot }}/org/apache/calcite/sql/validate/SqlConformance.html#isLimitStartCountAllowed--).
+
+"OFFSET start LIMIT count" is equivalent to "LIMIT count OFFSET start"
+but is only allowed in certain
+[conformance levels]({{ site.apiRoot }}/org/apache/calcite/sql/validate/SqlConformance.html#isOffsetStartLimitCountAllowed--).
 
 ## Keywords
 

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -3225,8 +3225,8 @@ public class SqlParserTest {
   }
 
   /**
-   * "LIMIT ... OFFSET ..." is the postgres equivalent of SQL:2008
-   * "OFFSET ... FETCH". It all maps down to a parse tree that looks like
+   * "LIMIT ... OFFSET ...", "OFFSET ... LIMIT ..." is the postgres/trino equivalent
+   * of SQL:2008 "OFFSET ... FETCH". It all maps down to a parse tree that looks like
    * SQL:2008.
    */
   @Test void testLimit() {
@@ -3246,6 +3246,16 @@ public class SqlParserTest {
             + "FROM `FOO`\n"
             + "ORDER BY `B`, `C`\n"
             + "OFFSET 1 ROWS");
+    /* Test case for
+     * <a href="https://issues.apache.org/jira/browse/CALCITE-5086">[CALCITE-5086]
+     * Calcite supports OFFSET start LIMIT count expression</a>.
+     */
+    sql("select a from foo order by b, c offset 1 limit 2")
+        .ok("SELECT `A`\n"
+            + "FROM `FOO`\n"
+            + "ORDER BY `B`, `C`\n"
+            + "OFFSET 1 ROWS\n"
+            + "FETCH NEXT 2 ROWS ONLY");
   }
 
   /** Test case for


### PR DESCRIPTION
support trino style query like: SELECT * FROM users OFFSET 10 LIMIT 10