### PR TITLE
[CALCITE-5454] Update BigQuery Conformance for != and % operators

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -2596,4 +2596,52 @@ FROM items;
 
 !ok
 
+#####################################################################
+# NOT EQUAL Operator (value1 != value2)
+#
+# Compares value1 and value2 and returns TRUE if not equal.
+SELECT (5 != 3) as result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+SELECT (5 != 5) as result;
++--------+
+| result |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
+#####################################################################
+# MODULO % OPERATOR (value1 % value2)
+#
+# Returns the remainder of dividing value1 by value2.
+SELECT (5 % 3) as result;
++--------+
+| result |
++--------+
+|      2 |
++--------+
+(1 row)
+
+!ok
+
+SELECT (19 % 19) as result;
++--------+
+| result |
++--------+
+|      0 |
++--------+
+(1 row)
+
+!ok
+
 # End big-query.iq

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -565,6 +565,54 @@ FROM t;
 !}
 
 #####################################################################
+# NOT EQUAL Operator (value1 != value2)
+#
+# Compares value1 and value2 and returns TRUE if not equal.
+SELECT (5 != 3) as result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+SELECT (5 != 5) as result;
++--------+
+| result |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
+#####################################################################
+# MODULO % OPERATOR (value1 % value2)
+#
+# Returns the remainder of dividing value1 by value2.
+SELECT (5 % 3) as result;
++--------+
+| result |
++--------+
+|      2 |
++--------+
+(1 row)
+
+!ok
+
+SELECT (19 % 19) as result;
++--------+
+| result |
++--------+
+|      0 |
++--------+
+(1 row)
+
+!ok
+
+#####################################################################
 # STRING
 #
 # STRING(timestamp_expression[, time_zone])
@@ -2593,54 +2641,6 @@ FROM items;
 |      |         |
 +------+---------+
 (4 rows)
-
-!ok
-
-#####################################################################
-# NOT EQUAL Operator (value1 != value2)
-#
-# Compares value1 and value2 and returns TRUE if not equal.
-SELECT (5 != 3) as result;
-+--------+
-| result |
-+--------+
-| true   |
-+--------+
-(1 row)
-
-!ok
-
-SELECT (5 != 5) as result;
-+--------+
-| result |
-+--------+
-| false  |
-+--------+
-(1 row)
-
-!ok
-
-#####################################################################
-# MODULO % OPERATOR (value1 % value2)
-#
-# Returns the remainder of dividing value1 by value2.
-SELECT (5 % 3) as result;
-+--------+
-| result |
-+--------+
-|      2 |
-+--------+
-(1 row)
-
-!ok
-
-SELECT (19 % 19) as result;
-+--------+
-| result |
-+--------+
-|      0 |
-+--------+
-(1 row)
 
 !ok
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -217,6 +217,7 @@ public enum SqlConformanceEnum implements SqlConformance {
     switch (this) {
     case LENIENT:
     case BABEL:
+    case BIG_QUERY:
     case MYSQL_5:
     case ORACLE_10:
     case ORACLE_12:
@@ -243,6 +244,7 @@ public enum SqlConformanceEnum implements SqlConformance {
     switch (this) {
     case BABEL:
     case LENIENT:
+    case BIG_QUERY:
     case MYSQL_5:
     case PRESTO:
       return true;

--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.parser.StringAndPos;
 import org.apache.calcite.sql.test.SqlTester.ResultChecker;
 import org.apache.calcite.sql.test.SqlTester.TypeChecker;
 import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.test.ConnectionFactories;
@@ -570,6 +571,18 @@ public interface SqlOperatorFixture extends AutoCloseable {
         consumer.accept(this.withLibrary(library));
       } catch (Exception e) {
         throw new RuntimeException("for library " + library, e);
+      }
+    });
+  }
+
+  /** Applies this fixture to some code for each of the given conformances. */
+  default void forEachConformance(Iterable<? extends SqlConformanceEnum> conformances,
+      Consumer<SqlOperatorFixture> consumer) {
+    conformances.forEach(conformance -> {
+      try {
+        consumer.accept(this.withConformance(conformance));
+      } catch (Exception e) {
+        throw new RuntimeException("for conformance " + conformance, e);
       }
     });
   }

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -2712,6 +2712,14 @@ public class SqlOperatorTest {
     f1.checkBoolean("1 <> 1", false);
     f1.checkBoolean("1 != 1", false);
     f1.checkBoolean("1 != null", null);
+
+    // "!=" is allowed under BIG_QUERY SQL conformance level
+    final SqlOperatorFixture f2 =
+        f.withConformance(SqlConformanceEnum.BIG_QUERY);
+    f2.checkBoolean("1 <> 1", false);
+    f2.checkBoolean("1 != 1", false);
+    f2.checkBoolean("2 != 1", true);
+    f2.checkBoolean("1 != null", null);
   }
 
   @Test void testNotEqualsOperatorIntervals() {

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -2706,20 +2706,16 @@ public class SqlOperatorTest {
         "Bang equal '!=' is not allowed under the current SQL conformance level",
         false);
 
-    // "!=" is allowed under ORACLE_10 SQL conformance level
-    final SqlOperatorFixture f1 =
-        f.withConformance(SqlConformanceEnum.ORACLE_10);
-    f1.checkBoolean("1 <> 1", false);
-    f1.checkBoolean("1 != 1", false);
-    f1.checkBoolean("1 != null", null);
+    final Consumer<SqlOperatorFixture> consumer = f1 -> {
+      f1.checkBoolean("1 <> 1", false);
+      f1.checkBoolean("1 != 1", false);
+      f1.checkBoolean("2 != 1", true);
+      f1.checkBoolean("1 != null", null);
+    };
 
-    // "!=" is allowed under BIG_QUERY SQL conformance level
-    final SqlOperatorFixture f2 =
-        f.withConformance(SqlConformanceEnum.BIG_QUERY);
-    f2.checkBoolean("1 <> 1", false);
-    f2.checkBoolean("1 != 1", false);
-    f2.checkBoolean("2 != 1", true);
-    f2.checkBoolean("1 != null", null);
+    final List<SqlConformanceEnum> conformances =
+        ImmutableList.of(SqlConformanceEnum.BIG_QUERY, SqlConformanceEnum.ORACLE_10);
+    f.forEachConformance(conformances, consumer);
   }
 
   @Test void testNotEqualsOperatorIntervals() {


### PR DESCRIPTION
Update SqlConformance to include BigQuery as an allowed dialect for != and % Operators. 