### PR TITLE
[CALCITE-5298] CalciteSystemProperty calcite.test.dataset path check fails under Java Security Manager

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -196,8 +196,13 @@ public final class CalciteSystemProperty<T> {
             "../../calcite-test-dataset"
         };
         for (String s : dirs) {
-          if (new File(s).exists() && new File(s, "vm").exists()) {
-            return s;
+          try {
+            if (new File(s).exists() && new File(s, "vm").exists()) {
+              return s;
+            }
+          } catch (SecurityException ignore) {
+            // Ignore SecurityException on purpose because if
+            // we can't get to the file we fall through.
           }
         }
         return ".";
@@ -449,10 +454,9 @@ public final class CalciteSystemProperty<T> {
       }
     } catch (IOException e) {
       throw new RuntimeException("while reading from saffron.properties file", e);
-    } catch (RuntimeException e) {
-      if (!"java.security.AccessControlException".equals(e.getClass().getName())) {
-        throw e;
-      }
+    } catch (SecurityException ignore) {
+      // Ignore SecurityException on purpose because if
+      // we can't get to the file we fall through.
     }
 
     // Merge system and saffron properties, mapping deprecated saffron

--- a/core/src/main/java/org/apache/calcite/util/SaffronProperties.java
+++ b/core/src/main/java/org/apache/calcite/util/SaffronProperties.java
@@ -133,10 +133,9 @@ public interface SaffronProperties {
         }
       } catch (IOException e) {
         throw new RuntimeException("while reading from saffron.properties file", e);
-      } catch (RuntimeException e) {
-        if (!"java.security.AccessControlException".equals(e.getClass().getName())) {
-          throw e;
-        }
+      } catch (SecurityException ignore) {
+        // Ignore SecurityException on purpose because if
+        // we can't get to the file we fall through.
       }
 
       // copy in all system properties which start with "saffron."


### PR DESCRIPTION
SOLR-16433 found that Calcite does not handle the Java security manager returning permission denied when checking that the calcite.test.dataset path exists. Solr runs with a security manager that doesn't allow arbitrary filesystem access. This failure causes Calcite to not load and therefore unusable.

The code in question is here: https://github.com/apache/calcite/blame/main/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java#L189

A few other places in Calcite already check for SecurityException: https://github.com/apache/calcite/search?q=SecurityException