### PR TITLE
[Minor] Refactor Matcher class with remove removePartialMatch

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/Matcher.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Matcher.java
@@ -186,10 +186,6 @@ public class Matcher<E> {
       return ImmutableSet.copyOf(partialMatches);
     }
 
-    public void removePartialMatch(PartialMatch<E> pm) {
-      partialMatches.remove(pm);
-    }
-
     public void clearPartitions() {
       partialMatches.clear();
     }


### PR DESCRIPTION
removePartialMatch is useless in Mather，and avoid be used by other function remove it