### PR TITLE
[CALCITE-5489] Cannot convert TIMESTAMP literal to class org.apache.calcite.avatica.util.TimeUnit

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampDiffFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampDiffFunction.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
@@ -63,7 +64,11 @@ class SqlTimestampDiffFunction extends SqlFunction {
     final TimeUnit timeUnit;
     final RelDataType type1;
     final RelDataType type2;
-    if (opBinding.isOperandLiteral(0, true)) {
+    final Object literal = opBinding.getOperandLiteralValue(2, Object.class);
+    if (opBinding.isOperandLiteral(0, true)
+        && (literal == null
+        || literal instanceof TimeUnit
+        || literal instanceof SqlIntervalLiteral.IntervalValue)) {
       type1 = opBinding.getOperandType(0);
       type2 = opBinding.getOperandType(1);
       timeUnit = opBinding.getOperandLiteralValue(2, TimeUnit.class);

--- a/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rex;
 
 import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -31,6 +32,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.test.RexImplicationCheckerFixtures;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.NlsString;
@@ -849,5 +851,17 @@ class RexBuilderTest {
     // when the space before "NOT NULL" is missing, the digest is not correct
     // and the suffix should not be removed.
     assertThat(literal.digest, is("0L:(udt)NOT NULL"));
+  }
+
+  @Test void testTimestampDiffCall() {
+    final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    final RexImplicationCheckerFixtures.Fixture f = new RexImplicationCheckerFixtures.Fixture();
+    final TimestampString ts =
+        TimestampString.fromCalendarFields(Util.calendar());
+
+    rexBuilder.makeCall(SqlStdOperatorTable.TIMESTAMP_DIFF,
+        ImmutableList.of(rexBuilder.makeFlag(TimeUnit.QUARTER),
+            f.timestampLiteral(ts), f.timestampLiteral(ts)));
   }
 }


### PR DESCRIPTION
It seems a regression after https://github.com/apache/calcite/pull/2998

The failing test (which is passing on 1.32) is at `org.apache.calcite.rex.RexBuilderTest#testTimestampDiffCall`