### PR TITLE
CompositeOperandTypeChecker's java doc uses wrong class name

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
@@ -46,8 +46,8 @@ import static java.util.Objects.requireNonNull;
  *
  * <blockquote>
  * <pre><code>
- * CompositeOperandsTypeChecking newCompositeRule =
- *     new CompositeOperandsTypeChecking(Composition.OR,
+ * CompositeOperandTypeChecker newCompositeRule =
+ *     new CompositeOperandTypeChecker(Composition.OR,
  *         new SqlOperandTypeChecker[]{stringRule, numericRule});
  * </code></pre>
  * </blockquote>
@@ -56,8 +56,8 @@ import static java.util.Objects.requireNonNull;
  *
  * <blockquote>
  * <pre><code>
- * CompositeOperandsTypeChecking newCompositeRule =
- *     new CompositeOperandsTypeChecking(Composition.AND,
+ * CompositeOperandTypeChecker newCompositeRule =
+ *     new CompositeOperandTypeChecker(Composition.AND,
  *         new SqlOperandTypeChecker[]{numericRule, literalRule});
  * </code></pre>
  * </blockquote>
@@ -67,8 +67,8 @@ import static java.util.Objects.requireNonNull;
  *
  * <blockquote>
  * <pre><code>
- * CompositeOperandsTypeChecking newCompositeRule =
- *     new CompositeOperandsTypeChecking(Composition.SEQUENCE,
+ * CompositeOperandTypeChecker newCompositeRule =
+ *     new CompositeOperandTypeChecker(Composition.SEQUENCE,
  *         new SqlOperandTypeChecker[]{stringRule, numericRule});
  * </code></pre>
  * </blockquote>


### PR DESCRIPTION
Fix typo in CompositeOperandTypeChecker: `CompositeOperandsTypeChecking` -> `CompositeOperandTypeChecker`