### PR TITLE
[CALCITE-5501] SqlToRelConverterTest.checkActualAndReferenceFiles fai…

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterExtendedTest.java
@@ -28,12 +28,14 @@ import org.apache.calcite.util.TestUtil;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.IOException;
 
 /**
  * Runs {@link org.apache.calcite.test.SqlToRelConverterTest} with extensions.
  */
+@ResourceLock(value = "SqlToRelConverterTest.xml")
 class SqlToRelConverterExtendedTest extends SqlToRelConverterTest {
   Hook.Closeable closeable;
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -56,6 +56,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -73,6 +74,7 @@ import static org.hamcrest.core.Is.isA;
  * Unit test for {@link org.apache.calcite.sql2rel.SqlToRelConverter}.
  * See {@link RelOptRulesTest} for an explanation of how to add tests;
  */
+@ResourceLock(value = "SqlToRelConverterTest.xml")
 class SqlToRelConverterTest extends SqlToRelTestBase {
 
   private static final SqlToRelFixture LOCAL_FIXTURE =


### PR DESCRIPTION
…ls intermittently in Jenkins CI

The PR addresses a race condition over the shared file `SqlToRelConverterTest.xml` by enforcing a lock between `SqlToRelConverterTest` and `SqlToRelConverterExtendedTest` classes.

The tests within the two classes, and with respect to any other test class, remain parallel, so no test runtime drop is expected.