### PR TITLE
[CALCITE-5297] Casting dynamic variable twice throws exception

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -235,8 +235,11 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
   private int nextGeneratedId;
   protected final RelDataTypeFactory typeFactory;
-
-  /** The type of dynamic parameters until a type is imposed on them. */
+  /**
+   * The type of dynamic parameters until a type is imposed on them.
+   * It is assumed that dynamic parameter is nullable.
+   * See {@link #inferUnknownTypes(RelDataType, SqlValidatorScope, SqlNode)}
+   */
   protected final RelDataType unknownType;
   private final RelDataType booleanType;
 
@@ -296,7 +299,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     this.typeFactory = requireNonNull(typeFactory, "typeFactory");
     this.config = requireNonNull(config, "config");
 
-    unknownType = typeFactory.createUnknownType();
+    unknownType = typeFactory.createTypeWithNullability(typeFactory.createUnknownType(), true);
     booleanType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
 
     final SqlNameMatcher nameMatcher = catalogReader.nameMatcher();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -235,11 +235,6 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
   private int nextGeneratedId;
   protected final RelDataTypeFactory typeFactory;
-  /**
-   * The type of dynamic parameters until a type is imposed on them.
-   * It is assumed that dynamic parameter is nullable.
-   * See {@link #inferUnknownTypes(RelDataType, SqlValidatorScope, SqlNode)}
-   */
   protected final RelDataType unknownType;
   private final RelDataType booleanType;
 
@@ -299,6 +294,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     this.typeFactory = requireNonNull(typeFactory, "typeFactory");
     this.config = requireNonNull(config, "config");
 
+    // It is assumed that unknown type is nullable by default
     unknownType = typeFactory.createTypeWithNullability(typeFactory.createUnknownType(), true);
     booleanType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4678,4 +4678,14 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         .withConformance(SqlConformanceEnum.LENIENT)
         .ok();
   }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5297">[CALCITE-5297]
+   * Casting dynamic variable twice throws exception</a>.
+   */
+  @Test void testDynamicParameterDoubleCast() {
+    String sql = "SELECT CAST(CAST(? AS INTEGER) AS INTEGER)";
+    sql(sql).ok();
+  }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4685,7 +4685,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
    * Casting dynamic variable twice throws exception</a>.
    */
   @Test void testDynamicParameterDoubleCast() {
-    String sql = "SELECT CAST(CAST(? AS INTEGER) AS INTEGER)";
+    String sql = "SELECT CAST(CAST(? AS INTEGER) AS CHAR)";
     sql(sql).ok();
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8847,6 +8847,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "select min(deptno) from dept as depts2)").ok();
   }
 
+  @Test void dynamicParameterType() {
+    expr("CAST(? AS INTEGER)")
+        .columnType("INTEGER");
+  }
+
   @Test void testRecordType() {
     // Have to qualify columns with table name.
     sql("SELECT ^coord^.x, coord.y FROM customer.contact")

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1563,11 +1563,11 @@ LogicalProject(FAKE2=[ITEM($0, 'fake_col2')])
   </TestCase>
   <TestCase name="testDynamicParameterDoubleCast">
     <Resource name="sql">
-      <![CDATA[SELECT CAST(CAST(? AS INTEGER) AS INTEGER)]]>
+      <![CDATA[SELECT CAST(CAST(? AS INTEGER) AS CHAR)]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(EXPR$0=[?0])
+LogicalProject(EXPR$0=[CAST(?0):CHAR(1)])
   LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1561,6 +1561,17 @@ LogicalProject(FAKE2=[ITEM($0, 'fake_col2')])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDynamicParameterDoubleCast">
+    <Resource name="sql">
+      <![CDATA[SELECT CAST(CAST(? AS INTEGER) AS INTEGER)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[?0])
+  LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDynamicSchemaUnnest">
     <Resource name="sql">
       <![CDATA[select t1.c_nationkey, t3.fake_col3


### PR DESCRIPTION
It was originally intended that dynamic parameter are nullable (see SqlValidatorImpl#inferUnknownTypes), but DeriveTypeVisitor made them non nullable. In the end row type has not been preserved after converting query from SqlNode to RelNode.