### PR TITLE
Calcite 5418 3

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/LateralTableScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/LateralTableScope.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql.validate;
 
+import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSelect;
 
@@ -27,7 +28,7 @@ import java.util.Objects;
  * <p>The objects visible are those in the parameters found on the left side of
  * the LATERAL TABLE clause, and objects inherited from the parent scope.
  */
-class TableScope extends ListScope {
+class LateralTableScope extends ListScope {
   //~ Instance fields --------------------------------------------------------
 
   private final SqlNode node;
@@ -39,7 +40,7 @@ class TableScope extends ListScope {
    *
    * @param parent  Parent scope
    */
-  TableScope(SqlValidatorScope parent, SqlNode node) {
+  LateralTableScope(SqlValidatorScope parent, SqlNode node) {
     super(Objects.requireNonNull(parent, "parent"));
     this.node = Objects.requireNonNull(node, "node");
   }
@@ -53,6 +54,8 @@ class TableScope extends ListScope {
   @Override public boolean isWithin(SqlValidatorScope scope2) {
     if (this == scope2) {
       return true;
+    } else if (scope2 instanceof Join && node == scope2.getNode()) {
+      throw new RuntimeException();
     }
     SqlValidatorScope s = getValidator().getSelectScope((SqlSelect) node);
     return s.isWithin(scope2);

--- a/core/src/main/java/org/apache/calcite/sql/validate/ScopeValidationRegister.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/ScopeValidationRegister.java
@@ -1,0 +1,531 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql.validate;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import static java.util.Objects.requireNonNull;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+import static org.apache.calcite.util.Util.first;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDelete;
+import org.apache.calcite.sql.SqlInsert;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLambda;
+import org.apache.calcite.sql.SqlMerge;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlUpdate;
+import org.apache.calcite.sql.SqlWith;
+import org.apache.calcite.sql.SqlWithItem;
+import org.apache.calcite.sql.util.IdPair;
+import org.apache.calcite.util.Util;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class ScopeValidationRegister {
+
+  Map<SqlNode, SqlValidatorScope> nodeToScope = new HashMap<>();
+
+  SqlValidatorScope register(
+      SqlNode sqlNode,
+      SqlValidatorScope lateralScope) {
+
+  }
+
+
+  /**
+   * Registers a query in a parent scope.
+   *
+   * @param parentScope Parent scope which this scope turns to in order to
+   *                    resolve objects
+   * @param usingScope  Scope whose child list this scope should add itself to
+   * @param node        Query node
+   * @param alias       Name of this query within its parent. Must be specified
+   *                    if usingScope != null
+   */
+  protected void registerQuery(
+      SqlValidatorScope parentScope,
+      @Nullable SqlValidatorScope usingScope,
+      SqlValidatorScope lateralScope,
+      SqlNode node,
+      SqlNode enclosingNode,
+      @Nullable String alias,
+      boolean forceNullable) {
+    checkArgument(usingScope == null || alias != null);
+    registerQuery(
+        parentScope,
+        usingScope,
+        lateralScope,
+        node,
+        enclosingNode,
+        alias,
+        forceNullable,
+        true);
+  }
+
+  /**
+   * Registers a query in a parent scope.
+   *
+   * @param parentScope Parent scope which this scope turns to in order to
+   *                    resolve objects
+   * @param usingScope  Scope whose child list this scope should add itself to
+   * @param node        Query node
+   * @param alias       Name of this query within its parent. Must be specified
+   *                    if usingScope != null
+   * @param checkUpdate if true, validate that the update feature is supported
+   *                    if validating the update statement
+   */
+  private void registerQuery(
+      SqlValidatorScope parentScope,
+      @Nullable SqlValidatorScope usingScope,
+      SqlValidatorScope lateralScope,
+      SqlNode node,
+      SqlNode enclosingNode,
+      @Nullable String alias,
+      boolean forceNullable,
+      boolean checkUpdate) {
+    requireNonNull(node, "node");
+    requireNonNull(enclosingNode, "enclosingNode");
+    checkArgument(usingScope == null || alias != null);
+
+    SqlCall call;
+    List<SqlNode> operands;
+    switch (node.getKind()) {
+    case SELECT:
+      final SqlSelect select = (SqlSelect) node;
+      final SelectNamespace selectNs =
+          createSelectNamespace(select, enclosingNode);
+      registerNamespace(usingScope, alias, selectNs, forceNullable);
+      final SqlValidatorScope windowParentScope =
+          first(usingScope, parentScope);
+      SelectScope selectScope =
+          new SelectScope(parentScope, windowParentScope, select);
+      scopes.put(select, selectScope);
+
+      // Start by registering the WHERE clause
+      clauseScopes.put(IdPair.of(select, SqlValidatorImpl.Clause.WHERE), selectScope);
+      registerOperandSubQueries(
+          selectScope,
+          select,
+          SqlSelect.WHERE_OPERAND);
+
+      // Register subqueries in the QUALIFY clause
+      registerOperandSubQueries(
+          selectScope,
+          select,
+          SqlSelect.QUALIFY_OPERAND);
+
+      // Register FROM with the inherited scope 'parentScope', not
+      // 'selectScope', otherwise tables in the FROM clause would be
+      // able to see each other.
+      final SqlNode from = select.getFrom();
+      if (from != null) {
+        final SqlNode newFrom =
+            registerFrom(
+                parentScope,
+                selectScope,
+                lateralScope,
+                true,
+                from,
+                from,
+                null,
+                null,
+                false,
+                false);
+        if (newFrom != from) {
+          select.setFrom(newFrom);
+        }
+      }
+
+      // If this is an aggregate query, the SELECT list and HAVING
+      // clause use a different scope, where you can only reference
+      // columns which are in the GROUP BY clause.
+      final SqlValidatorScope selectScope2 =
+          isAggregate(select)
+              ? new AggregatingSelectScope(selectScope, select, false)
+              : selectScope;
+      clauseScopes.put(IdPair.of(select, SqlValidatorImpl.Clause.SELECT), selectScope2);
+      clauseScopes.put(IdPair.of(select, SqlValidatorImpl.Clause.MEASURE),
+          new MeasureScope(selectScope, select));
+      if (select.getGroup() != null) {
+        GroupByScope groupByScope =
+            new GroupByScope(selectScope, select.getGroup(), select);
+        clauseScopes.put(IdPair.of(select, SqlValidatorImpl.Clause.GROUP_BY), groupByScope);
+        registerSubQueries(groupByScope, select.getGroup());
+      }
+      registerOperandSubQueries(
+          selectScope2,
+          select,
+          SqlSelect.HAVING_OPERAND);
+      registerSubQueries(selectScope2,
+          SqlNonNullableAccessors.getSelectList(select));
+      final SqlNodeList orderList = select.getOrderList();
+      if (orderList != null) {
+        // If the query is 'SELECT DISTINCT', restrict the columns
+        // available to the ORDER BY clause.
+        final SqlValidatorScope selectScope3 =
+            select.isDistinct()
+                ? new AggregatingSelectScope(selectScope, select, true)
+                : selectScope2;
+        OrderByScope orderScope =
+            new OrderByScope(selectScope3, orderList, select);
+        clauseScopes.put(IdPair.of(select, SqlValidatorImpl.Clause.ORDER), orderScope);
+        registerSubQueries(orderScope, orderList);
+
+        if (!isAggregate(select)) {
+          // Since this is not an aggregate query,
+          // there cannot be any aggregates in the ORDER BY clause.
+          SqlNode agg = aggFinder.findAgg(orderList);
+          if (agg != null) {
+            throw newValidationError(agg, RESOURCE.aggregateIllegalInOrderBy());
+          }
+        }
+      }
+      break;
+
+    case INTERSECT:
+      validateFeature(RESOURCE.sQLFeature_F302(), node.getParserPosition());
+      registerSetop(
+          parentScope,
+          usingScope,
+          lateralScope,
+          node,
+          node,
+          alias,
+          forceNullable);
+      break;
+
+    case EXCEPT:
+      validateFeature(RESOURCE.sQLFeature_E071_03(), node.getParserPosition());
+      registerSetop(
+          parentScope,
+          usingScope,
+          lateralScope,
+          node,
+          node,
+          alias,
+          forceNullable);
+      break;
+
+    case UNION:
+      registerSetop(
+          parentScope,
+          usingScope,
+          lateralScope,
+          node,
+          enclosingNode,
+          alias,
+          forceNullable);
+      break;
+
+    case LAMBDA:
+      call = (SqlCall) node;
+      SqlLambdaScope lambdaScope =
+          new SqlLambdaScope(parentScope, (SqlLambda) call);
+      scopes.put(call, lambdaScope);
+      final LambdaNamespace lambdaNamespace =
+          new LambdaNamespace(this, (SqlLambda) call, node);
+      registerNamespace(
+          usingScope,
+          alias,
+          lambdaNamespace,
+          forceNullable);
+      operands = call.getOperandList();
+      for (int i = 0; i < operands.size(); i++) {
+        registerOperandSubQueries(parentScope, call, i);
+      }
+      break;
+
+    case WITH:
+      registerWith(parentScope, usingScope, lateralScope, (SqlWith) node, enclosingNode,
+          alias, forceNullable, checkUpdate);
+      break;
+
+    case VALUES:
+      call = (SqlCall) node;
+      scopes.put(call, parentScope);
+      final TableConstructorNamespace tableConstructorNamespace =
+          new TableConstructorNamespace(
+              this,
+              call,
+              parentScope,
+              enclosingNode);
+      registerNamespace(
+          usingScope,
+          alias,
+          tableConstructorNamespace,
+          forceNullable);
+      operands = call.getOperandList();
+      for (int i = 0; i < operands.size(); ++i) {
+        assert operands.get(i).getKind() == SqlKind.ROW;
+
+        // FIXME jvs 9-Feb-2005:  Correlation should
+        // be illegal in these sub-queries.  Same goes for
+        // any non-lateral SELECT in the FROM list.
+        registerOperandSubQueries(parentScope, call, i);
+      }
+      break;
+
+    case INSERT:
+      SqlInsert insertCall = (SqlInsert) node;
+      SqlValidatorImpl.InsertNamespace insertNs =
+          new SqlValidatorImpl.InsertNamespace(
+              this,
+              insertCall,
+              enclosingNode,
+              parentScope);
+      registerNamespace(usingScope, null, insertNs, forceNullable);
+      registerQuery(
+          parentScope,
+          usingScope,
+          lateralScope,
+          insertCall.getSource(),
+          enclosingNode,
+          null,
+          false);
+      break;
+
+    case DELETE:
+      SqlDelete deleteCall = (SqlDelete) node;
+      SqlValidatorImpl.DeleteNamespace deleteNs =
+          new SqlValidatorImpl.DeleteNamespace(
+              this,
+              deleteCall,
+              enclosingNode,
+              parentScope);
+      registerNamespace(usingScope, null, deleteNs, forceNullable);
+      registerQuery(
+          parentScope,
+          usingScope,
+          lateralScope,
+          SqlNonNullableAccessors.getSourceSelect(deleteCall),
+          enclosingNode,
+          null,
+          false);
+      break;
+
+    case UPDATE:
+      if (checkUpdate) {
+        validateFeature(RESOURCE.sQLFeature_E101_03(),
+            node.getParserPosition());
+      }
+      SqlUpdate updateCall = (SqlUpdate) node;
+      SqlValidatorImpl.UpdateNamespace updateNs =
+          new SqlValidatorImpl.UpdateNamespace(
+              this,
+              updateCall,
+              enclosingNode,
+              parentScope);
+      registerNamespace(usingScope, null, updateNs, forceNullable);
+      registerQuery(
+          parentScope,
+          usingScope,
+          lateralScope,
+          SqlNonNullableAccessors.getSourceSelect(updateCall),
+          enclosingNode,
+          null,
+          false);
+      break;
+
+    case MERGE:
+      validateFeature(RESOURCE.sQLFeature_F312(), node.getParserPosition());
+      SqlMerge mergeCall = (SqlMerge) node;
+      SqlValidatorImpl.MergeNamespace mergeNs =
+          new SqlValidatorImpl.MergeNamespace(
+              this,
+              mergeCall,
+              enclosingNode,
+              parentScope);
+      registerNamespace(usingScope, null, mergeNs, forceNullable);
+      registerQuery(
+          parentScope,
+          usingScope,
+          lateralScope,
+          SqlNonNullableAccessors.getSourceSelect(mergeCall),
+          enclosingNode,
+          null,
+          false);
+
+      // update call can reference either the source table reference
+      // or the target table, so set its parent scope to the merge's
+      // source select; when validating the update, skip the feature
+      // validation check
+      SqlUpdate mergeUpdateCall = mergeCall.getUpdateCall();
+      if (mergeUpdateCall != null) {
+        registerQuery(
+            getScope(SqlNonNullableAccessors.getSourceSelect(mergeCall), SqlValidatorImpl.Clause.WHERE),
+            null,
+            lateralScope,
+            mergeUpdateCall,
+            enclosingNode,
+            null,
+            false,
+            false);
+      }
+      SqlInsert mergeInsertCall = mergeCall.getInsertCall();
+      if (mergeInsertCall != null) {
+        registerQuery(
+            parentScope,
+            null,
+            lateralScope,
+            mergeInsertCall,
+            enclosingNode,
+            null,
+            false);
+      }
+      break;
+
+    case UNNEST:
+      call = (SqlCall) node;
+      final UnnestNamespace unnestNs =
+          new UnnestNamespace(this, call, parentScope, enclosingNode);
+      registerNamespace(
+          usingScope,
+          alias,
+          unnestNs,
+          forceNullable);
+      registerOperandSubQueries(parentScope, call, 0);
+      scopes.put(node, parentScope);
+      break;
+    case OTHER_FUNCTION:
+      call = (SqlCall) node;
+      ProcedureNamespace procNs =
+          new ProcedureNamespace(
+              this,
+              parentScope,
+              call,
+              enclosingNode);
+      registerNamespace(
+          usingScope,
+          alias,
+          procNs,
+          forceNullable);
+      registerSubQueries(parentScope, call);
+      break;
+
+    case MULTISET_QUERY_CONSTRUCTOR:
+    case MULTISET_VALUE_CONSTRUCTOR:
+      validateFeature(RESOURCE.sQLFeature_S271(), node.getParserPosition());
+      call = (SqlCall) node;
+      CollectScope cs = new CollectScope(parentScope, usingScope, call);
+      final CollectNamespace tableConstructorNs =
+          new CollectNamespace(call, cs, enclosingNode);
+      final String alias2 = SqlValidatorUtil.alias(node, nextGeneratedId++);
+      registerNamespace(
+          usingScope,
+          alias2,
+          tableConstructorNs,
+          forceNullable);
+      operands = call.getOperandList();
+      for (int i = 0; i < operands.size(); i++) {
+        registerOperandSubQueries(parentScope, call, i);
+      }
+      break;
+
+    default:
+      throw Util.unexpected(node.getKind());
+    }
+  }
+
+  private void registerSetop(
+      SqlValidatorScope parentScope,
+      @Nullable SqlValidatorScope usingScope,
+      SqlValidatorScope lateralScope,
+      SqlNode node,
+      SqlNode enclosingNode,
+      @Nullable String alias,
+      boolean forceNullable) {
+    SqlCall call = (SqlCall) node;
+    final SetopNamespace setopNamespace =
+        createSetopNamespace(call, enclosingNode);
+    registerNamespace(usingScope, alias, setopNamespace, forceNullable);
+
+    // A setop is in the same scope as its parent.
+    scopes.put(call, parentScope);
+    @NonNull SqlValidatorScope recursiveScope = parentScope;
+    if (enclosingNode.getKind() == SqlKind.WITH_ITEM) {
+      if (node.getKind() != SqlKind.UNION) {
+        throw newValidationError(node, RESOURCE.recursiveWithMustHaveUnionSetOp());
+      } else if (call.getOperandList().size() > 2) {
+        throw newValidationError(node, RESOURCE.recursiveWithMustHaveTwoChildUnionSetOp());
+      }
+      final WithScope scope = (WithScope) scopes.get(enclosingNode);
+      // recursive scope is only set for the recursive queries.
+      recursiveScope = scope != null && scope.recursiveScope != null
+          ? Objects.requireNonNull(scope.recursiveScope) : parentScope;
+    }
+    for (int i = 0; i < call.getOperandList().size(); i++) {
+      SqlNode operand = call.getOperandList().get(i);
+      @NonNull SqlValidatorScope scope = i == 0 ? parentScope : recursiveScope;
+      registerQuery(
+          scope,
+          null,
+          lateralScope,
+          operand,
+          operand,
+          null,
+          false);
+    }
+  }
+
+  private void registerWith(
+      SqlValidatorScope parentScope,
+      @Nullable SqlValidatorScope usingScope,
+      SqlValidatorScope lateralScope,
+      SqlWith with,
+      SqlNode enclosingNode,
+      @Nullable String alias,
+      boolean forceNullable,
+      boolean checkUpdate) {
+    final WithNamespace withNamespace =
+        new WithNamespace(this, with, enclosingNode);
+    registerNamespace(usingScope, alias, withNamespace, forceNullable);
+    scopes.put(with, parentScope);
+
+    SqlValidatorScope scope = parentScope;
+    for (SqlNode withItem_ : with.withList) {
+      final SqlWithItem withItem = (SqlWithItem) withItem_;
+
+      final boolean isRecursiveWith = withItem.recursive.booleanValue();
+      final SqlValidatorScope withScope =
+          new WithScope(scope, withItem,
+              isRecursiveWith ? new WithRecursiveScope(scope, withItem) : null);
+      scopes.put(withItem, withScope);
+
+      registerQuery(scope, null, lateralScope, withItem.query,
+          withItem.recursive.booleanValue() ? withItem : with, withItem.name.getSimple(),
+          forceNullable);
+      registerNamespace(null, alias,
+          new WithItemNamespace(this, withItem, enclosingNode),
+          false);
+      scope = withScope;
+    }
+    registerQuery(scope, null, lateralScope, with.body, enclosingNode, alias, forceNullable,
+        checkUpdate);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -33,6 +33,7 @@ import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlLambda;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlMatchRecognize;
@@ -595,6 +596,14 @@ public interface SqlValidator {
    * @return naming scope for HAVING clause
    */
   SqlValidatorScope getHavingScope(SqlSelect select);
+
+  /**
+   * Returns scope for lateral variables.
+   *
+   * @param sqlJoin join for lateral scope
+   * @return scope for resolving variables
+   */
+  SqlValidatorScope getLateralScope(SqlJoin sqlJoin);
 
   /**
    * Returns the scope that expressions in the SELECT and HAVING clause of

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorScope.java
@@ -316,7 +316,7 @@ public interface SqlValidatorScope {
     @Override public void found(SqlValidatorNamespace namespace,
         boolean nullable, SqlValidatorScope scope, Path path,
         List<String> remainingNames) {
-      if (scope instanceof TableScope) {
+      if (scope instanceof LateralTableScope) {
         scope = scope.getValidator().getSelectScope((SqlSelect) scope.getNode());
       }
       if (scope instanceof AggregatingSelectScope) {
@@ -356,7 +356,7 @@ public interface SqlValidatorScope {
       this.namespace = requireNonNull(namespace, "namespace");
       this.nullable = nullable;
       this.scope = scope;
-      assert !(scope instanceof TableScope);
+      assert !(scope instanceof LateralTableScope);
       this.path = requireNonNull(path, "path");
       this.remainingNames = ImmutableList.copyOf(remainingNames);
     }

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -213,12 +213,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -288,6 +290,8 @@ public class SqlToRelConverter {
   private int explainParamCount;
   public final SqlToRelConverter.Config config;
   private final RelBuilder relBuilder;
+  private final List<CorrelationContext> scopeToCorrelationContext =
+      new ArrayList<>();
 
   /**
    * Fields used in name resolution for correlated sub-queries.
@@ -3278,6 +3282,7 @@ public class SqlToRelConverter {
   private void convertJoin(Blackboard bb, SqlJoin join) {
     SqlValidator validator = validator();
     final SqlValidatorScope scope = validator.getJoinScope(join);
+    final SqlValidatorScope lateralScope = validator.getLateralScope(join);
     final Blackboard fromBlackboard = createBlackboard(scope, null, false);
 
     SqlNode left = join.getLeft();
@@ -3291,9 +3296,11 @@ public class SqlToRelConverter {
         createBlackboard(rightScope, null, false);
     convertFrom(leftBlackboard, left);
     final RelNode leftRel = requireNonNull(leftBlackboard.root, "leftBlackboard.root");
+    final CorrelationContext lateralCorrelationContext =
+        findCorrelationContext(lateralScope, leftRel);
     convertFrom(rightBlackboard, right);
     final RelNode tempRightRel = requireNonNull(rightBlackboard.root, "rightBlackboard.root");
-
+    scopeToCorrelationContext.remove(lateralCorrelationContext);
     final JoinConditionType conditionType = join.getConditionType();
     final RexNode condition;
     RelNode rightRel;
@@ -4242,6 +4249,31 @@ public class SqlToRelConverter {
     return NullInitializerExpressionFactory.INSTANCE;
   }
 
+  private CorrelationContext findCorrelationContext(SqlValidatorScope sqlValidatorScope,
+      RelNode relNode) {
+    return findCorrelationContext(sqlValidatorScope, ImmutableList.of(relNode));
+  }
+
+
+  private CorrelationContext findCorrelationContext(SqlValidatorScope sqlValidatorScope,
+      List<RelNode> relNodes) {
+    Optional<CorrelationContext> correlationContext = scopeToCorrelationContext.stream()
+        .filter(cc
+            -> cc.sqlValidatorScope.isWithin(sqlValidatorScope))
+        .findFirst();
+    if (correlationContext.isPresent()) {
+      CorrelationContext correlationContext2 = correlationContext.get();
+      assert correlationContext2.sqlValidatorScope == sqlValidatorScope;
+      assert correlationContext2.relNodes.equals(relNodes);
+      return correlationContext2;
+    } else {
+      CorrelationContext correlationContext2 =
+          new CorrelationContext(cluster, sqlValidatorScope, relNodes);
+      scopeToCorrelationContext.add(correlationContext2);
+      return correlationContext2;
+    }
+  }
+
   private static <T extends Object> @Nullable T unwrap(@Nullable Object o, Class<T> clazz) {
     if (o instanceof Wrapper) {
       return ((Wrapper) o).unwrap(clazz);
@@ -5038,6 +5070,8 @@ public class SqlToRelConverter {
         true);
   }
 
+
+
   /** Processes names matching between incoming row and appropriate dataset
    * definition. Returns incoming fields positions in relation to dataset
    * representation. */
@@ -5166,6 +5200,14 @@ public class SqlToRelConverter {
       this.scope = requireNonNull(scope, "scope");
       this.nameToNodeMap = nameToNodeMap;
       this.top = top;
+    }
+
+    private RelAndCorrelationContext convertSubQuery(SqlNode node) {
+      CorrelationContext correlationContext =
+          findCorrelationContext(scope, Util.first(inputs, ImmutableList.of()));
+      RelRoot relRoot = convertQueryRecursive(node, false, null);
+      scopeToCorrelationContext.remove(correlationContext);
+      return new RelAndCorrelationContext(relRoot.rel, correlationContext);
     }
 
     public RelNode root() {
@@ -5418,13 +5460,23 @@ public class SqlToRelConverter {
           return rexBuilder.makeFieldAccess(e, field.getIndex());
         });
       } else {
+        assert ancestorScope != null;
+        final CorrelationId correlId;
+        if (config.isExpand()) {
+          correlId = cluster.createCorrel();
+        } else {
+          CorrelationContext correlScope = Iterables.getOnlyElement(
+              scopeToCorrelationContext.stream()
+                  .filter(cc -> cc.sqlValidatorScope.isWithin(ancestorScope))
+                  .collect(Collectors.toList()));
+          correlId = correlScope.getOrCreateCorrelationId();
+        }
         // We're referencing a relational expression which has not been
         // converted yet. This occurs when from items are correlated,
         // e.g. "select from emp as emp join emp.getDepts() as dept".
         // Create a temporary expression.
         DeferredLookup lookup =
             new DeferredLookup(this, qualified.identifier.names.get(0));
-        final CorrelationId correlId = cluster.createCorrel();
         mapCorrelToDeferred.put(correlId, lookup);
         if (resolve.path.steps().get(0).i < 0) {
           return Pair.of(rexBuilder.makeCorrel(rowType, correlId), null);
@@ -5588,7 +5640,7 @@ public class SqlToRelConverter {
       if (!config.isExpand()) {
         final SqlCall call;
         final SqlNode query;
-        final RelRoot root;
+        final RelAndCorrelationContext root;
         switch (kind) {
         case IN:
         case NOT_IN:
@@ -5597,7 +5649,10 @@ public class SqlToRelConverter {
           call = (SqlCall) expr;
           query = call.operand(1);
           if (!(query instanceof SqlNodeList)) {
-            root = convertQueryRecursive(query, false, null);
+            root = convertSubQuery(query);
+            final RelNode rel = root.rel;
+            final @Nullable CorrelationId correlationId =
+                root.correlationContext.correlationId;
             final SqlNode operand = call.operand(0);
             List<SqlNode> nodes;
             switch (operand.getKind()) {
@@ -5613,89 +5668,73 @@ public class SqlToRelConverter {
               builder.add(convertExpression(node));
             }
             final ImmutableList<RexNode> list = builder.build();
-            RelNode rel = root.rel;
-            // Fix the correlation namespaces and de-duplicate the correlation variables.
-            CorrelationUse correlationUse = getCorrelationUse(this, root.rel);
-            if (correlationUse != null) {
-              rel = correlationUse.r;
-            }
+
 
             switch (kind) {
             case IN:
-              return RexSubQuery.in(rel, list);
+              return RexSubQuery.in(rel, list, correlationId);
             case NOT_IN:
               return rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-                  RexSubQuery.in(rel, list));
+                  RexSubQuery.in(rel, list, correlationId));
             case SOME:
               return RexSubQuery.some(rel, list,
-                  (SqlQuantifyOperator) call.getOperator());
+                  (SqlQuantifyOperator) call.getOperator(), correlationId);
             case ALL:
               return rexBuilder.makeCall(SqlStdOperatorTable.NOT,
                   RexSubQuery.some(rel, list,
-                      negate((SqlQuantifyOperator) call.getOperator())));
+                      negate((SqlQuantifyOperator) call.getOperator()), correlationId));
             default:
               throw new AssertionError(kind);
             }
           }
           break;
 
-        case EXISTS:
+        case EXISTS: {
           call = (SqlCall) expr;
           query = Iterables.getOnlyElement(call.getOperandList());
-          root = convertQueryRecursive(query, false, null);
+          root = convertSubQuery(query);
           RelNode rel = root.rel;
-          // Fix the correlation namespaces and de-duplicate the correlation variables.
-          CorrelationUse correlationUse = getCorrelationUse(this, root.rel);
-          if (correlationUse != null) {
-            rel = correlationUse.r;
-          }
-
+          final @Nullable CorrelationId correlationId =
+              root.correlationContext.correlationId;
           while (rel instanceof Project
               || rel instanceof Sort
               && ((Sort) rel).fetch == null
               && ((Sort) rel).offset == null) {
             rel = ((SingleRel) rel).getInput();
           }
-          return RexSubQuery.exists(rel);
-
-        case UNIQUE:
+          return RexSubQuery.exists(rel, correlationId);
+        }
+        case UNIQUE: {
           call = (SqlCall) expr;
           query = Iterables.getOnlyElement(call.getOperandList());
-          root = convertQueryRecursive(query, false, null);
-          return RexSubQuery.unique(root.rel);
-
+          root = convertSubQuery(query);
+          return RexSubQuery.unique(root.rel, root.correlationContext.correlationId);
+        }
         case SCALAR_QUERY:
           call = (SqlCall) expr;
           query = Iterables.getOnlyElement(call.getOperandList());
-          root = convertQueryRecursive(query, false, null);
-          rel = root.rel;
-          // Fix the correlation namespaces and de-duplicate the correlation variables.
-          correlationUse = getCorrelationUse(this, root.rel);
-          if (correlationUse != null) {
-            rel = correlationUse.r;
-          }
-          return RexSubQuery.scalar(rel);
+          root = convertSubQuery(query);
+          return RexSubQuery.scalar(root.rel, root.correlationContext.correlationId);
 
         case ARRAY_QUERY_CONSTRUCTOR:
           call = (SqlCall) expr;
           query = Iterables.getOnlyElement(call.getOperandList());
           // let top=true to make the query be top-level query,
           // then ORDER BY will be reserved.
-          root = convertQueryRecursive(query, true, null);
-          return RexSubQuery.array(root.rel);
+          root = convertSubQuery(query);
+          return RexSubQuery.array(root.rel, root.correlationContext.correlationId);
 
         case MAP_QUERY_CONSTRUCTOR:
           call = (SqlCall) expr;
           query = Iterables.getOnlyElement(call.getOperandList());
-          root = convertQueryRecursive(query, false, null);
-          return RexSubQuery.map(root.rel);
+          root = convertSubQuery(query);
+          return RexSubQuery.map(root.rel, root.correlationContext.correlationId);
 
         case MULTISET_QUERY_CONSTRUCTOR:
           call = (SqlCall) expr;
           query = Iterables.getOnlyElement(call.getOperandList());
-          root = convertQueryRecursive(query, false, null);
-          return RexSubQuery.multiset(root.rel);
-
+          root = convertSubQuery(query);
+          return RexSubQuery.multiset(root.rel, root.correlationContext.correlationId);
         default:
           break;
         }
@@ -6657,6 +6696,49 @@ public class SqlToRelConverter {
         return measureScope.lookupMeasure(identifier.getSimple());
       }
       return super.lookupMeasure(identifier);
+    }
+  }
+
+  /** Contains the context for resolving correlate variables. */
+  private static class CorrelationContext {
+    private final RelOptCluster cluster;
+    final SqlValidatorScope sqlValidatorScope;
+    final List<RelNode> relNodes;
+    @Nullable CorrelationId correlationId = null;
+
+    CorrelationContext(RelOptCluster cluster, SqlValidatorScope sqlValidatorScope,
+        List<RelNode> relNodes) {
+      this.cluster = cluster;
+      this.sqlValidatorScope = sqlValidatorScope;
+      this.relNodes = relNodes;
+    }
+
+    CorrelationId getOrCreateCorrelationId() {
+      if (null == correlationId) {
+        correlationId = cluster.createCorrel();
+      }
+      return correlationId;
+    }
+
+    Set<CorrelationId> correlationIdSet(RelNode relNode) {
+      if (null != correlationId
+          && RelOptUtil.getVariablesUsed(relNode).contains(correlationId)) {
+        return ImmutableSet.of(correlationId);
+      } else {
+        return ImmutableSet.of();
+      }
+    }
+  }
+
+  /** RelNode and CorrelationContext for parsing a sub query. */
+  private static class RelAndCorrelationContext {
+    final RelNode rel;
+    final CorrelationContext correlationContext;
+
+    private RelAndCorrelationContext(RelNode rel,
+        CorrelationContext correlationContext) {
+      this.rel = rel;
+      this.correlationContext = correlationContext;
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -805,7 +805,14 @@ public class RelBuilder {
   /** Creates an IN predicate with a sub-query. */
   @Experimental
   public RexSubQuery in(RelNode rel, Iterable<? extends RexNode> nodes) {
-    return RexSubQuery.in(rel, ImmutableList.copyOf(nodes));
+    return RexSubQuery.in(rel, ImmutableList.copyOf(nodes), null);
+  }
+
+  /** Creates an IN predicate with a sub-query. */
+  @Experimental
+  public RexSubQuery in(RelNode rel, Iterable<? extends RexNode> nodes,
+      CorrelationId correlationId) {
+    return RexSubQuery.in(rel, ImmutableList.copyOf(nodes), correlationId);
   }
 
   /** Creates an IN predicate with a sub-query.
@@ -833,7 +840,13 @@ public class RelBuilder {
   @Experimental
   public RexNode in(RexNode arg, Function<RelBuilder, RelNode> f) {
     final RelNode rel = f.apply(this);
-    return RexSubQuery.in(rel, ImmutableList.of(arg));
+    return RexSubQuery.in(rel, ImmutableList.of(arg), null);
+  }
+
+  @Experimental
+  public RexNode in(RexNode arg, Function<RelBuilder, RelNode> f, CorrelationId correlationId) {
+    final RelNode rel = f.apply(this);
+    return RexSubQuery.in(rel, ImmutableList.of(arg), correlationId);
   }
 
   /** Creates a SOME (or ANY) predicate.
@@ -870,15 +883,21 @@ public class RelBuilder {
   @Experimental
   public RexSubQuery some(RexNode node, SqlOperator op,
       Function<RelBuilder, RelNode> f) {
-    return some_(node, op.kind, f);
+    return some(node, op, f, null);
+  }
+
+  @Experimental
+  public RexSubQuery some(RexNode node, SqlOperator op,
+      Function<RelBuilder, RelNode> f, CorrelationId correlationId) {
+    return some_(node, op.kind, f, correlationId);
   }
 
   private RexSubQuery some_(RexNode node, SqlKind kind,
-      Function<RelBuilder, RelNode> f) {
+      Function<RelBuilder, RelNode> f, CorrelationId correlationId) {
     final RelNode rel = f.apply(this);
     final SqlQuantifyOperator quantifyOperator =
         SqlStdOperatorTable.some(kind);
-    return RexSubQuery.some(rel, ImmutableList.of(node), quantifyOperator);
+    return RexSubQuery.some(rel, ImmutableList.of(node), quantifyOperator, correlationId);
   }
 
   /** Creates an ALL predicate.
@@ -916,7 +935,13 @@ public class RelBuilder {
   @Experimental
   public RexNode all(RexNode node, SqlOperator op,
       Function<RelBuilder, RelNode> f) {
-    return not(some_(node, op.kind.negateNullSafe(), f));
+    return not(some_(node, op.kind.negateNullSafe(), f, null));
+  }
+
+  @Experimental
+  public RexNode all(RexNode node, SqlOperator op,
+      Function<RelBuilder, RelNode> f, CorrelationId correlationId) {
+    return not(some_(node, op.kind.negateNullSafe(), f, correlationId));
   }
 
   /** Creates an EXISTS predicate.
@@ -943,7 +968,7 @@ public class RelBuilder {
   @Experimental
   public RexSubQuery exists(Function<RelBuilder, RelNode> f) {
     final RelNode rel = f.apply(this);
-    return RexSubQuery.exists(rel);
+    return RexSubQuery.exists(rel, null);
   }
 
   /** Creates a UNIQUE predicate.
@@ -971,7 +996,7 @@ public class RelBuilder {
   @Experimental
   public RexSubQuery unique(Function<RelBuilder, RelNode> f) {
     final RelNode rel = f.apply(this);
-    return RexSubQuery.unique(rel);
+    return RexSubQuery.unique(rel, null);
   }
 
   /** Creates a scalar sub-query.
@@ -997,7 +1022,7 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery scalarQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.scalar(f.apply(this));
+    return RexSubQuery.scalar(f.apply(this), null);
   }
 
   /** Creates an ARRAY sub-query.
@@ -1021,7 +1046,7 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery arrayQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.array(f.apply(this));
+    return RexSubQuery.array(f.apply(this), null);
   }
 
   /** Creates a MULTISET sub-query.
@@ -1045,7 +1070,12 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery multisetQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.multiset(f.apply(this));
+    return RexSubQuery.multiset(f.apply(this), null);
+  }
+
+  @Experimental
+  public RexSubQuery multisetQuery(Function<RelBuilder, RelNode> f, CorrelationId correlationId) {
+    return RexSubQuery.multiset(f.apply(this), null);
   }
 
   /** Creates a MAP sub-query.
@@ -1070,7 +1100,12 @@ public class RelBuilder {
    * }</pre> */
   @Experimental
   public RexSubQuery mapQuery(Function<RelBuilder, RelNode> f) {
-    return RexSubQuery.map(f.apply(this));
+    return RexSubQuery.map(f.apply(this), null);
+  }
+
+  @Experimental
+  public RexSubQuery mapQuery(Function<RelBuilder, RelNode> f, CorrelationId correlationId) {
+    return RexSubQuery.map(f.apply(this), correlationId);
   }
 
   /** Creates an AND. */

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelExVisitor.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelExVisitor.java
@@ -448,6 +448,6 @@ class PigRelExVisitor extends LogicalExpressionVisitor {
     List<RexNode> projectCol = Lists.newArrayList(builder.field(index));
     builder.project(projectCol);
 
-    stack.push(RexSubQuery.scalar(builder.build()));
+    stack.push(RexSubQuery.scalar(builder.build(), null));
   }
 }


### PR DESCRIPTION
Rework RexSubquery to contain the Correlate Id and for the correlate id to be used in subquery expansions.  This fixes bugs with nested correlated subqueries when expand is false.