### PR TITLE
[CALCITE-5489] Cannot convert TIMESTAMP literal to class TimeUnit

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -1792,6 +1792,17 @@ SELECT TIMESTAMP_DIFF("2001-02-01 01:00:00", "2001-02-01 00:00:01", HOUR) AS neg
 (1 row)
 
 !ok
+
+# In this example, the time unit is a 'flag' literal.
+SELECT TIMESTAMP_DIFF(TIMESTAMP '2008-12-25', TIMESTAMP '2008-09-25', `quarter`) as diff;
++------+
+| diff |
++------+
+|    1 |
++------+
+(1 row)
+
+!ok
 #####################################################################
 # DATE_TRUNC
 #

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -439,6 +439,9 @@ public enum SqlKind {
   /** {@code TIMESTAMP_DIFF} function (ODBC, SQL Server, MySQL). */
   TIMESTAMP_DIFF,
 
+  /** {@code TIMESTAMP_DIFF} function (BigQuery). */
+  BIG_QUERY_TIMESTAMP_DIFF,
+
   /** {@code TIMESTAMP_SUB} function (BigQuery). */
   TIMESTAMP_SUB,
 
@@ -1210,7 +1213,7 @@ public enum SqlKind {
                   DESCENDING, CUBE, ROLLUP, GROUPING_SETS, EXTEND, LATERAL,
                   SELECT, JOIN, OTHER_FUNCTION, POSITION, CAST, TRIM, FLOOR, CEIL,
                   DATE_SUB, TIME_ADD, TIME_SUB,
-                  TIMESTAMP_ADD, TIMESTAMP_DIFF, TIMESTAMP_SUB,
+                  TIMESTAMP_ADD, TIMESTAMP_DIFF, BIG_QUERY_TIMESTAMP_DIFF, TIMESTAMP_SUB,
                   EXTRACT, INTERVAL,
                   LITERAL_CHAIN, JDBC_FN, PRECEDING, FOLLOWING, ORDER_BY,
                   NULLS_FIRST, NULLS_LAST, COLLECTION_TABLE, TABLESAMPLE,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -107,7 +107,7 @@ public abstract class SqlLibraryOperators {
    * argument. */
   @LibraryOperator(libraries = {MSSQL, POSTGRESQL})
   public static final SqlFunction DATEDIFF =
-      new SqlTimestampDiffFunction("DATEDIFF",
+      new SqlTimestampDiffFunction("DATEDIFF", SqlKind.TIMESTAMP_DIFF,
           OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.DATE,
               SqlTypeFamily.DATE));
 
@@ -718,7 +718,7 @@ public abstract class SqlLibraryOperators {
    * {@code TIMESTAMPDIFF(unit, t2, t1)} and {@code (t1 - t2) unit}. */
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction TIMESTAMP_DIFF3 =
-      new SqlTimestampDiffFunction("TIMESTAMP_DIFF",
+      new SqlTimestampDiffFunction("TIMESTAMP_DIFF", SqlKind.BIG_QUERY_TIMESTAMP_DIFF,
           OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.TIMESTAMP,
               SqlTypeFamily.ANY));
 
@@ -734,7 +734,7 @@ public abstract class SqlLibraryOperators {
    * returns the number of timeUnit between the two time expressions. */
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction TIME_DIFF =
-      new SqlTimestampDiffFunction("TIME_DIFF",
+      new SqlTimestampDiffFunction("TIME_DIFF", SqlKind.BIG_QUERY_TIMESTAMP_DIFF,
           OperandTypes.family(SqlTypeFamily.TIME, SqlTypeFamily.TIME,
               SqlTypeFamily.ANY));
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1902,7 +1902,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
 
   /** The <code>TIMESTAMPDIFF</code> function. */
   public static final SqlFunction TIMESTAMP_DIFF =
-      new SqlTimestampDiffFunction("TIMESTAMPDIFF",
+      new SqlTimestampDiffFunction("TIMESTAMPDIFF", SqlKind.TIMESTAMP_DIFF,
           OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.TIMESTAMP,
               SqlTypeFamily.TIMESTAMP));
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampDiffFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampDiffFunction.java
@@ -63,7 +63,7 @@ class SqlTimestampDiffFunction extends SqlFunction {
     final TimeUnit timeUnit;
     final RelDataType type1;
     final RelDataType type2;
-    if (opBinding.isOperandLiteral(0, true)) {
+    if (SqlTypeName.DATETIME_TYPES.contains(opBinding.getOperandType(0).getSqlTypeName())) {
       type1 = opBinding.getOperandType(0);
       type2 = opBinding.getOperandType(1);
       timeUnit = opBinding.getOperandLiteralValue(2, TimeUnit.class);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampDiffFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampDiffFunction.java
@@ -63,7 +63,9 @@ class SqlTimestampDiffFunction extends SqlFunction {
     final TimeUnit timeUnit;
     final RelDataType type1;
     final RelDataType type2;
-    if (SqlTypeName.DATETIME_TYPES.contains(opBinding.getOperandType(0).getSqlTypeName())) {
+    /* To correctly assign the operands, check the operator to determine whether
+      it is BigQuery TIMESTAMP_DIFF or standard TIMESTAMPDIFF */
+    if (opBinding.getOperator().getKind().name() == "BIG_QUERY_TIMESTAMP_DIFF") {
       type1 = opBinding.getOperandType(0);
       type2 = opBinding.getOperandType(1);
       timeUnit = opBinding.getOperandLiteralValue(2, TimeUnit.class);
@@ -83,8 +85,8 @@ class SqlTimestampDiffFunction extends SqlFunction {
   }
 
   /** Creates a SqlTimestampDiffFunction. */
-  SqlTimestampDiffFunction(String name, SqlOperandTypeChecker operandTypeChecker) {
-    super(name, SqlKind.TIMESTAMP_DIFF,
+  SqlTimestampDiffFunction(String name, SqlKind sqlKind, SqlOperandTypeChecker operandTypeChecker) {
+    super(name, sqlKind,
         SqlTimestampDiffFunction::inferReturnType2, null, operandTypeChecker,
         SqlFunctionCategory.TIMEDATE);
   }

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -1959,7 +1959,9 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       SqlIntervalQualifier qualifier;
       final RexNode op1;
       final RexNode op2;
-      if (call.operand(0).getKind() == SqlKind.INTERVAL_QUALIFIER) {
+    /* To correctly assign the operands, check the operator to determine whether
+      it is BigQuery TIMESTAMP_DIFF or standard TIMESTAMPDIFF */
+      if (call.getOperator().getKind().name() == "TIMESTAMP_DIFF") {
         qualifier = call.operand(0);
         op1 = cx.convertExpression(call.operand(1));
         op2 = cx.convertExpression(call.operand(2));

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -2116,6 +2116,17 @@ select
 
 !ok
 
+# TIMESTAMPDIFF with 'flag' literal as time unit argument
+SELECT TIMESTAMPDIFF("quarter", TIMESTAMP '2008-12-25', TIMESTAMP '2008-09-25');
++--------+
+| EXPR$0 |
++--------+
+|     -1 |
++--------+
+(1 row)
+
+! ok
+
 # ARRAY and MULTISET
 select array[1,2] as a from (values (1));
 +--------+

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -8132,6 +8132,10 @@ public class SqlOperatorTest {
   @Test void testTimestampDiff() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.TIMESTAMP_DIFF, VmName.EXPAND);
+    f.checkScalar("timestampdiff(\"quarter\", "
+        + "timestamp '2016-02-24 12:42:25', "
+        + "timestamp '2016-02-24 15:42:25')",
+        "0", "INTEGER NOT NULL");
     HOUR_VARIANTS.forEach(s ->
         f.checkScalar("timestampdiff(" + s + ", "
                 + "timestamp '2016-02-24 12:42:25', "

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -8132,10 +8132,6 @@ public class SqlOperatorTest {
   @Test void testTimestampDiff() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.TIMESTAMP_DIFF, VmName.EXPAND);
-    f.checkScalar("timestampdiff(\"quarter\", "
-        + "timestamp '2016-02-24 12:42:25', "
-        + "timestamp '2016-02-24 15:42:25')",
-        "0", "INTEGER NOT NULL");
     HOUR_VARIANTS.forEach(s ->
         f.checkScalar("timestampdiff(" + s + ", "
                 + "timestamp '2016-02-24 12:42:25', "


### PR DESCRIPTION
The previous check that differentiated BigQuery's TIMESTAMP_DIFF(time, time2, timeUnit) and the standard TIMESTAMPDIFF(timeUnit, time, time2) checked whether the first argument was a literal or not. This meant that if a "flag" literal was passed in as the time unit for the standard TIMESTAMPDIFF, it would be handled as though it were BigQuery's TIMESTAMP_DIFF. This led to errors such as the one seen in the original JIRA case. The fix avoids this problem by modifying the check to determine whether the first argument is in the DATETIME SqlTypeFamily. BigQuery's TIMESTAMP_DIFF's first argument should always be in this family, while the standard TIMESTAMPDIFF's datetime arguments should always be the second and third operands.