### PR TITLE
[CALCITE-5410] Assertion error on PERCENT_REMAINDER operator with DECIMAL type

### DIFF
--- a/babel/src/test/resources/sql/select.iq
+++ b/babel/src/test/resources/sql/select.iq
@@ -60,4 +60,17 @@ select(...)
 !explain-validated-on mysql8+ oracle
 !}
 
+# [CALCITE-5410] Assertion error on PERCENT_REMAINDER operator with DECIMAL type
+
+select 1.0 % 2;
+
++--------+
+| EXPR$0 |
++--------+
+|    1.0 |
++--------+
+(1 row)
+
+!ok
+
 # End select.iq

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -301,7 +301,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           SqlKind.MOD,
           60,
           true,
-          ReturnTypes.ARG1_NULLABLE,
+          ReturnTypes.NULLABLE_MOD,
           null,
           OperandTypes.EXACT_NUMERIC_EXACT_NUMERIC);
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -501,6 +501,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
     expr("mod(5.1, 3)").ok();
     expr("mod(2,5.1)").ok();
+    expr("5.1 % 3")
+        .withConformance(SqlConformanceEnum.LENIENT)
+        .columnType("DECIMAL(2, 1) NOT NULL");
+    expr("2 % 5.1")
+        .withConformance(SqlConformanceEnum.LENIENT)
+        .columnType("DECIMAL(2, 1) NOT NULL");
     expr("exp(3.67)").ok();
   }
 


### PR DESCRIPTION
PERCENT_REMAINDER operator should have the same return type inference as MOD operator.