### PR TITLE
[CALCITE-5355] Use the Presto SQL dialect for AWS Athena

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
@@ -49,6 +49,8 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -74,6 +76,8 @@ import static java.util.Objects.requireNonNull;
  * as much as possible of the query logic to SQL.</p>
  */
 public class JdbcSchema implements Schema {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JdbcSchema.class);
+
   final DataSource dataSource;
   final @Nullable String catalog;
   final @Nullable String schema;
@@ -290,7 +294,7 @@ public class JdbcSchema implements Schema {
         final TableType tableType =
             Util.enumVal(TableType.OTHER, tableTypeName2);
         if (tableType == TableType.OTHER  && tableTypeName2 != null) {
-          System.out.println("Unknown table type: " + tableTypeName2);
+          LOGGER.info("Unknown table type: {}", tableTypeName2);
         }
         final JdbcTable table =
             new JdbcTable(this, tableDef.tableCat, tableDef.tableSchem,

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -289,6 +289,7 @@ public class SqlDialect {
     case "PHOENIX":
       return DatabaseProduct.PHOENIX;
     case "PRESTO":
+    case "AWS.ATHENA":
       return DatabaseProduct.PRESTO;
     case "MYSQL (INFOBRIGHT)":
       return DatabaseProduct.INFOBRIGHT;

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialectFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialectFactoryImpl.java
@@ -107,6 +107,9 @@ public class SqlDialectFactoryImpl implements SqlDialectFactory {
       return new OracleSqlDialect(c);
     case "PHOENIX":
       return new PhoenixSqlDialect(c);
+    case "PRESTO":
+    case "AWS.ATHENA":
+      return new PrestoSqlDialect(c);
     case "MYSQL (INFOBRIGHT)":
       return new InfobrightSqlDialect(c);
     case "MYSQL":


### PR DESCRIPTION
I used manual testing of the Drill query 
```
select * from athena.test_table limit 10 offset 3
```
where the storage plugin `athena` uses Drill's Calcite-based JDBC storage plugin. With Calcite 1.32.0 `FETCH NEXT 10 ROWS ONLY` is generated and rejected by Athena. With Calcite built from this branch the query succeeds and the expected limit and offset are applied.

A minor aside that I'd appreciate any pointers on is that Calcite prints the following to stdout for every query made against Athena.
```
Unknown table type: EXTERNAL_TABLE
```
I've seen the same thing when querying the H2 DBMS though IIRC the table type involved was different. When Drill runs in embedded mode then stdout is the same place as the user's sqlline session so these messages are quite noisy and will be disconcerting for users. Can I do something about this? Add new table types, change the warning to go to a log rather than stdout?

Thanks
James