### PR TITLE
Make ArraySqlType, MapSqlType and MultisetSqlType extending ApplySqlType

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/ArraySqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ArraySqlType.java
@@ -20,6 +20,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFamily;
 import org.apache.calcite.rel.type.RelDataTypePrecedenceList;
 
+import java.util.Collections;
+
 import static org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow;
 
 import static java.util.Objects.requireNonNull;
@@ -27,10 +29,8 @@ import static java.util.Objects.requireNonNull;
 /**
  * SQL array type.
  */
-public class ArraySqlType extends AbstractSqlType {
+public class ArraySqlType extends ApplySqlType {
   //~ Instance fields --------------------------------------------------------
-
-  private final RelDataType elementType;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -39,8 +39,8 @@ public class ArraySqlType extends AbstractSqlType {
    * from a factory method.
    */
   public ArraySqlType(RelDataType elementType, boolean isNullable) {
-    super(SqlTypeName.ARRAY, isNullable, null);
-    this.elementType = requireNonNull(elementType, "elementType");
+    super(SqlTypeName.ARRAY, isNullable,
+        Collections.singletonList(requireNonNull(elementType, "elementType")));
     computeDigest();
   }
 
@@ -49,16 +49,16 @@ public class ArraySqlType extends AbstractSqlType {
   // implement RelDataTypeImpl
   @Override protected void generateTypeString(StringBuilder sb, boolean withDetail) {
     if (withDetail) {
-      sb.append(elementType.getFullTypeString());
+      sb.append(getComponentType().getFullTypeString());
     } else {
-      sb.append(elementType.toString());
+      sb.append(getComponentType().toString());
     }
     sb.append(" ARRAY");
   }
 
   // implement RelDataType
   @Override public RelDataType getComponentType() {
-    return elementType;
+    return types.get(0);
   }
 
   // implement RelDataType

--- a/core/src/main/java/org/apache/calcite/sql/type/MapSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/MapSqlType.java
@@ -19,14 +19,17 @@ package org.apache.calcite.sql.type;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFamily;
 
+import java.util.Arrays;
+
+import static java.util.Objects.requireNonNull;
+
 /**
  * SQL map type.
  */
-public class MapSqlType extends AbstractSqlType {
+public class MapSqlType extends ApplySqlType {
   //~ Instance fields --------------------------------------------------------
-
-  private final RelDataType keyType;
-  private final RelDataType valueType;
+  private static final int KEY_TYPE_INDEX = 0;
+  private static final int VALUE_TYPE_INDEX = 1;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -36,26 +39,26 @@ public class MapSqlType extends AbstractSqlType {
    */
   public MapSqlType(
       RelDataType keyType, RelDataType valueType, boolean isNullable) {
-    super(SqlTypeName.MAP, isNullable, null);
-    assert keyType != null;
-    assert valueType != null;
-    this.keyType = keyType;
-    this.valueType = valueType;
+    super(SqlTypeName.MAP, isNullable,
+        Arrays.asList(requireNonNull(keyType, "keyType"),
+            requireNonNull(valueType, "valueType")));
     computeDigest();
   }
 
   //~ Methods ----------------------------------------------------------------
 
   @Override public RelDataType getValueType() {
-    return valueType;
+    return types.get(VALUE_TYPE_INDEX);
   }
 
   @Override public RelDataType getKeyType() {
-    return keyType;
+    return types.get(KEY_TYPE_INDEX);
   }
 
   // implement RelDataTypeImpl
   @Override protected void generateTypeString(StringBuilder sb, boolean withDetail) {
+    final RelDataType keyType = getKeyType();
+    final RelDataType valueType = getValueType();
     sb.append("(")
         .append(
             withDetail

--- a/core/src/main/java/org/apache/calcite/sql/type/MultisetSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/MultisetSqlType.java
@@ -20,15 +20,17 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFamily;
 import org.apache.calcite.rel.type.RelDataTypePrecedenceList;
 
+import java.util.Collections;
+
 import static org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * MultisetSqlType represents a standard SQL2003 multiset type.
  */
-public class MultisetSqlType extends AbstractSqlType {
+public class MultisetSqlType extends ApplySqlType {
   //~ Instance fields --------------------------------------------------------
-
-  private final RelDataType elementType;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -37,9 +39,8 @@ public class MultisetSqlType extends AbstractSqlType {
    * from a factory method.
    */
   public MultisetSqlType(RelDataType elementType, boolean isNullable) {
-    super(SqlTypeName.MULTISET, isNullable, null);
-    assert elementType != null;
-    this.elementType = elementType;
+    super(SqlTypeName.MULTISET, isNullable,
+        Collections.singletonList(requireNonNull(elementType, "elementType")));
     computeDigest();
   }
 
@@ -48,16 +49,16 @@ public class MultisetSqlType extends AbstractSqlType {
   // implement RelDataTypeImpl
   @Override protected void generateTypeString(StringBuilder sb, boolean withDetail) {
     if (withDetail) {
-      sb.append(elementType.getFullTypeString());
+      sb.append(getComponentType().getFullTypeString());
     } else {
-      sb.append(elementType.toString());
+      sb.append(getComponentType().toString());
     }
     sb.append(" MULTISET");
   }
 
   // implement RelDataType
   @Override public RelDataType getComponentType() {
-    return elementType;
+    return types.get(0);
   }
 
   // implement RelDataType


### PR DESCRIPTION
The PR is a POC for discussion in https://issues.apache.org/jira/browse/CALCITE-5570
especially this comment 
>I wonder whether it's possible to make MapSqlType, ArraySqlType, MultisetSqlType extend ApplySqlType?

at https://issues.apache.org/jira/browse/CALCITE-5570#comment-17700800