### PR TITLE
floor unparsing fails for postgres dialect

### DIFF
--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlUnparsingFailingTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlUnparsingFailingTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql.parser;
+
+import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+
+import org.junit.jupiter.api.Test;
+
+class SqlUnparsingFailingTest
+{
+  SqlParserFixture fixture = SqlParserFixture.DEFAULT.withDialect(PostgresqlSqlDialect.DEFAULT);
+
+  @Test void testFloorParsingPostgresDialect() {
+    fixture.sql("select FLOOR(TIMESTAMP '2022-08-01' TO Year)")
+        .ok("SELECT FLOOR(TIMESTAMP '2022-08-01 00:00:00' TO YEAR)");
+  }
+}

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -726,6 +726,12 @@ public class SqlParserTest {
             + "FROM `EMP`");
   }
 
+  @Test void testFloorPostgres() {
+    sql("select FLOOR(TIMESTAMP '2022-08-01' TO Year)")
+        .withDialect(POSTGRESQL)
+        .ok("SELECT FLOOR(TIMESTAMP '2022-08-01 00:00:00' TO YEAR)");
+  }
+
   @Test void testFromStarFails() {
     sql("select * from sales^.^*")
         .fails("(?s)Encountered \"\\. \\*\" at .*");


### PR DESCRIPTION
If `.withDialect(PostgresqlSqlDialect.DEFAULT)` is removed while creating the fixture, test case passes. JIRA ticket for this -https://issues.apache.org/jira/browse/CALCITE-5271