### PR TITLE
适应presto分页功能

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -976,8 +976,14 @@ public class SqlDialect {
   protected static void unparseFetchUsingLimit(SqlWriter writer, @Nullable SqlNode offset,
       @Nullable SqlNode fetch) {
     Preconditions.checkArgument(fetch != null || offset != null);
-    unparseLimit(writer, fetch);
-    unparseOffset(writer, offset);
+    if (writer.getDialect().getDatabaseProduct() == DatabaseProduct.PRESTO){
+      unparseOffset(writer, offset);
+      unparseLimit(writer, fetch);
+    }else {
+      unparseLimit(writer, fetch);
+      unparseOffset(writer, offset);
+    }
+  }
   }
 
   protected static void unparseLimit(SqlWriter writer, @Nullable SqlNode fetch) {


### PR DESCRIPTION
presto分页语句为:
SELECT  * FROM   db1.tb1 offset 100 limit 20;
原版本默认先拼limit再拼offset，不符合presto语法

 