### PR TITLE
[CALCITE-5299] JDBC adapter sometimes adds unnecessary parentheses around SELECT in WITH body

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCall.java
@@ -118,7 +118,7 @@ public abstract class SqlCall extends SqlNode {
     final SqlDialect dialect = writer.getDialect();
     if (leftPrec > operator.getLeftPrec()
         || (operator.getRightPrec() <= rightPrec && (rightPrec != 0))
-        || writer.isAlwaysUseParentheses() && isA(SqlKind.EXPRESSION) && !writer.inWithBody()) {
+        || writer.isAlwaysUseParentheses() && isA(SqlKind.EXPRESSION)) {
       final SqlWriter.Frame frame = writer.startList("(", ")");
       dialect.unparseCall(writer, this, 0, 0);
       writer.endList(frame);

--- a/core/src/main/java/org/apache/calcite/sql/SqlCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCall.java
@@ -118,7 +118,7 @@ public abstract class SqlCall extends SqlNode {
     final SqlDialect dialect = writer.getDialect();
     if (leftPrec > operator.getLeftPrec()
         || (operator.getRightPrec() <= rightPrec && (rightPrec != 0))
-        || writer.isAlwaysUseParentheses() && isA(SqlKind.EXPRESSION)) {
+        || writer.isAlwaysUseParentheses() && isA(SqlKind.EXPRESSION) && !writer.inWithBody()) {
       final SqlWriter.Frame frame = writer.startList("(", ")");
       dialect.unparseCall(writer, this, 0, 0);
       writer.endList(frame);

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1199,7 +1199,7 @@ public enum SqlKind {
                   NULLS_FIRST, NULLS_LAST, COLLECTION_TABLE, TABLESAMPLE,
                   VALUES, WITH, WITH_ITEM, ITEM, SKIP_TO_FIRST, SKIP_TO_LAST,
                   JSON_VALUE_EXPRESSION, UNNEST),
-              AGGREGATE, DML, DDL));
+              SET_QUERY, AGGREGATE, DML, DDL));
 
   /**
    * Category of all SQL statement types.

--- a/core/src/main/java/org/apache/calcite/sql/SqlWith.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWith.java
@@ -103,8 +103,9 @@ public class SqlWith extends SqlCall {
       }
       writer.endList(frame1);
       final SqlWriter.Frame frame2 =
-          writer.startList(SqlWriter.FrameTypeEnum.SIMPLE);
-      with.body.unparse(writer, 100, 100);
+          writer.startList(SqlWriter.FrameTypeEnum.WITH_BODY);
+      // leftPrec: 2, rightPrec: 3 are the low bound to WITH operator
+      with.body.unparse(writer, 2, 3);
       writer.endList(frame2);
       writer.endList(frame);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlWith.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWith.java
@@ -104,8 +104,8 @@ public class SqlWith extends SqlCall {
       writer.endList(frame1);
       final SqlWriter.Frame frame2 =
           writer.startList(SqlWriter.FrameTypeEnum.WITH_BODY);
-      // leftPrec: 2, rightPrec: 3 are the low bound to WITH operator
-      with.body.unparse(writer, 2, 3);
+      with.body.unparse(writer,
+          SqlWithOperator.INSTANCE.getLeftPrec(), SqlWithOperator.INSTANCE.getRightPrec());
       writer.endList(frame2);
       writer.endList(frame);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -548,11 +548,6 @@ public interface SqlWriter {
    */
   boolean inQuery();
 
