### PR TITLE
[CALCITE-3870] Change the default value of SqlToRelConverter.Config.expand from true to false

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -583,6 +583,7 @@ allprojects {
                     // (?-m) disables multiline, so $ matches the very end of the file rather than end of line
                     replaceRegex("Remove '// End file.java' trailer", "(?-m)\n// End [^\n]+\\.\\w+\\s*$", "")
                     replaceRegex("<p> should not be placed a the end of the line", "(?-m)\\s*+<p> *+\n \\* ", "\n *\n * <p>")
+                    replaceRegex("Method parameter list should not end in whitespace or newline", "(?<!;)\\s+\\) \\{", ") {")
                     // Assume developer copy-pasted the link, and updated text only, so the url is old, and we replace it with the proper one
                     replaceRegex(">[CALCITE-...] link styles: 1", "<a(?:(?!CALCITE-)[^>])++CALCITE-\\d+[^>]++>\\s*+\\[?(CALCITE-\\d+)\\]?", "<a href=\"https://issues.apache.org/jira/browse/\$1\">[\$1]")
                     // If the link was crafted manually, ensure it has [CALCITE-...] in the link text

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -171,8 +171,7 @@ public class RelSubset extends AbstractRelNode {
   private void computeBestCost(
       @UnderInitialization RelSubset this,
       RelOptCluster cluster,
-      RelOptPlanner planner
-  ) {
+      RelOptPlanner planner) {
     bestCost = planner.getCostFactory().makeInfiniteCost();
     final RelMetadataQuery mq = cluster.getMetadataQuery();
     @SuppressWarnings("method.invocation.invalid")

--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -235,7 +235,7 @@ public abstract class Prepare {
     final SqlToRelConverter.Config config =
         SqlToRelConverter.config()
             .withTrimUnusedFields(true)
-            .withExpand(castNonNull(THREAD_EXPAND.get()))
+            .withExpand(THREAD_EXPAND.get())
             .withInSubQueryThreshold(castNonNull(THREAD_INSUBQUERY_THRESHOLD.get()))
             .withExplain(sqlQuery.getKind() == SqlKind.EXPLAIN);
     final Holder<SqlToRelConverter.Config> configHolder = Holder.of(config);
@@ -374,7 +374,7 @@ public abstract class Prepare {
   protected RelRoot trimUnusedFields(RelRoot root) {
     final SqlToRelConverter.Config config = SqlToRelConverter.config()
         .withTrimUnusedFields(shouldTrim(root.rel))
-        .withExpand(castNonNull(THREAD_EXPAND.get()))
+        .withExpand(THREAD_EXPAND.get())
         .withInSubQueryThreshold(castNonNull(THREAD_INSUBQUERY_THRESHOLD.get()));
     final SqlToRelConverter converter =
         getSqlToRelConverter(getSqlValidator(), catalogReader, config);

--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -100,7 +100,7 @@ public abstract class Prepare {
   protected @MonotonicNonNull RelDataType parameterRowType;
 
   // temporary. for testing.
-  public static final TryThreadLocal<@Nullable Boolean> THREAD_TRIM =
+  public static final TryThreadLocal<Boolean> THREAD_TRIM =
       TryThreadLocal.of(false);
 
   /** Temporary, until
@@ -110,7 +110,7 @@ public abstract class Prepare {
    * <p>The default is false, meaning do not expand queries during sql-to-rel,
    * but a few tests override and set it to true. After CALCITE-1045
    * is fixed, remove those overrides and use false everywhere. */
-  public static final TryThreadLocal<@Nullable Boolean> THREAD_EXPAND =
+  public static final TryThreadLocal<Boolean> THREAD_EXPAND =
       TryThreadLocal.of(false);
 
   // temporary. for testing.
@@ -119,8 +119,7 @@ public abstract class Prepare {
 
   protected Prepare(CalcitePrepare.Context context, CatalogReader catalogReader,
       Convention resultConvention) {
-    assert context != null;
-    this.context = context;
+    this.context = requireNonNull(context, "context");
     this.catalogReader = catalogReader;
     this.resultConvention = resultConvention;
   }

--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -126,8 +126,7 @@ public abstract class AbstractRelNode implements RelNode {
 
   @Pure
   @Override public final @Nullable Convention getConvention(
-      @UnknownInitialization AbstractRelNode this
-  ) {
+      @UnknownInitialization AbstractRelNode this) {
     return traitSet == null ? null : traitSet.getTrait(ConventionTraitDef.INSTANCE);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -308,8 +308,7 @@ public abstract class RelDataTypeImpl
    */
   @SuppressWarnings("method.invocation.invalid")
   protected void computeDigest(
-      @UnknownInitialization RelDataTypeImpl this
-  ) {
+      @UnknownInitialization RelDataTypeImpl this) {
     StringBuilder sb = new StringBuilder();
     generateTypeString(sb, true);
     if (!isNullable()) {

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -298,8 +298,7 @@ public class RexLiteral extends RexNode {
    */
   @RequiresNonNull("type")
   RexDigestIncludeType digestIncludesType(
-      @UnknownInitialization RexLiteral this
-  ) {
+      @UnknownInitialization RexLiteral this) {
     return shouldIncludeType(value, type);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -6562,10 +6562,10 @@ public class SqlToRelConverter {
     Config withExplain(boolean explain);
 
     /** Returns the {@code expand} option. Controls whether to expand
-     * sub-queries. If false, each sub-query becomes a
+     * sub-queries. If false (the default), each sub-query becomes a
      * {@link org.apache.calcite.rex.RexSubQuery}. */
     @Value.Default default boolean isExpand() {
-      return true;
+      return false;
     }
 
     /** Sets {@link #isExpand()}. */

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -6563,12 +6563,18 @@ public class SqlToRelConverter {
 
     /** Returns the {@code expand} option. Controls whether to expand
      * sub-queries. If false (the default), each sub-query becomes a
-     * {@link org.apache.calcite.rex.RexSubQuery}. */
+     * {@link org.apache.calcite.rex.RexSubQuery}.
+     *
+     * <p>Setting {@code expand} to true is deprecated. Expansion still works,
+     * but there will be less development effort in that area. */
     @Value.Default default boolean isExpand() {
       return false;
     }
 
-    /** Sets {@link #isExpand()}. */
+    /** Sets {@link #isExpand()}.
+     *
+     * <p>Expansion is deprecated. We recommend that you do not call this
+     * method, and use the default value of {@link #isExpand()}, false. */
     Config withExpand(boolean expand);
 
     /** Returns the {@code inSubQueryThreshold} option,

--- a/core/src/main/java/org/apache/calcite/util/ImmutableBitSet.java
+++ b/core/src/main/java/org/apache/calcite/util/ImmutableBitSet.java
@@ -498,7 +498,7 @@ public class ImmutableBitSet
    * that occurs on or after the specified starting index. If no such
    * bit exists then {@code -1} is returned.
    *
-   * <p>Based upon {@link BitSet#nextSetBit}.
+   * <p>Based upon {@link BitSet#nextSetBit(int)}.
    *
    * @param  fromIndex the index to start checking from (inclusive)
    * @return the index of the next set bit, or {@code -1} if there
@@ -972,8 +972,7 @@ public class ImmutableBitSet
     @RequiresNonNull("equivalence")
     private ImmutableBitSet computeClosure(
         @UnderInitialization Closure this,
-        int pos
-    ) {
+        int pos) {
       ImmutableBitSet o = closure.get(pos);
       if (o != null) {
         return o;

--- a/core/src/main/java/org/apache/calcite/util/TryThreadLocal.java
+++ b/core/src/main/java/org/apache/calcite/util/TryThreadLocal.java
@@ -20,12 +20,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.function.Supplier;
 
+import static org.apache.calcite.linq4j.Nullness.castNonNull;
+
 /**
  * Thread-local variable that returns a handle that can be closed.
  *
  * @param <T> Value type
  */
-public class TryThreadLocal<@Nullable T> extends ThreadLocal<T> {
+public class TryThreadLocal<T> extends ThreadLocal<@Nullable T> {
   private final T initialValue;
 
   /** Creates a TryThreadLocal.
@@ -46,6 +48,10 @@ public class TryThreadLocal<@Nullable T> extends ThreadLocal<T> {
   // equal to the initial value.
   @Override protected final T initialValue() {
     return initialValue;
+  }
+
+  @Override public T get() {
+    return castNonNull(super.get());
   }
 
   /** Assigns the value as {@code value} for the current thread.

--- a/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
+++ b/core/src/main/java/org/apache/calcite/util/mapping/Mappings.java
@@ -1348,8 +1348,7 @@ public abstract class Mappings {
       }
 
       private void advance(
-          @UnknownInitialization MappingItr this
-      ) {
+          @UnknownInitialization MappingItr this) {
         do {
           ++i;
         } while (i < targets.length && targets[i] == -1);

--- a/core/src/test/java/org/apache/calcite/plan/volcano/MultipleTraitConversionTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/MultipleTraitConversionTest.java
@@ -168,8 +168,7 @@ public class MultipleTraitConversionTest {
         RelOptPlanner planner,
         RelNode rel,
         CustomTrait toTrait,
-        boolean allowInfiniteCostConverters
-    ) {
+        boolean allowInfiniteCostConverters) {
       return new CustomTraitEnforcer(
           rel.getCluster(),
           rel.getTraitSet().replace(toTrait),

--- a/core/src/test/java/org/apache/calcite/test/CoreQuidemTest.java
+++ b/core/src/test/java/org/apache/calcite/test/CoreQuidemTest.java
@@ -17,8 +17,6 @@
 package org.apache.calcite.test;
 
 import org.apache.calcite.config.CalciteConnectionProperty;
-import org.apache.calcite.prepare.Prepare;
-import org.apache.calcite.util.TryThreadLocal;
 
 import net.hydromatic.quidem.Quidem;
 
@@ -81,26 +79,6 @@ class CoreQuidemTest extends QuidemTest {
       // Oracle as the JDBC data source.
       return;
     }
-    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
-      checkRun(path);
-    }
+    checkRun(path);
   }
-
-  /** Override settings for "sql/scalar.iq". */
-  public void testSqlScalar(String path) throws Exception {
-    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
-      checkRun(path);
-    }
-  }
-
-  /** Runs the dummy script "sql/dummy.iq", which is checked in empty but
-   * which you may use as scratch space during development. */
-
-  // Do not disable this test; just remember not to commit changes to dummy.iq
-  public void testSqlDummy(String path) throws Exception {
-    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
-      checkRun(path);
-    }
-  }
-
 }

--- a/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/InterpreterTest.java
@@ -40,6 +40,7 @@ import org.apache.calcite.schema.impl.TableFunctionImpl;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
@@ -62,6 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -108,27 +110,36 @@ class InterpreterTest {
     private final String sql;
     private final SchemaPlus rootSchema;
     private final boolean project;
-    private final Function<RelBuilder, RelNode> relFn;
+    private final @Nullable Function<RelBuilder, RelNode> relFn;
+    private final UnaryOperator<SqlToRelConverter.Config> sqlToRelTransform;
 
     Sql(String sql, SchemaPlus rootSchema, boolean project,
-        @Nullable Function<RelBuilder, RelNode> relFn) {
+        @Nullable Function<RelBuilder, RelNode> relFn,
+        UnaryOperator<SqlToRelConverter.Config> sqlToRelTransform) {
       this.sql = sql;
       this.rootSchema = rootSchema;
       this.project = project;
       this.relFn = relFn;
+      this.sqlToRelTransform = sqlToRelTransform;
     }
 
     Sql withSql(String sql) {
-      return new Sql(sql, rootSchema, project, relFn);
+      return new Sql(sql, rootSchema, project, relFn, sqlToRelTransform);
     }
 
     @SuppressWarnings("SameParameterValue")
     Sql withProject(boolean project) {
-      return new Sql(sql, rootSchema, project, relFn);
+      return new Sql(sql, rootSchema, project, relFn, sqlToRelTransform);
     }
 
     Sql withRel(Function<RelBuilder, RelNode> relFn) {
-      return new Sql(sql, rootSchema, project, relFn);
+      return new Sql(sql, rootSchema, project, relFn, sqlToRelTransform);
+    }
+
+    Sql withSqlToRel(UnaryOperator<SqlToRelConverter.Config> transform) {
+      final UnaryOperator<SqlToRelConverter.Config> newTransform = c ->
+          transform.apply(this.sqlToRelTransform.apply(c));
+      return new Sql(sql, rootSchema, project, relFn, newTransform);
     }
 
     /** Interprets the sql and checks result with specified rows, ordered. */
@@ -146,6 +157,8 @@ class InterpreterTest {
     private Planner createPlanner() {
       final FrameworkConfig config = Frameworks.newConfigBuilder()
           .parserConfig(SqlParser.Config.DEFAULT)
+          .sqlToRelConverterConfig(
+              sqlToRelTransform.apply(SqlToRelConverter.config()))
           .defaultSchema(
               CalciteAssert.addSchema(rootSchema,
                   CalciteAssert.SchemaSpec.JDBC_SCOTT,
@@ -190,7 +203,7 @@ class InterpreterTest {
 
   /** Creates a {@link Sql}. */
   private Sql fixture() {
-    return new Sql("?", rootSchema, false, null);
+    return new Sql("?", rootSchema, false, null, UnaryOperator.identity());
   }
 
   private Sql sql(String sql) {
@@ -496,14 +509,16 @@ class InterpreterTest {
     final String sql = "select x, y from (values (1, 'a'), (2, 'b'), (3, 'c')) as t(x, y)\n"
         + "where x in\n"
         + "(select x from (values (1, 'd'), (3, 'g')) as t2(x, y))";
-    sql(sql).returnsRows("[1, a]", "[3, c]");
+    sql(sql).withSqlToRel(c -> c.withExpand(true))
+        .returnsRows("[1, a]", "[3, c]");
   }
 
   @Test void testInterpretSemiJoin() {
     final String sql = "select x, y from (values (1, 'a'), (2, 'b'), (3, 'c')) as t(x, y)\n"
         + "where x in\n"
         + "(select x from (values (1, 'd'), (3, 'g')) as t2(x, y))";
-    try (Planner planner = sql(sql).createPlanner()) {
+    try (Planner planner =
+             sql(sql).withSqlToRel(c -> c.withExpand(true)).createPlanner()) {
       SqlNode validate = planner.validate(planner.parse(sql));
       RelNode convert = planner.rel(validate).rel;
       final HepProgram program = new HepProgramBuilder()
@@ -526,7 +541,8 @@ class InterpreterTest {
     final String sql = "select x, y from (values (1, 'a'), (2, 'b'), (3, 'c')) as t(x, y)\n"
         + "where x not in\n"
         + "(select x from (values (1, 'd')) as t2(x, y))";
-    sql(sql).returnsRows("[2, b]", "[3, c]");
+    sql(sql).withSqlToRel(c -> c.withExpand(true))
+        .returnsRows("[2, b]", "[3, c]");
   }
 
   @Test void testInterpretFullJoin() {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -8157,7 +8157,7 @@ public class JdbcTest {
 
   /** Factory for EMP and DEPT tables. */
   public static class EmpDeptTableFactory implements TableFactory<Table> {
-    public static final TryThreadLocal<List<Employee>> THREAD_COLLECTION =
+    public static final TryThreadLocal<@Nullable List<Employee>> THREAD_COLLECTION =
         TryThreadLocal.of(null);
 
     public Table create(
@@ -8253,7 +8253,7 @@ public class JdbcTest {
 
   /** Mock driver that a given {@link Handler}. */
   public static class HandlerDriver extends org.apache.calcite.jdbc.Driver {
-    private static final TryThreadLocal<Handler> HANDLERS =
+    private static final TryThreadLocal<@Nullable Handler> HANDLERS =
         TryThreadLocal.of(null);
 
     public HandlerDriver() {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -5072,19 +5072,17 @@ public class JdbcTest {
   /** Tests a correlated scalar sub-query in the SELECT clause.
    *
    * <p>Note that there should be an extra row "empid=200; deptno=20;
-   * DNAME=null" but left join doesn't work.</p> */
+   * DNAME=null" but left join doesn't work. */
   @Test void testScalarSubQuery() {
-    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
-      CalciteAssert.hr()
-          .query("select \"empid\", \"deptno\",\n"
-              + " (select \"name\" from \"hr\".\"depts\"\n"
-              + "  where \"deptno\" = e.\"deptno\") as dname\n"
-              + "from \"hr\".\"emps\" as e")
-          .returnsUnordered("empid=100; deptno=10; DNAME=Sales",
-              "empid=110; deptno=10; DNAME=Sales",
-              "empid=150; deptno=10; DNAME=Sales",
-              "empid=200; deptno=20; DNAME=null");
-    }
+    CalciteAssert.hr()
+        .query("select \"empid\", \"deptno\",\n"
+            + " (select \"name\" from \"hr\".\"depts\"\n"
+            + "  where \"deptno\" = e.\"deptno\") as dname\n"
+            + "from \"hr\".\"emps\" as e")
+        .returnsUnordered("empid=100; deptno=10; DNAME=Sales",
+            "empid=110; deptno=10; DNAME=Sales",
+            "empid=150; deptno=10; DNAME=Sales",
+            "empid=200; deptno=20; DNAME=null");
   }
 
   /** Test case for
@@ -5251,21 +5249,19 @@ public class JdbcTest {
   }
 
   @Test void testScalarSubQueryInCase() {
-    try (TryThreadLocal.Memo ignored = Prepare.THREAD_EXPAND.push(true)) {
-      CalciteAssert.hr()
-          .query("select e.\"name\",\n"
-              + " (CASE e.\"deptno\"\n"
-              + "  WHEN (Select \"deptno\" from \"hr\".\"depts\" d\n"
-              + "        where d.\"deptno\" = e.\"deptno\")\n"
-              + "  THEN (Select d.\"name\" from \"hr\".\"depts\" d\n"
-              + "        where d.\"deptno\" = e.\"deptno\")\n"
-              + "  ELSE 'DepartmentNotFound'  END) AS DEPTNAME\n"
-              + "from \"hr\".\"emps\" e")
-          .returnsUnordered("name=Bill; DEPTNAME=Sales",
-              "name=Eric; DEPTNAME=DepartmentNotFound",
-              "name=Sebastian; DEPTNAME=Sales",
-              "name=Theodore; DEPTNAME=Sales");
-    }
+    CalciteAssert.hr()
+        .query("select e.\"name\",\n"
+            + " (CASE e.\"deptno\"\n"
+            + "  WHEN (Select \"deptno\" from \"hr\".\"depts\" d\n"
+            + "        where d.\"deptno\" = e.\"deptno\")\n"
+            + "  THEN (Select d.\"name\" from \"hr\".\"depts\" d\n"
+            + "        where d.\"deptno\" = e.\"deptno\")\n"
+            + "  ELSE 'DepartmentNotFound'  END) AS DEPTNAME\n"
+            + "from \"hr\".\"emps\" e")
+        .returnsUnordered("name=Bill; DEPTNAME=Sales",
+            "name=Eric; DEPTNAME=DepartmentNotFound",
+            "name=Sebastian; DEPTNAME=Sales",
+            "name=Theodore; DEPTNAME=Sales");
   }
 
   @Test void testScalarSubQueryInCase2() {

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -371,7 +371,10 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "SELECT CASE WHEN 1=2 "
         + "THEN cast((values(1)) as integer) "
         + "ELSE 2 end from (values(1))";
-    sql(sql).withPlanner(hepPlanner).checkUnchanged();
+    sql(sql)
+        .withExpand(true)
+        .withPlanner(hepPlanner)
+        .checkUnchanged();
   }
 
   @Test void testReduceNullableCase2() {
@@ -383,7 +386,10 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "SELECT deptno, ename, CASE WHEN 1=2 "
         + "THEN substring(ename, 1, cast(2 as int)) ELSE NULL end from emp"
         + " group by deptno, ename, case when 1=2 then substring(ename,1, cast(2 as int))  else null end";
-    sql(sql).withPlanner(hepPlanner).checkUnchanged();
+    sql(sql)
+        .withExpand(true)
+        .withPlanner(hepPlanner)
+        .checkUnchanged();
   }
 
   @Test void testProjectToWindowRuleForMultipleWindows() {
@@ -1135,6 +1141,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "  where emp.deptno = dept.deptno\n"
         + "  and emp.sal > 100)";
     sql(sql)
+        .withExpand(true)
         .withDecorrelate(true)
         .withTrim(true)
         .withRelBuilderConfig(b -> b.withPruneInputOfAggregate(true))
@@ -1164,6 +1171,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "from emp\n"
         + "where exists(select * from dept where emp.deptno = dept.deptno)";
     sql(sql)
+        .withExpand(true)
         .withDecorrelate(true)
         .withPreRule(CoreRules.PROJECT_MERGE)
         .withRule(CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN)
@@ -1175,6 +1183,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "from emp\n"
         + "where exists(select * from dept where emp.deptno = dept.deptno)";
     sql(sql)
+        .withExpand(true)
         .withDecorrelate(true)
         .withTrim(true)
         .withRule(CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN)
@@ -1190,10 +1199,11 @@ class RelOptRulesTest extends RelOptTestBase {
         + "from emp\n"
         + "where exists(select * from dept where emp.deptno = dept.deptno)";
     sql(sql)
-      .withDecorrelate(true)
-      .withTrim(true)
-      .withRule(CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN)
-      .check();
+        .withExpand(true)
+        .withDecorrelate(true)
+        .withTrim(true)
+        .withRule(CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN)
+        .check();
   }
 
   /** Test case for
@@ -1294,6 +1304,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "    select emp.deptno from emp))R\n"
         + "where R.deptno <=10";
     sql(sql)
+        .withExpand(true)
         .withDecorrelate(true)
         .withTrim(false)
         .withPreRule(CoreRules.PROJECT_TO_SEMI_JOIN)
@@ -1314,6 +1325,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "  select e2.deptno from emp e2 where e2.sal = 100)";
     sql(sql)
         .withDecorrelate(false)
+        .withExpand(true)
         .withTrim(true)
         .withPreRule(CoreRules.PROJECT_TO_SEMI_JOIN)
         .withRule(CoreRules.JOIN_REDUCE_EXPRESSIONS)
@@ -1339,6 +1351,7 @@ class RelOptRulesTest extends RelOptTestBase {
             .build();
 
     sql(sql)
+        .withExpand(true)
         .withDecorrelate(true)
         .withPre(program)
         .withRule() // empty program
@@ -4504,7 +4517,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "and e1.sal > (select avg(sal) from emp e2 where e1.empno = e2.empno)";
 
     // Convert sql to rel
-    final RelOptFixture fixture = sql(sql);
+    final RelOptFixture fixture = sql(sql).withExpand(true);
     final RelNode rel = fixture.toRel();
 
     // Create a duplicate rel tree with a CustomCorrelate instead of
@@ -4991,6 +5004,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "IN (select e.deptno from sales.emp e "
         + "where e.deptno = d.deptno or e.deptno = 4)";
     sql(sql)
+        .withExpand(true)
         .withPreRule(CoreRules.FILTER_INTO_JOIN,
             CoreRules.JOIN_CONDITION_PUSH,
             CoreRules.JOIN_PUSH_TRANSITIVE_PREDICATES)
@@ -5009,6 +5023,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "  from EMPNULLABLES_20 n2\n"
         + "  where n1.SAL = n2.SAL or n1.SAL = 4)";
     sql(sql).withDecorrelate(true)
+        .withExpand(true)
         .withRule(CoreRules.FILTER_INTO_JOIN,
             CoreRules.JOIN_CONDITION_PUSH,
             CoreRules.JOIN_PUSH_TRANSITIVE_PREDICATES)
@@ -6390,6 +6405,7 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "select * from emp e1 where exists ("
         + "select * from emp e2 where e1.deptno = (e2.deptno+30))";
     sql(sql).withDecorrelate(false)
+        .withExpand(true)
         .withRule(FilterFlattenCorrelatedConditionRule.Config.DEFAULT.toRule())
         .check();
   }
@@ -6398,6 +6414,7 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "select * from emp e1 where exists ("
         + "select * from emp e2 where (e1.deptno+30) = e2.deptno)";
     sql(sql).withDecorrelate(false)
+        .withExpand(true)
         .withRule(FilterFlattenCorrelatedConditionRule.Config.DEFAULT.toRule())
         .checkUnchanged();
   }
@@ -6406,6 +6423,7 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "select * from emp e1 where exists ("
         + "select * from emp e2 where e1.deptno = (2 * e2.deptno+30))";
     sql(sql).withDecorrelate(false)
+        .withExpand(true)
         .withRule(FilterFlattenCorrelatedConditionRule.Config.DEFAULT.toRule())
         .check();
   }
@@ -6414,6 +6432,7 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "select * from emp e1 where exists ("
         + "select * from emp e2 where (e1.deptno + (e2.deptno+30)) > 0)";
     sql(sql).withDecorrelate(false)
+        .withExpand(true)
         .withRule(FilterFlattenCorrelatedConditionRule.Config.DEFAULT.toRule())
         .checkUnchanged();
   }
@@ -6422,6 +6441,7 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "select * from emp e1 where exists ("
         + "select * from emp e2 where (e2.empno+50) < 20 and e1.deptno >= (30+e2.deptno))";
     sql(sql).withDecorrelate(false)
+        .withExpand(true)
         .withRule(FilterFlattenCorrelatedConditionRule.Config.DEFAULT.toRule())
         .check();
   }
@@ -6588,6 +6608,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + "  where A.mgr = B.empno\n"
         + "  group by deptno, 'abc')";
     sql(sql)
+        .withExpand(true)
         .withLateDecorrelate(true)
         .withTrim(true)
         .withRule() // empty program
@@ -7129,6 +7150,7 @@ class RelOptRulesTest extends RelOptTestBase {
     final String sql = "select * from sales.dept d where d.deptno in\n"
         + " (select e.deptno from sales.emp e) order by d.deptno";
     sql(sql)
+        .withExpand(true)
         .withPreRule(CoreRules.PROJECT_TO_SEMI_JOIN)
         .withRule(CoreRules.SORT_JOIN_COPY)
         .check();
@@ -7139,6 +7161,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + " (select e.deptno from sales.emp e) order by d.deptno limit 10 offset 2";
     // Do not copy the limit and offset
     sql(sql)
+        .withExpand(true)
         .withPreRule(CoreRules.PROJECT_TO_SEMI_JOIN)
         .withRule(CoreRules.SORT_JOIN_COPY)
         .check();
@@ -7149,6 +7172,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + " (select e.deptno from sales.emp e) order by d.deptno offset 2";
     // Do not copy the offset
     sql(sql)
+        .withExpand(true)
         .withPreRule(CoreRules.PROJECT_TO_SEMI_JOIN)
         .withRule(CoreRules.SORT_JOIN_COPY)
         .check();
@@ -7168,6 +7192,7 @@ class RelOptRulesTest extends RelOptTestBase {
 
     sql(sql)
         .withRule() // empty program
+        .withExpand(true)
         .withDecorrelate(true)
         .checkUnchanged();
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
@@ -112,7 +112,8 @@ class SqlHintsConverterTest {
           "?", false, false)
           .withFactory(f ->
               f.withSqlToRelConfig(c ->
-                  c.withHintStrategyTable(HintTools.HINT_STRATEGY_TABLE)));
+                  c.withHintStrategyTable(HintTools.HINT_STRATEGY_TABLE)
+                      .withExpand(true)));
 
   static final RelOptFixture RULE_FIXTURE =
       RelOptFixture.DEFAULT

--- a/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
@@ -535,6 +535,7 @@ class SqlHintsConverterTest {
           RelOptUtil.registerDefaultRules(p, false, false);
           ruleSet.forEach(p::addRule);
         })
+        .withExpand(true)
         .check();
   }
 
@@ -556,6 +557,7 @@ class SqlHintsConverterTest {
           RelOptUtil.registerDefaultRules(p, false, false);
           ruleSet.forEach(p::addRule);
         })
+        .withExpand(true)
         .check();
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1709,7 +1709,8 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
   @Test void testUniqueWithExpand() {
     final String sql = "select * from emp\n"
         + "where unique (select 1 from dept where deptno=55)";
-    sql(sql).withExpand(true).throws_("UNIQUE is only supported if expand = false");
+    sql(sql).withExpand(true)
+        .throws_("UNIQUE is only supported if expand = false");
   }
 
   @Test void testUniqueWithProjectLateral() {

--- a/core/src/test/java/org/apache/calcite/test/TopDownOptTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TopDownOptTest.java
@@ -277,7 +277,7 @@ class TopDownOptTest {
       p.removeRule(EnumerableRules.ENUMERABLE_JOIN_RULE);
       p.removeRule(EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE);
       p.removeRule(EnumerableRules.ENUMERABLE_SORT_RULE);
-    }).check();
+    }).withExpand(true).check();
   }
 
   // test if "order by mgr desc nulls last" can be pushed through the projection ("select mgr").

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -2345,7 +2345,8 @@ class UtilTest {
     memo1.close();
     assertThat(local1.get(), is("foo"));
 
-    final TryThreadLocal<String> local2 = TryThreadLocal.of(null);
+    final TryThreadLocal<@org.checkerframework.checker.nullness.qual.Nullable String> local2 =
+        TryThreadLocal.of(null);
     assertThat(local2.get(), nullValue());
     TryThreadLocal.Memo memo2 = local2.push("a");
     assertThat(local2.get(), is("a"));

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -360,12 +360,12 @@ where exists (select 1 from "hr"."emps");
 (3 rows)
 
 !ok
-EnumerableNestedLoopJoin(condition=[true], joinType=[semi])
-  EnumerableCalc(expr#0..3=[{inputs}], deptno=[$t0])
-    EnumerableTableScan(table=[[hr, depts]])
-  EnumerableCalc(expr#0=[{inputs}], expr#1=[IS NOT NULL($t0)], $f0=[$t0], $condition=[$t1])
-    EnumerableAggregate(group=[{}], agg#0=[MIN($0)])
-      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], $f0=[$t5])
+EnumerableCalc(expr#0..1=[{inputs}], deptno=[$t0])
+  EnumerableNestedLoopJoin(condition=[true], joinType=[inner])
+    EnumerableCalc(expr#0..3=[{inputs}], deptno=[$t0])
+      EnumerableTableScan(table=[[hr, depts]])
+    EnumerableAggregate(group=[{0}])
+      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], i=[$t5])
         EnumerableTableScan(table=[[hr, emps]])
 !plan
 
@@ -383,8 +383,8 @@ EnumerableCalc(expr#0..1=[{inputs}], expr#2=[IS NULL($t1)], deptno=[$t0], $condi
   EnumerableNestedLoopJoin(condition=[true], joinType=[left])
     EnumerableCalc(expr#0..3=[{inputs}], deptno=[$t0])
       EnumerableTableScan(table=[[hr, depts]])
-    EnumerableAggregate(group=[{}], agg#0=[MIN($0)])
-      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], $f0=[$t5])
+    EnumerableAggregate(group=[{0}])
+      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], i=[$t5])
         EnumerableTableScan(table=[[hr, emps]])
 !plan
 
@@ -398,12 +398,12 @@ where exists (select 1 from "hr"."emps" where "empid" < 0);
 (0 rows)
 
 !ok
-EnumerableNestedLoopJoin(condition=[true], joinType=[semi])
-  EnumerableCalc(expr#0..3=[{inputs}], deptno=[$t0])
-    EnumerableTableScan(table=[[hr, depts]])
-  EnumerableCalc(expr#0=[{inputs}], expr#1=[IS NOT NULL($t0)], $f0=[$t0], $condition=[$t1])
-    EnumerableAggregate(group=[{}], agg#0=[MIN($0)])
-      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], expr#6=[0], expr#7=[<($t0, $t6)], $f0=[$t5], $condition=[$t7])
+EnumerableCalc(expr#0..1=[{inputs}], deptno=[$t0])
+  EnumerableNestedLoopJoin(condition=[true], joinType=[inner])
+    EnumerableCalc(expr#0..3=[{inputs}], deptno=[$t0])
+      EnumerableTableScan(table=[[hr, depts]])
+    EnumerableAggregate(group=[{0}])
+      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], expr#6=[0], expr#7=[<($t0, $t6)], i=[$t5], $condition=[$t7])
         EnumerableTableScan(table=[[hr, emps]])
 !plan
 
@@ -424,8 +424,8 @@ EnumerableCalc(expr#0..1=[{inputs}], expr#2=[IS NULL($t1)], deptno=[$t0], $condi
   EnumerableNestedLoopJoin(condition=[true], joinType=[left])
     EnumerableCalc(expr#0..3=[{inputs}], deptno=[$t0])
       EnumerableTableScan(table=[[hr, depts]])
-    EnumerableAggregate(group=[{}], agg#0=[MIN($0)])
-      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], expr#6=[0], expr#7=[<($t0, $t6)], $f0=[$t5], $condition=[$t7])
+    EnumerableAggregate(group=[{0}])
+      EnumerableCalc(expr#0..4=[{inputs}], expr#5=[true], expr#6=[0], expr#7=[<($t0, $t6)], i=[$t5], $condition=[$t7])
         EnumerableTableScan(table=[[hr, emps]])
 !plan
 
@@ -466,8 +466,8 @@ EnumerableCalc(expr#0..6=[{inputs}], expr#7=[IS NULL($t6)], proj#0..4=[{exprs}],
     EnumerableSort(sort0=[$1], dir0=[ASC])
       EnumerableTableScan(table=[[hr, emps]])
     EnumerableSort(sort0=[$0], dir0=[ASC])
-      EnumerableAggregate(group=[{0}], agg#0=[MIN($1)])
-        EnumerableCalc(expr#0..3=[{inputs}], expr#4=[true], deptno=[$t0], $f0=[$t4])
+      EnumerableCalc(expr#0=[{inputs}], expr#1=[true], proj#0..1=[{exprs}])
+        EnumerableAggregate(group=[{0}])
           EnumerableTableScan(table=[[hr, depts]])
 !plan
 
@@ -491,18 +491,19 @@ or not exists (
 EnumerableCalc(expr#0..8=[{inputs}], expr#9=[IS NULL($t5)], expr#10=[IS NULL($t8)], expr#11=[OR($t9, $t10)], proj#0..4=[{exprs}], $condition=[$t11])
   EnumerableMergeJoin(condition=[=($6, $7)], joinType=[left])
     EnumerableSort(sort0=[$6], dir0=[ASC])
-      EnumerableCalc(expr#0..6=[{inputs}], expr#7=[CAST($t0):INTEGER NOT NULL], proj#0..4=[{exprs}], $f0=[$t6], empid0=[$t7])
+      EnumerableCalc(expr#0..6=[{inputs}], expr#7=[CAST($t0):INTEGER NOT NULL], proj#0..4=[{exprs}], i=[$t6], empid0=[$t7])
         EnumerableMergeJoin(condition=[=($1, $5)], joinType=[left])
           EnumerableSort(sort0=[$1], dir0=[ASC])
             EnumerableTableScan(table=[[hr, emps]])
           EnumerableSort(sort0=[$0], dir0=[ASC])
-            EnumerableAggregate(group=[{0}], agg#0=[MIN($1)])
-              EnumerableCalc(expr#0..3=[{inputs}], expr#4=[true], deptno=[$t0], $f0=[$t4])
+            EnumerableCalc(expr#0=[{inputs}], expr#1=[true], proj#0..1=[{exprs}])
+              EnumerableAggregate(group=[{0}])
                 EnumerableTableScan(table=[[hr, depts]])
     EnumerableSort(sort0=[$0], dir0=[ASC])
-      EnumerableAggregate(group=[{0}], agg#0=[MIN($1)])
-        EnumerableCalc(expr#0..3=[{inputs}], expr#4=[90], expr#5=[+($t0, $t4)], expr#6=[true], $f4=[$t5], $f0=[$t6])
-          EnumerableTableScan(table=[[hr, depts]])
+      EnumerableCalc(expr#0=[{inputs}], expr#1=[true], proj#0..1=[{exprs}])
+        EnumerableAggregate(group=[{0}])
+          EnumerableCalc(expr#0..3=[{inputs}], expr#4=[90], expr#5=[+($t0, $t4)], $f4=[$t5])
+            EnumerableTableScan(table=[[hr, depts]])
 !plan
 
 # Left join to a relation with one row is recognized as a trivial semi-join

--- a/core/src/test/resources/sql/some.iq
+++ b/core/src/test/resources/sql/some.iq
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 !use scott
-!set expand false
 !set outputformat mysql
 
 # =ANY

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -834,8 +834,6 @@ and empno in (7876, 7698, 7900);
 
 !set outputformat psql
 
-!set expand false
-
 # [CALCITE-2329] Enhance SubQueryRemoveRule to rewrite IN operator with the constant from the left side more optimally
 # Test project null IN null
 select sal,
@@ -2494,7 +2492,6 @@ from "scott".emp emp1;
 
 # [CALCITE-4486] UNIQUE predicate
 !use scott
-!set expand false
 !set outputformat mysql
 
 # singleton keys have unique value which excludes fully or partially null rows.

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BlockStatement.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/BlockStatement.java
@@ -43,8 +43,7 @@ public class BlockStatement extends Statement {
 
   private boolean distinctVariables(
       @UnderInitialization(BlockStatement.class) BlockStatement this,
-      boolean fail
-  ) {
+      boolean fail) {
     Set<String> names = new HashSet<>();
     for (Statement statement : statements) {
       if (statement instanceof DeclarationStatement) {

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -43,6 +43,19 @@ z.
 #### Breaking Changes
 {: #breaking-1-34-0}
 
+As of [CALCITE-3870](https://issues.apache.org/jira/browse/CALCITE-3870),
+the default value of
+[SqlToRelConverter.Config.expand](https://calcite.apache.org/javadocAggregate/org/apache/calcite/sql2rel/SqlToRelConverter.Config.html#isExpand())
+is now false, which means that `SqlToRelConverter` handles sub-queries (such
+as `IN`, `EXISTS`, and scalar sub-queries) by converting them to `RexSubQuery`
+expressions, rather than expanding them. To expand these `RexSubQuery`
+expressions, the `SubQueryRemoveRule` rule must be enabled in the planning
+phase.
+
+To keep the old behavior (which is discouraged but still supported),
+initialize `SqlToRelConverter` using
+`SqlToRelConverter.config().withExpand(true)` as the value for the `config`
+argument.
 
 Compatibility: This release is tested on Linux, macOS, Microsoft Windows;
 using JDK/OpenJDK versions 8 to 18;
@@ -350,7 +363,7 @@ other software versions as specified in gradle.properties.
 * [<a href="https://issues.apache.org/jira/browse/CALCITE-5433">CALCITE-5433</a>]
   Druid tests hang/fail intermittently in CI
 * [<a href="https://issues.apache.org/jira/browse/CALCITE-5474">CALCITE-5474</a>]
-  Disable Sonar quality gates to avoid checks appearing as failures 
+  Disable Sonar quality gates to avoid checks appearing as failures
 * [<a href="https://issues.apache.org/jira/browse/CALCITE-5475">CALCITE-5475</a>]
   Improve test coverage accuracy by aggregating modules
 

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -54,7 +54,7 @@ phase.
 
 To keep the old behavior (which is discouraged but still supported),
 initialize `SqlToRelConverter` using
-`SqlToRelConverter.config().withExpand(true)` as the value for the `config`
+`SqlToRelConverter.config().withExpandDeprecated(true)` as the value for the `config`
 argument.
 
 Compatibility: This release is tested on Linux, macOS, Microsoft Windows;

--- a/testkit/src/main/java/org/apache/calcite/test/RelOptFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelOptFixture.java
@@ -83,8 +83,8 @@ class RelOptFixture {
           null, RelSupplier.NONE, null, null,
           ImmutableMap.of(), (f, r) -> r, (f, r) -> r, false, false)
           .withFactory(f ->
-              f.withValidatorConfig(c ->
-                  c.withIdentifierExpansion(true)))
+              f.withValidatorConfig(c -> c.withIdentifierExpansion(true))
+                  .withSqlToRelConfig(c -> c.withExpand(true)))
           .withRelBuilderConfig(b -> b.withPruneInputOfAggregate(false));
 
   /**

--- a/testkit/src/main/java/org/apache/calcite/test/RelOptFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelOptFixture.java
@@ -84,7 +84,7 @@ class RelOptFixture {
           ImmutableMap.of(), (f, r) -> r, (f, r) -> r, false, false)
           .withFactory(f ->
               f.withValidatorConfig(c -> c.withIdentifierExpansion(true))
-                  .withSqlToRelConfig(c -> c.withExpand(true)))
+                  .withSqlToRelConfig(c -> c.withExpand(false)))
           .withRelBuilderConfig(b -> b.withPruneInputOfAggregate(false));
 
   /**


### PR DESCRIPTION
This is a breaking change. Clients should either call Config.withExpand(true), to keep the old behavior, or ensure that SubQueryRemoveRule is enabled during the planning phase.

We believe that the new behavior - expansion during the planning phase rather than during sql-to-rel phase - is superior because it handles ANY and ALL sub-queries and complex correlated sub-queries.