### PR TITLE
[CALCITE-5551]: Support SELECT * Except(column) in parser

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1306,6 +1306,7 @@ SqlSelect SqlSelect() :
     final SqlLiteral keyword;
     final SqlNodeList keywordList;
     final List<SqlNode> selectList = new ArrayList<SqlNode>();
+    final SqlNodeList except;
     final SqlNode fromClause;
     final SqlNode where;
     final SqlNodeList groupBy;
@@ -1331,7 +1332,7 @@ SqlSelect SqlSelect() :
         keywordList = new SqlNodeList(keywords, s.addAll(keywords).pos());
     }
     AddSelectItem(selectList)
-    ( <COMMA> AddSelectItem(selectList) )*
+    ( <COMMA> AddSelectItem(selectList) )* (except = Except() | { except = null; } )
     (
         <FROM> fromClause = FromClause()
         ( where = Where() | { where = null; } )
@@ -1352,6 +1353,7 @@ SqlSelect SqlSelect() :
     {
         return new SqlSelect(s.end(this), keywordList,
             new SqlNodeList(selectList, Span.of(selectList).pos()),
+            except,
             fromClause, where, groupBy, having, windowDecls, qualify,
             null, null, null, new SqlNodeList(hints, getPos()));
     }
@@ -2525,6 +2527,16 @@ SqlNode RowConstructor() :
         // but the distinction seems to be purely syntactic.
         return SqlStdOperatorTable.ROW.createCall(s.end(valueList),
             (List<SqlNode>) valueList);
+    }
+}
+
+SqlNodeList Except() :
+{
+  final SqlNodeList selectList;
+}
+{
+    <EXCEPT> selectList = SimpleIdentifierOrList() {
+      return selectList;
     }
 }
 

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcTable.java
@@ -149,7 +149,7 @@ public class JdbcTable extends AbstractQueryableTable
   SqlString generateSql() {
     final SqlNodeList selectList = SqlNodeList.SINGLETON_STAR;
     SqlSelect node =
-        new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY, selectList,
+        new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY, selectList, null,
             tableName(), null, null, null, null, null, null, null, null, null);
     final SqlWriterConfig config = SqlPrettyWriter.config()
         .withAlwaysUseParentheses(true)

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -284,6 +284,7 @@ public class RelToSqlConverter extends SqlImplementor
           new SqlSelect(POS, null,
               new SqlNodeList(
                   ImmutableList.of(ONE), POS),
+              null,
               fromPart, sqlCondition, null,
               null, null, null, null, null, null, null);
     }
@@ -783,6 +784,7 @@ public class RelToSqlConverter extends SqlImplementor
         list.add(
             new SqlSelect(POS, null,
                 new SqlNodeList(values2, POS),
+                null,
                 getDual(), null, null,
                 null, null, null, null, null, null, null));
       }
@@ -799,19 +801,19 @@ public class RelToSqlConverter extends SqlImplementor
         if (dual == null) {
           query =
               new SqlSelect(POS, null,
-                  new SqlNodeList(nullColumnNames, POS), null, null, null, null,
+                  new SqlNodeList(nullColumnNames, POS), null, null, null, null, null,
                   null, null, null, null, null, null);
 
           // Wrap "SELECT 1 AS x"
           // as "SELECT * FROM (SELECT 1 AS x) AS t WHERE false"
           query =
-              new SqlSelect(POS, null, SqlNodeList.SINGLETON_STAR,
+              new SqlSelect(POS, null, SqlNodeList.SINGLETON_STAR, null,
                   as(query, "t"), createAlwaysFalseCondition(), null, null,
                   null, null, null, null, null, null);
         } else {
           query =
               new SqlSelect(POS, null,
-                  new SqlNodeList(nullColumnNames, POS),
+                  new SqlNodeList(nullColumnNames, POS), null,
                   dual, createAlwaysFalseCondition(), null,
                   null, null, null, null, null, null, null);
         }
@@ -855,7 +857,7 @@ public class RelToSqlConverter extends SqlImplementor
           query = as(query, "t");
         }
         query =
-            new SqlSelect(POS, null, SqlNodeList.SINGLETON_STAR, query,
+            new SqlSelect(POS, null, SqlNodeList.SINGLETON_STAR, null, query,
                 createAlwaysFalseCondition(), null, null, null,
                 null, null, null, null, null);
       }
