### PR TITLE
[CALCITE-5479] FamilyOperandTypeChecker is not readily composable in sequences

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
@@ -312,7 +312,7 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
         if (!((SqlSingleOperandTypeChecker) rule).checkSingleOperandType(
             callBinding,
             callBinding.getCall().operand(ord.i),
-            rule.getClass() == FamilyOperandTypeChecker.class ? 0 : ord.i,
+            ord.i,
             throwOnFailure)) {
           if (callBinding.isTypeCoercionEnabled()) {
             return coerceOperands(callBinding, false);

--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeSingleOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeSingleOperandTypeChecker.java
@@ -64,7 +64,7 @@ public class CompositeSingleOperandTypeChecker
         getRules();
     if (composition == Composition.SEQUENCE) {
       return rules.get(iFormalOperand).checkSingleOperandType(
-          callBinding, node, 0, throwOnFailure);
+          callBinding, node, iFormalOperand, throwOnFailure);
     }
 
     int typeErrorCount = 0;

--- a/core/src/main/java/org/apache/calcite/sql/type/IntervalOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/IntervalOperandTypeChecker.java
@@ -37,8 +37,7 @@ public class IntervalOperandTypeChecker implements SqlSingleOperandTypeChecker {
   }
 
   @Override public boolean checkSingleOperandType(SqlCallBinding callBinding,
-      SqlNode node, int iFormalOperand, boolean throwOnFailure) {
-    final SqlNode operand = callBinding.operand(iFormalOperand);
+      SqlNode operand, int iFormalOperand, boolean throwOnFailure) {
     if (operand instanceof SqlIntervalQualifier) {
       final SqlIntervalQualifier interval = (SqlIntervalQualifier) operand;
       if (predicate.test(interval)) {

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -539,6 +539,7 @@ public abstract class OperandTypes {
             SqlCallBinding callBinding,
             SqlNode operand,
             int iFormalOperand,
+            SqlTypeFamily family,
             boolean throwOnFailure) {
           if (!LITERAL.checkSingleOperandType(
               callBinding,
@@ -552,6 +553,7 @@ public abstract class OperandTypes {
               callBinding,
               operand,
               iFormalOperand,
+              family,
               throwOnFailure)) {
             return false;
           }
@@ -583,14 +585,15 @@ public abstract class OperandTypes {
           i -> false) {
         @Override public boolean checkSingleOperandType(
             SqlCallBinding callBinding, SqlNode operand,
-            int iFormalOperand, boolean throwOnFailure) {
+            int iFormalOperand, SqlTypeFamily family,
+            boolean throwOnFailure) {
           if (iFormalOperand == 0) {
             return super.checkSingleOperandType(callBinding, operand,
-                iFormalOperand, throwOnFailure);
+                iFormalOperand, family, throwOnFailure);
           }
 
           return BOOLEAN_LITERAL.checkSingleOperandType(
-              callBinding, operand, 0, throwOnFailure);
+              callBinding, operand, iFormalOperand, throwOnFailure);
         }
       };
 
@@ -605,6 +608,7 @@ public abstract class OperandTypes {
             SqlCallBinding callBinding,
             SqlNode operand,
             int iFormalOperand,
+            SqlTypeFamily family,
             boolean throwOnFailure) {
           if (!LITERAL.checkSingleOperandType(
               callBinding,
@@ -618,6 +622,7 @@ public abstract class OperandTypes {
               callBinding,
               operand,
               iFormalOperand,
+              family,
               throwOnFailure)) {
             return false;
           }
@@ -660,14 +665,14 @@ public abstract class OperandTypes {
           i -> false) {
         @Override public boolean checkSingleOperandType(
             SqlCallBinding callBinding, SqlNode operand,
-            int iFormalOperand, boolean throwOnFailure) {
+            int iFormalOperand, SqlTypeFamily family, boolean throwOnFailure) {
           if (!LITERAL.checkSingleOperandType(callBinding, operand,
-              iFormalOperand, throwOnFailure)) {
+              0, throwOnFailure)) {
             return false;
           }
 
           if (!super.checkSingleOperandType(callBinding, operand,
-              iFormalOperand, throwOnFailure)) {
+              iFormalOperand, family, throwOnFailure)) {
             return false;
           }
 
@@ -698,14 +703,14 @@ public abstract class OperandTypes {
           i -> false) {
         @Override public boolean checkSingleOperandType(
             SqlCallBinding callBinding, SqlNode operand,
-            int iFormalOperand, boolean throwOnFailure) {
+            int iFormalOperand, SqlTypeFamily family, boolean throwOnFailure) {
           if (iFormalOperand == 0) {
             return super.checkSingleOperandType(callBinding, operand,
-                iFormalOperand, throwOnFailure);
+                iFormalOperand, family, throwOnFailure);
           }
 
           return UNIT_INTERVAL_NUMERIC_LITERAL.checkSingleOperandType(
-              callBinding, operand, 0, throwOnFailure);
+              callBinding, operand, iFormalOperand, throwOnFailure);
         }
       };
 
@@ -888,14 +893,14 @@ public abstract class OperandTypes {
       new FamilyOperandTypeChecker(ImmutableList.of(SqlTypeFamily.ANY),
           i -> false) {
         @Override public boolean checkSingleOperandType(
-            SqlCallBinding callBinding, SqlNode node,
-            int iFormalOperand, boolean throwOnFailure) {
-          if (!super.checkSingleOperandType(callBinding, node, iFormalOperand,
+            SqlCallBinding callBinding, SqlNode operand,
+            int iFormalOperand, SqlTypeFamily family, boolean throwOnFailure) {
+          if (!super.checkSingleOperandType(callBinding, operand, iFormalOperand, family,
               throwOnFailure)) {
             return false;
           }
           final SqlValidatorScope scope = callBinding.getScope();
-          if (!scope.isMeasureRef(node)) {
+          if (!scope.isMeasureRef(operand)) {
             if (throwOnFailure) {
               throw callBinding.newValidationError(
                   RESOURCE.argumentMustBeMeasure(
@@ -994,6 +999,15 @@ public abstract class OperandTypes {
             SqlCallBinding callBinding,
             boolean throwOnFailure) {
           if (!super.checkOperandTypes(callBinding, throwOnFailure)) {
+            return false;
+          }
+          return SAME_SAME.checkOperandTypes(callBinding, throwOnFailure);
+        }
+
+        @Override public boolean checkOperandTypesWithoutTypeCoercion(
+            final SqlCallBinding callBinding,
+            final boolean throwOnFailure) {
+          if (!super.checkOperandTypesWithoutTypeCoercion(callBinding, throwOnFailure)) {
             return false;
           }
           return SAME_SAME.checkOperandTypes(callBinding, throwOnFailure);

--- a/core/src/test/java/org/apache/calcite/sql/type/OperandTypesTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/OperandTypesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.test.SqlOperatorFixture;
+import org.apache.calcite.sql.util.SqlOperatorTables;
+import org.apache.calcite.test.Fixtures;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for operand checkers in {@link OperandTypes}.
+ */
+public class OperandTypesTest {
+
+  @Test void testSequenceOfFamily() throws Exception {
+    // Test for https://issues.apache.org/jira/browse/CALCITE-5479. The original checker that
+    // inspired this test was doing "and(family(STRING), LITERAL)". We tweak this a bit here because
+    // the test fixture does not preserve literals.
+    final SqlOperandTypeChecker fChecker =
+        OperandTypes.sequence("F(<STRING>, <TIMESTAMP or DATE>)",
+            OperandTypes.STRING, OperandTypes.or(OperandTypes.TIMESTAMP, OperandTypes.DATE));
+    final SqlOperator fOperator =
+        new SqlFunction("F", SqlKind.OTHER_FUNCTION, ReturnTypes.BIGINT, null, fChecker,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION);
+    final SqlOperatorTable operatorTable = SqlOperatorTables.of(fOperator, SqlStdOperatorTable.ROW);
+    try (SqlOperatorFixture f = Fixtures.forOperators(false).withOperatorTable(operatorTable)) {
+      f.setFor(fOperator);
+      f.checkType("F('foo', TIMESTAMP '2000-01-01 00:00:00')", "BIGINT NOT NULL");
+      f.checkFails("^F('foo', 1)^",
+          "Cannot apply 'F' to arguments of type 'F\\(<CHAR\\(3\\)>, <INTEGER>\\)'\\. Supported "
+              + "form\\(s\\): F\\(<STRING>, <TIMESTAMP or DATE>\\)", false);
+    }
+
+  }
+
+}


### PR DESCRIPTION
By adjusting handling of iFormalOperand in various checkers.

1) CompositeOperandTypeChecker: always send the proper iFormalOperand; never zero.

2) FamilyOperandTypeChecker: always look at the first (and only) family when being used as a SqlSingleOperandTypeChecker via checkSingleOperandType. Continue considering all families when used as a SqlOperandTypeChecker via checkOperandTypes.

3) IntervalOperandTypeChecker: use the SqlNode parameter, not the SqlCallBinding, to get the node to check. Using the SqlCallBinding violates the contract of SqlSingleOperandTypeChecker#checkSingleOperandType.