### PR TITLE
[CALCITE-5393] Support MySQL VALUE operator parse

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2444,7 +2444,17 @@ SqlNode TableConstructor() :
     final Span s;
 }
 {
-    ( <VALUES> | <VALUE> ) { s = span(); }
+    (
+        <VALUES> { s = span(); }
+    |
+        <VALUE>
+        {
+            s = span();
+            if (!this.conformance.isValueAllowed()) {
+                throw SqlUtil.newContextException(getPos(), RESOURCE.valueNotAllowed());
+            }
+        }
+    )
     AddRowConstructor(list)
     (
         LOOKAHEAD(2)

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3492,9 +3492,9 @@ SqlNode LeafQueryOrExpr(ExprContext exprContext) :
     SqlNode e;
 }
 {
-    e = Expression(exprContext) { return e; }
-|
     e = LeafQuery(exprContext) { return e; }
+|
+    e = Expression(exprContext) { return e; }
 }
 
 /** As {@link #Expression} but appends to a list. */

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2444,7 +2444,7 @@ SqlNode TableConstructor() :
     final Span s;
 }
 {
-    <VALUES> { s = span(); }
+    ( <VALUES> | <VALUE> ) { s = span(); }
     AddRowConstructor(list)
     (
         LOOKAHEAD(2)

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -998,4 +998,6 @@ public interface CalciteResource {
   @BaseMessage("A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics")
   ExInst<SqlValidatorException> multipleRowSemanticsTables(String funcName);
 
+  @BaseMessage("VALUE is not allowed under the current SQL conformance level")
+  ExInst<CalciteException> valueNotAllowed();
 }

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -48,6 +48,9 @@ public interface CalciteResource {
   @BaseMessage("APPLY operator is not allowed under the current SQL conformance level")
   ExInst<CalciteException> applyNotAllowed();
 
+  @BaseMessage("VALUE is not allowed under the current SQL conformance level")
+  ExInst<CalciteException> valueNotAllowed();
+
   @BaseMessage("Illegal {0} literal ''{1}'': {2}")
   ExInst<CalciteException> illegalLiteral(String a0, String a1, String a2);
 
@@ -998,6 +1001,4 @@ public interface CalciteResource {
   @BaseMessage("A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics")
   ExInst<SqlValidatorException> multipleRowSemanticsTables(String funcName);
 
-  @BaseMessage("VALUE is not allowed under the current SQL conformance level")
-  ExInst<CalciteException> valueNotAllowed();
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -133,6 +133,10 @@ public abstract class SqlAbstractConformance implements SqlConformance {
     return SqlConformanceEnum.DEFAULT.allowAliasUnnestItems();
   }
 
+  @Override public boolean isValueAllowed() {
+    return SqlConformanceEnum.DEFAULT.isValueAllowed();
+  }
+
   @Override public SqlLibrary semantics() {
     return SqlConformanceEnum.DEFAULT.semantics();
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -525,6 +525,18 @@ public interface SqlConformance {
   boolean allowQualifyingCommonColumn();
 
   /**
+   * Whether {@code VALUE} is allowed as an alternative to {@code VALUES} in
+   * the parser.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#BABEL},
+   * {@link SqlConformanceEnum#LENIENT},
+   * {@link SqlConformanceEnum#MYSQL_5};
+   * false otherwise.
+   */
+  boolean isValueAllowed();
+
+  /**
    * Controls the behavior of operators that are part of Standard SQL but
    * nevertheless have different behavior in different databases.
    *

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -404,6 +404,17 @@ public enum SqlConformanceEnum implements SqlConformance {
     }
   }
 
+  @Override public boolean isValueAllowed() {
+    switch (this) {
+    case BABEL:
+    case LENIENT:
+    case MYSQL_5:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   @Override public SqlLibrary semantics() {
     switch (this) {
     case BIG_QUERY:

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
@@ -79,6 +79,10 @@ public class SqlDelegatingConformance extends SqlAbstractConformance {
     return delegate.allowAliasUnnestItems();
   }
 
+  @Override public boolean isValueAllowed() {
+    return delegate.isValueAllowed();
+  }
+
   @Override public SqlLibrary semantics() {
     return delegate.semantics();
   }

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -326,4 +326,5 @@ InvalidPartitionKeys=Only tables with set semantics may be partitioned. Invalid 
 InvalidOrderBy=Only tables with set semantics may be ordered. Invalid ORDER BY clause in the {0,number,#}-th operand of table function ''{1}''
 MultipleRowSemanticsTables=A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics
 NoOperator=No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization
+ValueNotAllowed=VALUE is not allowed under the current SQL conformance level
 # End CalciteResource.properties

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -311,7 +311,7 @@ unpivotValue:
   |   '(' column [, column ]* ')' [ AS '(' literal [, literal ]* ')' ]
 
 values:
-      VALUES expression [, expression ]*
+      { VALUES | VALUE } expression [, expression ]*
 
 groupItem:
       expression
@@ -399,6 +399,10 @@ but is only allowed in certain
 
 "OFFSET start" may occur before "LIMIT count" in certain
 [conformance levels]({{ site.apiRoot }}/org/apache/calcite/sql/validate/SqlConformance.html#isOffsetLimitAllowed--).
+
+VALUE is equivalent to VALUES,
+but is not standard SQL and is only allowed in certain
+[conformance levels]({{ site.apiRoot }}/org/apache/calcite/sql/validate/SqlConformance.html#isValueAllowed--).
 
 ## Keywords
 

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4586,6 +4586,14 @@ public class SqlParserTest {
         .ok(expected);
   }
 
+  @Test void testInsertValue() {
+    final String expected = "INSERT INTO `EMPS`\n"
+        + "VALUES (ROW(1, 'Fredkin'))";
+    sql("insert into emps value (1, 'Fredkin')")
+        .ok(expected)
+        .node(not(isDdl()));
+  }
+
   @Test void testInsertValues() {
     final String expected = "INSERT INTO `EMPS`\n"
         + "VALUES (ROW(1, 'Fredkin'))";

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4586,10 +4586,19 @@ public class SqlParserTest {
         .ok(expected);
   }
 
+  /** Tests VALUE, which is equivalent to VALUES but only supported in some
+   * conformance levels (e.g. MYSQL). */
   @Test void testInsertValue() {
+    final String pattern =
+        "VALUE is not allowed under the current SQL conformance level";
+    final String sql = "insert into emps ^value^ (1, 'Fredkin')";
+    sql(sql)
+        .fails(pattern);
+
     final String expected = "INSERT INTO `EMPS`\n"
         + "VALUES (ROW(1, 'Fredkin'))";
-    sql("insert into emps value (1, 'Fredkin')")
+    sql(sql)
+        .withConformance(SqlConformanceEnum.MYSQL_5)
         .ok(expected)
         .node(not(isDdl()));
   }

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4073,8 +4073,17 @@ public class SqlParserTest {
   }
 
   @Test void testValues() {
+    final String expected = "VALUES (ROW(1, 'two'))";
+    final String pattern =
+        "VALUE is not allowed under the current SQL conformance level";
     sql("values(1,'two')")
-        .ok("VALUES (ROW(1, 'two'))");
+        .ok(expected);
+    sql("value(1,'two')")
+        .withConformance(SqlConformanceEnum.MYSQL_5)
+        .ok(expected)
+        .node(not(isDdl()));
+    sql("^value^(1,'two')")
+        .fails(pattern);
   }
 
   @Test void testValuesExplicitRow() {
@@ -4586,29 +4595,20 @@ public class SqlParserTest {
         .ok(expected);
   }
 
-  /** Tests VALUE, which is equivalent to VALUES but only supported in some
-   * conformance levels (e.g. MYSQL). */
-  @Test void testInsertValue() {
-    final String pattern =
-        "VALUE is not allowed under the current SQL conformance level";
-    final String sql = "insert into emps ^value^ (1, 'Fredkin')";
-    sql(sql)
-        .fails(pattern);
-
-    final String expected = "INSERT INTO `EMPS`\n"
-        + "VALUES (ROW(1, 'Fredkin'))";
-    sql(sql)
-        .withConformance(SqlConformanceEnum.MYSQL_5)
-        .ok(expected)
-        .node(not(isDdl()));
-  }
-
   @Test void testInsertValues() {
     final String expected = "INSERT INTO `EMPS`\n"
         + "VALUES (ROW(1, 'Fredkin'))";
+    final String pattern =
+        "VALUE is not allowed under the current SQL conformance level";
     sql("insert into emps values (1,'Fredkin')")
         .ok(expected)
         .node(not(isDdl()));
+    sql("insert into emps value (1, 'Fredkin')")
+        .withConformance(SqlConformanceEnum.MYSQL_5)
+        .ok(expected)
+        .node(not(isDdl()));
+    sql("insert into emps ^value^ (1, 'Fredkin')")
+        .fails(pattern);
   }
 
   @Test void testInsertValuesDefault() {


### PR DESCRIPTION
* add `VALUE` kerword to Paser.jj for `INSERT INTO ... VALUE ...` statement
* add unit test for `INSERT INTO ... VALUE ...` statement
* adjust LeafQueryOrExpr syntax order to ensure LeafQuery process first
* add isValueAllowed in BABEL, LENIENT and MYSQL_5 conformance