### PR TITLE
[CALCITE-4865] Allow table functions to be polymorphic

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1580,20 +1580,22 @@ SqlNode NamedRoutineCall(
 SqlNode TableParam() :
 {
     final Span s;
+    final SqlNodeList partitionList;
+    final SqlNodeList orderList;
     SqlNode tableRef;
-    SqlNodeList partitionList = SqlNodeList.EMPTY;
-    SqlNodeList orderList = SqlNodeList.EMPTY;
 }
 {
     { s = span(); }
     tableRef = ExplicitTable(getPos())
-    [
+    (
         <PARTITION> <BY>
         partitionList = SimpleIdentifierOrList()
-    ]
-    [
+    |   { partitionList = SqlNodeList.EMPTY; }
+    )
+    (
         orderList = OrderByInTableParam()
-    ]
+     |  { orderList = SqlNodeList.EMPTY; }
+    )
     {
         if (partitionList.isEmpty() && orderList.isEmpty()) {
           return tableRef;
@@ -1615,21 +1617,23 @@ SqlNode PartitionedQueryOrQueryOrExpr(ExprContext exprContext) :
     { return e; }
 }
 
-SqlNode PartitionedByAndOrderBy(SqlNode e):
+SqlNode PartitionedByAndOrderBy(SqlNode e) :
 {
     final Span s;
-    SqlNodeList partitionList = SqlNodeList.EMPTY;
-    SqlNodeList orderList = SqlNodeList.EMPTY;
+    final SqlNodeList partitionList;
+    final SqlNodeList orderList;
 }
 {
     { s = span(); }
-    [
+    (
         <PARTITION> <BY>
         partitionList = SimpleIdentifierOrList()
-    ]
-    [
+    |   { partitionList = SqlNodeList.EMPTY; }
+    )
+    (
         orderList = OrderByInTableParam()
-    ]
+     |  { orderList = SqlNodeList.EMPTY; }
+    )
     {
         if (partitionList.isEmpty() && orderList.isEmpty()) {
           return e;
@@ -1642,8 +1646,7 @@ SqlNode PartitionedByAndOrderBy(SqlNode e):
 
 SqlNodeList OrderByInTableParam() :
 {
-    List<SqlNode> list;
-    SqlNode e;
+    final List<SqlNode> list = new ArrayList<SqlNode>();
     final Span s;
 }
 {
@@ -1651,25 +1654,18 @@ SqlNodeList OrderByInTableParam() :
   <BY>
   (
       LOOKAHEAD(2)
-      <LPAREN> e = OrderItem()
-      {
-          list = startList(e);
-      }
+      <LPAREN> AddOrderItem(list)
       (
           LOOKAHEAD(2)
           <COMMA>
-          e = OrderItem()
-          {
-              list.add(e);
-          }
+          AddOrderItem(list)
       )*
       <RPAREN> {
           return new SqlNodeList(list, s.addAll(list).pos());
       }
   |
-      e = OrderItem()
+      AddOrderItem(list)
       {
-          list = startList(e);
           return new SqlNodeList(list, s.addAll(list).pos());
       }
   )

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1014,7 +1014,9 @@ void AddArg0(List<SqlNode> list, ExprContext exprContext) :
     (
         e = Default()
     |
-        e = OrderedQueryOrExpr(firstExprContext)
+        e = TableArg()
+    |
+        e = PartitionedQueryOrQueryOrExpr(firstExprContext)
     )
     {
         if (name != null) {
@@ -1039,6 +1041,8 @@ void AddArg(List<SqlNode> list, ExprContext exprContext) :
         e = Default()
     |
         e = Expression(exprContext)
+    |
+        e = TableArg()
     )
     {
         if (name != null) {
@@ -1567,6 +1571,108 @@ SqlNode NamedRoutineCall(
     {
         return createCall(name, s.end(this), routineType, null, list);
     }
+}
+
+/**
+ * Table argument of a table function.
+ * The input table with set semantics may be partitioned/ordered on one or more columns.
+ */
+SqlNode TableArg() :
+{
+    final Span s;
+    SqlNode tableRef;
+    SqlNodeList partitionList = SqlNodeList.EMPTY;
+    SqlNodeList orderList = SqlNodeList.EMPTY;
+}
+{
+    { s = span(); }
+    tableRef = ExplicitTable(getPos())
+    [
+        <PARTITION> <BY>
+        partitionList = SimpleIdentifierOrList()
+    ]
+    [
+        orderList = OrderByInTableParam()
+    ]
+    {
+        if (partitionList.isEmpty() && orderList.isEmpty()) {
+          return tableRef;
+        } else {
+          return SqlStdOperatorTable.SET_SEMANTICS_TABLE.createCall(
+              s.pos(), tableRef, partitionList, orderList);
+        }
+    }
+}
+
+SqlNode PartitionedQueryOrQueryOrExpr(ExprContext exprContext) :
+{
+    SqlNode e;
+}
+{
+    e = OrderedQueryOrExpr(exprContext)
+    e = PartitionedByAndOrderBy(e)
+
+    { return e; }
+}
+
+SqlNode PartitionedByAndOrderBy(SqlNode e):
+{
+    final Span s;
+    SqlNodeList partitionList = SqlNodeList.EMPTY;
+    SqlNodeList orderList = SqlNodeList.EMPTY;
+}
+{
+    { s = span(); }
+    [
+        <PARTITION> <BY>
+        partitionList = SimpleIdentifierOrList()
+    ]
+    [
+        orderList = OrderByInTableParam()
+    ]
+    {
+        if (partitionList.isEmpty() && orderList.isEmpty()) {
+          return e;
+        } else {
+          return SqlStdOperatorTable.SET_SEMANTICS_TABLE.createCall(
+              s.pos(), e, partitionList, orderList);
+        }
+    }
+}
+
+SqlNodeList OrderByInTableParam() :
+{
+    List<SqlNode> list;
+    SqlNode e;
+    final Span s;
+}
+{
+  <ORDER> { s = span(); }
+  <BY>
+  (
+      LOOKAHEAD(2)
+      <LPAREN> e = OrderItem()
+      {
+          list = startList(e);
+      }
+      (
+          LOOKAHEAD(2)
+          <COMMA>
+          e = OrderItem()
+          {
+              list.add(e);
+          }
+      )*
+      <RPAREN> {
+          return new SqlNodeList(list, s.addAll(list).pos());
+      }
+  |
+      e = OrderItem()
+      {
+          list = startList(e);
+          return new SqlNodeList(list, s.addAll(list).pos());
+      }
+  )
 }
 
 /**

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1574,7 +1574,7 @@ SqlNode NamedRoutineCall(
 }
 
 /**
- * Table argument of a table function.
+ * Table parameter of a table function.
  * The input table with set semantics may be partitioned/ordered on one or more columns.
  */
 SqlNode TableArg() :

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1014,6 +1014,7 @@ void AddArg0(List<SqlNode> list, ExprContext exprContext) :
     (
         e = Default()
     |
+        LOOKAHEAD(3)
         e = TableParam()
     |
         e = PartitionedQueryOrQueryOrExpr(firstExprContext)
@@ -1593,17 +1594,10 @@ SqlNode TableParam() :
     |   { partitionList = SqlNodeList.EMPTY; }
     )
     (
-        orderList = OrderByInTableParam()
+        orderList = OrderByOfSetSemanticsTable()
      |  { orderList = SqlNodeList.EMPTY; }
     )
-    {
-        if (partitionList.isEmpty() && orderList.isEmpty()) {
-          return tableRef;
-        } else {
-          return SqlStdOperatorTable.SET_SEMANTICS_TABLE.createCall(
-              s.pos(), tableRef, partitionList, orderList);
-        }
-    }
+    { return CreateSetSemanticsTableIfNeeded(s, tableRef, partitionList, orderList); }
 }
 
 SqlNode PartitionedQueryOrQueryOrExpr(ExprContext exprContext) :
@@ -1631,34 +1625,28 @@ SqlNode PartitionedByAndOrderBy(SqlNode e) :
     |   { partitionList = SqlNodeList.EMPTY; }
     )
     (
-        orderList = OrderByInTableParam()
+        orderList = OrderByOfSetSemanticsTable()
      |  { orderList = SqlNodeList.EMPTY; }
     )
-    {
-        if (partitionList.isEmpty() && orderList.isEmpty()) {
-          return e;
-        } else {
-          return SqlStdOperatorTable.SET_SEMANTICS_TABLE.createCall(
-              s.pos(), e, partitionList, orderList);
-        }
-    }
+    { return CreateSetSemanticsTableIfNeeded(s, e, partitionList, orderList); }
 }
 
-SqlNodeList OrderByInTableParam() :
+SqlNodeList OrderByOfSetSemanticsTable() :
 {
     final List<SqlNode> list = new ArrayList<SqlNode>();
     final Span s;
 }
 {
-  <ORDER> { s = span(); }
+  <ORDER>
+  { s = span(); }
   <BY>
   (
       LOOKAHEAD(2)
       <LPAREN> AddOrderItem(list)
       (
-          LOOKAHEAD(2)
-          <COMMA>
-          AddOrderItem(list)
+        // NOTE jvs 6-Feb-2004:  See comments at top of file for why
+        // hint is necessary here.
+        LOOKAHEAD(2) <COMMA> AddOrderItem(list)
       )*
       <RPAREN> {
           return new SqlNodeList(list, s.addAll(list).pos());
@@ -1669,6 +1657,26 @@ SqlNodeList OrderByInTableParam() :
           return new SqlNodeList(list, s.addAll(list).pos());
       }
   )
+}
+
+SqlNode CreateSetSemanticsTableIfNeeded(
+    final Span s,
+    final SqlNode e,
+    final SqlNodeList partitionList,
+    final SqlNodeList orderList) :
+{
+
+}
+{
+
+    {
+        if (partitionList.isEmpty() && orderList.isEmpty()) {
+            return e;
+        } else {
+            return SqlStdOperatorTable.SET_SEMANTICS_TABLE.createCall(
+                s.pos(), e, partitionList, orderList);
+        }
+    }
 }
 
 /**

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1014,7 +1014,7 @@ void AddArg0(List<SqlNode> list, ExprContext exprContext) :
     (
         e = Default()
     |
-        e = TableArg()
+        e = TableParam()
     |
         e = PartitionedQueryOrQueryOrExpr(firstExprContext)
     )
@@ -1042,7 +1042,7 @@ void AddArg(List<SqlNode> list, ExprContext exprContext) :
     |
         e = Expression(exprContext)
     |
-        e = TableArg()
+        e = TableParam()
     )
     {
         if (name != null) {
@@ -1577,7 +1577,7 @@ SqlNode NamedRoutineCall(
  * Table parameter of a table function.
  * The input table with set semantics may be partitioned/ordered on one or more columns.
  */
-SqlNode TableArg() :
+SqlNode TableParam() :
 {
     final Span s;
     SqlNode tableRef;

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -985,4 +985,5 @@ public interface CalciteResource {
 
   @BaseMessage("A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics")
   ExInst<SqlValidatorException> multipleRowSemanticsTables(String funcName);
+
 }

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -977,4 +977,12 @@ public interface CalciteResource {
   @BaseMessage("No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization")
   ExInst<CalciteException> noOperator(String name, String kind, String syntax);
 
+  @BaseMessage("Only tables with set semantics may be partitioned. Invalid PARTITION BY clause in the {0,number,#}-th operand of table function ''{1}''")
+  ExInst<SqlValidatorException> invalidPartitionKeys(int idx, String funcName);
+
+  @BaseMessage("Only tables with set semantics may be ordered. Invalid ORDER BY clause in the {0,number,#}-th operand of table function ''{1}''")
+  ExInst<SqlValidatorException> invalidOrderBy(int idx, String funcName);
+
+  @BaseMessage("A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics")
+  ExInst<SqlValidatorException> multipleRowSemanticsTables(String funcName);
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -130,6 +130,9 @@ public enum SqlKind {
    */
   OTHER_FUNCTION,
 
+  /** Clause of input table with set semantics of Table Function. */
+  SET_SEMANTICS_TABLE,
+
   /** POSITION function. */
   POSITION,
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -130,7 +130,18 @@ public enum SqlKind {
    */
   OTHER_FUNCTION,
 
-  /** Clause of input table with set semantics of Table Function. */
+  /**
+   * Input tables have either row semantics or set semantics.
+   * <ul>
+   * <li>Row semantics means that the the result of the PTF is decided on a
+   * row-by-row basis.
+   * <li>Set semantics means that the outcome of the function depends on how
+   * the data is partitioned.
+   * When the PTF is called from a query, the table argument can optionally be
+   * extended with either a PARTITION BY clause or
+   * an ORDER BY clause or both.
+   * </ul>
+   */
   SET_SEMANTICS_TABLE,
 
   /** POSITION function. */

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -133,12 +133,12 @@ public enum SqlKind {
   /**
    * Input tables have either row semantics or set semantics.
    * <ul>
-   * <li>Row semantics means that the the result of the PTF is decided on a
-   * row-by-row basis.
+   * <li>Row semantics means that the the result of the table function is
+   * decided on a row-by-row basis.
    * <li>Set semantics means that the outcome of the function depends on how
    * the data is partitioned.
-   * When the PTF is called from a query, the table argument can optionally be
-   * extended with either a PARTITION BY clause or
+   * When the table function is called from a query, the table parameter can
+   * optionally be extended with either a PARTITION BY clause or
    * an ORDER BY clause or both.
    * </ul>
    */

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
@@ -26,12 +26,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.List;
 
 /**
- * SetSemanticsTable appears as an argument in a Table Function.
+ * SetSemanticsTable appears as an parameter in a table function.
  * It represents as an input table with set semantics.
  * Set semantics means that the outcome of the function depends on how
  * the data is partitioned.
- * When the PTF is called from a query, the table argument can optionally be
- * extended with either a PARTITION BY clause or
+ * When the table function is called from a query, the table parameter can
+ * optionally be extended with either a PARTITION BY clause or
  * an ORDER BY clause or both.
  *
  */

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
@@ -28,8 +28,14 @@ import java.util.List;
 /**
  * SetSemanticsTable appears as an argument in a Table Function.
  * It represents as an input table with set semantics.
+ * Set semantics means that the outcome of the function depends on how
+ * the data is partitioned.
+ * When the PTF is called from a query, the table argument can optionally be
+ * extended with either a PARTITION BY clause or
+ * an ORDER BY clause or both.
+ *
  */
-public class SqlSetSemanticsTableOperator extends SqlSpecialOperator {
+public class SqlSetSemanticsTableOperator extends SqlInternalOperator {
 
   //~ Constructors -----------------------------------------------------------
 
@@ -49,7 +55,11 @@ public class SqlSetSemanticsTableOperator extends SqlSpecialOperator {
     return super.createCall(functionQualifier, pos, operands);
   }
 
-  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+  @Override public void unparse(
+      SqlWriter writer,
+      SqlCall call,
+      int leftPrec,
+      int rightPrec) {
     call.operand(0).unparse(writer, 0, 0);
 
     SqlNodeList partitionList = call.operand(1);
@@ -62,7 +72,10 @@ public class SqlSetSemanticsTableOperator extends SqlSpecialOperator {
     SqlNodeList orderList = call.operand(2);
     if (orderList.size() > 0) {
       writer.sep("ORDER BY");
-      writer.list(SqlWriter.FrameTypeEnum.ORDER_BY_LIST, SqlWriter.COMMA, orderList);
+      writer.list(
+          SqlWriter.FrameTypeEnum.ORDER_BY_LIST,
+          SqlWriter.COMMA,
+          orderList);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
@@ -83,13 +83,12 @@ public class SqlSetSemanticsTableOperator extends SqlInternalOperator {
       SqlValidator validator,
       SqlValidatorScope scope, SqlCall call) {
     final List<SqlNode> operands = call.getOperandList();
-    assert operands.size() == 3;
     RelDataType tableType = validator.deriveType(scope, operands.get(0));
     assert tableType != null;
     return tableType;
   }
 
   @Override public boolean argumentMustBeScalar(int ordinal) {
-    return ordinal != 0;
+    return false;
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+/**
+ * SetSemanticsTable appears as an argument in a Table Function.
+ * It represents as an input table with set semantics.
+ */
+public class SqlSetSemanticsTableOperator extends SqlSpecialOperator {
+
+  //~ Constructors -----------------------------------------------------------
+
+  public SqlSetSemanticsTableOperator() {
+    super("SET_SEMANTICS_TABLE", SqlKind.SET_SEMANTICS_TABLE);
+  }
+
+  @Override public SqlCall createCall(
+      @Nullable SqlLiteral functionQualifier,
+      SqlParserPos pos,
+      @Nullable SqlNode... operands) {
+    assert operands.length == 3;
+    SqlNode partitionList = operands[1];
+    SqlNode orderList = operands[2];
+    assert (partitionList != null && !SqlNodeList.isEmptyList(partitionList))
+        || (orderList != null && !SqlNodeList.isEmptyList(orderList));
+    return super.createCall(functionQualifier, pos, operands);
+  }
+
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    call.operand(0).unparse(writer, 0, 0);
+
+    SqlNodeList partitionList = call.operand(1);
+    if (partitionList.size() > 0) {
+      writer.sep("PARTITION BY");
+      final SqlWriter.Frame partitionFrame = writer.startList("", "");
+      partitionList.unparse(writer, 0, 0);
+      writer.endList(partitionFrame);
+    }
+    SqlNodeList orderList = call.operand(2);
+    if (orderList.size() > 0) {
+      writer.sep("ORDER BY");
+      writer.list(SqlWriter.FrameTypeEnum.ORDER_BY_LIST, SqlWriter.COMMA, orderList);
+    }
+  }
+
+  @Override public RelDataType deriveType(
+      SqlValidator validator,
+      SqlValidatorScope scope, SqlCall call) {
+    final List<SqlNode> operands = call.getOperandList();
+    assert operands.size() == 3;
+    RelDataType tableType = validator.deriveType(scope, operands.get(0));
+    assert tableType != null;
+    return tableType;
+  }
+
+  @Override public boolean argumentMustBeScalar(int ordinal) {
+    return ordinal != 0;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTableFunction.java
@@ -34,11 +34,13 @@ public interface SqlTableFunction {
   SqlReturnTypeInference getRowTypeInference();
 
   /**
-   * Returns the table parameter characteristics for <code>ordinal</code>th argument to this
-   * table function.
+   * Returns the table parameter characteristics for <code>ordinal</code>th
+   * parameter to this table function.
    *
-   * <p>Returns <code>Optional.empty</code> if the <code>ordinal</code>th argument is not table
-   * parameter.
+   * <p>Returns <code>null</code> if the <code>ordinal</code>th argument is
+   * not table parameter or the <code>ordinal</code> is smaller than 0 or
+   * the <code>ordinal</code> is greater than or equals to the number of
+   * parameters.
    */
   default @Nullable TableCharacteristic tableCharacteristic(int ordinal) {
     return null;

--- a/core/src/main/java/org/apache/calcite/sql/SqlTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTableFunction.java
@@ -18,6 +18,8 @@ package org.apache.calcite.sql;
 
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * A function that returns a table.
  */
@@ -30,4 +32,15 @@ public interface SqlTableFunction {
    * @return strategy to infer the row type of a call to this function
    */
   SqlReturnTypeInference getRowTypeInference();
+
+  /**
+   * Returns the table parameter characteristics for <code>ordinal</code>th argument to this
+   * table function.
+   *
+   * <p>Returns <code>Optional.empty</code> if the <code>ordinal</code>th argument is not table
+   * parameter.
+   */
+  default @Nullable TableCharacteristic tableCharacteristic(int ordinal) {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/TableCharacteristic.java
+++ b/core/src/main/java/org/apache/calcite/sql/TableCharacteristic.java
@@ -21,14 +21,139 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.Objects;
 
 /**
- * An input table of table function is classified by three characteristics.
+ * A table-valued input parameter of a table function is classified by three
+ * characteristics.
  * <ul>
- * <li>The first characteristic is semantics. The table has either row semantics or set semantics.
+ * <li>The first characteristic is semantics. The table has either
+ * row semantics or set semantics.
+ * <p>Row semantics means that the the result of the PTF is decided on a
+ * row-by-row basis.
  *
- * <li>The second characteristic only applies to input table with set semantics. It specifies
- * whether the table function can generate a result row even if the input table is empty.
+ * Example of PTF with row semantics input table parameter:
+ * We often need to read a CSV file, generally, the first line of the file
+ * contains a list of column names, and subsequent lines of the file contain
+ * data. The data in general can be treated as a large VARCHAR.
+ * However, some of the fields may be numeric or datetime.
+ * A PTF named CSVreader is designed to read a file of comma-separated values
+ * and interpret this file as a table.
  *
- * <li>The third characteristic is whether the input table supports pass-through columns or not.
+ * CSVreader function has three parameters:
+ * 1. The first parameter, File, is the name of a file on the query author's
+ * system. This file must contain the comma-separated values that are to be
+ * converted to a table. The first line of the file contains the names of
+ * the resulting columns. Succeeding lines contain the data. Each line after
+ * the first will result in one row of output, with column names as determined
+ * by the first line of the input.
+ * 2. Floats is a PTF descriptor area, which should provide a list of the
+ * column names that are to be interpreted numerically.
+ * These columns will be output with the data type FLOAT.
+ * 3. Dates is a PTF descriptor area, which provides a list of the column
+ * names that are to be interpreted as datetimes.
+ * These columns will be output with the data type DATE.
+ *
+ * How to use this PTF in query?
+ *
+ * For a csv file which contents are:
+ * docno,name,due_date,principle,interest
+ * 123,Mary,01/01/2014,234.56,345.67
+ * 234,Edgar,01/01/2014,654.32,543.21
+ *
+ * the query author may write a query such as the following:
+ *
+ * SELECT *
+ * FROM TABLE (
+ *   CSVreader (
+ *   'abc.csv',
+ *   DESCRIPTOR ("principle", "interest")
+ *   DESCRIPTOR ("due_date")))
+ *
+ * The result will be:
+ * +---------+--------+--------------+-------------+------------+
+ * |  docno  |  name  |  due_date    |  principle  |  interest  |
+ * +---------+--------+--------------+-------------+------------+
+ * |  123    |  Mary  |  01/01/2014  |  234.56     |  345.67    |
+ * +---------+--------+--------------+-------------+------------+
+ * |  234    |  Edgar |  01/01/2014  |  654.32     |  543.21    |
+ * +---------+--------+--------------+-------------+------------+
+ *
+ * <p>Set semantics means that the outcome of the function depends on how
+ * the data is partitioned. Set semantics is useful to implement user-defined
+ * analytics like aggregation or window functions.
+ * They operate on an entire table or a logical partition of it.
+ *
+ * Example of PTF with set semantics input table parameter:
+ * TopN takes an input table that has been sorted on a numeric column.
+ * It copies the first n rows through to the output table. Any additional
+ * rows are summarized in a single output row in which the sort column has
+ * been summed and all other columns are null.
+ *
+ * TopN has two parameters:
+ * 1. The first parameter, Input, is the input table. This table has set semantics, meaning that the
+ * result depends on the set of data (since the last row is a summary row). In addition, the
+ * table is marked as PRUNE WHEN EMPTY, meaning that the result is necessarily empty if the input
+ * is empty. The query author must order this input table on a single numeric column (syntax below).
+ * 2. The second parameter, Howmany, specifies how many input rows that the user wants to be copied
+ * into the output table; all rows after this will contribute to the final summary row in the
+ * output.
+ *
+ * How to use this PTF in query?
+ *
+ * Original records of table orders are:
+ * +---------+----------+-----------+
+ * | region  | product  |  sales    |
+ * +---------+----------+-----------+
+ * |  East   |    A     |  1234.56  |
+ * +---------+----------+-----------+
+ * |  East   |    B     |   987.65  |
+ * +---------+----------+-----------+
+ * |  East   |    C     |   876.54  |
+ * +---------+----------+-----------+
+ * |  East   |    D     |   765.43  |
+ * +---------+----------+-----------+
+ * |  East   |    E     |   654.32  |
+ * +---------+----------+-----------+
+ * |  West   |    E     |  2345.67  |
+ * +---------+----------+-----------+
+ * |  West   |    D     |  2001.33  |
+ * +---------+----------+-----------+
+ * |  West   |    C     |  1357.99  |
+ * +---------+----------+-----------+
+ * |  West   |    B     |   975.35  |
+ * +---------+----------+-----------+
+ * |  West   |    A     |   864,22  |
+ * +---------+----------+-----------+
+ *
+ * the query author may write a query such as the following:
+ *
+ * SELECT *
+ * FROM TABLE(
+ *   Topn(
+ *     TABLE orders PARTITION BY region ORDER BY sales desc,
+ *     3))
+ *
+ * The result will be:
+ * +---------+----------+-----------+
+ * | region  | product  |  sales    |
+ * +---------+----------+-----------+
+ * |  East   |    A     |  1234.56  |
+ * +---------+----------+-----------+
+ * |  East   |    B     |   987.65  |
+ * +---------+----------+-----------+
+ * |  East   |    C     |   876.54  |
+ * +---------+----------+-----------+
+ * |  West   |    E     |  2345.67  |
+ * +---------+----------+-----------+
+ * |  West   |    D     |  2001.33  |
+ * +---------+----------+-----------+
+ * |  West   |    C     |  1357.99  |
+ * +---------+----------+-----------+
+ *
+ * <li>The second characteristic only applies to input table with
+ * set semantics. It specifies whether the table function can generate
+ * a result row even if the input table is empty.
+ *
+ * <li>The third characteristic is whether the input table supports
+ * pass-through columns or not.
  * </ul>
  */
 public class TableCharacteristic {
@@ -39,17 +164,18 @@ public class TableCharacteristic {
   public final Semantics semantics;
 
   /**
-   * If the value is true, meaning that the DBMS can prune virtual processors from the query plan
-   * if the input table is empty.
-   * If the value is false, meaning that the DBMS must actually instantiate a virtual processor
-   * (or more than one virtual processor in the presence of other input tables).
+   * If the value is true, meaning that the DBMS can prune virtual processors
+   * from the query plan if the input table is empty.
+   * If the value is false, meaning that the DBMS must actually instantiate
+   * a virtual processor (or more than one virtual processor in the presence
+   * of other input tables).
    */
   public final boolean pruneIfEmpty;
 
   /**
-   * If the value is true, for each input row, the PTF makes the entire input row available in
-   * the output, qualified by a range variable associated with the input table. Otherwise the
-   * value is false.
+   * If the value is true, for each input row, the PTF makes the entire input
+   * row available in the output, qualified by a range variable associated
+   * with the input table. Otherwise the value is false.
    */
   public final boolean passColumnsThrough;
 
@@ -103,18 +229,19 @@ public class TableCharacteristic {
    */
   public enum Semantics {
     /**
-     * Row semantics means that the the result of the Window TableFunction is decided on a
-     * row-by-row basis.
-     * As an extreme example, the DBMS could atomize the input table into individual rows, and
-     * send each single row to a different virtual processor.
+     * Row semantics means that the the result of the Window TableFunction
+     * is decided on a row-by-row basis.
+     * As an extreme example, the DBMS could atomize the input table into
+     * individual rows, and send each single row to a different virtual
+     * processor.
      */
     ROW,
 
     /**
-     * Set semantics means that the outcome of the Window TableFunction depends on how the data
-     * is partitioned.
-     * A partition may not be split across virtual processors, nor may a virtual processor handle
-     * more than one partition.
+     * Set semantics means that the outcome of the Window TableFunction
+     * depends on how the data is partitioned.
+     * A partition may not be split across virtual processors, nor may a
+     * virtual processor handle more than one partition.
      */
     SET
   }

--- a/core/src/main/java/org/apache/calcite/sql/TableCharacteristic.java
+++ b/core/src/main/java/org/apache/calcite/sql/TableCharacteristic.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+/**
+ * An input table of table function is classified by three characteristics.
+ * <ul>
+ * <li>The first characteristic is semantics. The table has either row semantics or set semantics.
+ *
+ * <li>The second characteristic only applies to input table with set semantics. It specifies
+ * whether the table function can generate a result row even if the input table is empty.
+ *
+ * <li>The third characteristic is whether the input table supports pass-through columns or not.
+ * </ul>
+ */
+public class TableCharacteristic {
+
+  /**
+   * Input table has either row semantics or set semantics.
+   */
+  public final Semantics semantics;
+
+  /**
+   * If the value is true, meaning that the DBMS can prune virtual processors from the query plan
+   * if the input table is empty.
+   * If the value is false, meaning that the DBMS must actually instantiate a virtual processor
+   * (or more than one virtual processor in the presence of other input tables).
+   */
+  public final boolean pruneIfEmpty;
+
+  /**
+   * If the value is true, for each input row, the PTF makes the entire input row available in
+   * the output, qualified by a range variable associated with the input table. Otherwise the
+   * value is false.
+   */
+  public final boolean passColumnsThrough;
+
+  private TableCharacteristic(
+      Semantics semantics,
+      boolean pruneIfEmpty,
+      boolean passColumnsThrough) {
+    this.semantics = semantics;
+    this.pruneIfEmpty = pruneIfEmpty;
+    this.passColumnsThrough = passColumnsThrough;
+  }
+
+  public static TableCharacteristic withRowSemantic(boolean columnsPassThrough) {
+    // Tables with row semantics are always effectively prune when empty.
+    return new TableCharacteristic(Semantics.ROW, true, columnsPassThrough);
+  }
+
+  public static TableCharacteristic withSetSemantic(
+      boolean pruneIfEmpty,
+      boolean columnsPassThrough) {
+    return new TableCharacteristic(Semantics.SET, pruneIfEmpty, columnsPassThrough);
+  }
+
+  @Override public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableCharacteristic that = (TableCharacteristic) o;
+    return pruneIfEmpty == that.pruneIfEmpty
+        && passColumnsThrough == that.passColumnsThrough
+        && semantics == that.semantics;
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(semantics, pruneIfEmpty, passColumnsThrough);
+  }
+
+  @Override public String toString() {
+    return "TableCharacteristic{"
+        + "semantics=" + semantics
+        + ", pruneIfEmpty=" + pruneIfEmpty
+        + ", passColumnsThrough=" + passColumnsThrough
+        + '}';
+  }
+
+  /**
+   * Input table has either row semantics or set semantics.
+   */
+  public enum Semantics {
+    /**
+     * Row semantics means that the the result of the Window TableFunction is decided on a
+     * row-by-row basis.
+     * As an extreme example, the DBMS could atomize the input table into individual rows, and
+     * send each single row to a different virtual processor.
+     */
+    ROW,
+
+    /**
+     * Set semantics means that the outcome of the Window TableFunction depends on how the data
+     * is partitioned.
+     * A partition may not be split across virtual processors, nor may a virtual processor handle
+     * more than one partition.
+     */
+    SET
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/TableCharacteristic.java
+++ b/core/src/main/java/org/apache/calcite/sql/TableCharacteristic.java
@@ -269,19 +269,9 @@ public class TableCharacteristic {
     this.passColumnsThrough = passColumnsThrough;
   }
 
-  public static TableCharacteristic withRowSemantic(
-      boolean columnsPassThrough) {
-    // Tables with row semantics are always effectively prune when empty.
-    return new TableCharacteristic(Semantics.ROW, true, columnsPassThrough);
-  }
-
-  public static TableCharacteristic withSetSemantic(
-      boolean pruneIfEmpty,
-      boolean columnsPassThrough) {
-    return new TableCharacteristic(
-        Semantics.SET,
-        pruneIfEmpty,
-        columnsPassThrough);
+  /** Creates a builder. */
+  public static TableCharacteristic.Builder builder(Semantics semantics) {
+    return new Builder(semantics);
   }
 
   @Override public boolean equals(@Nullable Object o) {
@@ -329,5 +319,39 @@ public class TableCharacteristic {
      * virtual processor handle more than one partition.
      */
     SET
+  }
+
+  /**
+   * Builder for {@link TableCharacteristic}.
+   */
+  public static class Builder {
+    private final Semantics semantics;
+    private boolean pruneIfEmpty = false;
+    private boolean passColumnsThrough = false;
+
+    /** Creates the semantics. */
+    private Builder(Semantics semantics) {
+      if (semantics == Semantics.ROW) {
+        // Tables with row semantics are always effectively prune when empty.
+        this.pruneIfEmpty = true;
+      }
+      this.semantics = semantics;
+    }
+
+    /** DBMS could prune virtual processors if the input table is empty. */
+    public Builder pruneIfEmpty() {
+      this.pruneIfEmpty = true;
+      return this;
+    }
+
+    /** Input table supports pass-through columns. */
+    public Builder passColumnsThrough() {
+      this.passColumnsThrough = true;
+      return this;
+    }
+
+    public TableCharacteristic build() {
+      return new TableCharacteristic(semantics, pruneIfEmpty, passColumnsThrough);
+    }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -47,6 +47,7 @@ import org.apache.calcite.sql.SqlRankFunction;
 import org.apache.calcite.sql.SqlSampleSpec;
 import org.apache.calcite.sql.SqlSessionTableFunction;
 import org.apache.calcite.sql.SqlSetOperator;
+import org.apache.calcite.sql.SqlSetSemanticsTableOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlTumbleTableFunction;
@@ -2562,6 +2563,9 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           writer.endList(frame);
         }
       };
+
+  /** SetSemanticsTable represents as an input table with set semantics. */
+  public static final SqlSpecialOperator SET_SEMANTICS_TABLE = new SqlSetSemanticsTableOperator();
 
   //~ Methods ----------------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -2565,7 +2565,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       };
 
   /** SetSemanticsTable represents as an input table with set semantics. */
-  public static final SqlSpecialOperator SET_SEMANTICS_TABLE = new SqlSetSemanticsTableOperator();
+  public static final SqlInternalOperator SET_SEMANTICS_TABLE = new SqlSetSemanticsTableOperator();
 
   //~ Methods ----------------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -80,6 +80,7 @@ import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.sql.SqlWindowTableFunction;
 import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
+import org.apache.calcite.sql.TableCharacteristic;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -3377,6 +3378,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     case UNNEST:
       validateUnnest((SqlCall) node, scope, targetRowType);
       break;
+    case COLLECTION_TABLE:
+      validateTableFunction((SqlCall) node, scope, targetRowType);
+      break;
     default:
       validateQuery(node, scope, targetRowType);
       break;
@@ -3385,6 +3389,66 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // Validate the namespace representation of the node, just in case the
     // validation did not occur implicitly.
     getNamespaceOrThrow(node, scope).validate(targetRowType);
+  }
+
+  protected void validateTableFunction(SqlCall node, SqlValidatorScope scope,
+      RelDataType targetRowType) {
+    // Dig out real call; TABLE() wrapper is just syntactic.
+    SqlCall call = node.operand(0);
+    if (call.getOperator() instanceof SqlTableFunction) {
+      SqlTableFunction tableFunction = (SqlTableFunction) call.getOperator();
+      boolean visitedRowSemanticsTable = false;
+      for (int idx = 0; idx < call.operandCount(); idx++) {
+        TableCharacteristic tableCharacteristic = tableFunction.tableCharacteristic(idx);
+        if (tableCharacteristic != null) {
+          // Skip validate if current input table has set semantics
+          if (tableCharacteristic.semantics == TableCharacteristic.Semantics.SET) {
+            continue;
+          }
+          // A table function at most has one input table with row semantics
+          if (visitedRowSemanticsTable) {
+            throw newValidationError(
+                call,
+                RESOURCE.multipleRowSemanticsTables(call.getOperator().getName()));
+          }
+          visitedRowSemanticsTable = true;
+        }
+        // If table function defines the parameter is not table parameter, or is an input table
+        // parameter with row semantics, then it should not be with PARTITION BY OR ORDER BY.
+        SqlNode currentNode = call.operand(idx);
+        if (currentNode instanceof SqlCall) {
+          final SqlOperator op = ((SqlCall) currentNode).getOperator();
+          if (op == SqlStdOperatorTable.SET_SEMANTICS_TABLE) {
+            throwInvalidRowSemanticsTable(call, idx, (SqlCall) currentNode);
+          } else if (op == SqlStdOperatorTable.ARGUMENT_ASSIGNMENT) {
+            // Dig out the underlying operand
+            SqlNode realNode = ((SqlBasicCall) currentNode).operand(0);
+            if (realNode instanceof SqlCall) {
+              final SqlOperator realOp = ((SqlCall) realNode).getOperator();
+              if (realOp == SqlStdOperatorTable.SET_SEMANTICS_TABLE) {
+                throwInvalidRowSemanticsTable(call, idx, (SqlCall) realNode);
+              }
+            }
+          }
+        }
+      }
+    }
+    validateQuery(node, scope, targetRowType);
+  }
+
+  private void throwInvalidRowSemanticsTable(SqlCall call, int idx, SqlCall table) {
+    SqlNodeList partitionList = table.operand(1);
+    if (!partitionList.isEmpty()) {
+      throw newValidationError(call,
+          RESOURCE.invalidPartitionKeys(
+              idx, call.getOperator().getName()));
+    }
+    SqlNodeList orderList = table.operand(2);
+    if (!orderList.isEmpty()) {
+      throw newValidationError(call,
+          RESOURCE.invalidOrderBy(
+              idx, call.getOperator().getName()));
+    }
   }
 
   protected void validateOver(SqlCall call, SqlValidatorScope scope) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3417,18 +3417,17 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
         // parameter with row semantics, then it should not be with PARTITION BY OR ORDER BY.
         SqlNode currentNode = call.operand(idx);
         if (currentNode instanceof SqlCall) {
-          final SqlOperator op = ((SqlCall) currentNode).getOperator();
-          if (op == SqlStdOperatorTable.SET_SEMANTICS_TABLE) {
-            throwInvalidRowSemanticsTable(call, idx, (SqlCall) currentNode);
-          } else if (op == SqlStdOperatorTable.ARGUMENT_ASSIGNMENT) {
+          SqlOperator op = ((SqlCall) currentNode).getOperator();
+          if (op == SqlStdOperatorTable.ARGUMENT_ASSIGNMENT) {
             // Dig out the underlying operand
             SqlNode realNode = ((SqlBasicCall) currentNode).operand(0);
             if (realNode instanceof SqlCall) {
-              final SqlOperator realOp = ((SqlCall) realNode).getOperator();
-              if (realOp == SqlStdOperatorTable.SET_SEMANTICS_TABLE) {
-                throwInvalidRowSemanticsTable(call, idx, (SqlCall) realNode);
-              }
+              currentNode = realNode;
+              op = ((SqlCall) realNode).getOperator();
             }
+          }
+          if (op == SqlStdOperatorTable.SET_SEMANTICS_TABLE) {
+            throwInvalidRowSemanticsTable(call, idx, (SqlCall) currentNode);
           }
         }
       }

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rel.core.Uncollect;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalCalc;
 import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalExchange;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalIntersect;
 import org.apache.calcite.rel.logical.LogicalJoin;
@@ -43,6 +44,7 @@ import org.apache.calcite.rel.logical.LogicalMinus;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSnapshot;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalSortExchange;
 import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
 import org.apache.calcite.rel.logical.LogicalTableModify;
 import org.apache.calcite.rel.logical.LogicalUnion;
@@ -590,6 +592,14 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
 
   public void rewriteRel(SelfFlatteningRel rel) {
     rel.flattenRel(this);
+  }
+
+  public void rewriteRel(LogicalExchange rel) {
+    rewriteGeneric(rel);
+  }
+
+  public void rewriteRel(LogicalSortExchange rel) {
+    rewriteGeneric(rel);
   }
 
   public void rewriteGeneric(RelNode rel) {

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1377,42 +1377,60 @@ public class SqlToRelConverter {
       if (!config.isExpand()) {
         return;
       }
-      call = (SqlBasicCall) subQuery.node;
-      query = call.operand(0);
-      final SqlValidatorScope innerTableScope =
-          (query instanceof SqlSelect)
-              ? validator().getSelectScope((SqlSelect) query)
-              : null;
-      final Blackboard setSemanticsTableBb = createBlackboard(innerTableScope, null, false);
-      final RelNode inputOfSetSemanticsTable = convertQueryRecursive(query, false, null).project();
-      requireNonNull(inputOfSetSemanticsTable, () -> "input RelNode is null for query " + query);
-      SqlNodeList partitionList = call.operand(1);
-      final ImmutableBitSet partitionKeys = buildPartitionKeys(setSemanticsTableBb, partitionList);
-      // For set semantics table, distribution is singleton if does not specify partition keys
-      RelDistribution distribution = partitionKeys.isEmpty()
-          ? RelDistributions.SINGLETON
-          : RelDistributions.hash(partitionKeys.asList());
-      // ORDER BY
-      final SqlNodeList orderList = call.operand(2);
-      final RelCollation orders = buildCollation(setSemanticsTableBb, orderList);
-      relBuilder.push(inputOfSetSemanticsTable);
-      if (orderList.isEmpty()) {
-        relBuilder.exchange(distribution);
-      } else {
-        relBuilder.sortExchange(distribution, orders);
-      }
-      RelNode tableRel = relBuilder.build();
-      subQuery.expr = bb.register(tableRel, JoinRelType.LEFT);
-      // This is used when converting window table functions:
-      //
-      // select * from table(tumble(table emps, descriptor(deptno), interval '3' DAY))
-      //
-      bb.cursors.add(tableRel);
+      substituteSubQueryOfSetSemanticsInputTable(bb, subQuery);
       return;
     default:
       throw new AssertionError("unexpected kind of sub-query: "
           + subQuery.node);
     }
+  }
+
+  private void substituteSubQueryOfSetSemanticsInputTable(
+      Blackboard bb,
+      SubQuery subQuery) {
+    SqlBasicCall call;
+    SqlNode query;
+    call = (SqlBasicCall) subQuery.node;
+    query = call.operand(0);
+    final SqlValidatorScope innerTableScope =
+        (query instanceof SqlSelect)
+            ? validator().getSelectScope((SqlSelect) query)
+            : null;
+    final Blackboard setSemanticsTableBb = createBlackboard(
+        innerTableScope, null, false);
+    final RelNode inputOfSetSemanticsTable = convertQueryRecursive(
+        query, false, null).project();
+    requireNonNull(
+        inputOfSetSemanticsTable,
+        () -> "input RelNode is null for query " + query);
+    SqlNodeList partitionList = call.operand(1);
+    final ImmutableBitSet partitionKeys = buildPartitionKeys(
+        setSemanticsTableBb,
+        partitionList);
+    // For set semantics table, distribution is singleton if does not specify
+    // partition keys
+    RelDistribution distribution = partitionKeys.isEmpty()
+        ? RelDistributions.SINGLETON
+        : RelDistributions.hash(partitionKeys.asList());
+    // ORDER BY
+    final SqlNodeList orderList = call.operand(2);
+    final RelCollation orders = buildCollation(
+        setSemanticsTableBb,
+        orderList);
+    relBuilder.push(inputOfSetSemanticsTable);
+    if (orderList.isEmpty()) {
+      relBuilder.exchange(distribution);
+    } else {
+      relBuilder.sortExchange(distribution, orders);
+    }
+    RelNode tableRel = relBuilder.build();
+    subQuery.expr = bb.register(tableRel, JoinRelType.LEFT);
+    // This is used when converting window table functions:
+    //
+    // select * from table(tumble(table emps, descriptor(deptno),
+    // interval '3' DAY))
+    //
+    bb.cursors.add(tableRel);
   }
 
   private ImmutableBitSet buildPartitionKeys(Blackboard bb, SqlNodeList partitionList) {

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -32,6 +32,8 @@ import org.apache.calcite.prepare.RelOptTableImpl;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
@@ -1371,10 +1373,95 @@ public class SqlToRelConverter {
       //
       bb.cursors.add(converted.r);
       return;
-
+    case SET_SEMANTICS_TABLE:
+      if (!config.isExpand()) {
+        return;
+      }
+      call = (SqlBasicCall) subQuery.node;
+      query = call.operand(0);
+      final SqlValidatorScope innerTableScope =
+          (query instanceof SqlSelect)
+              ? validator().getSelectScope((SqlSelect) query)
+              : null;
+      final Blackboard setSemanticsTableBb = createBlackboard(innerTableScope, null, false);
+      final RelNode inputOfSetSemanticsTable = convertQueryRecursive(query, false, null).project();
+      requireNonNull(inputOfSetSemanticsTable, () -> "input RelNode is null for query " + query);
+      SqlNodeList partitionList = call.operand(1);
+      final ImmutableBitSet partitionKeys = buildPartitionKeys(setSemanticsTableBb, partitionList);
+      // For set semantics table, distribution is singleton if does not specify partition keys
+      RelDistribution distribution = partitionKeys.isEmpty()
+          ? RelDistributions.SINGLETON
+          : RelDistributions.hash(partitionKeys.asList());
+      // ORDER BY
+      final SqlNodeList orderList = call.operand(2);
+      final RelCollation orders = buildCollation(setSemanticsTableBb, orderList);
+      relBuilder.push(inputOfSetSemanticsTable);
+      if (orderList.isEmpty()) {
+        relBuilder.exchange(distribution);
+      } else {
+        relBuilder.sortExchange(distribution, orders);
+      }
+      RelNode tableRel = relBuilder.build();
+      subQuery.expr = bb.register(tableRel, JoinRelType.LEFT);
+      // This is used when converting window table functions:
+      //
+      // select * from table(tumble(table emps, descriptor(deptno), interval '3' DAY))
+      //
+      bb.cursors.add(tableRel);
+      return;
     default:
       throw new AssertionError("unexpected kind of sub-query: "
           + subQuery.node);
+    }
+  }
+
+  private ImmutableBitSet buildPartitionKeys(Blackboard bb, SqlNodeList partitionList) {
+    final ImmutableBitSet.Builder partitionKeys = ImmutableBitSet.builder();
+    for (SqlNode partition : partitionList) {
+      validator().deriveType(bb.scope(), partition);
+      RexNode e = bb.convertExpression(partition);
+      partitionKeys.set(parseFieldIdx(e));
+    }
+    return partitionKeys.build();
+  }
+
+  private RelCollation buildCollation(Blackboard bb, SqlNodeList orderList) {
+    final List<RelFieldCollation> orderKeys = new ArrayList<>();
+    for (SqlNode order : orderList) {
+      final RelFieldCollation.Direction direction;
+      switch (order.getKind()) {
+      case DESCENDING:
+        direction = RelFieldCollation.Direction.DESCENDING;
+        order = ((SqlCall) order).operand(0);
+        break;
+      case NULLS_FIRST:
+      case NULLS_LAST:
+        throw new AssertionError();
+      default:
+        direction = RelFieldCollation.Direction.ASCENDING;
+        break;
+      }
+      final RelFieldCollation.NullDirection nullDirection =
+          validator().config().defaultNullCollation().last(desc(direction))
+              ? RelFieldCollation.NullDirection.LAST
+              : RelFieldCollation.NullDirection.FIRST;
+      RexNode e = bb.convertExpression(order);
+      orderKeys.add(
+          new RelFieldCollation(parseFieldIdx(e), direction, nullDirection));
+    }
+    return cluster.traitSet().canonize(RelCollations.of(orderKeys));
+  }
+
+  private static int parseFieldIdx(RexNode e) {
+    switch (e.getKind()) {
+    case FIELD_ACCESS:
+      final RexFieldAccess f = (RexFieldAccess) e;
+      return f.getField().getIndex();
+    case INPUT_REF:
+      final RexInputRef ref = (RexInputRef) e;
+      return ref.getIndex();
+    default:
+      throw new AssertionError();
     }
   }
 
@@ -1889,6 +1976,7 @@ public class SqlToRelConverter {
     case ARRAY_QUERY_CONSTRUCTOR:
     case MAP_QUERY_CONSTRUCTOR:
     case CURSOR:
+    case SET_SEMANTICS_TABLE:
     case SCALAR_QUERY:
       if (!registerOnlyScalarSubQueries
           || (kind == SqlKind.SCALAR_QUERY)) {
@@ -2329,39 +2417,11 @@ public class SqlToRelConverter {
 
     // PARTITION BY
     final SqlNodeList partitionList = matchRecognize.getPartitionList();
-    final ImmutableBitSet.Builder partitionKeys = ImmutableBitSet.builder();
-    for (SqlNode partition : partitionList) {
-      RexNode e = matchBb.convertExpression(partition);
-      partitionKeys.set(((RexInputRef) e).getIndex());
-    }
+    final ImmutableBitSet partitionKeys = buildPartitionKeys(matchBb, partitionList);
 
     // ORDER BY
     final SqlNodeList orderList = matchRecognize.getOrderList();
-    final List<RelFieldCollation> orderKeys = new ArrayList<>();
-    for (SqlNode order : orderList) {
-      final RelFieldCollation.Direction direction;
-      switch (order.getKind()) {
-      case DESCENDING:
-        direction = RelFieldCollation.Direction.DESCENDING;
-        order = ((SqlCall) order).operand(0);
-        break;
-      case NULLS_FIRST:
-      case NULLS_LAST:
-        throw new AssertionError();
-      default:
-        direction = RelFieldCollation.Direction.ASCENDING;
-        break;
-      }
-      final RelFieldCollation.NullDirection nullDirection =
-          validator().config().defaultNullCollation().last(desc(direction))
-              ? RelFieldCollation.NullDirection.LAST
-              : RelFieldCollation.NullDirection.FIRST;
-      RexNode e = matchBb.convertExpression(order);
-      orderKeys.add(
-          new RelFieldCollation(((RexInputRef) e).getIndex(), direction,
-              nullDirection));
-    }
-    final RelCollation orders = cluster.traitSet().canonize(RelCollations.of(orderKeys));
+    final RelCollation orders = buildCollation(matchBb, orderList);
 
     // convert pattern
     final Set<String> patternVarsSet = new HashSet<>();
@@ -2473,7 +2533,7 @@ public class SqlToRelConverter {
             rowType, matchRecognize.getStrictStart().booleanValue(),
             matchRecognize.getStrictEnd().booleanValue(),
             definitionNodes.build(), measureNodes.build(), after, subsetMap,
-            allRows, partitionKeys.build(), orders, intervalNode);
+            allRows, partitionKeys, orders, intervalNode);
     bb.setRoot(rel, false);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -93,7 +93,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.apache.calcite.sql.SqlKind.SET_SEMANTICS_TABLE;
 import static org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow;
 
 import static java.util.Objects.requireNonNull;
@@ -966,7 +965,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       // skip set semantic table node of table function
       operandList =
           call.getOperandList().stream().filter(
-              operand -> operand.getKind() != SET_SEMANTICS_TABLE).collect(Collectors.toList());
+              operand -> operand.getKind() != SqlKind.SET_SEMANTICS_TABLE)
+              .collect(Collectors.toList());
     } else {
       operandList = call.getOperandList();
     }

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -49,6 +49,7 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlTableFunction;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWindowTableFunction;
 import org.apache.calcite.sql.fun.SqlArrayValueConstructor;
@@ -90,7 +91,9 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import static org.apache.calcite.sql.SqlKind.SET_SEMANTICS_TABLE;
 import static org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow;
 
 import static java.util.Objects.requireNonNull;
@@ -958,7 +961,16 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
 
   private static List<RexNode> convertOperands(SqlRexContext cx,
       SqlCall call, SqlOperandTypeChecker.Consistency consistency) {
-    return convertOperands(cx, call, call.getOperandList(), consistency);
+    List<SqlNode> operandList;
+    if (call.getOperator() instanceof SqlTableFunction) {
+      // skip set semantic table node of table function
+      operandList =
+          call.getOperandList().stream().filter(
+              operand -> operand.getKind() != SET_SEMANTICS_TABLE).collect(Collectors.toList());
+    } else {
+      operandList = call.getOperandList();
+    }
+    return convertOperands(cx, call, operandList, consistency);
   }
 
   private static List<RexNode> convertOperands(SqlRexContext cx,

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -319,4 +319,7 @@ InvalidInputForExtractXml=Invalid input for EXTRACT xpath: ''{0}'', namespace: '
 InvalidInputForExistsNode=Invalid input for EXISTSNODE xpath: ''{0}'', namespace: ''{1}''
 DifferentLengthForBitwiseOperands=Different length for bitwise operands: the first: {0,number,#}, the second: {1,number,#}
 NoOperator=No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization
+InvalidPartitionKeys=Only tables with set semantics may be partitioned. Invalid PARTITION BY clause in the {0,number,#}-th operand of table function ''{1}''
+InvalidOrderBy=Only tables with set semantics may be ordered. Invalid ORDER BY clause in the {0,number,#}-th operand of table function ''{1}''
+MultipleRowSemanticsTables=A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics
 # End CalciteResource.properties

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -318,8 +318,8 @@ InvalidInputForExtractValue=Invalid input for EXTRACTVALUE: xml: ''{0}'', xpath 
 InvalidInputForExtractXml=Invalid input for EXTRACT xpath: ''{0}'', namespace: ''{1}''
 InvalidInputForExistsNode=Invalid input for EXISTSNODE xpath: ''{0}'', namespace: ''{1}''
 DifferentLengthForBitwiseOperands=Different length for bitwise operands: the first: {0,number,#}, the second: {1,number,#}
-NoOperator=No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization
 InvalidPartitionKeys=Only tables with set semantics may be partitioned. Invalid PARTITION BY clause in the {0,number,#}-th operand of table function ''{1}''
 InvalidOrderBy=Only tables with set semantics may be ordered. Invalid ORDER BY clause in the {0,number,#}-th operand of table function ''{1}''
 MultipleRowSemanticsTables=A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics
+NoOperator=No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization
 # End CalciteResource.properties

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2284,6 +2284,24 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test void testTableFunctionWithMultipleInputTables() {
+    final String sql = "select *\n"
+        + "from table(\n"
+        + "similarlity(\n"
+        + "  table emp partition by deptno order by empno nulls first,\n"
+        + "  table emp_b partition by deptno order by empno nulls first))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithMultipleInputTablesWithParamNames() {
+    final String sql = "select *\n"
+        + "from table(\n"
+        + "similarlity(\n"
+        + "  LTABLE => table emp partition by deptno order by empno nulls first,\n"
+        + "  RTABLE => table emp_b partition by deptno order by empno nulls first))";
+    sql(sql).ok();
+  }
+
   @Test void testNotNotIn() {
     final String sql = "select * from EMP where not (ename not in ('Fred') )";
     sql(sql).ok();

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2217,6 +2217,66 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test void testTableFunctionWithPartitionKey() {
+    final String sql = "select *\n"
+        + "from table(topn(table orders partition by productid, 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithMultiplePartitionKeys() {
+    final String sql = "select *\n"
+        + "from table(topn(table orders partition by (orderId, productid), 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithOrderKey() {
+    final String sql = "select *\n"
+        + "from table(topn(table orders order by orderId, 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithMultipleOrderKeys() {
+    final String sql = "select *\n"
+        + "from table(topn(table orders order by (orderId, productid), 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithComplexOrderBy() {
+    final String sql = "select *\n"
+        + "from table(topn(table orders order by (orderId desc, productid desc), 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithPartitionKeyAndOrderKey() {
+    final String sql = "select *\n"
+        + "from table(topn(table orders partition by productid order by orderId, 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithParamNames() {
+    final String sql = "select *\n"
+        + "from table(\n"
+        + "topn(\n"
+        + "  DATA => table orders partition by productid order by orderId,\n"
+        + "  COL => 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithSubQuery() {
+    final String sql = "select *\n"
+        + "from table(topn(select * from orders partition by productid order by orderId, 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithSubQueryWithParamNames() {
+    final String sql = "select *\n"
+        + "from table(\n"
+        + "topn(\n"
+        + "  DATA => select * from orders partition by productid order by orderId,\n"
+        + "  COL => 3))";
+    sql(sql).ok();
+  }
+
   @Test void testNotNotIn() {
     final String sql = "select * from EMP where not (ename not in ('Fred') )";
     sql(sql).ok();

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2243,7 +2243,13 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
 
   @Test void testTableFunctionWithComplexOrderBy() {
     final String sql = "select *\n"
-        + "from table(topn(table orders order by (orderId desc, productid desc), 3))";
+        + "from table(topn(table orders order by (orderId desc, productid desc nulls last), 3))";
+    sql(sql).ok();
+  }
+
+  @Test void testTableFunctionWithOrderByWithNullLast() {
+    final String sql = "select *\n"
+        + "from table(topn(table orders order by orderId desc nulls last, 3))";
     sql(sql).ok();
   }
 
@@ -2264,7 +2270,8 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
 
   @Test void testTableFunctionWithSubQuery() {
     final String sql = "select *\n"
-        + "from table(topn(select * from orders partition by productid order by orderId, 3))";
+        + "from table(topn("
+        + "select * from orders partition by productid order by orderId desc nulls last, 3))";
     sql(sql).ok();
   }
 
@@ -2272,7 +2279,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     final String sql = "select *\n"
         + "from table(\n"
         + "topn(\n"
-        + "  DATA => select * from orders partition by productid order by orderId,\n"
+        + "  DATA => select * from orders partition by productid order by orderId nulls first,\n"
         + "  COL => 3))";
     sql(sql).ok();
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1564,6 +1564,50 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("No match found for function signature FOO..");
   }
 
+  @Test void testInvalidTableFunction() {
+    // A table function at most have one input table with row semantics
+    sql("select * from table(^invalid(table orders, table emp)^)")
+        .fails("A table function at most has one input table with row semantics."
+            + " Table function 'INVALID' has multiple input tables with row semantics");
+    // Only tables with set semantics may be partitioned
+    sql("select * from table(^score(table orders partition by productid)^)")
+        .fails("Only tables with set semantics may be partitioned."
+            + " Invalid PARTITION BY clause in the 0-th operand of table function 'SCORE'");
+    // Only tables with set semantics may be ordered
+    sql("select * from table(^score(table orders order by orderId)^)")
+        .fails("Only tables with set semantics may be ordered."
+            + " Invalid ORDER BY clause in the 0-th operand of table function 'SCORE'");
+  }
+
+  @Test void testTableFunctionWithTableParam() {
+    // test input table with row semantic
+    sql("select * from table(score(table orders))").ok();
+    // test no partition by clause and order by clause for input table with set semantic
+    sql("select * from table(topn(table orders, 3))").ok();
+    // test one partition key for input table with set semantic
+    sql("select * from table(topn(table orders partition by productid, 3))")
+        .ok();
+    // test multiple partition keys for input table with set semantic
+    sql("select * from table(topn(table orders partition by (orderId, productid), 3))")
+        .ok();
+    // test one order key for input table with set semantic
+    sql("select * from table(topn(table orders order by orderId, 3))")
+        .ok();
+    // test multiple order keys for input table with set semantic
+    sql("select * from table(topn(table orders order by (orderId, productid), 3))")
+        .ok();
+    // test complex order-by clause for input table with set semantic
+    sql("select * from table(topn(table orders order by (orderId desc, productid asc), 3))")
+        .ok();
+    // test partition by clause and order by clause for input table with set semantic
+    sql("select * from table(topn(table orders partition by productid order by orderId, 3))")
+        .ok();
+    // test partition by clause and order by clause for subquery
+    sql("select * from table(topn(select * from Orders partition by productid "
+        + "order by orderId, 3))")
+        .ok();
+  }
+
   @Test void testUnknownFunctionHandling() {
     final SqlValidatorFixture s = fixture().withLenientOperatorLookup(true);
     s.withExpr("concat('a', 2)").ok();
@@ -9703,6 +9747,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "\n"
         + "$throw -\n"
         + "Reinterpret -\n"
+        + "SET_SEMANTICS_TABLE -\n"
         + "TABLE pre\n"
         + "VALUES -\n"
         + "\n"

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1603,8 +1603,14 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select * from table(topn(table orders partition by productid order by orderId, 3))")
         .ok();
     // test partition by clause and order by clause for subquery
-    sql("select * from table(topn(select * from Orders partition by productid "
+    sql("select * from table(topn(select * from Orders partition by productid\n "
         + "order by orderId, 3))")
+        .ok();
+    // test multiple input tables
+    sql("select * from table(\n"
+        + "similarlity(\n"
+        + "  table emp partition by deptno order by empno,\n"
+        + "  table emp_b partition by deptno order by empno))")
         .ok();
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -9747,7 +9747,6 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "\n"
         + "$throw -\n"
         + "Reinterpret -\n"
-        + "SET_SEMANTICS_TABLE -\n"
         + "TABLE pre\n"
         + "VALUES -\n"
         + "\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6917,6 +6917,147 @@ LogicalProject(ORDERID=[$0], ROWTIME=[$1], window_start=[$2], window_end=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTableFunctionWithComplexOrderBy">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(table orders order by (orderId desc, productid desc), 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[single], collation=[[2 DESC, 1 DESC]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithMultipleOrderKeys">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(table orders order by (orderId, productid), 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[single], collation=[[2, 1]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithMultiplePartitionKeys">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(table orders partition by (orderId, productid), 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalExchange(distribution=[hash[1, 2]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithOrderKey">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(table orders order by orderId, 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[single], collation=[[2]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithParamNames">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(
+topn(
+  DATA => table orders partition by productid order by orderId,
+  COL => 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[hash[1]], collation=[[2]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithPartitionKey">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(table orders partition by productid, 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalExchange(distribution=[hash[1]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithPartitionKeyAndOrderKey">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(table orders partition by productid order by orderId, 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[hash[1]], collation=[[2]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithSubQuery">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(select * from orders partition by productid order by orderId, 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[hash[1]], collation=[[2]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithSubQueryWithParamNames">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(
+topn(
+  DATA => select * from orders partition by productid order by orderId,
+  COL => 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[hash[1]], collation=[[2]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTableSubset">
     <Resource name="sql">
       <![CDATA[select deptno, name from dept]]>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6920,13 +6920,13 @@ LogicalProject(ORDERID=[$0], ROWTIME=[$1], window_start=[$2], window_end=[$3])
   <TestCase name="testTableFunctionWithComplexOrderBy">
     <Resource name="sql">
       <![CDATA[select *
-from table(topn(table orders order by (orderId desc, productid desc), 3))]]>
+from table(topn(table orders order by (orderId desc, productid desc nulls last), 3))]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
   LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
-    LogicalSortExchange(distribution=[single], collation=[[2 DESC, 1 DESC]])
+    LogicalSortExchange(distribution=[single], collation=[[2 DESC, 1 DESC-nulls-last]])
       LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
         LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
 ]]>
@@ -6957,6 +6957,21 @@ from table(topn(table orders partition by (orderId, productid), 3))]]>
 LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
   LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
     LogicalExchange(distribution=[hash[1, 2]])
+      LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
+        LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithOrderByWithNullLast">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(topn(table orders order by orderId desc nulls last, 3))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
+  LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
+    LogicalSortExchange(distribution=[single], collation=[[2 DESC-nulls-last]])
       LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
         LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
 ]]>
@@ -7028,13 +7043,13 @@ LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
   <TestCase name="testTableFunctionWithSubQuery">
     <Resource name="sql">
       <![CDATA[select *
-from table(topn(select * from orders partition by productid order by orderId, 3))]]>
+from table(topn(select * from orders partition by productid order by orderId desc nulls last, 3))]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
   LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
-    LogicalSortExchange(distribution=[hash[1]], collation=[[2]])
+    LogicalSortExchange(distribution=[hash[1]], collation=[[2 DESC-nulls-last]])
       LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
         LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
 ]]>
@@ -7045,14 +7060,14 @@ LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
       <![CDATA[select *
 from table(
 topn(
-  DATA => select * from orders partition by productid order by orderId,
+  DATA => select * from orders partition by productid order by orderId nulls first,
   COL => 3))]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
   LogicalTableFunctionScan(invocation=[TOPN(3)], rowType=[RecordType(TIMESTAMP(0) ROWTIME, INTEGER PRODUCTID, INTEGER ORDERID, BIGINT RANK_NUMBER)])
-    LogicalSortExchange(distribution=[hash[1]], collation=[[2]])
+    LogicalSortExchange(distribution=[hash[1]], collation=[[2 ASC-nulls-first]])
       LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2])
         LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
 ]]>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6932,6 +6932,48 @@ LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], RANK_NUMBER=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTableFunctionWithMultipleInputTables">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(
+similarlity(
+  table emp partition by deptno order by empno nulls first,
+  table emp_b partition by deptno order by empno nulls first))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(VAL=[$0])
+  LogicalTableFunctionScan(invocation=[SIMILARLITY()], rowType=[RecordType(DECIMAL(5, 2) VAL)])
+    LogicalSortExchange(distribution=[hash[7]], collation=[[0 ASC-nulls-first]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalSortExchange(distribution=[hash[7]], collation=[[0 ASC-nulls-first]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], BIRTHDATE=[$9])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableFunctionWithMultipleInputTablesWithParamNames">
+    <Resource name="sql">
+      <![CDATA[select *
+from table(
+similarlity(
+  LTABLE => table emp partition by deptno order by empno nulls first,
+  RTABLE => table emp_b partition by deptno order by empno nulls first))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(VAL=[$0])
+  LogicalTableFunctionScan(invocation=[SIMILARLITY()], rowType=[RecordType(DECIMAL(5, 2) VAL)])
+    LogicalSortExchange(distribution=[hash[7]], collation=[[0 ASC-nulls-first]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalSortExchange(distribution=[hash[7]], collation=[[0 ASC-nulls-first]])
+      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], BIRTHDATE=[$9])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTableFunctionWithMultipleOrderKeys">
     <Resource name="sql">
       <![CDATA[select *

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1961,12 +1961,32 @@ Not implemented:
 
 Table functions occur in the `FROM` clause.
 
+Table functions may have generic table parameters (i.e., no row type declared when the table function is created), and the row type of the result might depend on the row type(s) of the input tables.
+Besides, input tables are classified by three characteristics.
+The first characteristic is semantics. Input tables have either row semantics or set semantics, as follows:
+* Row semantics means that the result of the table function depends on a row-by-row basis.
+* Set semantics means that the outcome of the function depends on how the data is partitioned.
+
+The second characteristic, which applies only to input tables with set semantics, is whether the table function can generate a result row even if the input table is empty.
+* If the table function can generate a result row on empty input, the table is said to be "keep when empty".
+* The alternative is called "prune when empty", meaning that the result would be pruned out if the input table is empty.
+
+The third characteristic is whether the input table supports pass-through columns or not. Pass-through columns is a mechanism enabling the table function to copy every column of an input row into columns of an output row.
+
+The input tables with set semantics may be partitioned on one or more columns.
+The input tables with set semantics may be ordered on one or more columns.
+
+Note:
+* The input tables with row semantics may not be partitioned or ordered.
+* A polymorphic table function may have multiple input tables. However, at most one input table could have row semantics.
+
 #### TUMBLE
 
 In streaming queries, TUMBLE assigns a window for each row of a relation based
 on a timestamp column. An assigned window is specified by its beginning and
 ending. All assigned windows have the same length, and that's why tumbling
 sometimes is named as "fixed windowing".
+The first parameter of TUMBLE table function is a generic table parameter. The input table has row semantics and supports pass-through columns.
 
 | Operator syntax      | Description
 |:-------------------- |:-----------
@@ -1998,7 +2018,7 @@ whether data is complete.
 
 In streaming queries, HOP assigns windows that cover rows within the interval of *size* and shifting every *slide* based
 on a timestamp column. Windows assigned could have overlapping so hopping sometime is named as "sliding windowing".
-
+The first parameter of HOP table function is a generic table parameter. The input table has row semantics and supports pass-through columns.
 
 | Operator syntax      | Description
 |:-------------------- |:-----------
@@ -2032,7 +2052,7 @@ orders that tells data completeness.
 
 In streaming queries, SESSION assigns windows that cover rows based on *datetime*. Within a session window, distances
 of rows are less than *interval*. Session window is applied per *key*.
-
+The first parameter of SESSION table function is a generic table parameter. The input table has set semantics and supports pass-through columns. Besides, the SESSION table function would not generate a result row if the input table is empty.
 
 | Operator syntax      | Description
 |:-------------------- |:-----------
@@ -2043,18 +2063,16 @@ Here is an example:
 {% highlight sql %}
 SELECT * FROM TABLE(
   SESSION(
-    TABLE orders,
+    TABLE orders PARTITION BY product,
     DESCRIPTOR(rowtime),
-    DESCRIPTOR(product),
     INTERVAL '20' MINUTE));
 
 -- or with the named params
 -- note: the DATA param must be the first
 SELECT * FROM TABLE(
   SESSION(
-    DATA => TABLE orders,
+    DATA => TABLE orders PARTITION BY product,
     TIMECOL => DESCRIPTOR(rowtime),
-    KEY => DESCRIPTOR(product),
     SIZE => INTERVAL '20' MINUTE));
 {% endhighlight %}
 

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1961,24 +1961,37 @@ Not implemented:
 
 Table functions occur in the `FROM` clause.
 
-Table functions may have generic table parameters (i.e., no row type declared when the table function is created), and the row type of the result might depend on the row type(s) of the input tables.
+Table functions may have generic table parameters (i.e., no row type is
+declared when the table function is created), and the row type of the result
+ might depend on the row type(s) of the input tables.
 Besides, input tables are classified by three characteristics.
-The first characteristic is semantics. Input tables have either row semantics or set semantics, as follows:
-* Row semantics means that the result of the table function depends on a row-by-row basis.
-* Set semantics means that the outcome of the function depends on how the data is partitioned.
+The first characteristic is semantics. Input tables have either row semantics
+or set semantics, as follows:
+* Row semantics means that the result of the table function depends on a
+row-by-row basis.
+* Set semantics means that the outcome of the function depends on how the
+data is partitioned.
 
-The second characteristic, which applies only to input tables with set semantics, is whether the table function can generate a result row even if the input table is empty.
-* If the table function can generate a result row on empty input, the table is said to be "keep when empty".
-* The alternative is called "prune when empty", meaning that the result would be pruned out if the input table is empty.
+The second characteristic, which applies only to input tables with
+set semantics, is whether the table function can generate a result row
+even if the input table is empty.
+* If the table function can generate a result row on empty input,
+the table is said to be "keep when empty".
+* The alternative is called "prune when empty", meaning that
+the result would be pruned out if the input table is empty.
 
-The third characteristic is whether the input table supports pass-through columns or not. Pass-through columns is a mechanism enabling the table function to copy every column of an input row into columns of an output row.
+The third characteristic is whether the input table supports
+pass-through columns or not. Pass-through columns is a mechanism
+enabling the table function to copy every column of an input row
+into columns of an output row.
 
 The input tables with set semantics may be partitioned on one or more columns.
 The input tables with set semantics may be ordered on one or more columns.
 
 Note:
 * The input tables with row semantics may not be partitioned or ordered.
-* A polymorphic table function may have multiple input tables. However, at most one input table could have row semantics.
+* A polymorphic table function may have multiple input tables. However,
+at most one input table could have row semantics.
 
 #### TUMBLE
 
@@ -1986,7 +1999,8 @@ In streaming queries, TUMBLE assigns a window for each row of a relation based
 on a timestamp column. An assigned window is specified by its beginning and
 ending. All assigned windows have the same length, and that's why tumbling
 sometimes is named as "fixed windowing".
-The first parameter of TUMBLE table function is a generic table parameter. The input table has row semantics and supports pass-through columns.
+The first parameter of the TUMBLE table function is a generic table parameter.
+The input table has row semantics and supports pass-through columns.
 
 | Operator syntax      | Description
 |:-------------------- |:-----------
@@ -2018,7 +2032,8 @@ whether data is complete.
 
 In streaming queries, HOP assigns windows that cover rows within the interval of *size* and shifting every *slide* based
 on a timestamp column. Windows assigned could have overlapping so hopping sometime is named as "sliding windowing".
-The first parameter of HOP table function is a generic table parameter. The input table has row semantics and supports pass-through columns.
+The first parameter of the HOP table function is a generic table parameter.
+The input table has row semantics and supports pass-through columns.
 
 | Operator syntax      | Description
 |:-------------------- |:-----------
@@ -2052,7 +2067,10 @@ orders that tells data completeness.
 
 In streaming queries, SESSION assigns windows that cover rows based on *datetime*. Within a session window, distances
 of rows are less than *interval*. Session window is applied per *key*.
-The first parameter of SESSION table function is a generic table parameter. The input table has set semantics and supports pass-through columns. Besides, the SESSION table function would not generate a result row if the input table is empty.
+The first parameter of the SESSION table function is a generic table parameter.
+The input table has set semantics and supports pass-through columns.
+Besides, the SESSION table function would not generate a result row
+if the input table is empty.
 
 | Operator syntax      | Description
 |:-------------------- |:-----------

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4164,6 +4164,77 @@ public class SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testTableFunction() {
+    final String sql = "select * from table(score(table orders))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`SCORE`((TABLE `ORDERS`)))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithPartitionKey() {
+    // test one partition key for input table
+    final String sql = "select * from table(topn(table orders partition by productid, 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((TABLE `ORDERS`) PARTITION BY `PRODUCTID`), 3))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithMultiplePartitionKeys() {
+    // test multiple partition keys for input table
+    final String sql =
+        "select * from table(topn(table orders partition by (orderId, productid), 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((TABLE `ORDERS`) PARTITION BY `ORDERID`, `PRODUCTID`), 3))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithOrderKey() {
+    // test one order key for input table
+    final String sql =
+        "select * from table(topn(table orders order by orderId, 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((TABLE `ORDERS`) ORDER BY `ORDERID`), 3))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithMultipleOrderKeys() {
+    // test multiple order keys for input table
+    final String sql =
+        "select * from table(topn(table orders order by (orderId, productid), 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((TABLE `ORDERS`) ORDER BY `ORDERID`, `PRODUCTID`), 3))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithComplexOrderBy() {
+    // test complex order-by clause for input table
+    final String sql =
+        "select * from table(topn(table orders order by (orderId desc, productid asc), 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((TABLE `ORDERS`) ORDER BY `ORDERID` DESC, `PRODUCTID`), 3))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithPartitionKeyAndOrderKey() {
+    // test partition by clause and order by clause for input table
+    final String sql =
+        "select * from table(topn(table orders partition by productid order by orderId, 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((TABLE `ORDERS`) PARTITION BY `PRODUCTID` ORDER BY `ORDERID`), 3))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithSubQuery() {
+    // test partition by clause and order by clause for subquery
+    final String sql =
+        "select * from table(topn(select * from Orders partition by productid "
+            + "order by orderId, 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((SELECT *\n"
+        + "FROM `ORDERS`) PARTITION BY `PRODUCTID` ORDER BY `ORDERID`), 3))";
+    sql(sql).ok(expected);
+  }
+
   @Test void testIllegalCursors() {
     sql("select ^cursor^(select * from emps) from emps")
         .fails("CURSOR expression encountered in illegal context");

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4235,6 +4235,24 @@ public class SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testTableFunctionWithMultipleInputTables() {
+    final String sql = "select * from table(similarlity(table emp, table emp_b))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`SIMILARLITY`((TABLE `EMP`), (TABLE `EMP_B`)))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithMultipleInputTablesAndSubClauses() {
+    final String sql = "select * from table("
+        + "similarlity("
+        + "  table emp partition by deptno order by empno, "
+        + "  table emp_b partition by deptno order by empno))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`SIMILARLITY`(((TABLE `EMP`) PARTITION BY `DEPTNO` ORDER BY `EMPNO`), "
+        + "((TABLE `EMP_B`) PARTITION BY `DEPTNO` ORDER BY `EMPNO`)))";
+    sql(sql).ok(expected);
+  }
+
   @Test void testIllegalCursors() {
     sql("select ^cursor^(select * from emps) from emps")
         .fails("CURSOR expression encountered in illegal context");

--- a/testkit/src/main/java/org/apache/calcite/test/MockSqlOperatorTable.java
+++ b/testkit/src/main/java/org/apache/calcite/test/MockSqlOperatorTable.java
@@ -19,13 +19,18 @@ package org.apache.calcite.test;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlTableFunction;
+import org.apache.calcite.sql.TableCharacteristic;
 import org.apache.calcite.sql.fun.SqlLibrary;
 import org.apache.calcite.sql.fun.SqlLibraryOperatorTableFactory;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -33,15 +38,23 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandMetadata;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.calcite.sql.util.SqlOperatorTables;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Optionality;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Mock operator table for testing purposes. Contains the standard SQL operator
@@ -81,7 +94,10 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
                 new NotATableFunction(),
                 new BadTableFunction(),
                 new StructuredFunction(),
-                new CompositeFunction())));
+                new CompositeFunction(),
+                new ScoreTableFunction(),
+                new TopNTableFunction(),
+                new InvalidTableFunction())));
   }
 
   /** Adds a library set. */
@@ -185,6 +201,205 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
       return opBinding -> opBinding.getTypeFactory().builder()
           .add("NAME", SqlTypeName.VARCHAR, 1024)
           .build();
+    }
+  }
+
+  /** "Score" user-defined table function. First parameter is input table
+   * with row semantics. */
+  public static class ScoreTableFunction extends SqlFunction
+      implements SqlTableFunction {
+
+    private final Map<Integer, TableCharacteristic> tableParams =
+        ImmutableMap.of(0, TableCharacteristic.withRowSemantic(true));
+
+    public ScoreTableFunction() {
+      super("SCORE",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.CURSOR,
+          null,
+          new OperandMetadataImpl(),
+          SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
+    }
+
+    private static RelDataType inferRowType(SqlOperatorBinding opBinding) {
+      final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+      final RelDataType inputRowType = opBinding.getOperandType(0);
+      final RelDataType bigintType =
+          typeFactory.createSqlType(SqlTypeName.BIGINT);
+      return typeFactory.builder()
+          .kind(inputRowType.getStructKind())
+          .addAll(inputRowType.getFieldList())
+          .add("SCORE_VALUE", bigintType).nullable(true)
+          .build();
+    }
+
+    @Override public SqlReturnTypeInference getRowTypeInference() {
+      return ScoreTableFunction::inferRowType;
+    }
+
+    @Override public TableCharacteristic tableCharacteristic(int ordinal) {
+      return tableParams.get(ordinal);
+    }
+
+    @Override public boolean argumentMustBeScalar(int ordinal) {
+      return !tableParams.containsKey(ordinal);
+    }
+
+    /** Operand type checker for {@link ScoreTableFunction}. */
+    private static class OperandMetadataImpl implements SqlOperandMetadata {
+
+      @Override public List<RelDataType> paramTypes(RelDataTypeFactory typeFactory) {
+        return ImmutableList.of(typeFactory.createSqlType(SqlTypeName.ANY));
+      }
+
+      @Override public List<String> paramNames() {
+        return ImmutableList.of("DATA");
+      }
+
+      @Override public boolean checkOperandTypes(
+          SqlCallBinding callBinding, boolean throwOnFailure) {
+        return true;
+      }
+
+      @Override public SqlOperandCountRange getOperandCountRange() {
+        return SqlOperandCountRanges.of(1);
+      }
+
+      @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+        return "Score(TABLE table_name)";
+      };
+
+      @Override public SqlOperandTypeChecker.Consistency getConsistency() {
+        return Consistency.NONE;
+      }
+
+      @Override public boolean isOptional(int i) {
+        return false;
+      }
+    }
+  }
+
+  /** "TopN" user-defined table function. First parameter is input table
+   * with set semantics. */
+  public static class TopNTableFunction extends SqlFunction
+      implements SqlTableFunction {
+
+    private final Map<Integer, TableCharacteristic> tableParams =
+        ImmutableMap.of(0, TableCharacteristic.withSetSemantic(true, true));
+
+    public TopNTableFunction() {
+      super("TOPN",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.CURSOR,
+          null,
+          new OperandMetadataImpl(),
+          SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
+    }
+
+    private static RelDataType inferRowType(SqlOperatorBinding opBinding) {
+      final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+      final RelDataType inputRowType = opBinding.getOperandType(0);
+      final RelDataType bigintType =
+          typeFactory.createSqlType(SqlTypeName.BIGINT);
+      return typeFactory.builder()
+          .kind(inputRowType.getStructKind())
+          .addAll(inputRowType.getFieldList())
+          .add("RANK_NUMBER", bigintType).nullable(true)
+          .build();
+    }
+
+    @Override public SqlReturnTypeInference getRowTypeInference() {
+      return TopNTableFunction::inferRowType;
+    }
+
+    @Override public TableCharacteristic tableCharacteristic(int ordinal) {
+      return tableParams.get(ordinal);
+    }
+
+    @Override public boolean argumentMustBeScalar(int ordinal) {
+      return !tableParams.containsKey(ordinal);
+    }
+
+    /** Operand type checker for {@link TopNTableFunction}. */
+    private static class OperandMetadataImpl implements SqlOperandMetadata {
+
+      @Override public List<RelDataType> paramTypes(RelDataTypeFactory typeFactory) {
+        return ImmutableList.of(
+            typeFactory.createSqlType(SqlTypeName.ANY),
+            typeFactory.createSqlType(SqlTypeName.INTEGER));
+      }
+
+      @Override public List<String> paramNames() {
+        return ImmutableList.of("DATA", "COL");
+      }
+
+      @Override public boolean checkOperandTypes(
+          SqlCallBinding callBinding, boolean throwOnFailure) {
+        final SqlNode operand1 = callBinding.operand(1);
+        final SqlValidator validator = callBinding.getValidator();
+        final RelDataType type = validator.getValidatedNodeType(operand1);
+        if (!SqlTypeUtil.isIntType(type)) {
+          if (throwOnFailure) {
+            throw callBinding.newValidationSignatureError();
+          } else {
+            return false;
+          }
+        } else {
+          return true;
+        }
+      }
+
+      @Override public SqlOperandCountRange getOperandCountRange() {
+        return SqlOperandCountRanges.of(2);
+      }
+
+      @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+        return "TopN(TABLE table_name, BIGINT rows)";
+      }
+
+      @Override public Consistency getConsistency() {
+        return Consistency.NONE;
+      }
+
+      @Override public boolean isOptional(int i) {
+        return false;
+      }
+    }
+  }
+
+  /** Invalid user-defined table function with multiple input tables with
+   * row semantics. */
+  public static class InvalidTableFunction extends SqlFunction
+      implements SqlTableFunction {
+
+    private final Map<Integer, TableCharacteristic> tableParams =
+        ImmutableMap.of(
+            0,
+            TableCharacteristic.withRowSemantic(true),
+            1,
+            TableCharacteristic.withRowSemantic(true));
+
+    public InvalidTableFunction() {
+      super("INVALID",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.CURSOR,
+          null,
+          OperandTypes.VARIADIC,
+          SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
+    }
+
+    @Override public SqlReturnTypeInference getRowTypeInference() {
+      return opBinding -> opBinding.getTypeFactory().builder()
+          .add("NAME", SqlTypeName.VARCHAR, 1024)
+          .build();
+    }
+
+    @Override public TableCharacteristic tableCharacteristic(int ordinal) {
+      return tableParams.get(ordinal);
+    }
+
+    @Override public boolean argumentMustBeScalar(int ordinal) {
+      return !tableParams.containsKey(ordinal);
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This pr aims to extend table function to support Polymorphic Table Function. 

## Brief change log

  - Update `Parser.jj` to support partition by clause and order by clause for input table with set semantics of PTF
  - Introduce `TableCharacteristics` which contains three characteristics of input table of table function
  - Update `SqlTableFunction` to add a method `tableCharacteristics`,  the method returns the table characteristics for the ordinal-th argument to this table function. Default return value is Optional.empty which means the ordinal-th argument is not table.
  - Introduce `SqlSetSemanticsTable` which represents input table with set semantics of Table Function, its `SqlKind` is `SET_SEMANTICS_TABLE`
  - Updates `SqlValidatorImpl` to validate only set semantic table of Table Function could have partition by and order by clause
  - Update `SqlToRelConverter#substituteSubQuery` to parse subQuery which represents set semantics table.

## Verifying this change

  - Add tests in `SqlToRelConveterTest`, `SqlValidatorTest`