### PR TITLE
[CALCITE-5493] Time zone tests in SqlFunctions should pass in Europe/London

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -1023,11 +1023,11 @@ class SqlFunctionsTest {
     final java.sql.Date epoch = java.sql.Date.valueOf("1970-01-01");
 
     final TimeZone minusDayZone = TimeZone.getDefault();
-    minusDayZone.setRawOffset((int) (minusDayZone.getOffset(0L) - MILLIS_PER_DAY));
+    minusDayZone.setRawOffset((int) (minusDayZone.getRawOffset() - MILLIS_PER_DAY));
     assertThat(toInt(epoch, minusDayZone), is(-1));
 
     final TimeZone plusDayZone = TimeZone.getDefault();
-    plusDayZone.setRawOffset((int) (plusDayZone.getOffset(0L) + MILLIS_PER_DAY));
+    plusDayZone.setRawOffset((int) (plusDayZone.getRawOffset() + MILLIS_PER_DAY));
     assertThat(toInt(epoch, plusDayZone), is(1));
   }
 


### PR DESCRIPTION
The `SqlFunctionsTest.testToIntWithTimeZone` test fails in the Europe/London time zone. The issue is due to the use of `TimeZone.setRawOffset(int)` which expects the provided value to be the offset from GMT, but the test provides the offset from UTC.

I tested the changes in multiple timezones and they all passed.