### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,9 @@
 name: "Validate Gradle Wrapper"
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"

--- a/.github/workflows/publish-non-release-website-updates.yml
+++ b/.github/workflows/publish-non-release-website-updates.yml
@@ -27,8 +27,13 @@ on:
       - 'site/_docs/howto.md'         # or site/_docs/howto.md
       - 'site/_docs/powered_by.md'    # or site/_docs/powered_by.md
 
+permissions:
+  contents: read
+
 jobs:
   cherry-pick-to-site:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,6 +52,8 @@ jobs:
           git push origin site
 
   publish-website:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     needs: cherry-pick-to-site
     steps:

--- a/.github/workflows/publish-website-on-release.yml
+++ b/.github/workflows/publish-website-on-release.yml
@@ -21,8 +21,13 @@ on:
     tags:
       - calcite-[0-9]+.[0-9]+.[0-9]+ # Trigger only when a tag that matches calcite-X.Y.Z is pushed
 
+permissions:
+  contents: read
+
 jobs:
   sync-main-site:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -35,6 +40,8 @@ jobs:
           git push --force origin site
 
   publish-website:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     needs: sync-main-site
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
