### PR TITLE
[CALCITE-5606] Add SqlLibrary.ALL and change the library of TANH, COSH, SINH to it

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
@@ -30,7 +30,8 @@ import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 
-import java.util.List;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Properties;
 
 /** Implementation of {@link CalciteConnectionConfig}. */
@@ -113,10 +114,13 @@ public class CalciteConnectionConfigImpl extends ConnectionConfigImpl
     if (fun == null || fun.equals("") || fun.equals("standard")) {
       return defaultOperatorTable;
     }
-    final List<SqlLibrary> libraryList = SqlLibrary.parse(fun);
+    final HashSet<SqlLibrary> librarySet = new HashSet<>(SqlLibrary.parse(fun));
+    if (librarySet.remove(SqlLibrary.ALL)) {
+      librarySet.addAll(SqlLibrary.getExpandedLibrariesForAll());
+    }
     final SqlOperatorTable operatorTable =
             SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(
-                ConsList.of(SqlLibrary.STANDARD, libraryList), true);
+                ConsList.of(SqlLibrary.STANDARD, new ArrayList<>(librarySet)), true);
     return operatorTableClass.cast(operatorTable);
   }
 

--- a/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteConnectionConfigImpl.java
@@ -116,7 +116,7 @@ public class CalciteConnectionConfigImpl extends ConnectionConfigImpl
     final List<SqlLibrary> libraryList = SqlLibrary.parse(fun);
     final SqlOperatorTable operatorTable =
             SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(
-                ConsList.of(SqlLibrary.STANDARD, libraryList));
+                ConsList.of(SqlLibrary.STANDARD, libraryList), true);
     return operatorTableClass.cast(operatorTable);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -68,7 +69,9 @@ public enum SqlLibrary {
   POSTGRESQL("p", "postgresql"),
   /** A collection of operators that are in Apache Spark but not in standard
    * SQL. */
-  SPARK("s", "spark");
+  SPARK("s", "spark"),
+  /** A collection of operators that could be used in all libraries except STANDARD and SPATIAL. */
+  ALL("*", "all");
 
   /** Abbreviation for the library used in SQL reference. */
   public final String abbrev;
@@ -94,11 +97,21 @@ public enum SqlLibrary {
   /** Parses a comma-separated string such as "standard,oracle". */
   public static List<SqlLibrary> parse(String libraryNameList) {
     final ImmutableList.Builder<SqlLibrary> list = ImmutableList.builder();
-    for (String libraryName : libraryNameList.split(",")) {
-      SqlLibrary library =
-          requireNonNull(SqlLibrary.of(libraryName),
-              () -> "library does not exist: " + libraryName);
-      list.add(library);
+    List<String> libList = Arrays.asList(libraryNameList.split(","));
+    if (libList.contains(ALL.abbrev) || libList.contains(ALL.fun)) {
+      // Add all the libraries except ALL, STANDARD, SPATIAL for 'all' and '*'.
+      for (SqlLibrary value : values()) {
+        if (value != ALL && value != STANDARD && value != SPATIAL) {
+          list.add(value);
+        }
+      }
+    } else {
+      for (String libraryName : libraryNameList.split(",")) {
+        SqlLibrary library =
+            requireNonNull(SqlLibrary.of(libraryName),
+                () -> "library does not exist: " + libraryName);
+        list.add(library);
+      }
     }
     return list.build();
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
@@ -45,6 +45,8 @@ import static java.util.Objects.requireNonNull;
  * @see LibraryOperator
  */
 public enum SqlLibrary {
+  /** A collection of operators that could be used in all libraries except STANDARD and SPATIAL. */
+  ALL("*", "all"),
   /** The standard operators. */
   STANDARD("", "standard"),
   /** Geospatial operators. */
@@ -69,9 +71,7 @@ public enum SqlLibrary {
   POSTGRESQL("p", "postgresql"),
   /** A collection of operators that are in Apache Spark but not in standard
    * SQL. */
-  SPARK("s", "spark"),
-  /** A collection of operators that could be used in all libraries except STANDARD and SPATIAL. */
-  ALL("*", "all");
+  SPARK("s", "spark");
 
   /** Abbreviation for the library used in SQL reference. */
   public final String abbrev;
@@ -106,7 +106,7 @@ public enum SqlLibrary {
         }
       }
     } else {
-      for (String libraryName : libraryNameList.split(",")) {
+      for (String libraryName : libList) {
         SqlLibrary library =
             requireNonNull(SqlLibrary.of(libraryName),
                 () -> "library does not exist: " + libraryName);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibrary.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -97,20 +96,21 @@ public enum SqlLibrary {
   /** Parses a comma-separated string such as "standard,oracle". */
   public static List<SqlLibrary> parse(String libraryNameList) {
     final ImmutableList.Builder<SqlLibrary> list = ImmutableList.builder();
-    List<String> libList = Arrays.asList(libraryNameList.split(","));
-    if (libList.contains(ALL.abbrev) || libList.contains(ALL.fun)) {
-      // Add all the libraries except ALL, STANDARD, SPATIAL for 'all' and '*'.
-      for (SqlLibrary value : values()) {
-        if (value != ALL && value != STANDARD && value != SPATIAL) {
-          list.add(value);
-        }
-      }
-    } else {
-      for (String libraryName : libList) {
-        SqlLibrary library =
-            requireNonNull(SqlLibrary.of(libraryName),
-                () -> "library does not exist: " + libraryName);
-        list.add(library);
+    for (String libraryName : libraryNameList.split(",")) {
+      SqlLibrary library =
+          requireNonNull(SqlLibrary.of(libraryName),
+              () -> "library does not exist: " + libraryName);
+      list.add(library);
+    }
+    return list.build();
+  }
+
+  /** Get expanded libraries for {@link SqlLibrary.ALL}. */
+  public static List<SqlLibrary> getExpandedLibrariesForAll() {
+    final ImmutableList.Builder<SqlLibrary> list = ImmutableList.builder();
+    for (SqlLibrary value : values()) {
+      if (value != ALL && value != STANDARD && value != SPATIAL) {
+        list.add(value);
       }
     }
     return list.build();

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -52,6 +52,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.calcite.sql.fun.SqlLibrary.ALL;
 import static org.apache.calcite.sql.fun.SqlLibrary.BIG_QUERY;
 import static org.apache.calcite.sql.fun.SqlLibrary.CALCITE;
 import static org.apache.calcite.sql.fun.SqlLibrary.HIVE;
@@ -1140,21 +1141,21 @@ public abstract class SqlLibraryOperators {
           OperandTypes.INTEGER,
           SqlFunctionCategory.STRING);
 
-  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
+  @LibraryOperator(libraries = {ALL})
   public static final SqlFunction TANH =
       SqlBasicFunction.create("TANH",
           ReturnTypes.DOUBLE_NULLABLE,
           OperandTypes.NUMERIC,
           SqlFunctionCategory.NUMERIC);
 
-  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
+  @LibraryOperator(libraries = {ALL})
   public static final SqlFunction COSH =
       SqlBasicFunction.create("COSH",
           ReturnTypes.DOUBLE_NULLABLE,
           OperandTypes.NUMERIC,
           SqlFunctionCategory.NUMERIC);
 
-  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
+  @LibraryOperator(libraries = {ALL})
   public static final SqlFunction SINH =
       SqlBasicFunction.create("SINH",
           ReturnTypes.DOUBLE_NULLABLE,

--- a/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
@@ -877,7 +877,7 @@ class LatticeSuggesterTest {
 
     Tester withLibrary(SqlLibrary library) {
       SqlOperatorTable opTab = SqlLibraryOperatorTableFactory.INSTANCE
-          .getOperatorTable(EnumSet.of(SqlLibrary.STANDARD, library));
+          .getOperatorTable(EnumSet.of(SqlLibrary.STANDARD, library), true);
       return withConfig(builder().operatorTable(opTab).build());
     }
   }

--- a/core/src/test/java/org/apache/calcite/sql/test/DocumentationTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/DocumentationTest.java
@@ -104,15 +104,18 @@ class DocumentationTest {
     final FileFixture f = new FileFixture();
     final Map<String, PatternOp> map = new TreeMap<>();
     addOperators(map, "", SqlStdOperatorTable.instance().getOperatorList());
+    addOperators(map, "\\| \\* ", SqlLibraryOperatorTableFactory.INSTANCE
+        .getOperatorTable(SqlLibrary.ALL).getOperatorList());
     for (SqlLibrary library : SqlLibrary.values()) {
       switch (library) {
       case STANDARD:
       case SPATIAL:
+      case ALL:
         continue;
       }
       addOperators(map, "\\| [^|]*" + library.abbrev + "[^|]* ",
           SqlLibraryOperatorTableFactory.INSTANCE
-              .getOperatorTable(EnumSet.of(library)).getOperatorList());
+              .getOperatorTable(EnumSet.of(library), false).getOperatorList());
     }
     final Set<String> regexSeen = new HashSet<>();
     try (LineNumberReader r = new LineNumberReader(Util.reader(f.inFile))) {

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2616,6 +2616,7 @@ To enable an operator table, set the
 connect string parameter.
 
 The 'C' (compatibility) column contains value:
+* '*' for all libraries,
 * 'b' for Google BigQuery ('fun=bigquery' in the connect string),
 * 'c' for Apache Calcite ('fun=calcite' in the connect string),
 * 'h' for Apache Hive ('fun=hive' in the connect string),

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2648,7 +2648,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b | ARRAY_REVERSE(array)                           | Reverses elements of *array*
 | m s | CHAR(integer)                                | Returns the character whose ASCII code is *integer* % 256, or null if *integer* &lt; 0
 | o p | CHR(integer)                                 | Returns the character whose UTF-8 code is *integer*
-| b o | COSH(numeric)                                | Returns the hyperbolic cosine of *numeric*
+| * | COSH(numeric)                                  | Returns the hyperbolic cosine of *numeric*
 | o | CONCAT(string, string)                         | Concatenates two strings
 | b m p | CONCAT(string [, string ]*)                | Concatenates two or more strings
 | m | COMPRESS(string)                               | Compresses a string using zlib compression and returns the result as a binary string
@@ -2724,7 +2724,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b o | RTRIM(string)                                | Returns *string* with all blanks removed from the end
 | b | SAFE_CAST(value AS type)                       | Converts *value* to *type*, returning NULL if conversion fails
 | b m p | SHA1(string)                               | Calculates a SHA-1 hash value of *string* and returns it as a hex string
-| b o | SINH(numeric)                                | Returns the hyperbolic sine of *numeric*
+| * | SINH(numeric)                                  | Returns the hyperbolic sine of *numeric*
 | b m o p | SOUNDEX(string)                          | Returns the phonetic representation of *string*; throws if *string* is encoded with multi-byte encoding such as UTF-8
 | m | SPACE(integer)                                 | Returns a string of *integer* spaces; returns an empty string if *integer* is less than 1
 | b | SPLIT(string [, delimiter ])                   | Returns the string array of *string* split at *delimiter* (if omitted, default is comma)
@@ -2732,7 +2732,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | m | STRCMP(string, string)                         | Returns 0 if both of the strings are same and returns -1 when the first argument is smaller than the second and 1 when the second one is smaller than the first one
 | b p | STRPOS(string, substring)                    | Equivalent to `POSITION(substring IN string)`
 | b m o p | SUBSTR(string, position [, substringLength ]) | Returns a portion of *string*, beginning at character *position*, *substringLength* characters long. SUBSTR calculates lengths using characters as defined by the input character set
-| b o | TANH(numeric)                                | Returns the hyperbolic tangent of *numeric*
+| * | TANH(numeric)                                  | Returns the hyperbolic tangent of *numeric*
 | b | TIME(hour, minute, second)                     | Returns a TIME value *hour*, *minute*, *second* (all of type INTEGER)
 | b | TIME(timestamp)                                | Extracts the TIME from *timestamp* (a local time; BigQuery's DATETIME type)
 | b | TIME(instant)                                  | Extracts the TIME from *timestampLtz* (an instant; BigQuery's TIMESTAMP type), assuming UTC

--- a/testkit/src/main/java/org/apache/calcite/test/MockSqlOperatorTable.java
+++ b/testkit/src/main/java/org/apache/calcite/test/MockSqlOperatorTable.java
@@ -106,7 +106,7 @@ public class MockSqlOperatorTable extends ChainedSqlOperatorTable {
     return new MockSqlOperatorTable(
         SqlOperatorTables.chain(parentTable,
             SqlLibraryOperatorTableFactory.INSTANCE
-                .getOperatorTable(librarySet)));
+                .getOperatorTable(librarySet, true)));
   }
 
   /** "RAMP" user-defined table function. */

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -5346,7 +5346,7 @@ public class SqlOperatorTest {
       f.checkNull("cosh(cast(null as integer))");
       f.checkNull("cosh(cast(null as double))");
     };
-    f0.forEachLibrary(SqlLibrary.parse("*"), consumer);
+    f0.forEachLibrary(SqlLibrary.getExpandedLibrariesForAll(), consumer);
   }
 
   @Test void testCotFunc() {
@@ -5524,7 +5524,7 @@ public class SqlOperatorTest {
       f.checkNull("sinh(cast(null as integer))");
       f.checkNull("sinh(cast(null as double))");
     };
-    f0.forEachLibrary(SqlLibrary.parse("*"), consumer);
+    f0.forEachLibrary(SqlLibrary.getExpandedLibrariesForAll(), consumer);
   }
 
   @Test void testTanFunc() {
@@ -5565,7 +5565,7 @@ public class SqlOperatorTest {
       f.checkNull("tanh(cast(null as integer))");
       f.checkNull("tanh(cast(null as double))");
     };
-    f0.forEachLibrary(SqlLibrary.parse("*"), consumer);
+    f0.forEachLibrary(SqlLibrary.getExpandedLibrariesForAll(), consumer);
   }
 
   @Test void testTruncFunc() {

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -5346,7 +5346,7 @@ public class SqlOperatorTest {
       f.checkNull("cosh(cast(null as integer))");
       f.checkNull("cosh(cast(null as double))");
     };
-    f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE), consumer);
+    f0.forEachLibrary(SqlLibrary.parse("*"), consumer);
   }
 
   @Test void testCotFunc() {
@@ -5524,7 +5524,7 @@ public class SqlOperatorTest {
       f.checkNull("sinh(cast(null as integer))");
       f.checkNull("sinh(cast(null as double))");
     };
-    f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE), consumer);
+    f0.forEachLibrary(SqlLibrary.parse("*"), consumer);
   }
 
   @Test void testTanFunc() {
@@ -5565,7 +5565,7 @@ public class SqlOperatorTest {
       f.checkNull("tanh(cast(null as integer))");
       f.checkNull("tanh(cast(null as double))");
     };
-    f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE), consumer);
+    f0.forEachLibrary(SqlLibrary.parse("*"), consumer);
   }
 
   @Test void testTruncFunc() {


### PR DESCRIPTION
Add a new SqlLibrary named 'ALL' with abbreviation '*', if an operator is marked with this SqlLibrary, it means it's a common one and should belong to all the library. TANH, COSH, SINH are three of these operators.