### PR TITLE
[CALCITE-5283] Add ARG_MIN, ARG_MAX aggregate functions

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -181,9 +181,9 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ABS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ACOS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.AND;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ANY_VALUE;
-import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ARG_MAX;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ARG_MIN;
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ASCII;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ASIN;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ATAN;
@@ -1209,8 +1209,7 @@ public class RexImpTable {
 
   /** Implementor for the {@code ARG_MIN} and {@code ARG_MAX} aggregate functions. */
   static class ARGMinMaxImplementor extends StrictAggImplementor {
-    @Override
-    protected void implementNotNullReset(AggContext info,
+    @Override protected void implementNotNullReset(AggContext info,
         AggResetContext reset) {
       // acc[0] = null;
       reset.currentBlock().add(
@@ -1229,8 +1228,7 @@ public class RexImpTable {
                   Expressions.constant(inf, compType))));
     }
 
-    @Override
-    public void implementNotNullAdd(AggContext info,
+    @Override public void implementNotNullAdd(AggContext info,
         AggAddContext add) {
       Expression accComp = add.accumulator().get(1);
       Expression argValue = add.arguments().get(0);
@@ -1247,9 +1245,11 @@ public class RexImpTable {
           accComp);
 
       BlockBuilder thenBlock = new BlockBuilder(true, add.currentBlock());
-      thenBlock.add(Expressions.statement(
+      thenBlock.add(
+          Expressions.statement(
           Expressions.assign(add.accumulator().get(0), argValue)));
-      thenBlock.add(Expressions.statement(
+      thenBlock.add(
+          Expressions.statement(
           Expressions.assign(add.accumulator().get(1), argComp)));
 
       add.currentBlock().add(Expressions.ifThen(compareExpression, thenBlock.toBlock()));

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -148,7 +148,9 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.LEFT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_AND;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_OR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LPAD;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAX_BY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MD5;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.MIN_BY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MONTHNAME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.POW;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_REPLACE;
@@ -737,6 +739,8 @@ public class RexImpTable {
       aggMap.put(MAX, minMax);
       aggMap.put(ARG_MIN, constructorSupplier(ARGMinMaxImplementor.class));
       aggMap.put(ARG_MAX, constructorSupplier(ARGMinMaxImplementor.class));
+      aggMap.put(MIN_BY, constructorSupplier(ARGMinMaxImplementor.class));
+      aggMap.put(MAX_BY, constructorSupplier(ARGMinMaxImplementor.class));
       aggMap.put(ANY_VALUE, minMax);
       aggMap.put(SOME, minMax);
       aggMap.put(EVERY, minMax);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1974,6 +1974,17 @@ public class SqlFunctions {
     return b0 == null || b1 != null && b0.compareTo(b1) < 0 ? b1 : b0;
   }
 
+  /** less than */
+  public static <T extends Comparable<T>> boolean lessThan(T b0, T b1) {
+    return b1 == null || b0 != null && b0.compareTo(b1) < 0;
+  }
+
+  /** grater than */
+  public static <T extends Comparable<T>> boolean greaterThan(T b0, T b1) {
+    return b1 == null || b0 != null && b0.compareTo(b1) > 0;
+  }
+
+
   /** Boolean comparison. */
   public static int compare(boolean x, boolean y) {
     return x == y ? 0 : x ? 1 : -1;

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1974,12 +1974,12 @@ public class SqlFunctions {
     return b0 == null || b1 != null && b0.compareTo(b1) < 0 ? b1 : b0;
   }
 
-  /** less than */
+  /** Less than. */
   public static <T extends Comparable<T>> boolean lessThan(T b0, T b1) {
     return b1 == null || b0 != null && b0.compareTo(b1) < 0;
   }
 
-  /** grater than */
+  /** Grater than. */
   public static <T extends Comparable<T>> boolean greaterThan(T b0, T b1) {
     return b1 == null || b0 != null && b0.compareTo(b1) > 0;
   }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1974,16 +1974,79 @@ public class SqlFunctions {
     return b0 == null || b1 != null && b0.compareTo(b1) < 0 ? b1 : b0;
   }
 
-  /** Less than. */
-  public static <T extends Comparable<T>> boolean lessThan(T b0, T b1) {
-    return b1 == null || b0 != null && b0.compareTo(b1) < 0;
-  }
-
   /** Grater than. */
   public static <T extends Comparable<T>> boolean greaterThan(T b0, T b1) {
     return b1 == null || b0 != null && b0.compareTo(b1) > 0;
   }
 
+  /** Less than. */
+  public static <T extends Comparable<T>> boolean lessThan(T b0, T b1) {
+    return b1 == null || b0 != null && b0.compareTo(b1) < 0;
+  }
+
+  public static boolean greaterThan(boolean b0, boolean b1) {
+    return b0 && !b1;
+  }
+
+  public static boolean lessThan(boolean b0, boolean b1) {
+    return !b0 && b1;
+  }
+
+  public static boolean greaterThan(byte b0, byte b1) {
+    return b0 > b1;
+  }
+
+  public static boolean lessThan(byte b0, byte b1) {
+    return b0 < b1;
+  }
+
+  public static boolean greaterThan(char b0, char b1) {
+    return b0 > b1;
+  }
+
+  public static boolean lessThan(char b0, char b1) {
+    return b0 < b1;
+  }
+
+  public static boolean greaterThan(short b0, short b1) {
+    return b0 > b1;
+  }
+
+  public static boolean lessThan(short b0, short b1) {
+    return b0 < b1;
+  }
+
+  public static boolean greaterThan(int b0, int b1) {
+    return b0 > b1;
+  }
+
+  public static boolean lessThan(int b0, int b1) {
+    return b0 < b1;
+  }
+
+  public static boolean greaterThan(long b0, long b1) {
+    return b0 > b1;
+  }
+
+  public static boolean lessThan(long b0, long b1) {
+    return b0 < b1;
+  }
+
+  public static boolean greaterThan(float b0, float b1) {
+    return b0 > b1;
+  }
+
+  public static boolean lessThan(float b0, float b1) {
+    return b0 < b1;
+  }
+
+  public static boolean greaterThan(double b0, double b1) {
+    return b0 > b1;
+  }
+
+  public static boolean lessThan(double b0, double b1) {
+    return b0 < b1;
+  }
 
   /** Boolean comparison. */
   public static int compare(boolean x, boolean y) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -888,6 +888,12 @@ public enum SqlKind {
   /** The {@code MODE} aggregate function. */
   MODE,
 
+  /** The {@code ARG_MAX} aggregate function. */
+  ARG_MAX,
+
+  /** The {@code ARG_MIN} aggregate function. */
+  ARG_MIN,
+
   /** The {@code PERCENTILE_CONT} aggregate function. */
   PERCENTILE_CONT,
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBasicAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBasicAggFunction.java
@@ -128,6 +128,15 @@ public final class SqlBasicAggFunction extends SqlAggFunction {
     return requireNonNull(super.getOperandTypeChecker(), "operandTypeChecker");
   }
 
+  /** Sets {@link #getName()}. */
+  public SqlAggFunction withName(String name) {
+    return new SqlBasicAggFunction(name, getSqlIdentifier(), kind,
+        getReturnTypeInference(), getOperandTypeInference(),
+        getOperandTypeChecker(), getFunctionType(), requiresOrder(),
+        requiresOver(), requiresGroupOrder(), distinctOptionality, syntax,
+        allowsNullTreatment, allowsSeparator, percentile);
+  }
+
   /** Sets {@link #getDistinctOptionality()}. */
   SqlBasicAggFunction withDistinct(Optionality distinctOptionality) {
     return new SqlBasicAggFunction(getName(), getSqlIdentifier(), kind,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -474,6 +474,18 @@ public abstract class SqlLibraryOperators {
           .withAllowsSeparator(true)
           .withSyntax(SqlSyntax.ORDERED_FUNCTION);
 
+  /** The "MAX_BY(value, comp)" aggregate function, Spark's
+   * equivalent to {@link SqlStdOperatorTable#ARG_MAX}. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlAggFunction MAX_BY =
+      SqlStdOperatorTable.ARG_MAX.withName("MAX_BY");
+
+  /** The "MIN_BY(condition)" aggregate function, Spark's
+   * equivalent to {@link SqlStdOperatorTable#ARG_MIN}. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlAggFunction MIN_BY =
+      SqlStdOperatorTable.ARG_MIN.withName("MIN_BY");
+
   /** The "DATE(string)" function, equivalent to "CAST(string AS DATE). */
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction DATE =

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -17,12 +17,15 @@
 package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeComparability;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlAsOperator;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlBasicFunction;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlDescriptorOperator;
 import org.apache.calcite.sql.SqlFilterOperator;
 import org.apache.calcite.sql.SqlFunction;
@@ -63,6 +66,7 @@ import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -1004,6 +1008,56 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
    */
   public static final SqlAggFunction APPROX_COUNT_DISTINCT =
       new SqlCountAggFunction("APPROX_COUNT_DISTINCT");
+
+  /**
+   * <code>ARG_MAX</code> aggregate function.
+   */
+  public static final SqlAggFunction ARG_MAX =
+      SqlBasicAggFunction
+          .create("ARG_MAX", SqlKind.ARG_MAX, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
+              new SqlOperandTypeChecker() {
+                @Override
+                public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+                  getOperandCountRange().isValidCount(callBinding.getOperandCount());
+                  RelDataType type = callBinding.getOperandType(1);
+                  return type.getComparability().ordinal() == RelDataTypeComparability.ALL.ordinal();
+                }
+                @Override
+                public SqlOperandCountRange getOperandCountRange() {
+                  return SqlOperandCountRanges.of(2);
+                }
+                @Override
+                public String getAllowedSignatures(SqlOperator op, String opName) {
+                  return "ARG_MAX(<ANY>, <COMPARABLE_TYPE>)";
+                }
+              })
+          .withGroupOrder(Optionality.FORBIDDEN)
+          .withFunctionType(SqlFunctionCategory.SYSTEM);
+
+  /**
+   * <code>ARG_MIN</code> aggregate function.
+   */
+  public static final SqlAggFunction ARG_MIN =
+      SqlBasicAggFunction
+          .create("ARG_MIN", SqlKind.ARG_MIN, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
+              new SqlOperandTypeChecker() {
+                @Override
+                public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+                  getOperandCountRange().isValidCount(callBinding.getOperandCount());
+                  RelDataType type = callBinding.getOperandType(1);
+                  return type.getComparability().ordinal() == RelDataTypeComparability.ALL.ordinal();
+                }
+                @Override
+                public SqlOperandCountRange getOperandCountRange() {
+                  return SqlOperandCountRanges.of(2);
+                }
+                @Override
+                public String getAllowedSignatures(SqlOperator op, String opName) {
+                  return "ARG_MIN(<ANY>, <COMPARABLE_TYPE>)";
+                }
+              })
+          .withGroupOrder(Optionality.FORBIDDEN)
+          .withFunctionType(SqlFunctionCategory.SYSTEM);
 
   /**
    * <code>MIN</code> aggregate function.

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1016,18 +1016,15 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       SqlBasicAggFunction
           .create("ARG_MAX", SqlKind.ARG_MAX, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
               new SqlOperandTypeChecker() {
-                @Override
-                public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+                @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
                   getOperandCountRange().isValidCount(callBinding.getOperandCount());
                   RelDataType type = callBinding.getOperandType(1);
                   return type.getComparability().ordinal() == RelDataTypeComparability.ALL.ordinal();
                 }
-                @Override
-                public SqlOperandCountRange getOperandCountRange() {
+                @Override public SqlOperandCountRange getOperandCountRange() {
                   return SqlOperandCountRanges.of(2);
                 }
-                @Override
-                public String getAllowedSignatures(SqlOperator op, String opName) {
+                @Override public String getAllowedSignatures(SqlOperator op, String opName) {
                   return "ARG_MAX(<ANY>, <COMPARABLE_TYPE>)";
                 }
               })
@@ -1041,18 +1038,15 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       SqlBasicAggFunction
           .create("ARG_MIN", SqlKind.ARG_MIN, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
               new SqlOperandTypeChecker() {
-                @Override
-                public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+                @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
                   getOperandCountRange().isValidCount(callBinding.getOperandCount());
                   RelDataType type = callBinding.getOperandType(1);
                   return type.getComparability().ordinal() == RelDataTypeComparability.ALL.ordinal();
                 }
-                @Override
-                public SqlOperandCountRange getOperandCountRange() {
+                @Override public SqlOperandCountRange getOperandCountRange() {
                   return SqlOperandCountRanges.of(2);
                 }
-                @Override
-                public String getAllowedSignatures(SqlOperator op, String opName) {
+                @Override public String getAllowedSignatures(SqlOperator op, String opName) {
                   return "ARG_MIN(<ANY>, <COMPARABLE_TYPE>)";
                 }
               })

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -17,15 +17,12 @@
 package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.avatica.util.TimeUnit;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeComparability;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlAsOperator;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlBasicFunction;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlCall;
-import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlDescriptorOperator;
 import org.apache.calcite.sql.SqlFilterOperator;
 import org.apache.calcite.sql.SqlFunction;
@@ -66,7 +63,6 @@ import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
-import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -1012,46 +1008,18 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   /**
    * <code>ARG_MAX</code> aggregate function.
    */
-  public static final SqlAggFunction ARG_MAX =
-      SqlBasicAggFunction
-          .create("ARG_MAX", SqlKind.ARG_MAX, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
-              new SqlOperandTypeChecker() {
-                @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
-                    boolean throwOnFailure) {
-                  getOperandCountRange().isValidCount(callBinding.getOperandCount());
-                  RelDataType type = callBinding.getOperandType(1);
-                  return type.getComparability() == RelDataTypeComparability.ALL;
-                }
-                @Override public SqlOperandCountRange getOperandCountRange() {
-                  return SqlOperandCountRanges.of(2);
-                }
-                @Override public String getAllowedSignatures(SqlOperator op, String opName) {
-                  return "ARG_MAX(<ANY>, <COMPARABLE_TYPE>)";
-                }
-              })
+  public static final SqlBasicAggFunction ARG_MAX =
+      SqlBasicAggFunction.create("ARG_MAX", SqlKind.ARG_MAX,
+          ReturnTypes.ARG0_NULLABLE_IF_EMPTY, OperandTypes.ANY_COMPARABLE)
           .withGroupOrder(Optionality.FORBIDDEN)
           .withFunctionType(SqlFunctionCategory.SYSTEM);
 
   /**
    * <code>ARG_MIN</code> aggregate function.
    */
-  public static final SqlAggFunction ARG_MIN =
-      SqlBasicAggFunction
-          .create("ARG_MIN", SqlKind.ARG_MIN, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
-              new SqlOperandTypeChecker() {
-                @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
-                    boolean throwOnFailure) {
-                  getOperandCountRange().isValidCount(callBinding.getOperandCount());
-                  RelDataType type = callBinding.getOperandType(1);
-                  return type.getComparability() == RelDataTypeComparability.ALL;
-                }
-                @Override public SqlOperandCountRange getOperandCountRange() {
-                  return SqlOperandCountRanges.of(2);
-                }
-                @Override public String getAllowedSignatures(SqlOperator op, String opName) {
-                  return "ARG_MIN(<ANY>, <COMPARABLE_TYPE>)";
-                }
-              })
+  public static final SqlBasicAggFunction ARG_MIN =
+      SqlBasicAggFunction.create("ARG_MIN", SqlKind.ARG_MIN,
+              ReturnTypes.ARG0_NULLABLE_IF_EMPTY, OperandTypes.ANY_COMPARABLE)
           .withGroupOrder(Optionality.FORBIDDEN)
           .withFunctionType(SqlFunctionCategory.SYSTEM);
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1016,10 +1016,11 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       SqlBasicAggFunction
           .create("ARG_MAX", SqlKind.ARG_MAX, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
               new SqlOperandTypeChecker() {
-                @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+                @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
+                    boolean throwOnFailure) {
                   getOperandCountRange().isValidCount(callBinding.getOperandCount());
                   RelDataType type = callBinding.getOperandType(1);
-                  return type.getComparability().ordinal() == RelDataTypeComparability.ALL.ordinal();
+                  return type.getComparability() == RelDataTypeComparability.ALL;
                 }
                 @Override public SqlOperandCountRange getOperandCountRange() {
                   return SqlOperandCountRanges.of(2);
@@ -1038,10 +1039,11 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       SqlBasicAggFunction
           .create("ARG_MIN", SqlKind.ARG_MIN, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
               new SqlOperandTypeChecker() {
-                @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+                @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
+                    boolean throwOnFailure) {
                   getOperandCountRange().isValidCount(callBinding.getOperandCount());
                   RelDataType type = callBinding.getOperandType(1);
-                  return type.getComparability().ordinal() == RelDataTypeComparability.ALL.ordinal();
+                  return type.getComparability() == RelDataTypeComparability.ALL;
                 }
                 @Override public SqlOperandCountRange getOperandCountRange() {
                   return SqlOperandCountRanges.of(2);

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -665,6 +665,29 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker ANY_STRING_STRING =
       family(SqlTypeFamily.ANY, SqlTypeFamily.STRING, SqlTypeFamily.STRING);
 
+  /**
+   * Operand type-checking strategy used by {@code ARG_MIN(value, comp)} and
+   * similar functions, where the first operand can have any type and the second
+   * must be comparable.
+   */
+  public static final SqlOperandTypeChecker ANY_COMPARABLE =
+      new SqlOperandTypeChecker() {
+        @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
+            boolean throwOnFailure) {
+          getOperandCountRange().isValidCount(callBinding.getOperandCount());
+          RelDataType type = callBinding.getOperandType(1);
+          return type.getComparability() == RelDataTypeComparability.ALL;
+        }
+
+        @Override public SqlOperandCountRange getOperandCountRange() {
+          return SqlOperandCountRanges.of(2);
+        }
+
+        @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+          return opName + "(<ANY>, <COMPARABLE_TYPE>)";
+        }
+  };
+
   public static final SqlSingleOperandTypeChecker CURSOR =
       family(SqlTypeFamily.CURSOR);
 

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -455,6 +455,8 @@ public enum BuiltInMethod {
   NOT(SqlFunctions.class, "not", Boolean.class),
   LESSER(SqlFunctions.class, "lesser", Comparable.class, Comparable.class),
   GREATER(SqlFunctions.class, "greater", Comparable.class, Comparable.class),
+  LESS_THAN(SqlFunctions.class, "lessThan", Comparable.class, Comparable.class),
+  GREATER_THAN(SqlFunctions.class, "greaterThan", Comparable.class, Comparable.class),
   BIT_AND(SqlFunctions.class, "bitAnd", long.class, long.class),
   BIT_OR(SqlFunctions.class, "bitOr", long.class, long.class),
   BIT_XOR(SqlFunctions.class, "bitXor", long.class, long.class),

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4277,6 +4277,32 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test void testArgMinFunction() {
+    final String sql = "select arg_min(ename, deptno)\n"
+        + "from emp";
+    sql(sql).withTrim(true).ok();
+  }
+
+  @Test void testArgMinFunctionWithWinAgg() {
+    final String sql = "select job,\n"
+        + "  arg_min(ename, deptno) over (partition by job order by sal)\n"
+        + "from emp";
+    sql(sql).withTrim(true).ok();
+  }
+
+  @Test void testArgMaxFunction() {
+    final String sql = "select arg_max(ename, deptno)\n"
+        + "from emp";
+    sql(sql).withTrim(true).ok();
+  }
+
+  @Test void testArgMaxFunctionWithWinAgg() {
+    final String sql = "select job,\n"
+        + "  arg_max(ename, deptno) over (partition by job order by sal)\n"
+        + "from emp";
+    sql(sql).withTrim(true).ok();
+  }
+
   @Test void testModeFunction() {
     final String sql = "select mode(deptno)\n"
         + "from emp";

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8739,6 +8739,16 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("SELECT MAX(5) FROM emp").ok();
   }
 
+  @Test void testArgMinMaxFunctions() {
+    sql("SELECT ARG_MIN(1, true) from emp").ok();
+    sql("SELECT ARG_MAX(2, false) from emp").ok();
+
+    sql("SELECT ARG_MIN(sal, deptno) FROM emp").ok();
+    sql("SELECT ARG_MAX(deptno, sal) FROM emp").ok();
+    sql("SELECT ARG_MIN('a', 5.5) FROM emp").ok();
+    sql("SELECT ARG_MAX('b', 5) FROM emp").ok();
+  }
+
   @Test void testModeFunction() {
     sql("select MODE(sal) from emp").ok();
     sql("select MODE(sal) over (order by empno) from emp").ok();

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -366,6 +366,58 @@ LogicalAggregate(group=[{}], ANYEMPNO=[ANY_VALUE($0)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testArgMaxFunction">
+    <Resource name="sql">
+      <![CDATA[select arg_max(ename, deptno)
+from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[ARG_MAX($0, $1)])
+  LogicalProject(ENAME=[$1], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testArgMaxFunctionWithWinAgg">
+    <Resource name="sql">
+      <![CDATA[select job,
+  arg_max(ename, deptno) over (partition by job order by sal)
+from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(JOB=[$2], EXPR$1=[ARG_MAX($1, $7) OVER (PARTITION BY $2 ORDER BY $5)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testArgMinFunction">
+    <Resource name="sql">
+      <![CDATA[select arg_min(ename, deptno)
+from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[ARG_MIN($0, $1)])
+  LogicalProject(ENAME=[$1], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testArgMinFunctionWithWinAgg">
+    <Resource name="sql">
+      <![CDATA[select job,
+  arg_min(ename, deptno) over (partition by job order by sal)
+from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(JOB=[$2], EXPR$1=[ARG_MIN($1, $7) OVER (PARTITION BY $2 ORDER BY $5)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testArrayElementDoublyNestedPrimitive">
     <Resource name="sql">
       <![CDATA[select dn.employees[0]['detail']['skills'][0]['type']

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3592,4 +3592,18 @@ group by deptno;
 
 !ok
 
+# ARG_MIN, ARG_MAX applied to an integer.
+select arg_min(deptno, empno) as mi,
+  arg_max(deptno, empno) as ma,
+  arg_max(deptno, empno) filter (where gender = 'm') as gen
+from EMPS;
++----+----+-----+
+| MI | MA | GEN |
++----+----+-----+
+| 10 | 40 |     |
++----+----+-----+
+(1 row)
+
+!ok
+
 # End agg.iq

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3520,4 +3520,76 @@ where
 (2 rows)
 
 !ok
+
+# [CALCITE-5283] Add ARG_MIN, ARG_MAX aggregate function
+
+# ARG_MIN, ARG_MAX without GROUP BY
+select arg_min(ename, deptno) as mi, arg_max(ename, deptno) as ma
+from emp;
++-------+-------+
+| MI    | MA    |
++-------+-------+
+| Jane  | Grace |
++-------+-------+
+(1 row)
+
+!ok
+
+# ARG_MIN, ARG_MAX with DISTINCT
+select arg_min(distinct ename, deptno) as mi, arg_max(distinct ename, deptno) as ma
+from emp;
++-------+-------+
+| MI    | MA    |
++-------+-------+
+| Jane  | Grace |
++-------+-------+
+(1 row)
+
+!ok
+
+# ARG_MIN, ARG_MAX function with WHERE.
+select arg_min(ename, deptno) as mi, arg_max(ename, deptno) as ma
+from emp
+where deptno <= 20;
++-------+-------+
+| MI    | MA    |
++-------+-------+
+| Jane  | Eric  |
++-------+-------+
+(1 row)
+
+!ok
+
+# ARG_MIN, ARG_MAX function with WHERE that removes all rows.
+# Result is NULL even though ARG_MIN, ARG_MAX is applied to a not-NULL column.
+select arg_min(ename, deptno) as mi, arg_max(ename, deptno) as ma
+from emp
+where deptno > 60;
++----+----+
+| MI | MA |
++----+----+
+|    |    |
++----+----+
+(1 row)
+
+!ok
+
+# ARG_MIN, ARG_MAX function with GROUP BY. note that key is NULL but result is not NULL.
+select deptno, arg_min(ename, ename) as mi, arg_max(ename, ename) as ma
+from emp
+group by deptno;
++--------+-------+-------+
+| DEPTNO | MI    | MA    |
++--------+-------+-------+
+|     10 | Bob   | Jane  |
+|     20 | Eric  | Eric  |
+|     30 | Alice | Susan |
+|     50 | Adam  | Eve   |
+|     60 | Grace | Grace |
+|        | Wilma | Wilma |
++--------+-------+-------+
+(6 rows)
+
+!ok
+
 # End agg.iq

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3529,7 +3529,7 @@ from emp;
 +-------+-------+
 | MI    | MA    |
 +-------+-------+
-| Jane  | Grace |
+| CLARK | ALLEN |
 +-------+-------+
 (1 row)
 
@@ -3541,7 +3541,7 @@ from emp;
 +-------+-------+
 | MI    | MA    |
 +-------+-------+
-| Jane  | Grace |
+| CLARK | ALLEN |
 +-------+-------+
 (1 row)
 
@@ -3554,7 +3554,7 @@ where deptno <= 20;
 +-------+-------+
 | MI    | MA    |
 +-------+-------+
-| Jane  | Eric  |
+| CLARK | SMITH |
 +-------+-------+
 (1 row)
 
@@ -3578,32 +3578,28 @@ where deptno > 60;
 select deptno, arg_min(ename, ename) as mi, arg_max(ename, ename) as ma
 from emp
 group by deptno;
-+--------+-------+-------+
-| DEPTNO | MI    | MA    |
-+--------+-------+-------+
-|     10 | Bob   | Jane  |
-|     20 | Eric  | Eric  |
-|     30 | Alice | Susan |
-|     50 | Adam  | Eve   |
-|     60 | Grace | Grace |
-|        | Wilma | Wilma |
-+--------+-------+-------+
-(6 rows)
++--------+-------+--------+
+| DEPTNO | MI    | MA     |
++--------+-------+--------+
+|     10 | CLARK | MILLER |
+|     20 | ADAMS | SMITH  |
+|     30 | ALLEN | WARD   |
++--------+-------+--------+
+(3 rows)
 
 !ok
 
 # ARG_MIN, ARG_MAX applied to an integer.
 select arg_min(deptno, empno) as mi,
   arg_max(deptno, empno) as ma,
-  arg_max(deptno, empno) filter (where gender = 'm') as gen
-from EMPS;
-+----+----+-----+
-| MI | MA | GEN |
-+----+----+-----+
-| 10 | 40 |     |
-+----+----+-----+
+  arg_max(deptno, empno) filter (where job = 'MANAGER') as mamgr
+from emp;
++----+----+-------+
+| MI | MA | MAMGR |
++----+----+-------+
+| 20 | 10 |    10 |
++----+----+-------+
 (1 row)
 
 !ok
-
 # End agg.iq

--- a/core/src/test/resources/sql/winagg.iq
+++ b/core/src/test/resources/sql/winagg.iq
@@ -741,4 +741,28 @@ from emp;
 (9 rows)
 
 !ok
+
+# [CALCITE-5283] Add ARG_MIN, ARG_MAX aggregate function
+
+# ARG_MIN, ARG_MAX function without ORDER BY.
+select gender,
+  arg_min(ename, deptno) over (partition by gender order by ename) as mi,
+  arg_max(ename, deptno) over (partition by gender order by ename) as ma
+from emp;
++--------+-------+-------+
+| GENDER | MI    | MA    |
++--------+-------+-------+
+| F      | Alice | Alice |
+| F      | Alice | Eve   |
+| F      | Alice | Grace |
+| F      | Jane  | Grace |
+| F      | Jane  | Grace |
+| F      | Jane  | Grace |
+| M      | Adam  | Adam  |
+| M      | Bob   | Adam  |
+| M      | Bob   | Adam  |
++--------+-------+-------+
+(9 rows)
+
+!ok
 # End winagg.iq

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1852,6 +1852,8 @@ and `LISTAGG`).
 | Operator syntax                    | Description
 |:---------------------------------- |:-----------
 | ANY_VALUE( [ ALL &#124; DISTINCT ] value)     | Returns one of the values of *value* across all input values; this is NOT specified in the SQL standard
+| ARG_MAX(value, comp)                          | Returns *value* for the maximum value of *comp* in the group
+| ARG_MIN(value, comp)                          | Returns *value* for the minimum value of *comp* in the group
 | APPROX_COUNT_DISTINCT(value [, value ]*)      | Returns the approximate number of distinct values of *value*; the database is allowed to use an approximation but is not required to
 | AVG( [ ALL &#124; DISTINCT ] numeric)         | Returns the average (arithmetic mean) of *numeric* across all input values
 | BIT_AND( [ ALL &#124; DISTINCT ] value)       | Returns the bitwise AND of all non-null input values, or null if none; integer and binary types are supported

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2732,6 +2732,8 @@ Dialect-specific aggregate functions.
 | m | GROUP_CONCAT( [ ALL &#124; DISTINCT ] value [, value ]* [ ORDER BY orderItem [, orderItem ]* ] [ SEPARATOR separator ] ) | MySQL-specific variant of `LISTAGG`
 | b | LOGICAL_AND(condition)                         | Synonym for `EVERY`
 | b | LOGICAL_OR(condition)                          | Synonym for `SOME`
+| s | MAX_BY(value, comp)                            | Synonym for `ARG_MAX`
+| s | MIN_BY(value, comp)                            | Synonym for `ARG_MIN`
 | b p | STRING_AGG( [ ALL &#124; DISTINCT ] value [, separator] [ ORDER BY orderItem [, orderItem ]* ] ) | Synonym for `LISTAGG`
 
 Usage Examples:

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -9376,6 +9376,24 @@ public class SqlOperatorTest {
         isSingle("02"));
   }
 
+  @Test void testArgMin() {
+    final SqlOperatorFixture f0 = fixture().withTester(t -> TESTER);
+    final String[] xValues = {"2", "3", "4", "4", "5", "7"};
+
+    final Consumer<SqlOperatorFixture> consumer = f -> {
+      f.checkAgg("arg_min(mod(x, 3), x)", xValues, isSingle("2"));
+      f.checkAgg("arg_max(mod(x, 3), x)", xValues, isSingle("1"));
+    };
+
+    final Consumer<SqlOperatorFixture> consumer2 = f -> {
+      f.checkAgg("min_by(mod(x, 3), x)", xValues, isSingle("2"));
+      f.checkAgg("max_by(mod(x, 3), x)", xValues, isSingle("1"));
+    };
+
+    consumer.accept(f0);
+    consumer2.accept(f0.withLibrary(SqlLibrary.SPARK));
+  }
+
   /**
    * Tests that CAST fails when given a value just outside the valid range for
    * that type. For example,


### PR DESCRIPTION
Add ARG_MIN, ARG_MAX (aka MIN_BY, MAX_BY) aggregate functions.
- **ARG_MAX(value, comp)**   Returns *value* for the maximum value of *comp* in the group
- **ARG_MIN(value, comp)**    Returns *value* for the minimum value of *comp* in the group
