### PR TITLE
[CALCITE-5336] Infer constants from predicates with IS NOT DISTINCT FROM operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.prepare;
 
+import org.apache.calcite.DataContexts;
 import org.apache.calcite.adapter.enumerable.EnumerableCalc;
 import org.apache.calcite.adapter.enumerable.EnumerableConvention;
 import org.apache.calcite.adapter.enumerable.EnumerableInterpretable;
@@ -72,6 +73,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexExecutorImpl;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
@@ -442,6 +444,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     }
     final VolcanoPlanner planner =
         new VolcanoPlanner(costFactory, externalContext);
+    planner.setExecutor(new RexExecutorImpl(DataContexts.EMPTY));
     planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
     if (CalciteSystemProperty.ENABLE_COLLATION_TRAIT.value()) {
       planner.addRelTraitDef(RelCollationTraitDef.INSTANCE);

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -387,14 +387,16 @@ public class RexUtil {
       RexNode predicate, Map<RexNode, C> map, Set<RexNode> excludeSet,
       RexBuilder rexBuilder) {
     if (predicate.getKind() != SqlKind.EQUALS
-            && predicate.getKind() != SqlKind.IS_NULL) {
+        && predicate.getKind() != SqlKind.IS_NULL
+        && predicate.getKind() != SqlKind.IS_NOT_DISTINCT_FROM) {
       decompose(excludeSet, predicate);
       return;
     }
     final List<RexNode> operands = ((RexCall) predicate).getOperands();
     final RexNode left;
     final RexNode right;
-    if (predicate.getKind() == SqlKind.EQUALS) {
+    if (predicate.getKind() == SqlKind.EQUALS
+        || predicate.getKind() == SqlKind.IS_NOT_DISTINCT_FROM) {
       left = operands.get(0);
       right = operands.get(1);
     } else { // is null

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -99,6 +99,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.TableFunctionReturnTypeInference;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
@@ -475,6 +476,8 @@ public class RelBuilder {
     } else if (value instanceof Enum) {
       return rexBuilder.makeLiteral(value,
           getTypeFactory().createSqlType(SqlTypeName.SYMBOL));
+    } else if (value instanceof DateString) {
+      return rexBuilder.makeDateLiteral((DateString) value);
     } else {
       throw new IllegalArgumentException("cannot convert " + value
           + " (" + value.getClass() + ") to a constant");

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -123,6 +123,7 @@ import org.apache.calcite.tools.Programs;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
+import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.collect.ImmutableList;
@@ -7443,5 +7444,34 @@ class RelOptRulesTest extends RelOptTestBase {
         .withFactory(f -> f.withTypeFactoryFactory(typeFactoryFactory))
         .withRule(CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES_TO_JOIN)
         .check();
+  }
+
+  /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5336">[CALCITE-5336]
+   * Support inferring constants from predicates with IS NOT DISTINCT FROM operator</a>.
+   * <p>
+   * Reduce expression rules should identify constants with IS_NOT_DISTINCT_FROM operator as well.
+   * </p>
+   */
+  @Test void testProjectReduceExpressionsWithIsNotDistinctFrom() {
+
+    // Build a rel equivalent to sql:
+    // SELECT hiredate from emp where hiredate is not distinct from '2020-12-11'
+
+    final Function<RelBuilder, RelNode> relFn = b -> {
+      b = b.scan("EMP");
+
+      final RexNode filterCond = b.getRexBuilder()
+          .makeCall(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM,
+              b.field(4),
+              b.literal(new DateString(2020, 12, 11)));
+
+      return b.filter(filterCond)
+          .project(b.field(4))
+          .build();
+    };
+
+    relFn(relFn).withRule(CoreRules.PROJECT_REDUCE_EXPRESSIONS).check();
+
   }
 }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6925,6 +6925,22 @@ LogicalProject(EXPR$0=[ROW_NUMBER() OVER (ORDER BY $0)], COL1=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectReduceExpressionsWithIsNotDistinctFrom">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(HIREDATE=[$4])
+  LogicalFilter(condition=[IS NOT DISTINCT FROM($4, 2020-12-11)])
+    LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(HIREDATE=[CAST(2020-12-11):DATE])
+  LogicalFilter(condition=[IS NOT DISTINCT FROM($4, 2020-12-11)])
+    LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProjectSetOpTranspose">
     <Resource name="sql">
       <![CDATA[select job, sum(sal + 100) over (partition by deptno) from


### PR DESCRIPTION
RexUtil#gatherConstraints infer constants from a predicate with IS_NOT_DISTINCT_FROM operator.