### PR TITLE
[CALCITE-5503] Address issue in CheapestPlanReplacer where repeated nodes in a DAG are not reused.

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -51,6 +51,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -605,6 +606,7 @@ public class RelSubset extends AbstractRelNode {
    */
   static class CheapestPlanReplacer {
     VolcanoPlanner planner;
+    final Map<Integer, RelNode> visited = new HashMap<>();
 
     CheapestPlanReplacer(VolcanoPlanner planner) {
       super();
@@ -623,6 +625,13 @@ public class RelSubset extends AbstractRelNode {
         RelNode p,
         int ordinal,
         @Nullable RelNode parent) {
+      final int pId = p.getId();
+      RelNode prevVisit = visited.get(pId);
+      if (prevVisit != null) {
+        // return memoized result of previous visit if available
+        return prevVisit;
+      }
+
       if (p instanceof RelSubset) {
         RelSubset subset = (RelSubset) p;
         RelNode cheapest = subset.best;
@@ -737,6 +746,7 @@ public class RelSubset extends AbstractRelNode {
         planner.provenanceMap.put(
             p, new VolcanoPlanner.DirectProvenance(pOld));
       }
+      visited.put(pId, p); // memoize result for pId
       return p;
     }
   }


### PR DESCRIPTION
When using `CheapestPlanReplacer`, semantics of a `RelNode` tree change if it contains the same node multiple times in case this node has inputs itself that have to be replaced. During replacement such nodes get copied on each occurrence.

Instead `CheapestPlanReplacer` should memoize previously visited nodes and emit the same result again in the that case.