### PR TITLE
CALCITE-5628: add parser option to skip map constructor

### DIFF
--- a/core/src/main/codegen/default_config.fmpp
+++ b/core/src/main/codegen/default_config.fmpp
@@ -445,4 +445,5 @@ parser: {
   includeBraces: true
   includeAdditionalDeclarations: false
   includeParsingStringLiteralAsArrayLiteral: false
+  includeMapConstructor: true
 }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4060,9 +4060,11 @@ SqlNode AtomicRowExpression() :
         e = MultisetConstructor()
     |
         e = ArrayConstructor()
+<#if (parser.includeMapConstructor!default.parser.includeMapConstructor) >
     |
         LOOKAHEAD(3)
         e = MapConstructor()
+</#if>
     |
         e = PeriodConstructor()
     |
@@ -4766,6 +4768,7 @@ SqlCall ArrayLiteral() :
     }
 }
 
+<#if (parser.includeMapConstructor!default.parser.includeMapConstructor) >
 /** Parses a MAP constructor */
 SqlNode MapConstructor() :
 {
@@ -4800,6 +4803,7 @@ SqlNode MapConstructor() :
         }
     )
 }
+</#if>
 
 /** Parses a PERIOD constructor */
 SqlNode PeriodConstructor() :
@@ -7339,6 +7343,9 @@ SqlIdentifier ReservedFunctionName() :
     |   <LOCALTIME>
     |   <LOCALTIMESTAMP>
     |   <LOWER>
+<#if (!parser.includeMapConstructor!default.parser.includeMapConstructor) >
+    |   <MAP>
+</#if>
     |   <MAX>
     |   <MIN>
     |   <MINUTE>


### PR DESCRIPTION
for example Apache Spark uses a built-in function do define maps:

```
> SELECT map(1.0, '2', 3.0, '4');
 {1.0:"2",3.0:"4"}
```

https://spark.apache.org/docs/latest/api/sql/index.html#map

related: https://github.com/apache/calcite/pull/3137