### PR TITLE
[CALCITE-5130] AssertionError: "Conversion to relational algebra failed to preserve datatypes" when union VARCHAR literal and CAST(null AS INTEGER)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
@@ -442,6 +442,12 @@ public abstract class AbstractTypeCoercion implements TypeCoercion {
     if (SqlTypeUtil.isCharacter(type1) && SqlTypeUtil.isAtomic(type2)) {
       resultType = factory.createSqlType(SqlTypeName.VARCHAR);
     }
+
+    if (null != resultType) {
+      resultType = factory.createTypeWithNullability(resultType,
+          type1.isNullable() || type2.isNullable());
+    }
+
     return resultType;
   }
 

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
@@ -132,4 +132,12 @@ class TypeCoercionConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5130">[CALCITE-5130]
+   * AssertionError: "Conversion to relational algebra failed to preserve datatypes"
+   * when union VARCHAR literal and CAST(null AS INTEGER) </a>. */
+  @Test void testCastNullAsIntUnionChar() {
+    String sql = "select CAST(null AS INTEGER) union select '10'";
+    sql(sql).ok();
+  }
 }

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
@@ -216,7 +216,7 @@ class TypeCoercionTest {
     sql("select '1' from (values(true)) union values 2")
         .type("RecordType(VARCHAR NOT NULL EXPR$0) NOT NULL");
     sql("select (select 1+2 from (values true)) tt from (values(true)) union values '2'")
-        .type("RecordType(VARCHAR NOT NULL TT) NOT NULL");
+        .type("RecordType(VARCHAR TT) NOT NULL");
     // union with star
     sql("select * from (values(1, '3')) union select * from (values('2', 4))")
         .type("RecordType(VARCHAR NOT NULL EXPR$0, VARCHAR NOT NULL EXPR$1) NOT NULL");

--- a/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
@@ -77,6 +77,18 @@ LogicalProject(EXPR$0=[CAST($3):DECIMAL(19, 0) NOT NULL])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCastNullAsIntUnionChar">
+    <Resource name="sql">
+      <![CDATA[select CAST(null AS INTEGER) union select '10']]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalUnion(all=[false])
+  LogicalValues(tuples=[[{ null }]])
+  LogicalValues(tuples=[[{ '10' }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testInDateTimestamp">
     <Resource name="sql">
       <![CDATA[select (t1_timestamp, t1_date)


### PR DESCRIPTION
In AbstractTypeCoercion#promoteToVarChar() return resultType with nullability if any of the types being promoted are nullable.