### PR TITLE
[MINOR] Add default catalog link to test fixtures

### DIFF
--- a/testkit/src/main/java/org/apache/calcite/test/RelOptTestBase.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelOptTestBase.java
@@ -34,7 +34,10 @@ abstract class RelOptTestBase {
     return RelOptFixture.DEFAULT;
   }
 
-  /** Creates a fixture and sets its SQL statement. */
+  /**
+   * Creates a test context with a SQL query.
+   * Default catalog: {@link org.apache.calcite.test.catalog.MockCatalogReaderSimple#init()}.
+   */
   protected final RelOptFixture sql(String sql) {
     return fixture().sql(sql);
   }

--- a/testkit/src/main/java/org/apache/calcite/test/SqlToRelTestBase.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlToRelTestBase.java
@@ -55,7 +55,10 @@ public abstract class SqlToRelTestBase {
     return SqlToRelFixture.DEFAULT;
   }
 
-  /** Sets the SQL statement for a test. */
+  /**
+   * Creates a test context with a SQL query.
+   * Default catalog: {@link org.apache.calcite.test.catalog.MockCatalogReaderSimple#init()}.
+   */
   public final SqlToRelFixture sql(String sql) {
     return fixture().expression(false).withSql(sql);
   }

--- a/testkit/src/main/java/org/apache/calcite/test/SqlValidatorTestCase.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlValidatorTestCase.java
@@ -49,7 +49,10 @@ public class SqlValidatorTestCase {
     return FIXTURE;
   }
 
-  /** Creates a test context with a SQL query. */
+  /**
+   * Creates a test context with a SQL query.
+   * Default catalog: {@link org.apache.calcite.test.catalog.MockCatalogReaderSimple#init()}.
+   */
   public final SqlValidatorFixture sql(String sql) {
     return fixture().withSql(sql);
   }


### PR DESCRIPTION
- When I write a unit test, I often see which tables and columns are available. At present, I have to search the catalog. If there is a link to jump directly, it is very convenient.
- For new contributor, it will be easier to find the default catalog.