-  /**
-   * Returns whether we are currently in a WITH body query context.
-   */
-  boolean inWithBody();
-
   //~ Inner Interfaces -------------------------------------------------------
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -150,6 +150,11 @@ public interface SqlWriter {
     WITH,
 
     /**
+     * The body query of WITH.
+     */
+    WITH_BODY,
+
+    /**
      * OFFSET clause.
      *
      * <p>Example:</p>
@@ -542,6 +547,11 @@ public interface SqlWriter {
    * UNION, INTERSECT, EXCEPT, and the ORDER BY operator).
    */
   boolean inQuery();
+
+  /**
+   * Returns whether we are currently in a WITH body query context.
+   */
+  boolean inWithBody();
 
   //~ Inner Interfaces -------------------------------------------------------
 

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -402,10 +402,6 @@ public class SqlPrettyWriter implements SqlWriter {
         || (frame.frameType == FrameTypeEnum.SETOP);
   }
 
-  @Override public boolean inWithBody() {
-    return frame != null && frame.frameType == FrameTypeEnum.WITH_BODY;
-  }
-
   @Deprecated
   @Override public boolean isQuoteAllIdentifiers() {
     return config.quoteAllIdentifiers();

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -398,8 +398,12 @@ public class SqlPrettyWriter implements SqlWriter {
     return (frame == null)
         || (frame.frameType == FrameTypeEnum.SELECT)
         || (frame.frameType == FrameTypeEnum.ORDER_BY)
-        || (frame.frameType == FrameTypeEnum.WITH)
+        || (frame.frameType == FrameTypeEnum.WITH_BODY)
         || (frame.frameType == FrameTypeEnum.SETOP);
+  }
+
+  @Override public boolean inWithBody() {
+    return frame != null && frame.frameType == FrameTypeEnum.WITH_BODY;
   }
 
   @Deprecated

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2737,6 +2737,21 @@ public class SqlParserTest {
     sql(sql6).ok(expected6);
   }
 
+  @Test void testUnionIntersect() {
+    // Note that the union sub-query has parentheses.
+    final String sql = "(select * from a union select * from b)\n"
+        + "intersect select * from c";
+    final String expected = "(SELECT *\n"
+        + "FROM `A`\n"
+        + "UNION\n"
+        + "SELECT *\n"
+        + "FROM `B`)\n"
+        + "INTERSECT\n"
+        + "SELECT *\n"
+        + "FROM `C`";
+    sql(sql).ok(expected);
+  }
+
   @Test void testUnionOfNonQueryFails() {
     sql("select 1 from emp union ^2^ + 5")
         .fails("Non-query expression encountered in illegal context");

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2266,9 +2266,6 @@ public class SqlParserTest {
     sql(sql).ok(expected);
   }
 
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5299">[CALCITE-5299]
-   * JDBC adapter sometimes adds unnecessary parentheses around SELECT in WITH body</a>. */
   @Test void testWithNestedInSubQuery() {
     // SQL standard does not allow sub-query to contain WITH but we do
     final String sql = "with emp2 as (select * from emp)\n"
@@ -2282,9 +2279,6 @@ public class SqlParserTest {
     sql(sql).ok(expected);
   }
 
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5299">[CALCITE-5299]
-   * JDBC adapter sometimes adds unnecessary parentheses around SELECT in WITH body</a>. */
   @Test void testWithUnion() {
     // Per the standard WITH ... SELECT ... UNION is valid even without parens.
     final String sql = "with emp2 as (select * from emp)\n"

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2530,11 +2530,11 @@ public class SqlParserTest {
         + "select * from dept) and false")
         .ok("SELECT *\n"
             + "FROM `EMP`\n"
-            + "WHERE ((`DEPTNO` IN ((SELECT `DEPTNO`\n"
+            + "WHERE ((`DEPTNO` IN (SELECT `DEPTNO`\n"
             + "FROM `DEPT`\n"
             + "UNION\n"
             + "SELECT *\n"
-            + "FROM `DEPT`)\n"
+            + "FROM `DEPT`\n"
             + "EXCEPT\n"
             + "SELECT *\n"
             + "FROM `DEPT`)) AND FALSE)");
@@ -2594,23 +2594,23 @@ public class SqlParserTest {
 
   @Test void testUnion() {
     sql("select * from a union select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "UNION\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
     sql("select * from a union all select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "UNION ALL\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
     sql("select * from a union distinct select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "UNION\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
   }
 
   @Test void testUnionOrder() {
@@ -2618,11 +2618,11 @@ public class SqlParserTest {
         + "union all "
         + "select x, y from u "
         + "order by 1 asc, 2 desc")
-        .ok("(SELECT `A`, `B`\n"
+        .ok("SELECT `A`, `B`\n"
             + "FROM `T`\n"
             + "UNION ALL\n"
             + "SELECT `X`, `Y`\n"
-            + "FROM `U`)\n"
+            + "FROM `U`\n"
             + "ORDER BY 1, 2 DESC");
   }
 
@@ -2648,13 +2648,13 @@ public class SqlParserTest {
     final String sql = "(select a from t limit 10)\n"
         + "union all\n"
         + "(select b from t offset 20)";
-    final String expected = "((SELECT `A`\n"
+    final String expected = "(SELECT `A`\n"
         + "FROM `T`\n"
         + "FETCH NEXT 10 ROWS ONLY)\n"
         + "UNION ALL\n"
         + "(SELECT `B`\n"
         + "FROM `T`\n"
-        + "OFFSET 20 ROWS))";
+        + "OFFSET 20 ROWS)";
     sql(sql).ok(expected);
   }
 
@@ -2664,76 +2664,76 @@ public class SqlParserTest {
     final String sql = "select a from t\n"
         + "union all\n"
         + "(select b from t order by b offset 3 fetch next 5 rows only)";
-    final String expected = "(SELECT `A`\n"
+    final String expected = "SELECT `A`\n"
         + "FROM `T`\n"
         + "UNION ALL\n"
         + "(SELECT `B`\n"
         + "FROM `T`\n"
         + "ORDER BY `B`\n"
         + "OFFSET 3 ROWS\n"
-        + "FETCH NEXT 5 ROWS ONLY))";
+        + "FETCH NEXT 5 ROWS ONLY)";
     sql(sql).ok(expected);
 
     // as above, just ORDER BY
     final String sql2 = "select a from t\n"
         + "union all\n"
         + "(select b from t order by b)";
-    final String expected2 = "(SELECT `A`\n"
+    final String expected2 = "SELECT `A`\n"
         + "FROM `T`\n"
         + "UNION ALL\n"
         + "(SELECT `B`\n"
         + "FROM `T`\n"
-        + "ORDER BY `B`))";
+        + "ORDER BY `B`)";
     sql(sql2).ok(expected2);
 
     // as above, just OFFSET
     final String sql3 = "select a from t\n"
         + "union all\n"
         + "(select b from t offset 3)";
-    final String expected3 = "(SELECT `A`\n"
+    final String expected3 = "SELECT `A`\n"
         + "FROM `T`\n"
         + "UNION ALL\n"
         + "(SELECT `B`\n"
         + "FROM `T`\n"
-        + "OFFSET 3 ROWS))";
+        + "OFFSET 3 ROWS)";
     sql(sql3).ok(expected3);
 
     // as above, just FETCH
     final String sql4 = "select a from t\n"
         + "union all\n"
         + "(select b from t fetch next 5 rows only)";
-    final String expected4 = "(SELECT `A`\n"
+    final String expected4 = "SELECT `A`\n"
         + "FROM `T`\n"
         + "UNION ALL\n"
         + "(SELECT `B`\n"
         + "FROM `T`\n"
-        + "FETCH NEXT 5 ROWS ONLY))";
+        + "FETCH NEXT 5 ROWS ONLY)";
     sql(sql4).ok(expected4);
 
     // as above, just FETCH and OFFSET
     final String sql5 = "select a from t\n"
         + "union all\n"
         + "(select b from t offset 3 fetch next 5 rows only)";
-    final String expected5 = "(SELECT `A`\n"
+    final String expected5 = "SELECT `A`\n"
         + "FROM `T`\n"
         + "UNION ALL\n"
         + "(SELECT `B`\n"
         + "FROM `T`\n"
         + "OFFSET 3 ROWS\n"
-        + "FETCH NEXT 5 ROWS ONLY))";
+        + "FETCH NEXT 5 ROWS ONLY)";
     sql(sql5).ok(expected5);
 
     // as previous, INTERSECT
     final String sql6 = "select a from t\n"
         + "intersect\n"
         + "(select b from t offset 3 fetch next 5 rows only)";
-    final String expected6 = "(SELECT `A`\n"
+    final String expected6 = "SELECT `A`\n"
         + "FROM `T`\n"
         + "INTERSECT\n"
         + "(SELECT `B`\n"
         + "FROM `T`\n"
         + "OFFSET 3 ROWS\n"
-        + "FETCH NEXT 5 ROWS ONLY))";
+        + "FETCH NEXT 5 ROWS ONLY)";
     sql(sql6).ok(expected6);
   }
 
@@ -2755,23 +2755,23 @@ public class SqlParserTest {
 
   @Test void testExcept() {
     sql("select * from a except select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "EXCEPT\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
     sql("select * from a except all select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "EXCEPT ALL\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
     sql("select * from a except distinct select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "EXCEPT\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
   }
 
   /** Tests MINUS, which is equivalent to EXCEPT but only supported in some
@@ -2782,22 +2782,22 @@ public class SqlParserTest {
     final String sql = "select col1 from table1 ^MINUS^ select col1 from table2";
     sql(sql).fails(pattern);
 
-    final String expected = "(SELECT `COL1`\n"
+    final String expected = "SELECT `COL1`\n"
         + "FROM `TABLE1`\n"
         + "EXCEPT\n"
         + "SELECT `COL1`\n"
-        + "FROM `TABLE2`)";
+        + "FROM `TABLE2`";
     sql(sql)
         .withConformance(SqlConformanceEnum.ORACLE_10)
         .ok(expected);
 
     final String sql2 =
         "select col1 from table1 MINUS ALL select col1 from table2";
-    final String expected2 = "(SELECT `COL1`\n"
+    final String expected2 = "SELECT `COL1`\n"
         + "FROM `TABLE1`\n"
         + "EXCEPT ALL\n"
         + "SELECT `COL1`\n"
-        + "FROM `TABLE2`)";
+        + "FROM `TABLE2`";
     sql(sql2)
         .withConformance(SqlConformanceEnum.ORACLE_10)
         .ok(expected2);
@@ -2818,23 +2818,23 @@ public class SqlParserTest {
 
   @Test void testIntersect() {
     sql("select * from a intersect select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "INTERSECT\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
     sql("select * from a intersect all select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "INTERSECT ALL\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
     sql("select * from a intersect distinct select * from a")
-        .ok("(SELECT *\n"
+        .ok("SELECT *\n"
             + "FROM `A`\n"
             + "INTERSECT\n"
             + "SELECT *\n"
-            + "FROM `A`)");
+            + "FROM `A`");
   }
 
   @Test void testJoinCross() {
@@ -3299,12 +3299,12 @@ public class SqlParserTest {
 
   @Test void testOrderInternal() {
     sql("(select * from emp order by empno) union select * from emp")
-        .ok("((SELECT *\n"
+        .ok("(SELECT *\n"
             + "FROM `EMP`\n"
             + "ORDER BY `EMPNO`)\n"
             + "UNION\n"
             + "SELECT *\n"
-            + "FROM `EMP`)");
+            + "FROM `EMP`");
 
     sql("select * from (select * from t order by x, y) where a = b")
         .ok("SELECT *\n"
@@ -3454,11 +3454,11 @@ public class SqlParserTest {
         + "union\n"
         + "select b from baz\n"
         + "limit 3";
-    final String expected5 = "(SELECT A\n"
+    final String expected5 = "SELECT A\n"
         + "FROM FOO\n"
         + "UNION\n"
         + "SELECT B\n"
-        + "FROM BAZ)\n"
+        + "FROM BAZ\n"
         + "LIMIT 3";
     sql(sql5).withDialect(SparkSqlDialect.DEFAULT).ok(expected5);
   }
@@ -3774,26 +3774,26 @@ public class SqlParserTest {
         + "select * from e except "
         + "select * from f union "
         + "select * from g";
-    final String expected = "((((SELECT *\n"
+    final String expected = "SELECT *\n"
         + "FROM `A`\n"
         + "UNION\n"
-        + "((SELECT *\n"
+        + "SELECT *\n"
         + "FROM `B`\n"
         + "INTERSECT\n"
         + "SELECT *\n"
-        + "FROM `C`)\n"
+        + "FROM `C`\n"
         + "INTERSECT\n"
         + "SELECT *\n"
-        + "FROM `D`))\n"
+        + "FROM `D`\n"
         + "EXCEPT\n"
         + "SELECT *\n"
-        + "FROM `E`)\n"
+        + "FROM `E`\n"
         + "EXCEPT\n"
         + "SELECT *\n"
-        + "FROM `F`)\n"
+        + "FROM `F`\n"
         + "UNION\n"
         + "SELECT *\n"
-        + "FROM `G`)";
+        + "FROM `G`";
     sql(sql).ok(expected);
   }
 
@@ -4410,11 +4410,11 @@ public class SqlParserTest {
     sql("describe statement (select * from emps)").ok(expected0);
     final String expected2 = ""
         + "EXPLAIN PLAN INCLUDING ATTRIBUTES WITH IMPLEMENTATION FOR\n"
-        + "(SELECT `DEPTNO`\n"
+        + "SELECT `DEPTNO`\n"
         + "FROM `EMPS`\n"
         + "UNION\n"
         + "SELECT `DEPTNO`\n"
-        + "FROM `DEPTS`)";
+        + "FROM `DEPTS`";
     sql("describe select deptno from emps union select deptno from depts").ok(expected2);
     final String expected3 = ""
         + "EXPLAIN PLAN INCLUDING ATTRIBUTES WITH IMPLEMENTATION FOR\n"
@@ -4444,11 +4444,11 @@ public class SqlParserTest {
 
   @Test void testInsertUnion() {
     final String expected = "INSERT INTO `EMPS`\n"
-        + "(SELECT *\n"
+        + "SELECT *\n"
         + "FROM `EMPS1`\n"
         + "UNION\n"
         + "SELECT *\n"
-        + "FROM `EMPS2`)";
+        + "FROM `EMPS2`";
     sql("insert into emps select * from emps1 union select * from emps2")
         .ok(expected);
   }
@@ -8415,14 +8415,14 @@ public class SqlParserTest {
         + "  select y from b)\n"
         + "except\n"
         + "(select z from c)";
-    final String expected = "((SELECT `X`\n"
+    final String expected = "SELECT `X`\n"
         + "FROM `A`\n"
         + "UNION\n"
         + "SELECT `Y`\n"
-        + "FROM `B`)\n"
+        + "FROM `B`\n"
         + "EXCEPT\n"
         + "SELECT `Z`\n"
-        + "FROM `C`)";
+        + "FROM `C`";
     sql(sql).ok(expected);
   }
 


### PR DESCRIPTION
Remove unnecessary parentheses around SELECT in WITH body