### PR TITLE
[CALCITE-5180] Implement some of the overloads for BigQuery's DATE and TIMESTAMP

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -533,6 +533,7 @@ data: {
     # Example: "DateFunctionCall()".
     builtinFunctionCallMethods: [
        "DateFunctionCall()"
+       "TimestampFunctionCall()"
        "DateaddFunctionCall()"
     ]
 

--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -534,6 +534,7 @@ data: {
     builtinFunctionCallMethods: [
        "DateFunctionCall()"
        "TimestampFunctionCall()"
+       "TimeFunctionCall()"
        "DateaddFunctionCall()"
     ]
 

--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -24,7 +24,7 @@ JoinType LeftSemiJoin() :
 
 SqlNode DateFunctionCall() :
 {
-    final SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+    final SqlFunctionCategory funcType = SqlFunctionCategory.TIMEDATE;
     final SqlIdentifier qualifiedName;
     final Span s;
     final SqlLiteral quantifier;
@@ -44,7 +44,7 @@ SqlNode DateFunctionCall() :
 
 SqlNode TimestampFunctionCall() :
 {
-    final SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+    final SqlFunctionCategory funcType = SqlFunctionCategory.TIMEDATE;
     final SqlIdentifier qualifiedName;
     final Span s;
     final SqlLiteral quantifier;
@@ -64,7 +64,7 @@ SqlNode TimestampFunctionCall() :
 
 SqlNode TimeFunctionCall() :
 {
-    final SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+    final SqlFunctionCategory funcType = SqlFunctionCategory.TIMEDATE;
     final SqlIdentifier qualifiedName;
     final Span s;
     final SqlLiteral quantifier;

--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -62,6 +62,26 @@ SqlNode TimestampFunctionCall() :
     }
 }
 
+SqlNode TimeFunctionCall() :
+{
+    final SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+    final SqlIdentifier qualifiedName;
+    final Span s;
+    final SqlLiteral quantifier;
+    final List<? extends SqlNode> args;
+}
+{
+    <TIME> {
+        s = span();
+        qualifiedName = new SqlIdentifier(unquotedIdentifier(), getPos());
+    }
+    args = FunctionParameterList(ExprContext.ACCEPT_SUB_QUERY) {
+        quantifier = (SqlLiteral) args.get(0);
+        args.remove(0);
+        return createCall(qualifiedName, s.end(this), funcType, quantifier, args);
+    }
+}
+
 SqlNode DateaddFunctionCall() :
 {
     final Span s;

--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -42,6 +42,26 @@ SqlNode DateFunctionCall() :
     }
 }
 
+SqlNode TimestampFunctionCall() :
+{
+    final SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+    final SqlIdentifier qualifiedName;
+    final Span s;
+    final SqlLiteral quantifier;
+    final List<? extends SqlNode> args;
+}
+{
+    <TIMESTAMP> {
+        s = span();
+        qualifiedName = new SqlIdentifier(unquotedIdentifier(), getPos());
+    }
+    args = FunctionParameterList(ExprContext.ACCEPT_SUB_QUERY) {
+        quantifier = (SqlLiteral) args.get(0);
+        args.remove(0);
+        return createCall(qualifiedName, s.end(this), funcType, quantifier, args);
+    }
+}
+
 SqlNode DateaddFunctionCall() :
 {
     final Span s;

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -1051,29 +1051,27 @@ select unix_date(timestamp '2008-12-25') as d;
 
 !ok
 
-# DATE
-# 'date(x) is shorthand for 'cast(x as date)'
-select date('1970-01-01') as d;
+# DATE(year, month, day)
+select date(2022, 11, 15) as d;
 +------------+
 | d          |
 +------------+
-| 1970-01-01 |
+| 2022-11-15 |
 +------------+
 (1 row)
 
 !ok
 
-!if (false) {
-select date(cast(null as varchar(10))) as d;
-+---+
-| D |
-+---+
-|   |
-+---+
+# DATE(timestamp)
+select date(timestamp("2008-12-25 15:30:00+00")) as d;
++------------+
+| d          |
++------------+
+| 2008-12-25 |
++------------+
 (1 row)
 
 !ok
-!}
 
 #####################################################################
 # DATE_ADD

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -1062,13 +1062,84 @@ select date(2022, 11, 15) as d;
 
 !ok
 
+# TIMESTAMP(string)
+# All these timestamps should be equal.
+# This tests the BQ timestamp literal string formatter
+# (option 'T', optional leading zeros, optional offset with proper conversion).
+select timestamp("2008-01-01 01:03:05+00") as t_space,
+       timestamp("2008-01-01T01:03:05+00") as t_iso,
+       timestamp("2008-01-01 01:03:05") as t_no_offset,
+       timestamp("2008-1-1 3:5:7+02:02:02") as t_offset;
++---------------------+---------------------+---------------------+---------------------+
+| t_space             | t_iso               | t_no_offset         | t_offset            |
++---------------------+---------------------+---------------------+---------------------+
+| 2008-01-01 01:03:05 | 2008-01-01 01:03:05 | 2008-01-01 01:03:05 | 2008-01-01 01:03:05 |
++---------------------+---------------------+---------------------+---------------------+
+(1 row)
+
+!ok
+
+# TIME(hour, minute, second)
+select time(12, 30, 59) as t;
++----------+
+| t        |
++----------+
+| 12:30:59 |
++----------+
+(1 row)
+
+!ok
+
 # DATE(timestamp)
-select date(timestamp("2008-12-25 15:30:00+00")) as d;
-+------------+
-| d          |
-+------------+
-| 2008-12-25 |
-+------------+
+# Test timezone conversion. Denver observes DST whereas Phoenix does not.
+# Both cities have a -07:00 offset in winter, but Denver has -06:00 in summer.
+select date(timestamp("2008-06-21 06:30:00")) as sum_utc,
+       date(timestamp("2008-06-21 06:30:00"), "America/Denver") as sum_dst,
+       date(timestamp("2008-06-21 06:30:00"), "America/Phoenix") as sum_std,
+       date(timestamp("2008-12-21 06:30:00")) as win_utc,
+       date(timestamp("2008-12-21 06:30:00"), "America/Denver") as win_dst,
+       date(timestamp("2008-12-21 06:30:00"), "America/Phoenix") as win_std;
++------------+------------+------------+------------+------------+------------+
+| sum_utc    | sum_dst    | sum_std    | win_utc    | win_dst    | win_std    |
++------------+------------+------------+------------+------------+------------+
+| 2008-06-21 | 2008-06-21 | 2008-06-20 | 2008-12-21 | 2008-12-20 | 2008-12-20 |
++------------+------------+------------+------------+------------+------------+
+(1 row)
+
+!ok
+
+# TIME(timestamp)
+# Test timezone conversion. Denver observes DST whereas Phoenix does not.
+# Both cities have a -07:00 offset in winter, but Denver has -06:00 in summer.
+select time(timestamp("2008-06-21 06:30:00")) as sum_utc,
+       time(timestamp("2008-06-21 06:30:00"), "America/Denver") as sum_dst,
+       time(timestamp("2008-06-21 06:30:00"), "America/Phoenix") as sum_std,
+       time(timestamp("2008-12-21 06:30:00")) as win_utc,
+       time(timestamp("2008-12-21 06:30:00"), "America/Denver") as win_dst,
+       time(timestamp("2008-12-21 06:30:00"), "America/Phoenix") as win_std;
++----------+----------+----------+----------+----------+----------+
+| sum_utc  | sum_dst  | sum_std  | win_utc  | win_dst  | win_std  |
++----------+----------+----------+----------+----------+----------+
+| 06:30:00 | 00:30:00 | 23:30:00 | 06:30:00 | 23:30:00 | 23:30:00 |
++----------+----------+----------+----------+----------+----------+
+(1 row)
+
+!ok
+
+# TIMESTAMP(date)
+# Test timezone conversion. Denver observes DST whereas Phoenix does not.
+# Both cities have a -07:00 offset in winter, but Denver has -06:00 in summer.
+select timestamp(date(2008, 6, 21)) as sum_utc,
+       timestamp(date(2008, 6, 21), "America/Denver") as sum_dst,
+       timestamp(date(2008, 6, 21), "America/Phoenix") as sum_std,
+       timestamp(date(2008, 12, 21)) as win_utc,
+       timestamp(date(2008, 12, 21), "America/Denver") as win_dst,
+       timestamp(date(2008, 12, 21), "America/Phoenix") as win_std;
++---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+
+| sum_utc             | sum_dst             | sum_std             | win_utc             | win_dst             | win_std             |
++---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+
+| 2008-06-21 00:00:00 | 2008-06-21 06:00:00 | 2008-06-21 07:00:00 | 2008-12-21 00:00:00 | 2008-12-21 07:00:00 | 2008-12-21 07:00:00 |
++---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+
 (1 row)
 
 !ok

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -1051,7 +1051,21 @@ select unix_date(timestamp '2008-12-25') as d;
 
 !ok
 
-# DATE(year, month, day)
+#####################################################################
+# DATE
+#
+# 1. DATE(year, month, day)
+# 2. DATE(timestamp_expression[, time_zone])
+# 3. DATE(datetime_expression)
+#
+# 1. Constructs a DATE from INT64 values representing the year, month, and day.
+# 1. Extracts the DATE from a TIMESTAMP expression. It supports an optional
+#    parameter to specify a time zone. If no time zone is specified, the default
+#    time zone, UTC, is used.
+# 1. Extracts the DATE from a DATETIME expression.
+#
+# Return Data Type: DATE
+
 select date(2022, 11, 15) as d;
 +------------+
 | d          |
@@ -1062,10 +1076,30 @@ select date(2022, 11, 15) as d;
 
 !ok
 
-# TIMESTAMP(string)
+#####################################################################
+# TIMESTAMP
+#
+# TIMESTAMP(string_expression[, time_zone])
+# TIMESTAMP(date_expression[, time_zone])
+# TIMESTAMP(datetime_expression[, time_zone])
+#
+# - string_expression[, time_zone]:
+#   Converts a STRING expression to a TIMESTAMP data type. string_expression
+#   must include a timestamp literal. If string_expression includes a time_zone
+#   in the timestamp literal, do not include an explicit time_zone argument.
+# - date_expression[, time_zone]: Converts a DATE object to a TIMESTAMP data
+#   type.
+# - datetime_expression[, time_zone]: Converts a DATETIME object to a TIMESTAMP
+#   data type.
+#
+# This function supports an optional parameter to specify a time zone. If no
+# time zone is specified, the default time zone, UTC, is used.
+#
+# Return Data Type: TIMESTAMP
+
 # All these timestamps should be equal.
 # This tests the BQ timestamp literal string formatter
-# (option 'T', optional leading zeros, optional offset with proper conversion).
+# (optional 'T', optional leading zeros, optional offset with conversion).
 select timestamp("2008-01-01 01:03:05+00") as t_space,
        timestamp("2008-01-01T01:03:05+00") as t_iso,
        timestamp("2008-01-01 01:03:05") as t_no_offset,
@@ -1079,7 +1113,22 @@ select timestamp("2008-01-01 01:03:05+00") as t_space,
 
 !ok
 
-# TIME(hour, minute, second)
+#####################################################################
+# TIME
+#
+# 1. TIME(hour, minute, second)
+# 2. TIME(timestamp[, time_zone])
+# 3. TIME(datetime)
+#
+# 1. Constructs a TIME object using INT64 values representing the hour, minute,
+#    and second.
+# 2. Constructs a TIME object using a TIMESTAMP object. It supports an optional
+#    parameter to specify a time zone. If no time zone is specified, the default
+#    time zone, UTC, is used.
+# 3. Constructs a TIME object using a DATETIME object.
+#
+# Return Data Type: TIMESTAMP
+
 select time(12, 30, 59) as t;
 +----------+
 | t        |
@@ -1090,8 +1139,8 @@ select time(12, 30, 59) as t;
 
 !ok
 
-# DATE(timestamp)
-# Test timezone conversion. Denver observes DST whereas Phoenix does not.
+# Test timezone conversion when converting TIMESTAMP to DATE.
+# Denver observes DST whereas Phoenix does not.
 # Both cities have a -07:00 offset in winter, but Denver has -06:00 in summer.
 select date(timestamp("2008-06-21 06:30:00")) as sum_utc,
        date(timestamp("2008-06-21 06:30:00"), "America/Denver") as sum_dst,
@@ -1108,8 +1157,8 @@ select date(timestamp("2008-06-21 06:30:00")) as sum_utc,
 
 !ok
 
-# TIME(timestamp)
-# Test timezone conversion. Denver observes DST whereas Phoenix does not.
+# Test timezone conversion when converting TIMESTAMP to TIME.
+# Denver observes DST whereas Phoenix does not.
 # Both cities have a -07:00 offset in winter, but Denver has -06:00 in summer.
 select time(timestamp("2008-06-21 06:30:00")) as sum_utc,
        time(timestamp("2008-06-21 06:30:00"), "America/Denver") as sum_dst,
@@ -1126,8 +1175,8 @@ select time(timestamp("2008-06-21 06:30:00")) as sum_utc,
 
 !ok
 
-# TIMESTAMP(date)
-# Test timezone conversion. Denver observes DST whereas Phoenix does not.
+# Test timezone conversion when converting DATE to TIMESTAMP.
+# Denver observes DST whereas Phoenix does not.
 # Both cities have a -07:00 offset in winter, but Denver has -06:00 in summer.
 select timestamp(date(2008, 6, 21)) as sum_utc,
        timestamp(date(2008, 6, 21), "America/Denver") as sum_dst,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -155,6 +155,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.SOUNDEX;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPACE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.STRCMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TANH;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIMESTAMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIMESTAMP_MICROS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIMESTAMP_MILLIS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIMESTAMP_SECONDS;
@@ -529,6 +530,9 @@ public class RexImpTable {
       defineMethod(DATE_FROM_UNIX_DATE, "dateFromUnixDate", NullPolicy.STRICT);
       defineMethod(UNIX_DATE, "unixDate", NullPolicy.STRICT);
 
+      defineMethod(DATE, "date", NullPolicy.STRICT);
+      defineMethod(TIMESTAMP, "timestamp", NullPolicy.STRICT);
+
       map.put(IS_NULL, new IsNullImplementor());
       map.put(IS_NOT_NULL, new IsNotNullImplementor());
       map.put(IS_TRUE, new IsTrueImplementor());
@@ -603,7 +607,6 @@ public class RexImpTable {
 
       map.put(COALESCE, new CoalesceImplementor());
       map.put(CAST, new CastImplementor());
-      map.put(DATE, new CastImplementor());
 
       map.put(REINTERPRET, new ReinterpretImplementor());
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -155,6 +155,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.SOUNDEX;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPACE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.STRCMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TANH;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIMESTAMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIMESTAMP_MICROS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TIMESTAMP_MILLIS;
@@ -532,6 +533,7 @@ public class RexImpTable {
 
       defineMethod(DATE, "date", NullPolicy.STRICT);
       defineMethod(TIMESTAMP, "timestamp", NullPolicy.STRICT);
+      defineMethod(TIME, "time", NullPolicy.STRICT);
 
       map.put(IS_NULL, new IsNullImplementor());
       map.put(IS_NOT_NULL, new IsNotNullImplementor());

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -59,13 +59,18 @@ import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.text.DecimalFormat;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -2300,21 +2305,106 @@ public class SqlFunctions {
   /** For {@link SqlLibraryOperators#DATE} of the form {@code DATE(<year>, <month>, <day>)}. */
   public static int date(int year, int month, int day) {
     // Calcite represents dates as Unix integers (days since epoch).
-    return (int) ChronoUnit.DAYS.between(LocalDate.EPOCH, LocalDate.of(year, month, day));
+    return (int) LocalDate.of(year, month, day).toEpochDay();
   }
 
   /** For {@link SqlLibraryOperators#DATE} of the form {@code DATE(<timestamp>)}. */
-  public static int date(long millis) {
-    // Calcite represents dates as Unix integers (days).
-    return (int) (millis / DateTimeUtils.MILLIS_PER_DAY);
+  public static int date(long timestampMillis) {
+    // Calcite represents dates as Unix integers (days since epoch).
+    // Unix time ignores leap seconds; every day has the exact same number of milliseconds.
+    return (int) (timestampMillis / DateTimeUtils.MILLIS_PER_DAY);
+  }
+
+  /** For {@link SqlLibraryOperators#DATE} of the form {@code DATE(<timestamp>, <timezone>)}. */
+  public static int date(long timestampMillis, String timezone) {
+    // Calcite represents dates as Unix integers (days since epoch).
+    return (int)
+        OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestampMillis), ZoneId.of(timezone))
+            .toLocalDate()
+            .toEpochDay();
   }
 
   /** For {@link SqlLibraryOperators#TIMESTAMP} of the form {@code TIMESTAMP(<string>)}. */
   public static long timestamp(String expression) {
     // Calcite represents timestamps as Unix integers (milliseconds since epoch).
-    return OffsetDateTime.parse(expression, BIG_QUERY_TIMESTAMP_LITERAL_FORMATTER)
+    return parseBigQueryTimestampLiteral(expression).toInstant().toEpochMilli();
+  }
+
+  /**
+   * For {@link SqlLibraryOperators#TIMESTAMP}
+   * of the form {@code TIMESTAMP(<string>, <timezone>)}.
+   */
+  public static long timestamp(String expression, String timezone) {
+    // Calcite represents timestamps as Unix integers (milliseconds since epoch).
+    return parseBigQueryTimestampLiteral(expression)
+        .atZoneSimilarLocal(ZoneId.of(timezone))
         .toInstant()
         .toEpochMilli();
+  }
+
+  private static OffsetDateTime parseBigQueryTimestampLiteral(String expression) {
+    // First try to parse with an offset, otherwise parse as a local and assume UTC ("no offset").
+    try {
+      return OffsetDateTime
+          .parse(expression, BIG_QUERY_TIMESTAMP_LITERAL_FORMATTER);
+    } catch (DateTimeParseException e) {
+      try {
+        return LocalDateTime
+            .parse(expression, BIG_QUERY_TIMESTAMP_LITERAL_FORMATTER)
+            .atOffset(ZoneOffset.UTC);
+      } catch (DateTimeParseException e2) {
+        throw new IllegalArgumentException(
+            String.format(Locale.ROOT, "Could not parse BigQuery string literal: %s", expression),
+            e2);
+      }
+    }
+  }
+
+  /** For {@link SqlLibraryOperators#TIMESTAMP} of the form {@code TIMESTAMP(<date>)}. */
+  public static long timestamp(int days) {
+    // Calcite represents timestamps as Unix integers (milliseconds since epoch).
+    // Unix time ignores leap seconds; every day has the exact same number of milliseconds.
+    return ((long) days) * DateTimeUtils.MILLIS_PER_DAY;
+  }
+
+  /**
+   * For {@link SqlLibraryOperators#TIMESTAMP}
+   * of the form {@code TIMESTAMP(<date>, <timezone>)}.
+   */
+  public static long timestamp(int days, String timezone) {
+    // Calcite represents timestamps as Unix integers (milliseconds since epoch).
+    final LocalDateTime localDateTime =
+        LocalDateTime.of(LocalDate.ofEpochDay(days), LocalTime.MIDNIGHT);
+    return OffsetDateTime.of(
+            localDateTime,
+            ZoneId.of(timezone).getRules().getOffset(localDateTime))
+        .toInstant()
+        .toEpochMilli();
+  }
+
+  /** For {@link SqlLibraryOperators#TIME} of the form {@code TIME(<hour>, <minute>, <second>)}. */
+  public static int time(int hour, int minute, int second) {
+    // Calcite represents time as Unix integers (milliseconds since midnight).
+    return (int)
+        (LocalTime.of(hour, minute, second).toSecondOfDay() * DateTimeUtils.MILLIS_PER_SECOND);
+  }
+
+  /** For {@link SqlLibraryOperators#TIME} of the form {@code TIME(<timestamp>)}. */
+  public static int time(long timestampMillis) {
+    // Calcite represents time as Unix integers (milliseconds since midnight).
+    // Unix time ignores leap seconds; every day has the exact same number of milliseconds.
+    return (int) (timestampMillis % DateTimeUtils.MILLIS_PER_DAY);
+  }
+
+  /** For {@link SqlLibraryOperators#TIME} of the form {@code TIME(<timestamp>, <timezone>)}. */
+  public static int time(long timestampMillis, String timezone) {
+    // Calcite represents time as Unix integers (milliseconds since midnight).
+    // Unix time ignores leap seconds; every day has the exact same number of milliseconds.
+    return (int) (
+        OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestampMillis), ZoneId.of(timezone))
+            .toLocalTime()
+            .toNanoOfDay()
+            / (1000L * 1000L)); // milli > micro > nano
   }
 
   public static @PolyNull Long toTimestampWithLocalTimeZone(@PolyNull String v) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlDateFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlDateFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.Locale;
+
+/**
+ * The Google BigQuery {@code DATE} function returns a date object and can be invoked in 3 ways:
+ *     DATE(year, month, day)
+ *     DATE(timestamp_expression[, time_zone])
+ *     DATE(datetime_expression)
+ *
+ * https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date
+ */
+public class SqlDateFunction extends SqlFunction {
+
+  SqlDateFunction() {
+    super("DATE", SqlKind.OTHER_FUNCTION, SqlDateFunction::deduceReturnType, null,
+        new DateOperandTypeChecker(), SqlFunctionCategory.TIMEDATE);
+  }
+
+  private static RelDataType deduceReturnType(SqlOperatorBinding opBinding) {
+    final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    // The date object is nullable if any of its operands are nullable.
+    final boolean isNullable = opBinding.getOperandType(0).isNullable()
+        || (opBinding.getOperandCount() > 1 && opBinding.getOperandType(1).isNullable())
+        || (opBinding.getOperandCount() > 2 && opBinding.getOperandType(2).isNullable());
+    return typeFactory.createTypeWithNullability(
+        typeFactory.createSqlType(SqlTypeName.DATE), isNullable);
+  }
+
+  /** Operand type checker for {@link SqlDateFunction}. */
+  private static class DateOperandTypeChecker implements SqlOperandTypeChecker {
+
+    @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+      switch (callBinding.getOperandType(0).getSqlTypeName()) {
+      case INTEGER:
+        // Must be DATE(year, month, day) where all operands are integers.
+        return callBinding.getOperandCount() == 3
+            && callBinding.getOperandType(1).getSqlTypeName() == SqlTypeName.INTEGER
+            && callBinding.getOperandType(2).getSqlTypeName() == SqlTypeName.INTEGER;
+      case TIMESTAMP:
+        // Must be DATE(timestamp_expression[, time_zone]).
+        return callBinding.getOperandCount() == 1
+            || (callBinding.getOperandCount() == 2
+                && SqlTypeName.CHAR_TYPES
+                    .contains(callBinding.getOperandType(1).getSqlTypeName()));
+      default:
+        // TODO: Support DATE(datetime_expression).
+        return false;
+      }
+    }
+
+    @Override public SqlOperandCountRange getOperandCountRange() {
+      return SqlOperandCountRanges.between(1, 3); // Takes 1, 2, or 3 parameters.
+    }
+
+    @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+      return String.format(
+          Locale.ROOT,
+          "%s(INTEGER, INTEGER, INTEGER) | %s(TIMESTAMP[, STRING]) | %s(DATETIME)",
+          opName, opName, opName);
+    }
+
+    @Override public boolean isOptional(int i) {
+      return i > 1; // Only the first parameter is required.
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlDateFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlDateFunction.java
@@ -32,12 +32,16 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import java.util.Locale;
 
 /**
- * The Google BigQuery {@code DATE} function returns a date object and can be invoked in 3 ways:
- *     DATE(year, month, day)
- *     DATE(timestamp_expression[, time_zone])
- *     DATE(datetime_expression)
+ * <p>The Google BigQuery {@code DATE} function returns a date object
+ * and can be invoked in one of three ways:</p>
  *
- * https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date
+ * <ul>
+ *   <li>DATE(year, month, day)</li>
+ *   <li>DATE(timestamp_expression[, time_zone])</li>
+ *   <li>DATE(datetime_expression)</li>
+ * </ul>
+ *
+ * @see <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date">Documentation</a>
  */
 public class SqlDateFunction extends SqlFunction {
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -424,12 +424,19 @@ public abstract class SqlLibraryOperators {
           .withAllowsSeparator(true)
           .withSyntax(SqlSyntax.ORDERED_FUNCTION);
 
-  /** The "DATE(string)" function, equivalent to "CAST(string AS DATE). */
+  /**
+   * BigQuery's {@code DATE} function can take various operands.
+   * See {@link SqlDateFunction}.
+   */
   @LibraryOperator(libraries = {BIG_QUERY})
-  public static final SqlFunction DATE =
-      new SqlFunction("DATE", SqlKind.OTHER_FUNCTION,
-          ReturnTypes.DATE_NULLABLE, null, OperandTypes.STRING,
-          SqlFunctionCategory.TIMEDATE);
+  public static final SqlFunction DATE = new SqlDateFunction();
+
+  /**
+   * BigQuery's {@code TIMESTAMP} function can take various operands.
+   * See {@link SqlTimestampFunction}.
+   */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction TIMESTAMP = new SqlTimestampFunction();
 
   /** The "CURRENT_DATETIME([timezone])" function. */
   @LibraryOperator(libraries = {BIG_QUERY})

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -438,6 +438,13 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction TIMESTAMP = new SqlTimestampFunction();
 
+  /**
+   * BigQuery's {@code TIME} function can take various operands.
+   * See {@link SqlTimeFunction}.
+   */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction TIME = new SqlTimeFunction();
+
   /** The "CURRENT_DATETIME([timezone])" function. */
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction CURRENT_DATETIME =

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimeFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimeFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.Locale;
+
+/**
+ * The Google BigQuery {@code TIME} function returns a time object and can be invoked in 3 ways:
+ *     TIME(hour, minute, second)
+ *     TIME(timestamp, [time_zone])
+ *     TIME(datetime)
+ *
+ * https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time
+ */
+public class SqlTimeFunction extends SqlFunction {
+
+  SqlTimeFunction() {
+    super("TIME", SqlKind.OTHER_FUNCTION, SqlTimeFunction::deduceReturnType, null,
+        new TimeOperandTypeChecker(), SqlFunctionCategory.TIMEDATE);
+  }
+
+  private static RelDataType deduceReturnType(SqlOperatorBinding opBinding) {
+    final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    // The time object is nullable if any of its operands are nullable.
+    final boolean isNullable = opBinding.getOperandType(0).isNullable()
+        || (opBinding.getOperandCount() > 1 && opBinding.getOperandType(1).isNullable())
+        || (opBinding.getOperandCount() > 2 && opBinding.getOperandType(2).isNullable());
+    return typeFactory.createTypeWithNullability(
+        typeFactory.createSqlType(SqlTypeName.TIME), isNullable);
+  }
+
+  /** Operand type checker for {@link SqlTimeFunction}. */
+  private static class TimeOperandTypeChecker implements SqlOperandTypeChecker {
+
+    @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+      switch (callBinding.getOperandType(0).getSqlTypeName()) {
+      case INTEGER:
+        // Must be TIME(hour, minute, second) where all operands are integers.
+        return callBinding.getOperandCount() == 3
+            && callBinding.getOperandType(1).getSqlTypeName() == SqlTypeName.INTEGER
+            && callBinding.getOperandType(2).getSqlTypeName() == SqlTypeName.INTEGER;
+      case TIMESTAMP:
+        // Must be DATE(timestamp[, time_zone]).
+        return callBinding.getOperandCount() == 1
+            || (callBinding.getOperandCount() == 2
+                && SqlTypeName.CHAR_TYPES
+                    .contains(callBinding.getOperandType(1).getSqlTypeName()));
+      default:
+        // TODO: Support TIME(datetime).
+        return false;
+      }
+    }
+
+    @Override public SqlOperandCountRange getOperandCountRange() {
+      return SqlOperandCountRanges.between(1, 3); // Takes 1, 2, or 3 parameters.
+    }
+
+    @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+      return String.format(
+          Locale.ROOT,
+          "%s(INTEGER, INTEGER, INTEGER) | %s(TIMESTAMP[, STRING]) | %s(DATETIME)",
+          opName, opName, opName);
+    }
+
+    @Override public boolean isOptional(int i) {
+      return i > 1; // Only the first parameter is required.
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimeFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimeFunction.java
@@ -32,12 +32,16 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import java.util.Locale;
 
 /**
- * The Google BigQuery {@code TIME} function returns a time object and can be invoked in 3 ways:
- *     TIME(hour, minute, second)
- *     TIME(timestamp, [time_zone])
- *     TIME(datetime)
+ * <p>The Google BigQuery {@code TIME} function returns a time object
+ * and can be invoked in one of three ways:</p>
  *
- * https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time
+ * <ul>
+ *   <li>TIME(hour, minute, second)</li>
+ *   <li>TIME(timestamp, [time_zone])</li>
+ *   <li>TIME(datetime)</li>
+ * </ul>
+ *
+ * @see <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time">Documentation</a>
  */
 public class SqlTimeFunction extends SqlFunction {
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.Locale;
+
+/**
+ * The Google BigQuery {@code TIMESTAMP} function returns a timestamp object
+ * and can be invoked in 3 ways:
+ *     TIMESTAMP(string_expression[, time_zone])
+ *     TIMESTAMP(date_expression[, time_zone])
+ *     TIMESTAMP(datetime_expression[, time_zone])
+ *
+ * https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp
+ */
+public class SqlTimestampFunction extends SqlFunction {
+
+  SqlTimestampFunction() {
+    super("TIMESTAMP", SqlKind.OTHER_FUNCTION, SqlTimestampFunction::deduceReturnType, null,
+        new TimestampOperandTypeChecker(), SqlFunctionCategory.TIMEDATE);
+  }
+
+  private static RelDataType deduceReturnType(SqlOperatorBinding opBinding) {
+    final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    // The timestamp object is nullable if any of its operands are nullable.
+    final boolean isNullable = opBinding.getOperandType(0).isNullable()
+        || (opBinding.getOperandCount() > 1 && opBinding.getOperandType(1).isNullable());
+    return typeFactory.createTypeWithNullability(
+        typeFactory.createSqlType(SqlTypeName.TIMESTAMP), isNullable);
+  }
+
+  /** Operand type checker for {@link SqlTimestampFunction}. */
+  private static class TimestampOperandTypeChecker implements SqlOperandTypeChecker {
+
+    @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+      switch (callBinding.getOperandType(0).getSqlTypeName()) {
+      case CHAR:
+      case VARCHAR:
+      case DATE:
+        // No matter what the first operand is, the second is an optional string.
+        return callBinding.getOperandCount() == 1
+            || (callBinding.getOperandCount() == 2
+                && SqlTypeName.CHAR_TYPES
+                    .contains(callBinding.getOperandType(1).getSqlTypeName()));
+      default:
+        // TODO: Support TIMESTAMP(datetime_expression[, time_zone]).
+        return false;
+      }
+    }
+
+    @Override public SqlOperandCountRange getOperandCountRange() {
+      return SqlOperandCountRanges.between(1, 2); // Takes 1 or 2 parameters.
+    }
+
+    @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+      return String.format(
+          Locale.ROOT,
+          "%s(STRING[, STRING]) | %s(DATE[, STRING]) | %s(DATETIME[, STRING])",
+          opName, opName, opName);
+    }
+
+    @Override public boolean isOptional(int i) {
+      return i > 1; // Only the first parameter is required.
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampFunction.java
@@ -32,13 +32,16 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import java.util.Locale;
 
 /**
- * The Google BigQuery {@code TIMESTAMP} function returns a timestamp object
- * and can be invoked in 3 ways:
- *     TIMESTAMP(string_expression[, time_zone])
- *     TIMESTAMP(date_expression[, time_zone])
- *     TIMESTAMP(datetime_expression[, time_zone])
+ * <p>The Google BigQuery {@code TIMESTAMP} function returns a timestamp object
+ * and can be invoked in one of three ways:</p>
  *
- * https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp
+ * <ul>
+ *   <li>TIMESTAMP(string_expression[, time_zone])</li>
+ *   <li>TIMESTAMP(date_expression[, time_zone])</li>
+ *   <li>TIMESTAMP(datetime_expression[, time_zone])</li>
+ * </ul>
+ *
+ * @see <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp">Documentation</a>
  */
 public class SqlTimestampFunction extends SqlFunction {
 

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2598,7 +2598,14 @@ semantics.
 | m | DAYNAME(datetime)                              | Returns the name, in the connection's locale, of the weekday in *datetime*; for example, it returns '星期日' for both DATE '2020-02-10' and TIMESTAMP '2020-02-10 10:10:10'
 | b | DATE(integer, integer, integer)                | Returns a date object given year, month, and day
 | b | DATE(timestamp)                                | Extracts the UTC date from a timestamp
+| b | DATE(timestamp, string)                        | Extracts the date from a timestamp, in a given time zone
 | b | TIMESTAMP(string)                              | Equivalent to `CAST(string AS TIMESTAMP)`
+| b | TIMESTAMP(string, string)                      | Equivalent to `CAST(string AS TIMESTAMP)`, converted to a given time zone
+| b | TIMESTAMP(date)                                | Convert a UTC date to a timestamp (at midnight)
+| b | TIMESTAMP(date, string)                        | Convert a date to a timestamp (at midnight), in a given time zone
+| b | TIME(integer, integer, integer)                | Returns a time object given hour, minute, and second
+| b | TIME(timestamp)                                | Extracts the UTC time from a timestamp
+| b | TIME(timestamp, string)                        | Extracts the time from a timestamp, in a given time zone
 | p q | DATEADD(timeUnit, integer, datetime)         | Equivalent to `TIMESTAMPADD(timeUnit, integer, datetime)`
 | p q | DATEDIFF(timeUnit, datetime, datetime2)      | Equivalent to `TIMESTAMPDIFF(timeUnit, datetime, datetime2)`
 | q | DATEPART(timeUnit, datetime)                   | Equivalent to `EXTRACT(timeUnit FROM  datetime)`

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2596,7 +2596,9 @@ semantics.
 | p | CONVERT_TIMEZONE(tz1, tz2, datetime)           | Converts the timezone of *datetime* from *tz1* to *tz2*
 | b | CURRENT_DATETIME([timezone])                   | Returns the current time as a TIMESTAMP from *timezone*
 | m | DAYNAME(datetime)                              | Returns the name, in the connection's locale, of the weekday in *datetime*; for example, it returns '星期日' for both DATE '2020-02-10' and TIMESTAMP '2020-02-10 10:10:10'
-| b | DATE(string)                                   | Equivalent to `CAST(string AS DATE)`
+| b | DATE(integer, integer, integer)                | Returns a date object given year, month, and day
+| b | DATE(timestamp)                                | Extracts the UTC date from a timestamp
+| b | TIMESTAMP(string)                              | Equivalent to `CAST(string AS TIMESTAMP)`
 | p q | DATEADD(timeUnit, integer, datetime)         | Equivalent to `TIMESTAMPADD(timeUnit, integer, datetime)`
 | p q | DATEDIFF(timeUnit, datetime, datetime2)      | Equivalent to `TIMESTAMPDIFF(timeUnit, datetime, datetime2)`
 | q | DATEPART(timeUnit, datetime)                   | Equivalent to `EXTRACT(timeUnit FROM  datetime)`

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2597,15 +2597,8 @@ semantics.
 | b | CURRENT_DATETIME([timezone])                   | Returns the current time as a TIMESTAMP from *timezone*
 | m | DAYNAME(datetime)                              | Returns the name, in the connection's locale, of the weekday in *datetime*; for example, it returns '星期日' for both DATE '2020-02-10' and TIMESTAMP '2020-02-10 10:10:10'
 | b | DATE(integer, integer, integer)                | Returns a date object given year, month, and day
-| b | DATE(timestamp)                                | Extracts the UTC date from a timestamp
+| b | DATE(timestamp)                                | Extracts the date from a timestamp, assuming UTC
 | b | DATE(timestamp, string)                        | Extracts the date from a timestamp, in a given time zone
-| b | TIMESTAMP(string)                              | Equivalent to `CAST(string AS TIMESTAMP)`
-| b | TIMESTAMP(string, string)                      | Equivalent to `CAST(string AS TIMESTAMP)`, converted to a given time zone
-| b | TIMESTAMP(date)                                | Convert a UTC date to a timestamp (at midnight)
-| b | TIMESTAMP(date, string)                        | Convert a date to a timestamp (at midnight), in a given time zone
-| b | TIME(integer, integer, integer)                | Returns a time object given hour, minute, and second
-| b | TIME(timestamp)                                | Extracts the UTC time from a timestamp
-| b | TIME(timestamp, string)                        | Extracts the time from a timestamp, in a given time zone
 | p q | DATEADD(timeUnit, integer, datetime)         | Equivalent to `TIMESTAMPADD(timeUnit, integer, datetime)`
 | p q | DATEDIFF(timeUnit, datetime, datetime2)      | Equivalent to `TIMESTAMPDIFF(timeUnit, datetime, datetime2)`
 | q | DATEPART(timeUnit, datetime)                   | Equivalent to `EXTRACT(timeUnit FROM  datetime)`
@@ -2649,6 +2642,13 @@ semantics.
 | b m o p | SUBSTR(string, position [, substringLength ]) | Returns a portion of *string*, beginning at character *position*, *substringLength* characters long. SUBSTR calculates lengths using characters as defined by the input character set
 | m | STRCMP(string, string)                         | Returns 0 if both of the strings are same and returns -1 when the first argument is smaller than the second and 1 when the second one is smaller than the first one
 | o | TANH(numeric)                                  | Returns the hyperbolic tangent of *numeric*
+| b | TIME(integer, integer, integer)                | Returns a time object given hour, minute, and second
+| b | TIME(timestamp)                                | Extracts the time from a timestamp, assuming UTC
+| b | TIME(timestamp, string)                        | Extracts the time from a timestamp, in a given time zone
+| b | TIMESTAMP(string)                              | Equivalent to `CAST(string AS TIMESTAMP)`
+| b | TIMESTAMP(string, string)                      | Equivalent to `CAST(string AS TIMESTAMP)`, converted to a given time zone
+| b | TIMESTAMP(date)                                | Convert a UTC date to a timestamp (at midnight)
+| b | TIMESTAMP(date, string)                        | Convert a date to a timestamp (at midnight), in a given time zone
 | b | TIMESTAMP_MICROS(integer)                      | Returns the TIMESTAMP that is *integer* microseconds after 1970-01-01 00:00:00
 | b | TIMESTAMP_MILLIS(integer)                      | Returns the TIMESTAMP that is *integer* milliseconds after 1970-01-01 00:00:00
 | b | TIMESTAMP_SECONDS(integer)                     | Returns the TIMESTAMP that is *integer* seconds after 1970-01-01 00:00:00

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -4982,10 +4982,8 @@ public class SqlOperatorTest {
     f.checkNull("timestamp_micros(cast(null as bigint))");
     f.checkScalar("date_from_unix_date(0)", "1970-01-01", "DATE NOT NULL");
 
-    // Have to quote the "DATE" function because we're not using the Babel
-    // parser. In the regular parser, DATE is a reserved keyword.
-    f.checkNull("\"DATE\"(null)");
-    f.checkScalar("\"DATE\"('1985-12-06')", "1985-12-06", "DATE NOT NULL");
+    f.checkNull("CAST(null AS DATE)");
+    f.checkScalar("CAST('1985-12-06' AS DATE)", "1985-12-06", "DATE NOT NULL");
     f.checkType("CURRENT_DATETIME()", "TIMESTAMP(0) NOT NULL");
     f.checkType("CURRENT_DATETIME('America/Los_Angeles')", "TIMESTAMP(0) NOT NULL");
     f.checkType("CURRENT_DATETIME(CAST(NULL AS VARCHAR(20)))", "TIMESTAMP(0)");


### PR DESCRIPTION
There is an existing implementation for a BQ `DATE` function but it wrongly thinks this is simply a typecast. See documentation [here][1].

This PR implements 2 of the 4 possible overloads for `DATE` (considering the optional time zone in the second form) as well as 1 of the possible overloads for `TIMESTAMP`, and was able to get a quidem test to pass utilizing both functions. I intend to implement the rest of the overloads in a follow-up commit but was hoping for some feedback now and thought this was a decent-sized commit to review at once.

[1]: https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date