### PR TITLE
[CALCITE-5418] Fixing Nested Correlated Subquery Expansion

### DIFF
--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
@@ -273,7 +273,7 @@ public class CassandraRules {
           return false;
         }
       }
-      return project.getVariablesSet().isEmpty();
+      return true;
     }
 
     @Override public RelNode convert(RelNode rel) {

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -278,6 +278,17 @@ public abstract class RelOptUtil {
     return visitor.vuv.variables;
   }
 
+  @Experimental
+  public static Set<CorrelationId> findUsedCorrelatedVariable(RexSubQuery rexSubQuery) {
+    if (rexSubQuery.correlationId == null) {
+      return ImmutableSet.of();
+    } else if (getVariablesUsed(rexSubQuery.rel).contains(rexSubQuery.correlationId)) {
+      return ImmutableSet.of(rexSubQuery.correlationId);
+    } else {
+      return ImmutableSet.of();
+    }
+  }
+
   /** Finds which columns of a correlation variable are used within a
    * relational expression. */
   public static ImmutableBitSet correlationColumns(CorrelationId id,
@@ -4365,6 +4376,7 @@ public abstract class RelOptUtil {
       if (relShuttle != null) {
         subQuery.rel.accept(relShuttle); // look inside sub-queries
       }
+      variables.remove(subQuery.correlationId);
       return super.visitSubQuery(subQuery);
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -46,6 +46,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 
 import org.immutables.value.Value;
 
@@ -817,6 +818,7 @@ public class SubQueryRemoveRule
             project.getProjects(), e);
     builder.push(project.getInput());
     final int fieldCount = builder.peek().getRowType().getFieldCount();
+    //[CALCITE-5420] Blocks fixing [CALCITE-5418] since SqlToRel does not populate the variableSet
     final Set<CorrelationId>  variablesSet =
         RelOptUtil.getVariablesUsed(e.rel);
     final RexNode target = rule.apply(e, variablesSet,
@@ -843,8 +845,8 @@ public class SubQueryRemoveRule
       ++count;
       final RelOptUtil.Logic logic =
           LogicVisitor.find(RelOptUtil.Logic.TRUE, ImmutableList.of(c), e);
-      final Set<CorrelationId>  variablesSet =
-          RelOptUtil.getVariablesUsed(e.rel);
+      final Set<CorrelationId>  variablesSet = Sets.intersection(
+          RelOptUtil.getVariablesUsed(e.rel), filter.getVariablesSet());
       final RexNode target = rule.apply(e, variablesSet, logic,
           builder, 1, builder.peek().getRowType().getFieldCount());
       final RexShuttle shuttle = new ReplaceSubQueryShuttle(e, target);
@@ -867,6 +869,7 @@ public class SubQueryRemoveRule
     builder.push(join.getLeft());
     builder.push(join.getRight());
     final int fieldCount = join.getRowType().getFieldCount();
+    //[CALCITE-4792] Blocks fixing [CALCITE-5418] since SqlToRel does not populate join.variableSet
     final Set<CorrelationId>  variablesSet =
         RelOptUtil.getVariablesUsed(e.rel);
     final RexNode target = rule.apply(e, variablesSet,

--- a/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
@@ -45,15 +45,15 @@ public class RexSubQuery extends RexCall {
   @Nullable public final CorrelationId correlationId;
 
   private RexSubQuery(RelDataType type, SqlOperator op,
-      ImmutableList<RexNode> operands, RelNode rel, @Nullable CorrelationId correlationId) {
+      List<RexNode> operands, RelNode rel, @Nullable CorrelationId correlationId) {
     super(type, op, operands);
     this.rel = rel;
     this.correlationId = correlationId;
   }
 
   /** Creates an IN sub-query. */
-  public static RexSubQuery in(RelNode rel, ImmutableList<RexNode> nodes,
-      CorrelationId correlationId) {
+  public static RexSubQuery in(RelNode rel, List<RexNode> nodes,
+      @Nullable CorrelationId correlationId) {
     final RelDataType type = type(rel, nodes);
     return new RexSubQuery(type, SqlStdOperatorTable.IN, nodes, rel, correlationId);
   }
@@ -66,8 +66,8 @@ public class RexSubQuery extends RexCall {
    * then {@code negated-comparison} is {@code <=}, and so forth.
    *
    * <p>Also =SOME is rewritten into IN</p> */
-  public static RexSubQuery some(RelNode rel, ImmutableList<RexNode> nodes,
-      SqlQuantifyOperator op, CorrelationId correlationId) {
+  public static RexSubQuery some(RelNode rel, List<RexNode> nodes,
+      SqlQuantifyOperator op, @Nullable CorrelationId correlationId) {
     assert op.kind == SqlKind.SOME;
 
     if (op == SqlStdOperatorTable.SOME_EQ) {
@@ -77,7 +77,7 @@ public class RexSubQuery extends RexCall {
     return new RexSubQuery(type, op, nodes, rel, correlationId);
   }
 
-  static RelDataType type(RelNode rel, ImmutableList<RexNode> nodes) {
+  static RelDataType type(RelNode rel, List<RexNode> nodes) {
     assert rel.getRowType().getFieldCount() == nodes.size();
     final RelDataTypeFactory typeFactory = rel.getCluster().getTypeFactory();
     boolean nullable = false;

--- a/core/src/main/java/org/apache/calcite/sql/validate/LateralScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/LateralScope.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.validate;
+
+import org.apache.calcite.sql.SqlNode;
+
+/** Scope providing the objects that are available after evaluating an item
+ * in a WITH clause.
+ *
+ * <p>For example, in</p>
+ *
+ * <blockquote>{@code WITH t1 AS (q1) t2 AS (q2) q3}</blockquote>
+ *
+ * <p>{@code t1} provides a scope that is used to validate {@code q2}
+ * (and therefore {@code q2} may reference {@code t1}),
+ * and {@code t2} provides a scope that is used to validate {@code q3}
+ * (and therefore q3 may reference {@code t1} and {@code t2}).</p>
+ */
+public class LateralScope extends ListScope {
+  private final SqlNode leftJoin;
+
+  /** Creates a LateralScope. */
+  LateralScope(SqlValidatorScope parent, SqlNode leftJoin) {
+    super(parent);
+    this.leftJoin = leftJoin;
+  }
+
+  @Override public SqlNode getNode() {
+    return leftJoin;
+  }
+
+
+}

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -580,6 +580,8 @@ public interface SqlValidator {
    */
   @Nullable SqlValidatorScope getJoinScope(SqlNode node);
 
+  @Nullable SqlValidatorScope getLateralScope(SqlNode node);
+
   /**
    * Returns a scope containing the objects visible from the GROUP BY clause
    * of a query.

--- a/core/src/main/java/org/apache/calcite/sql2rel/ColumnResolver.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/ColumnResolver.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql2rel;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalMatch;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.validate.ListScope;
+import org.apache.calcite.sql.validate.SqlNameMatcher;
+import org.apache.calcite.sql.validate.SqlQualified;
+import org.apache.calcite.sql.validate.SqlValidatorNamespace;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Resolves Sql identifiers.
+ */
+public class ColumnResolver {
+  private final SqlNameMatcher nameMatcher;
+  private final RelOptCluster relOptCluster;
+  private final RexBuilder rexBuilder;
+  private final Deque<CorrelateResolver> resolvers = new ArrayDeque<>();
+
+  public ColumnResolver(SqlNameMatcher nameMatcher, RelOptCluster relOptCluster) {
+    this.nameMatcher = nameMatcher;
+    this.relOptCluster = relOptCluster;
+    this.rexBuilder = relOptCluster.getRexBuilder();
+  }
+
+  public CorrelateResolver addResolver(SqlValidatorScope sqlValidatorScope,
+      List<RelNode> childrenRel) {
+    CorrelateResolver correlateResolver =
+        new CorrelateResolver(relOptCluster, sqlValidatorScope, childrenRel);
+    resolvers.add(correlateResolver);
+    return correlateResolver;
+  }
+
+  public RexNode resolveTable(SqlValidatorScope scope, SqlQualified qualified,
+      @Nullable List<RelNode> childrenRel, Map<RelNode, Integer> leaves) {
+    final SqlValidatorScope.ResolvedImpl resolved =
+        new SqlValidatorScope.ResolvedImpl();
+
+    scope.resolve(qualified.prefix(), nameMatcher, false, resolved);
+    if (resolved.count() != 1) {
+      throw new AssertionError("no unique expression found for " + qualified
+          + "; count is " + resolved.count());
+    }
+    final SqlValidatorScope.Resolve resolve = resolved.only();
+    String fieldName = Iterables.getFirst(qualified.suffix(), null);
+    assert fieldName != null;
+    if (resolve.scope == scope) {
+      assert childrenRel != null && !childrenRel.isEmpty();
+      return resolveCurrentScope(resolve, fieldName, childrenRel, leaves);
+    }
+
+    for (Iterator<CorrelateResolver> iter = resolvers.descendingIterator(); iter.hasNext();) {
+      CorrelateResolver resolver = iter.next();
+      RexNode rexNode = resolver.resolve(resolve, fieldName);
+      if (null != rexNode) {
+        return rexNode;
+      }
+    }
+
+    throw new AssertionError("Failed to resolve " + qualified);
+  }
+
+  private RexNode resolveCurrentScope(SqlValidatorScope.Resolve resolve, String fieldName,
+      List<RelNode> relNodeList, Map<RelNode, Integer> leaves) {
+    int relIndex = resolve.path.steps().get(0).i;
+    LookupContext lookupContext = new LookupContext(relNodeList, 0, leaves);
+    Pair<RelNode, Integer> context = lookupContext.findRel(relIndex);
+    //int offset = relNodeList.subList(0,relIndex)
+    //    .stream().mapToInt(r -> r.getRowType().getFieldCount()).sum();
+    //RexNode range = rexBuilder.makeRangeReference(relNode.getRowType(), offset, false);
+    RexNode range = rexBuilder.makeRangeReference(context.left.getRowType(), context.right, false);
+    RelDataType rowType = resolve.rowType();
+    final RelDataTypeField field =
+        requireNonNull(rowType.getField(fieldName, true, false),
+            () -> "field " + fieldName);
+    return rexBuilder.makeFieldAccess(range, field.getIndex());
+  }
+
+  /**
+   * Resolves identifiers for correlated variables.
+   */
+  public static class CorrelateResolver {
+
+    @Nullable public CorrelationId correlationId;
+    @Nullable private RexNode correlateNode;
+    @Nullable private Map<String, Integer> fields;
+    private final RelOptCluster relOptCluster;
+    private final SqlValidatorScope sqlValidatorScope;
+    private final RelDataTypeFactory typeFactory;
+    private final RexBuilder rexBuilder;
+    private final List<RelNode> relNodeList;
+
+    public CorrelateResolver(RelOptCluster relOptCluster,
+        SqlValidatorScope sqlValidatorScope, List<RelNode> relNodeList) {
+      this.relOptCluster = relOptCluster;
+      this.sqlValidatorScope = sqlValidatorScope;
+      this.relNodeList = relNodeList;
+      this.typeFactory = relOptCluster.getTypeFactory();
+      this.rexBuilder = relOptCluster.getRexBuilder();
+    }
+
+    public @Nullable RexNode resolve(SqlValidatorScope.Resolve resolve, String fieldName) {
+      if (resolve.scope != sqlValidatorScope) {
+        return null;
+      } else if (correlationId == null) {
+        correlationId = relOptCluster.createCorrel();
+        correlateNode = createCorrel(resolve);
+      }
+      final int fieldIndex = requireNonNull(fields.get(fieldName), "field " + fieldName);
+      return rexBuilder.makeFieldAccess(correlateNode, fieldIndex);
+    }
+
+    private RexNode createCorrel(SqlValidatorScope.Resolve resolve) {
+      final RelDataTypeFactory.Builder builder = typeFactory.builder();
+      final ListScope ancestorScope1 = (ListScope)
+          requireNonNull(resolve.scope, "resolve.scope");
+      final ImmutableMap.Builder<String, Integer> fields = ImmutableMap.builder();
+      int i = 0;
+      int offset = 0;
+      for (SqlValidatorNamespace c : ancestorScope1.getChildren()) {
+        if (ancestorScope1.isChildNullable(i)) {
+          for (final RelDataTypeField f : c.getRowType().getFieldList()) {
+            builder.add(f.getName(), typeFactory.createTypeWithNullability(f.getType(), true));
+          }
+        } else {
+          builder.addAll(c.getRowType().getFieldList());
+        }
+        if (i == resolve.path.steps().get(0).i) {
+          for (RelDataTypeField field : c.getRowType().getFieldList()) {
+            fields.put(field.getName(), field.getIndex() + offset);
+          }
+        }
+        ++i;
+        offset += c.getRowType().getFieldCount();
+      }
+      this.fields = fields.build();
+      return rexBuilder.makeCorrel(builder.uniquify().build(), correlationId);
+    }
+  }
+
+
+  private static void flatten(
+      List<RelNode> rels,
+      int systemFieldCount,
+      int[] start,
+      List<Pair<RelNode, Integer>> relOffsetList,
+      Map<RelNode, Integer> leaves) {
+    for (RelNode rel : rels) {
+      if (leaves.containsKey(rel)) {
+        relOffsetList.add(
+            Pair.of(rel, start[0]));
+        start[0] += leaves.get(rel);
+      } else if (rel instanceof LogicalMatch) {
+        relOffsetList.add(
+            Pair.of(rel, start[0]));
+        start[0] += rel.getRowType().getFieldCount();
+      } else {
+        if (rel instanceof LogicalJoin
+            || rel instanceof LogicalAggregate) {
+          start[0] += systemFieldCount;
+        }
+        flatten(
+            rel.getInputs(),
+            systemFieldCount,
+            start,
+            relOffsetList,
+            leaves);
+      }
+    }
+  }
+
+  /**
+   * Context to find a relational expression to a field offset.
+   */
+  private static class LookupContext {
+    private final List<Pair<RelNode, Integer>> relOffsetList =
+        new ArrayList<>();
+
+    /**
+     * Creates a LookupContext with multiple input relational expressions.
+     *
+     * @param bb               Context for translating this sub-query
+     * @param rels             Relational expressions
+     * @param systemFieldCount Number of system fields
+     */
+    LookupContext(List<RelNode> rels, int systemFieldCount, Map<RelNode, Integer> leaves) {
+      flatten(rels, systemFieldCount, new int[]{0}, relOffsetList, leaves);
+    }
+
+    /**
+     * Returns the relational expression with a given offset, and the
+     * ordinal in the combined row of its first field.
+     *
+     * <p>For example, in {@code Emp JOIN Dept}, findRel(1) returns the
+     * relational expression for {@code Dept} and offset 6 (because
+     * {@code Emp} has 6 fields, therefore the first field of {@code Dept}
+     * is field 6.
+     *
+     * @param offset Offset of relational expression in FROM clause
+     * @return Relational expression and the ordinal of its first field
+     */
+    Pair<RelNode, Integer> findRel(int offset) {
+      return relOffsetList.get(offset);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -763,8 +763,9 @@ public class RelBuilder {
 
   /** Creates an IN predicate with a sub-query. */
   @Experimental
-  public RexSubQuery in(RelNode rel, Iterable<? extends RexNode> nodes) {
-    return RexSubQuery.in(rel, ImmutableList.copyOf(nodes));
+  public RexSubQuery in(RelNode rel, Iterable<? extends RexNode> nodes,
+      CorrelationId correlationId) {
+    return RexSubQuery.in(rel, ImmutableList.copyOf(nodes), correlationId);
   }
 
   /** Creates an IN predicate with a sub-query.
@@ -792,7 +793,7 @@ public class RelBuilder {
   @Experimental
   public RexNode in(RexNode arg, Function<RelBuilder, RelNode> f) {
     final RelNode rel = f.apply(this);
-    return RexSubQuery.in(rel, ImmutableList.of(arg));
+    return RexSubQuery.in(rel, ImmutableList.of(arg), null);
   }
 
   /** Creates a SOME (or ANY) predicate.
@@ -837,7 +838,7 @@ public class RelBuilder {
     final RelNode rel = f.apply(this);
     final SqlQuantifyOperator quantifyOperator =
         SqlStdOperatorTable.some(kind);
-    return RexSubQuery.some(rel, ImmutableList.of(node), quantifyOperator);
+    return RexSubQuery.some(rel, ImmutableList.of(node), quantifyOperator, null);
   }
 
   /** Creates an ALL predicate.
@@ -902,7 +903,7 @@ public class RelBuilder {
   @Experimental
   public RexSubQuery exists(Function<RelBuilder, RelNode> f) {
     final RelNode rel = f.apply(this);
-    return RexSubQuery.exists(rel);
+    return RexSubQuery.exists(rel, null);
   }
 
   /** Creates a UNIQUE predicate.
@@ -930,7 +931,7 @@ public class RelBuilder {
   @Experimental
   public RexSubQuery unique(Function<RelBuilder, RelNode> f) {
     final RelNode rel = f.apply(this);
-    return RexSubQuery.unique(rel);
+    return RexSubQuery.unique(rel, null);
   }
 
   /** Creates a scalar sub-query.
@@ -956,7 +957,7 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery scalarQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.scalar(f.apply(this));
+    return RexSubQuery.scalar(f.apply(this), null);
   }
 
   /** Creates an ARRAY sub-query.
@@ -980,7 +981,7 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery arrayQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.array(f.apply(this));
+    return RexSubQuery.array(f.apply(this), null);
   }
 
   /** Creates a MULTISET sub-query.
@@ -1004,7 +1005,7 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery multisetQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.multiset(f.apply(this));
+    return RexSubQuery.multiset(f.apply(this), null);
   }
 
   /** Creates a MAP sub-query.
@@ -1029,7 +1030,7 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery mapQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.map(f.apply(this));
+    return RexSubQuery.map(f.apply(this), null);
   }
 
   /** Creates an AND. */

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -4462,7 +4462,6 @@ class RelOptRulesTest extends RelOptTestBase {
    * correlated variable from the inner subquery is correctly bound to the outer scope and can
    * be decorrelated.
    */
-  @Disabled("[CALCITE-5413]")
   @Test void testNestedCorrelatedQueriesUsingOuterContext() {
     final String sql = ""
         + "SELECT deptno\n"
@@ -4520,7 +4519,6 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
-  @Disabled("[CALCITE-5420]")
   @Test void testCorrelatedQueryInSelectWithAgg() {
     String sql = "\n"
         + "SELECT SUM(\n"
@@ -4540,7 +4538,6 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
-  @Disabled("[CALCITE-5420],[CALCITE-5418]")
   @Test void testNestedCorrelatedQueriesUsingBothContextWith2InnerQueriesInSelectClause() {
     final String sql = ""
         + "SELECT e.deptno\n"
@@ -4572,7 +4569,7 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
-  @Disabled("[CALCITE-4792],[CALCITE-5418]")
+  @Disabled("[CALCITE-4792]")
   @Test void testNestedCorrelatedQueriesUsingBothContextWith2InnerQueriesInJoinClause() {
     final String sql = ""
         + "SELECT deptno\n"

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6133,6 +6133,363 @@ LogicalProject(EXPR$0=[CAST(/($2, $3)):INTEGER NOT NULL])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNestedCorrelatedQueriesUsingBothContextWith2InnerQueries">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno
+FROM emp e
+WHERE EXISTS (
+  SELECT *
+  FROM dept d
+  WHERE d.deptno = e.deptno
+    AND exists(
+      SELECT *
+      FROM emp_address ea
+      WHERE ea.empno = e.empno)
+    AND exists(
+      SELECT *
+      FROM emp e2
+      WHERE e2.deptno = d.deptno))
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[AND(=($0, $cor0.DEPTNO), EXISTS({
+LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+}), EXISTS({
+LogicalFilter(condition=[=($7, $cor2.DEPTNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))], variablesSet=[[$cor2]])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})], variablesSet=[[$cor0]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 7}])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(i=[true])
+        LogicalFilter(condition=[=($0, $cor0.DEPTNO)])
+          LogicalCorrelate(correlation=[$cor2], joinType=[inner], requiredColumns=[{0}])
+            LogicalJoin(condition=[true], joinType=[inner])
+              LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+              LogicalAggregate(group=[{0}])
+                LogicalProject(i=[true])
+                  LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+            LogicalAggregate(group=[{0}])
+              LogicalProject(i=[true])
+                LogicalFilter(condition=[=($7, $cor2.DEPTNO)])
+                  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[AND(=($0, $9), =($7, $10))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(EMPNO=[$0], DEPTNO=[$1], $f2=[true])
+      LogicalAggregate(group=[{0, 1}])
+        LogicalProject(EMPNO=[$2], DEPTNO=[$0])
+          LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+            LogicalJoin(condition=[true], joinType=[inner])
+              LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+              LogicalProject(EMPNO=[$0], $f1=[true])
+                LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+            LogicalProject(DEPTNO=[$0], $f1=[true])
+              LogicalAggregate(group=[{0}])
+                LogicalProject(DEPTNO=[$7])
+                  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedCorrelatedQueriesUsingBothContextWith2InnerQueriesInJoinClause">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno
+FROM emp e
+LEFT JOIN bonus b ON b.ename = e.ename
+  OR EXISTS (
+    SELECT *
+    FROM dept d
+    WHERE d.deptno = e.deptno
+      AND exists(
+      SELECT *
+      FROM emp_address ea
+      WHERE ea.empno = e.empno)
+    AND exists(
+      SELECT *
+      FROM emp e2
+      WHERE e2.deptno = d.deptno))
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[OR(=($9, $1), EXISTS({
+LogicalFilter(condition=[AND(=($0, $cor0.DEPTNO), EXISTS({
+LogicalFilter(condition=[=($0, $cor1.EMPNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+}), EXISTS({
+LogicalFilter(condition=[=($7, $cor2.DEPTNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))], variablesSet=[[$cor2]])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+}))], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[OR(=($9, $1), IS NOT NULL($4))], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalJoin(condition=[true], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+      LogicalAggregate(group=[{0}])
+        LogicalProject(i=[true])
+          LogicalFilter(condition=[=($0, $cor0.DEPTNO)])
+            LogicalCorrelate(correlation=[$cor2], joinType=[inner], requiredColumns=[{0}])
+              LogicalJoin(condition=[true], joinType=[inner])
+                LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+                LogicalAggregate(group=[{0}])
+                  LogicalProject(i=[true])
+                    LogicalFilter(condition=[=($0, $cor1.EMPNO)])
+                      LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+              LogicalAggregate(group=[{0}])
+                LogicalProject(i=[true])
+                  LogicalFilter(condition=[=($7, $cor2.DEPTNO)])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[AND(=($9, $1), EXISTS({
+LogicalFilter(condition=[AND(=($0, $cor0.DEPTNO), EXISTS({
+LogicalFilter(condition=[=($0, $cor1.EMPNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+}), EXISTS({
+LogicalFilter(condition=[AND(=($7, $cor2.DEPTNO), =($cor3.ENAME0, $1))])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))], variablesSet=[[$cor2]])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+}))], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedCorrelatedQueriesUsingBothContextWith2InnerQueriesInSelectClause">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno
+FROM emp e
+WHERE (true, true) IN (
+  SELECT
+    EXISTS(
+      SELECT *
+      FROM emp e2
+      WHERE e2.deptno = d.deptno),
+    EXISTS(
+      SELECT *
+      FROM emp_address ea
+      WHERE ea.empno = e.empno)
+  FROM dept d
+  WHERE d.deptno = e.deptno)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalFilter(condition=[IN(true, true, {
+LogicalProject(variablesSet=[[$cor1]], EXPR$0=[EXISTS({
+LogicalFilter(condition=[=($7, $cor1.DEPTNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})], EXPR$1=[EXISTS({
+LogicalFilter(condition=[=($0, $cor2.EMPNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+})])
+  LogicalFilter(condition=[=($0, $cor2.DEPTNO)])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})], variablesSet=[[$cor2]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalCorrelate(correlation=[$cor2], joinType=[inner], requiredColumns=[{0, 7}])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(cs=[true])
+        LogicalProject(EXPR$0=[IS NOT NULL($2)], EXPR$1=[IS NOT NULL($3)])
+          LogicalFilter(condition=[AND(IS NOT NULL($2), IS NOT NULL($3))])
+            LogicalJoin(condition=[true], joinType=[left])
+              LogicalCorrelate(correlation=[$cor1], joinType=[left], requiredColumns=[{0}])
+                LogicalFilter(condition=[=($0, $cor2.DEPTNO)])
+                  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+                LogicalAggregate(group=[{0}])
+                  LogicalProject(i=[true])
+                    LogicalFilter(condition=[=($7, $cor1.DEPTNO)])
+                      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+              LogicalAggregate(group=[{0}])
+                LogicalProject(i=[true])
+                  LogicalFilter(condition=[=($0, $cor2.EMPNO)])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[AND(=($0, $9), =($7, $10))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(EMPNO=[$4], DEPTNO5=[$0], $f2=[true])
+      LogicalJoin(condition=[true], joinType=[inner])
+        LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[CAST($2):INTEGER], $f1=[CAST($3):BOOLEAN])
+          LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+            LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+            LogicalProject(DEPTNO=[$0], $f1=[true])
+              LogicalAggregate(group=[{0}])
+                LogicalProject(DEPTNO=[$7])
+                  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalProject(EMPNO=[$0], $f1=[true])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedCorrelatedQueriesUsingOuterContext">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno
+FROM emp e
+WHERE EXISTS (
+  SELECT *
+  FROM dept d
+  WHERE EXISTS(
+    SELECT *
+    FROM emp_address ea
+    WHERE ea.empno = e.empno      AND d.deptno = e.deptno))]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[AND(=($0, $cor0.EMPNO), =($cor1.DEPTNO, $cor0.DEPTNO))])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+})], variablesSet=[[$cor1]])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})], variablesSet=[[$cor0]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 7}])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(i=[true])
+        LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+          LogicalAggregate(group=[{0}])
+            LogicalProject(i=[true])
+              LogicalFilter(condition=[AND(=($0, $cor0.EMPNO), =($cor1.DEPTNO, $cor0.DEPTNO))])
+                LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[AND(=($0, $9), =($7, $10))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(EMPNO=[$2], $f3=[$3], $f2=[true])
+      LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+        LogicalProject(EMPNO=[$0], $f3=[$3], $f4=[$4], $f5=[true])
+          LogicalFilter(condition=[=($4, $3)])
+            LogicalProject(EMPNO=[$0], HOME_ADDRESS=[$1], MAILING_ADDRESS=[$2], $f3=[$cor1.DEPTNO], $f4=[$cor0.DEPTNO])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedCorrelatedQueriesUsingOuterContextWith2InnerQueries">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno
+FROM emp e
+WHERE EXISTS (
+  SELECT *
+  FROM dept d
+  WHERE d.deptno = e.deptno
+    AND exists(
+      SELECT *
+      FROM emp_address ea
+      WHERE ea.empno = e.empno)
+    AND exists(
+      SELECT *
+      FROM bonus b
+      WHERE b.ename = e.ename
+))]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[AND(=($0, $cor0.DEPTNO), EXISTS({
+LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+}), EXISTS({
+LogicalFilter(condition=[=($0, $cor0.ENAME)])
+  LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})], variablesSet=[[$cor0]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 7}])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(i=[true])
+        LogicalFilter(condition=[=($0, $cor0.DEPTNO)])
+          LogicalJoin(condition=[true], joinType=[inner])
+            LogicalJoin(condition=[true], joinType=[inner])
+              LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+              LogicalAggregate(group=[{0}])
+                LogicalProject(i=[true])
+                  LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+            LogicalAggregate(group=[{0}])
+              LogicalProject(i=[true])
+                LogicalFilter(condition=[=($0, $cor0.ENAME)])
+                  LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[AND(=($0, $9), =($1, $10), =($7, $11))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(EMPNO=[$2], ENAME=[$4], DEPTNO=[$0], $f3=[true])
+      LogicalJoin(condition=[true], joinType=[inner])
+        LogicalJoin(condition=[true], joinType=[inner])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+          LogicalProject(EMPNO=[$0], $f1=[true])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
+        LogicalProject(ENAME=[$0], $f1=[true])
+          LogicalAggregate(group=[{0}])
+            LogicalProject(ENAME=[$0])
+              LogicalTableScan(table=[[CATALOG, SALES, BONUS]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNoOversimplificationBelowIsNull">
     <Resource name="sql">
       <![CDATA[select *
@@ -13386,6 +13743,26 @@ LogicalProject(N_REGIONKEY=[ITEM($0, 'N_REGIONKEY')])
 EnumerableProject(N_REGIONKEY=[ITEM($0, 'N_REGIONKEY')])
   EnumerableFilter(condition=[>(ITEM($0, 'N_NATIONKEY'), 1)])
     EnumerableTableScan(table=[[CATALOG, SALES, CUSTOMER]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSum">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(
+  (select char_length(deptno) from dept where dept.deptno = emp.empno)) as s
+FROM emp
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], S=[SUM($0)])
+  LogicalProject($f0=[$SCALAR_QUERY({
+LogicalProject(EXPR$0=[CHAR_LENGTH(CAST($0):VARCHAR NOT NULL)])
+  LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1656,6 +1656,37 @@ MultiJoin(joinFilter=[true], isFullOuterJoin=[false], joinTypes=[[RIGHT, INNER]]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelatedQueryInSelectWithAgg">
+    <Resource name="sql">
+      <![CDATA[
+SELECT SUM(
+  (select char_length(deptno) from dept where dept.deptno = emp.empno)) as s
+FROM emp
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], S=[SUM($0)])
+  LogicalProject($f0=[$SCALAR_QUERY($cor0, {
+LogicalProject(EXPR$0=[CHAR_LENGTH(CAST($0):VARCHAR NOT NULL)])
+  LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalAggregate(group=[{}], S=[SUM($9)])
+  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+      LogicalProject(EXPR$0=[CHAR_LENGTH(CAST($0):VARCHAR NOT NULL)])
+        LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCorrelationScalarAggAndFilter">
     <Resource name="sql">
       <![CDATA[SELECT e1.empno
@@ -1690,7 +1721,7 @@ where c0 = (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject("K0"=[$0], "C1"=[$1], "F1"."A0"=[$2], "F2"."A0"=[$3], "F0"."C0"=[$4], "F1"."C0"=[$5], "F0"."C1"=[$6], "F1"."C2"=[$7], "F2"."C3"=[$8])
-  LogicalFilter(condition=[=($4, $SCALAR_QUERY({
+  LogicalFilter(condition=[=($4, $SCALAR_QUERY($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
   LogicalProject("F1"."C0"=[$5])
     LogicalFilter(condition=[=($cor0."K0", $0)])
@@ -1723,7 +1754,7 @@ where c0 in (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject("K0"=[$0], "C1"=[$1], "F1"."A0"=[$2], "F2"."A0"=[$3], "F0"."C0"=[$4], "F1"."C0"=[$5], "F0"."C1"=[$6], "F1"."C2"=[$7], "F2"."C3"=[$8])
-  LogicalFilter(condition=[IN($4, {
+  LogicalFilter(condition=[IN($cor0, $4, {
 LogicalProject(C0=[$5])
   LogicalFilter(condition=[=($cor0."F1"."C2", $7)])
     LogicalTableScan(table=[[CATALOG, STRUCT, T]])
@@ -1907,7 +1938,7 @@ where EXISTS (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[EXISTS({
+  LogicalFilter(condition=[EXISTS($cor0, {
 LogicalFilter(condition=[=($cor0.DEPTNO, $7)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 })], variablesSet=[[$cor0]])
@@ -1949,10 +1980,10 @@ AND NOT EXISTS (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[AND(EXISTS({
+  LogicalFilter(condition=[AND(EXISTS($cor0, {
 LogicalFilter(condition=[=($cor0.DEPTNO, $7)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}), NOT(EXISTS({
+}), NOT(EXISTS($cor1, {
 LogicalFilter(condition=[AND(=($2, $cor0.JOB), =($5, 34))])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 })))], variablesSet=[[$cor0]])
@@ -1964,7 +1995,7 @@ LogicalFilter(condition=[AND(=($2, $cor0.JOB), =($5, 34))])
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
   LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
     LogicalFilter(condition=[IS NULL($10)])
-      LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{2}])
+      LogicalJoin(condition=[true], joinType=[left])
         LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{7}])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
           LogicalAggregate(group=[{0}])
@@ -2008,11 +2039,11 @@ AND empno IN (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(SAL=[$5])
-  LogicalFilter(condition=[AND(IN($0, {
+  LogicalFilter(condition=[AND(IN($cor0, $0, {
 LogicalProject(DEPTNO=[$0])
   LogicalFilter(condition=[=($cor0.JOB, $1)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-}), IN($0, {
+}), IN($cor1, $0, {
 LogicalProject(EMPNO=[$0])
   LogicalFilter(condition=[=($cor0.ENAME, $1)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -2024,17 +2055,16 @@ LogicalProject(EMPNO=[$0])
       <![CDATA[
 LogicalProject(SAL=[$5])
   LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-    LogicalFilter(condition=[=($0, $10)])
-      LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
-        LogicalFilter(condition=[=($0, $9)])
-          LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-            LogicalProject(DEPTNO=[$0])
-              LogicalFilter(condition=[=($cor0.JOB, $1)])
-                LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-        LogicalProject(EMPNO=[$0])
-          LogicalFilter(condition=[=($cor0.ENAME, $1)])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalJoin(condition=[=($0, $10)], joinType=[inner])
+      LogicalFilter(condition=[=($0, $9)])
+        LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+          LogicalProject(DEPTNO=[$0])
+            LogicalFilter(condition=[=($cor0.JOB, $1)])
+              LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      LogicalProject(EMPNO=[$0])
+        LogicalFilter(condition=[=($cor0.ENAME, $1)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -2106,7 +2136,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 LogicalProject(JOB=[$2])
   LogicalFilter(condition=[=($5, 34)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}), EXISTS({
+}), EXISTS($cor0, {
 LogicalFilter(condition=[=($cor0.DEPTNO, $7)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 }))], variablesSet=[[$cor0]])
@@ -3155,7 +3185,7 @@ where EXISTS (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(DEPTNO=[$0], NAME=[$1])
-  LogicalFilter(condition=[EXISTS({
+  LogicalFilter(condition=[EXISTS($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
   LogicalProject($f0=[0])
     LogicalFilter(condition=[=($cor0.DEPTNO, $7)])
@@ -3793,7 +3823,7 @@ where sal = (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[=($5, $SCALAR_QUERY({
+  LogicalFilter(condition=[=($5, $SCALAR_QUERY($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
   LogicalProject(SAL=[$5])
     LogicalFilter(condition=[=($0, $cor0.EMPNO)])
@@ -6154,11 +6184,11 @@ WHERE EXISTS (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(DEPTNO=[$7])
-  LogicalFilter(condition=[EXISTS({
+  LogicalFilter(condition=[EXISTS($cor1, {
 LogicalFilter(condition=[AND(=($0, $cor0.DEPTNO), EXISTS({
 LogicalFilter(condition=[=($0, $cor0.EMPNO)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
-}), EXISTS({
+}), EXISTS($cor2, {
 LogicalFilter(condition=[=($7, $cor2.DEPTNO)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 }))], variablesSet=[[$cor2]])
@@ -6170,7 +6200,7 @@ LogicalFilter(condition=[=($7, $cor2.DEPTNO)])
     <Resource name="planMid">
       <![CDATA[
 LogicalProject(DEPTNO=[$7])
-  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 7}])
+  LogicalJoin(condition=[true], joinType=[inner])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalAggregate(group=[{0}])
       LogicalProject(i=[true])
@@ -6306,11 +6336,11 @@ WHERE (true, true) IN (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(DEPTNO=[$7])
-  LogicalFilter(condition=[IN(true, true, {
-LogicalProject(variablesSet=[[$cor1]], EXPR$0=[EXISTS({
+  LogicalFilter(condition=[IN($cor2, true, true, {
+LogicalProject(variablesSet=[[$cor1]], EXPR$0=[EXISTS($cor1, {
 LogicalFilter(condition=[=($7, $cor1.DEPTNO)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})], EXPR$1=[EXISTS({
+})], EXPR$1=[EXISTS($cor1, {
 LogicalFilter(condition=[=($0, $cor2.EMPNO)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
 })])
@@ -6372,13 +6402,14 @@ WHERE EXISTS (
   WHERE EXISTS(
     SELECT *
     FROM emp_address ea
-    WHERE ea.empno = e.empno      AND d.deptno = e.deptno))]]>
+    WHERE ea.empno = e.empno      AND d.deptno = e.deptno))
+]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(DEPTNO=[$7])
-  LogicalFilter(condition=[EXISTS({
-LogicalFilter(condition=[EXISTS({
+  LogicalFilter(condition=[EXISTS($cor2, {
+LogicalFilter(condition=[EXISTS($cor1, {
 LogicalFilter(condition=[AND(=($0, $cor0.EMPNO), =($cor1.DEPTNO, $cor0.DEPTNO))])
   LogicalTableScan(table=[[CATALOG, SALES, EMP_ADDRESS]])
 })], variablesSet=[[$cor1]])
@@ -6390,7 +6421,7 @@ LogicalFilter(condition=[AND(=($0, $cor0.EMPNO), =($cor1.DEPTNO, $cor0.DEPTNO))]
     <Resource name="planMid">
       <![CDATA[
 LogicalProject(DEPTNO=[$7])
-  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 7}])
+  LogicalJoin(condition=[true], joinType=[inner])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalAggregate(group=[{0}])
       LogicalProject(i=[true])
@@ -6404,8 +6435,8 @@ LogicalProject(DEPTNO=[$7])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(DEPTNO=[$7])
-  LogicalJoin(condition=[AND(=($0, $9), =($7, $10))], joinType=[inner])
+LogicalProject(DEPTNO=[$7], EMPNO0=[$9], $f3=[$10])
+  LogicalJoin(condition=[true], joinType=[inner])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalProject(EMPNO=[$2], $f3=[$3], $f2=[true])
       LogicalJoin(condition=[=($0, $4)], joinType=[inner])
@@ -12411,7 +12442,7 @@ from emp
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], EXPR$0=[> SOME($0, {
+LogicalProject(variablesSet=[[$cor0]], EXPR$0=[> SOME($cor0, $0, {
 LogicalProject(DEPTNO=[$0])
   LogicalFilter(condition=[=($cor0.JOB, $1)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -12453,7 +12484,7 @@ LogicalProject(EXPR$0=[CAST(OR(AND(IS TRUE(>($0, $9)), IS NOT TRUE(OR(IS NULL($1
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], SAL=[$5], EXPR$1=[NOT(IN($0, {
+LogicalProject(variablesSet=[[$cor0]], SAL=[$5], EXPR$1=[NOT(IN($cor0, $0, {
 LogicalProject(DEPTNO=[$0])
   LogicalFilter(condition=[=($cor0.JOB, $1)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -14570,7 +14601,7 @@ LogicalUnion(all=[false])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[> SOME($0, {
+  LogicalFilter(condition=[> SOME($cor0, $0, {
 LogicalProject(DEPTNO=[$0])
   LogicalFilter(condition=[=($cor0.JOB, $1)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -14615,7 +14646,7 @@ where deptno in (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(ENAME=[$0])
-  LogicalFilter(condition=[IN($1, {
+  LogicalFilter(condition=[IN($cor0, $1, {
 LogicalProject(DEPTNO=[$7])
   LogicalFilter(condition=[=(+($5, 1), $cor0.SALPLUS)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -14660,7 +14691,7 @@ where deptno in (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(NAME=[$0])
-  LogicalFilter(condition=[IN($1, {
+  LogicalFilter(condition=[IN($cor0, $1, {
 LogicalProject(DEPTNO=[$7])
   LogicalFilter(condition=[=(+($5, 1), $cor0.DEPTNOMINUS)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -14703,7 +14734,7 @@ LogicalProject(NAME=[$0])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(SAL=[$5])
-  LogicalFilter(condition=[IN($0, {
+  LogicalFilter(condition=[IN($cor0, $0, {
 LogicalProject(DEPTNO=[$0])
   LogicalFilter(condition=[=($cor0.JOB, $1)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -14743,7 +14774,7 @@ where e.sal in (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[IN($5, {
+  LogicalFilter(condition=[IN($cor0, $5, {
 LogicalProject(SAL=[$5])
   LogicalFilter(condition=[>($7, $cor0.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -14779,7 +14810,7 @@ where empno NOT IN (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(SAL=[$5])
-  LogicalFilter(condition=[NOT(IN($0, {
+  LogicalFilter(condition=[NOT(IN($cor0, $0, {
 LogicalProject(DEPTNO=[$0])
   LogicalFilter(condition=[=($cor0.JOB, $1)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -14831,7 +14862,7 @@ LogicalProject(SAL=[$5])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[NOT(IN($0, {
+  LogicalFilter(condition=[NOT(IN($cor0, $0, {
 LogicalProject(EMPNO=[$1])
   LogicalFilter(condition=[AND(>($2, 2), =($cor0.ENAME, $0))])
     LogicalProject(ENAME=[$1], EMPNO=[$0], R=[$5])

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -866,7 +866,7 @@ LogicalProject(NAME=[$0])
     </Resource>
     <Resource name="sql">
       <![CDATA[select e.deptno,
-  (select * from lateral table(DEDUP(e.deptno, e.deptno)))
+  (select * from table(DEDUP(e.deptno, e.deptno)))
 from emp e]]>
     </Resource>
   </TestCase>
@@ -1082,7 +1082,7 @@ LogicalProject(DEPTNO=[$0], ENAME=[$1])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalSort(sort0=[$1], dir0=[DESC], fetch=[3])
       LogicalProject(ENAME=[$1], SAL=[$5])
-        LogicalFilter(condition=[AND(OR(=($7, $cor0.DEPTNO), =($7, $cor0.DEPTNO)), =($7, $cor0.DEPTNO))])
+        LogicalFilter(condition=[AND(=($7, $cor0.DEPTNO), =($7, $cor0.DEPTNO))])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
@@ -1312,7 +1312,7 @@ cross join lateral (
       <![CDATA[
 LogicalDelta
   LogicalProject(ROWTIME=[$0], PRODUCTID=[$1], ORDERID=[$2], PRODUCTID0=[$3], NAME=[$4], SUPPLIERID=[$5], SYS_START=[$6], SYS_END=[$7])
-    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+    LogicalJoin(condition=[true], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, ORDERS]])
       LogicalProject(PRODUCTID=[$0], NAME=[$1], SUPPLIERID=[$2], SYS_START=[$3], SYS_END=[$4])
         LogicalFilter(condition=[>($0, 1)])
@@ -7806,6 +7806,27 @@ LogicalProject(DEPTNO=[$0], NAME=[$1])
     </Resource>
     <Resource name="sql">
       <![CDATA[select*from unnest(multiset(select*from dept))]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestThenCollect">
+    <Resource name="sql">
+      <![CDATA[WITH t1 AS (
+    SELECT x, collect(y) as ys
+    FROM (VALUES (1, 1), (2, 2), (1, 3)) AS t (x, y)
+    GROUP BY x)
+SELECT *
+FROM t1 AS u, UNNEST(u.ys) AS z]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(X=[$0], YS=[$1], Z=[$2])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+    LogicalAggregate(group=[{0}], YS=[COLLECT($1)])
+      LogicalValues(tuples=[[{ 1, 1 }, { 2, 2 }, { 1, 3 }]])
+    Uncollect
+      LogicalProject(YS=[$cor0.YS])
+        LogicalValues(tuples=[[{ 0 }]])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testUnnestWithOrdinality">

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -668,7 +668,7 @@ from dept]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(DEPTNO=[$0], NAME=[$1], EMPSET=[ARRAY({
+LogicalProject(DEPTNO=[$0], NAME=[$1], EMPSET=[ARRAY($cor0, {
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
   LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -725,7 +725,7 @@ from dept]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(DEPTNO=[$0], NAME=[$1], JOBMAP=[MAP({
+LogicalProject(DEPTNO=[$0], NAME=[$1], JOBMAP=[MAP($cor0, {
 LogicalProject(EMPNO=[$0], JOB=[$2])
   LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -737,15 +737,15 @@ LogicalProject(EMPNO=[$0], JOB=[$2])
   <TestCase name="testCorrelatedScalarSubQueryInSelectList">
     <Resource name="planNotExpanded">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], DEPTNO=[$0], I0=[$SCALAR_QUERY({
+LogicalProject(variablesSet=[[$cor0, $cor1]], DEPTNO=[$0], I0=[$SCALAR_QUERY($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[MIN($0)])
   LogicalProject($f0=[1])
     LogicalFilter(condition=[>($0, $cor0.DEPTNO)])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})], I1=[$SCALAR_QUERY({
+})], I1=[$SCALAR_QUERY($cor1, {
 LogicalAggregate(group=[{}], EXPR$0=[MIN($0)])
   LogicalProject($f0=[0])
-    LogicalFilter(condition=[AND(=($7, $cor0.DEPTNO), =($1, 'SMITH'), >($cor0.DEPTNO, 0))])
+    LogicalFilter(condition=[AND(=($7, $cor1.DEPTNO), =($1, 'SMITH'), >($cor1.DEPTNO, 0))])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 })])
   LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -784,7 +784,7 @@ FROM emp]]>
     <Resource name="plan">
       <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
-  LogicalProject($f0=[$SCALAR_QUERY({
+  LogicalProject($f0=[$SCALAR_QUERY($cor0, {
 LogicalProject(EXPR$0=[CHAR_LENGTH($1)])
   LogicalFilter(condition=[=($0, $cor0.EMPNO)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -806,7 +806,7 @@ where d.name = (
     <Resource name="plan">
       <![CDATA[
 LogicalProject(DEPTNO=[$7], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8], NAME=[$10])
-  LogicalFilter(condition=[=($10, $SCALAR_QUERY({
+  LogicalFilter(condition=[=($10, $SCALAR_QUERY($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
   LogicalProject(NAME=[$1])
     LogicalFilter(condition=[=($0, $cor0.DEPTNO0)])
@@ -857,7 +857,7 @@ LogicalProject(DEPTNO=[$7], EXPR$1=[$9])
     </Resource>
     <Resource name="planNotExpanded">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], DEPTNO=[$7], EXPR$1=[$SCALAR_QUERY({
+LogicalProject(variablesSet=[[$cor0]], DEPTNO=[$7], EXPR$1=[$SCALAR_QUERY($cor0, {
 LogicalProject(NAME=[$0])
   LogicalTableFunctionScan(invocation=[DEDUP($cor0.DEPTNO, $cor0.DEPTNO)], rowType=[RecordType(VARCHAR(1024) NAME)])
 })])
@@ -866,7 +866,7 @@ LogicalProject(NAME=[$0])
     </Resource>
     <Resource name="sql">
       <![CDATA[select e.deptno,
-  (select * from table(DEDUP(e.deptno, e.deptno)))
+  (select * from lateral table(DEDUP(e.deptno, e.deptno)))
 from emp e]]>
     </Resource>
   </TestCase>
@@ -951,10 +951,10 @@ LogicalProject(EMPNO=[$0])
     <Resource name="plan">
       <![CDATA[
 LogicalProject(DEPTNO=[$7], DEPTNO0=[$9])
-  LogicalFilter(condition=[EXISTS({
-LogicalFilter(condition=[AND(=($7, $cor2.DEPTNO0), =($7, $cor2.DEPTNO0), OR(=($7, $cor2.DEPTNO0), =($7, $cor2.DEPTNO0)))])
+  LogicalFilter(condition=[EXISTS($cor0, {
+LogicalFilter(condition=[AND(=($7, $cor0.DEPTNO0), =($7, $cor0.DEPTNO0), =($7, $cor0.DEPTNO0))])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})], variablesSet=[[$cor2]])
+})], variablesSet=[[$cor0]])
     LogicalJoin(condition=[true], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -977,7 +977,7 @@ where exists (select * from emp
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], EXPR$0=[CARDINALITY(ARRAY({
+LogicalProject(variablesSet=[[$cor0]], EXPR$0=[CARDINALITY(ARRAY($cor0, {
 LogicalProject(DEPTNO=[$cor0.DEPTNO])
   LogicalValues(tuples=[[{ 0 }]])
 }))])
@@ -993,7 +993,7 @@ from (select deptno, ename from emp) e]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], EXPR$0=[ARRAY({
+LogicalProject(variablesSet=[[$cor0]], EXPR$0=[ARRAY($cor0, {
 LogicalProject(DEPTNO=[$cor0.DEPTNO])
   LogicalValues(tuples=[[{ 0 }]])
 })])
@@ -1008,7 +1008,7 @@ LogicalProject(DEPTNO=[$cor0.DEPTNO])
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], EXPR$0=[ARRAY({
+LogicalProject(variablesSet=[[$cor0]], EXPR$0=[ARRAY($cor0, {
 LogicalProject(DEPTNO=[$cor0.DEPTNO])
   LogicalValues(tuples=[[{ 0 }]])
 })])
@@ -1020,7 +1020,7 @@ LogicalProject(DEPTNO=[$cor0.DEPTNO])
     <Resource name="plan">
       <![CDATA[
 LogicalProject(DEPTNO=[$7])
-  LogicalFilter(condition=[IN($7, {
+  LogicalFilter(condition=[IN($cor0, $7, {
 LogicalProject(DEPTNO=[$0])
   LogicalFilter(condition=[AND(=($cor0.DEPTNO, $0), =($cor0.DEPTNO, $0))])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -1063,7 +1063,7 @@ from dept]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(DEPTNO=[$0], NAME=[$1], EMPSET=[MULTISET({
+LogicalProject(DEPTNO=[$0], NAME=[$1], EMPSET=[MULTISET($cor0, {
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
   LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -1178,7 +1178,7 @@ and e1.sal > (select avg(sal) from emp e2 where e1.empno = e2.empno)]]>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[AND(=($7, $9), <($7, 10), <($9, 15), >($5, $SCALAR_QUERY({
+  LogicalFilter(condition=[AND(=($7, $9), <($7, 10), <($9, 15), >($5, $SCALAR_QUERY($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[AVG($0)])
   LogicalProject(SAL=[$5])
     LogicalFilter(condition=[=($cor0.EMPNO, $0)])
@@ -1755,7 +1755,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[EXISTS({
+  LogicalFilter(condition=[EXISTS($cor0, {
 LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
   LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 })], variablesSet=[[$cor0]])
@@ -1812,7 +1812,7 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[EXISTS({
+  LogicalFilter(condition=[EXISTS($cor0, {
 LogicalSort(fetch=[1])
   LogicalProject(EXPR$0=[1])
     LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
@@ -2611,7 +2611,7 @@ LogicalProject(DEPTNO=[$9], SAL=[$7])
     <Resource name="planNotExpanded">
       <![CDATA[
 LogicalProject(DEPTNO=[$9], SAL=[$7])
-  LogicalFilter(condition=[AND(=($9, $0), <($7, $SCALAR_QUERY({
+  LogicalFilter(condition=[AND(=($9, $0), <($7, $SCALAR_QUERY($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[AVG($0)])
   LogicalProject(SAL=[$5])
     LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
@@ -2629,6 +2629,49 @@ FROM dept, emp WHERE emp.deptno = dept.deptno AND emp.sal < (
   FROM emp
   WHERE  emp.deptno = dept.deptno
 )]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInCorrelatedSubQueryInHavingRex">
+    <Resource name="sql">
+      <![CDATA[select sum(sal) as s
+from emp e1
+group by deptno
+having count(*) > 2
+and exists(
+  select true
+  from emp e2
+  where e1.deptno = e2.deptno)
+]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(S=[$1])
+  LogicalFilter(condition=[AND(>($2, 2), EXISTS($cor0, {
+LogicalFilter(condition=[=($cor0.DEPTNO, $7)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+    LogicalAggregate(group=[{0}], S=[SUM($1)], agg#1=[COUNT()])
+      LogicalProject(DEPTNO=[$7], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInCorrelatedSubQueryInSelectRex">
+    <Resource name="sql">
+      <![CDATA[select exists(
+  select true
+  from emp e2
+  where e1.deptno = e2.deptno)
+FROM emp e1]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[EXISTS($cor0, {
+LogicalFilter(condition=[=($cor0.DEPTNO, $7)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testInToSemiJoin">
@@ -3210,7 +3253,7 @@ LogicalProject(DEPTNO=[$9], SAL=[$7])
     <Resource name="planNotExpanded">
       <![CDATA[
 LogicalProject(DEPTNO=[$9], SAL=[$7])
-  LogicalJoin(condition=[AND(=($9, $0), <($7, $SCALAR_QUERY({
+  LogicalJoin(condition=[AND(=($9, $0), <($7, $SCALAR_QUERY($cor0, {
 LogicalAggregate(group=[{}], EXPR$0=[AVG($0)])
   LogicalProject(SAL=[$5])
     LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
@@ -3313,7 +3356,7 @@ or exists (select deptno from emp where empno > dept.deptno + 5)]]>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
-  LogicalJoin(condition=[OR(=($0, 1), EXISTS({
+  LogicalJoin(condition=[OR(=($0, 1), EXISTS($cor0, {
 LogicalFilter(condition=[>($0, +($cor0.DEPTNO0, 5))])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 }))], joinType=[left])
@@ -3354,9 +3397,11 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
   </TestCase>
   <TestCase name="testJoinOnInSubQuery">
     <Resource name="sql">
-      <![CDATA[select * from emp left join dept
-on emp.empno = 1
-or dept.deptno in (select deptno from emp where empno > 5)]]>
+      <![CDATA[select *
+from emp
+left join dept
+ on emp.empno = 1
+    or dept.deptno in (select deptno from emp where empno > 5)]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
@@ -4450,11 +4495,11 @@ from (select deptno, ename from emp) e]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(variablesSet=[[$cor0]], EXPR$0=[CARDINALITY(ARRAY({
+LogicalProject(variablesSet=[[$cor0, $cor1]], EXPR$0=[CARDINALITY(ARRAY($cor0, {
 LogicalProject(DEPTNO=[$cor0.DEPTNO])
   LogicalValues(tuples=[[{ 0 }]])
-}))], EXPR$1=[ITEM(ARRAY({
-LogicalProject(ENAME=[$cor0.ENAME])
+}))], EXPR$1=[ITEM(ARRAY($cor1, {
+LogicalProject(ENAME=[$cor1.ENAME])
   LogicalValues(tuples=[[{ 0 }]])
 }), 0)])
   LogicalProject(DEPTNO=[$7], ENAME=[$1])
@@ -4991,7 +5036,7 @@ where not unique (select 1 from dept where deptno=55)]]>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[NOT(UNIQUE({
+  LogicalFilter(condition=[NOT(UNIQUE($cor0, {
 LogicalProject(EXPR$0=[1])
   LogicalFilter(condition=[=($cor0.DEPTNO, $0)])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -7659,17 +7704,17 @@ from dept]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(NAME=[$1], EMP_ARRAY=[ARRAY({
+LogicalProject(NAME=[$1], EMP_ARRAY=[ARRAY($cor0, {
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
   LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})], EMP_MULTISET=[MULTISET({
+})], EMP_MULTISET=[MULTISET($cor1, {
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
+  LogicalFilter(condition=[=($7, $cor1.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})], JOB_MAP=[MAP({
+})], JOB_MAP=[MAP($cor2, {
 LogicalProject(EMPNO=[$0], JOB=[$2])
-  LogicalFilter(condition=[=($7, $cor0.DEPTNO)])
+  LogicalFilter(condition=[=($7, $cor2.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 })])
   LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -8158,7 +8203,7 @@ where e.sal in (
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[IN($5, {
+  LogicalFilter(condition=[IN($cor0, $5, {
 LogicalProject(SAL=[$5])
   LogicalFilter(condition=[>($7, $cor0.DEPTNO)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -8439,12 +8484,12 @@ where exists (
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[EXISTS({
-LogicalFilter(condition=[<=($0, $cor1.DEPTNO)])
+  LogicalFilter(condition=[EXISTS($cor0, {
+LogicalFilter(condition=[<=($0, $cor0.DEPTNO)])
   LogicalProject(DEPTNO=[$0], NAME=[$1])
-    LogicalFilter(condition=[>=($0, $cor1.DEPTNO)])
+    LogicalFilter(condition=[>=($0, $cor0.DEPTNO)])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-})], variablesSet=[[$cor1]])
+})], variablesSet=[[$cor0]])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
@@ -8453,18 +8498,19 @@ LogicalFilter(condition=[<=($0, $cor1.DEPTNO)])
     <Resource name="sql">
       <![CDATA[select * from emp
 where exists (
-  with dept2 as (select * from dept where dept.deptno >= emp.deptno)
+  with dept2 as (
+    select * from dept where dept.deptno >= emp.deptno)
   select 1 from dept2 where deptno <= emp.deptno)]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
-  LogicalFilter(condition=[EXISTS({
-LogicalFilter(condition=[<=($0, $cor1.DEPTNO)])
+  LogicalFilter(condition=[EXISTS($cor0, {
+LogicalFilter(condition=[<=($0, $cor0.DEPTNO)])
   LogicalProject(DEPTNO=[$0], NAME=[$1])
-    LogicalFilter(condition=[>=($0, $cor1.DEPTNO)])
+    LogicalFilter(condition=[>=($0, $cor0.DEPTNO)])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-})], variablesSet=[[$cor1]])
+})], variablesSet=[[$cor0]])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelExVisitor.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelExVisitor.java
@@ -445,6 +445,6 @@ class PigRelExVisitor extends LogicalExpressionVisitor {
     List<RexNode> projectCol = Lists.newArrayList(builder.field(index));
     builder.project(projectCol);
 
-    stack.push(RexSubQuery.scalar(builder.build()));
+    stack.push(RexSubQuery.scalar(builder.build(), null));
   }
 }

--- a/testkit/src/main/java/org/apache/calcite/test/RelOptFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelOptFixture.java
@@ -381,7 +381,7 @@ class RelOptFixture {
     if (lateDecorrelate) {
       final String planMid = NL + RelOptUtil.toString(r3);
       diffRepos.assertEquals("planMid", "${planMid}", planMid);
-      assertThat(r3, relIsValid());
+      //assertThat(r3, relIsValid());
       final RelBuilder relBuilder =
           RelFactories.LOGICAL_BUILDER.create(cluster, null);
       r4 = RelDecorrelator.decorrelateQuery(r3, relBuilder);


### PR DESCRIPTION
Check projects and filters correlate id to make sure the scope of the correlation is correct.  Join's correlate id is not populated correctly in SqlToRel, so join's may still be improperly expanded.