### PR TITLE
[CALCITE-5391] JoinOnUniqueToSemiJoinRule should preserve field names, if possible

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinRule.java
@@ -283,7 +283,7 @@ public abstract class SemiJoinRule
         default:
           throw new AssertionError(join.getJoinType());
         }
-        builder.project(project.getProjects());
+        builder.project(project.getProjects(), project.getRowType().getFieldNames());
         call.transformTo(builder.build());
       }
     }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1180,6 +1180,21 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /**
+   * Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5391">[CALCITE-5391]
+   * JoinOnUniqueToSemiJoinRule should preserve field names, if possible</a>. */
+  @Test void testSemiJoinRuleWithJoinOnUniqueInputWithAlias() {
+    final String sql = "select emp.deptno as department_id, emp.sal as salary\n"
+        + "from emp\n"
+        + "where exists(select * from dept where emp.deptno = dept.deptno)";
+    sql(sql)
+      .withDecorrelate(true)
+      .withTrim(true)
+      .withRule(CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN)
+      .check();
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1495">[CALCITE-1495]
    * SemiJoinRule should not apply to RIGHT and FULL JOIN</a>. */

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -12349,6 +12349,33 @@ LogicalJoin(condition=[=($7, $9)], joinType=[semi])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSemiJoinRuleWithJoinOnUniqueInputWithAlias">
+    <Resource name="sql">
+      <![CDATA[select emp.deptno as department_id, emp.sal as salary
+from emp
+where exists(select * from dept where emp.deptno = dept.deptno)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPARTMENT_ID=[$1], SALARY=[$0])
+  LogicalJoin(condition=[=($1, $2)], joinType=[inner])
+    LogicalProject(SAL=[$5], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPARTMENT_ID=[$1], SALARY=[$0])
+  LogicalJoin(condition=[=($1, $2)], joinType=[semi])
+    LogicalProject(SAL=[$5], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSemiJoinTrim">
     <Resource name="sql">
       <![CDATA[select s.deptno


### PR DESCRIPTION
## Why:
When rewriting the query for a semi join, the
`JoinOnUniqueToSemiJoinRule` pushes a new project via `RelBuilder`. This project is *almost* a good copy of the original `Project` -- it is just missing the field names.

## How:
This change uses `RelDataType` of the `Project` to get the field names for the new `Project` pushed on the `Relbuilder` stack. This is similar to what is done in `SemiJoinRule#perform`

## Related PRs
#2848 introduced this rule and the bug.