### PR TITLE
[MINOR][JAVADOC] Updated javadoc instructions for RelColumnOrigin#isDerived method

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelColumnOrigin.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelColumnOrigin.java
@@ -62,7 +62,7 @@ public class RelColumnOrigin {
   /**
    * Consider the query <code>select a+b as c, d as e from t</code>. The
    * output column c has two origins (a and b), both of them derived. The
-   * output column d as one origin (c), which is not derived.
+   * output column e has one origin (d), which is not derived.
    *
    * @return false if value taken directly from column in origin table; true
    * otherwise


### PR DESCRIPTION
This is a typo of RelColumnOrigin#isDerived method