### PR TITLE
[CALCITE-5636] Consult root schema type map for coercion during validation

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
@@ -113,6 +113,8 @@ class BabelQuidemTest extends QuidemTest {
               .with(CalciteConnectionProperty.CONFORMANCE,
                   SqlConformanceEnum.BABEL)
               .with(CalciteConnectionProperty.LENIENT_OPERATOR_LOOKUP, true)
+              // BigQuery always assumes UTC by default.
+              .with(CalciteConnectionProperty.TIME_ZONE, "UTC")
               .with(
                   ConnectionFactories.addType("DATETIME", typeFactory ->
                       typeFactory.createSqlType(SqlTypeName.TIMESTAMP)))

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -2152,24 +2152,79 @@ SELECT
 
 !ok
 
-# The following example shows the result of DATETIME_DIFF for two days
-# in succession. The first date falls on a Monday and the second date
-# falls on a Sunday. DATETIME_DIFF with the date part WEEK returns 0
-# because this time part uses weeks that begin on
-# Sunday. DATETIME_DIFF with the date part WEEK(MONDAY) returns
-# 1. DATETIME_DIFF with the date part ISOWEEK also returns 1 because
-# ISO weeks begin on Monday.
+# The following example shows the result of DATETIME_DIFF for many nearby dates.
+# 2017-12-18 is a Monday and the other date is between 2017-12-25 (a Friday)
+# and 2017-12-09 (a Saturday). The date part WEEK treats weeks as starting on
+# Sunday, whereas WEEK(MONDAY) and ISOWEEK both treat weeks as starting on
+# Monday.
 
-SELECT
-  DATETIME_DIFF('2017-12-18', '2017-12-17', WEEK) AS week_diff,
-  DATETIME_DIFF('2017-12-18', '2017-12-17', WEEK(MONDAY)) AS week_weekday_diff,
-  DATETIME_DIFF('2017-12-18', '2017-12-17', ISOWEEK) AS isoweek_diff;
+WITH Diffs AS (
+  SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-25', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-25', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-25', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-24', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-24', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-24', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-23', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-23', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-23', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-19', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-19', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-19', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-18', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-18', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-18', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-17', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-17', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-17', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-16', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-16', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-16', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-15', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-15', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-15', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-12', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-12', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-12', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-11', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-11', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-11', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-10', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-10', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-10', ISOWEEK) AS isoweek_diff
+  UNION ALL SELECT
+    DATETIME_DIFF('2017-12-18', '2017-12-09', WEEK) AS week_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-09', WEEK(MONDAY)) AS week_weekday_diff,
+    DATETIME_DIFF('2017-12-18', '2017-12-09', ISOWEEK) AS isoweek_diff
+) SELECT * FROM Diffs;
 +-----------+-------------------+--------------+
 | week_diff | week_weekday_diff | isoweek_diff |
 +-----------+-------------------+--------------+
+|        -1 |                -1 |           -1 |
+|        -1 |                 0 |            0 |
+|         0 |                 0 |            0 |
+|         0 |                 0 |            0 |
+|         0 |                 0 |            0 |
 |         0 |                 1 |            1 |
+|         1 |                 1 |            1 |
+|         1 |                 1 |            1 |
+|         1 |                 1 |            1 |
+|         1 |                 1 |            1 |
+|         1 |                 2 |            2 |
+|         2 |                 2 |            2 |
 +-----------+-------------------+--------------+
-(1 row)
+(12 rows)
 
 !ok
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -401,7 +401,7 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
       case VARCHAR:
         return Expressions.call(
             BuiltInMethod.STRING_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE.method,
-            operand);
+            getRoot(), operand);
 
       case DATE:
         return Expressions.call(

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -38,7 +38,6 @@ import org.apache.calcite.runtime.FlatLists.ComparableList;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.util.NumberUtil;
 import org.apache.calcite.util.TimeWithTimeZoneString;
-import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.TimestampWithTimeZoneString;
 import org.apache.calcite.util.Unsafe;
 import org.apache.calcite.util.Util;
@@ -2968,7 +2967,7 @@ public class SqlFunctions {
         / (1000L * 1000L)); // milli > micro > nano
   }
 
