### PR TITLE
Site: Update the Tutorial - Add a missing Java method mentioned in the text

### DIFF
--- a/site/_docs/tutorial.md
+++ b/site/_docs/tutorial.md
@@ -234,6 +234,13 @@ Here is the relevant code from <code>CsvSchema</code>, overriding the
 method in the <code>AbstractSchema</code> base class.
 
 {% highlight java %}
+@Override protected Map<String, Table> getTableMap() {
+  if (tableMap == null) {
+    tableMap = createTableMap();
+  }
+  return tableMap;
+}
+
 private Map<String, Table> createTableMap() {
   // Look for files in the directory ending in ".csv", ".csv.gz", ".json",
   // ".json.gz".


### PR DESCRIPTION
Add the `getTableMap()` method body in the `CsvSchema` code snippet in the text.


Note: When one (especially a new user) reads the tutorial doc without reading the corresponding source codes simultaneously, he/she may not able to find the `getTableMap()` method body in the text. (Note that as far as I recall, the `getTableMap()` method body used to exist in the tutorial doc.) 


Thanks a lot.