### PR TITLE
[CALCITE-5477] Prefer Util.checkArgument over Preconditions.checkArgument

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelFactories.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableRelFactories.java
@@ -25,8 +25,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -72,7 +71,7 @@ public class EnumerableRelFactories {
         List<? extends RexNode> childExprs,
         @Nullable List<? extends @Nullable String> fieldNames,
         Set<CorrelationId> variablesSet) {
-      Preconditions.checkArgument(variablesSet.isEmpty(),
+      Util.checkArgument(variablesSet.isEmpty(),
           "EnumerableProject does not allow variables");
       final RelDataType rowType =
           RexUtil.createStructType(input.getCluster().getTypeFactory(), childExprs,

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -71,7 +71,6 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.trace.CalciteTrace;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -98,7 +97,7 @@ public class JdbcRules {
 
   static final RelFactories.ProjectFactory PROJECT_FACTORY =
       (input, hints, projects, fieldNames, variablesSet) -> {
-        Preconditions.checkArgument(variablesSet.isEmpty(),
+        Util.checkArgument(variablesSet.isEmpty(),
             "JdbcProject does not allow variables");
         final RelOptCluster cluster = input.getCluster();
         final RelDataType rowType =
@@ -110,7 +109,7 @@ public class JdbcRules {
 
   static final RelFactories.FilterFactory FILTER_FACTORY =
       (input, condition, variablesSet) -> {
-        Preconditions.checkArgument(variablesSet.isEmpty(),
+        Util.checkArgument(variablesSet.isEmpty(),
             "JdbcFilter does not allow variables");
         return new JdbcFilter(input.getCluster(),
             input.getTraitSet(), input, condition);

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -75,8 +75,8 @@ import org.apache.calcite.schema.Table;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -219,7 +219,7 @@ public class Bindables {
       super(cluster, traitSet, ImmutableList.of(), table);
       this.filters = Objects.requireNonNull(filters, "filters");
       this.projects = Objects.requireNonNull(projects, "projects");
-      Preconditions.checkArgument(canHandle(table));
+      Util.checkArgument(canHandle(table));
     }
 
     /** Creates a BindableTableScan. */

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteConnectionImpl.java
@@ -69,7 +69,6 @@ import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -148,7 +147,7 @@ abstract class CalciteConnectionImpl
         requireNonNull(rootSchema != null
             ? rootSchema
             : CalciteSchema.createRootSchema(true));
-    Preconditions.checkArgument(this.rootSchema.isRoot(), "must be root schema");
+    Util.checkArgument(this.rootSchema.isRoot(), "must be root schema");
     this.properties.put(InternalProperty.CASE_SENSITIVE, cfg.caseSensitive());
     this.properties.put(InternalProperty.UNQUOTED_CASING, cfg.unquotedCasing());
     this.properties.put(InternalProperty.QUOTED_CASING, cfg.quotedCasing());

--- a/core/src/main/java/org/apache/calcite/jdbc/CalcitePrepare.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalcitePrepare.java
@@ -45,9 +45,9 @@ import org.apache.calcite.sql.validate.CyclicDefinitionException;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.tools.RelRunner;
 import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Util;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -312,7 +312,7 @@ public interface CalcitePrepare {
       this.constraint = constraint;
       this.columnMapping = columnMapping;
       this.modifiable = modifiable;
-      Preconditions.checkArgument(modifiable == (table != null));
+      Util.checkArgument(modifiable == (table != null));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteSchema.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteSchema.java
@@ -34,8 +34,8 @@ import org.apache.calcite.util.NameMap;
 import org.apache.calcite.util.NameMultimap;
 import org.apache.calcite.util.NameSet;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -454,7 +454,7 @@ public abstract class CalciteSchema {
    * @return the schema snapshot.
    */
   public CalciteSchema createSnapshot(SchemaVersion version) {
-    Preconditions.checkArgument(this.isRoot(), "must be root schema");
+    Util.checkArgument(this.isRoot(), "must be root schema");
     return snapshot(null, version);
   }
 

--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -57,7 +57,6 @@ import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
 import org.apache.calcite.util.mapping.IntPair;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -130,7 +129,7 @@ public class Lattice {
       // [CALCITE-429] Add statistics SPI for lattice optimization algorithm
       rowCountEstimate = 1000d;
     }
-    Preconditions.checkArgument(rowCountEstimate > 0d);
+    Util.checkArgument(rowCountEstimate > 0d);
     this.rowCountEstimate = rowCountEstimate;
     @SuppressWarnings("argument.type.incompatible")
     LatticeStatisticProvider statisticProvider =
@@ -798,7 +797,7 @@ public class Lattice {
 
     public Builder(LatticeSpace space, CalciteSchema schema, String sql) {
       this.rootSchema = requireNonNull(schema.root());
-      Preconditions.checkArgument(rootSchema.isRoot(), "must be root schema");
+      Util.checkArgument(rootSchema.isRoot(), "must be root schema");
       CalcitePrepare.ConvertResult parsed =
           Schemas.convert(MaterializedViewTable.MATERIALIZATION_CONNECTION,
               schema, schema.path(null), sql);
@@ -934,7 +933,7 @@ public class Lattice {
                   LatticeStatisticProvider.Factory.class,
                   this.statisticProvider)
               : Lattices.CACHED_SQL;
-      Preconditions.checkArgument(rootSchema.isRoot(), "must be root schema");
+      Util.checkArgument(rootSchema.isRoot(), "must be root schema");
       final ImmutableList.Builder<Column> columnBuilder =
           ImmutableList.<Column>builder()
           .addAll(baseColumns)

--- a/core/src/main/java/org/apache/calcite/materialize/LatticeNode.java
+++ b/core/src/main/java/org/apache/calcite/materialize/LatticeNode.java
@@ -17,9 +17,9 @@
 package org.apache.calcite.materialize;
 
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.IntPair;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.initialization.qual.Initialized;
@@ -51,8 +51,8 @@ public abstract class LatticeNode {
     this.startCol = mutableNode.startCol;
     this.endCol = mutableNode.endCol;
     this.alias = mutableNode.alias;
-    Preconditions.checkArgument(startCol >= 0);
-    Preconditions.checkArgument(endCol > startCol);
+    Util.checkArgument(startCol >= 0);
+    Util.checkArgument(endCol > startCol);
 
     final StringBuilder sb = new StringBuilder()
         .append(space.simpleName(table));

--- a/core/src/main/java/org/apache/calcite/materialize/MaterializationActor.java
+++ b/core/src/main/java/org/apache/calcite/materialize/MaterializationActor.java
@@ -18,8 +18,8 @@ package org.apache.calcite.materialize;
 
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
@@ -78,7 +78,7 @@ class MaterializationActor {
         @Nullable List<String> viewSchemaPath) {
       this.key = key;
       this.rootSchema = Objects.requireNonNull(rootSchema, "rootSchema");
-      Preconditions.checkArgument(rootSchema.isRoot(), "must be root schema");
+      Util.checkArgument(rootSchema.isRoot(), "must be root schema");
       this.materializedTable = materializedTable; // may be null
       this.sql = sql;
       this.rowType = rowType;

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -68,9 +68,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
+import static org.apache.calcite.util.Util.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/org/apache/calcite/plan/hep/HepProgramBuilder.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepProgramBuilder.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.calcite.util.Util.checkArgument;
 
 /**
  * HepProgramBuilder creates instances of {@link HepProgram}.

--- a/core/src/main/java/org/apache/calcite/profile/ProfilerImpl.java
+++ b/core/src/main/java/org/apache/calcite/profile/ProfilerImpl.java
@@ -27,7 +27,6 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.PartiallyOrderedSet;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
@@ -96,8 +95,8 @@ public class ProfilerImpl implements Profiler {
    */
   ProfilerImpl(int combinationsPerPass,
       int interestingCount, Predicate<Pair<Space, Column>> predicate) {
-    Preconditions.checkArgument(combinationsPerPass > 2);
-    Preconditions.checkArgument(interestingCount > 2);
+    Util.checkArgument(combinationsPerPass > 2);
+    Util.checkArgument(interestingCount > 2);
     this.combinationsPerPass = combinationsPerPass;
     this.interestingCount = interestingCount;
     this.predicate = predicate;
@@ -763,8 +762,8 @@ public class ProfilerImpl implements Profiler {
     SurpriseQueue(int warmUpCount, int size) {
       this.warmUpCount = warmUpCount;
       this.size = size;
-      Preconditions.checkArgument(warmUpCount > 3);
-      Preconditions.checkArgument(size > 0);
+      Util.checkArgument(warmUpCount > 3);
+      Util.checkArgument(size > 0);
     }
 
     @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollationImpl.java
@@ -26,7 +26,6 @@ import org.apache.calcite.runtime.Utilities;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mappings;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.UnmodifiableIterator;
 
@@ -55,7 +54,7 @@ public class RelCollationImpl implements RelCollation {
 
   protected RelCollationImpl(ImmutableList<RelFieldCollation> fieldCollations) {
     this.fieldCollations = fieldCollations;
-    Preconditions.checkArgument(
+    Util.checkArgument(
         Util.isDistinct(RelCollations.ordinals(fieldCollations)),
         "fields must be distinct");
   }

--- a/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
@@ -46,7 +46,6 @@ import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.math.IntMath;
 
@@ -102,7 +101,7 @@ public abstract class Aggregate extends SingleRel implements Hintable {
    * before 2.0. */
   @Experimental
   public static void checkIndicator(boolean indicator) {
-    Preconditions.checkArgument(!indicator,
+    Util.checkArgument(!indicator,
         "indicator is no longer supported; use GROUPING function instead");
   }
 
@@ -173,7 +172,7 @@ public abstract class Aggregate extends SingleRel implements Hintable {
     assert groupSet.length() <= input.getRowType().getFieldCount();
     for (AggregateCall aggCall : aggCalls) {
       assert typeMatchesInferred(aggCall, Litmus.THROW);
-      Preconditions.checkArgument(aggCall.filterArg < 0
+      Util.checkArgument(aggCall.filterArg < 0
           || isPredicate(input, aggCall.filterArg),
           "filter must be BOOLEAN NOT NULL");
     }

--- a/core/src/main/java/org/apache/calcite/rel/core/AggregateCall.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/AggregateCall.java
@@ -27,10 +27,10 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Optionality;
+import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.Mappings;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -112,10 +112,10 @@ public class AggregateCall {
     this.distinct = distinct;
     this.approximate = approximate;
     this.ignoreNulls = ignoreNulls;
-    Preconditions.checkArgument(
+    Util.checkArgument(
         aggFunction.getDistinctOptionality() != Optionality.IGNORED || !distinct,
         "DISTINCT has no effect for this aggregate function, so must be false");
-    Preconditions.checkArgument(filterArg < 0 || aggFunction.allowsFilter());
+    Util.checkArgument(filterArg < 0 || aggFunction.allowsFilter());
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/rel/core/Match.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Match.java
@@ -34,8 +34,8 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.fun.SqlSumAggFunction;
 import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -105,7 +105,7 @@ public abstract class Match extends SingleRel {
     super(cluster, traitSet, input);
     this.rowType = Objects.requireNonNull(rowType, "rowType");
     this.pattern = Objects.requireNonNull(pattern, "pattern");
-    Preconditions.checkArgument(patternDefinitions.size() > 0);
+    Util.checkArgument(patternDefinitions.size() > 0);
     this.strictStart = strictStart;
     this.strictEnd = strictEnd;
     this.patternDefinitions = ImmutableMap.copyOf(patternDefinitions);

--- a/core/src/main/java/org/apache/calcite/rel/core/SetOp.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/SetOp.java
@@ -30,7 +30,6 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -57,7 +56,7 @@ public abstract class SetOp extends AbstractRelNode implements Hintable {
   protected SetOp(RelOptCluster cluster, RelTraitSet traits, List<RelHint> hints,
       List<RelNode> inputs, SqlKind kind, boolean all) {
     super(cluster, traits);
-    Preconditions.checkArgument(kind == SqlKind.UNION
+    Util.checkArgument(kind == SqlKind.UNION
         || kind == SqlKind.INTERSECT
         || kind == SqlKind.EXCEPT);
     this.kind = kind;

--- a/core/src/main/java/org/apache/calcite/rel/core/TableModify.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/TableModify.java
@@ -35,8 +35,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeUtil;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -126,15 +125,15 @@ public abstract class TableModify extends SingleRel {
     if (operation == Operation.UPDATE) {
       requireNonNull(updateColumnList, "updateColumnList");
       requireNonNull(sourceExpressionList, "sourceExpressionList");
-      Preconditions.checkArgument(sourceExpressionList.size()
+      Util.checkArgument(sourceExpressionList.size()
           == updateColumnList.size());
     } else {
       if (operation == Operation.MERGE) {
         requireNonNull(updateColumnList, "updateColumnList");
       } else {
-        Preconditions.checkArgument(updateColumnList == null);
+        Util.checkArgument(updateColumnList == null);
       }
-      Preconditions.checkArgument(sourceExpressionList == null);
+      Util.checkArgument(sourceExpressionList == null);
     }
     RelOptSchema relOptSchema = table.getRelOptSchema();
     if (relOptSchema != null) {

--- a/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/ReflectiveRelMetadataProvider.java
@@ -25,7 +25,6 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.ReflectiveVisitor;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -87,7 +86,7 @@ public class ReflectiveRelMetadataProvider
       Class<? extends Metadata> metadataClass0,
       Multimap<Method, MetadataHandler<?>> handlerMap,
       Class<? extends MetadataHandler<?>> handlerClass) {
-    Preconditions.checkArgument(!map.isEmpty(), "ReflectiveRelMetadataProvider "
+    Util.checkArgument(!map.isEmpty(), "ReflectiveRelMetadataProvider "
         + "methods map is empty; are your methods named wrong?");
     this.map = map;
     this.metadataClass0 = metadataClass0;

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdUtil.java
@@ -47,7 +47,6 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.NumberUtil;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -882,8 +881,8 @@ public class RelMdUtil {
    */
   public static double linear(int x, int minX, int maxX, double minY, double
       maxY) {
-    Preconditions.checkArgument(minX < maxX);
-    Preconditions.checkArgument(minY < maxY);
+    Util.checkArgument(minX < maxX);
+    Util.checkArgument(minY < maxY);
     if (x < minX) {
       return minY;
     }

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
@@ -281,7 +281,7 @@ public final class AggregateExpandDistinctAggregatesRule
 
     // In this case, we are assuming that there is a single distinct function.
     // So make sure that argLists is of size one.
-    Preconditions.checkArgument(argLists.size() == 1);
+    Util.checkArgument(argLists.size() == 1);
 
     // For example,
     //    SELECT deptno, COUNT(*), SUM(bonus), MIN(DISTINCT sal)

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcRelSplitter.java
@@ -43,7 +43,6 @@ import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
 
-import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -242,7 +241,7 @@ public abstract class CalcRelSplitter {
       inputExprOrdinals = projectExprOrdinals;
     }
 
-    Preconditions.checkArgument(doneCondition || (conditionRef == null),
+    Util.checkArgument(doneCondition || (conditionRef == null),
         "unhandled condition");
     return rel;
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
@@ -45,7 +45,6 @@ import org.apache.calcite.util.graph.DefaultEdge;
 import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.graph.TopologicalOrderIterator;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.immutables.value.Value;
@@ -253,7 +252,7 @@ public abstract class ProjectToWindowRule
 
           @Override protected RelNode makeRel(RelOptCluster cluster, RelTraitSet traitSet,
               RelBuilder relBuilder, RelNode input, RexProgram program) {
-            Preconditions.checkArgument(program.getCondition() == null,
+            Util.checkArgument(program.getCondition() == null,
                 "WindowedAggregateRel cannot accept a condition");
             return LogicalWindow.create(cluster, traitSet, relBuilder, input,
                 program);

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewAggregateRule.java
@@ -54,11 +54,11 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilder.AggCall;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableList;
@@ -744,7 +744,7 @@ public abstract class MaterializedViewAggregateRule<C extends MaterializedViewAg
       BiMap<RelTableRef, RelTableRef> tableMapping,
       EquivalenceClasses sourceEC,
       List<RexNode> additionalExprs) {
-    Preconditions.checkArgument(additionalExprs.isEmpty());
+    Util.checkArgument(additionalExprs.isEmpty());
     Multimap<Integer, Integer> m = ArrayListMultimap.create();
     Map<RexTableInputRef, Set<RexTableInputRef>> equivalenceClassesMap =
         sourceEC.getEquivalenceClassesMap();

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -50,7 +50,6 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
@@ -346,7 +345,7 @@ public class RexBuilder {
       boolean indicator, List<AggregateCall> aggCalls,
       Map<AggregateCall, RexNode> aggCallMapping,
       final @Nullable List<RelDataType> aggArgTypes) {
-    Preconditions.checkArgument(!indicator,
+    Util.checkArgument(!indicator,
         "indicator is deprecated, use GROUPING function instead");
     return addAggCall(aggCall, groupCount, aggCalls,
         aggCallMapping, aggArgTypes);
@@ -425,7 +424,7 @@ public class RexBuilder {
           makeNullLiteral(type));
     }
     if (!allowPartial) {
-      Preconditions.checkArgument(rows, "DISALLOW PARTIAL over RANGE");
+      Util.checkArgument(rows, "DISALLOW PARTIAL over RANGE");
       final RelDataType bigintType =
           typeFactory.createSqlType(SqlTypeName.BIGINT);
       // todo: read bound

--- a/core/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
@@ -19,8 +19,7 @@ package org.apache.calcite.rex;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlKind;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -72,7 +71,7 @@ public class RexFieldAccess extends RexNode {
   private static void checkValid(RexNode expr, RelDataTypeField field) {
     RelDataType exprType = expr.getType();
     int fieldIdx = field.getIndex();
-    Preconditions.checkArgument(
+    Util.checkArgument(
         fieldIdx >= 0 && fieldIdx < exprType.getFieldList().size()
             && exprType.getFieldList().get(fieldIdx).equals(field),
         "Field " + field + " does not exist for expression " + expr);

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -42,7 +42,6 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
@@ -228,9 +227,9 @@ public class RexLiteral extends RexNode {
     this.value = value;
     this.type = requireNonNull(type, "type");
     this.typeName = requireNonNull(typeName, "typeName");
-    Preconditions.checkArgument(valueMatchesType(value, typeName, true));
-    Preconditions.checkArgument((value == null) == type.isNullable());
-    Preconditions.checkArgument(typeName != SqlTypeName.ANY);
+    Util.checkArgument(valueMatchesType(value, typeName, true));
+    Util.checkArgument((value == null) == type.isNullable());
+    Util.checkArgument(typeName != SqlTypeName.ANY);
     this.digest = computeDigest(RexDigestIncludeType.OPTIONAL);
   }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexOver.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexOver.java
@@ -22,8 +22,6 @@ import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.util.ControlFlowException;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
@@ -70,7 +68,7 @@ public class RexOver extends RexCall {
       boolean distinct,
       boolean ignoreNulls) {
     super(type, op, operands);
-    Preconditions.checkArgument(op.isAggregator());
+    Util.checkArgument(op.isAggregator());
     this.window = Objects.requireNonNull(window, "window");
     this.distinct = distinct;
     this.ignoreNulls = ignoreNulls;

--- a/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
@@ -27,8 +27,8 @@ import org.apache.calcite.sql.fun.SqlQuantifyOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -146,7 +146,7 @@ public class RexSubQuery extends RexCall {
   public static RexSubQuery map(RelNode rel) {
     final RelDataTypeFactory typeFactory = rel.getCluster().getTypeFactory();
     final RelDataType rowType = rel.getRowType();
-    Preconditions.checkArgument(rowType.getFieldCount() == 2,
+    Util.checkArgument(rowType.getFieldCount() == 2,
         "MAP requires exactly two fields, got %s; row type %s",
         rowType.getFieldCount(), rowType);
     final List<RelDataTypeField> fieldList = rowType.getFieldList();

--- a/core/src/main/java/org/apache/calcite/rex/RexWindow.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexWindow.java
@@ -17,8 +17,8 @@
 package org.apache.calcite.rex;
 
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -83,7 +83,7 @@ public class RexWindow {
     this.isRows = isRows;
     this.nodeCount = computeCodeCount();
     this.digest = computeDigest();
-    Preconditions.checkArgument(
+    Util.checkArgument(
         !(lowerBound.isUnbounded() && lowerBound.isPreceding()
             && upperBound.isUnbounded() && upperBound.isFollowing() && isRows),
         "use RANGE for unbounded, not ROWS");

--- a/core/src/main/java/org/apache/calcite/runtime/AutomatonBuilder.java
+++ b/core/src/main/java/org/apache/calcite/runtime/AutomatonBuilder.java
@@ -22,7 +22,6 @@ import org.apache.calcite.runtime.Automaton.SymbolTransition;
 import org.apache.calcite.runtime.Automaton.Transition;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -209,9 +208,9 @@ public class AutomatonBuilder {
     // fromState ---> state0 ---> state1 ---> state2 ---> state3 ---> toState
     //            e        pattern     pattern     pattern        e
     //
-    Preconditions.checkArgument(0 <= minRepeat);
-    Preconditions.checkArgument(minRepeat <= maxRepeat);
-    Preconditions.checkArgument(1 <= maxRepeat);
+    Util.checkArgument(0 <= minRepeat);
+    Util.checkArgument(minRepeat <= maxRepeat);
+    Util.checkArgument(1 <= maxRepeat);
     State prevState = fromState;
     for (int i = 0; i <= maxRepeat; i++) {
       final State s = createState();

--- a/core/src/main/java/org/apache/calcite/runtime/Pattern.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Pattern.java
@@ -16,7 +16,8 @@
  */
 package org.apache.calcite.runtime;
 
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
+
 import com.google.common.collect.ImmutableList;
 
 import java.util.Objects;
@@ -181,8 +182,8 @@ public interface Pattern {
 
     OpPattern(Op op, Pattern... patterns) {
       super(op);
-      Preconditions.checkArgument(patterns.length >= op.minArity);
-      Preconditions.checkArgument(op.maxArity == -1
+      Util.checkArgument(patterns.length >= op.minArity);
+      Util.checkArgument(op.maxArity == -1
           || patterns.length <= op.maxArity);
       this.patterns = ImmutableList.copyOf(patterns);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -38,8 +38,8 @@ import org.apache.calcite.sql.type.AbstractSqlType;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 
@@ -949,7 +949,7 @@ public class SqlDialect {
    * fetch ROWS ONLY" syntax. */
   protected static void unparseFetchUsingAnsi(SqlWriter writer, @Nullable SqlNode offset,
       @Nullable SqlNode fetch) {
-    Preconditions.checkArgument(fetch != null || offset != null);
+    Util.checkArgument(fetch != null || offset != null);
     if (offset != null) {
       writer.newlineAndIndent();
       final SqlWriter.Frame offsetFrame =
@@ -975,7 +975,7 @@ public class SqlDialect {
   /** Unparses offset/fetch using "LIMIT fetch OFFSET offset" syntax. */
   protected static void unparseFetchUsingLimit(SqlWriter writer, @Nullable SqlNode offset,
       @Nullable SqlNode fetch) {
-    Preconditions.checkArgument(fetch != null || offset != null);
+    Util.checkArgument(fetch != null || offset != null);
     unparseLimit(writer, fetch);
     unparseOffset(writer, offset);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlGroupedWindowFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlGroupedWindowFunction.java
@@ -21,8 +21,8 @@ import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -70,7 +70,7 @@ public class SqlGroupedWindowFunction extends SqlFunction {
     super(name, kind, returnTypeInference, operandTypeInference,
         operandTypeChecker, category);
     this.groupFunction = groupFunction;
-    Preconditions.checkArgument(groupFunction == null
+    Util.checkArgument(groupFunction == null
         || groupFunction.groupFunction == null);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlJoin.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJoin.java
@@ -22,8 +22,6 @@ import org.apache.calcite.sql.util.SqlString;
 import org.apache.calcite.util.ImmutableNullableList;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
@@ -75,7 +73,7 @@ public class SqlJoin extends SqlCall {
     this.conditionType = requireNonNull(conditionType, "conditionType");
     this.condition = condition;
 
-    Preconditions.checkArgument(natural.getTypeName() == SqlTypeName.BOOLEAN);
+    Util.checkArgument(natural.getTypeName() == SqlTypeName.BOOLEAN);
     conditionType.getValueAs(JoinConditionType.class);
     joinType.getValueAs(JoinType.class);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlMatchRecognize.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlMatchRecognize.java
@@ -22,8 +22,7 @@ import org.apache.calcite.sql.util.SqlVisitor;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.ImmutableNullableList;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -82,11 +81,11 @@ public class SqlMatchRecognize extends SqlCall {
     this.strictStart = strictStart;
     this.strictEnd = strictEnd;
     this.patternDefList = Objects.requireNonNull(patternDefList, "patternDefList");
-    Preconditions.checkArgument(patternDefList.size() > 0);
+    Util.checkArgument(patternDefList.size() > 0);
     this.measureList = Objects.requireNonNull(measureList, "measureList");
     this.after = after;
     this.subsetList = subsetList;
-    Preconditions.checkArgument(rowsPerMatch == null
+    Util.checkArgument(rowsPerMatch == null
         || rowsPerMatch.value instanceof RowsPerMatchOption);
     this.rowsPerMatch = rowsPerMatch;
     this.partitionList = Objects.requireNonNull(partitionList, "partitionList");
@@ -137,7 +136,7 @@ public class SqlMatchRecognize extends SqlCall {
       break;
     case OPERAND_PATTERN_DEFINES:
       patternDefList = Objects.requireNonNull((SqlNodeList) operand);
-      Preconditions.checkArgument(patternDefList.size() > 0);
+      Util.checkArgument(patternDefList.size() > 0);
       break;
     case OPERAND_MEASURES:
       measureList = Objects.requireNonNull((SqlNodeList) operand);
@@ -150,7 +149,7 @@ public class SqlMatchRecognize extends SqlCall {
       break;
     case OPERAND_ROWS_PER_MATCH:
       rowsPerMatch = (SqlLiteral) operand;
-      Preconditions.checkArgument(rowsPerMatch == null
+      Util.checkArgument(rowsPerMatch == null
           || rowsPerMatch.value instanceof RowsPerMatchOption);
       break;
     case OPERAND_PARTITION_BY:

--- a/core/src/main/java/org/apache/calcite/sql/SqlNullTreatmentOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNullTreatmentOperator.java
@@ -22,8 +22,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.ImmutableNullableList;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -41,7 +40,7 @@ import static org.apache.calcite.util.Static.RESOURCE;
 public class SqlNullTreatmentOperator extends SqlSpecialOperator {
   public SqlNullTreatmentOperator(SqlKind kind) {
     super(kind.sql, kind, 20, true, ReturnTypes.ARG0, null, OperandTypes.ANY);
-    Preconditions.checkArgument(kind == SqlKind.RESPECT_NULLS
+    Util.checkArgument(kind == SqlKind.RESPECT_NULLS
         || kind == SqlKind.IGNORE_NULLS);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlTimeLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTimeLiteral.java
@@ -19,8 +19,7 @@ package org.apache.calcite.sql;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.TimeString;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import java.util.Objects;
 
@@ -36,7 +35,7 @@ public class SqlTimeLiteral extends SqlAbstractDateTimeLiteral {
   SqlTimeLiteral(TimeString t, int precision, boolean hasTimeZone,
       SqlParserPos pos) {
     super(t, hasTimeZone, SqlTypeName.TIME, precision, pos);
-    Preconditions.checkArgument(this.precision >= 0);
+    Util.checkArgument(this.precision >= 0);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/SqlTimestampLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTimestampLiteral.java
@@ -19,8 +19,7 @@ package org.apache.calcite.sql;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.TimestampString;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import java.util.Objects;
 
@@ -36,7 +35,7 @@ public class SqlTimestampLiteral extends SqlAbstractDateTimeLiteral {
   SqlTimestampLiteral(TimestampString ts, int precision,
       boolean hasTimeZone, SqlParserPos pos) {
     super(ts, hasTimeZone, SqlTypeName.TIMESTAMP, precision, pos);
-    Preconditions.checkArgument(this.precision >= 0);
+    Util.checkArgument(this.precision >= 0);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/SqlWindowTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWindowTableFunction.java
@@ -28,8 +28,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlNameMatcher;
 import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -124,7 +124,7 @@ public class SqlWindowTableFunction extends SqlFunction
         int mandatoryParamCount) {
       this.paramNames = ImmutableList.copyOf(paramNames);
       this.mandatoryParamCount = mandatoryParamCount;
-      Preconditions.checkArgument(mandatoryParamCount >= 0
+      Util.checkArgument(mandatoryParamCount >= 0
           && mandatoryParamCount <= paramNames.size());
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateForeignSchema.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateForeignSchema.java
@@ -27,8 +27,8 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -60,7 +60,7 @@ public class SqlCreateForeignSchema extends SqlCreate {
     this.name = Objects.requireNonNull(name, "name");
     this.type = type;
     this.library = library;
-    Preconditions.checkArgument((type == null) != (library == null),
+    Util.checkArgument((type == null) != (library == null),
         "of type and library, exactly one must be specified");
     this.optionList = optionList; // may be null
   }

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateFunction.java
@@ -29,8 +29,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -54,7 +52,7 @@ public class SqlCreateFunction extends SqlCreate {
     this.name = Objects.requireNonNull(name, "name");
     this.className = className;
     this.usingList = Objects.requireNonNull(usingList, "usingList");
-    Preconditions.checkArgument(usingList.size() % 2 == 0);
+    Util.checkArgument(usingList.size() % 2 == 0);
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec,

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
@@ -28,8 +28,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.RelToSqlConverterUtil;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -72,7 +71,7 @@ public class PrestoSqlDialect extends SqlDialect {
   /** Unparses offset/fetch using "OFFSET offset LIMIT fetch " syntax. */
   private static void unparseUsingLimit(SqlWriter writer, @Nullable SqlNode offset,
       @Nullable SqlNode fetch) {
-    Preconditions.checkArgument(fetch != null || offset != null);
+    Util.checkArgument(fetch != null || offset != null);
     unparseOffset(writer, offset);
     unparseLimit(writer, fetch);
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlAnyValueAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlAnyValueAggFunction.java
@@ -23,8 +23,7 @@ import org.apache.calcite.sql.SqlSplittableAggFunction;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.util.Optionality;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -50,7 +49,7 @@ public class SqlAnyValueAggFunction extends SqlAggFunction {
         false,
         false,
         Optionality.FORBIDDEN);
-    Preconditions.checkArgument(kind == SqlKind.ANY_VALUE);
+    Util.checkArgument(kind == SqlKind.ANY_VALUE);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlAvgAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlAvgAggFunction.java
@@ -23,8 +23,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.util.Optionality;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 /**
  * <code>Avg</code> is an aggregator which returns the average of the values
@@ -54,7 +53,7 @@ public class SqlAvgAggFunction extends SqlAggFunction {
         false,
         false,
         Optionality.FORBIDDEN);
-    Preconditions.checkArgument(SqlKind.AVG_AGG_FUNCTIONS.contains(kind),
+    Util.checkArgument(SqlKind.AVG_AGG_FUNCTIONS.contains(kind),
         "unsupported sql kind");
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBitOpAggFunction.java
@@ -23,8 +23,7 @@ import org.apache.calcite.sql.SqlSplittableAggFunction;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.util.Optionality;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -51,7 +50,7 @@ public class SqlBitOpAggFunction extends SqlAggFunction {
         false,
         false,
         Optionality.FORBIDDEN);
-    Preconditions.checkArgument(kind == SqlKind.BIT_AND
+    Util.checkArgument(kind == SqlKind.BIT_AND
         || kind == SqlKind.BIT_OR
         || kind == SqlKind.BIT_XOR);
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCovarAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCovarAggFunction.java
@@ -23,8 +23,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.util.Optionality;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 /**
  * <code>Covar</code> is an aggregator which returns the Covariance of the
@@ -51,7 +50,7 @@ public class SqlCovarAggFunction extends SqlAggFunction {
         false,
         false,
         Optionality.FORBIDDEN);
-    Preconditions.checkArgument(SqlKind.COVAR_AVG_AGG_FUNCTIONS.contains(kind),
+    Util.checkArgument(SqlKind.COVAR_AVG_AGG_FUNCTIONS.contains(kind),
         "unsupported sql kind: " + kind);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlFirstLastValueAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlFirstLastValueAggFunction.java
@@ -25,8 +25,8 @@ import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Optionality;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -51,7 +51,7 @@ public class SqlFirstLastValueAggFunction extends SqlAggFunction {
         false,
         true,
         Optionality.FORBIDDEN);
-    Preconditions.checkArgument(kind == SqlKind.FIRST_VALUE
+    Util.checkArgument(kind == SqlKind.FIRST_VALUE
         || kind == SqlKind.LAST_VALUE);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlFloorFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlFloorFunction.java
@@ -32,8 +32,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 /**
  * Definition of the "FLOOR" and "CEIL" built-in SQL functions.
@@ -50,7 +49,7 @@ public class SqlFloorFunction extends SqlMonotonicUnaryFunction {
                 OperandTypes.DATETIME,
                 OperandTypes.ANY)),
         SqlFunctionCategory.NUMERIC);
-    Preconditions.checkArgument(kind == SqlKind.FLOOR || kind == SqlKind.CEIL);
+    Util.checkArgument(kind == SqlKind.FLOOR || kind == SqlKind.CEIL);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLeadLagAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLeadLagAggFunction.java
@@ -28,8 +28,7 @@ import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeTransform;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.util.Optionality;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 /**
  * <code>LEAD</code> and <code>LAG</code> aggregate functions
@@ -56,7 +55,7 @@ public class SqlLeadLagAggFunction extends SqlAggFunction {
         false,
         true,
         Optionality.FORBIDDEN);
-    Preconditions.checkArgument(kind == SqlKind.LEAD
+    Util.checkArgument(kind == SqlKind.LEAD
         || kind == SqlKind.LAG);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
@@ -17,8 +17,8 @@
 package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -79,7 +79,7 @@ public enum SqlLibrary {
   SqlLibrary(String abbrev, String fun) {
     this.abbrev = Objects.requireNonNull(abbrev, "abbrev");
     this.fun = Objects.requireNonNull(fun, "fun");
-    Preconditions.checkArgument(
+    Util.checkArgument(
         fun.equals(name().toLowerCase(Locale.ROOT).replace("_", "")));
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlMinMaxAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlMinMaxAggFunction.java
@@ -26,8 +26,8 @@ import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.util.Optionality;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -89,7 +89,7 @@ public class SqlMinMaxAggFunction extends SqlAggFunction {
         Optionality.FORBIDDEN);
     this.argTypes = ImmutableList.of();
     this.minMaxKind = MINMAX_COMPARABLE;
-    Preconditions.checkArgument(kind == SqlKind.MIN
+    Util.checkArgument(kind == SqlKind.MIN
         || kind == SqlKind.MAX);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlQuantifyOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlQuantifyOperator.java
@@ -17,8 +17,7 @@
 package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.sql.SqlKind;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import java.util.Objects;
 
@@ -50,13 +49,13 @@ public class SqlQuantifyOperator extends SqlInOperator {
   SqlQuantifyOperator(SqlKind kind, SqlKind comparisonKind) {
     super(comparisonKind.sql + " " + kind, kind);
     this.comparisonKind = Objects.requireNonNull(comparisonKind, "comparisonKind");
-    Preconditions.checkArgument(comparisonKind == SqlKind.EQUALS
+    Util.checkArgument(comparisonKind == SqlKind.EQUALS
         || comparisonKind == SqlKind.NOT_EQUALS
         || comparisonKind == SqlKind.LESS_THAN_OR_EQUAL
         || comparisonKind == SqlKind.LESS_THAN
         || comparisonKind == SqlKind.GREATER_THAN_OR_EQUAL
         || comparisonKind == SqlKind.GREATER_THAN);
-    Preconditions.checkArgument(kind == SqlKind.SOME
+    Util.checkArgument(kind == SqlKind.SOME
         || kind == SqlKind.ALL);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlRegrCountAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlRegrCountAggFunction.java
@@ -18,8 +18,7 @@ package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.OperandTypes;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 /**
  * Definition of the SQL <code>REGR_COUNT</code> aggregation function.
@@ -30,6 +29,6 @@ import com.google.common.base.Preconditions;
 public class SqlRegrCountAggFunction extends SqlCountAggFunction {
   public SqlRegrCountAggFunction(SqlKind kind) {
     super("REGR_COUNT", OperandTypes.NUMERIC_NUMERIC);
-    Preconditions.checkArgument(SqlKind.REGR_COUNT == kind, "unsupported sql kind: " + kind);
+    Util.checkArgument(SqlKind.REGR_COUNT == kind, "unsupported sql kind: " + kind);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -47,7 +47,6 @@ import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.trace.CalciteTrace;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -415,7 +414,7 @@ public final class SqlParserUtil {
   public static long intervalToMillis(
       String literal,
       SqlIntervalQualifier intervalQualifier) {
-    Preconditions.checkArgument(!intervalQualifier.isYearMonth(),
+    Util.checkArgument(!intervalQualifier.isYearMonth(),
         "interval must be day time");
     int[] ret;
     try {
@@ -456,7 +455,7 @@ public final class SqlParserUtil {
   public static long intervalToMonths(
       String literal,
       SqlIntervalQualifier intervalQualifier) {
-    Preconditions.checkArgument(intervalQualifier.isYearMonth(),
+    Util.checkArgument(intervalQualifier.isYearMonth(),
         "interval must be year month");
     int[] ret;
     try {
@@ -795,7 +794,7 @@ public final class SqlParserUtil {
       int end,
       T o) {
     requireNonNull(list, "list");
-    Preconditions.checkArgument(start < end);
+    Util.checkArgument(start < end);
     for (int i = end - 1; i > start; --i) {
       list.remove(i);
     }

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -29,7 +29,6 @@ import org.apache.calcite.sql.util.SqlString;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.trace.CalciteLogger;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -881,7 +880,7 @@ public class SqlPrettyWriter implements SqlWriter {
 
   @Override public void endList(@Nullable Frame frame) {
     FrameImpl endedFrame = (FrameImpl) frame;
-    Preconditions.checkArgument(frame == this.frame,
+    Util.checkArgument(frame == this.frame,
         "Frame does not match current frame");
     if (endedFrame == null) {
       throw new RuntimeException("No list started");

--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -19,8 +19,7 @@ package org.apache.calcite.sql.type;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.util.SerializableCharset;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -140,7 +139,7 @@ public class BasicSqlType extends AbstractSqlType {
    */
   BasicSqlType createWithCharsetAndCollation(Charset charset,
       SqlCollation collation) {
-    Preconditions.checkArgument(SqlTypeUtil.inCharFamily(this));
+    Util.checkArgument(SqlTypeUtil.inCharFamily(this));
     return new BasicSqlType(this.typeSystem, this.typeName, this.isNullable,
         this.precision, this.scale, collation,
         SerializableCharset.forCharset(charset));

--- a/core/src/main/java/org/apache/calcite/sql/type/MatchReturnTypeInference.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/MatchReturnTypeInference.java
@@ -18,8 +18,8 @@ package org.apache.calcite.sql.type;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -53,10 +53,10 @@ public class MatchReturnTypeInference implements SqlReturnTypeInference {
    * position start (zero based).
    */
   public MatchReturnTypeInference(int start, Iterable<SqlTypeName> typeNames) {
-    Preconditions.checkArgument(start >= 0);
+    Util.checkArgument(start >= 0);
     this.start = start;
     this.typeNames = ImmutableList.copyOf(typeNames);
-    Preconditions.checkArgument(!this.typeNames.isEmpty());
+    Util.checkArgument(!this.typeNames.isEmpty());
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -44,9 +44,8 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import static org.apache.calcite.util.Static.RESOURCE;
+import static org.apache.calcite.util.Util.checkArgument;
 
 /**
  * Strategies for checking operand types.

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -34,8 +34,6 @@ import org.apache.calcite.sql.validate.SqlValidatorNamespace;
 import org.apache.calcite.util.Glossary;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
-
 import java.util.AbstractList;
 import java.util.List;
 import java.util.function.UnaryOperator;
@@ -721,7 +719,7 @@ public abstract class ReturnTypes {
             && !containsNullType
             && !(SqlTypeUtil.inCharOrBinaryFamilies(argType0)
             && SqlTypeUtil.inCharOrBinaryFamilies(argType1))) {
-          Preconditions.checkArgument(
+          Util.checkArgument(
               SqlTypeUtil.sameNamedType(argType0, argType1));
         }
         SqlCollation pickedCollation = null;

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlOperandCountRanges.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlOperandCountRanges.java
@@ -17,8 +17,7 @@
 package org.apache.calcite.sql.type;
 
 import org.apache.calcite.sql.SqlOperandCountRange;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 /**
  * Helpers for {@link SqlOperandCountRange}.
@@ -48,8 +47,8 @@ public abstract class SqlOperandCountRanges {
     RangeImpl(int min, int max) {
       this.min = min;
       this.max = max;
-      Preconditions.checkArgument(min <= max || max == -1);
-      Preconditions.checkArgument(min >= 0);
+      Util.checkArgument(min <= max || max == -1);
+      Util.checkArgument(min >= 0);
     }
 
     @Override public boolean isValidCount(int count) {

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlReturnTypeInferenceChain.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlReturnTypeInferenceChain.java
@@ -18,8 +18,8 @@ package org.apache.calcite.sql.type;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -44,7 +44,7 @@ public class SqlReturnTypeInferenceChain implements SqlReturnTypeInference {
    * Use {@link org.apache.calcite.sql.type.ReturnTypes#chain}.</p>
    */
   SqlReturnTypeInferenceChain(SqlReturnTypeInference... rules) {
-    Preconditions.checkArgument(rules.length > 1);
+    Util.checkArgument(rules.length > 1);
     this.rules = ImmutableList.copyOf(rules);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransformCascade.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransformCascade.java
@@ -18,8 +18,8 @@ package org.apache.calcite.sql.type;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -46,7 +46,7 @@ public class SqlTypeTransformCascade implements SqlReturnTypeInference {
   public SqlTypeTransformCascade(
       SqlReturnTypeInference rule,
       SqlTypeTransform... transforms) {
-    Preconditions.checkArgument(transforms.length > 0);
+    Util.checkArgument(transforms.length > 0);
     this.rule = Objects.requireNonNull(rule, "rule");
     this.transforms = ImmutableList.copyOf(transforms);
   }

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -42,7 +42,6 @@ import org.apache.calcite.util.NumberUtil;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
@@ -1174,7 +1173,7 @@ public abstract class SqlTypeUtil {
    * two fields. */
   public static RelDataType createMapTypeFromRecord(
       RelDataTypeFactory typeFactory, RelDataType type) {
-    Preconditions.checkArgument(type.getFieldCount() == 2,
+    Util.checkArgument(type.getFieldCount() == 2,
         "MAP requires exactly two fields, got %s; row type %s",
         type.getFieldCount(), type);
     return createMapType(typeFactory, type.getFieldList().get(0).getType(),
@@ -1282,9 +1281,9 @@ public abstract class SqlTypeUtil {
       RelDataTypeFactory factory,
       RelDataType type1,
       RelDataType type2) {
-    Preconditions.checkArgument(isCollection(type1),
+    Util.checkArgument(isCollection(type1),
         "Input type1 must be collection type");
-    Preconditions.checkArgument(isCollection(type2),
+    Util.checkArgument(isCollection(type2),
         "Input type2 must be collection type");
 
     return (type1 == type2)
@@ -1307,8 +1306,8 @@ public abstract class SqlTypeUtil {
       RelDataTypeFactory factory,
       RelDataType type1,
       RelDataType type2) {
-    Preconditions.checkArgument(isMap(type1), "Input type1 must be map type");
-    Preconditions.checkArgument(isMap(type2), "Input type2 must be map type");
+    Util.checkArgument(isMap(type1), "Input type1 must be map type");
+    Util.checkArgument(isMap(type2), "Input type2 must be map type");
 
     MapSqlType mType1 = (MapSqlType) type1;
     MapSqlType mType2 = (MapSqlType) type2;
@@ -1335,8 +1334,8 @@ public abstract class SqlTypeUtil {
       RelDataType type1,
       RelDataType type2,
       @Nullable SqlNameMatcher nameMatcher) {
-    Preconditions.checkArgument(type1.isStruct(), "Input type1 must be struct type");
-    Preconditions.checkArgument(type2.isStruct(), "Input type2 must be struct type");
+    Util.checkArgument(type1.isStruct(), "Input type1 must be struct type");
+    Util.checkArgument(type2.isStruct(), "Input type2 must be struct type");
 
     if (type1 == type2) {
       return true;

--- a/core/src/main/java/org/apache/calcite/sql/validate/AbstractNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AbstractNamespace.java
@@ -23,7 +23,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -83,10 +82,10 @@ abstract class AbstractNamespace implements SqlValidatorNamespace {
     case UNVALIDATED:
       try {
         status = SqlValidatorImpl.Status.IN_PROGRESS;
-        Preconditions.checkArgument(rowType == null,
+        Util.checkArgument(rowType == null,
             "Namespace.rowType must be null before validate has been called");
         RelDataType type = validateImpl(targetRowType);
-        Preconditions.checkArgument(type != null,
+        Util.checkArgument(type != null,
             "validateImpl() returned null");
         setType(type);
       } finally {

--- a/core/src/main/java/org/apache/calcite/sql/validate/DelegatingScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/DelegatingScope.java
@@ -34,7 +34,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 
@@ -601,7 +600,7 @@ public abstract class DelegatingScope implements SqlValidatorScope {
   }
 
   private AggregatingSelectScope.Resolved resolve() {
-    Preconditions.checkArgument(groupAnalyzer == null,
+    Util.checkArgument(groupAnalyzer == null,
         "resolve already in progress");
     SqlValidatorUtil.GroupAnalyzer groupAnalyzer = new SqlValidatorUtil.GroupAnalyzer();
     this.groupAnalyzer = groupAnalyzer;

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1875,7 +1875,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       return ns.getType();
     }
     type = deriveTypeImpl(scope, expr);
-    Preconditions.checkArgument(
+    Util.checkArgument(
         type != null,
         "SqlValidator.deriveTypeInternal returned null");
     setValidatedNodeType(expr, type);
@@ -2692,7 +2692,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       SqlNode enclosingNode,
       @Nullable String alias,
       boolean forceNullable) {
-    Preconditions.checkArgument(usingScope == null || alias != null);
+    Util.checkArgument(usingScope == null || alias != null);
     registerQuery(
         parentScope,
         usingScope,
@@ -2725,7 +2725,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       boolean checkUpdate) {
     requireNonNull(node, "node");
     requireNonNull(enclosingNode, "enclosingNode");
-    Preconditions.checkArgument(usingScope == null || alias != null);
+    Util.checkArgument(usingScope == null || alias != null);
 
     SqlCall call;
     List<SqlNode> operands;
@@ -3521,7 +3521,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // Validate condition.
     switch (conditionType) {
     case NONE:
-      Preconditions.checkArgument(join.getCondition() == null);
+      Util.checkArgument(join.getCondition() == null);
       break;
     case ON:
       final SqlNode condition = expand(getCondition(join), joinScope);
@@ -3534,7 +3534,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
           (List) getCondition(join);
 
       // Parser ensures that using clause is not empty.
-      Preconditions.checkArgument(!list.isEmpty(), "Empty USING clause");
+      Util.checkArgument(!list.isEmpty(), "Empty USING clause");
       for (SqlIdentifier id : list) {
         validateCommonJoinColumn(id, left, right, scope, natural);
       }
@@ -3638,7 +3638,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   }
 
   private RelDataType checkAndDeriveDataType(SqlIdentifier id, SqlNode node) {
-    Preconditions.checkArgument(id.names.size() == 1);
+    Util.checkArgument(id.names.size() == 1);
     String name = id.names.get(0);
     SqlNameMatcher nameMatcher = getCatalogReader().nameMatcher();
     RelDataType rowType = getNamespaceOrThrow(node).getRowType();
@@ -3652,7 +3652,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
    * NATURAL join, in the left or right input to the join. */
   private RelDataType validateCommonInputJoinColumn(SqlIdentifier id,
       SqlNode leftOrRight, SqlValidatorScope scope, boolean natural) {
-    Preconditions.checkArgument(id.names.size() == 1);
+    Util.checkArgument(id.names.size() == 1);
     final String name = id.names.get(0);
     final SqlValidatorNamespace namespace = getNamespaceOrThrow(leftOrRight);
     final RelDataType rowType = namespace.getRowType();
@@ -6411,7 +6411,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     }
 
     @Override public Void visit(SqlIdentifier id) {
-      Preconditions.checkArgument(id.isSimple());
+      Util.checkArgument(id.isSimple());
       scope.addPatternVar(id.getSimple());
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -60,7 +60,6 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -323,7 +322,7 @@ public class SqlValidatorUtil {
    * "expr$<i>ordinal</i>"; never null
    */
   public static String alias(SqlNode node, int ordinal) {
-    Preconditions.checkArgument(ordinal >= 0);
+    Util.checkArgument(ordinal >= 0);
     return requireNonNull(alias_(node, ordinal), "alias");
   }
 
@@ -1445,11 +1444,11 @@ public class SqlValidatorUtil {
         @Nullable SqlCall distinctCall, @Nullable SqlCall orderCall) {
       this.aggregateCall =
           Objects.requireNonNull(aggregateCall, "aggregateCall");
-      Preconditions.checkArgument(filterCall == null
+      Util.checkArgument(filterCall == null
           || filterCall.getKind() == SqlKind.FILTER);
-      Preconditions.checkArgument(distinctCall == null
+      Util.checkArgument(distinctCall == null
           || distinctCall.getKind() == SqlKind.WITHIN_DISTINCT);
-      Preconditions.checkArgument(orderCall == null
+      Util.checkArgument(orderCall == null
           || orderCall.getKind() == SqlKind.WITHIN_GROUP);
       this.filterCall = filterCall;
       this.filter = filterCall == null ? null : filterCall.operand(1);

--- a/core/src/main/java/org/apache/calcite/sql2rel/ReflectiveConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/ReflectiveConvertletTable.java
@@ -21,8 +21,7 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -206,7 +205,7 @@ public class ReflectiveConvertletTable implements SqlRexConvertletTable {
       final SqlOperator alias, final SqlOperator target) {
     map.put(
         alias, (SqlRexConvertlet) (cx, call) -> {
-          Preconditions.checkArgument(call.getOperator() == alias,
+          Util.checkArgument(call.getOperator() == alias,
               "call to wrong operator");
           final SqlCall newCall =
               target.createCall(SqlParserPos.ZERO, call.getOperandList());

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlNodeToRexConverterImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlNodeToRexConverterImpl.java
@@ -33,8 +33,6 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
-
 import java.math.BigDecimal;
 
 /**
@@ -99,7 +97,7 @@ public class SqlNodeToRexConverterImpl implements SqlNodeToRexConverter {
       return rexBuilder.makeLiteral(literal.getValueAs(Boolean.class));
     case BINARY:
       final BitString bitString = literal.getValueAs(BitString.class);
-      Preconditions.checkArgument((bitString.getBitCount() % 8) == 0,
+      Util.checkArgument((bitString.getBitCount() % 8) == 0,
           "incomplete octet");
 
       // An even number of hexits (e.g. X'ABCD') makes whole number

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -211,10 +211,9 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
 import static org.apache.calcite.sql.SqlUtil.stripAs;
+import static org.apache.calcite.util.Util.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -82,7 +82,6 @@ import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
@@ -1701,7 +1700,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
 
     SubstrConvertlet(SqlLibrary library) {
       this.library = library;
-      Preconditions.checkArgument(library == SqlLibrary.ORACLE
+      Util.checkArgument(library == SqlLibrary.ORACLE
           || library == SqlLibrary.MYSQL
           || library == SqlLibrary.BIG_QUERY
           || library == SqlLibrary.POSTGRESQL);

--- a/core/src/main/java/org/apache/calcite/tools/Hoist.java
+++ b/core/src/main/java/org/apache/calcite/tools/Hoist.java
@@ -24,8 +24,8 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -152,10 +152,10 @@ public class Hoist {
       end = SqlParserUtil.lineColToIndex(originalSql,
           pos.getEndLineNum(), pos.getEndColumnNum()) + 1;
 
-      Preconditions.checkArgument(ordinal >= 0);
-      Preconditions.checkArgument(start >= 0);
-      Preconditions.checkArgument(start <= end);
-      Preconditions.checkArgument(end <= originalSql.length());
+      Util.checkArgument(ordinal >= 0);
+      Util.checkArgument(start >= 0);
+      Util.checkArgument(start <= end);
+      Util.checkArgument(end <= originalSql.length());
     }
 
     /** Returns SQL text of the region of the statement covered by this

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -112,7 +112,6 @@ import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mapping;
 import org.apache.calcite.util.mapping.Mappings;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -2195,7 +2194,7 @@ public class RelBuilder {
    */
   public RelBuilder rename(List<? extends @Nullable String> fieldNames) {
     final List<String> oldFieldNames = peek().getRowType().getFieldNames();
-    Preconditions.checkArgument(fieldNames.size() <= oldFieldNames.size(),
+    Util.checkArgument(fieldNames.size() <= oldFieldNames.size(),
         "More names than fields");
     final List<String> newFieldNames = new ArrayList<>(oldFieldNames);
     for (int i = 0; i < fieldNames.size(); i++) {

--- a/core/src/main/java/org/apache/calcite/util/DateString.java
+++ b/core/src/main/java/org/apache/calcite/util/DateString.java
@@ -18,8 +18,6 @@ package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Calendar;
@@ -45,13 +43,13 @@ public class DateString implements Comparable<DateString> {
   @SuppressWarnings("method.invocation.invalid")
   public DateString(String v) {
     this(v, false);
-    Preconditions.checkArgument(PATTERN.matcher(v).matches(),
+    Util.checkArgument(PATTERN.matcher(v).matches(),
         "Invalid date format:", v);
-    Preconditions.checkArgument(getYear() >= 1 && getYear() <= 9999,
-        "Year out of range:", getYear());
-    Preconditions.checkArgument(getMonth() >= 1 && getMonth() <= 12,
-        "Month out of range:", getMonth());
-    Preconditions.checkArgument(getDay() >= 1 && getDay() <= 31,
+    Util.checkArgument(getYear() >= 1 && getYear() <= 9999,
+        "Year out of range:", Integer.valueOf(getYear()));
+    Util.checkArgument(getMonth() >= 1 && getMonth() <= 12,
+        "Month out of range:", Integer.valueOf(getMonth()));
+    Util.checkArgument(getDay() >= 1 && getDay() <= 31,
         "Day out of range:", getDay());
   }
 
@@ -62,11 +60,11 @@ public class DateString implements Comparable<DateString> {
 
   /** Validates a year-month-date and converts to a string. */
   private static String ymd(int year, int month, int day) {
-    Preconditions.checkArgument(year >= 1 && year <= 9999,
+    Util.checkArgument(year >= 1 && year <= 9999,
         "Year out of range:", year);
-    Preconditions.checkArgument(month >= 1 && month <= 12,
+    Util.checkArgument(month >= 1 && month <= 12,
         "Month out of range:", month);
-    Preconditions.checkArgument(day >= 1 && day <= 31,
+    Util.checkArgument(day >= 1 && day <= 31,
         "Day out of range:", day);
     final StringBuilder b = new StringBuilder();
     DateTimeStringUtils.ymd(b, year, month, day);

--- a/core/src/main/java/org/apache/calcite/util/JdbcTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/util/JdbcTypeImpl.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.util;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.math.BigDecimal;
@@ -52,7 +50,7 @@ enum JdbcTypeImpl implements JdbcType {
     @Override public Boolean get(int column,
         ResultSet resultSet) throws SQLException {
       boolean v = resultSet.getBoolean(column);
-      Preconditions.checkArgument(v || !resultSet.wasNull());
+      Util.checkArgument(v || !resultSet.wasNull());
       return v;
     }
   },
@@ -69,7 +67,7 @@ enum JdbcTypeImpl implements JdbcType {
     @Override public Double get(int column,
         ResultSet resultSet) throws SQLException {
       double v = resultSet.getDouble(column);
-      Preconditions.checkArgument(v != 0 || !resultSet.wasNull());
+      Util.checkArgument(v != 0 || !resultSet.wasNull());
       return v;
     }
   },
@@ -86,7 +84,7 @@ enum JdbcTypeImpl implements JdbcType {
     @Override public Integer get(int column,
         ResultSet resultSet) throws SQLException {
       int v = resultSet.getInt(column);
-      Preconditions.checkArgument(v != 0 || !resultSet.wasNull());
+      Util.checkArgument(v != 0 || !resultSet.wasNull());
       return v;
     }
   },

--- a/core/src/main/java/org/apache/calcite/util/TimeString.java
+++ b/core/src/main/java/org/apache/calcite/util/TimeString.java
@@ -18,7 +18,6 @@ package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -49,13 +48,13 @@ public class TimeString implements Comparable<TimeString> {
   @SuppressWarnings("method.invocation.invalid")
   public TimeString(String v) {
     this(v, false);
-    Preconditions.checkArgument(PATTERN.matcher(v).matches(),
+    Util.checkArgument(PATTERN.matcher(v).matches(),
         "Invalid time format:", v);
-    Preconditions.checkArgument(getHour() >= 0 && getHour() < 24,
+    Util.checkArgument(getHour() >= 0 && getHour() < 24,
         "Hour out of range:", getHour());
-    Preconditions.checkArgument(getMinute() >= 0 && getMinute() < 60,
+    Util.checkArgument(getMinute() >= 0 && getMinute() < 60,
         "Minute out of range:", getMinute());
-    Preconditions.checkArgument(getSecond() >= 0 && getSecond() < 60,
+    Util.checkArgument(getSecond() >= 0 && getSecond() < 60,
         "Second out of range:", getSecond());
   }
 
@@ -66,9 +65,9 @@ public class TimeString implements Comparable<TimeString> {
 
   /** Validates an hour-minute-second value and converts to a string. */
   private static String hms(int h, int m, int s) {
-    Preconditions.checkArgument(h >= 0 && h < 24, "Hour out of range:", h);
-    Preconditions.checkArgument(m >= 0 && m < 60, "Minute out of range:", m);
-    Preconditions.checkArgument(s >= 0 && s < 60, "Second out of range:", s);
+    Util.checkArgument(h >= 0 && h < 24, "Hour out of range:", h);
+    Util.checkArgument(m >= 0 && m < 60, "Minute out of range:", m);
+    Util.checkArgument(s >= 0 && s < 60, "Second out of range:", s);
     final StringBuilder b = new StringBuilder();
     DateTimeStringUtils.hms(b, h, m, s);
     return b.toString();
@@ -81,7 +80,7 @@ public class TimeString implements Comparable<TimeString> {
    * {@code new TimeString(1970, 1, 1, 2, 3, 4).withMillis(56)}
    * yields {@code TIME '1970-01-01 02:03:04.056'}. */
   public TimeString withMillis(int millis) {
-    Preconditions.checkArgument(millis >= 0 && millis < 1000);
+    Util.checkArgument(millis >= 0 && millis < 1000);
     return withFraction(DateTimeStringUtils.pad(3, millis));
   }
 
@@ -92,7 +91,7 @@ public class TimeString implements Comparable<TimeString> {
    * {@code new TimeString(1970, 1, 1, 2, 3, 4).withNanos(56789)}
    * yields {@code TIME '1970-01-01 02:03:04.000056789'}. */
   public TimeString withNanos(int nanos) {
-    Preconditions.checkArgument(nanos >= 0 && nanos < 1000000000);
+    Util.checkArgument(nanos >= 0 && nanos < 1000000000);
     return withFraction(DateTimeStringUtils.pad(9, nanos));
   }
 
@@ -152,7 +151,7 @@ public class TimeString implements Comparable<TimeString> {
   }
 
   public TimeString round(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     int targetLength = 9 + precision;
     if (v.length() <= targetLength) {
       return this;
@@ -208,7 +207,7 @@ public class TimeString implements Comparable<TimeString> {
   /** Converts this TimestampString to a string, truncated or padded with
    * zeros to a given precision. */
   public String toString(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     final int p = precision();
     if (precision < p) {
       return round(precision).toString(precision);

--- a/core/src/main/java/org/apache/calcite/util/TimeWithTimeZoneString.java
+++ b/core/src/main/java/org/apache/calcite/util/TimeWithTimeZoneString.java
@@ -18,8 +18,6 @@ package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.text.SimpleDateFormat;
@@ -52,7 +50,7 @@ public class TimeWithTimeZoneString implements Comparable<TimeWithTimeZoneString
   public TimeWithTimeZoneString(String v) {
     this.localTime = new TimeString(v.substring(0, 8));
     String timeZoneString = v.substring(9);
-    Preconditions.checkArgument(DateTimeStringUtils.isValidTimeZone(timeZoneString));
+    Util.checkArgument(DateTimeStringUtils.isValidTimeZone(timeZoneString));
     this.timeZone = TimeZone.getTimeZone(timeZoneString);
     this.v = v;
   }
@@ -70,7 +68,7 @@ public class TimeWithTimeZoneString implements Comparable<TimeWithTimeZoneString
    * {@code new TimeWithTimeZoneString(1970, 1, 1, 2, 3, 4, "UTC").withMillis(56)}
    * yields {@code TIME WITH LOCAL TIME ZONE '1970-01-01 02:03:04.056 UTC'}. */
   public TimeWithTimeZoneString withMillis(int millis) {
-    Preconditions.checkArgument(millis >= 0 && millis < 1000);
+    Util.checkArgument(millis >= 0 && millis < 1000);
     return withFraction(DateTimeStringUtils.pad(3, millis));
   }
 
@@ -81,7 +79,7 @@ public class TimeWithTimeZoneString implements Comparable<TimeWithTimeZoneString
    * {@code new TimeWithTimeZoneString(1970, 1, 1, 2, 3, 4, "UTC").withNanos(56789)}
    * yields {@code TIME WITH LOCAL TIME ZONE '1970-01-01 02:03:04.000056789 UTC'}. */
   public TimeWithTimeZoneString withNanos(int nanos) {
-    Preconditions.checkArgument(nanos >= 0 && nanos < 1000000000);
+    Util.checkArgument(nanos >= 0 && nanos < 1000000000);
     return withFraction(DateTimeStringUtils.pad(9, nanos));
   }
 
@@ -165,7 +163,7 @@ public class TimeWithTimeZoneString implements Comparable<TimeWithTimeZoneString
   }
 
   public TimeWithTimeZoneString round(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     return new TimeWithTimeZoneString(
         localTime.round(precision), timeZone);
   }
@@ -179,7 +177,7 @@ public class TimeWithTimeZoneString implements Comparable<TimeWithTimeZoneString
   /** Converts this TimeWithTimeZoneString to a string, truncated or padded with
    * zeros to a given precision. */
   public String toString(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     return localTime.toString(precision) + " " + timeZone.getID();
   }
 

--- a/core/src/main/java/org/apache/calcite/util/TimestampString.java
+++ b/core/src/main/java/org/apache/calcite/util/TimestampString.java
@@ -18,7 +18,6 @@ package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -49,7 +48,7 @@ public class TimestampString implements Comparable<TimestampString> {
   /** Creates a TimeString. */
   public TimestampString(String v) {
     this.v = v;
-    Preconditions.checkArgument(PATTERN.matcher(v).matches(), v);
+    Util.checkArgument(PATTERN.matcher(v).matches(), v);
   }
 
   /** Creates a TimestampString for year, month, day, hour, minute, second,
@@ -65,7 +64,7 @@ public class TimestampString implements Comparable<TimestampString> {
    * {@code new TimestampString(1970, 1, 1, 2, 3, 4).withMillis(56)}
    * yields {@code TIMESTAMP '1970-01-01 02:03:04.056'}. */
   public TimestampString withMillis(int millis) {
-    Preconditions.checkArgument(millis >= 0 && millis < 1000);
+    Util.checkArgument(millis >= 0 && millis < 1000);
     return withFraction(DateTimeStringUtils.pad(3, millis));
   }
 
@@ -76,7 +75,7 @@ public class TimestampString implements Comparable<TimestampString> {
    * {@code new TimestampString(1970, 1, 1, 2, 3, 4).withNanos(56789)}
    * yields {@code TIMESTAMP '1970-01-01 02:03:04.000056789'}. */
   public TimestampString withNanos(int nanos) {
-    Preconditions.checkArgument(nanos >= 0 && nanos < 1000000000);
+    Util.checkArgument(nanos >= 0 && nanos < 1000000000);
     return withFraction(DateTimeStringUtils.pad(9, nanos));
   }
 
@@ -134,7 +133,7 @@ public class TimestampString implements Comparable<TimestampString> {
   }
 
   public TimestampString round(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     int targetLength = 20 + precision;
     if (v.length() <= targetLength) {
       return this;
@@ -191,7 +190,7 @@ public class TimestampString implements Comparable<TimestampString> {
   /** Converts this TimestampString to a string, truncated or padded with
    * zeros to a given precision. */
   public String toString(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     final int p = precision();
     if (precision < p) {
       return round(precision).toString(precision);

--- a/core/src/main/java/org/apache/calcite/util/TimestampWithTimeZoneString.java
+++ b/core/src/main/java/org/apache/calcite/util/TimestampWithTimeZoneString.java
@@ -18,8 +18,6 @@ package org.apache.calcite.util;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.text.SimpleDateFormat;
@@ -53,7 +51,7 @@ public class TimestampWithTimeZoneString
   public TimestampWithTimeZoneString(String v) {
     this.localDateTime = new TimestampString(v.substring(0, v.indexOf(' ', 11)));
     String timeZoneString = v.substring(v.indexOf(' ', 11) + 1);
-    Preconditions.checkArgument(DateTimeStringUtils.isValidTimeZone(timeZoneString));
+    Util.checkArgument(DateTimeStringUtils.isValidTimeZone(timeZoneString));
     this.timeZone = TimeZone.getTimeZone(timeZoneString);
     this.v = v;
   }
@@ -73,7 +71,7 @@ public class TimestampWithTimeZoneString
    * {@code new TimestampWithTimeZoneString(1970, 1, 1, 2, 3, 4, "GMT").withMillis(56)}
    * yields {@code TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 02:03:04.056 GMT'}. */
   public TimestampWithTimeZoneString withMillis(int millis) {
-    Preconditions.checkArgument(millis >= 0 && millis < 1000);
+    Util.checkArgument(millis >= 0 && millis < 1000);
     return withFraction(DateTimeStringUtils.pad(3, millis));
   }
 
@@ -84,7 +82,7 @@ public class TimestampWithTimeZoneString
    * {@code new TimestampWithTimeZoneString(1970, 1, 1, 2, 3, 4, "GMT").withNanos(56789)}
    * yields {@code TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 02:03:04.000056789 GMT'}. */
   public TimestampWithTimeZoneString withNanos(int nanos) {
-    Preconditions.checkArgument(nanos >= 0 && nanos < 1000000000);
+    Util.checkArgument(nanos >= 0 && nanos < 1000000000);
     return withFraction(DateTimeStringUtils.pad(9, nanos));
   }
 
@@ -161,7 +159,7 @@ public class TimestampWithTimeZoneString
   }
 
   public TimestampWithTimeZoneString round(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     return new TimestampWithTimeZoneString(
         localDateTime.round(precision), timeZone);
   }
@@ -177,7 +175,7 @@ public class TimestampWithTimeZoneString
   /** Converts this TimestampWithTimeZoneString to a string, truncated or padded with
    * zeros to a given precision. */
   public String toString(int precision) {
-    Preconditions.checkArgument(precision >= 0);
+    Util.checkArgument(precision >= 0);
     return localDateTime.toString(precision) + " " + timeZone.getID();
   }
 

--- a/core/src/main/java/org/apache/calcite/util/Unsafe.java
+++ b/core/src/main/java/org/apache/calcite/util/Unsafe.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.util;
 
+import com.google.common.base.Preconditions;
+
 import java.io.StringWriter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -86,5 +88,28 @@ public class Unsafe {
     matcher.appendTail(sb);
 
     return sb.toString();
+  }
+
+  /** Equivalent to {@link Preconditions#checkArgument(boolean)}.
+   * Unlike {@link #checkArgument(boolean, String, Object...)}, this one is not required
+   * for compatibility with Guava prior to 20.0. However, it's nice to make all checkArgument
+   * calls in a consistent way. */
+  public static void checkArgument(boolean test) {
+    Preconditions.checkArgument(test);
+  }
+
+  /** Equivalent to {@link Preconditions#checkArgument(boolean, Object)}.
+   * Unlike {@link #checkArgument(boolean, String, Object...)}, this one is not required
+   * for compatibility with Guava prior to 20.0. However, it's nice to make all checkArgument
+   * calls in a consistent way. */
+  public static void checkArgument(boolean test, Object message) {
+    Preconditions.checkArgument(test, message);
+  }
+
+  /** Equivalent to {@link Preconditions#checkArgument(boolean, String, Object...)}.
+   * Assists in compatibility with Guava versions prior to 20.0, where many new overloads were
+   * introduced. */
+  public static void checkArgument(boolean test, String messageTemplate, Object... parameters) {
+    Preconditions.checkArgument(test, messageTemplate, parameters);
   }
 }

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -2094,6 +2094,23 @@ public class Util {
     return v0 != null ? v0 : v1;
   }
 
+  /** Equivalent to {@link Preconditions#checkArgument(boolean)}. */
+  public static void checkArgument(boolean test) {
+    Unsafe.checkArgument(test);
+  }
+
+  /** Equivalent to {@link Preconditions#checkArgument(boolean, Object)}. */
+  public static void checkArgument(boolean test, Object message) {
+    Unsafe.checkArgument(test, message);
+  }
+
+  /** Equivalent to {@link Preconditions#checkArgument(boolean, String, Object...)}.
+   * Assists in compatibility with Guava versions prior to 20.0, where many new overloads were
+   * introduced. */
+  public static void checkArgument(boolean test, String messageTemplate, Object... parameters) {
+    Unsafe.checkArgument(test, messageTemplate, parameters);
+  }
+
   public static <T> Iterable<T> orEmpty(@Nullable Iterable<T> v0) {
     return v0 != null ? v0 : ImmutableList.of();
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -59,8 +59,8 @@ import org.apache.calcite.testlib.annotations.LocaleEnUs;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
@@ -12757,7 +12757,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     }
 
     private SqlIdentifier rewriteIdentifier(SqlIdentifier sqlIdentifier) {
-      Preconditions.checkArgument(sqlIdentifier.names.size() == 2);
+      Util.checkArgument(sqlIdentifier.names.size() == 2);
       if (sqlIdentifier.names.get(0).equals("UNEXPANDED")) {
         return new SqlIdentifier(asList("DEPT", sqlIdentifier.names.get(1)),
             null, sqlIdentifier.getParserPosition(),

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -119,6 +119,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -1699,6 +1700,24 @@ class UtilTest {
     assertThat(Util.commaList(ImmutableList.of(2, 3)), equalTo("2, 3"));
     assertThat(Util.commaList(Arrays.asList(2, null, 3)),
         equalTo("2, null, 3"));
+  }
+
+  /** Tests {@link Util#checkArgument(boolean)}. */
+  @Test void testCheckArgument1() {
+    Util.checkArgument(true); // Does nothing
+    assertThrows(IllegalArgumentException.class, () -> Util.checkArgument(false));
+  }
+
+  /** Tests {@link Util#checkArgument(boolean, Object)}. */
+  @Test void testCheckArgument2() {
+    Util.checkArgument(true, "message"); // Does nothing
+    assertThrows(IllegalArgumentException.class, () -> Util.checkArgument(false, "message"));
+  }
+
+  /** Tests {@link Util#checkArgument(boolean, Object)}. */
+  @Test void testCheckArgument3() {
+    Util.checkArgument(true, "%s", "message"); // Does nothing
+    assertThrows(IllegalArgumentException.class, () -> Util.checkArgument(false, "%s", "message"));
   }
 
   /** Unit test for {@link Util#firstDuplicate(java.util.List)}. */

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTable.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidTable.java
@@ -36,8 +36,8 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSelectKeyword;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -232,8 +232,8 @@ public class DruidTable extends AbstractTable implements TranslatableTable {
   @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
     final RelDataType rowType = protoRowType.apply(typeFactory);
     final List<String> fieldNames = rowType.getFieldNames();
-    Preconditions.checkArgument(fieldNames.contains(timestampFieldName));
-    Preconditions.checkArgument(fieldNames.containsAll(metricFieldNames));
+    Util.checkArgument(fieldNames.contains(timestampFieldName));
+    Util.checkArgument(fieldNames.containsAll(metricFieldNames));
     return rowType;
   }
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchema.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchema.java
@@ -18,11 +18,11 @@ package org.apache.calcite.adapter.elasticsearch;
 
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.util.Util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
@@ -72,7 +72,7 @@ public class ElasticsearchSchema extends AbstractSchema {
     super();
     this.client = Objects.requireNonNull(client, "client");
     this.mapper = Objects.requireNonNull(mapper, "mapper");
-    Preconditions.checkArgument(fetchSize > 0,
+    Util.checkArgument(fetchSize > 0,
         "invalid fetch size. Expected %s > 0", fetchSize);
     this.fetchSize = fetchSize;
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
@@ -19,6 +19,7 @@ package org.apache.calcite.adapter.elasticsearch;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaFactory;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.util.Util;
 
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -29,7 +30,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -154,7 +154,7 @@ public class ElasticsearchSchemaFactory implements SchemaFactory {
                                     String username, String password) {
 
     Objects.requireNonNull(hosts, "hosts or coordinates");
-    Preconditions.checkArgument(!hosts.isEmpty(), "no ES hosts specified");
+    Util.checkArgument(!hosts.isEmpty(), "no ES hosts specified");
     // Two lists are considered equal when all of their corresponding elements are equal
     // making a list of RestClient parms a suitable cache key.
     List cacheKey = ImmutableList.of(hosts, pathPrefix, username, password);

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/PredicateAnalyzer.java
@@ -31,6 +31,7 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Sarg;
+import org.apache.calcite.util.Util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -280,7 +281,7 @@ class PredicateAnalyzer {
 
     private static String convertQueryString(List<Expression> fields, Expression query) {
       int index = 0;
-      Preconditions.checkArgument(query instanceof LiteralExpression,
+      Util.checkArgument(query instanceof LiteralExpression,
           "Query string must be a string literal");
       String queryString = ((LiteralExpression) query).stringValue();
       @SuppressWarnings("ModifiedButNotUsed")
@@ -300,7 +301,7 @@ class PredicateAnalyzer {
     }
 
     private QueryExpression prefix(RexCall call) {
-      Preconditions.checkArgument(call.getKind() == SqlKind.NOT,
+      Util.checkArgument(call.getKind() == SqlKind.NOT,
           "Expected %s got %s", SqlKind.NOT, call.getKind());
 
       if (call.getOperands().size() != 1) {
@@ -313,7 +314,7 @@ class PredicateAnalyzer {
     }
 
     private QueryExpression postfix(RexCall call) {
-      Preconditions.checkArgument(call.getKind() == SqlKind.IS_NULL
+      Util.checkArgument(call.getKind() == SqlKind.IS_NULL
           || call.getKind() == SqlKind.IS_NOT_NULL);
       if (call.getOperands().size() != 1) {
         String message = String.format(Locale.ROOT, "Unsupported operator: [%s]", call);

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/Scrolling.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/Scrolling.java
@@ -16,8 +16,9 @@
  */
 package org.apache.calcite.adapter.elasticsearch;
 
+import org.apache.calcite.util.Util;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.Iterators;
 
@@ -41,7 +42,7 @@ class Scrolling {
   Scrolling(ElasticsearchTransport transport) {
     this.transport = Objects.requireNonNull(transport, "transport");
     final int fetchSize = transport.fetchSize;
-    Preconditions.checkArgument(fetchSize > 0,
+    Util.checkArgument(fetchSize > 0,
         "invalid fetch size. Expected %s > 0", fetchSize);
     this.fetchSize = fetchSize;
   }
@@ -147,7 +148,7 @@ class Scrolling {
         final ElasticsearchTransport transport, final long limit) {
       super(first);
       this.transport = transport;
-      Preconditions.checkArgument(limit >= 0,
+      Util.checkArgument(limit >= 0,
           "limit: %s >= 0", limit);
       this.limit = limit;
     }

--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvEnumerator.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvEnumerator.java
@@ -50,9 +50,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
+import static org.apache.calcite.util.Util.checkArgument;
 
 /** Enumerator that reads from a CSV file.
  *

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
@@ -37,8 +37,6 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
@@ -219,7 +217,7 @@ public class GeodeFilter extends Filter implements GeodeRel {
 
     /** Creates OQL {@code IN SET} predicate string. */
     private String translateInSet(List<RexNode> disjunctions) {
-      Preconditions.checkArgument(
+      Util.checkArgument(
           !disjunctions.isEmpty(), "empty disjunctions");
 
       RexNode firstNode = disjunctions.get(0);

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
@@ -39,8 +39,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import org.immutables.value.Value;
 
@@ -152,7 +151,7 @@ public class GeodeRules {
 
     @Override public RelNode convert(RelNode rel) {
       final LogicalProject project = (LogicalProject) rel;
-      Preconditions.checkArgument(project.getVariablesSet().isEmpty(),
+      Util.checkArgument(project.getVariablesSet().isEmpty(),
           "GeodeProject does now allow variables");
       final RelTraitSet traitSet =
           project.getTraitSet().replace(getOutConvention());

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbSchema.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbSchema.java
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.calcite.util.Util.checkArgument;
 
 import static java.util.stream.Collectors.toList;
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ModularInteger.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ModularInteger.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.linq4j;
 
-import com.google.common.base.Preconditions;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -32,7 +30,10 @@ class ModularInteger {
 
   /** Creates a ModularInteger. */
   ModularInteger(int value, int modulus) {
-    Preconditions.checkArgument(value >= 0 && value < modulus);
+    // Ordinarily would use Util.checkArgument, but linq4j does not depend on core.
+    if (value < 0 || value >= modulus) {
+      throw new IllegalArgumentException("value >= 0 && value < modulus");
+    }
     this.value = value;
     this.modulus = modulus;
   }

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigRelFactories.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigRelFactories.java
@@ -31,7 +31,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -78,7 +77,7 @@ public class PigRelFactories {
 
     @Override public RelNode createFilter(RelNode input, RexNode condition,
         Set<CorrelationId> variablesSet) {
-      Preconditions.checkArgument(variablesSet.isEmpty(),
+      Util.checkArgument(variablesSet.isEmpty(),
           "PigFilter does not allow variables");
       final RelTraitSet traitSet =
           input.getTraitSet().replace(PigRel.CONVENTION);

--- a/redis/src/main/java/org/apache/calcite/adapter/redis/RedisSchemaFactory.java
+++ b/redis/src/main/java/org/apache/calcite/adapter/redis/RedisSchemaFactory.java
@@ -19,8 +19,7 @@ package org.apache.calcite.adapter.redis;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaFactory;
 import org.apache.calcite.schema.SchemaPlus;
-
-import com.google.common.base.Preconditions;
+import org.apache.calcite.util.Util;
 
 import java.util.List;
 import java.util.Map;
@@ -39,13 +38,13 @@ public class RedisSchemaFactory implements SchemaFactory {
 
   @Override public Schema create(SchemaPlus schema, String name,
       Map<String, Object> operand) {
-    Preconditions.checkArgument(operand.get("tables") != null,
+    Util.checkArgument(operand.get("tables") != null,
         "tables must be specified");
-    Preconditions.checkArgument(operand.get("host") != null,
+    Util.checkArgument(operand.get("host") != null,
         "host must be specified");
-    Preconditions.checkArgument(operand.get("port") != null,
+    Util.checkArgument(operand.get("port") != null,
         "port must be specified");
-    Preconditions.checkArgument(operand.get("database") != null,
+    Util.checkArgument(operand.get("database") != null,
         "database must be specified");
 
     @SuppressWarnings("unchecked") List<Map<String, Object>> tables =

--- a/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
+++ b/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
@@ -86,7 +86,6 @@ import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -238,7 +237,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
     final Schema subSchema;
     final String libraryName;
     if (create.type != null) {
-      Preconditions.checkArgument(create.library == null);
+      Util.checkArgument(create.library == null);
       final String typeName = (String) value(create.type);
       final JsonSchema.Type type =
           Util.enumVal(JsonSchema.Type.class,
@@ -260,7 +259,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
                 Arrays.toString(JsonSchema.Type.values())));
       }
     } else {
-      Preconditions.checkArgument(create.library != null);
+      Util.checkArgument(create.library != null);
       libraryName = (String) value(create.library);
     }
     final SchemaFactory schemaFactory =
@@ -578,7 +577,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
       this.expr = expr;
       this.type = type;
       this.strategy = Objects.requireNonNull(strategy, "strategy");
-      Preconditions.checkArgument(
+      Util.checkArgument(
           strategy == ColumnStrategy.NULLABLE
               || strategy == ColumnStrategy.NOT_NULLABLE
               || expr != null);

--- a/src/main/config/forbidden-apis/signatures.txt
+++ b/src/main/config/forbidden-apis/signatures.txt
@@ -61,12 +61,40 @@ java.lang.Enum#equals(java.lang.Object)
 @defaultMessage It does not handle encoded URLs, use Sources.of(URL).file() instead
 java.net.URL#getPath()
 
-# Preconditions.checkArgument,
-# Preconditions.checkPositionIndex, and
+# Preconditions.checkPositionIndex and
 # Preconditions.checkState are still OK
 @defaultMessage Use Objects.requireNonNull
 com.google.common.base.Preconditions#checkNotNull(java.lang.Object)
 com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.Object)
+
+# Preconditions.checkArgument gained new overloads in Guava 20.0, which prevents code built using
+# Guava 20.0 from running properly with earlier versions of Guava
+@defaultMessage Use Util.checkArgument
+com.google.common.base.Preconditions#checkArgument(boolean)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.Object)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object[])
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,char)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,int)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,long)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,char,char)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,char,int)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,char,long)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,char,java.lang.Object)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,int,char)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,int,int)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,int,long)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,int,java.lang.Object)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,long,char)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,long,int)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,long,long)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,long,java.lang.Object)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object,char)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object,int)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object,long)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object,java.lang.Object)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object,java.lang.Object,java.lang.Object)
+com.google.common.base.Preconditions#checkArgument(boolean,java.lang.String,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object)
 
 @defaultMessage Use java.util.Objects.equals
 com.google.common.base.Objects#equal(java.lang.Object, java.lang.Object)

--- a/testkit/src/main/java/org/apache/calcite/test/Matchers.java
+++ b/testkit/src/main/java/org/apache/calcite/test/Matchers.java
@@ -24,7 +24,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.RangeSet;
 
@@ -409,7 +408,7 @@ public class Matchers {
     private final double epsilon;
 
     public IsWithin(T expectedValue, double epsilon) {
-      Preconditions.checkArgument(epsilon >= 0D);
+      Util.checkArgument(epsilon >= 0D);
       this.expectedValue = expectedValue;
       this.epsilon = epsilon;
     }

--- a/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
@@ -40,8 +40,8 @@ import org.apache.calcite.sql.test.SqlTestFactory;
 import org.apache.calcite.sql.test.SqlTester;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
@@ -196,7 +196,7 @@ public class RelMetadataFixture {
     metadataConfig.applyMetadata(rel.getCluster());
     if (convertAsCalc) {
       Project project = (Project) rel;
-      Preconditions.checkArgument(project.getVariablesSet().isEmpty(),
+      Util.checkArgument(project.getVariablesSet().isEmpty(),
           "Calc does not allow variables");
       RexProgram program = RexProgram.create(
           project.getInput().getRowType(),

--- a/testkit/src/main/java/org/apache/calcite/test/SqlValidatorFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlValidatorFixture.java
@@ -46,8 +46,6 @@ import org.apache.calcite.test.catalog.MockCatalogReaderExtended;
 import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
-import com.google.common.base.Preconditions;
-
 import org.hamcrest.Matcher;
 
 import java.nio.charset.Charset;
@@ -181,7 +179,7 @@ public class SqlValidatorFixture {
   }
 
   SqlValidatorFixture withWhole(boolean whole) {
-    Preconditions.checkArgument(sap.cursor < 0);
+    Util.checkArgument(sap.cursor < 0);
     final StringAndPos sap = StringAndPos.of("^" + this.sap.sql + "^");
     return new SqlValidatorFixture(tester, factory, sap, expression, whole);
   }


### PR DESCRIPTION
Preconditions.checkArgument gained new overloads in Guava 20.0, which prevents code built using Guava 20.0 from running properly with earlier versions of Guava.