### PR TITLE
[CALCITE-5163] MysqlSqlDialect support to unparse LISTAGG aggregate function

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -40,6 +40,8 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlCase;
+import org.apache.calcite.sql.fun.SqlInternalOperators;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.InferTypes;
@@ -47,7 +49,11 @@ import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
 
+import com.google.common.collect.ImmutableList;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
 
 /**
  * A <code>SqlDialect</code> implementation for the MySQL database.
@@ -223,9 +229,55 @@ public class MysqlSqlDialect extends SqlDialect {
       unparseFloor(writer, call);
       break;
 
+    case WITHIN_GROUP:
+      final List<SqlNode> operands = call.getOperandList();
+      if (operands.size() <= 0 || operands.get(0).getKind() != SqlKind.LISTAGG) {
+        super.unparseCall(writer, call, leftPrec, rightPrec);
+        return;
+      }
+      unparseListAggCall(writer, (SqlCall) operands.get(0),
+          operands.size() == 2 ? operands.get(1) : null, leftPrec, rightPrec);
+      break;
+
+    case LISTAGG:
+      unparseListAggCall(writer, call, null, leftPrec, rightPrec);
+      break;
+
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }
+  }
+
+  /**
+   * Unparses LISTAGG for MySQL. This call is translated to GROUP_CONCAT.<br/>
+   * For example:
+   * source: <code>LISTAGG(DISTINCT c1, ',') WITHIN GROUP (ORDER BY c2, c3)</code>
+   * target: <code>GROUP_CONCAT(DISTINCT c1 ORDER BY c2, c3 SEPARATOR ',')</code>
+   *
+   * @param writer Writer
+   * @param listAggCall Call of LISTAGG
+   * @param orderItemNode Elems of WITHIN_GROUP, NULL means none elem in the WITHIN_GROUP
+   * @param leftPrec leftPrec
+   * @param rightPrec rightPrec
+   */
+  private void unparseListAggCall(SqlWriter writer, SqlCall listAggCall,
+      @Nullable SqlNode orderItemNode, int leftPrec, int rightPrec) {
+    final List<SqlNode> listAggCallOperands = listAggCall.getOperandList();
+    final boolean separatorExist = listAggCallOperands.size() == 2;
+
+    final ImmutableList.Builder<SqlNode> newOperandListBuilder = ImmutableList.<SqlNode>builder()
+        .add(listAggCallOperands.get(0));
+    if (orderItemNode != null) {
+      newOperandListBuilder.add(orderItemNode);
+    }
+    if (separatorExist) {
+      newOperandListBuilder.add(
+          SqlInternalOperators.SEPARATOR.createCall(
+          SqlParserPos.ZERO, listAggCallOperands.get(1)));
+    }
+    SqlLibraryOperators.GROUP_CONCAT.createCall(listAggCall.getFunctionQuantifier(),
+        listAggCall.getParserPosition(), newOperandListBuilder.build())
+        .unparse(writer, leftPrec, rightPrec);
   }
 
   /**


### PR DESCRIPTION
ISSUE Link: https://issues.apache.org/jira/browse/CALCITE-5163

Simple Description:
MysqlSqlDialect translate function of `LISTAGG` to `GROUP_CONCAT`, when meeting `SqlKind#WITHIN_GROUP` or `SqlKind#LISTAGG`.