### PR TITLE
[CALCITE-5514] Add a public RelJson#toRex() instance method

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -637,6 +637,20 @@ public class RelJson {
     return map;
   }
 
+  /**
+   * Translates a JSON expression into a RexNode,
+   * using a given {@link InputTranslator} to transform JSON objects that
+   * represent input references into RexNodes.
+   *
+   * @param cluster The optimization environment
+   * @param o JSON object
+   * @return the transformed RexNode
+   */
+  public @PolyNull RexNode toRex(RelOptCluster cluster, @PolyNull Object o) {
+    RelInput input = new RelInputForCluster(cluster);
+    return toRex(input, o);
+  }
+
   @SuppressWarnings({"rawtypes", "unchecked"})
   @PolyNull RexNode toRex(RelInput relInput, @PolyNull Object o) {
     final RelOptCluster cluster = relInput.getCluster();
@@ -857,7 +871,10 @@ public class RelJson {
    * @param translator Input translator
    * @param o JSON object
    * @return the transformed RexNode
+   *
+   * @deprecated Use {@link #toRex(RelOptCluster, Object)}
    */
+  @Deprecated // to be removed before 2.0
   public static RexNode readExpression(RelOptCluster cluster,
       InputTranslator translator, Map<String, Object> o) {
     RelInput relInput = new RelInputForCluster(cluster);

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -779,7 +779,7 @@ class RelWriterTest {
       throw TestUtil.rethrow(e);
     }
     RexNode e =
-        RelJson.readExpression(cluster, RelWriterTest::translateInput, o);
+        RelJson.create().withInputTranslator(RelWriterTest::translateInput).toRex(cluster, o);
     assertThat(e.toString(), is(matcher));
   }
 


### PR DESCRIPTION
Follow up to [CALCITE-5349](https://issues.apache.org/jira/browse/CALCITE-5349) so it is easier to deserialize JSON with a customized `RelJson` instance.