### PR TITLE
[CALCITE-5399] Remove Proj4J from the api dependencies

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -48,7 +48,11 @@ dependencies {
 
     api("org.locationtech.jts:jts-core")
     api("org.locationtech.jts.io:jts-io-common")
-    api("org.locationtech.proj4j:proj4j")
+
+    // Due to restricting terms of use, we cannot include Proj4J as an API dependency.
+    compileOnly("org.locationtech.proj4j:proj4j")
+    testRuntimeOnly("org.locationtech.proj4j:proj4j")
+
     api("com.fasterxml.jackson.core:jackson-annotations")
     api("com.google.errorprone:error_prone_annotations")
     api("com.google.guava:guava")

--- a/core/src/main/java/org/apache/calcite/runtime/ProjectionTransformer.java
+++ b/core/src/main/java/org/apache/calcite/runtime/ProjectionTransformer.java
@@ -40,6 +40,14 @@ import java.util.stream.Stream;
 
 /**
  * Transforms the projection of a geometry.
+ *
+ * This class uses Proj4J to transform the projection of a geometry
+ * and should not be used beyond the scope of the Spatial Type Extensions.
+ * Proj4J is released under the Apache License 2.0, however, it also uses the EPSG dataset,
+ * which has restricting <a href="https://epsg.org/terms-of-use.html">terms of use</a>.
+ * As a result, Proj4J is not suitable for inclusion in Apache Calcite
+ * and this class will throw {@code ClassNotFoundException}s
+ * if Proj4J is not added to the classpath by the user.
  */
 public class ProjectionTransformer extends GeometryTransformer {
 

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -841,6 +841,8 @@ your key to the keyservers used by Nexus, see above.
   that the `META-INF` directory contains `LICENSE`,
   `NOTICE`
 * Check PGP, per [this](https://httpd.apache.org/dev/verification.html)
+* Check that Proj4J is not among the api and implementation dependencies,
+  as the EPSG database is not redistributable.
 
 Verify the staged artifacts in the Nexus repository:
 

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2430,6 +2430,13 @@ Not implemented:
 
 #### Geometry projection functions
 
+Projection functions rely on Proj4J to transform the geometries.
+Proj4J is released under the Apache License 2.0, however, it also uses the EPSG dataset,
+which has restricting [terms of use](https://epsg.org/terms-of-use.html).
+As a result, Proj4J is not suitable for inclusion in Apache Calcite
+and some of these functions may throw `ClassNotFoundException`s.
+Users can still use these functions by including Proj4J in their classpath.
+
 | C | Operator syntax      | Description
 |:- |:-------------------- |:-----------
 | o | ST_SetSRID(geom, srid) | Returns a copy of *geom* with a new SRID

--- a/site/_docs/spatial.md
+++ b/site/_docs/spatial.md
@@ -148,6 +148,15 @@ These rewrites are worth performing because they are much quicker to apply,
 and often allow range scans on the Hilbert index.
 But for safety, Calcite applies the original predicate, to remove false positives.
 
+## Limitations
+
+Some spatial functions rely on Proj4J to transform the projection of spatial objects.
+Proj4J is released under the Apache License 2.0, however, it also uses the EPSG dataset,
+which has restricting [terms of use](https://epsg.org/terms-of-use.html).
+As a result, Proj4J is not suitable for inclusion in Apache Calcite
+and these functions will throw `ClassNotFoundException`s.
+Users can still use these functions by including Proj4J in their classpath.
+
 ## Acknowledgements
 
 Calcite's OpenGIS implementation uses the


### PR DESCRIPTION
Proj4J uses the EPSG dataset and has restricting terms of use. Making Proj4J a compileOnly dependency addresses this issue.