### PR TITLE
[CALCITE-5433] Druid tests hang/fail intermittently in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -410,13 +410,13 @@ jobs:
 
   linux-druid:
     if: github.event.action != 'labeled'
-    name: 'Linux (JDK 8) Druid Tests'
+    name: 'Druid Tests'
     runs-on: ubuntu-latest
     steps:
-    - name: 'Set up JDK 8'
+    - name: 'Set up JDK 17'
       uses: actions/setup-java@v2
       with:
-        java-version: 8
+        java-version: 17
         distribution: 'zulu'
     - name: 'Checkout Druid dataset'
       uses: actions/checkout@v3


### PR DESCRIPTION
Run Druid tests using JDK 17 to overcome DriverManager deadlock affecting JDK 8.