### PR TITLE
[CALCITE-5521] Remove redundant rowtype double checks in RelSubset#add

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -387,7 +387,9 @@ public abstract class RelOptUtil {
         + "set type is " + expectedRowType.getFullTypeString()
         + "\nexpression type is " + actualRowType.getFullTypeString()
         + "\nset is " + equivalenceClass.toString()
-        + "\nexpression is " + RelOptUtil.toString(newRel);
+        + "\nexpression is " + RelOptUtil.toString(newRel)
+        + getFullTypeDifferenceString("rowtype of original rel", expectedRowType,
+        "rowtype of new rel", actualRowType);
     throw new AssertionError(s);
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -33,7 +33,6 @@ import org.apache.calcite.rel.externalize.RelWriterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlExplainLevel;
-import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.trace.CalciteTrace;
@@ -364,12 +363,6 @@ public class RelSubset extends AbstractRelNode {
       planner.getListener().relEquivalenceFound(event);
     }
 
-    // If this isn't the first rel in the set, it must have compatible
-    // row type.
-    if (set.rel != null) {
-      RelOptUtil.equal("rowtype of new rel", rel.getRowType(),
-          "rowtype of set", getRowType(), Litmus.THROW);
-    }
     set.addInternal(rel);
     if (false) {
       Set<CorrelationId> variablesSet = RelOptUtil.getVariablesSet(rel);

--- a/core/src/test/java/org/apache/calcite/plan/volcano/RelSetTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/RelSetTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.plan.volcano;
+
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.Util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit test for {@link RelSet}.
+ */
+public class RelSetTest {
+
+  /**
+   * Tests for adding RelNode with same RelDataType.
+   */
+  @Test void testAddRelNodeWithSameRowType() {
+    RelBuilder builder = createRelBuilder();
+    RelNode relNodeA = builder.scan("myTable")
+        .project(builder.field("a")).build();
+    RelNode relNodeE = builder.scan("myTable")
+        .project(builder.field("e")).build();
+    RelSet relSet = new RelSet(1, Util.minus(
+        RelOptUtil.getVariablesSet(relNodeA), relNodeA.getVariablesSet()),
+        RelOptUtil.getVariablesUsed(relNodeA));
+    relSet.add(relNodeA);
+    relSet.add(relNodeE);
+  }
+
+  /**
+   * Tests for adding RelNode with different RelDataType.
+   */
+  @Test void testAddRelNodeWithDifferentRowType() {
+    RelBuilder builder = createRelBuilder();
+    RelNode relNodeA = builder.scan("myTable")
+        .project(builder.field("a")).build();
+    RelNode relNodeN = builder.scan("myTable")
+        .project(builder.field("n1")).build();
+    RelSet relSet = new RelSet(1, Util.minus(
+        RelOptUtil.getVariablesSet(relNodeA), relNodeA.getVariablesSet()),
+        RelOptUtil.getVariablesUsed(relNodeA));
+    relSet.add(relNodeA);
+    assertThrows(AssertionError.class, () -> relSet.add(relNodeN));
+  }
+
+  private RelBuilder createRelBuilder() {
+    SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    SchemaPlus defaultSchema = CalciteAssert.addSchema(rootSchema, CalciteAssert.SchemaSpec.MY_DB);
+    FrameworkConfig config = Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(defaultSchema)
+        .build();
+    return RelBuilder.create(config);
+  }
+}

--- a/core/src/test/java/org/apache/calcite/plan/volcano/RelSetTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/RelSetTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.calcite.plan.volcano;
 
 import org.apache.calcite.plan.RelOptUtil;

--- a/core/src/test/java/org/apache/calcite/plan/volcano/RelSetTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/RelSetTest.java
@@ -45,8 +45,11 @@ public class RelSetTest {
         .project(builder.field("a")).build();
     RelNode relNodeE = builder.scan("myTable")
         .project(builder.field("e")).build();
-    RelSet relSet = new RelSet(1, Util.minus(
-        RelOptUtil.getVariablesSet(relNodeA), relNodeA.getVariablesSet()),
+    RelSet relSet = new RelSet(
+        1,
+        Util.minus(
+            RelOptUtil.getVariablesSet(relNodeA),
+            relNodeA.getVariablesSet()),
         RelOptUtil.getVariablesUsed(relNodeA));
     relSet.add(relNodeA);
     relSet.add(relNodeE);
@@ -61,8 +64,11 @@ public class RelSetTest {
         .project(builder.field("a")).build();
     RelNode relNodeN = builder.scan("myTable")
         .project(builder.field("n1")).build();
-    RelSet relSet = new RelSet(1, Util.minus(
-        RelOptUtil.getVariablesSet(relNodeA), relNodeA.getVariablesSet()),
+    RelSet relSet = new RelSet(
+        1,
+        Util.minus(
+            RelOptUtil.getVariablesSet(relNodeA),
+            relNodeA.getVariablesSet()),
         RelOptUtil.getVariablesUsed(relNodeA));
     relSet.add(relNodeA);
     assertThrows(AssertionError.class, () -> relSet.add(relNodeN));


### PR DESCRIPTION
jira: [CALCITE-5521](https://issues.apache.org/jira/browse/CALCITE-5521)
Double checking relset rowtype and input parameter relNode rowtype may be unnecessary, removing it might make VolcanoPlanner run slightly faster