### PR TITLE
CALCITE-5624: add parser option to skip array constructor

### DIFF
--- a/core/src/main/codegen/default_config.fmpp
+++ b/core/src/main/codegen/default_config.fmpp
@@ -445,4 +445,5 @@ parser: {
   includeBraces: true
   includeAdditionalDeclarations: false
   includeParsingStringLiteralAsArrayLiteral: false
+  includeArrayConstructor: true
 }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4699,6 +4699,8 @@ SqlNode MultisetConstructor() :
     )
 }
 
+<#if (parser.includeArrayConstructor!default.parser.includeArrayConstructor) >
+
 /** Parses an ARRAY constructor */
 SqlNode ArrayConstructor() :
 {
@@ -4745,6 +4747,7 @@ SqlNode ArrayConstructor() :
 </#if>
     )
 }
+</#if>
 
 SqlCall ArrayLiteral() :
 {
@@ -7309,6 +7312,9 @@ SqlIdentifier ReservedFunctionName() :
     (
         <ABS>
     |   <AVG>
+<#if (!parser.includeArrayConstructor!default.parser.includeArrayConstructor) >
+    |   <ARRAY>
+</#if>
     |   <CARDINALITY>
     |   <CEILING>
     |   <CHAR>

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4058,8 +4058,10 @@ SqlNode AtomicRowExpression() :
         e = JdbcFunctionCall()
     |
         e = MultisetConstructor()
+<#if (parser.includeArrayConstructor!default.parser.includeArrayConstructor) >
     |
         e = ArrayConstructor()
+</#if>
     |
         LOOKAHEAD(3)
         e = MapConstructor()


### PR DESCRIPTION
for example in Apache Spark the array constructor is defined using a buildtin function:
array(1, 2, 3)

I don't think there is an easy way to test parser freemarker options, alternatively, I could implement this using SqlParser.Config. 