### PR TITLE
[CALCITE-5109] RelMdAllPredicates and RelMdExpressionLineage support to analyze left/right join

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdExpressionLineage.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
@@ -185,6 +186,7 @@ public class RelMdExpressionLineage
   public @Nullable Set<RexNode> getExpressionLineage(Join rel, RelMetadataQuery mq,
       RexNode outputExpression) {
     final RexBuilder rexBuilder = rel.getCluster().getRexBuilder();
+    final RelDataTypeFactory factory = rexBuilder.getTypeFactory();
     final RelNode leftInput = rel.getLeft();
     final RelNode rightInput = rel.getRight();
     final int nLeftColumns = leftInput.getRowType().getFieldList().size();
@@ -192,27 +194,16 @@ public class RelMdExpressionLineage
     // Extract input fields referenced by expression
     final ImmutableBitSet inputFieldsUsed = extractInputRefs(outputExpression);
 
-    if (rel.getJoinType().isOuterJoin()) {
-      // If we reference the inner side, we will bail out
-      if (rel.getJoinType() == JoinRelType.LEFT) {
-        ImmutableBitSet rightFields = ImmutableBitSet.range(
-            nLeftColumns, rel.getRowType().getFieldCount());
-        if (inputFieldsUsed.intersects(rightFields)) {
-          // We cannot map origin of this expression.
-          return null;
-        }
-      } else if (rel.getJoinType() == JoinRelType.RIGHT) {
-        ImmutableBitSet leftFields = ImmutableBitSet.range(
-            0, nLeftColumns);
-        if (inputFieldsUsed.intersects(leftFields)) {
-          // We cannot map origin of this expression.
-          return null;
-        }
-      } else {
-        // We cannot map origin of this expression.
+    final JoinRelType joinType = rel.getJoinType();
+    if (joinType.isOuterJoin()) {
+      if (joinType == JoinRelType.FULL) {
+        // We cannot map origin of this expression, if join's type is full join.
         return null;
       }
     }
+
+    final boolean wrapLeftNullable = rel.getJoinType() == JoinRelType.RIGHT;
+    final boolean wrapRightNullable = rel.getJoinType() == JoinRelType.LEFT;
 
     // Gather table references
     final Set<RelTableRef> leftTableRefs = mq.getTableReferences(leftInput);
@@ -251,8 +242,33 @@ public class RelMdExpressionLineage
           // Bail out
           return null;
         }
+        final Set<RexNode> newExprs;
+        if (wrapLeftNullable) {
+          newExprs = new HashSet<>();
+          for (RexNode originalExpr : originalExprs) {
+            // Bail out
+            if (!(originalExpr instanceof RexTableInputRef)) {
+              return null;
+            }
+            // Rebuild a left's node for wrap_left_nullable
+            final RexTableInputRef expr = (RexTableInputRef) originalExpr;
+            newExprs.add(
+                RexTableInputRef.of(
+                    factory, RelTableRef.of(
+                    expr.getTableRef().getTable(), expr.getTableRef().getEntityNumber()),
+                expr.getIndex(), expr.getType(), true));
+          }
+        } else {
+          newExprs = originalExprs;
+        }
         // Left input references remain unchanged
-        mapping.put(RexInputRef.of(idx, rel.getRowType().getFieldList()), originalExprs);
+        final RexInputRef joinRef;
+        if (wrapLeftNullable) {
+          joinRef = RexTableInputRef.ofNullable(factory, idx, rel.getRowType());
+        } else {
+          joinRef = RexInputRef.of(idx, rel.getRowType());
+        }
+        mapping.put(joinRef, newExprs);
       } else {
         // Right input.
         final RexInputRef inputRef = RexInputRef.of(idx - nLeftColumns,
@@ -271,10 +287,22 @@ public class RelMdExpressionLineage
             null,
             ImmutableList.of());
         final Set<RexNode> updatedExprs = ImmutableSet.copyOf(
-            Util.transform(originalExprs, e ->
-                RexUtil.swapTableReferences(rexBuilder, e,
-                    currentTablesMapping)));
-        mapping.put(RexInputRef.of(idx, fullRowType), updatedExprs);
+            Util.transform(originalExprs, e -> {
+              if (wrapRightNullable) {
+                return RexUtil.swapTableReferencesNullable(rexBuilder, e,
+                    currentTablesMapping);
+              } else {
+                return RexUtil.swapTableReferences(rexBuilder, e,
+                    currentTablesMapping);
+              }
+            }));
+        final RexInputRef joinRef;
+        if (wrapRightNullable) {
+          joinRef = RexTableInputRef.ofNullable(factory, idx, fullRowType);
+        } else {
+          joinRef = RexInputRef.of(idx, fullRowType);
+        }
+        mapping.put(joinRef, updatedExprs);
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexInputRef.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexInputRef.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rex;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.Pair;
@@ -92,6 +93,15 @@ public class RexInputRef extends RexSlot {
    */
   public static RexInputRef of(int index, List<RelDataTypeField> fields) {
     return new RexInputRef(index, fields.get(index).getType());
+  }
+
+  /**
+   * It's same to {@link RexInputRef#of(int, RelDataType)}, but it makes nullable reference.
+   */
+  public static RexInputRef ofNullable(RelDataTypeFactory factory, int index, RelDataType rowType) {
+    final List<RelDataTypeField> fields = rowType.getFieldList();
+    final RelDataType type = fields.get(index).getType();
+    return new RexInputRef(index, factory.createTypeWithNullability(type, true));
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rex/RexTableInputRef.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexTableInputRef.java
@@ -57,8 +57,9 @@ public class RexTableInputRef extends RexInputRef {
   private RexTableInputRef(RelTableRef tableRef, int index, RelDataType type,
       boolean forceNullable) {
     super(index, type);
-    // Nullable of type must be true, if this input ref is wrapped by left/right join.
-    assert !forceNullable || type.isNullable();
+    // Nullable of type should be true, because this input may emit nullable type,
+    // if this input ref is wrapped by left/right join.
+    assert !forceNullable || type.isNullable() : "Type should be nullable, if forced for nullable";
     this.tableRef = tableRef;
     this.forceNullable = forceNullable;
     this.digest = tableRef + ".$" + index + (forceNullable ? "(nullable)" : "");

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -2276,7 +2276,7 @@ public class RexUtil {
 
   public static RexNode swapTableColumnReferences(final RexBuilder rexBuilder,
       final RexNode node, final @Nullable Map<RelTableRef, RelTableRef> tableMapping,
-      final @Nullable Map<RexTableInputRef, Set<RexTableInputRef>> ec, boolean wrapJoinNullable) {
+      final @Nullable Map<RexTableInputRef, Set<RexTableInputRef>> ec, boolean forceNullable) {
     RelDataTypeFactory factory = rexBuilder.getTypeFactory();
     RexShuttle visitor =
         new RexShuttle() {
@@ -2288,7 +2288,7 @@ public class RexUtil {
                       () -> "tableMapping.get(...) for " + inputRefFinal.getTableRef()),
                   inputRef.getIndex(),
                   inputRef.getType(),
-                  wrapJoinNullable || inputRef.getWrapJoinNullable());
+                  forceNullable || inputRef.getForceNullable());
             }
             if (ec != null) {
               Set<RexTableInputRef> s = ec.get(inputRef);

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -2423,7 +2423,7 @@ public class RelMetadataTest {
     final Set<RexNode> empNode = mq.getExpressionLineage(rel, empRef);
     assertThat(empNode.size(), is(1));
     final RexNode empTargetNode = empNode.iterator().next();
-    assertThat(((RexTableInputRef) empTargetNode).getWrapJoinNullable(), is(false));
+    assertThat(((RexTableInputRef) empTargetNode).getForceNullable(), is(false));
     assertThat(empTargetNode.toString(), startsWith(EMP_QNAME.toString()));
     assertThat(
         empTargetNode.toString(),
@@ -2436,7 +2436,7 @@ public class RelMetadataTest {
     final Set<RexNode> deptNode = mq.getExpressionLineage(rel, deptRef);
     assertThat(deptNode.size(), is(1));
     final RexNode deptTargetNode = deptNode.iterator().next();
-    assertThat(((RexTableInputRef) deptTargetNode).getWrapJoinNullable(), is(true));
+    assertThat(((RexTableInputRef) deptTargetNode).getForceNullable(), is(true));
     assertThat(deptTargetNode.toString(), startsWith(DEPT_QNAME.toString()));
     assertThat(
         deptTargetNode.toString(),
@@ -2459,7 +2459,7 @@ public class RelMetadataTest {
     final Set<RexNode> empNode = mq.getExpressionLineage(rel, empRef);
     assertThat(empNode.size(), is(1));
     final RexNode empTargetNode = empNode.iterator().next();
-    assertThat(((RexTableInputRef) empTargetNode).getWrapJoinNullable(), is(false));
+    assertThat(((RexTableInputRef) empTargetNode).getForceNullable(), is(false));
     assertThat(empTargetNode.toString(), startsWith(EMP_QNAME.toString()));
     assertThat(
         empTargetNode.toString(),
@@ -2472,7 +2472,7 @@ public class RelMetadataTest {
     final Set<RexNode> deptNode = mq.getExpressionLineage(rel, deptRef);
     assertThat(deptNode.size(), is(1));
     final RexNode deptTargetNode = deptNode.iterator().next();
-    assertThat(((RexTableInputRef) deptTargetNode).getWrapJoinNullable(), is(true));
+    assertThat(((RexTableInputRef) deptTargetNode).getForceNullable(), is(true));
     assertThat(deptTargetNode.toString(), startsWith(DEPT_QNAME.toString()));
     assertThat(
         deptTargetNode.toString(),

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -132,6 +132,7 @@ import static org.apache.calcite.test.Matchers.sortsAs;
 import static org.apache.calcite.test.Matchers.within;
 
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -175,6 +176,9 @@ public class RelMetadataTest {
 
   private static final List<String> EMP_QNAME =
       ImmutableList.of("CATALOG", "SALES", "EMP");
+
+  private static final List<String> DEPT_QNAME =
+      ImmutableList.of("CATALOG", "SALES", "DEPT");
 
   /** Ensures that tests that use a lot of memory do not run at the same
    * time. */
@@ -2394,15 +2398,87 @@ public class RelMetadataTest {
         not(((RexTableInputRef) r2.iterator().next()).getIdentifier()));
   }
 
-  @Test void testExpressionLineageOuterJoin() {
-    // lineage cannot be determined
-    final RelNode rel = sql("select name as dname from emp left outer join dept"
+  @Test void testExpressionLineageFullOuterJoin() {
+    // lineage of full join cannot be determined
+    final RelNode rel = sql("select name as dname from emp full outer join dept"
         + " on emp.deptno = dept.deptno").toRel();
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
 
     final RexNode ref = RexInputRef.of(0, rel.getRowType().getFieldList());
     final Set<RexNode> r = mq.getExpressionLineage(rel, ref);
     assertNull(r);
+  }
+
+  @Test void testExpressionLineageLeftOuterJoin() {
+    // support to analyze for out join.
+    final RelNode rel = sql("select emp.sal as e_sal, dept.name as d_name\n"
+        + "from emp left outer join dept\n"
+        + "on emp.deptno = dept.deptno").toRel();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final RelNode empTableRel = sql("select * from emp").toRel();
+    final RelNode depTableRel = sql("select * from dept").toRel();
+
+    // check left's input of left-join (emp's field)
+    final RexNode empRef = RexInputRef.of(0, rel.getRowType().getFieldList());
+    final Set<RexNode> empNode = mq.getExpressionLineage(rel, empRef);
+    assertThat(empNode.size(), is(1));
+    final RexNode empTargetNode = empNode.iterator().next();
+    assertThat(((RexTableInputRef) empTargetNode).getWrapJoinNullable(), is(false));
+    assertThat(empTargetNode.toString(), startsWith(EMP_QNAME.toString()));
+    assertThat(
+        empTargetNode.toString(),
+        endsWith(
+            RexInputRef.of(
+        5, empTableRel.getRowType()).toString()));
+
+    // check right's input of left-join (dept's field)
+    final RexNode deptRef = RexInputRef.of(1, rel.getRowType().getFieldList());
+    final Set<RexNode> deptNode = mq.getExpressionLineage(rel, deptRef);
+    assertThat(deptNode.size(), is(1));
+    final RexNode deptTargetNode = deptNode.iterator().next();
+    assertThat(((RexTableInputRef) deptTargetNode).getWrapJoinNullable(), is(true));
+    assertThat(deptTargetNode.toString(), startsWith(DEPT_QNAME.toString()));
+    assertThat(
+        deptTargetNode.toString(),
+        containsString(
+            RexInputRef.ofNullable(
+        rel.getCluster().getTypeFactory(), 1, depTableRel.getRowType()).toString()));
+  }
+
+  @Test void testExpressionLineageRightOuterJoin() {
+    // support to analyze for out join
+    final RelNode rel = sql("select dept.name as d_name, emp.sal as e_sal\n"
+        + "from dept right outer join emp\n"
+        + "on emp.deptno = dept.deptno").toRel();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final RelNode empTableRel = sql("select * from emp").toRel();
+    final RelNode depTableRel = sql("select * from dept").toRel();
+
+    // check right's input of right-join (emp's field)
+    final RexNode empRef = RexInputRef.of(1, rel.getRowType().getFieldList());
+    final Set<RexNode> empNode = mq.getExpressionLineage(rel, empRef);
+    assertThat(empNode.size(), is(1));
+    final RexNode empTargetNode = empNode.iterator().next();
+    assertThat(((RexTableInputRef) empTargetNode).getWrapJoinNullable(), is(false));
+    assertThat(empTargetNode.toString(), startsWith(EMP_QNAME.toString()));
+    assertThat(
+        empTargetNode.toString(),
+        endsWith(
+            RexInputRef.of(
+        5, empTableRel.getRowType()).toString()));
+
+    // check left's input of right-join (dept's field)
+    final RexNode deptRef = RexInputRef.of(0, rel.getRowType().getFieldList());
+    final Set<RexNode> deptNode = mq.getExpressionLineage(rel, deptRef);
+    assertThat(deptNode.size(), is(1));
+    final RexNode deptTargetNode = deptNode.iterator().next();
+    assertThat(((RexTableInputRef) deptTargetNode).getWrapJoinNullable(), is(true));
+    assertThat(deptTargetNode.toString(), startsWith(DEPT_QNAME.toString()));
+    assertThat(
+        deptTargetNode.toString(),
+        containsString(
+            RexInputRef.ofNullable(
+        rel.getCluster().getTypeFactory(), 1, depTableRel.getRowType()).toString()));
   }
 
   @Test void testExpressionLineageFilter() {
@@ -2688,6 +2764,130 @@ public class RelMetadataTest {
         equalTo("[[CATALOG, SALES, DEPT].#0, [CATALOG, SALES, DEPT].#1, "
             + "[CATALOG, SALES, EMP].#0, [CATALOG, SALES, EMP].#1, "
             + "[CATALOG, SALES, EMP].#2, [CATALOG, SALES, EMP].#3]"));
+  }
+
+  @Test void testAllPredicatesAndTablesLeftJoin() {
+    final String sql = "select empno, dept.deptno\n"
+        + "from (select deptno from dept where deptno > 1) dept\n"
+        + "left join (select * from emp where emp.deptno < 1001) emp\n"
+        + "on emp.deptno = dept.deptno and emp.deptno < 1002\n"
+        + "where empno > 2";
+    final RelNode rel = sql(sql).toRel();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final RelOptPredicateList allPredicates = mq.getAllPredicates(rel);
+    assertThat(allPredicates.pulledUpPredicates,
+        sortsAs("[>([CATALOG, SALES, DEPT].#0.$0, 1), "
+            + ">([CATALOG, SALES, EMP].#0.$0(nullable), 2)]"));
+    assertThat(allPredicates.rightInferredPredicates,
+        sortsAs("[<([CATALOG, SALES, EMP].#0.$7, 1001), "
+            + "AND(=([CATALOG, SALES, EMP].#0.$7(nullable), [CATALOG, SALES, DEPT].#0.$0), "
+            + "<([CATALOG, SALES, EMP].#0.$7(nullable), 1002))]"));
+    final Set<RelTableRef> tableReferences =
+        Sets.newTreeSet(mq.getTableReferences(rel));
+    assertThat(tableReferences.toString(),
+        equalTo("[[CATALOG, SALES, DEPT].#0, [CATALOG, SALES, EMP].#0]"));
+  }
+
+  @Test void testAllPredicatesAndTablesMoreLeftJoin() {
+    final String sql = "select a.empno as empno_1, a.deptno as deptno_1, "
+        + "b.empno as empno_2, b.deptno as deptno_2\n"
+        + "from (\n"
+        + "select emp.empno as empno, emp.deptno as deptno\n"
+        + "from (select deptno from dept where deptno > 1) dept\n"
+        + "left join\n"
+        + "(select * from emp where emp.deptno < 1001) emp\n"
+        + "on emp.deptno = dept.deptno and emp.deptno < 1002\n"
+        + "where empno > 2\n"
+        + ") a\n"
+        + "left join\n"
+        + "(select emp.empno as empno, emp.deptno as deptno\n"
+        + "from (select deptno from dept where deptno > 11) dept\n"
+        + "left join\n"
+        + "(select * from emp where emp.deptno < 11001) emp\n"
+        + "on emp.deptno = dept.deptno and emp.deptno < 11002\n"
+        + "where empno > 22\n"
+        + ") b\n"
+        + "on a.empno = b.empno and a.empno > 1222\n"
+        + "where a.empno > 222";
+    final RelNode rel = sql(sql).toRel();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final RelOptPredicateList allPredicates = mq.getAllPredicates(rel);
+    assertThat(allPredicates.pulledUpPredicates,
+        sortsAs("[>([CATALOG, SALES, DEPT].#0.$0, 1), "
+            + ">([CATALOG, SALES, EMP].#0.$0(nullable), 2), "
+            + ">([CATALOG, SALES, EMP].#0.$0(nullable), 222)]"));
+    assertThat(allPredicates.rightInferredPredicates,
+        sortsAs("[>([CATALOG, SALES, DEPT].#1.$0, 11), "
+            + ">([CATALOG, SALES, EMP].#1.$0(nullable), 22), "
+            + "AND(=([CATALOG, SALES, EMP].#0.$0(nullable), [CATALOG, SALES, EMP].#1.$0(nullable)), "
+            + ">([CATALOG, SALES, EMP].#0.$0(nullable), 1222))]"));
+    final Set<RelTableRef> tableReferences =
+        Sets.newTreeSet(mq.getTableReferences(rel));
+    assertThat(tableReferences.toString(),
+        equalTo("[[CATALOG, SALES, DEPT].#0, [CATALOG, SALES, DEPT].#1, "
+            + "[CATALOG, SALES, EMP].#0, [CATALOG, SALES, EMP].#1]"));
+  }
+
+  @Test void testAllPredicatesAndTablesLeftInnerJoin() {
+    final String sql = "select a.empno as empno_1, a.deptno as deptno_1, "
+        + "b.empno as empno_2, b.deptno as deptno_2\n"
+        + "from (\n"
+        + "select emp.empno as empno, emp.deptno as deptno\n"
+        + "from (select deptno from dept where deptno > 1) dept\n"
+        + "inner join\n"
+        + "(select * from emp where emp.deptno < 1001) emp\n"
+        + "on emp.deptno = dept.deptno and emp.deptno < 1002\n"
+        + "where empno > 2\n"
+        + ") a\n"
+        + "left join\n"
+        + "(select emp.empno as empno, emp.deptno as deptno\n"
+        + "from (select deptno from dept where deptno > 11) dept\n"
+        + "left join\n"
+        + "(select * from emp where emp.deptno < 11001) emp\n"
+        + "on emp.deptno = dept.deptno and emp.deptno < 11002\n"
+        + "where empno > 22\n"
+        + ") b\n"
+        + "on a.empno = b.empno and a.empno > 1222\n"
+        + "where a.empno > 222";
+    final RelNode rel = sql(sql).toRel();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final RelOptPredicateList allPredicates = mq.getAllPredicates(rel);
+    assertThat(allPredicates.pulledUpPredicates,
+        sortsAs("[<([CATALOG, SALES, EMP].#0.$7, 1001), >([CATALOG, SALES, DEPT].#0.$0, 1), "
+            + ">([CATALOG, SALES, EMP].#0.$0, 2), >([CATALOG, SALES, EMP].#0.$0, 222), "
+            + "AND(=([CATALOG, SALES, EMP].#0.$7, [CATALOG, SALES, DEPT].#0.$0), "
+            + "<([CATALOG, SALES, EMP].#0.$7, 1002))]"));
+    assertThat(allPredicates.rightInferredPredicates,
+        sortsAs("[>([CATALOG, SALES, DEPT].#1.$0, 11), "
+            + ">([CATALOG, SALES, EMP].#1.$0(nullable), 22), "
+            + "AND(=([CATALOG, SALES, EMP].#0.$0, [CATALOG, SALES, EMP].#1.$0(nullable)), "
+            + ">([CATALOG, SALES, EMP].#0.$0, 1222))]"));
+    final Set<RelTableRef> tableReferences =
+        Sets.newTreeSet(mq.getTableReferences(rel));
+    assertThat(tableReferences.toString(),
+        equalTo("[[CATALOG, SALES, DEPT].#0, [CATALOG, SALES, DEPT].#1, "
+            + "[CATALOG, SALES, EMP].#0, [CATALOG, SALES, EMP].#1]"));
+  }
+
+  @Test void testAllPredicatesAndTablesRightJoin() {
+    final String sql = "select empno, dept.deptno as d_deptno, emp.deptno as e_deptno\n"
+        + "from (select deptno from dept where deptno > 1) dept\n"
+        + "right join (select * from emp where emp.deptno < 1001) emp\n"
+        + "on emp.deptno = dept.deptno and emp.deptno < 1002\n"
+        + "where empno > 2";
+    final RelNode rel = sql(sql).toRel();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final RelOptPredicateList allPredicates = mq.getAllPredicates(rel);
+    assertThat(allPredicates.pulledUpPredicates,
+        sortsAs("[<([CATALOG, SALES, EMP].#0.$7, 1001), >([CATALOG, SALES, EMP].#0.$0, 2)]"));
+    assertThat(allPredicates.leftInferredPredicates,
+        sortsAs("[>([CATALOG, SALES, DEPT].#0.$0, 1), "
+            + "AND(=([CATALOG, SALES, EMP].#0.$7, [CATALOG, SALES, DEPT].#0.$0(nullable)), "
+            + "<([CATALOG, SALES, EMP].#0.$7, 1002))]"));
+    final Set<RelTableRef> tableReferences =
+        Sets.newTreeSet(mq.getTableReferences(rel));
+    assertThat(tableReferences.toString(),
+        equalTo("[[CATALOG, SALES, DEPT].#0, [CATALOG, SALES, EMP].#0]"));
   }
 
   @Test void testAllPredicatesAndTablesCalc() {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/CALCITE-5109

Summary:
- Expand Model of RexTableInputRef
- RelMdExpressionLineage support the analysis of left/right join
- RelMdAllPredicates support the analysis of left/right join