### PR TITLE
[CALCITE-5089] Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2499,11 +2499,19 @@ SqlNode WhereOpt() :
 SqlNodeList GroupByOpt() :
 {
     List<SqlNode> list = new ArrayList<SqlNode>();
+    boolean distinct = false;
     final Span s;
 }
 {
     <GROUP> { s = span(); }
-    <BY> list = GroupingElementList() {
+    <BY>
+    [ <DISTINCT> { distinct = true; } | <ALL> ]
+    list = GroupingElementList() {
+        if (distinct) {
+            SqlNode groupByDistinct = SqlStdOperatorTable.GROUP_BY_DISTINCT.createCall(s.pos(), list);
+            list = new ArrayList<SqlNode>();
+            list.add(groupByDistinct);
+        }
         return new SqlNodeList(list, s.addAll(list).pos());
     }
 |

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2508,7 +2508,7 @@ SqlNodeList GroupByOpt() :
     [ <DISTINCT> { distinct = true; } | <ALL> ]
     list = GroupingElementList() {
         if (distinct) {
-            SqlNode groupByDistinct = SqlStdOperatorTable.GROUP_BY_DISTINCT.createCall(s.pos(), list);
+            SqlNode groupByDistinct = SqlInternalOperators.GROUP_BY_DISTINCT.createCall(s.pos(), list);
             list = new ArrayList<SqlNode>();
             list.add(groupByDistinct);
         }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -120,6 +120,7 @@ import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.util.Glossary;
+import org.apache.calcite.util.ImmutableNullableList;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.SourceStringReader;
@@ -2509,8 +2510,7 @@ SqlNodeList GroupByOpt() :
     list = GroupingElementList() {
         if (distinct) {
             SqlNode groupByDistinct = SqlInternalOperators.GROUP_BY_DISTINCT.createCall(s.add(getPos()).pos(), list);
-            list = new ArrayList<SqlNode>();
-            list.add(groupByDistinct);
+            list = ImmutableNullableList.of(groupByDistinct);
         }
         return new SqlNodeList(list, s.addAll(list).pos());
     }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2508,7 +2508,7 @@ SqlNodeList GroupByOpt() :
     [ <DISTINCT> { distinct = true; } | <ALL> ]
     list = GroupingElementList() {
         if (distinct) {
-            SqlNode groupByDistinct = SqlInternalOperators.GROUP_BY_DISTINCT.createCall(s.pos(), list);
+            SqlNode groupByDistinct = SqlInternalOperators.GROUP_BY_DISTINCT.createCall(s.add(getPos()).pos(), list);
             list = new ArrayList<SqlNode>();
             list.add(groupByDistinct);
         }

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -157,7 +157,7 @@ public enum SqlKind {
   /** A dynamic parameter. */
   DYNAMIC_PARAM,
 
-  /** GROUP BY DISTINCT clause. */
+  /** The DISTINCT keyword of the GROUP BY clause. */
   GROUP_BY_DISTINCT,
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -157,6 +157,9 @@ public enum SqlKind {
   /** A dynamic parameter. */
   DYNAMIC_PARAM,
 
+  /** GROUP BY DISTINCT clause. */
+  GROUP_BY_DISTINCT,
+
   /**
    * ORDER BY clause.
    *

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -19,8 +19,11 @@ package org.apache.calcite.sql;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.sql.util.SqlVisitor;
+
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -202,10 +205,15 @@ public class SqlSelectOperator extends SqlOperator {
       }
     }
     if (select.groupBy != null) {
-      writer.sep("GROUP BY");
-      final SqlNodeList groupBy =
-          select.groupBy.size() == 0 ? SqlNodeList.SINGLETON_EMPTY
-              : select.groupBy;
+      SqlNodeList groupBy = select.groupBy.size() == 0 ? SqlNodeList.SINGLETON_EMPTY : select.groupBy;
+      if (groupBy.size() > 0 && groupBy.get(0) != null
+          && groupBy.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {
+        writer.sep("GROUP BY DISTINCT");
+        List<SqlNode> operandList = ((SqlCall) select.groupBy.get(0)).getOperandList();
+        groupBy = new SqlNodeList(operandList, groupBy.getParserPosition());
+      } else {
+        writer.sep("GROUP BY");
+      }
       writer.list(SqlWriter.FrameTypeEnum.GROUP_BY_LIST, SqlWriter.COMMA,
           groupBy);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -205,7 +205,7 @@ public class SqlSelectOperator extends SqlOperator {
       SqlNodeList groupBy =
           select.groupBy.size() == 0 ? SqlNodeList.SINGLETON_EMPTY
               : select.groupBy;
-      // if the GROUP_BY_DISTINCT operator is present it can be the only item
+      // if the DISTINCT keyword of GROUP BY is present it can be the only item
       if (groupBy.size() == 1 && groupBy.get(0) != null
           && groupBy.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {
         writer.sep("GROUP BY DISTINCT");

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -19,11 +19,8 @@ package org.apache.calcite.sql;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ReturnTypes;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.sql.util.SqlVisitor;
-
-import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -206,10 +203,11 @@ public class SqlSelectOperator extends SqlOperator {
     }
     if (select.groupBy != null) {
       SqlNodeList groupBy = select.groupBy.size() == 0 ? SqlNodeList.SINGLETON_EMPTY : select.groupBy;
-      if (groupBy.size() > 0 && groupBy.get(0) != null
+      // if the GROUP_BY_DISTINCT operator is present it can be the only item
+      if (groupBy.size() == 1 && groupBy.get(0) != null
           && groupBy.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {
         writer.sep("GROUP BY DISTINCT");
-        List<SqlNode> operandList = ((SqlCall) select.groupBy.get(0)).getOperandList();
+        List<SqlNode> operandList = ((SqlCall) groupBy.get(0)).getOperandList();
         groupBy = new SqlNodeList(operandList, groupBy.getParserPosition());
       } else {
         writer.sep("GROUP BY");

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -202,7 +202,9 @@ public class SqlSelectOperator extends SqlOperator {
       }
     }
     if (select.groupBy != null) {
-      SqlNodeList groupBy = select.groupBy.size() == 0 ? SqlNodeList.SINGLETON_EMPTY : select.groupBy;
+      SqlNodeList groupBy =
+          select.groupBy.size() == 0 ? SqlNodeList.SINGLETON_EMPTY
+              : select.groupBy;
       // if the GROUP_BY_DISTINCT operator is present it can be the only item
       if (groupBy.size() == 1 && groupBy.get(0) != null
           && groupBy.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlInternalOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlInternalOperators.java
@@ -115,4 +115,8 @@ public abstract class SqlInternalOperators {
       new SqlInternalOperator("SEPARATOR", SqlKind.SEPARATOR, 20, false,
           ReturnTypes.ARG0, InferTypes.RETURN_TYPE, OperandTypes.ANY);
 
+  /** {@code DISTINCT} operator, occurs within {@code GROUP BY} clause. */
+  public static final SqlInternalOperator GROUP_BY_DISTINCT =
+      new SqlRollupOperator("GROUP BY DISTINCT", SqlKind.GROUP_BY_DISTINCT);
+
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlRollupOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlRollupOperator.java
@@ -53,6 +53,11 @@ class SqlRollupOperator extends SqlInternalOperator {
         return;
       }
       break;
+    case GROUP_BY_DISTINCT:
+      writer.keyword(call.getOperator().getName());
+      SqlNodeList groupBy = new SqlNodeList(call.getOperandList(), call.getParserPosition());
+      writer.list(SqlWriter.FrameTypeEnum.GROUP_BY_LIST, SqlWriter.COMMA, groupBy);
+      return;
     default:
       break;
     }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -219,6 +219,10 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlInternalOperator GROUPING_SETS =
       new SqlRollupOperator("GROUPING SETS", SqlKind.GROUPING_SETS);
 
+  /** {@code DISTINCT} operator, occurs within {@code GROUP BY} clause. */
+  public static final SqlInternalOperator GROUP_BY_DISTINCT =
+      new SqlRollupOperator("GROUP BY DISTINCT", SqlKind.GROUP_BY_DISTINCT);
+
   /** {@code GROUPING(c1 [, c2, ...])} function.
    *
    * <p>Occurs in similar places to an aggregate

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -219,10 +219,6 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlInternalOperator GROUPING_SETS =
       new SqlRollupOperator("GROUPING SETS", SqlKind.GROUPING_SETS);
 
-  /** {@code DISTINCT} operator, occurs within {@code GROUP BY} clause. */
-  public static final SqlInternalOperator GROUP_BY_DISTINCT =
-      new SqlRollupOperator("GROUP BY DISTINCT", SqlKind.GROUP_BY_DISTINCT);
-
   /** {@code GROUPING(c1 [, c2, ...])} function.
    *
    * <p>Occurs in similar places to an aggregate

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.sql.validate;
 
-import com.google.common.collect.ImmutableSet;
-
 import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.rel.type.RelDataType;
@@ -33,6 +31,7 @@ import org.apache.calcite.util.Pair;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMultiset;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -99,7 +98,8 @@ public class AggregatingSelectScope
       boolean groupByDistinct = false;
       if (select.getGroup() != null) {
         SqlNodeList groupList = select.getGroup();
-        if (groupList.size() > 0 && groupList.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {
+        // if the GROUP_BY_DISTINCT operator is present it can be the only item
+        if (groupList.size() == 1 && groupList.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {
           groupList = new SqlNodeList(((SqlCall)groupList.get(0)).getOperandList(),
               groupList.getParserPosition());
           groupByDistinct = true;

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
@@ -98,7 +98,7 @@ public class AggregatingSelectScope
       boolean groupByDistinct = false;
       if (select.getGroup() != null) {
         SqlNodeList groupList = select.getGroup();
-        // if the GROUP_BY_DISTINCT operator is present it can be the only item
+        // if the DISTINCT keyword of GROUP BY is present it can be the only item
         if (groupList.size() == 1 && groupList.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {
           groupList = new SqlNodeList(((SqlCall) groupList.get(0)).getOperandList(),
               groupList.getParserPosition());

--- a/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggregatingSelectScope.java
@@ -100,7 +100,7 @@ public class AggregatingSelectScope
         SqlNodeList groupList = select.getGroup();
         // if the GROUP_BY_DISTINCT operator is present it can be the only item
         if (groupList.size() == 1 && groupList.get(0).getKind() == SqlKind.GROUP_BY_DISTINCT) {
-          groupList = new SqlNodeList(((SqlCall)groupList.get(0)).getOperandList(),
+          groupList = new SqlNodeList(((SqlCall) groupList.get(0)).getOperandList(),
               groupList.getParserPosition());
           groupByDistinct = true;
         }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -4182,10 +4182,16 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   private void validateGroupByExpr(SqlNode groupByItem,
       SqlValidatorScope groupByScope) {
     switch (groupByItem.getKind()) {
+    case GROUP_BY_DISTINCT:
+      SqlCall call = (SqlCall) groupByItem;
+      for (SqlNode operand : call.getOperandList()) {
+        validateGroupByExpr(operand, groupByScope);
+      }
+      break;
     case GROUPING_SETS:
     case ROLLUP:
     case CUBE:
-      final SqlCall call = (SqlCall) groupByItem;
+      call = (SqlCall) groupByItem;
       for (SqlNode operand : call.getOperandList()) {
         validateExpr(operand, groupByScope);
       }
@@ -4260,6 +4266,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // expressions, because they do not have a type.
     for (SqlNode node : groupList) {
       switch (node.getKind()) {
+      case GROUP_BY_DISTINCT:
       case GROUPING_SETS:
       case ROLLUP:
       case CUBE:
@@ -4296,6 +4303,11 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       @Nullable AggregatingSelectScope aggregatingScope,
       SqlNode groupItem) {
     switch (groupItem.getKind()) {
+    case GROUP_BY_DISTINCT:
+      for (SqlNode sqlNode : ((SqlCall) groupItem).getOperandList()) {
+        validateGroupItem(groupScope, aggregatingScope, sqlNode);
+      }
+      break;
     case GROUPING_SETS:
     case ROLLUP:
     case CUBE:

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4484,4 +4484,28 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         .withTrim(false)
         .ok();
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
+   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
+  @Test void testGroupByDistinct() {
+    final String sql = "SELECT deptno, job, count(*)\n"
+        + "FROM emp\n"
+        + "GROUP BY DISTINCT\n"
+        + "CUBE (deptno, job),\n"
+        + "ROLLUP (deptno, job)";
+    sql(sql).ok();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5089">[CALCITE-5089]
+   * Allow GROUP BY ALL or DISTINCT set quantifier on GROUPING SETS</a>. */
+  @Test void testGroupByAll() {
+    final String sql = "SELECT deptno, job, count(*)\n"
+        + "FROM emp\n"
+        + "GROUP BY ALL\n"
+        + "CUBE (deptno, job),\n"
+        + "ROLLUP (deptno, job)";
+    sql(sql).ok();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1839,6 +1839,41 @@ LogicalProject(D=[$0], EXPR$1=[+($0, $1)])
 from emp group by d,mgr]]>
     </Resource>
   </TestCase>
+  <TestCase name="testGroupByAll">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, job, count(*)
+FROM emp
+GROUP BY ALL
+CUBE (deptno, job),
+ROLLUP (deptno, job)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalUnion(all=[true])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}]], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+    LogicalProject(DEPTNO=[$7], JOB=[$2])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testGroupByCaseIn">
     <Resource name="sql">
       <![CDATA[select
@@ -1916,6 +1951,22 @@ from
   customer.contact_peek
 group by
   cube (coord_ne.sub.a, coord.x, coord."unit")]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupByDistinct">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, job, count(*)
+FROM emp
+GROUP BY DISTINCT
+CUBE (deptno, job),
+ROLLUP (deptno, job)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}], groups=[[{0, 1}, {0}, {1}, {}]], EXPR$2=[COUNT()])
+  LogicalProject(DEPTNO=[$7], JOB=[$2])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testGroupByExpression">

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -617,6 +617,39 @@ select deptno, gender, count(*) from emp where deptno = 20 group by distinct cub
 
 !ok
 
