### PR TITLE
Remove unreachable condition in CsvTableScan

### DIFF
--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvTableScan.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvTableScan.java
@@ -106,13 +106,6 @@ public class CsvTableScan extends TableScan implements EnumerableRel {
             getRowType(),
             pref.preferArray());
 
-    if (table instanceof JsonTable) {
-      return implementor.result(
-          physType,
-          Blocks.toBlock(
-              Expressions.call(table.getExpression(JsonTable.class),
-                  "enumerable")));
-    }
     return implementor.result(
         physType,
         Blocks.toBlock(


### PR DESCRIPTION
This removes an unreachable condition in CsvTableScan when checking if a table is a JsonTable. The table object can only take the form of a RelOptTable and not a Table.