### PR TITLE
[CALCITE-4698] Respect input types and precision for datetime_plus and timestampadd

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -321,7 +321,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
     final SqlIntervalQualifier intervalQualifier = type1.getIntervalQualifier();
     if (isInt1
         || !dateTimeType.getSqlTypeName().allowsPrec()
-        || (intervalQualifier.useDefaultFractionalSecondPrecision()
+        || intervalQualifier != null && (intervalQualifier.useDefaultFractionalSecondPrecision()
         || intervalQualifier
         .getFractionalSecondPrecision(typeSystem) <= dateTimeType.getPrecision())) {
       return dateTimeType;

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -317,12 +317,12 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   protected RelDataType leastRestrictiveIntervalDatetimeType(
       final RelDataType dateTimeType, final RelDataType type1) {
     assert SqlTypeUtil.isDatetime(dateTimeType);
-    assert SqlTypeUtil.isInterval(type1);
+    if (SqlTypeUtil.isIntType(type1)) {
+      return dateTimeType;
+    }
     final SqlIntervalQualifier intervalQualifier = type1.getIntervalQualifier();
     assert intervalQualifier != null;
-    final boolean isInt1 = SqlTypeUtil.isIntType(type1);
-    if (isInt1
-        || !dateTimeType.getSqlTypeName().allowsPrec()
+    if (!dateTimeType.getSqlTypeName().allowsPrec()
         || intervalQualifier.useDefaultFractionalSecondPrecision()
         || intervalQualifier
         .getFractionalSecondPrecision(typeSystem) <= dateTimeType.getPrecision()) {

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -317,13 +317,15 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
   protected RelDataType leastRestrictiveIntervalDatetimeType(
       final RelDataType dateTimeType, final RelDataType type1) {
     assert SqlTypeUtil.isDatetime(dateTimeType);
-    final boolean isInt1 = SqlTypeUtil.isIntType(type1);
+    assert SqlTypeUtil.isInterval(type1);
     final SqlIntervalQualifier intervalQualifier = type1.getIntervalQualifier();
+    assert intervalQualifier != null;
+    final boolean isInt1 = SqlTypeUtil.isIntType(type1);
     if (isInt1
         || !dateTimeType.getSqlTypeName().allowsPrec()
-        || intervalQualifier != null && (intervalQualifier.useDefaultFractionalSecondPrecision()
+        || intervalQualifier.useDefaultFractionalSecondPrecision()
         || intervalQualifier
-        .getFractionalSecondPrecision(typeSystem) <= dateTimeType.getPrecision())) {
+        .getFractionalSecondPrecision(typeSystem) <= dateTimeType.getPrecision()) {
       return dateTimeType;
     } else {
       return

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
@@ -82,8 +82,8 @@ public class SqlTimestampAddFunction extends SqlFunction {
         operandType1.isNullable() || operandType2.isNullable());
   }
 
-  static RelDataType deduceType(
-      RelDataTypeFactory typeFactory, TimeUnit timeUnit, RelDataType datetimeType) {
+  static RelDataType deduceType(RelDataTypeFactory typeFactory,
+      @Nullable TimeUnit timeUnit, RelDataType datetimeType) {
     final TimeUnit timeUnit2 = first(timeUnit, TimeUnit.EPOCH);
     SqlTypeName typeName = datetimeType.getSqlTypeName();
     switch (timeUnit2) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
@@ -103,7 +103,7 @@ public class SqlTimestampAddFunction extends SqlFunction {
     case NANOSECOND:
       return typeFactory.createSqlType(
           typeName,
-          Math.max(FRAC_SECOND_PRECISION_MAP.get(timeUnit2),
+          Math.max(FRAC_SECOND_PRECISION_MAP.getOrDefault(timeUnit2, 0),
               datetimeType.getPrecision()));
     case HOUR:
     case MINUTE:

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -473,7 +473,7 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
         if (types.size() > (i + 1)) {
           RelDataType type1 = types.get(i + 1);
           if (SqlTypeUtil.isDatetime(type1)) {
-            resultType = type1;
+            resultType = leastRestrictiveIntervalDatetimeType(type1, type);
             return createTypeWithNullability(resultType,
                 nullCount > 0 || nullableCount > 0);
           }
@@ -497,9 +497,10 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
         // datetime +/- interval (or integer) = datetime
         if (types.size() > (i + 1)) {
           RelDataType type1 = types.get(i + 1);
-          if (SqlTypeUtil.isInterval(type1)
-              || SqlTypeUtil.isIntType(type1)) {
-            resultType = type;
+          final boolean isInterval1 = SqlTypeUtil.isInterval(type1);
+          final boolean isInt1 = SqlTypeUtil.isIntType(type1);
+          if (isInterval1 || isInt1) {
+            resultType = leastRestrictiveIntervalDatetimeType(type, type1);
             return createTypeWithNullability(resultType,
                 nullCount > 0 || nullableCount > 0);
           }

--- a/testkit/src/main/java/org/apache/calcite/sql/test/ResultCheckers.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/ResultCheckers.java
@@ -28,6 +28,9 @@ import org.hamcrest.Matcher;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -55,6 +58,18 @@ public class ResultCheckers {
   public static SqlTester.ResultChecker isExactly(String value) {
     return new MatcherResultChecker<>(is(new BigDecimal(value)),
         JdbcType.BIG_DECIMAL);
+  }
+
+  public static SqlTester.ResultChecker isExactDateTime(LocalDateTime dateTime) {
+    return new MatcherResultChecker<>(
+        is(BigDecimal.valueOf(dateTime.toInstant(ZoneOffset.UTC).toEpochMilli())),
+        JdbcType.BIG_DECIMAL);
+  }
+
+  public static SqlTester.ResultChecker isExactTime(LocalTime time) {
+    return new MatcherResultChecker<>(
+        is((int) (time.toNanoOfDay() / 1000_000)),
+        JdbcType.INTEGER);
   }
 
   public static SqlTester.ResultChecker isWithin(double value, double delta) {

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -8071,6 +8071,22 @@ public class SqlOperatorTest {
         // "2016-02-24 12:42:25.000002",
         "TIMESTAMP(3) NOT NULL");
 
+    f.checkType(
+        "timestampadd(SQL_TSI_FRAC_SECOND, 2, timestamp with local time zone '2016-02-24 12:42:25.000000')",
+        "TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL");
+
+    f.checkType(
+        "timestampadd(SECOND, 2, timestamp '2016-02-24 12:42:25.000')",
+        "TIMESTAMP(3) NOT NULL");
+
+    f.checkType(
+        "timestampadd(HOUR, 2, time '12:42:25.000')",
+        "TIME(3) NOT NULL");
+
+    f.checkType(
+        "timestampadd(MINUTE, 2, time '12:42:25')",
+        "TIME(0) NOT NULL");
+
     // The following test would correctly return "TIMESTAMP(6) NOT NULL" if max
     // precision were 6 or higher
     assumeTrue(f.getFactory().getTypeFactory().getTypeSystem()

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -2619,6 +2619,9 @@ public class SqlOperatorTest {
     f.checkScalar("date '2005-03-02' - interval '25:45:54' hour to second",
         "2005-03-01", "DATE NOT NULL");
     f.checkScalar("timestamp '2003-08-02 12:54:01' "
+            + "- interval '-4 2:4' day to minute",
+        "2003-08-06 14:58:01", "TIMESTAMP(0) NOT NULL");
+    f.checkScalar("timestamp '2003-08-02 12:54:01' "
             + "- interval '0.01' second(1, 3)",
         isExactDateTime(LocalDateTime.of(2003, 8, 2, 12, 54, 0, 990_000_000)),
         "TIMESTAMP(3) NOT NULL");


### PR DESCRIPTION
The PR makes TimestampAddFunction respecting incoming type e.g. `timestamp with local time zone` and precision.