+# GROUP BY over empty columns
+select count(*) from emp where deptno = 20 group by ();
++--------+
+| EXPR$0 |
++--------+
+|      1 |
++--------+
+(1 row)
+
+!ok
+
+# GROUP BY DISTINCT over empty columns
+select count(*) from emp where deptno = 20 group by distinct ();
++--------+
+| EXPR$0 |
++--------+
+|      1 |
++--------+
+(1 row)
+
+!ok
+
+# GROUP BY DISTINCT x + y
+select deptno + 1, count(*) from emp where deptno = 20 group by distinct deptno + 1;
++--------+--------+
+| EXPR$0 | EXPR$1 |
++--------+--------+
+|     21 |      1 |
++--------+--------+
+(1 row)
+
+!ok
+
 # CUBE and JOIN
 select e.deptno, e.gender, min(e.ename) as min_name
 from emp as e join dept as d using (deptno)

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -581,6 +581,42 @@ select distinct count(*) from emp group by cube(deptno, gender);
 
 !ok
 
+# CUBE and ROLLUP cartesian product over same columns
+select deptno, gender, count(*) from emp where deptno = 20 group by cube(deptno, gender), rollup(deptno, gender);
++--------+--------+--------+
+| DEPTNO | GENDER | EXPR$2 |
++--------+--------+--------+
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 | M      |      1 |
+|     20 |        |      1 |
+|     20 |        |      1 |
+|     20 |        |      1 |
+|        | M      |      1 |
+|        |        |      1 |
++--------+--------+--------+
+(12 rows)
+
+!ok
+
+# GROUP BY DISTINCT CUBE and ROLLUP cartesian product over same columns
+select deptno, gender, count(*) from emp where deptno = 20 group by distinct cube(deptno, gender), rollup(deptno, gender);
++--------+--------+--------+
+| DEPTNO | GENDER | EXPR$2 |
++--------+--------+--------+
+|     20 | M      |      1 |
+|     20 |        |      1 |
+|        | M      |      1 |
+|        |        |      1 |
++--------+--------+--------+
+(4 rows)
+
+!ok
+
 # CUBE and JOIN
 select e.deptno, e.gender, min(e.ename) as min_name
 from emp as e join dept as d using (deptno)

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -203,7 +203,7 @@ select:
           { * | projectItem [, projectItem ]* }
       FROM tableExpression
       [ WHERE booleanExpression ]
