### PR TITLE
[CALCITE-5580] Add SPLIT() Function (Enabled for BigQuery)

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -625,6 +625,55 @@ SELECT (19 % 19) as result;
 !ok
 
 #####################################################################
+# SPLIT
+#
+# SPLIT(string [, delimiter])
+#
+# Splits string using the delimiter argument. For STRING, the default
+# delimiter is the comma.
+#
+# Returns a STRING array as result.
+WITH letters AS
+  (SELECT '' as letter_group
+  UNION ALL
+  SELECT 'a' as letter_group
+  UNION ALL
+  SELECT 'b c d' as letter_group)
+
+SELECT SPLIT(letter_group, ' ') as example
+FROM letters;
++-----------+
+| example   |
++-----------+
+| []        |
+| [a]       |
+| [b, c, d] |
++-----------+
+(3 rows)
+
+!ok
+
+SELECT SPLIT("h,e,l,l,o") as result;
++-----------------+
+| result          |
++-----------------+
+| [h, e, l, l, o] |
++-----------------+
+(1 row)
+
+!ok
+
+SELECT SPLIT("") as result;
++--------+
+| result |
++--------+
+| []     |
++--------+
+(1 row)
+
+!ok
+
+#####################################################################
 # STRING
 #
 # STRING(timestamp_expression[, time_zone])

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -168,6 +168,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.SHA1;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SINH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SOUNDEX;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPACE;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPLIT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.STARTS_WITH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.STRCMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.TANH;
@@ -442,6 +443,7 @@ public class RexImpTable {
       defineMethod(SOUNDEX, BuiltInMethod.SOUNDEX.method, NullPolicy.STRICT);
       defineMethod(DIFFERENCE, BuiltInMethod.DIFFERENCE.method, NullPolicy.STRICT);
       defineMethod(REVERSE, BuiltInMethod.REVERSE.method, NullPolicy.STRICT);
+      defineMethod(SPLIT, "split", NullPolicy.STRICT);
 
       map.put(TRIM, new TrimImplementor());
 

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -463,6 +463,16 @@ public class SqlFunctions {
     return s0.startsWith(s1);
   }
 
+  /** SQL {@code SPLIT(string, string)} function. */
+  public static List<String> split(String s0, String s1) {
+    return Arrays.asList(s0.split(s1));
+  }
+
+  /** SQL {@code SPLIT(string)} function. */
+  public static List<String> split(String s) {
+    return split(s, ",");
+  }
+
   /** SQL SUBSTRING(string FROM ...) function. */
   public static String substring(String c, int s) {
     final int s0 = s - 1;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -255,6 +255,13 @@ public abstract class SqlLibraryOperators {
           OperandTypes.STRING)
           .withFunctionType(SqlFunctionCategory.STRING);
 
+  /** The "SPLIT(string [, delimiter])" function. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction SPLIT =
+      SqlBasicFunction.create("SPLIT", ReturnTypes.ARG0.andThen(SqlTypeTransforms.TO_ARRAY),
+          OperandTypes.STRING_OPTIONAL_STRING,
+          SqlFunctionCategory.STRING);
+
   /** Generic "SUBSTR(string, position [, substringLength ])" function. */
   private static final SqlBasicFunction SUBSTR =
       SqlBasicFunction.create("SUBSTR", ReturnTypes.ARG0_NULLABLE_VARYING,

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -380,6 +380,12 @@ public abstract class OperandTypes {
   public static final FamilyOperandTypeChecker STRING_STRING =
       family(SqlTypeFamily.STRING, SqlTypeFamily.STRING);
 
+  public static final FamilyOperandTypeChecker STRING_OPTIONAL_STRING =
+      family(
+          ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.STRING),
+          // Second operand optional (operand index 0, 1)
+          number -> number == 1);
+
   public static final FamilyOperandTypeChecker STRING_STRING_STRING =
       family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING);
 

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2708,6 +2708,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b o | SINH(numeric)                                | Returns the hyperbolic sine of *numeric*
 | b m o p | SOUNDEX(string)                          | Returns the phonetic representation of *string*; throws if *string* is encoded with multi-byte encoding such as UTF-8
 | m | SPACE(integer)                                 | Returns a string of *integer* spaces; returns an empty string if *integer* is less than 1
+| b | SPLIT(string1 [, string2 ])                    | Returns the string array of *string1* being split at delimiter *string2*, the default delimiter is a comma if *string2* is not provided
 | b | STARTS_WITH(string1, string2)                  | Returns whether *string2* is a prefix of *string1*
 | m | STRCMP(string, string)                         | Returns 0 if both of the strings are same and returns -1 when the first argument is smaller than the second and 1 when the second one is smaller than the first one
 | b m o p | SUBSTR(string, position [, substringLength ]) | Returns a portion of *string*, beginning at character *position*, *substringLength* characters long. SUBSTR calculates lengths using characters as defined by the input character set

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -6066,6 +6066,27 @@ public class SqlOperatorTest {
     f.checkBoolean("ends_with(x'', x'')", true);
   }
 
+  /** Tests the {@code SPLIT} operator. */
+  @Test void testSplitFunction() {
+    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.SPLIT);
+    f0.checkFails("^split('hello')^",
+        "No match found for function signature SPLIT\\(<CHARACTER>\\)",
+        false);
+    final SqlOperatorFixture f = f0.withLibrary(SqlLibrary.BIG_QUERY);
+    f.checkScalar("SPLIT('h,e,l,l,o')", "[h, e, l, l, o]",
+        "CHAR(9) NOT NULL ARRAY NOT NULL");
+    f.checkScalar("SPLIT('h-e-l-l-o', '-')", "[h, e, l, l, o]",
+        "CHAR(9) NOT NULL ARRAY NOT NULL");
+    f.checkScalar("SPLIT('hello', '-')", "[hello]",
+        "CHAR(5) NOT NULL ARRAY NOT NULL");
+    f.checkScalar("SPLIT('')", "[]",
+        "CHAR(0) NOT NULL ARRAY NOT NULL");
+    f.checkScalar("SPLIT('', '-')", "[]",
+        "CHAR(0) NOT NULL ARRAY NOT NULL");
+    f.checkNull("SPLIT(null)");
+    f.checkNull("SPLIT('hello', null)");
+  }
+
   /** Tests the {@code SUBSTRING} operator. Many test cases that used to be
    * have been moved to {@link SubFunChecker#assertSubFunReturns}, and are
    * called for both {@code SUBSTRING} and {@code SUBSTR}. */


### PR DESCRIPTION
BigQuery offers the `SPLIT()` function which splits a string at an optionally-specified delimiter into a string array. If no delimiter is specified, it is default to a comma. If the string is empty, an array of a single empty string is returned. If the delimiter is not found in the string, an array with a single element (the string) is returned. 

In BigQuery, the function can also accept bytes. In order to implement this, I think some modifications to ByteString.java may be required. I will probably not do this at least for my initial draft. If anyone has any suggestions or guidance on whether or not it should be supported, I would appreciate it. 

Documentation and example cases may be found below.

EXAMPLE: `SPLIT('h,e,l,l,o')` would return: `[h, e, l, l, o]`.
EXAMPLE: `SPLIT('h-e-l-l-o', '-')` would return: `[h, e, l, l, o]`.

[BigQuery docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#split) 
[JIRA Case](https://issues.apache.org/jira/browse/CALCITE-5580)