### PR TITLE
[CALCITE-5260] Pop the last RelNode added into the bindings list when failing to apply a rule

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Stack;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -527,7 +528,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
       }
     }
 
-    final List<RelNode> bindings = new ArrayList<>();
+    final Stack<RelNode> bindings = new Stack<>();
     final Map<RelNode, List<RelNode>> nodeChildren = new HashMap<>();
     boolean match =
         matchOperands(
@@ -614,7 +615,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
   private static boolean matchOperands(
       RelOptRuleOperand operand,
       RelNode rel,
-      List<RelNode> bindings,
+      Stack<RelNode> bindings,
       Map<RelNode, List<RelNode>> nodeChildren) {
     if (!operand.matches(rel)) {
       return false;
@@ -649,6 +650,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
           }
         }
         if (!match) {
+          bindings.pop();
           return false;
         }
       }
@@ -661,6 +663,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
     default:
       int n = operand.getChildOperands().size();
       if (childRels.size() < n) {
+        bindings.pop();
         return false;
       }
       for (Pair<HepRelVertex, RelOptRuleOperand> pair
@@ -672,6 +675,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
                 bindings,
                 nodeChildren);
         if (!match) {
+          bindings.pop();
           return false;
         }
       }


### PR DESCRIPTION
When fail to match a subtree, HepPlanner should pop the last RelNode added into the bindings list, where the nodes left are 'real' matched when applying a rule. 

Otherwise, using some temporary and unnecessary nodes to construct a HepRuleCall will cause an assertion error.
