### PR TITLE
[CALCITE-5428] Drop minimum Guava version to 16.0.1.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TZ: 'America/New_York' # flips between −05:00 and −04:00
-      GUAVA: '19.0' # oldest supported Guava version
+      GUAVA: '16.0.1' # oldest supported Guava version
     steps:
       - uses: actions/checkout@v3
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -74,7 +74,7 @@ errorprone.version=2.5.1
 # The property is used in https://github.com/wildfly/jandex regression testing, so avoid renaming
 jandex.version=2.2.3.Final
 
-# We support Guava versions as old as 19.0 but prefer more recent versions.
+# We support Guava versions as old as 16.0.1 but prefer more recent versions.
 # elasticsearch does not like asm:6.2.1+
 aggdesigner-algorithm.version=6.0
 apiguardian-api.version=1.1.2

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -50,7 +50,7 @@ z.
 
 Compatibility: This release is tested on Linux, macOS, Microsoft Windows;
 using JDK/OpenJDK versions 8 to 18;
-Guava versions 19.0 to 31.1-jre;
+Guava versions 16.0.1 to 31.1-jre;
 other software versions as specified in gradle.properties.
 
 #### New features


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CALCITE-5428.