### PR TITLE
[CALCITE-5605] Add BigQuery as supported library for CHR

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1133,7 +1133,7 @@ public abstract class SqlLibraryOperators {
 
   /** The "CHR(n)" function; returns the character whose UTF-8 code is
    * {@code n}. */
-  @LibraryOperator(libraries = {ORACLE, POSTGRESQL})
+  @LibraryOperator(libraries = {BIG_QUERY, ORACLE, POSTGRESQL})
   public static final SqlFunction CHR =
       SqlBasicFunction.create("CHR",
           ReturnTypes.CHAR,

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2647,7 +2647,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b | ARRAY_LENGTH(array)                            | Synonym for `CARDINALITY`
 | b | ARRAY_REVERSE(array)                           | Reverses elements of *array*
 | m s | CHAR(integer)                                | Returns the character whose ASCII code is *integer* % 256, or null if *integer* &lt; 0
-| o p | CHR(integer)                                 | Returns the character whose UTF-8 code is *integer*
+| b o p | CHR(integer)                               | Returns the character whose UTF-8 code is *integer*
 | b o | COSH(numeric)                                | Returns the hyperbolic cosine of *numeric*
 | o | CONCAT(string, string)                         | Concatenates two strings
 | b m p | CONCAT(string [, string ]*)                | Concatenates two or more strings

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -1747,12 +1747,16 @@ public class SqlOperatorTest {
   @Test void testChr() {
     final SqlOperatorFixture f0 = fixture()
         .setFor(SqlLibraryOperators.CHR, VM_FENNEL, VM_JAVA);
-    final SqlOperatorFixture f = f0.withLibrary(SqlLibrary.ORACLE);
-    f.checkScalar("chr(97)", "a", "CHAR(1) NOT NULL");
-    f.checkScalar("chr(48)", "0", "CHAR(1) NOT NULL");
-    f.checkScalar("chr(0)", String.valueOf('\u0000'), "CHAR(1) NOT NULL");
     f0.checkFails("^chr(97.1)^",
         "No match found for function signature CHR\\(<NUMERIC>\\)", false);
+    final Consumer<SqlOperatorFixture> consumer = f -> {
+      f.checkScalar("chr(97)", "a", "CHAR(1) NOT NULL");
+      f.checkScalar("chr(48)", "0", "CHAR(1) NOT NULL");
+      f.checkScalar("chr(0)", String.valueOf('\u0000'), "CHAR(1) NOT NULL");
+      f.checkNull("chr(null)");
+    };
+    f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE, SqlLibrary.POSTGRESQL),
+        consumer);
   }
 
   @Test void testSelect() {


### PR DESCRIPTION
Calcite already supports the CHR function for Oracle and PostgreSQL. BigQuery supports it as well ([link](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#chr)) so I would just like to enable it and add a couple more tests.