### PR TITLE
[CALCITE-5563] Reduce loops to optimize RelSubset#getParents and RelSubset#getParentSubsets

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -295,6 +295,7 @@ public class RelSubset extends AbstractRelNode {
         // see usage of this method in propagateCostImprovements0()
         if (rel == this) {
           list.add(parent);
+          break;
         }
       }
     }
@@ -311,6 +312,7 @@ public class RelSubset extends AbstractRelNode {
       for (RelSubset rel : inputSubsets(parent)) {
         if (rel.set == set && rel.getTraitSet().equals(traitSet)) {
           list.add(planner.getSubsetNonNull(parent));
+          break;
         }
       }
     }


### PR DESCRIPTION
jira: [CALCITE-5563](https://issues.apache.org/jira/browse/CALCITE-5563)
Once we have found a matching Relsubset from its parent input, we can immediately end the inner loop