### PR TITLE
[CALCITE-5238] Add a maxNodeCount parameter to RexUtil.toDnf

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -90,6 +90,23 @@ public class RexImplicationChecker {
    * it doesn't know if implication holds
    */
   public boolean implies(RexNode first, RexNode second) {
+    return implies(first, second, -1);
+  }
+
+  /**
+   * Similar to {@link #implies(RexNode, RexNode)}; however, it lets you
+   * specify a threshold in the number of nodes that can be created out of
+   * the DNF conversion.
+   *
+   * <p>If the threshold is negative it is ignored.
+   *
+   * @param first first condition
+   * @param second second condition
+   * @param maxNodeCount max number of nodes that can be created out of the DNF conversion
+   * @return true if it can prove first &rArr; second; otherwise false i.e.,
+   * it doesn't know if implication holds
+   */
+  public boolean implies(RexNode first, RexNode second, int maxNodeCount) {
     // Validation
     if (!validate(first, second)) {
       return false;
@@ -98,8 +115,8 @@ public class RexImplicationChecker {
     LOGGER.debug("Checking if {} => {}", first.toString(), second.toString());
 
     // Get DNF
-    RexNode firstDnf = RexUtil.toDnf(builder, first);
-    RexNode secondDnf = RexUtil.toDnf(builder, second);
+    RexNode firstDnf = RexUtil.toDnf(builder, maxNodeCount, first);
+    RexNode secondDnf = RexUtil.toDnf(builder, maxNodeCount, second);
 
     // Check Trivial Cases
     if (firstDnf.isAlwaysFalse()

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1734,7 +1734,7 @@ public class RexUtil {
    *
    * <blockquote>(a AND b) OR (c AND d)</blockquote>
    *
-   * <p>The following expression is not in CNF:
+   * <p>The following expression is not in DNF:
    *
    * <blockquote>(a OR b) AND c</blockquote>
    *
@@ -1742,18 +1742,35 @@ public class RexUtil {
    *
    * <blockquote>(a AND c) OR (b AND c)</blockquote>
    *
-   * <p>The following expression is not in CNF:
+   * <p>The following expression is not in DNF:
    *
-   * <blockquote>NOT (a OR NOT b)</blockquote>
+   * <blockquote>NOT (a AND NOT b)</blockquote>
    *
    * <p>but can be converted to DNF by applying de Morgan's theorem:
    *
-   * <blockquote>NOT a AND b</blockquote>
+   * <blockquote>NOT a OR b</blockquote>
    *
    * <p>Expressions not involving AND, OR or NOT at the top level are in DNF.
    */
   public static RexNode toDnf(RexBuilder rexBuilder, RexNode rex) {
-    return new DnfHelper(rexBuilder).toDnf(rex);
+    return new DnfHelper(rexBuilder, -1).toDnf(rex);
+  }
+
+  /**
+   * Similar to {@link #toDnf(RexBuilder, RexNode)}; however, it lets you
+   * specify a threshold in the number of nodes that can be created out of
+   * the conversion.
+   *
+   * <p>If the number of resulting nodes exceeds that threshold,
+   * stops conversion and returns the original expression.
+   *
+   * <p>If the threshold is negative it is ignored.
+   *
+   * <p>Leaf nodes in the expression do not count towards the threshold.
+   */
+  public static RexNode toDnf(RexBuilder rexBuilder, int maxNodeCount,
+      RexNode rex) {
+    return new DnfHelper(rexBuilder, maxNodeCount).toDnf(rex);
   }
 
   /**
@@ -2686,21 +2703,35 @@ public class RexUtil {
   /** Helps {@link org.apache.calcite.rex.RexUtil#toDnf}. */
   private static class DnfHelper {
     final RexBuilder rexBuilder;
+    int currentCount;
+    final int maxNodeCount; // negative means no limit
 
-    private DnfHelper(RexBuilder rexBuilder) {
+    private DnfHelper(RexBuilder rexBuilder, int maxNodeCount) {
       this.rexBuilder = rexBuilder;
+      this.maxNodeCount = maxNodeCount;
     }
 
     public RexNode toDnf(RexNode rex) {
+      try {
+        this.currentCount = 0;
+        return toDnf2(rex);
+      } catch (DnfHelper.OverflowError e) {
+        Util.swallow(e, null);
+        return rex;
+      }
+    }
+
+    public RexNode toDnf2(RexNode rex) {
       final List<RexNode> operands;
       switch (rex.getKind()) {
       case AND:
+        incrementAndCheck();
         operands = flattenAnd(((RexCall) rex).getOperands());
         final RexNode head = operands.get(0);
-        final RexNode headDnf = toDnf(head);
+        final RexNode headDnf = toDnf2(head);
         final List<RexNode> headDnfs = RelOptUtil.disjunctions(headDnf);
         final RexNode tail = and(Util.skip(operands));
-        final RexNode tailDnf = toDnf(tail);
+        final RexNode tailDnf = toDnf2(tail);
         final List<RexNode> tailDnfs = RelOptUtil.disjunctions(tailDnf);
         final List<RexNode> list = new ArrayList<>();
         for (RexNode h : headDnfs) {
@@ -2710,42 +2741,43 @@ public class RexUtil {
         }
         return or(list);
       case OR:
+        incrementAndCheck();
         operands = flattenOr(((RexCall) rex).getOperands());
-        return or(toDnfs(operands));
+        final List<RexNode> dnfOperands = new ArrayList<>();
+        for (RexNode node : operands) {
+          RexNode dnf = toDnf2(node);
+          switch (dnf.getKind()) {
+          case OR:
+            incrementAndCheck();
+            dnfOperands.addAll(((RexCall) dnf).getOperands());
+            break;
+          default:
+            incrementAndCheck();
+            dnfOperands.add(dnf);
+          }
+        }
+        return or(dnfOperands);
       case NOT:
         final RexNode arg = ((RexCall) rex).getOperands().get(0);
         switch (arg.getKind()) {
         case NOT:
-          return toDnf(((RexCall) arg).getOperands().get(0));
+          return toDnf2(((RexCall) arg).getOperands().get(0));
         case OR:
           operands = ((RexCall) arg).getOperands();
-          return toDnf(
+          return toDnf2(
               and(Util.transform(flattenOr(operands), RexUtil::addNot)));
         case AND:
           operands = ((RexCall) arg).getOperands();
-          return toDnf(
+          return toDnf2(
               or(Util.transform(flattenAnd(operands), RexUtil::addNot)));
         default:
+          incrementAndCheck();
           return rex;
         }
       default:
+        incrementAndCheck();
         return rex;
       }
-    }
-
-    private List<RexNode> toDnfs(List<RexNode> nodes) {
-      final List<RexNode> list = new ArrayList<>();
-      for (RexNode node : nodes) {
-        RexNode dnf = toDnf(node);
-        switch (dnf.getKind()) {
-        case OR:
-          list.addAll(((RexCall) dnf).getOperands());
-          break;
-        default:
-          list.add(dnf);
-        }
-      }
-      return list;
     }
 
     private RexNode and(Iterable<? extends RexNode> nodes) {
@@ -2754,6 +2786,21 @@ public class RexUtil {
 
     private RexNode or(Iterable<? extends RexNode> nodes) {
       return composeDisjunction(rexBuilder, nodes);
+    }
+
+    private void incrementAndCheck() {
+      if (maxNodeCount >= 0 && ++currentCount > maxNodeCount) {
+        throw DnfHelper.OverflowError.INSTANCE;
+      }
+    }
+
+    /** Exception to catch when we pass the limit. */
+    @SuppressWarnings("serial")
+    private static class OverflowError extends ControlFlowException {
+      @SuppressWarnings("ThrowableInstanceNeverThrown")
+      protected static final DnfHelper.OverflowError INSTANCE = new DnfHelper.OverflowError();
+
+      private OverflowError() {}
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -3387,4 +3387,49 @@ class RexProgramTest extends RexProgramTestBase {
 
     checkSimplify(add(zero, sub(nullInt, nullInt)), "null:INTEGER");
   }
+
+  /** Unit test for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5238">[CALCITE-5238]
+   * Add a maxNodeCount parameter to RexUtil.toDnf</a>. */
+  @Test public void testThresholdDnf() {
+    final RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    final RelDataType rowType = typeFactory.builder()
+        .add("x", intType)
+        .add("y", intType)
+        .build();
+
+    final RexDynamicParam range = rexBuilder.makeDynamicParam(rowType, 0);
+    final RexNode xRef = rexBuilder.makeFieldAccess(range, 0);
+    final RexNode yRef = rexBuilder.makeFieldAccess(range, 1);
+
+    final RexLiteral literal1 =
+        rexBuilder.makeExactLiteral(BigDecimal.valueOf(1));
+    final RexLiteral literal2 =
+        rexBuilder.makeExactLiteral(BigDecimal.valueOf(2));
+    final RexLiteral literal3 =
+        rexBuilder.makeExactLiteral(BigDecimal.valueOf(3));
+    final RexLiteral literal4 =
+        rexBuilder.makeExactLiteral(BigDecimal.valueOf(4));
+
+    // Expression
+    //   AND(=(?0.x, 1), OR(=(?0.x, 2), =(?0.y, 3)))
+    // transformation creates 7 nodes
+    //   OR(AND(=(?0.x, 1), =(?0.x, 2)), AND(=(?0.x, 1), =(?0.y, 3)))
+    // Thus, it is triggered.
+    checkThresholdDnf(
+        and(eq(xRef, literal1), or(eq(xRef, literal2), eq(yRef, literal3))),
+        8, "OR(AND(=(?0.x, 1), =(?0.x, 2)), AND(=(?0.x, 1), =(?0.y, 3)))");
+
+    // Expression
+    //   AND(=(?0.x, 1), =(?0.x, 2), OR(=(?0.x, 3), =(?0.y, 4)))
+    // transformation creates 9 nodes
+    //   OR(AND(=(?0.x, 1), =(?0.x, 2), =(?0.x, 3)),
+    //       AND(=(?0.x, 1), =(?0.x, 2), =(?0.y, 4)))
+    // Thus, it is NOT triggered.
+    checkThresholdDnf(
+        and(eq(xRef, literal1), eq(xRef, literal2),
+            or(eq(xRef, literal3), eq(yRef, literal4))),
+        8, "AND(=(?0.x, 1), =(?0.x, 2), OR(=(?0.x, 3), =(?0.y, 4)))");
+  }
+
 }

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTestBase.java
@@ -55,6 +55,11 @@ class RexProgramTestBase extends RexProgramBuilderBase {
         equalTo(expected));
   }
 
+  protected void checkThresholdDnf(RexNode node, int threshold, String expected) {
+    assertThat("RexUtil.toDnf(rexBuilder, threshold=" + threshold + " , " + node + ")",
+        RexUtil.toDnf(rexBuilder, threshold, node).toString(),
+        equalTo(expected));
+  }
   protected void checkPullFactorsUnchanged(RexNode node) {
     checkPullFactors(node, node.toString());
   }


### PR DESCRIPTION
- Port over maxNodeCount parameter implementation from RexUtil.toCnf to RexUtil.toDnf
- Add new version of RexImplicationChecker.implies() that takes maxNodeCount parameter and pass it to RexUtil.toDnf