### PR TITLE
[CALCITE-5360] Implement BigQuery TIMESTAMP_ADD

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -465,6 +465,7 @@ data: {
 #     "TIME"
       "TIME_TRUNC"
 #     "TIMESTAMP"
+      "TIMESTAMP_ADD"
       "TIMESTAMP_TRUNC"
       "TIMEZONE_HOUR"
       "TIMEZONE_MINUTE"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4824,7 +4824,7 @@ SqlNode IntervalLiteralOrExpression() :
         |
             e = CompoundIdentifier()
         )
-        intervalQualifier = IntervalQualifierStart() {
+        intervalQualifier = TimeUnitOrName() {
             if (sign == -1) {
                 e = SqlStdOperatorTable.UNARY_MINUS.createCall(e.getParserPosition(), e);
             }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -634,6 +634,13 @@ public abstract class SqlLibraryOperators {
       ImmutableSet.<TimeUnitRange>builder()
           .addAll(MONTH_UNITS).addAll(DATE_UNITS).addAll(TIME_UNITS).build();
 
+  /** The "TIMESTAMP_ADD(timestamp_expression, INTERVAL int64_expression date_part)"
+   * function (BigQuery); Adds int64_expression units of date_part to the timestamp,
+   * independent of any time zone.*/
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction TIMESTAMP_ADD_BIG_QUERY =
+      new SqlTimestampAddBigQueryFunction("TIMESTAMP_ADD");
+
   /** The "TIME_TRUNC(time_expression, time_part)" function (BigQuery);
    * truncates a TIME value to the granularity of time_part. The TIME value is
    * always rounded to the beginning of time_part. */

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddBigQueryFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddBigQueryFunction.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIntervalLiteral;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+import org.apache.calcite.sql.SqlBasicCall;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static org.apache.calcite.util.Util.first;
+
+/**
+ * The <code>TIMESTAMPADD</code> function, which adds an interval to a
+ * datetime (TIMESTAMP, TIME or DATE).
+ *
+ * <p>The SQL syntax is
+ *
+ * <blockquote>
+ * <code>TIMESTAMPADD(<i>timestamp interval</i>, <i>quantity</i>,
+ * <i>datetime</i>)</code>
+ * </blockquote>
+ *
+ * <p>The interval time unit can one of the following literals:<ul>
+ * <li>NANOSECOND (and synonym SQL_TSI_FRAC_SECOND)
+ * <li>MICROSECOND (and synonyms SQL_TSI_MICROSECOND, FRAC_SECOND)
+ * <li>SECOND (and synonym SQL_TSI_SECOND)
+ * <li>MINUTE (and synonym  SQL_TSI_MINUTE)
+ * <li>HOUR (and synonym  SQL_TSI_HOUR)
+ * <li>DAY (and synonym SQL_TSI_DAY)
+ * <li>WEEK (and synonym  SQL_TSI_WEEK)
+ * <li>MONTH (and synonym SQL_TSI_MONTH)
+ * <li>QUARTER (and synonym SQL_TSI_QUARTER)
+ * <li>YEAR (and synonym  SQL_TSI_YEAR)
+ * </ul>
+ *
+ * <p>Returns modified datetime.
+ */
+public class SqlTimestampAddBigQueryFunction extends SqlFunction {
+
+  private static final int MILLISECOND_PRECISION = 3;
+  private static final int MICROSECOND_PRECISION = 6;
+
+  private static final SqlReturnTypeInference RETURN_TYPE_INFERENCE =
+      opBinding -> {
+        SqlCallBinding callBinding = (SqlCallBinding) opBinding;
+        SqlCall call = callBinding.getCall();
+        SqlBasicCall operandCall = call.operand(1);
+
+        SqlIntervalQualifier qualifier = operandCall.operand(1);
+        TimeUnit unit = qualifier.timeUnitRange.startUnit;
+        return deduceType(opBinding.getTypeFactory(), unit, opBinding.getOperandType(1),
+            opBinding.getOperandType(0));
+      };
+
+
+  public static RelDataType deduceType(RelDataTypeFactory typeFactory,
+      @Nullable TimeUnit timeUnit, RelDataType operandType1,
+      RelDataType timestamp) {
+    final RelDataType type;
+    TimeUnit timeUnit2 = first(timeUnit, TimeUnit.EPOCH);
+    switch (timeUnit2) {
+    case HOUR:
+    case MINUTE:
+    case SECOND:
+    case MILLISECOND:
+    case MICROSECOND:
+      switch (timeUnit2) {
+      case MILLISECOND:
+        type = typeFactory.createSqlType(SqlTypeName.TIMESTAMP,
+            MILLISECOND_PRECISION);
+        break;
+      case MICROSECOND:
+        type = typeFactory.createSqlType(SqlTypeName.TIMESTAMP,
+            MICROSECOND_PRECISION);
+        break;
+      default:
+        type = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+      }
+      break;
+    default:
+    case EPOCH:
+      type = timestamp;
+    }
+    return typeFactory.createTypeWithNullability(type,
+        operandType1.isNullable()
+            || timestamp.isNullable());
+  }
+
+  @Override public void validateCall(SqlCall call, SqlValidator validator,
+      SqlValidatorScope scope, SqlValidatorScope operandScope) {
+    super.validateCall(call, validator, scope, operandScope);
+
+    SqlBasicCall opCall = call.operand(1);
+    SqlIntervalQualifier qualifier = opCall.operand(1);
+    validator.validateTimeFrame(qualifier);
+  }
+
+  /** Creates a SqlTimestampAddBigQueryFunction. */
+  SqlTimestampAddBigQueryFunction(String name) {
+    super(name, SqlKind.TIMESTAMP_ADD, RETURN_TYPE_INFERENCE, null,
+        OperandTypes.TIMESTAMP_INTERVAL, SqlFunctionCategory.TIMEDATE);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -264,6 +264,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     final SqlRexConvertlet floorCeilConvertlet = new FloorCeilConvertlet();
     registerOp(SqlStdOperatorTable.FLOOR, floorCeilConvertlet);
     registerOp(SqlStdOperatorTable.CEIL, floorCeilConvertlet);
+    registerOp(SqlStdOperatorTable.TIMESTAMP_ADD,
+        new TimestampAddConvertlet(SqlLibrary.STANDARD));
     registerOp(SqlStdOperatorTable.TIMESTAMP_DIFF,
         new TimestampDiffConvertlet());
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -165,6 +165,9 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     registerOp(SqlLibraryOperators.SUBSTR_POSTGRESQL,
         new SubstrConvertlet(SqlLibrary.POSTGRESQL));
 
+    registerOp(SqlLibraryOperators.TIMESTAMP_ADD_BIG_QUERY,
+        new TimestampAddConvertlet(SqlLibrary.BIG_QUERY));
+
     registerOp(SqlLibraryOperators.NVL, StandardConvertletTable::convertNvl);
     registerOp(SqlLibraryOperators.DECODE,
         StandardConvertletTable::convertDecode);
@@ -261,8 +264,6 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     final SqlRexConvertlet floorCeilConvertlet = new FloorCeilConvertlet();
     registerOp(SqlStdOperatorTable.FLOOR, floorCeilConvertlet);
     registerOp(SqlStdOperatorTable.CEIL, floorCeilConvertlet);
-
-    registerOp(SqlStdOperatorTable.TIMESTAMP_ADD, new TimestampAddConvertlet());
     registerOp(SqlStdOperatorTable.TIMESTAMP_DIFF,
         new TimestampDiffConvertlet());
 
@@ -1824,16 +1825,38 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
 
   /** Convertlet that handles the {@code TIMESTAMPADD} function. */
   private static class TimestampAddConvertlet implements SqlRexConvertlet {
+    private final SqlLibrary library;
+
+    TimestampAddConvertlet(SqlLibrary library) {
+      this.library = library;
+      Preconditions.checkArgument(library == SqlLibrary.STANDARD
+          || library == SqlLibrary.BIG_QUERY);
+    }
+
     @Override public RexNode convertCall(SqlRexContext cx, SqlCall call) {
       // TIMESTAMPADD(unit, count, timestamp)
       //  => timestamp + count * INTERVAL '1' UNIT
       final RexBuilder rexBuilder = cx.getRexBuilder();
-      SqlIntervalQualifier qualifier = call.operand(0);
+      SqlIntervalQualifier qualifier;
+      final SqlBasicCall operandCall;
+      final RexNode op1;
+      final RexNode op2;
+      switch(library) {
+      case BIG_QUERY:
+        operandCall = call.operand(1);
+        qualifier  = operandCall.operand(1);
+        op1 = cx.convertExpression(operandCall.operand(0));
+        op2 = cx.convertExpression(call.operand(0));
+        break;
+      default:
+        qualifier = call.operand(0);
+        op1 = cx.convertExpression(call.operand(1));
+        op2 = cx.convertExpression(call.operand(2));
+      }
+
       final TimeFrame timeFrame = cx.getValidator().validateTimeFrame(qualifier);
       final TimeUnit unit = first(timeFrame.unit(), TimeUnit.EPOCH);
       final RelDataType type = cx.getValidator().getValidatedNodeType(call);
-      final RexNode op1 = cx.convertExpression(call.operand(1));
-      final RexNode op2 = cx.convertExpression(call.operand(2));
       if (unit == TimeUnit.EPOCH && qualifier.timeFrameName != null) {
         // Custom time frames have a different path. They are kept as names,
         // and then handled by Java functions such as

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1013,6 +1013,7 @@ TIES,
 **TIMESTAMP**,
 TIMESTAMPADD,
 TIMESTAMPDIFF,
+TIMESTAMP_ADD,
 TIMESTAMP_TRUNC,
 **TIMEZONE_HOUR**,
 **TIMEZONE_MINUTE**,
@@ -2649,6 +2650,7 @@ semantics.
 | b m o p | SUBSTR(string, position [, substringLength ]) | Returns a portion of *string*, beginning at character *position*, *substringLength* characters long. SUBSTR calculates lengths using characters as defined by the input character set
 | m | STRCMP(string, string)                         | Returns 0 if both of the strings are same and returns -1 when the first argument is smaller than the second and 1 when the second one is smaller than the first one
 | b o | TANH(numeric)                                | Returns the hyperbolic tangent of *numeric*
+| b | TIMESTAMP_ADD(timestamp, interval int64 date_part) | Adds int64_expression units of date_part to the timestamp, independent of any time zone.
 | b | TIMESTAMP_MICROS(integer)                      | Returns the TIMESTAMP that is *integer* microseconds after 1970-01-01 00:00:00
 | b | TIMESTAMP_MILLIS(integer)                      | Returns the TIMESTAMP that is *integer* milliseconds after 1970-01-01 00:00:00
 | b | TIMESTAMP_SECONDS(integer)                     | Returns the TIMESTAMP that is *integer* seconds after 1970-01-01 00:00:00

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -7913,7 +7913,50 @@ public class SqlOperatorTest {
         "2015-01-01 00:00:00", "TIMESTAMP(0) NOT NULL");
   }
 
-  @Test void testDenseRankFunc() {
+  @Test void testBigQueryTimestampAdd() {
+    final SqlOperatorFixture nonBigQuery = fixture()
+        .setFor(SqlLibraryOperators.TIMESTAMP_ADD_BIG_QUERY);
+    nonBigQuery.checkFails("^timestamp_add(timestamp '2008-12-25 15:30:00', "
+            + "interval 5 minute)^",
+        "No match found for function signature "
+            + "TIMESTAMP_ADD\\(<TIMESTAMP>, <INTERVAL_DAY_TIME>\\)", false);
+
+    final SqlOperatorFixture f = fixture()
+        .withLibrary(SqlLibrary.BIG_QUERY)
+        .setFor(SqlLibraryOperators.TIMESTAMP_ADD_BIG_QUERY);
+    f.checkScalar("timestamp_add(timestamp '2008-12-25 15:30:00', "
+            + "interval 5000000000 nanosecond)",
+        "2008-12-25 15:30:05",
+        "TIMESTAMP(0) NOT NULL");
+    f.checkScalar(
+        "timestamp_add(timestamp '2008-12-25 15:30:00', interval 100000000000 microsecond)",
+        "2008-12-26 19:16:40",
+        "TIMESTAMP(3) NOT NULL");
+    f.checkScalar("timestamp_add(timestamp '2008-12-25 15:30:00', interval 100000000 millisecond)",
+        "2008-12-26 19:16:40",
+        "TIMESTAMP(3) NOT NULL");
+    f.checkScalar("timestamp_add(timestamp '2016-02-24 12:42:25', interval 2 second)",
+        "2016-02-24 12:42:27",
+        "TIMESTAMP(0) NOT NULL");
+    f.checkScalar("timestamp_add(timestamp '2016-02-24 12:42:25', interval 2 minute)",
+        "2016-02-24 12:44:25",
+        "TIMESTAMP(0) NOT NULL");
+    f.checkScalar("timestamp_add(timestamp '2016-02-24 12:42:25', interval -2000 hour)",
+        "2015-12-03 04:42:25",
+        "TIMESTAMP(0) NOT NULL");
+    f.checkScalar("timestamp_add(timestamp '2016-02-24 12:42:25', interval 1 day)",
+        "2016-02-25 12:42:25",
+        "TIMESTAMP(0) NOT NULL");
+    f.checkScalar("timestamp_add(timestamp '2016-02-24 12:42:25', interval 1 month)",
+        "2016-03-24 12:42:25",
+        "TIMESTAMP(0) NOT NULL");
+    f.checkScalar("timestamp_add(timestamp '2016-02-24 12:42:25', interval 1 year)",
+        "2017-02-24 12:42:25",
+        "TIMESTAMP(0) NOT NULL");
+    f.checkNull("timestamp_add(CAST(NULL AS TIMESTAMP), interval 5 minute)");
+  }
+
+    @Test void testDenseRankFunc() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.DENSE_RANK, VM_FENNEL, VM_JAVA);
   }


### PR DESCRIPTION
Implement BigQuery's TIMESTAMP_ADD. This implementation is similar to that of the standard timestampadd but accounts for the difference in operand number and type. JIRA issue https://issues.apache.org/jira/browse/CALCITE-5360 includes TIMESTAMP_DIFF as well but this PR is being opened primarily for feedback to avoid potential duplicate mistakes as TIMESTAMP_DIFF should follow a similar implementation.