### PR TITLE
[CALCITE-5501]: Fix flaky test by using XmlUnit

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -85,7 +85,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
   @AfterAll
   public static void checkActualAndReferenceFiles() {
     if (diffRepos != null) {
-      diffRepos.checkActualAndReferenceFiles();
+      diffRepos.checkActualAndReferenceXMLFiles();
     }
   }
 

--- a/testkit/build.gradle.kts
+++ b/testkit/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     compileOnly("org.immutables:value-annotations")
     implementation("org.incava:java-diff")
     implementation("org.junit.jupiter:junit-jupiter")
+    implementation("org.xmlunit:xmlunit-matchers:2.9.1")
 
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit5"))


### PR DESCRIPTION
To fix [CALCITE-5501](https://issues.apache.org/jira/browse/CALCITE-5501), i propose to use XmlUnit; that is more accurate to compare XML files.