### PR TITLE
[CALCITE-5196] Bump apiguardian to 1.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -77,7 +77,7 @@ jandex.version=2.2.3.Final
 # We support Guava versions as old as 19.0 but prefer more recent versions.
 # elasticsearch does not like asm:6.2.1+
 aggdesigner-algorithm.version=6.0
-apiguardian-api.version=1.1.0
+apiguardian-api.version=1.1.2
 asm.version=7.2
 bouncycastle.version=1.60
 byte-buddy.version=1.9.3


### PR DESCRIPTION
This is a trivial PR updating apiguardian version to 1.1.2