@@ -1200,7 +1202,7 @@ public class RelToSqlConverter extends SqlImplementor
         new SqlBasicCall(SqlStdOperatorTable.COLLECTION_TABLE,
             ImmutableList.of(callNode), SqlParserPos.ZERO);
     SqlNode select =
-        new SqlSelect(SqlParserPos.ZERO, null, SqlNodeList.SINGLETON_STAR,
+        new SqlSelect(SqlParserPos.ZERO, null, SqlNodeList.SINGLETON_STAR, null,
             tableCall, null, null, null, null, null, null, null, null,
             SqlNodeList.EMPTY);
     return result(select, ImmutableList.of(Clause.SELECT), e, null);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -544,7 +544,7 @@ public abstract class SqlImplementor {
     if (requiresAlias(node)) {
       node = as(node, "t");
     }
-    return new SqlSelect(POS, SqlNodeList.EMPTY, SqlNodeList.SINGLETON_STAR,
+    return new SqlSelect(POS, SqlNodeList.EMPTY, SqlNodeList.SINGLETON_STAR, null,
         node, null, null, null, SqlNodeList.EMPTY, null, null, null, null, null);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlJoin.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJoin.java
@@ -273,7 +273,7 @@ public class SqlJoin extends SqlCall {
   @Override public SqlString toSqlString(UnaryOperator<SqlWriterConfig> transform) {
     SqlNode selectWrapper =
         new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY,
-            SqlNodeList.SINGLETON_STAR, this, null, null, null,
+            SqlNodeList.SINGLETON_STAR, null, this, null, null, null,
             SqlNodeList.EMPTY, null, null, null, null, SqlNodeList.EMPTY);
     return selectWrapper.toSqlString(transform);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlProcedureCallOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlProcedureCallOperator.java
@@ -45,6 +45,7 @@ public class SqlProcedureCallOperator extends SqlPrefixOperator {
         new SqlNodeList(
             Collections.singletonList(call.operand(0)),
             SqlParserPos.ZERO),
+        null,
         SqlStdOperatorTable.VALUES.createCall(
             SqlParserPos.ZERO,
             SqlStdOperatorTable.ROW.createCall(

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelect.java
@@ -39,13 +39,14 @@ public class SqlSelect extends SqlCall {
   //~ Static fields/initializers ---------------------------------------------
 
   // constants representing operand positions
-  public static final int FROM_OPERAND = 2;
-  public static final int WHERE_OPERAND = 3;
-  public static final int HAVING_OPERAND = 5;
-  public static final int QUALIFY_OPERAND = 7;
+  public static final int FROM_OPERAND = 3;
+  public static final int WHERE_OPERAND = 4;
+  public static final int HAVING_OPERAND = 6;
+  public static final int QUALIFY_OPERAND = 8;
 
   SqlNodeList keywordList;
   SqlNodeList selectList;
+  @Nullable SqlNodeList except;
   @Nullable SqlNode from;
   @Nullable SqlNode where;
   @Nullable SqlNodeList groupBy;
@@ -62,6 +63,7 @@ public class SqlSelect extends SqlCall {
   public SqlSelect(SqlParserPos pos,
       @Nullable SqlNodeList keywordList,
       SqlNodeList selectList,
+      @Nullable SqlNodeList except,
       @Nullable SqlNode from,
       @Nullable SqlNode where,
       @Nullable SqlNodeList groupBy,
@@ -76,6 +78,7 @@ public class SqlSelect extends SqlCall {
     this.keywordList = requireNonNull(keywordList != null
         ? keywordList : new SqlNodeList(pos));
     this.selectList = requireNonNull(selectList, "selectList");
+    this.except = except;
     this.from = from;
     this.where = where;
     this.groupBy = groupBy;
@@ -94,6 +97,7 @@ public class SqlSelect extends SqlCall {
   public SqlSelect(SqlParserPos pos,
       @Nullable SqlNodeList keywordList,
       SqlNodeList selectList,
+      @Nullable SqlNodeList except,
       @Nullable SqlNode from,
       @Nullable SqlNode where,
       @Nullable SqlNodeList groupBy,
@@ -103,7 +107,7 @@ public class SqlSelect extends SqlCall {
       @Nullable SqlNode offset,
       @Nullable SqlNode fetch,
       @Nullable SqlNodeList hints) {
-    this(pos, keywordList, selectList, from, where, groupBy, having,
+    this(pos, keywordList, selectList, except, from, where, groupBy, having,
         windowDecls, null, orderBy, offset, fetch, hints);
   }
 
@@ -119,7 +123,7 @@ public class SqlSelect extends SqlCall {
 
   @SuppressWarnings("nullness")
   @Override public List<SqlNode> getOperandList() {
-    return ImmutableNullableList.of(keywordList, selectList, from, where,
+    return ImmutableNullableList.of(keywordList, selectList, except, from, where,
         groupBy, having, windowDecls, qualify, orderBy, offset, fetch, hints);
   }
 
@@ -132,30 +136,33 @@ public class SqlSelect extends SqlCall {
       selectList = requireNonNull((SqlNodeList) operand);
       break;
     case 2:
-      from = operand;
+      except = (SqlNodeList) operand;
       break;
     case 3:
-      where = operand;
+      from = operand;
       break;
     case 4:
-      groupBy = (SqlNodeList) operand;
+      where = operand;
       break;
     case 5:
-      having = operand;
+      groupBy = (SqlNodeList) operand;
       break;
     case 6:
-      windowDecls = requireNonNull((SqlNodeList) operand);
+      having = operand;
       break;
     case 7:
-      qualify = operand;
+      windowDecls = requireNonNull((SqlNodeList) operand);
       break;
     case 8:
-      orderBy = (SqlNodeList) operand;
+      qualify = operand;
       break;
     case 9:
-      offset = operand;
+      orderBy = (SqlNodeList) operand;
       break;
     case 10:
+      offset = operand;
+      break;
+    case 11:
       fetch = operand;
       break;
     default:
@@ -176,6 +183,14 @@ public class SqlSelect extends SqlCall {
       }
     }
     return null;
+  }
+
+  public final @Nullable SqlNodeList getExcept() {
+    return except;
+  }
+
+  public void setExcept(@Nullable SqlNodeList except) {
+    this.except = except;
   }
 
   @Pure

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -251,6 +251,11 @@ public interface SqlWriter {
     CASE,
 
     /**
+     * The EXCEPT clause of a SELECT statement.
+     */
+    EXCEPT_LIST,
+
+    /**
      * Same behavior as user-defined frame type.
      */
     OTHER;

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -189,7 +189,7 @@ public class MysqlSqlDialect extends SqlDialect {
     final SqlLiteral nullLiteral = SqlLiteral.createNull(SqlParserPos.ZERO);
     final SqlNode unionOperand =
         new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY,
-            SqlNodeList.of(nullLiteral), null, null, null, null,
+            null, SqlNodeList.of(nullLiteral), null, null, null, null,
             SqlNodeList.EMPTY, null, null, null, null, SqlNodeList.EMPTY);
     // For MySQL, generate
     //   CASE COUNT(*)

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1478,7 +1478,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       } else {
         orderList = orderBy.orderList;
       }
-      return new SqlSelect(SqlParserPos.ZERO, null, selectList, orderBy.query,
+      return new SqlSelect(SqlParserPos.ZERO, null, selectList, null, orderBy.query,
           null, null, null, null, null, orderList, orderBy.offset,
           orderBy.fetch, null);
     }
@@ -1488,7 +1488,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       SqlCall call = (SqlCall) node;
       final SqlNodeList selectList = new SqlNodeList(SqlParserPos.ZERO);
       selectList.add(SqlIdentifier.star(SqlParserPos.ZERO));
-      return new SqlSelect(SqlParserPos.ZERO, null, selectList, call.operand(0),
+      return new SqlSelect(SqlParserPos.ZERO, null, selectList, null, call.operand(0),
           null, null, null, null, null, null, null, null, null);
     }
 
@@ -1585,7 +1585,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
             JoinConditionType.ON.symbol(SqlParserPos.ZERO),
             call.getCondition());
     SqlSelect select =
-        new SqlSelect(SqlParserPos.ZERO, null, selectList, outerJoin, null,
+        new SqlSelect(SqlParserPos.ZERO, null, selectList, null, outerJoin, null,
             null, null, null, null, null, null, null, null);
     call.setSourceSelect(select);
 
@@ -1603,7 +1603,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
               SqlParserPos.ZERO);
       final SqlNode insertSource = SqlNode.clone(sourceTableRef);
       select =
-          new SqlSelect(SqlParserPos.ZERO, null, selectList, insertSource, null,
+          new SqlSelect(SqlParserPos.ZERO, null, selectList, null, insertSource, null,
               null, null, null, null, null, null, null, null);
       insertCall.setSource(select);
     }
@@ -1670,7 +1670,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       ++i;
     }
     source =
-        new SqlSelect(SqlParserPos.ZERO, null, selectList, source, null, null,
+        new SqlSelect(SqlParserPos.ZERO, null, selectList, null, source, null, null,
             null, null, null, null, null, null, null);
     source = SqlValidatorUtil.addAlias(source, UPDATE_SRC_ALIAS);
     SqlMerge mergeCall =
@@ -1726,7 +1726,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
               sourceTable,
               alias.getSimple());
     }
-    return new SqlSelect(SqlParserPos.ZERO, null, selectList, sourceTable,
+    return new SqlSelect(SqlParserPos.ZERO, null, selectList, null, sourceTable,
         call.getCondition(), null, null, null, null, null, null, null, null);
   }
 
@@ -1748,7 +1748,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
               sourceTable,
               alias.getSimple());
     }
-    return new SqlSelect(SqlParserPos.ZERO, null, selectList, sourceTable,
+    return new SqlSelect(SqlParserPos.ZERO, null, selectList, null, sourceTable,
         call.getCondition(), null, null, null, null, null, null, null, null);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -1203,7 +1203,7 @@ public class SqlValidatorUtil {
     final SqlSelect select0 =
         new SqlSelect(SqlParserPos.ZERO, null,
             new SqlNodeList(Collections.singletonList(expr), SqlParserPos.ZERO),
-            new SqlIdentifier(tableName, SqlParserPos.ZERO),
+            null, new SqlIdentifier(tableName, SqlParserPos.ZERO),
             null, null, null, null, null, null, null, null, null);
     Prepare.CatalogReader catalogReader =
         createSingleTableCatalogReader(caseSensitive, tableName, typeFactory,

--- a/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
+++ b/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
@@ -178,7 +178,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
                 .add(new SqlIdentifier("_", p))
                 .addAll(columnList)
                 .build());
-    return new SqlSelect(p, null, selectList, from, null, null, null, null,
+    return new SqlSelect(p, null, selectList, null, from, null, null, null, null,
         null, null, null, null, null);
   }
 

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -748,6 +748,14 @@ public class SqlParserTest {
         .fails("(?s)Encountered \"\\*\" at .*");
   }
 
+  @Test void testSelectStarExcept() {
+    sql("select * except id from foo")
+        .ok("SELECT *\nEXCEPT `ID`\nFROM `FOO`");
+
+    sql("select * except (id, bar) from foo")
+        .ok("SELECT *\nEXCEPT (`ID`, `BAR`)\nFROM `FOO`");
+  }
+
   @Test void testHyphenatedTableName() {
     sql("select * from bigquery^-^foo-bar.baz")
         .fails("(?s)Encountered \"-\" at .*")

--- a/testkit/src/main/java/org/apache/calcite/test/MockDdlExecutor.java
+++ b/testkit/src/main/java/org/apache/calcite/test/MockDdlExecutor.java
@@ -117,7 +117,7 @@ public class MockDdlExecutor extends DdlExecutorImpl {
                 .add(new SqlIdentifier("_", p))
                 .addAll(columnList)
                 .build());
-    return new SqlSelect(p, null, selectList, from, null, null, null, null,
+    return new SqlSelect(p, null, selectList, null, from, null, null, null, null,
         null, null, null, null, null);
   }
 


### PR DESCRIPTION
Sometimes it is useful to be able to select all columns in a table except one or two columns.

This is a useful feature in for instance bigquery.

I could not figure out how to make the parser deal with dialects, so I added this to the default parser.

I do not think that this is supported by all databases, so not sure where this should live, please advice.