### PR TITLE
[CALCITE-5314] Prune empty parts of a query by exploiting stats/metadata

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
@@ -103,6 +103,7 @@ public class RelOptRules {
       PruneEmptyRules.JOIN_LEFT_INSTANCE,
       PruneEmptyRules.JOIN_RIGHT_INSTANCE,
       PruneEmptyRules.SORT_FETCH_ZERO_INSTANCE,
+      PruneEmptyRules.EMPTY_TABLE_INSTANCE,
       CoreRules.UNION_MERGE,
       CoreRules.INTERSECT_MERGE,
       CoreRules.MINUS_MERGE,

--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -572,10 +572,6 @@ public abstract class PruneEmptyRules {
 
         @Override public void onMatch(RelOptRuleCall call) {
           RelNode node = call.rel(0);
-          Double maxRowCount = call.getMetadataQuery().getMaxRowCount(node);
-          if (maxRowCount == null || maxRowCount > 0.0) {
-            return;
-          }
           RelNode emptyValues = call.builder().push(node).empty().build();
           RelTraitSet traits = node.getTraitSet();
           // propagate all traits (except convention) from the original tableScan

--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -167,6 +167,19 @@ public abstract class PruneEmptyRules {
   }
 
   /**
+   * Rule that converts a {@link org.apache.calcite.rel.core.TableScan}
+   * to empty if the table has no rows in it.
+   *
+   * The rule exploits the {@link org.apache.calcite.rel.metadata.RelMdMaxRowCount} to derive if
+   * the table is empty or not.
+   */
+  public static final RelOptRule EMPTY_TABLE_INSTANCE =
+      ImmutableZeroMaxRowsRuleConfig.of()
+          .withOperandSupplier(b0 -> b0.operand(TableScan.class).noInputs())
+          .withDescription("PruneZeroRowsTable")
+          .toRule();
+
+  /**
    * Rule that converts a {@link org.apache.calcite.rel.core.Project}
    * to empty if its child is empty.
    *
@@ -542,16 +555,10 @@ public abstract class PruneEmptyRules {
     }
   }
 
-
-  public static final RelOptRule EMPTY_TABLE_INSTANCE =
-      ImmutableZeroMaxRowsRuleConfig.of()
-          .withOperandSupplier(b0 -> b0.operand(TableScan.class).noInputs())
-          .withDescription("PruneZeroRowsTable")
-          .toRule();
-
-  /** Configuration for rule that transforms an empty table into an empty values node.
-   * MaxRowCount is used as the stat to transform, hence Table implementer needs
-   * to supply this metadata if this optimization needs to be applied.*/
+  /** Configuration for rule that transforms an empty relational expression into an empty values.
+   *
+   * It relies on {@link org.apache.calcite.rel.metadata.RelMdMaxRowCount} to derive if the relation
+   * is empty or not. If the stats are not available then the rule is a noop. */
   @Value.Immutable
   public interface ZeroMaxRowsRuleConfig extends PruneEmptyRule.Config {
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -557,6 +557,12 @@ public abstract class PruneEmptyRules {
 
     @Override default PruneEmptyRule toRule() {
       return new PruneEmptyRule(this) {
+        @Override public boolean matches(RelOptRuleCall call) {
+          RelNode node = call.rel(0);
+          Double maxRowCount = call.getMetadataQuery().getMaxRowCount(node);
+          return maxRowCount != null && maxRowCount == 0.0;
+        }
+
         @Override public void onMatch(RelOptRuleCall call) {
           RelNode node = call.rel(0);
           Double maxRowCount = call.getMetadataQuery().getMaxRowCount(node);

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -87,6 +87,7 @@ class SqlAdvisorTest extends SqlValidatorTestCase {
           "TABLE(CATALOG.SALES.EMP_B)",
           "TABLE(CATALOG.SALES.EMP_20)",
           "TABLE(CATALOG.SALES.EMPNULLABLES_20)",
+          "TABLE(CATALOG.SALES.EMPTY_PRODUCTS)",
           "TABLE(CATALOG.SALES.EMP_ADDRESS)",
           "TABLE(CATALOG.SALES.DEPT)",
           "TABLE(CATALOG.SALES.DEPT_NESTED)",

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3413,39 +3413,17 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
-  @Test void testEmptyTableProject() {
+  @Test void testEmptyTable() {
     // table is transformed to empty values and extra project will be removed.
     final String sql = "select * from EMPTY_PRODUCTS\n";
     sql(sql)
         .withRule(
-            PruneEmptyRules.EMPTY_TABLE,
+            PruneEmptyRules.EMPTY_TABLE_INSTANCE,
             PruneEmptyRules.PROJECT_INSTANCE)
         .check();
   }
 
-  @Test void testEmptyTableJoinLeft() {
-    // inner join is eliminated after the left table is transformed to empty values.
-    final String sql = "select * from EMPTY_PRODUCTS as e\n"
-        + ",products as d where e.PRODUCTID = d.PRODUCTID\n";
-    sql(sql)
-        .withRule(
-            PruneEmptyRules.EMPTY_TABLE,
-            PruneEmptyRules.JOIN_LEFT_INSTANCE)
-        .check();
-  }
-
-  @Test void testEmptyTableJoinRight() {
-    // inner join is eliminated after the right table is transformed to empty values.
-    final String sql = "select * from products as e\n"
-        + ",EMPTY_PRODUCTS as d where e.PRODUCTID = d.PRODUCTID\n";
-    sql(sql)
-        .withRule(
-            PruneEmptyRules.EMPTY_TABLE,
-            PruneEmptyRules.JOIN_RIGHT_INSTANCE)
-        .check();
-  }
-
-  @Test void testComplexEmptyTable() {
+  @Test void testEmptyTableInComplexQuery() {
     // inner join is eliminated after the table is transformed into empty
     final String sql = "select * from products left join "
         + "(select * from products as e\n"
@@ -3454,7 +3432,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + " on products.PRODUCTID = dt.PRODUCTID";
     sql(sql)
         .withRule(
-            PruneEmptyRules.EMPTY_TABLE,
+            PruneEmptyRules.EMPTY_TABLE_INSTANCE,
             PruneEmptyRules.JOIN_RIGHT_INSTANCE,
             PruneEmptyRules.FILTER_INSTANCE,
             PruneEmptyRules.PROJECT_INSTANCE)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -3078,15 +3078,17 @@ LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testEmptyTableInComplexQuery">
+  <TestCase name="testEmptyTableTransformsComplexQueryToSingleTableScan">
     <Resource name="sql">
-      <![CDATA[select * from products left join (select * from products as e
- inner join EMPTY_PRODUCTS as d on e.PRODUCTID = d.PRODUCTID  where e.SUPPLIERID > 10) dt
+      <![CDATA[select products.PRODUCTID, products.NAME from products left join
+(select * from products as e
+ inner join EMPTY_PRODUCTS as d on e.PRODUCTID = d.PRODUCTID
+ where e.SUPPLIERID > 10) dt
  on products.PRODUCTID = dt.PRODUCTID]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
+LogicalProject(PRODUCTID=[$0], NAME=[$1])
   LogicalJoin(condition=[=($0, $3)], joinType=[left])
     LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
     LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
@@ -3098,10 +3100,8 @@ LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
-  LogicalJoin(condition=[=($0, $3)], joinType=[left])
-    LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
-    LogicalValues(tuples=[[]])
+LogicalProject(PRODUCTID=[$0], NAME=[$1])
+  LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1500,6 +1500,33 @@ LogicalProject(T=[CASE(<(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE, 
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testComplexEmptyTable">
+    <Resource name="sql">
+      <![CDATA[select * from products as e
+,EMPTY_PRODUCTS as d where e.PRODUCTID = d.PRODUCTID
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
+  LogicalJoin(condition=[=($0, $3)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+    LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
+      LogicalFilter(condition=[>($2, 10)])
+        LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+          LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+          LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
+  LogicalJoin(condition=[=($0, $3)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+    LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testConvertMultiJoinRule">
     <Resource name="sql">
       <![CDATA[select e1.ename from emp e1, dept d, emp e2
@@ -3061,6 +3088,84 @@ LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEmptyTableJoinLeft">
+    <Resource name="sql">
+      <![CDATA[select * from EMPTY_PRODUCTS as e,
+      products as d where e.PRODUCTID = d.PRODUCTID]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
+  LogicalFilter(condition=[=($0, $3)])
+    LogicalJoin(condition=[true], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
+      LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
+  LogicalFilter(condition=[=($0, $3)])
+    LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEmptyTableJoinRight">
+    <Resource name="sql">
+      <![CDATA[select * from products as e
+,EMPTY_PRODUCTS as d where e.PRODUCTID = d.PRODUCTID
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
+  LogicalFilter(condition=[=($0, $3)])
+    LogicalJoin(condition=[true], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
+  LogicalFilter(condition=[=($0, $3)])
+    LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEmptyTableProject">
+    <Resource name="sql">
+      <![CDATA[select * from EMPTY_PRODUCTS
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2])
+  LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEmptytableMinus">
+    <Resource name="sql">
+      <![CDATA[select * from EMPTY_PRODUCTS]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject
+  LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEnumerableCalcRule">
     <Resource name="sql">
       <![CDATA[select FNAME, LNAME
@@ -3926,7 +4031,7 @@ emp LHS
 left join dept RHS on LHS.EMPNO = RHS.DEPTNO
 where
 RHS.DEPTNO is not null
-AND LHS.EMPNO is not null]]>
+AND RHS.NAME is not null]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -4545,8 +4650,7 @@ LogicalJoin(condition=[true], joinType=[inner])
     <Resource name="sql">
       <![CDATA[select *
 from emp e1, emp e2, dept d2
-where e1.deptno = d2.deptno and e2.deptno = d2.deptno
-]]>
+where e1.deptno = d2.deptno and e2.deptno = d2.deptno]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -4574,8 +4678,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     <Resource name="sql">
       <![CDATA[select *
 from emp e, dept d
-where e.deptno = d.deptno and e.empno = d.deptno
-]]>
+where e.deptno = d.deptno and e.empno = d.deptno]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -4600,8 +4703,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     <Resource name="sql">
       <![CDATA[select *
 from emp e full join dept d
-on e.deptno = d.deptno and e.empno = d.deptno
-]]>
+on e.deptno = d.deptno and e.empno = d.deptno]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -4645,8 +4747,7 @@ LogicalProject(DEPTNO=[$0])
     <Resource name="sql">
       <![CDATA[select *
 from emp e left join dept d
-on e.deptno = d.deptno and e.empno = d.deptno
-]]>
+on e.deptno = d.deptno and e.empno = d.deptno]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -4661,8 +4762,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     <Resource name="sql">
       <![CDATA[select *
 from emp e right join dept d
-on e.deptno = d.deptno and e.empno = d.deptno
-]]>
+on e.deptno = d.deptno and e.empno = d.deptno]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -4736,8 +4836,7 @@ LogicalProject(DEPTNO=[$7])
   <TestCase name="testJoinDeriveIsNotNullFilterRule12">
     <Resource name="sql">
       <![CDATA[select t1.deptno from empnullables t1 inner join
-empnullables t2 on t1.ename = t2.ename and t1.mgr is not distinct from t2.mgr
-]]>
+empnullables t2 on t1.ename = t2.ename and t1.mgr is not distinct from t2.mgr]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1500,33 +1500,6 @@ LogicalProject(T=[CASE(<(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE, 
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testComplexEmptyTable">
-    <Resource name="sql">
-      <![CDATA[select * from products as e
-,EMPTY_PRODUCTS as d where e.PRODUCTID = d.PRODUCTID
-]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
-  LogicalJoin(condition=[=($0, $3)], joinType=[left])
-    LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
-    LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
-      LogicalFilter(condition=[>($2, 10)])
-        LogicalJoin(condition=[=($0, $3)], joinType=[inner])
-          LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
-          LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
-  LogicalJoin(condition=[=($0, $3)], joinType=[left])
-    LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
-    LogicalValues(tuples=[[]])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testConvertMultiJoinRule">
     <Resource name="sql">
       <![CDATA[select e1.ename from emp e1, dept d, emp e2
@@ -3088,52 +3061,7 @@ LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testEmptyTableJoinLeft">
-    <Resource name="sql">
-      <![CDATA[select * from EMPTY_PRODUCTS as e,
-      products as d where e.PRODUCTID = d.PRODUCTID]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
-  LogicalFilter(condition=[=($0, $3)])
-    LogicalJoin(condition=[true], joinType=[inner])
-      LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
-      LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
-  LogicalFilter(condition=[=($0, $3)])
-    LogicalValues(tuples=[[]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testEmptyTableJoinRight">
-    <Resource name="sql">
-      <![CDATA[select * from products as e
-,EMPTY_PRODUCTS as d where e.PRODUCTID = d.PRODUCTID
-]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
-  LogicalFilter(condition=[=($0, $3)])
-    LogicalJoin(condition=[true], joinType=[inner])
-      LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
-      LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
-  LogicalFilter(condition=[=($0, $3)])
-    LogicalValues(tuples=[[]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testEmptyTableProject">
+  <TestCase name="testEmptyTable">
     <Resource name="sql">
       <![CDATA[select * from EMPTY_PRODUCTS
 ]]>
@@ -3150,19 +3078,30 @@ LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testEmptytableMinus">
+  <TestCase name="testEmptyTableInComplexQuery">
     <Resource name="sql">
-      <![CDATA[select * from EMPTY_PRODUCTS]]>
+      <![CDATA[select * from products left join (select * from products as e
+ inner join EMPTY_PRODUCTS as d on e.PRODUCTID = d.PRODUCTID  where e.SUPPLIERID > 10) dt
+ on products.PRODUCTID = dt.PRODUCTID]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject
-  LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
+  LogicalJoin(condition=[=($0, $3)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+    LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5])
+      LogicalFilter(condition=[>($2, 10)])
+        LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+          LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+          LogicalTableScan(table=[[CATALOG, SALES, EMPTY_PRODUCTS]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalValues(tuples=[[]])
+LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], PRODUCTID0=[$3], NAME0=[$4], SUPPLIERID0=[$5], PRODUCTID00=[$6], NAME00=[$7], SUPPLIERID00=[$8])
+  LogicalJoin(condition=[=($0, $3)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, PRODUCTS]])
+    LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReader.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReader.java
@@ -294,7 +294,9 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
    * Mock implementation of
    * {@link org.apache.calcite.prepare.Prepare.PreparingTable}.
    */
-  public static class MockTable extends Prepare.AbstractPreparingTable {
+  public static class MockTable extends Prepare.AbstractPreparingTable
+      implements BuiltInMetadata.MaxRowCount.Handler {
+
     protected final MockCatalogReader catalogReader;
     protected final boolean stream;
     protected final double rowCount;
@@ -306,6 +308,7 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
     protected RelDataType rowType;
     protected List<RelCollation> collationList;
     protected final List<String> names;
+    protected final Double maxRowCount;
     protected final Set<String> monotonicColumnSet = new HashSet<>();
     protected StructKind kind = StructKind.FULLY_QUALIFIED;
     protected final ColumnResolver resolver;
@@ -324,7 +327,16 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
         InitializerExpressionFactory initializerFactory) {
       this(catalogReader, ImmutableList.of(catalogName, schemaName, name),
           stream, temporal, rowCount, resolver, initializerFactory,
-          ImmutableList.of());
+          ImmutableList.of(), Double.POSITIVE_INFINITY);
+    }
+
+    public MockTable(MockCatalogReader catalogReader, String catalogName,
+        String schemaName, String name, boolean stream, boolean temporal,
+        double rowCount, ColumnResolver resolver,
+        InitializerExpressionFactory initializerFactory, Double maxRowCount) {
+      this(catalogReader, ImmutableList.of(catalogName, schemaName, name),
+          stream, temporal, rowCount, resolver, initializerFactory,
+          ImmutableList.of(), maxRowCount);
     }
 
     public void registerRolledUpColumn(String columnName) {
@@ -334,7 +346,8 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
     private MockTable(MockCatalogReader catalogReader, List<String> names,
         boolean stream, boolean temporal, double rowCount,
         ColumnResolver resolver,
-        InitializerExpressionFactory initializerFactory, List<Object> wraps) {
+        InitializerExpressionFactory initializerFactory, List<Object> wraps,
+        Double maxRowCount) {
       this.catalogReader = catalogReader;
       this.stream = stream;
       this.temporal = temporal;
@@ -343,6 +356,7 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
       this.resolver = resolver;
       this.initializerFactory = initializerFactory;
       this.wraps = ImmutableList.copyOf(wraps);
+      this.maxRowCount = maxRowCount;
     }
 
     /**
@@ -363,6 +377,7 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
       this.names = names;
       this.kind = kind;
       this.resolver = resolver;
+      this.maxRowCount = Double.POSITIVE_INFINITY;
       this.initializerFactory = initializerFactory;
       for (String name : monotonicColumnSet) {
         addMonotonic(name);
@@ -375,6 +390,14 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
         wraps = new ArrayList<>(wraps);
       }
       wraps.add(wrap);
+    }
+
+    @Override public @Nullable Double getMaxRowCount(RelNode r, RelMetadataQuery mq) {
+      return maxRowCount;
+    }
+
+    @Override public MetadataDef<BuiltInMetadata.MaxRowCount> getDef() {
+      return BuiltInMetadata.MaxRowCount.Handler.super.getDef();
     }
 
     /** Implementation of AbstractModifiableTable. */
@@ -446,7 +469,7 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
 
     @Override protected RelOptTable extend(final Table extendedTable) {
       return new MockTable(catalogReader, names, stream, temporal, rowCount,
-          resolver, initializerFactory, wraps) {
+          resolver, initializerFactory, wraps, maxRowCount) {
         @Override public RelDataType getRowType() {
           return extendedTable.getRowType(catalogReader.typeFactory);
         }
@@ -459,9 +482,14 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
     }
 
     public static MockTable create(MockCatalogReader catalogReader,
+        MockSchema schema, String name, boolean stream, double rowCount, double maxRowCount) {
+      return create(catalogReader, schema, name, stream, rowCount, null, maxRowCount);
+    }
+
+    public static MockTable create(MockCatalogReader catalogReader,
         List<String> names, boolean stream, double rowCount) {
       return new MockTable(catalogReader, names, stream, false, rowCount, null,
-          NullInitializerExpressionFactory.INSTANCE, ImmutableList.of());
+          NullInitializerExpressionFactory.INSTANCE, ImmutableList.of(), Double.POSITIVE_INFINITY);
     }
 
     public static MockTable create(MockCatalogReader catalogReader,
@@ -469,6 +497,26 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
         ColumnResolver resolver) {
       return create(catalogReader, schema, name, stream, rowCount, resolver,
           NullInitializerExpressionFactory.INSTANCE, false);
+    }
+
+    public static MockTable create(MockCatalogReader catalogReader,
+        MockSchema schema, String name, boolean stream, double rowCount,
+        ColumnResolver resolver, double maxRowCount) {
+      return create(catalogReader, schema, name, stream, rowCount, resolver,
+          NullInitializerExpressionFactory.INSTANCE, false, maxRowCount);
+    }
+
+    public static MockTable create(MockCatalogReader catalogReader,
+        MockSchema schema, String name, boolean stream, double rowCount,
+        ColumnResolver resolver,
+        InitializerExpressionFactory initializerExpressionFactory,
+        boolean temporal, Double maxRowCount) {
+      MockTable table =
+          new MockTable(catalogReader, schema.getCatalogName(), schema.name,
+              name, stream, temporal, rowCount, resolver,
+              initializerExpressionFactory, maxRowCount);
+      schema.addTable(name);
+      return table;
     }
 
     public static MockTable create(MockCatalogReader catalogReader,
@@ -622,57 +670,6 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
   }
 
   /**
-   * Mock implementation of
-   * {@link org.apache.calcite.prepare.Prepare.PreparingTable} which supplies MaxRow stat.
-   */
-  public static class MaxRowMockTable
-      extends MockTable implements BuiltInMetadata.MaxRowCount.Handler {
-
-    private final double maxRowCount;
-
-    public MaxRowMockTable(MockCatalogReader catalogReader, String catalogName, String schemaName,
-        String name, boolean stream, boolean temporal, double rowCount, ColumnResolver resolver,
-        InitializerExpressionFactory initializerFactory, double maxRowCount) {
-      super(catalogReader, catalogName, schemaName, name, stream, temporal, rowCount, resolver,
-          initializerFactory);
-      this.maxRowCount = maxRowCount;
-    }
-
-    public static MockTable create(MockCatalogReader catalogReader,
-        MockSchema schema, String name, boolean stream, double rowCount,
-        ColumnResolver resolver,
-        InitializerExpressionFactory initializerExpressionFactory,
-        boolean temporal, double maxRowCount) {
-      MockTable table =
-          new MaxRowMockTable(catalogReader, schema.getCatalogName(), schema.name,
-              name, stream, temporal, rowCount, resolver,
-              initializerExpressionFactory, maxRowCount);
-      schema.addTable(name);
-      return table;
-    }
-
-    public static MockTable create(MockCatalogReader catalogReader,
-        MockSchema schema, String name, boolean stream, double rowCount, double maxRowCount) {
-      return create(catalogReader, schema, name, stream, rowCount, null, maxRowCount);
-    }
-
-    public static MockTable create(MockCatalogReader catalogReader,
-        MockSchema schema, String name, boolean stream, double rowCount,
-        ColumnResolver resolver, double maxRowCount) {
-      return create(catalogReader, schema, name, stream, rowCount, resolver,
-          NullInitializerExpressionFactory.INSTANCE, false, maxRowCount);
-    }
-
-    @Override public @Nullable Double getMaxRowCount(RelNode r, RelMetadataQuery mq) {
-      return maxRowCount;
-    }
-
-    @Override public MetadataDef<BuiltInMetadata.MaxRowCount> getDef() {
-      return BuiltInMetadata.MaxRowCount.Handler.super.getDef();
-    }
-  }
-
-  /**
    * Alternative to MockViewTable that exercises code paths in ModifiableViewTable
    * and ModifiableViewTableInitializerExpressionFactory.
    */
@@ -685,7 +682,7 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
         InitializerExpressionFactory initializerExpressionFactory) {
       super(catalogReader, ImmutableList.of(catalogName, schemaName, name),
           stream, false, rowCount, resolver, initializerExpressionFactory,
-          ImmutableList.of());
+          ImmutableList.of(), Double.POSITIVE_INFINITY);
       this.modifiableViewTable = modifiableViewTable;
     }
 
@@ -798,7 +795,7 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
         InitializerExpressionFactory initializerExpressionFactory) {
       super(catalogReader, ImmutableList.of(catalogName, schemaName, name),
           stream, false, rowCount, resolver, initializerExpressionFactory,
-          ImmutableList.of());
+          ImmutableList.of(), Double.POSITIVE_INFINITY);
       this.viewTable = viewTable;
     }
 

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -263,7 +263,7 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
 
     // Register "EMPTY_PRODUCTS" table.
     MockTable emptyProductsTable = MockTable.create(this, salesSchema, "EMPTY_PRODUCTS",
-        false, 2000D, 0.0);
+        false, 0D, 0D);
     emptyProductsTable.addColumn("PRODUCTID", fixture.intType);
     emptyProductsTable.addColumn("NAME", fixture.varchar20Type);
     emptyProductsTable.addColumn("SUPPLIERID", fixture.intType);

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -262,7 +262,7 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     registerTable(productsTable);
 
     // Register "EMPTY_PRODUCTS" table.
-    MockTable emptyProductsTable = MaxRowMockTable.create(this, salesSchema, "EMPTY_PRODUCTS",
+    MockTable emptyProductsTable = MockTable.create(this, salesSchema, "EMPTY_PRODUCTS",
         false, 2000D, 0.0);
     emptyProductsTable.addColumn("PRODUCTID", fixture.intType);
     emptyProductsTable.addColumn("NAME", fixture.varchar20Type);

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -261,6 +261,14 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     productsTable.addColumn("SUPPLIERID", fixture.intType);
     registerTable(productsTable);
 
+    // Register "EMPTY_PRODUCTS" table.
+    MockTable emptyProductsTable = MaxRowMockTable.create(this, salesSchema, "EMPTY_PRODUCTS",
+        false, 2000D, 0.0);
+    emptyProductsTable.addColumn("PRODUCTID", fixture.intType);
+    emptyProductsTable.addColumn("NAME", fixture.varchar20Type);
+    emptyProductsTable.addColumn("SUPPLIERID", fixture.intType);
+    registerTable(emptyProductsTable);
+
     // Register "PRODUCTS_TEMPORAL" table.
     MockTable productsTemporalTable =
         MockTable.create(this, salesSchema, "PRODUCTS_TEMPORAL", false, 200D,


### PR DESCRIPTION
The following changes are made to implement an optimization for pruning out the sub trees when a base-table is empty. The detection of a table being empty is done using MaxRow stat.

I have not used existing stats like rowcount etc for triggering the optimization as they are estimates and can be stale. I also thought about introducing a new stat like exactRowCount but it seems like an overkill (just for base table it is valid and it soon will be an estimate after base table for any other node in the tree). After due consideration, it seems like MaxRow stat fits well for this scenario.
1) It is not a default stat and it needs to be supplied for a table by overloading the MaxRowHandler.
2) Default value of the MaxRow is large value (Infinity) and hence the optimization doesn't trigger by default.

EmptyTableOptimizationConfig change adds a new rule to transform the base table to empty values node when maxRowCount is zero. All the existing PruneEmptyRules will do the necessary optimizations to prune out the complex sub-tree once the emptyValues node is created.

Please review the changes.