### PR TITLE
[CALCITE-5091] RelMdRowCount can return more accurate rowCount

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -33,7 +33,6 @@ import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
-import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -147,22 +146,13 @@ public class RelMdRowCount
     if (rowCount == null) {
       return null;
     }
-    if (rel.offset instanceof RexDynamicParam) {
-      return rowCount;
-    }
-    final int offset = rel.offset == null ? 0 : RexLiteral.intValue(rel.offset);
+
+    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
-    if (rel.fetch != null) {
-      if (rel.fetch instanceof RexDynamicParam) {
-        return rowCount;
-      }
-      final int limit = RexLiteral.intValue(rel.fetch);
-      if (limit < rowCount) {
-        return (double) limit;
-      }
-    }
-    return rowCount;
+    final double limit =
+        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+    return limit < rowCount ? limit : rowCount;
   }
 
   public @Nullable Double getRowCount(EnumerableLimit rel, RelMetadataQuery mq) {
@@ -170,22 +160,13 @@ public class RelMdRowCount
     if (rowCount == null) {
       return null;
     }
-    if (rel.offset instanceof RexDynamicParam) {
-      return rowCount;
-    }
-    final int offset = rel.offset == null ? 0 : RexLiteral.intValue(rel.offset);
+
+    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
-    if (rel.fetch != null) {
-      if (rel.fetch instanceof RexDynamicParam) {
-        return rowCount;
-      }
-      final int limit = RexLiteral.intValue(rel.fetch);
-      if (limit < rowCount) {
-        return (double) limit;
-      }
-    }
-    return rowCount;
+    final double limit =
+        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+    return limit < rowCount ? limit : rowCount;
   }
 
   // Covers Converter, Interpreter

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -648,7 +648,7 @@ public class RelMetadataTest {
     sql("select * from emp order by ename limit ? offset ?")
         .assertThatRowCount(is(EMP_SIZE), is(0D), is(Double.POSITIVE_INFINITY));
     sql("select * from emp order by ename limit 1 offset ?")
-        .assertThatRowCount(is(EMP_SIZE), is(0D), is(1D));
+        .assertThatRowCount(is(1D), is(0D), is(1D));
     sql("select * from emp order by ename limit ? offset 1")
         .assertThatRowCount(is(EMP_SIZE - 1), is(0D), is(Double.POSITIVE_INFINITY));
   }


### PR DESCRIPTION
Here is the sql that fetch is deterministic and offset is dynamic 
`select * from emp order by ename limit 1 offset ?`
**RelMdRowCount#getRowCount** will return 14d, because it always return rowCount when offset is dynamic.

```
  if (rel.offset instanceof RexDynamicParam) {
    return rowCount;
  }
```
Obviously, rowCount will not exceed 1 because LIMIT 1. We can improve it