### PR TITLE
[CALCITE-5251] Support SQL hint for Snapshot

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/hint/HintPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/HintPredicates.java
@@ -80,6 +80,11 @@ public abstract class HintPredicates {
   public static final HintPredicate WINDOW =
       new NodeTypeHintPredicate(NodeTypeHintPredicate.NodeType.WINDOW);
 
+  /** A hint predicate that indicates a hint can only be used to
+   * {@link org.apache.calcite.rel.core.Snapshot} nodes. */
+  public static final HintPredicate SNAPSHOT =
+      new NodeTypeHintPredicate(NodeTypeHintPredicate.NodeType.SNAPSHOT);
+
   /**
    * Returns a composed hint predicate that represents a short-circuiting logical
    * AND of an array of hint predicates {@code hintPredicates}.  When evaluating the composed

--- a/core/src/main/java/org/apache/calcite/rel/hint/NodeTypeHintPredicate.java
+++ b/core/src/main/java/org/apache/calcite/rel/hint/NodeTypeHintPredicate.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.core.Snapshot;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Values;
@@ -99,7 +100,12 @@ public class NodeTypeHintPredicate implements HintPredicate {
     /**
      * The hint would be propagated to the Window nodes.
      */
-    WINDOW(Window.class);
+    WINDOW(Window.class),
+
+    /**
+     * The hint would be propagated to the Snapshot nodes.
+     */
+    SNAPSHOT(Snapshot.class);
 
     /** Relational expression clazz that the hint can apply to. */
     @SuppressWarnings("ImmutableEnumChecker")

--- a/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
@@ -200,9 +200,8 @@ EnumerableProject(ENAME=[$3], JOB=[$4], SAL=[$7], NAME=[$1])
   </TestCase>
   <TestCase name="testHintsPropagationInVolcanoPlannerRules2">
     <Resource name="sql">
-      <![CDATA[select /*+ my_hint */ ename, job
-from emp where not exists (select 1 from dept where emp.deptno = dept.deptno)
-]]>
+      <![CDATA[select /*+ no_hash_join */ ename, job
+from emp where not exists (select 1 from dept where emp.deptno = dept.deptno)]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -232,9 +231,8 @@ EnumerableProject(ENAME=[$0], JOB=[$1])
   </TestCase>
   <TestCase name="testHintsPropagationInVolcanoPlannerRules3">
     <Resource name="sql">
-      <![CDATA[select /*+ my_hint */ ename, job
-from emp where not exists (select 1 from dept where emp.deptno = dept.deptno) order by ename
-]]>
+      <![CDATA[select /*+ no_hash_join */ ename, job
+from emp where not exists (select 1 from dept where emp.deptno = dept.deptno) order by ename]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -358,6 +356,19 @@ on emp.deptno = dept.deptno]]>
 Project:[[PROPERTIES inheritPath:[] options:{K1=v1, K2=v2}]]
 TableScan:[[INDEX inheritPath:[] options:[IDX1, IDX2]], [PROPERTIES inheritPath:[0, 0] options:{K1=v1, K2=v2}]]
 TableScan:[[PROPERTIES inheritPath:[] options:{K1=v1, K2=v2}], [PROPERTIES inheritPath:[0, 1] options:{K1=v1, K2=v2}]]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSnapshotHints">
+    <Resource name="sql">
+      <![CDATA[select /*+ fast_snapshot(products_temporal) */ stream * from
+ orders join products_temporal for system_time as of timestamp '2022-08-11 15:00:00'
+ on orders.productid = products_temporal.productid]]>
+    </Resource>
+    <Resource name="hints">
+      <![CDATA[
+Project:[[FAST_SNAPSHOT inheritPath:[] options:[PRODUCTS_TEMPORAL]]]
+Snapshot:[[FAST_SNAPSHOT inheritPath:[0, 1] options:[PRODUCTS_TEMPORAL]]]
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
Current, `snapshot` does not support hint yet and this blocks hint propagation to the underlying temporal table.
This pr aims to support Snapshot node.