-  public static @PolyNull Long toTimestampWithLocalTimeZone(@PolyNull String v) {
+  public static @PolyNull Long toTimestampWithLocalTimeZone(DataContext ctx, @PolyNull String v) {
     if (v == null) {
       return castNonNull(null);
     }
@@ -2978,7 +2977,12 @@ public class SqlFunctions {
           .getLocalTimestampString()
           .getMillisSinceEpoch();
     } catch (StringIndexOutOfBoundsException e) {
-      return DateTimeUtils.timestampStringToUnixDate(v);
+      long timestamp = DateTimeUtils.timestampStringToUnixDate(v);
+      TimeZone tz = DataContext.Variable.TIME_ZONE.get(ctx);
+      if (tz != null) {
+        timestamp -= tz.getOffset(timestamp);
+      }
+      return timestamp;
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -38,6 +38,7 @@ import org.apache.calcite.runtime.FlatLists.ComparableList;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.util.NumberUtil;
 import org.apache.calcite.util.TimeWithTimeZoneString;
+import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.TimestampWithTimeZoneString;
 import org.apache.calcite.util.Unsafe;
 import org.apache.calcite.util.Util;
@@ -2971,10 +2972,14 @@ public class SqlFunctions {
     if (v == null) {
       return castNonNull(null);
     }
-    return new TimestampWithTimeZoneString(v)
-        .withTimeZone(DateTimeUtils.UTC_ZONE)
-        .getLocalTimestampString()
-        .getMillisSinceEpoch();
+    try {
+      return new TimestampWithTimeZoneString(v)
+          .withTimeZone(DateTimeUtils.UTC_ZONE)
+          .getLocalTimestampString()
+          .getMillisSinceEpoch();
+    } catch (StringIndexOutOfBoundsException e) {
+      return DateTimeUtils.timestampStringToUnixDate(v);
+    }
   }
 
   public static @PolyNull Long toTimestampWithLocalTimeZone(@PolyNull String v,

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/AbstractTypeCoercion.java
@@ -695,54 +695,61 @@ public abstract class AbstractTypeCoercion implements TypeCoercion {
             SqlTypeFamily.TIMESTAMP);
     // If the expected type is already a parent of the input type, no need to cast.
     if (expected.getTypeNames().contains(in.getSqlTypeName())) {
-      return in;
+      return possiblyMapped(in);
     }
     // Cast null type (usually from null literals) into target type.
     if (SqlTypeUtil.isNull(in)) {
-      return expected.getDefaultConcreteType(factory);
+      return possiblyMapped(expected.getDefaultConcreteType(factory));
     }
     if (SqlTypeUtil.isNumeric(in) && expected == SqlTypeFamily.DECIMAL) {
-      return factory.decimalOf(in);
+      return possiblyMapped(factory.decimalOf(in));
     }
     // FLOAT/DOUBLE -> DECIMAL
     if (SqlTypeUtil.isApproximateNumeric(in) && expected == SqlTypeFamily.EXACT_NUMERIC) {
-      return factory.decimalOf(in);
+      return possiblyMapped(factory.decimalOf(in));
     }
     // DATE to TIMESTAMP
     if (SqlTypeUtil.isDate(in) && expected == SqlTypeFamily.TIMESTAMP) {
-      return factory.createSqlType(SqlTypeName.TIMESTAMP);
+      return possiblyMapped(factory.createSqlType(SqlTypeName.TIMESTAMP));
     }
     // TIMESTAMP to DATE.
     if (SqlTypeUtil.isTimestamp(in) && expected == SqlTypeFamily.DATE) {
-      return factory.createSqlType(SqlTypeName.DATE);
+      return possiblyMapped(factory.createSqlType(SqlTypeName.DATE));
     }
     // If the function accepts any NUMERIC type and the input is a STRING,
     // returns the expected type family's default type.
     // REVIEW Danny 2018-05-22: same with MS-SQL and MYSQL.
     if (SqlTypeUtil.isCharacter(in) && numericFamilies.contains(expected)) {
-      return expected.getDefaultConcreteType(factory);
+      return possiblyMapped(expected.getDefaultConcreteType(factory));
     }
     // STRING + DATE -> DATE;
     // STRING + TIME -> TIME;
     // STRING + TIMESTAMP -> TIMESTAMP
     if (SqlTypeUtil.isCharacter(in) && dateTimeFamilies.contains(expected)) {
-      return expected.getDefaultConcreteType(factory);
+      return possiblyMapped(expected.getDefaultConcreteType(factory));
     }
     // STRING + BINARY -> VARBINARY
     if (SqlTypeUtil.isCharacter(in) && expected == SqlTypeFamily.BINARY) {
-      return expected.getDefaultConcreteType(factory);
+      return possiblyMapped(expected.getDefaultConcreteType(factory));
     }
     // If we get here, `in` will never be STRING type.
     if (SqlTypeUtil.isAtomic(in)
         && (expected == SqlTypeFamily.STRING
         || expected == SqlTypeFamily.CHARACTER)) {
-      return expected.getDefaultConcreteType(factory);
+      return possiblyMapped(expected.getDefaultConcreteType(factory));
     }
     // CHAR -> GEOMETRY
     if (SqlTypeUtil.isCharacter(in) && expected == SqlTypeFamily.GEO) {
-      return expected.getDefaultConcreteType(factory);
+      return possiblyMapped(expected.getDefaultConcreteType(factory));
     }
     return null;
+  }
+
+  private RelDataType possiblyMapped(RelDataType canonicalType) {
+    RelDataType mappedType =
+        validator.getCatalogReader().getNamedType(
+            new SqlIdentifier(canonicalType.getSqlTypeName().toString(), SqlParserPos.ZERO));
+    return mappedType != null ? mappedType : canonicalType;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -485,7 +485,7 @@ public enum BuiltInMethod {
   TIME_STRING_TO_TIME_WITH_LOCAL_TIME_ZONE(SqlFunctions.class, "toTimeWithLocalTimeZone",
       String.class, TimeZone.class),
   STRING_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE(SqlFunctions.class, "toTimestampWithLocalTimeZone",
-      String.class),
+      DataContext.class, String.class),
   TIMESTAMP_STRING_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE(SqlFunctions.class,
       "toTimestampWithLocalTimeZone", String.class, TimeZone.class),
   TIME_WITH_LOCAL_TIME_ZONE_TO_TIME(SqlFunctions.class, "timeWithLocalTimeZoneToTime",

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -35,9 +35,11 @@ import org.apache.calcite.util.Util;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -45,6 +47,7 @@ import java.util.List;
  */
 public class MockCatalogReaderSimple extends MockCatalogReader {
   private final ObjectSqlType addressType;
+  private final HashMap<String, RelDataType> rootSchemaTypeMap;
 
   /**
    * Creates a MockCatalogReader.
@@ -60,6 +63,7 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     super(typeFactory, caseSensitive);
 
     addressType = new Fixture(typeFactory).addressType;
+    rootSchemaTypeMap = new HashMap();
   }
 
   /** Creates and initializes a MockCatalogReaderSimple. */
@@ -68,12 +72,21 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     return new MockCatalogReaderSimple(typeFactory, caseSensitive).init();
   }
 
-  @Override public RelDataType getNamedType(SqlIdentifier typeName) {
+  @Override public @Nullable RelDataType getNamedType(SqlIdentifier typeName) {
     if (typeName.equalsDeep(addressType.getSqlIdentifier(), Litmus.IGNORE)) {
       return addressType;
     } else {
-      return super.getNamedType(typeName);
+      RelDataType r = rootSchemaTypeMap.get(typeName.getSimple());
+      return r != null ? r : super.getNamedType(typeName);
     }
+  }
+
+  public void addNamedTypeToRootSchema(String name, RelDataType dataType) {
+    rootSchemaTypeMap.put(name, dataType);
+  }
+
+  public void clearRootSchemaTypeMap() {
+    rootSchemaTypeMap.clear();
   }
 
   private void registerTableEmp(MockTable empTable, Fixture fixture) {


### PR DESCRIPTION
Always look in the root schema's type map when inserting a `CAST` for automatic type coercion.

Other things to note:
- I modified `SqlFunctions.toTimestampWithLocalTimeZone(String)`, which is only invoked by the rex-to-lix translator to convert strings to `TIMESTAMP WITH LOCAL TIME ZONE` values, such as during coercion or casting in general. The method was implemented to address [CALCITE-1947](https://issues.apache.org/jira/browse/CALCITE-1947) but requires an explicit time zone component in the string literal to avoid a string-index-out-of-bounds exception in the constructor for `TimestampWithTimeZoneString`, which was originally named `TimestampWithLocalTimeZoneString` but renamed after the discussion in the Jira ticket to avoid confusion. It appears the problem with the name was address but the problem of semantics remains; one cannot cast a string without an explicit time zone to a timestamp w/ LTZ. I added a fallback that invokes `DateTimeUtils.timestampStringToUnixDate()`, which is the same function invoked by the rex-to-lix translator to convert strings to regular `TIMESTAMP` values. This effectively assumes UTC for all timestamp w/ LTZ conversions lacking an explicit time zone. Currently looking into getting the proper zone out of the `DataContext` but having trouble figuring out where it gets passed in.
- I set the default time zone for the BQ Quidem test to UTC, which causes `TIMESTAMP WITH LOCAL TIME ZONE` to assume UTC for the coercion of strings without an explicit time zone component (this is consistent with how BigQuery actually behaves).