### PR TITLE
[CALCITE-5452] Add BigQuery LENGTH() as synonym for CHAR_LENGTH()

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -2596,4 +2596,18 @@ FROM items;
 
 !ok
 
+#####################################################################
+# LENGTH(string)
+#
+# Returns the number of characters in the provided string.
+SELECT LENGTH("hello") as length;
++--------+
+| length |
++--------+
+|      5 |
++--------+
+(1 row)
+
+!ok
+
 # End big-query.iq

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -582,6 +582,19 @@ SELECT STRING(TIMESTAMP "2008-12-25 15:30:00+00", "UTC") AS string;
 !ok
 !}
 
+#####################################################################
+# LENGTH(string)
+#
+# Returns the number of characters in the provided string.
+SELECT LENGTH("hello") as length;
++--------+
+| length |
++--------+
+|      5 |
++--------+
+(1 row)
+
+!ok
 
 #####################################################################
 # DATE
@@ -2593,20 +2606,6 @@ FROM items;
 |      |         |
 +------+---------+
 (4 rows)
-
-!ok
-
-#####################################################################
-# LENGTH(string)
-#
-# Returns the number of characters in the provided string.
-SELECT LENGTH("hello") as length;
-+--------+
-| length |
-+--------+
-|      5 |
-+--------+
-(1 row)
 
 !ok
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -188,6 +188,11 @@ public abstract class SqlLibraryOperators {
               .andThen(SqlTypeTransforms.TO_NULLABLE_ALL),
           OperandTypes.SAME_SAME);
 
+  /** THE "LENGTH(string)" function. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction LENGTH =
+      SqlStdOperatorTable.CHAR_LENGTH.withName("LENGTH");
+
   /** The "LTRIM(string)" function. */
   @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
   public static final SqlFunction LTRIM =

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1395,25 +1395,25 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlFunction JSON_ARRAY = new SqlJsonArrayFunction();
 
   @Deprecated // to be removed before 2.0
-  public static final SqlFunction JSON_TYPE = SqlLibraryOperators.JSON_TYPE;
+  public static final SqlFunction JSON_TYPE = new SqlJsonTypeFunction();
 
   @Deprecated // to be removed before 2.0
-  public static final SqlFunction JSON_DEPTH = SqlLibraryOperators.JSON_DEPTH;
+  public static final SqlFunction JSON_DEPTH = new SqlJsonDepthFunction();
 
   @Deprecated // to be removed before 2.0
-  public static final SqlFunction JSON_LENGTH = SqlLibraryOperators.JSON_LENGTH;
+  public static final SqlFunction JSON_LENGTH = new SqlJsonLengthFunction();
 
   @Deprecated // to be removed before 2.0
-  public static final SqlFunction JSON_KEYS = SqlLibraryOperators.JSON_KEYS;
+  public static final SqlFunction JSON_KEYS = new SqlJsonKeysFunction();
 
   @Deprecated // to be removed before 2.0
-  public static final SqlFunction JSON_PRETTY = SqlLibraryOperators.JSON_PRETTY;
+  public static final SqlFunction JSON_PRETTY = new SqlJsonPrettyFunction();
 
   @Deprecated // to be removed before 2.0
-  public static final SqlFunction JSON_REMOVE = SqlLibraryOperators.JSON_REMOVE;
+  public static final SqlFunction JSON_REMOVE = new SqlJsonRemoveFunction();
 
   @Deprecated // to be removed before 2.0
