### PR TITLE
[CALCITE-5510] Support sort by ordinal when sort by column is an expression in RelToSqlConverter

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1122,7 +1122,7 @@ public abstract class SqlImplementor {
         final boolean first =
             field.nullDirection == RelFieldCollation.NullDirection.FIRST;
         SqlNode nullDirectionNode =
-            dialect.emulateNullDirection(orderField(field.getFieldIndex()),
+            dialect.emulateNullDirection(field(field.getFieldIndex()),
                 first, field.direction.isDescending());
         if (nullDirectionNode != null) {
           orderByList.add(nullDirectionNode);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1854,11 +1854,12 @@ public abstract class SqlImplementor {
           return false;
         }
         for (SqlNode sqlNode : orderList) {
-          if (sqlNode instanceof SqlBasicCall) {
-            for (SqlNode operand : ((SqlBasicCall) sqlNode).getOperandList()) {
-              if (operand instanceof SqlNumericLiteral) {
-                return true;
-              }
+          if (!(sqlNode instanceof SqlBasicCall)) {
+            return false;
+          }
+          for (SqlNode operand : ((SqlBasicCall) sqlNode).getOperandList()) {
+            if (operand instanceof SqlNumericLiteral) {
+              return true;
             }
           }
         }

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -615,6 +615,13 @@ public abstract class SqlImplementor {
         final String strValue = ((SqlNumericLiteral) node).toValue();
         return SqlLiteral.createCharString(strValue, node.getParserPosition());
       }
+      if (node instanceof SqlCall
+          && dialect.getConformance().isSortByOrdinal()) {
+        // If the filed is expression and sort by ordinal is set in dialect,
+        // convert it to ordinal.
+        return SqlLiteral.createExactNumeric(
+            Integer.toString(ordinal + 1), SqlParserPos.ZERO);
+      }
       return node;
     }
 
@@ -1115,7 +1122,7 @@ public abstract class SqlImplementor {
         final boolean first =
             field.nullDirection == RelFieldCollation.NullDirection.FIRST;
         SqlNode nullDirectionNode =
-            dialect.emulateNullDirection(field(field.getFieldIndex()),
+            dialect.emulateNullDirection(orderField(field.getFieldIndex()),
                 first, field.direction.isDescending());
         if (nullDirectionNode != null) {
           orderByList.add(nullDirectionNode);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -617,7 +617,7 @@ public abstract class SqlImplementor {
       }
       if (node instanceof SqlCall
           && dialect.getConformance().isSortByOrdinal()) {
-        // If the filed is expression and sort by ordinal is set in dialect,
+        // If the field is expression and sort by ordinal is set in dialect,
         // convert it to ordinal.
         return SqlLiteral.createExactNumeric(
             Integer.toString(ordinal + 1), SqlParserPos.ZERO);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1762,7 +1762,7 @@ class RelToSqlConverterTest {
    * RelToSqlConverter don't support sort by ordinal when sort by column is an expression</a>.
    */
   @Test void testOrderByOrdinalWithExpression() {
-    String query = "select \"product_id\", count(*) as \"c\"\n"
+    final String query = "select \"product_id\", count(*) as \"c\"\n"
         + "from \"product\"\n"
         + "group by \"product_id\"\n"
         + "order by 2";

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -765,12 +765,12 @@ class RelToSqlConverterTest {
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY `product_class_id` WITH ROLLUP\n"
         + "ORDER BY `product_class_id` IS NULL, `product_class_id`,"
-        + " 2 IS NULL, 2";
+        + " COUNT(*) IS NULL, 2";
     final String expectedPresto = "SELECT \"product_class_id\", COUNT(*) AS \"C\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\")\n"
         + "ORDER BY \"product_class_id\" IS NULL, \"product_class_id\", "
-        + "2 IS NULL, 2";
+        + "COUNT(*) IS NULL, 2";
     sql(query)
         .ok(expected)
         .withMysql().ok(expectedMysql)
@@ -817,7 +817,7 @@ class RelToSqlConverterTest {
         + "GROUP BY `product_class_id`, `brand_name` WITH ROLLUP\n"
         + "ORDER BY `product_class_id` IS NULL, `product_class_id`,"
         + " `brand_name` IS NULL, `brand_name`,"
-        + " 3 IS NULL, 3";
+        + " COUNT(*) IS NULL, 3";
     sql(query)
         .ok(expected)
         .withMysql().ok(expectedMysql);
@@ -1777,7 +1777,7 @@ class RelToSqlConverterTest {
     final String prestoExpected = "SELECT \"product_id\", COUNT(*) AS \"c\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY \"product_id\"\n"
-        + "ORDER BY 2 IS NULL, 2";
+        + "ORDER BY COUNT(*) IS NULL, 2";
     sql(query)
         .ok(ordinalExpected)
         .dialect(nonOrdinalDialect())
@@ -1815,7 +1815,7 @@ class RelToSqlConverterTest {
     final String expectedMysql = "SELECT `net_weight` AS `product_id`,"
         + " `product_id` AS `product_id0`\n"
         + "FROM `foodmart`.`product`\n"
-        + "ORDER BY 2 IS NULL, 2";
+        + "ORDER BY `product_id` IS NULL, 2";
     sql(query).ok(expected)
         .withMysql().ok(expectedMysql);
   }
@@ -6710,7 +6710,7 @@ class RelToSqlConverterTest {
         + "FROM SCOTT.EMP\n"
         + "GROUP BY DEPTNO\n"
         + "HAVING COUNT(DISTINCT EMPNO) > 0\n"
-        + "ORDER BY 2 IS NULL DESC, 2 DESC";
+        + "ORDER BY COUNT(DISTINCT EMPNO) IS NULL DESC, 2 DESC";
 
     // Convert rel node to SQL with BigQuery dialect,
     // in which "isHavingAlias" is true.

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -1362,7 +1362,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "BIGINT) AS $f1, CAST(SUM(SAL) AS DECIMAL(19, 0)) AS salSum\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 3";
     pig(script).assertResult(is(result))
         .assertSql(is(sql));
   }
@@ -1480,7 +1480,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "(19, 0)) AS salAvg\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 3";
     pig(script).assertRel(hasTree(plan))
         .assertOptimizedRel(hasTree(optimizedPlan))
         .assertResult(is(result))
@@ -1501,7 +1501,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "AS A\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 3";
     pig(script2).assertSql(is(sql2));
 
     final String script3 = ""
@@ -1551,7 +1551,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "COLLECT(COMM) AS comArray, CAST(SUM(SAL) AS DECIMAL(19, 0)) AS salSum\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
+        + "ORDER BY 7";
     pig(script).assertRel(hasTree(plan))
         .assertOptimizedRel(hasTree(optimizedPlan))
         .assertSql(is(sql));
@@ -1610,7 +1610,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "    FROM scott.DEPT\n"
         + "    WHERE DEPTNO >= 20\n"
         + "    GROUP BY CAST(DEPTNO AS INTEGER)) AS t7 ON t4.DEPTNO = t7.DEPTNO\n"
-        + "ORDER BY CASE WHEN t4.DEPTNO IS NOT NULL THEN t4.DEPTNO ELSE t7.DEPTNO END";
+        + "ORDER BY 1";
     pig(script).assertRel(hasTree(plan))
         .assertResult(is(result))
         .assertSql(is(sql));


### PR DESCRIPTION
Keep the output sort by column to ordinary when sort by ordinal in dialect is true and the column is an expression.