### PR TITLE
[CALCITE-5339] Use Method#getParameterCount rather than Method#getParameterTypes to get length

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGeneratorUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGeneratorUtil.java
@@ -197,7 +197,7 @@ class CacheGeneratorUtil {
       @Override void cacheKeyBlock(StringBuilder buff, Method method, int methodIndex) {
         buff.append("    key = ")
             .append(
-                (method.getParameterTypes().length < 6
+                (method.getParameterCount() < 6
                     ? org.apache.calcite.runtime.FlatLists.class
                     : ImmutableList.class).getName())
             .append(".of(");

--- a/core/src/main/java/org/apache/calcite/schema/impl/ReflectiveFunctionBase.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ReflectiveFunctionBase.java
@@ -71,7 +71,7 @@ public abstract class ReflectiveFunctionBase implements Function {
    */
   static boolean classHasPublicZeroArgsConstructor(Class<?> clazz) {
     for (Constructor<?> constructor : clazz.getConstructors()) {
-      if (constructor.getParameterTypes().length == 0
+      if (constructor.getParameterCount() == 0
           && Modifier.isPublic(constructor.getModifiers())) {
         return true;
       }
@@ -89,7 +89,7 @@ public abstract class ReflectiveFunctionBase implements Function {
    */
   static boolean classHasPublicFunctionContextConstructor(Class<?> clazz) {
     for (Constructor<?> constructor : clazz.getConstructors()) {
-      if (constructor.getParameterTypes().length == 1
+      if (constructor.getParameterCount() == 1
           && constructor.getParameterTypes()[0] == FunctionContext.class
           && Modifier.isPublic(constructor.getModifiers())) {
         return true;

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -1388,7 +1388,7 @@ public class SqlPrettyWriter implements SqlWriter {
       for (Method method : o.getClass().getMethods()) {
         if (method.getName().startsWith("set")
             && (method.getReturnType() == Void.class)
-            && (method.getParameterTypes().length == 1)) {
+            && (method.getParameterCount() == 1)) {
           String attributeName =
               stripPrefix(
                   method.getName(),
@@ -1397,7 +1397,7 @@ public class SqlPrettyWriter implements SqlWriter {
         }
         if (method.getName().startsWith("get")
             && (method.getReturnType() != Void.class)
-            && (method.getParameterTypes().length == 0)) {
+            && (method.getParameterCount() == 0)) {
           String attributeName =
               stripPrefix(
                   method.getName(),
@@ -1406,7 +1406,7 @@ public class SqlPrettyWriter implements SqlWriter {
         }
         if (method.getName().startsWith("is")
             && (method.getReturnType() == Boolean.class)
-            && (method.getParameterTypes().length == 0)) {
+            && (method.getParameterCount() == 0)) {
           String attributeName =
               stripPrefix(
                   method.getName(),

--- a/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlTestGen.java
@@ -77,7 +77,7 @@ class SqlTestGen {
       if (method.getName().startsWith("test")
           && Modifier.isPublic(method.getModifiers())
           && !Modifier.isStatic(method.getModifiers())
-          && (method.getParameterTypes().length == 0)
+          && (method.getParameterCount() == 0)
           && (method.getReturnType() == Void.TYPE)) {
         list.add(method);
       }

--- a/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
+++ b/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
@@ -723,7 +723,7 @@ public class CalciteAssert {
     loop:
       for (Method method1 : aClass.getMethods()) {
         if (method1.getName().equals(methodName)
-            && method1.getParameterTypes().length == args.length
+            && method1.getParameterCount() == args.length
             && Modifier.isPublic(method1.getDeclaringClass().getModifiers())) {
           for (Pair<Object, Class> pair
               : Pair.zip(args, (Class[]) method1.getParameterTypes())) {


### PR DESCRIPTION
As stated in jira issue `Method#getParameterTypes` each time creates a new array so it's better to use  `Method#getParameterCount` to know length of array