### PR TITLE
[CALCITE-5565] Implement BigQuery LOG Function

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -731,6 +731,33 @@ Call to function 'SPLIT' with argument of type 'BINARY(2)' requires extra delimi
 !error
 
 #####################################################################
+# LOG
+#
+# LOG(value1, value2)
+#
+# If only value1 is present, LOG is a synonym of LN. If value2 is also
+# present, LOG computes the logarithm of value1 to base value2.
+SELECT LOG(64, 8) as result;
++--------+
+| result |
++--------+
+|    2.0 |
++--------+
+(1 row)
+
+!ok
+
+SELECT LOG(100) as result;
++-------------------+
+| result            |
++-------------------+
+| 4.605170185988092 |
++-------------------+
+(1 row)
+
+!ok
+
+#####################################################################
 # STRING
 #
 # STRING(timestamp_expression[, time_zone])

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -153,6 +153,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_SET;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_STORAGE_SIZE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.JSON_TYPE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LEFT;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOG;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_AND;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_OR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LPAD;
@@ -490,9 +491,11 @@ public class RexImpTable {
       defineMethod(MOD, "mod", NullPolicy.STRICT);
       defineMethod(EXP, "exp", NullPolicy.STRICT);
       defineMethod(POWER, "power", NullPolicy.STRICT);
-      defineMethod(LN, "ln", NullPolicy.STRICT);
-      defineMethod(LOG10, "log10", NullPolicy.STRICT);
       defineMethod(ABS, "abs", NullPolicy.STRICT);
+
+      map.put(LN, new LogImplementor());
+      map.put(LOG, new LogImplementor());
+      map.put(LOG10, new LogImplementor());
 
       map.put(RAND, new RandImplementor());
       map.put(RAND_INTEGER, new RandIntegerImplementor());
@@ -3681,6 +3684,46 @@ public class RexImpTable {
     @Override Expression implementSafe(final RexToLixTranslator translator,
         final RexCall call, final List<Expression> argValueList) {
       return Expressions.call(BuiltInMethod.NOT.method, argValueList);
+    }
+  }
+
+  /** Implementor for the {@code LN}, {@code LOG}, and {@code LOG10} operators
+   *
+   * <p>Handles all logarithm functions using log rules to determine the
+   * appropriate base (i.e. base e for LN).
+   */
+  private static class LogImplementor extends AbstractRexCallImplementor {
+    LogImplementor() {
+      super("log", NullPolicy.STRICT, true);
+    }
+
+    @Override Expression implementSafe(final RexToLixTranslator translator,
+        final RexCall call, final List<Expression> argValueList) {
+      Expression operand0 = argValueList.get(0);
+      Expression operand1;
+
+      switch (call.getOperator().getName()) {
+      case "LN":
+        operand1 = Expressions.constant(Math.exp(1));
+        break;
+      case "LOG":
+        switch (argValueList.size()) {
+        case 1:
+          operand1 = Expressions.constant(Math.exp(1));
+          break;
+        default:
+          operand1 = argValueList.get(1);
+        }
+        break;
+      case "LOG10":
+        operand1 = Expressions.constant(BigDecimal.TEN);
+        break;
+      default:
+        throw new UnsupportedOperationException("Operator not found:"
+            + call.getOperator().getName());
+      }
+
+      return Expressions.call(BuiltInMethod.LOG.method, Expressions.list(operand0, operand1));
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1567,28 +1567,27 @@ public class SqlFunctions {
     return Math.pow(b0.doubleValue(), b1.doubleValue());
   }
 
-  // LN
 
-  /** SQL {@code LN(number)} function applied to double values. */
-  public static double ln(double d) {
-    return Math.log(d);
+  // LN, LOG, LOG10
+
+  /** SQL {@code LOG(number, number2)} function applied to double values. */
+  public static double log(double d0, double d1) {
+    return Math.log(d0) / Math.log(d1);
   }
 
-  /** SQL {@code LN(number)} function applied to BigDecimal values. */
-  public static double ln(BigDecimal d) {
-    return Math.log(d.doubleValue());
+  /** SQL {@code LOG(number, number2)} function applied to double and BigDecimal values. */
+  public static double log(double d0, BigDecimal d1) {
+    return Math.log(d0) / Math.log(d1.doubleValue());
   }
 
-  // LOG10
-
-  /** SQL <code>LOG10(numeric)</code> operator applied to double values. */
-  public static double log10(double b0) {
-    return Math.log10(b0);
+  /** SQL {@code LOG(number, number2)} function applied to double and BigDecimal values. */
+  public static double log(BigDecimal d0, double d1) {
+    return Math.log(d0.doubleValue()) / Math.log(d1);
   }
 
-  /** SQL {@code LOG10(number)} function applied to BigDecimal values. */
-  public static double log10(BigDecimal d) {
-    return Math.log10(d.doubleValue());
+  /** SQL {@code LOG(number, number2)} function applied to double values. */
+  public static double log(BigDecimal d0, BigDecimal d1) {
+    return Math.log(d0.doubleValue()) / Math.log(d1.doubleValue());
   }
 
   // MOD

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1177,6 +1177,14 @@ public abstract class SqlLibraryOperators {
           OperandTypes.STRING.or(OperandTypes.BINARY),
           SqlFunctionCategory.STRING);
 
+  /** The "LOG(value, [, value2])" function. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction LOG =
+      SqlBasicFunction.create("LOG",
+          ReturnTypes.DOUBLE_NULLABLE,
+          OperandTypes.NUMERIC_OPTIONAL_NUMERIC,
+          SqlFunctionCategory.NUMERIC);
+
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction POW =
       SqlStdOperatorTable.POWER.withName("POW");

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -354,6 +354,11 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker INTEGER =
       family(SqlTypeFamily.INTEGER);
 
+  public static final SqlSingleOperandTypeChecker NUMERIC_OPTIONAL_NUMERIC =
+      family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+          // Second operand optional (operand index 0, 1)
+          number -> number == 1);
+
   public static final SqlSingleOperandTypeChecker NUMERIC_OPTIONAL_INTEGER =
       family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.INTEGER),
           // Second operand optional (operand index 0, 1)

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -432,6 +432,7 @@ public enum BuiltInMethod {
   RAND_INTEGER(RandomFunction.class, "randInteger", int.class),
   RAND_INTEGER_SEED(RandomFunction.class, "randIntegerSeed", int.class,
       int.class),
+  LOG(SqlFunctions.class, "log", long.class, long.class),
   TANH(SqlFunctions.class, "tanh", long.class),
   SINH(SqlFunctions.class, "sinh", long.class),
   TRUNCATE(SqlFunctions.class, "truncate", String.class, int.class),

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2706,6 +2706,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b o | LEAST(expr [, expr ]* )                      | Returns the least of the expressions
 | b m p | LEFT(string, length)                       | Returns the leftmost *length* characters from the *string*
 | b | LENGTH(string)                                 | Equivalent to `CHAR_LENGTH(string)`
+| b | LOG(value1 [, value2 ])                        | Returns the logarithm of *value1* to base *value2*, or base e if *value2* is not present
 | b o | LPAD(string, length[, pattern ])             | Returns a string or bytes value that consists of *string* prepended to *length* with *pattern*
 | m | TO_BASE64(string)                              | Converts the *string* to base-64 encoded form and returns a encoded string
 | b m | FROM_BASE64(string)                          | Returns the decoded result of a base-64 *string* as a string

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -5057,7 +5057,7 @@ public class SqlOperatorTest {
     f.checkNull("ln(cast(null as tinyint))");
   }
 
-  @Test void testLogFunc() {
+  @Test void testLog10Func() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.LOG10, VmName.EXPAND);
     f.checkScalarApprox("log10(10)", "DOUBLE NOT NULL",
@@ -5071,6 +5071,32 @@ public class SqlOperatorTest {
     f.checkScalarApprox("log10(cast(10e-3 as real))", "DOUBLE NOT NULL",
         isWithin(-2.0, 0.000001));
     f.checkNull("log10(cast(null as real))");
+  }
+
+  @Test void testLogFunc() {
+    final SqlOperatorFixture f0 = fixture()
+        .setFor(SqlLibraryOperators.LOG, VmName.EXPAND);
+    f0.checkFails("^log(100, 10)^",
+        "No match found for function signature LOG\\(<NUMERIC>, <NUMERIC>\\)", false);
+    final SqlOperatorFixture f = f0.withLibrary(SqlLibrary.BIG_QUERY);
+    f.checkScalarApprox("log(10, 10)", "DOUBLE NOT NULL",
+        isWithin(1.0, 0.000001));
+    f.checkScalarApprox("log(64, 8)", "DOUBLE NOT NULL",
+        isWithin(2.0, 0.000001));
+    f.checkScalarApprox("log(27,3)", "DOUBLE NOT NULL",
+        isWithin(3.0, 0.000001));
+    f.checkScalarApprox("log(100, 10)", "DOUBLE NOT NULL",
+        isWithin(2.0, 0.000001));
+    f.checkScalarApprox("log(10, 100)", "DOUBLE NOT NULL",
+        isWithin(0.5, 0.000001));
+    f.checkScalarApprox("log(cast(10e6 as double), 10)", "DOUBLE NOT NULL",
+        isWithin(7.0, 0.000001));
+    f.checkScalarApprox("log(cast(10e8 as float), 10)", "DOUBLE NOT NULL",
+        isWithin(9.0, 0.000001));
+    f.checkScalarApprox("log(cast(10e-3 as real), 10)", "DOUBLE NOT NULL",
+        isWithin(-2.0, 0.000001));
+    f.checkNull("log(cast(null as real), 10)");
+    f.checkNull("log(10, cast(null as real))");
   }
 
   @Test void testRandFunc() {


### PR DESCRIPTION
Calcite currently supports the LN and LOG10 function. BigQuery offers the LOG function which allows for the base of the logarithm to be specified as a second argument. If the second argument is not provided, the base is defaulted to e (making it identical to the LN function).

Example: LOG(64, 10) would return 2.
Example 2: LOG(10) would return the same as LN(10).

BigQuery docs: https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#log