### PR TITLE
[CALCITE-5245] Array element accessing in BigQuery should invoke `ORDINAL` operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -188,9 +188,9 @@ public class BigQuerySqlDialect extends SqlDialect {
       unparseTrim(writer, call, leftPrec, rightPrec);
       break;
     case ITEM:
-      SqlBasicCall firstOperand = call.operand(0);
-      if (firstOperand.getOperator().equals(ARRAY_VALUE_CONSTRUCTOR)
-          || firstOperand.getOperator().equals(ARRAY_QUERY)) {
+      if (call.operand(0) instanceof SqlBasicCall
+          && (((SqlBasicCall) call.operand(0)).getOperator().equals(ARRAY_VALUE_CONSTRUCTOR)
+          || ((SqlBasicCall) call.operand(0)).getOperator().equals(ARRAY_QUERY))) {
         call.operand(0).unparse(writer, leftPrec, rightPrec);
         final SqlWriter.Frame indexFrame = writer.startList("[", "]");
         // Because Calcite use 1-based array index, use `ORDINAL` to access the target array.

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -183,6 +183,15 @@ public class BigQuerySqlDialect extends SqlDialect {
     case TRIM:
       unparseTrim(writer, call, leftPrec, rightPrec);
       break;
+    case ITEM:
+      call.operand(0).unparse(writer, leftPrec, rightPrec);
+      final SqlWriter.Frame indexFrame = writer.startList("[", "]");
+      // Because Calcite use 1-based array index, use `ORDINAL` to access the target array.
+      final SqlWriter.Frame funcFrame = writer.startFunCall("ORDINAL");
+      call.operand(1).unparse(writer, leftPrec, rightPrec);
+      writer.endFunCall(funcFrame);
+      writer.endList(indexFrame);
+      break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -6466,6 +6466,15 @@ class RelToSqlConverterTest {
         .withBigQuery().ok(expected);
   }
 
+  @Test void testBigQueryArrayElementAccessing() {
+    final String sql = ""
+        + "SELECT array[1, 2, 3][1]";
+    final String expected = ""
+        + "SELECT array[1, 2, 3][ORDINAL(1)]";
+    sql(sql)
+        .withBigQuery().ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final CalciteAssert.SchemaSpec schemaSpec;

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -6467,12 +6467,29 @@ class RelToSqlConverterTest {
   }
 
   @Test void testBigQueryArrayElementAccessing() {
-    final String sql = ""
-        + "SELECT array[1, 2, 3][1]";
-    final String expected = ""
+    final String arrayCtorSql = ""
+        + "SELECT ARRAY[1, 2, 3][1]";
+    final String expectedArrayCtorSql = ""
         + "SELECT ARRAY[1, 2, 3][ORDINAL(1)]";
-    sql(sql)
-        .withBigQuery().ok(expected);
+    sql(arrayCtorSql)
+        .withBigQuery().ok(expectedArrayCtorSql);
+
+    // TODO: Got error from
+    //  `SqlImplementor`: Need to implement org.apache.calcite.rel.core.Collect
+    // final String arrayQuerySql = ""
+    //     + "SELECT ARRAY(SELECT 1, 2)[1]";
+    // final String expectedArrayQuerySql = ""
+    //     + "SELECT ARRAY(SELECT 1, 2)[ORDINAL(1)]";
+    // sql(arrayQuerySql)
+    //     .withBigQuery().ok(expectedArrayQuerySql);
+
+    // won't be changed
+    final String mapSql = ""
+        + "SELECT map['a', 1, 'b', 2]['a']";
+    final String expectedMapSql = ""
+        + "SELECT MAP['a', 1, 'b', 2]['a']";
+    sql(mapSql)
+        .withBigQuery().ok(expectedMapSql);
   }
 
   /** Fluid interface to run tests. */

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -6470,7 +6470,7 @@ class RelToSqlConverterTest {
     final String sql = ""
         + "SELECT array[1, 2, 3][1]";
     final String expected = ""
-        + "SELECT array[1, 2, 3][ORDINAL(1)]";
+        + "SELECT ARRAY[1, 2, 3][ORDINAL(1)]";
     sql(sql)
         .withBigQuery().ok(expected);
   }


### PR DESCRIPTION
Invoke `ORDINAL` operator when accessing the array elements.