-  public static final SqlFunction JSON_STORAGE_SIZE = SqlLibraryOperators.JSON_STORAGE_SIZE;
+  public static final SqlFunction JSON_STORAGE_SIZE = new SqlJsonStorageSizeFunction();
 
   public static final SqlJsonArrayAggAggFunction JSON_ARRAYAGG =
       new SqlJsonArrayAggAggFunction(SqlKind.JSON_ARRAYAGG,

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -115,6 +115,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
 
     // Register aliases (operators which have a different name but
     // identical behavior to other operators).
+    addAlias(SqlLibraryOperators.LENGTH,
+        SqlStdOperatorTable.CHAR_LENGTH);
     addAlias(SqlStdOperatorTable.CHARACTER_LENGTH,
         SqlStdOperatorTable.CHAR_LENGTH);
     addAlias(SqlStdOperatorTable.IS_UNKNOWN,

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1771,6 +1771,7 @@ period:
 | {fn LENGTH(string)} | Returns the number of characters in a string
 | {fn LOCATE(string1, string2 [, integer])} | Returns the position in *string2* of the first occurrence of *string1*. Searches from the beginning of *string2*, unless *integer* is specified.
 | {fn LEFT(string, length)} | Returns the leftmost *length* characters from *string*
+| {fn LENGTH(string)} | Returns the number of characters in *string*
 | {fn LTRIM(string)} | Returns *string* with leading space characters removed
 | {fn REPLACE(string, search, replacement)} | Returns a string in which all the occurrences of *search* in *string* are replaced with *replacement*; if *replacement* is the empty string, the occurrences of *search* are removed
 | {fn REVERSE(string)} | Returns *string* with the order of the characters reversed
@@ -2634,6 +2635,7 @@ semantics.
 | m | JSON_STORAGE_SIZE(jsonValue)                   | Returns the number of bytes used to store the binary representation of *jsonValue*
 | b o | LEAST(expr [, expr ]* )                      | Returns the least of the expressions
 | b m p | LEFT(string, length)                       | Returns the leftmost *length* characters from the *string*
+| b | LENGTH(string)                                 | Returns the number of characters in the *string*
 | m | TO_BASE64(string)                              | Converts the *string* to base-64 encoded form and returns a encoded string
 | b m | FROM_BASE64(string)                          | Returns the decoded result of a base-64 *string* as a string
 | b o | LTRIM(string)                                | Returns *string* with all blanks removed from the start

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1771,7 +1771,6 @@ period:
 | {fn LENGTH(string)} | Returns the number of characters in a string
 | {fn LOCATE(string1, string2 [, integer])} | Returns the position in *string2* of the first occurrence of *string1*. Searches from the beginning of *string2*, unless *integer* is specified.
 | {fn LEFT(string, length)} | Returns the leftmost *length* characters from *string*
-| {fn LENGTH(string)} | Returns the number of characters in *string*
 | {fn LTRIM(string)} | Returns *string* with leading space characters removed
 | {fn REPLACE(string, search, replacement)} | Returns a string in which all the occurrences of *search* in *string* are replaced with *replacement*; if *replacement* is the empty string, the occurrences of *search* are removed
 | {fn REVERSE(string)} | Returns *string* with the order of the characters reversed
@@ -2352,7 +2351,7 @@ The following functions transform 2D geometries.
 | o | ST_Scale(geom, xFactor, yFactor) | Scales *geom* by multiplying the ordinates by the indicated scale factors
 | o | ST_Translate(geom, x, y) | Translates *geom* by the vector (x, y)
 
-Not implemented:
+Not implemented:CHARACTER_LENGTH
 
 * ST_Scale(geom, xFactor, yFactor [, zFactor ]) Scales *geom* by multiplying the ordinates by the indicated scale factors
 * ST_Translate(geom, x, y, [, z]) Translates *geom*
@@ -2635,7 +2634,7 @@ semantics.
 | m | JSON_STORAGE_SIZE(jsonValue)                   | Returns the number of bytes used to store the binary representation of *jsonValue*
 | b o | LEAST(expr [, expr ]* )                      | Returns the least of the expressions
 | b m p | LEFT(string, length)                       | Returns the leftmost *length* characters from the *string*
-| b | LENGTH(string)                                 | Returns the number of characters in the *string*
+| b | LENGTH(string)                                 | As CHAR_LENGTH(string).
 | m | TO_BASE64(string)                              | Converts the *string* to base-64 encoded form and returns a encoded string
 | b m | FROM_BASE64(string)                          | Returns the decoded result of a base-64 *string* as a string
 | b o | LTRIM(string)                                | Returns *string* with all blanks removed from the start

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -6231,6 +6231,28 @@ public class SqlOperatorTest {
     f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE), consumer);
   }
 
