### PR TITLE
[CALCITE-5571] Remove org.jetbrains.annotations from java source code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -334,6 +334,11 @@ allprojects {
     val javaUsed = file("src/main/java").isDirectory
     if (javaUsed) {
         apply(plugin = "java-library")
+        configurations {
+            "implementation" {
+                exclude(group = "org.jetbrains", module = "annotations")
+            }
+        }
     }
 
     plugins.withId("java-library") {

--- a/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ScannableTableTest.java
@@ -46,7 +46,6 @@ import org.apache.calcite.util.Pair;
 import com.google.common.collect.ImmutableMap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -652,7 +651,7 @@ public class ScannableTableTest {
       @Override public Enumerable<@Nullable Object[]> scan(DataContext root) {
         scanCount.incrementAndGet();
         return new AbstractEnumerable<Object[]>() {
-          @NotNull @Override public Enumerator<Object[]> enumerator() {
+          @Override public Enumerator<Object[]> enumerator() {
             enumerateCount.incrementAndGet();
             final Enumerator<Object[]> enumerator =
                 superScan(root).enumerator();

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -47,12 +47,11 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.hamcrest.TypeSafeMatcher;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.io.PrintWriter;
@@ -2054,10 +2053,10 @@ class UtilTest {
   /** Tests {@link ReflectUtil#mightBeAssignableFrom(Class, Class)}. */
   @Test void testMightBeAssignableFrom() {
     final Object myMap = new HashMap<String, Integer>() {
-      @Override public @NotNull Set<Entry<String, Integer>> entrySet() {
+      @Override public Set<Entry<String, Integer>> entrySet() {
         throw new UnsupportedOperationException();
       }
-      @Override public @Nullable Integer put(String key, Integer value) {
+      @Override public Integer put(String key, Integer value) {
         throw new UnsupportedOperationException();
       }
       @Override public int size() {
@@ -2342,7 +2341,7 @@ class UtilTest {
     memo1.close();
     assertThat(local1.get(), is("foo"));
 
-    final TryThreadLocal<@org.checkerframework.checker.nullness.qual.Nullable String> local2 =
+    final TryThreadLocal<@Nullable String> local2 =
         TryThreadLocal.of(null);
     assertThat(local2.get(), nullValue());
     TryThreadLocal.Memo memo2 = local2.push("a");


### PR DESCRIPTION
The project primarily uses checkerframework annotations (org .checkerframework.checker.nullness.qual) for specifying nullability; not org.jetbrains.annotations.

To keep things consistent and also avoid mixing up annotations from different providers in the future, this commit removes the last references to org.jetbrains.annotations and excludes the org.jetbrains:annotations dependency from the build to avoid accidentally using such annotations in the future.