### PR TITLE
Fix ColumnMetaData.Rep for nested arrays

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -787,7 +787,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     if (type.getComponentType() != null) {
       final ColumnMetaData.AvaticaType componentType =
           avaticaType(typeFactory, type.getComponentType(), null);
-      final Type clazz = typeFactory.getJavaClass(type.getComponentType());
+      final Type clazz = typeFactory.getJavaClass(type);
       final ColumnMetaData.Rep rep = ColumnMetaData.Rep.of(clazz);
       assert rep != null;
       return ColumnMetaData.array(componentType, typeName, rep);


### PR DESCRIPTION
For array of array of int (nested arrays), the Rep of one of the arrays is PRIMITIVE_INT, not MULTISET. This breaks when calling ResultSet.getObject, failing in the array-accessor with the wrong Rep.

I am very new to Apache Calcite. Based on my preliminary testing, this appears to be the correct change. However, I don't have any proper automated tests for this change to add as part of this pull request.