-      [ GROUP BY { groupItem [, groupItem ]* } ]
+      [ GROUP BY [ ALL | DISTINCT] { groupItem [, groupItem ]* } ]
       [ HAVING booleanExpression ]
       [ WINDOW windowName AS windowSpec [, windowName AS windowSpec ]* ]
 
@@ -369,6 +369,10 @@ function).
 
 An IN, EXISTS, UNIQUE or scalar sub-query may be correlated; that is, it
 may refer to tables in the FROM clause of an enclosing query.
+
+GROUP BY ALL is equivalent to GROUP BY, GROUP BY DISTINCT will remove
+duplicate grouping sets (such as GROUP BY DISTINCT grouping sets ((a), (a))
+is equivalent to GROUP BY grouping sets ((a))).
 
 *selectWithoutFrom* is equivalent to VALUES,
 but is not standard SQL and is only allowed in certain

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2122,6 +2122,29 @@ public class SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testGroupByAllOrDistinct() {
+    final String sql = "select deptno from emp\n"
+        + "group by all cube (a, b), rollup (a, b)";
+    final String expected = "SELECT `DEPTNO`\n"
+        + "FROM `EMP`\n"
+        + "GROUP BY CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
+    sql(sql).ok(expected);
+
+    final String sql1 = "select deptno from emp\n"
+        + "group by distinct cube (a, b), rollup (a, b)";
+    final String expected1 = "SELECT `DEPTNO`\n"
+        + "FROM `EMP`\n"
+        + "GROUP BY DISTINCT CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
+    sql(sql1).ok(expected1);
+
+    final String sql2 = "select deptno from emp\n"
+        + "group by cube (a, b), rollup (a, b)";
+    final String expected2 = "SELECT `DEPTNO`\n"
+        + "FROM `EMP`\n"
+        + "GROUP BY CUBE(`A`, `B`), ROLLUP(`A`, `B`)";
+    sql(sql2).ok(expected2);
+  }
+
   @Test void testGroupByCube2() {
     final String sql = "select deptno from emp\n"
         + "group by cube ((a, b), (c, d)) order by a";


### PR DESCRIPTION
This change will allow the following sql:
SELECT deptno, job, count() FROM emp GROUP BY ALL CUBE (deptno, job), ROLLUP (deptno, job)
and
SELECT deptno, job, count() FROM emp GROUP BY DISTINCT CUBE (deptno, job), ROLLUP (deptno, job)

The GROUP BY ALL is equivalent to GROUP BY, The GROUP BY DISTINCT will remove duplicates from cartesian product of CUBE and ROLLUP.