+  @Test void testLengthFunc() {
+    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.LENGTH);
+    f0.checkFails("^length('hello')^",
+        "No match found for function signature LENGTH\\(<CHARACTER>\\)",
+        false);
+
+    final SqlOperatorFixture f = f0.withLibrary(SqlLibrary.BIG_QUERY);
+    f.checkScalar("length('hello')",
+        "5",
+        "INTEGER NOT NULL");
+    f.checkScalar("length('')",
+        "0",
+        "INTEGER NOT NULL");
+    f.checkScalar("length(CAST('x' as CHAR(3)))",
+        "3",
+        "INTEGER NOT NULL");
+    f.checkScalar("length(CAST('x' as VARCHAR(4)))",
+        "1",
+        "INTEGER NOT NULL");
+    f.checkNull("length(CAST(NULL as CHAR(5)))");
+  }
+
   @Test void testLtrimFunc() {
     final SqlOperatorFixture f0 = fixture()
         .setFor(SqlLibraryOperators.LTRIM, VmName.EXPAND);

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -3629,6 +3629,31 @@ public class SqlOperatorTest {
     f.checkNull("CHARACTER_LENGTH(cast(null as varchar(1)))");
   }
 
+  @Test void testLengthFunc() {
+    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.LENGTH);
+    f0.checkFails("^length('hello')^",
+        "No match found for function signature LENGTH\\(<CHARACTER>\\)",
+        false);
+
+    final Consumer<SqlOperatorFixture> consumer = f -> {
+      f.checkScalar("length('hello')",
+          "5",
+          "INTEGER NOT NULL");
+      f.checkScalar("length('')",
+          "0",
+          "INTEGER NOT NULL");
+      f.checkScalar("length(CAST('x' as CHAR(3)))",
+          "3",
+          "INTEGER NOT NULL");
+      f.checkScalar("length(CAST('x' as VARCHAR(4)))",
+          "1",
+          "INTEGER NOT NULL");
+      f.checkNull("length(CAST(NULL as CHAR(5)))");
+    };
+    f0.forEachLibrary(list(SqlLibrary.BIG_QUERY), consumer);
+
+  }
+
   @Test void testOctetLengthFunc() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.OCTET_LENGTH, VmName.EXPAND);
@@ -6229,28 +6254,6 @@ public class SqlOperatorTest {
       f.checkNull("rtrim(CAST(NULL AS VARCHAR(6)))");
     };
     f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE), consumer);
-  }
-
-  @Test void testLengthFunc() {
-    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.LENGTH);
-    f0.checkFails("^length('hello')^",
-        "No match found for function signature LENGTH\\(<CHARACTER>\\)",
-        false);
-
-    final SqlOperatorFixture f = f0.withLibrary(SqlLibrary.BIG_QUERY);
-    f.checkScalar("length('hello')",
-        "5",
-        "INTEGER NOT NULL");
-    f.checkScalar("length('')",
-        "0",
-        "INTEGER NOT NULL");
-    f.checkScalar("length(CAST('x' as CHAR(3)))",
-        "3",
-        "INTEGER NOT NULL");
-    f.checkScalar("length(CAST('x' as VARCHAR(4)))",
-        "1",
-        "INTEGER NOT NULL");
-    f.checkNull("length(CAST(NULL as CHAR(5)))");
   }
 
   @Test void testLtrimFunc() {


### PR DESCRIPTION
Add LENGTH() as a library function as an alias for the standard CHAR_LENGTH(). Some dependencies for soon-to-be deprecated standard functions refactored to avoid null pointer exceptions as a result of circular dependencies between the standard and library operators. This decision was made with the help of @mkou .