### PR TITLE
[CALCITE-2989] Use ISO calendar system when converting from java.sql.Date/Time/Timestamp to a unix timestamp

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -210,6 +210,20 @@ public class RexUtil {
   }
 
   /**
+   * Returns whether a node represents a {@link SqlTypeName#SYMBOL} literal.
+   */
+  public static boolean isSymbolLiteral(RexNode expr) {
+    switch (expr.getKind()) {
+    case LITERAL:
+      return ((RexLiteral) expr).getTypeName() == SqlTypeName.SYMBOL;
+    case CAST:
+      return isSymbolLiteral(((RexCall) expr).operands.get(0));
+    default:
+      return false;
+    }
+  }
+
+  /**
    * Returns whether a node represents a literal.
    *
    * <p>Examples:

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -539,7 +539,7 @@ public abstract class SqlLibraryOperators {
 
   /** The "CONCAT(arg, ...)" function that concatenates strings.
    * For example, "CONCAT('a', 'bc', 'd')" returns "abcd". */
-  @LibraryOperator(libraries = {MYSQL, POSTGRESQL})
+  @LibraryOperator(libraries = {MYSQL, POSTGRESQL, BIG_QUERY})
   public static final SqlFunction CONCAT_FUNCTION =
       new SqlFunction("CONCAT",
           SqlKind.OTHER_FUNCTION,

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRule.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRule.java
@@ -193,6 +193,9 @@ public class SqlTypeAssignmentRule implements SqlTypeMappingRule {
     // MAP is assignable from ...
     rules.add(SqlTypeName.MAP, EnumSet.of(SqlTypeName.MAP));
 
+    // SYMBOL is assignable from ...
+    rules.add(SqlTypeName.SYMBOL, EnumSet.of(SqlTypeName.SYMBOL));
+
     // ANY is assignable from ...
     rule.clear();
     rule.add(SqlTypeName.TINYINT);

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -1790,10 +1790,11 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
     @Override public RexNode visitLiteral(RexLiteral literal) {
       // Use nullIndicator to decide whether to project null.
-      // Do nothing if the literal is null.
+      // Do nothing if the literal is null or symbol.
       if (!RexUtil.isNull(literal)
           && projectPulledAboveLeftCorrelator
-          && (nullIndicator != null)) {
+          && (nullIndicator != null)
+          && !RexUtil.isSymbolLiteral(literal)) {
         return createCaseExpression(nullIndicator, null, literal);
       }
       return literal;

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -3569,4 +3569,18 @@ SELECT ARRAY(SELECT s.x) FROM (SELECT 1 as x) s;
 
 !ok
 
+# Test case for [CALCITE-5310] JSON_OBJECT in scalar sub-query throws AssertionError
+SELECT (SELECT json_object('1': (a.attidentity = 'a'), '2': v) FROM UNNEST(ARRAY[1]) as v) as options
+FROM UNNEST(ARRAY['a', 'b']) AS a(attidentity);
+
++-------------------+
+| OPTIONS           |
++-------------------+
+| {"1":false,"2":1} |
+| {"1":true,"2":1}  |
++-------------------+
+(2 rows)
+
+!ok
+
 # End sub-query.iq

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -1834,6 +1834,7 @@ public class SqlOperatorTest {
     final SqlOperatorFixture f = fixture();
     checkConcatFunc(f.withLibrary(SqlLibrary.MYSQL));
     checkConcatFunc(f.withLibrary(SqlLibrary.POSTGRESQL));
+    checkConcatFunc(f.withLibrary(SqlLibrary.BIG_QUERY));
     checkConcat2Func(f.withLibrary(SqlLibrary.ORACLE));
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/schemata/catchall/CatchallSchema.java
+++ b/testkit/src/main/java/org/apache/calcite/test/schemata/catchall/CatchallSchema.java
@@ -51,8 +51,8 @@ public class CatchallSchema {
       new EveryType(
           false, (byte) 0, (char) 0, (short) 0, 0, 0L, 0F, 0D,
           false, (byte) 0, (char) 0, (short) 0, 0, 0L, 0F, 0D,
-          new java.sql.Date(0), new Time(0), new Timestamp(0),
-          new Date(0), "1", BigDecimal.ZERO),
+          java.sql.Date.valueOf("1970-01-01"), Time.valueOf("00:00:00"),
+          Timestamp.valueOf("1970-01-01 00:00:00"), new Date(0), "1", BigDecimal.ZERO),
       new EveryType(
           true, Byte.MAX_VALUE, Character.MAX_VALUE, Short.MAX_VALUE,
           Integer.MAX_VALUE, Long.MAX_VALUE, Float.MAX_VALUE,


### PR DESCRIPTION
This changes the unix timestamp to Date/Time/Timestamp conversion in `SqlFunctions` to convert between the ISO calendar system and the standard Gregorian calendar. This ensures that unix timestamps created by `SqlFunctions` will have the same value as unix timestamps created by `DateTimeUtils`.

Some of the tests may fail without this corresponding change to Avatica:
https://github.com/apache/calcite-avatica/pull/197