### PR TITLE
[CALCITE-5089] Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -58,6 +58,7 @@ import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlGroupBy;
 import org.apache.calcite.sql.SqlHint;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlInsert;
@@ -1277,7 +1278,7 @@ SqlSelect SqlSelect() :
     List<SqlNode> selectList;
     final SqlNode fromClause;
     final SqlNode where;
-    final SqlNodeList groupBy;
+    final SqlGroupBy groupBy;
     final SqlNode having;
     final SqlNodeList windowDecls;
     final List<SqlNode> hints = new ArrayList<SqlNode>();
@@ -2496,15 +2497,22 @@ SqlNode WhereOpt() :
 /**
  * Parses the optional GROUP BY clause for SELECT.
  */
-SqlNodeList GroupByOpt() :
+SqlGroupBy GroupByOpt() :
 {
     List<SqlNode> list = new ArrayList<SqlNode>();
+    final SqlLiteral qualifier;
     final Span s;
 }
 {
     <GROUP> { s = span(); }
-    <BY> list = GroupingElementList() {
-        return new SqlNodeList(list, s.addAll(list).pos());
+    <BY>
+    (
+        qualifier = AllOrDistinct()
+    |
+        { qualifier = null; }
+    )
+    list = GroupingElementList() {
+        return new SqlGroupBy(s.addAll(list).pos(), qualifier, new SqlNodeList(list, s.pos()));
     }
 |
     {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -62,6 +62,7 @@ import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDelete;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlGroupBy;
 import org.apache.calcite.sql.SqlHint;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlInsert;
@@ -561,7 +562,7 @@ public class RelToSqlConverter extends SqlImplementor
     if (!groupByList.isEmpty() || e.getAggCallList().isEmpty()) {
       // Some databases don't support "GROUP BY ()". We can omit it as long
       // as there is at least one aggregate function.
-      builder.setGroupBy(new SqlNodeList(groupByList, POS));
+      builder.setGroupBy(new SqlGroupBy(POS, null, new SqlNodeList(groupByList, POS)));
     }
 
     if (builder.clauses.contains(Clause.HAVING) && !e.getGroupSet()

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -62,6 +62,7 @@ import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlDynamicParam;
+import org.apache.calcite.sql.SqlGroupBy;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
@@ -2067,9 +2068,9 @@ public abstract class SqlImplementor {
       select.setWhere(node);
     }
 
-    public void setGroupBy(SqlNodeList nodeList) {
+    public void setGroupBy(SqlGroupBy groupBy) {
       assert clauses.contains(Clause.GROUP_BY);
-      select.setGroupBy(nodeList);
+      select.setGroupBy(groupBy);
     }
 
     public void setHaving(SqlNode node) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlCallBinding.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCallBinding.java
@@ -104,10 +104,10 @@ public class SqlCallBinding extends SqlOperatorBinding {
       return 0;
     }
     final SqlSelect select = selectScope.getNode();
-    final SqlNodeList group = select.getGroup();
-    if (group != null) {
+    final SqlGroupBy groupBy = select.getGroup();
+    if (groupBy != null) {
       int n = 0;
-      for (SqlNode groupItem : group) {
+      for (SqlNode groupItem : groupBy.groupList) {
         if (!(groupItem instanceof SqlNodeList)
             || ((SqlNodeList) groupItem).size() != 0) {
           ++n;

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
@@ -79,7 +79,6 @@ public class SqlGroupBy extends SqlCall {
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     final SqlWriter.Frame frame =
         writer.startList(SqlWriter.FrameTypeEnum.GROUP_BY);
-    writer.sep("GROUP BY");
     if (qualifier != null) {
       qualifier.unparse(writer, 0, 0);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
@@ -77,8 +77,8 @@ public class SqlGroupBy extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    if (qualifier != null && isDistinct()) {
-      qualifier.unparse(writer, 0, 0);
+    if (isDistinct()) {
+      requireNonNull(qualifier, "qualifier").unparse(writer, 0, 0);
     }
     final SqlNodeList groupBy =
         groupList.size() == 0 ? SqlNodeList.SINGLETON_EMPTY

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Parse tree node that represents a {@code GROUP BY} clause within a query.
+ */
+public class SqlGroupBy extends SqlCall {
+  public @Nullable SqlLiteral qualifier;
+  public @NonNull SqlNodeList groupList;
+
+  //~ Constructors -----------------------------------------------------------
+
+  public SqlGroupBy(SqlParserPos pos, @Nullable SqlLiteral qualifier, SqlNodeList groupList) {
+    super(pos);
+    this.qualifier = qualifier;
+    this.groupList = requireNonNull(groupList, "groupList");
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public void setOperand(int i, @Nullable SqlNode operand) {
+    switch (i) {
+    case 0:
+      qualifier = (SqlLiteral) operand;
+      break;
+    case 1:
+      groupList = requireNonNull((SqlNodeList) operand);
+      break;
+    default:
+      throw new AssertionError(i);
+    }
+  }
+
+  @Override public SqlKind getKind() {
+    return SqlKind.GROUP_BY;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return SqlGroupByOperator.INSTANCE;
+  }
+
+  @SuppressWarnings("nullness")
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(qualifier, groupList);
+  }
+
+  public final boolean isDistinct() {
+    if (qualifier == null) {
+      return false;
+    }
+    return qualifier.symbolValue(SqlSelectKeyword.class) == SqlSelectKeyword.DISTINCT;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    final SqlWriter.Frame frame =
+        writer.startList(SqlWriter.FrameTypeEnum.GROUP_BY);
+    writer.sep("GROUP BY");
+    if (qualifier != null) {
+      qualifier.unparse(writer, 0, 0);
+    }
+    final SqlNodeList groupBy =
+        groupList.size() == 0 ? SqlNodeList.SINGLETON_EMPTY
+            : groupList;
+    writer.list(SqlWriter.FrameTypeEnum.GROUP_BY_LIST, SqlWriter.COMMA,
+        groupBy);
+    writer.endList(frame);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
@@ -77,7 +77,7 @@ public class SqlGroupBy extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    if (isDistinct()) {
+    if (qualifier != null && isDistinct()) {
       qualifier.unparse(writer, 0, 0);
     }
     final SqlNodeList groupBy =

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
@@ -77,8 +77,6 @@ public class SqlGroupBy extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    final SqlWriter.Frame frame =
-        writer.startList(SqlWriter.FrameTypeEnum.GROUP_BY);
     if (qualifier != null) {
       qualifier.unparse(writer, 0, 0);
     }
@@ -87,6 +85,5 @@ public class SqlGroupBy extends SqlCall {
             : groupList;
     writer.list(SqlWriter.FrameTypeEnum.GROUP_BY_LIST, SqlWriter.COMMA,
         groupBy);
-    writer.endList(frame);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupBy.java
@@ -77,7 +77,7 @@ public class SqlGroupBy extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    if (qualifier != null) {
+    if (isDistinct()) {
       qualifier.unparse(writer, 0, 0);
     }
     final SqlNodeList groupBy =

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupByOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupByOperator.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.sql.parser.SqlParserPos;
-
 import org.apache.calcite.util.ImmutableNullableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupByOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupByOperator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import org.apache.calcite.util.ImmutableNullableList;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+
+/**
+ * An operator describing a GROUP BY.
+ *
+ * <p>Operands are:</p>
+ *
+ * <ul>
+ * <li>0: distinct ({@link SqlLiteral})</li>
+ * <li>1: groupingElementList ({@link SqlNodeList})</li>
+ * </ul>
+ */
+public class SqlGroupByOperator extends SqlOperator {
+  public static final SqlGroupByOperator INSTANCE =
+      new SqlGroupByOperator();
+
+  //~ Constructors -----------------------------------------------------------
+
+  private SqlGroupByOperator() {
+    super("GROUP BY", SqlKind.GROUP_BY, 0, true, null, null, null);
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public SqlSyntax getSyntax() {
+    return SqlSyntax.POSTFIX;
+  }
+
+  @Override public SqlCall createCall(
+      @Nullable SqlLiteral qualifier,
+      SqlParserPos pos,
+      @Nullable SqlNode... operands) {
+    return new SqlGroupBy(pos,
+        qualifier,
+        new SqlNodeList(new ArrayList<>(ImmutableNullableList.copyOf(operands)), pos));
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupByOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupByOperator.java
@@ -21,7 +21,7 @@ import org.apache.calcite.util.ImmutableNullableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 /**
  * An operator describing a GROUP BY.
@@ -55,6 +55,7 @@ public class SqlGroupByOperator extends SqlOperator {
       @Nullable SqlNode... operands) {
     return new SqlGroupBy(pos,
         qualifier,
-        new SqlNodeList(new ArrayList<>(ImmutableNullableList.copyOf(operands)), pos));
+        new SqlNodeList(ImmutableNullableList.copyOf(operands).stream()
+            .filter(o -> o != null).collect(Collectors.toList()), pos));
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -157,6 +157,9 @@ public enum SqlKind {
   /** A dynamic parameter. */
   DYNAMIC_PARAM,
 
+  /** GROUP BY clause. */
+  GROUP_BY,
+
   /**
    * ORDER BY clause.
    *

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
@@ -46,7 +46,7 @@ public class SqlSelect extends SqlCall {
   SqlNodeList selectList;
   @Nullable SqlNode from;
   @Nullable SqlNode where;
-  @Nullable SqlNodeList groupBy;
+  @Nullable SqlGroupBy groupBy;
   @Nullable SqlNode having;
   SqlNodeList windowDecls;
   @Nullable SqlNodeList orderBy;
@@ -61,7 +61,7 @@ public class SqlSelect extends SqlCall {
       SqlNodeList selectList,
       @Nullable SqlNode from,
       @Nullable SqlNode where,
-      @Nullable SqlNodeList groupBy,
+      @Nullable SqlGroupBy groupBy,
       @Nullable SqlNode having,
       @Nullable SqlNodeList windowDecls,
       @Nullable SqlNodeList orderBy,
@@ -115,7 +115,7 @@ public class SqlSelect extends SqlCall {
       where = operand;
       break;
     case 4:
-      groupBy = (SqlNodeList) operand;
+      groupBy = (SqlGroupBy) operand;
       break;
     case 5:
       having = operand;
@@ -162,11 +162,11 @@ public class SqlSelect extends SqlCall {
   }
 
   @Pure
-  public final @Nullable SqlNodeList getGroup() {
+  public final @Nullable SqlGroupBy getGroup() {
     return groupBy;
   }
 
-  public void setGroupBy(@Nullable SqlNodeList groupBy) {
+  public void setGroupBy(@Nullable SqlGroupBy groupBy) {
     this.groupBy = groupBy;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -202,6 +202,7 @@ public class SqlSelectOperator extends SqlOperator {
       }
     }
     if (select.groupBy != null) {
+      writer.sep("GROUP BY");
       select.groupBy.unparse(writer, 0, 0);
     }
     if (select.having != null) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -42,7 +42,7 @@ import static java.util.Objects.requireNonNull;
  * <li>2: fromClause ({@link SqlCall} to "join" operator)</li>
  * <li>3: whereClause ({@link SqlNode})</li>
  * <li>4: havingClause ({@link SqlNode})</li>
- * <li>5: groupClause ({@link SqlNode})</li>
+ * <li>5: groupClause ({@link SqlGroupBy})</li>
  * <li>6: windowClause ({@link SqlNodeList})</li>
  * <li>7: orderClause ({@link SqlNode})</li>
  * </ul>
@@ -73,7 +73,7 @@ public class SqlSelectOperator extends SqlOperator {
         requireNonNull((SqlNodeList) operands[1], "selectList"),
         operands[2],
         operands[3],
-        (SqlNodeList) operands[4],
+        (SqlGroupBy) operands[4],
         operands[5],
         (SqlNodeList) operands[6],
         (SqlNodeList) operands[7],
@@ -93,7 +93,7 @@ public class SqlSelectOperator extends SqlOperator {
       SqlNodeList selectList,
       SqlNode fromClause,
       SqlNode whereClause,
-      SqlNodeList groupBy,
+      SqlGroupBy groupBy,
       SqlNode having,
       SqlNodeList windowDecls,
       SqlNodeList orderBy,
@@ -202,12 +202,7 @@ public class SqlSelectOperator extends SqlOperator {
       }
     }
     if (select.groupBy != null) {
-      writer.sep("GROUP BY");
-      final SqlNodeList groupBy =
-          select.groupBy.size() == 0 ? SqlNodeList.SINGLETON_EMPTY
-              : select.groupBy;
-      writer.list(SqlWriter.FrameTypeEnum.GROUP_BY_LIST, SqlWriter.COMMA,
-          groupBy);
+      select.groupBy.unparse(writer, 0, 0);
     }
     if (select.having != null) {
       writer.sep("HAVING");

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -170,6 +170,12 @@ public interface SqlWriter {
     FETCH,
 
     /**
+     * GROUP BY clause of a SELECT statement. The "list" has only two items:
+     * the query and the group by clause, with GROUP BY as the separator.
+     */
+    GROUP_BY,
+
+    /**
      * GROUP BY list.
      *
      * <p>Example:</p>

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -639,6 +639,7 @@ public class SqlPrettyWriter implements SqlWriter {
       newlineAfterSep = false;
       break;
 
+    case GROUP_BY:
     case ORDER_BY:
     case OFFSET:
     case FETCH:

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
@@ -94,7 +94,7 @@ public class AggregatingSelectScope
       final ImmutableList.Builder<ImmutableList<ImmutableBitSet>> builder =
           ImmutableList.builder();
       if (select.getGroup() != null) {
-        final SqlNodeList groupList = select.getGroup();
+        final SqlNodeList groupList = select.getGroup().groupList;
         for (SqlNode groupExpr : groupList) {
           SqlValidatorUtil.analyzeGroupItem(this, groupAnalyzer, builder,
               groupExpr);

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3468,46 +3468,6 @@ public class JdbcTest {
             "deptno=20; C=1; S=8000.0");
   }
 
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
-   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
-  @Test void testGroupByDistinct() {
-    CalciteAssert.hr()
-        .query("select \"deptno\", \"commission\", sum(\"salary\") as s\n"
-            + "from \"hr\".\"emps\"\n"
-            + "where \"deptno\" = 20\n"
-            + "group by distinct cube(\"deptno\", \"commission\"), rollup(\"deptno\", \"commission\")")
-        .returnsUnordered(
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=null; S=8000.0",
-            "deptno=null; commission=500; S=8000.0",
-            "deptno=null; commission=null; S=8000.0");
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
-   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
-  @Test void testGroupByAll() {
-    CalciteAssert.hr()
-        .query("select \"deptno\", \"commission\", sum(\"salary\") as s\n"
-            + "from \"hr\".\"emps\"\n"
-            + "where \"deptno\" = 20\n"
-            + "group by all cube(\"deptno\", \"commission\"), rollup(\"deptno\", \"commission\")")
-        .returnsUnordered(
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=500; S=8000.0",
-            "deptno=20; commission=null; S=8000.0",
-            "deptno=20; commission=null; S=8000.0",
-            "deptno=20; commission=null; S=8000.0",
-            "deptno=null; commission=500; S=8000.0",
-            "deptno=null; commission=null; S=8000.0");
-  }
-
   @Test void testCaseWhenOnNullableField() {
     CalciteAssert.hr()
         .query("select case when \"commission\" is not null "

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3468,6 +3468,46 @@ public class JdbcTest {
             "deptno=20; C=1; S=8000.0");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
+   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
+  @Test void testGroupByDistinct() {
+    CalciteAssert.hr()
+        .query("select \"deptno\", \"commission\", sum(\"salary\") as s\n"
+            + "from \"hr\".\"emps\"\n"
+            + "where \"deptno\" = 20\n"
+            + "group by distinct cube(\"deptno\", \"commission\"), rollup(\"deptno\", \"commission\")")
+        .returnsUnordered(
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=null; S=8000.0",
+            "deptno=null; commission=500; S=8000.0",
+            "deptno=null; commission=null; S=8000.0");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
+   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
+  @Test void testGroupByAll() {
+    CalciteAssert.hr()
+        .query("select \"deptno\", \"commission\", sum(\"salary\") as s\n"
+            + "from \"hr\".\"emps\"\n"
+            + "where \"deptno\" = 20\n"
+            + "group by all cube(\"deptno\", \"commission\"), rollup(\"deptno\", \"commission\")")
+        .returnsUnordered(
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=500; S=8000.0",
+            "deptno=20; commission=null; S=8000.0",
+            "deptno=20; commission=null; S=8000.0",
+            "deptno=20; commission=null; S=8000.0",
+            "deptno=null; commission=500; S=8000.0",
+            "deptno=null; commission=null; S=8000.0");
+  }
+
   @Test void testCaseWhenOnNullableField() {
     CalciteAssert.hr()
         .query("select case when \"commission\" is not null "

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4484,4 +4484,28 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         .withTrim(false)
         .ok();
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
+   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
+  @Test void testGroupByDistinct() {
+    final String sql = "SELECT deptno, job, count(*)\n"
+        + "FROM emp\n"
+        + "GROUP BY DISTINCT\n"
+        + "CUBE (deptno, job),\n"
+        + "ROLLUP (deptno, job)";
+    sql(sql).ok();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
+   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
+  @Test void testGroupByAll() {
+    final String sql = "SELECT deptno, job, count(*)\n"
+        + "FROM emp\n"
+        + "GROUP BY ALL\n"
+        + "CUBE (deptno, job),\n"
+        + "ROLLUP (deptno, job)";
+    sql(sql).ok();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1839,6 +1839,41 @@ LogicalProject(D=[$0], EXPR$1=[+($0, $1)])
 from emp group by d,mgr]]>
     </Resource>
   </TestCase>
+  <TestCase name="testGroupByAll">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, job, count(*)
+FROM emp
+GROUP BY ALL
+CUBE (deptno, job),
+ROLLUP (deptno, job)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalUnion(all=[true])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testGroupByCaseIn">
     <Resource name="sql">
       <![CDATA[select
@@ -1916,6 +1951,22 @@ from
   customer.contact_peek
 group by
   cube (coord_ne.sub.a, coord.x, coord."unit")]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupByDistinct">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, job, count(*)
+FROM emp
+GROUP BY DISTINCT
+CUBE (deptno, job),
+ROLLUP (deptno, job)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], EXPR$2=[COUNT()])
+  LogicalProject(DEPTNO=[$7], JOB=[$2])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testGroupByExpression">

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -581,6 +581,42 @@ select distinct count(*) from emp group by cube(deptno, gender);
 
 !ok
 
+# CUBE and ROLLUP cartesian product over same columns
+select deptno, gender, count(*) from emp where deptno = 20 group by cube(deptno, gender), rollup(deptno, gender);
++--------+--------+--------+
+| DEPTNO | GENDER | EXPR$2 |
++--------+--------+--------+
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 |        |      1 |
+|     20 |        |      1 |
+|     20 |        |      1 |
+|        | M      |      1 |
+|        |        |      1 |
++--------+--------+--------+
+(12 rows)
+
+!ok
+
+# GROUP BY DISTINCT CUBE and ROLLUP cartesian product over same columns
+select deptno, gender, count(*) from emp where deptno = 20 group by distinct cube(deptno, gender), rollup(deptno, gender);
++--------+--------+--------+
+| DEPTNO | GENDER | EXPR$2 |
++--------+--------+--------+
+|     20 | M      |      1 |
+|     20 |        |      1 |
+|        | M      |      1 |
+|        |        |      1 |
++--------+--------+--------+
+(4 rows)
+
+!ok
+
 # CUBE and JOIN
 select e.deptno, e.gender, min(e.ename) as min_name
 from emp as e join dept as d using (deptno)

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -203,7 +203,7 @@ select:
           { * | projectItem [, projectItem ]* }
       FROM tableExpression
       [ WHERE booleanExpression ]
-      [ GROUP BY { groupItem [, groupItem ]* } ]
+      [ GROUP BY [ ALL | DISTINCT] { groupItem [, groupItem ]* } ]
       [ HAVING booleanExpression ]
       [ WINDOW windowName AS windowSpec [, windowName AS windowSpec ]* ]
 
@@ -369,6 +369,10 @@ function).
 
 An IN, EXISTS, UNIQUE or scalar sub-query may be correlated; that is, it
 may refer to tables in the FROM clause of an enclosing query.
+
+GROUP BY ALL is equivalent to GROUP BY, GROUP BY DISTINCT will remove
+duplicate grouping sets (such as GROUP BY DISTINCT grouping sets ((a), (a))
+is equivalent to GROUP BY grouping sets ((a))).
 
 *selectWithoutFrom* is equivalent to VALUES,
 but is not standard SQL and is only allowed in certain

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2155,7 +2155,7 @@ public class SqlParserTest {
         + "group by all cube (a, b), rollup (a, b)";
     final String expected = "SELECT `DEPTNO`\n"
         + "FROM `EMP`\n"
-        + "GROUP BY ALL CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
+        + "GROUP BY CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
     sql(sql).ok(expected);
 
     final String sql1 = "select deptno from emp\n"

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2150,6 +2150,29 @@ public class SqlParserTest {
     sql(sql1).fails("(?s)Encountered \", rollup\" at .*");
   }
 
+  @Test void testGroupByAllOrDistinct() {
+    final String sql = "select deptno from emp\n"
+        + "group by all cube (a, b), rollup (a, b)";
+    final String expected = "SELECT `DEPTNO`\n"
+        + "FROM `EMP`\n"
+        + "GROUP BY ALL CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
+    sql(sql).ok(expected);
+
+    final String sql1 = "select deptno from emp\n"
+        + "group by distinct cube (a, b), rollup (a, b)";
+    final String expected1 = "SELECT `DEPTNO`\n"
+        + "FROM `EMP`\n"
+        + "GROUP BY DISTINCT CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
+    sql(sql1).ok(expected1);
+
+    final String sql2 = "select deptno from emp\n"
+        + "group by cube (a, b), rollup (a, b)";
+    final String expected2 = "SELECT `DEPTNO`\n"
+        + "FROM `EMP`\n"
+        + "GROUP BY CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
+    sql(sql2).ok(expected2);
+  }
+
   @Test void testGrouping() {
     final String sql = "select deptno, grouping(deptno) from emp\n"
         + "group by grouping sets (deptno, (deptno, gender), ())";


### PR DESCRIPTION
This change will allow the following sql:
SELECT deptno, job, count(*) FROM emp GROUP BY ALL CUBE (deptno, job), ROLLUP (deptno, job)
and
SELECT deptno, job, count(*) FROM emp GROUP BY DISTINCT CUBE (deptno, job), ROLLUP (deptno, job)
