### PR TITLE
[CALCITE-5644] Add CONTAINS_SUBSTR function (enabled in BigQuery library)

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -146,6 +146,7 @@ data: {
       "CONSTRAINTS"
       "CONSTRUCTOR"
       "CONTAINS"
+      "CONTAINS_SUBSTR"
       "CONTINUE"
       "CONVERT"
       "CORR"

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -1321,6 +1321,143 @@ SELECT STRPOS("abcabc", "bc") as result;
 !ok
 
 #####################################################################
+# CONTAINS_SUBSTR
+#
+# CONTAINS_SUBSTR(expression, search_value_literal[, json_scope=>json_scope_value])
+#
+# Performs a normalized, case-insensitive search to see if a value
+# exists as a substring in an expression. Returns TRUE if the value
+# exists, otherwise returns FALSE.
+SELECT CONTAINS_SUBSTR('the blue house', 'Blue house') AS result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR('the red house', 'blue') AS result;
++--------+
+| result |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
+SELECT '\u2168 day' AS a, 'IX' AS b, CONTAINS_SUBSTR('\u2168', 'IX') AS result;
++------------+----+--------+
+| a          | b  | result |
++------------+----+--------+
+| \u2168 day | IX | true   |
++------------+----+--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR((23, 35, 41), '35') AS result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR(TIMESTAMP '2008-12-25 15:30:00', '15:30') AS result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR((23, NULL, 41), '41') AS result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR((23, NULL, 41), '35') AS result;
++--------+
+| result |
++--------+
+|        |
++--------+
+(1 row)
+
+!ok
+
+# Search column references
+WITH Recipes AS
+ (SELECT 'Blueberry pancakes' as Breakfast, 'Egg salad sandwich' as Lunch, 'Potato dumplings' as Dinner UNION ALL
+  SELECT 'Potato pancakes', 'Toasted cheese sandwich', 'Beef stroganoff' UNION ALL
+  SELECT 'Ham scramble', 'Steak avocado salad', 'Tomato pasta' UNION ALL
+  SELECT 'Avocado toast', 'Tomato soup', 'Blueberry salmon' UNION ALL
+  SELECT 'Corned beef hash', 'Lentil potato soup', 'Glazed ham')
+SELECT * FROM Recipes WHERE CONTAINS_SUBSTR((Lunch, Dinner), 'potato');
++--------------------+-------------------------+------------------+
+| Breakfast          | Lunch                   | Dinner           |
++--------------------+-------------------------+------------------+
+| Blueberry pancakes | Egg salad sandwich      | Potato dumplings |
+| Corned beef hash   | Lentil potato soup      | Glazed ham       |
++--------------------+-------------------------+------------------+
+(2 rows)
+
+!ok
+
+# If no JSON_SCOPE is specified, "JSON_VALUES" is the default
+SELECT CONTAINS_SUBSTR('{"lunch":"soup"}', "lunch") AS result;
++--------+
+| result |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR('{"lunch":"soup"}', "lunch", json_scope=>"JSON_KEYS") AS result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR('{"lunch":"soup"}', "lunch", json_scope=>"JSON_VALUES") AS result;
++--------+
+| result |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
+SELECT CONTAINS_SUBSTR('{"lunch":"soup"}', "lunch", json_scope=>"JSON_KEYS_AND_VALUES") AS result;
++--------+
+| result |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok
+
+#####################################################################
 # DATE
 #
 # 0. DATE(string)

--- a/core/src/main/codegen/default_config.fmpp
+++ b/core/src/main/codegen/default_config.fmpp
@@ -79,6 +79,7 @@ parser: {
     "CONSTRAINTS"
     "CONSTRAINT_SCHEMA"
     "CONSTRUCTOR"
+    "CONTAINS_SUBSTR"
     "CONTINUE"
     "CURSOR_NAME"
     "DATA"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6303,6 +6303,8 @@ SqlNode BuiltinFunctionCall() :
             return SqlStdOperatorTable.TRIM.createCall(s.end(this), args);
         }
     |
+        node = ContainsSubstrFunctionCall() { return node; }
+    |
         node = DateTimeConstructorCall() { return node; }
     |
         node = DateDiffFunctionCall() { return node; }
@@ -6822,6 +6824,32 @@ SqlCall JsonArrayAggFunctionCall() :
             .createCall(span.end(this), valueExpr, orderList);
     }
 }
+
+ /**
+ * Parses the CONTAINS_SUBSTR function, which has a unique optional third argument "JSON_SCOPE"
+ * that specifies what scope to search if the first argument is a JSON string.
+ */
+ SqlCall ContainsSubstrFunctionCall() :
+ {
+    final List<SqlNode> args = new ArrayList<SqlNode>();
+    final Span s;
+    SqlNode e;
+ }
+ {
+     <CONTAINS_SUBSTR> { s = span(); }
+     <LPAREN>
+     AddExpression(args, ExprContext.ACCEPT_SUB_QUERY)
+     <COMMA>
+     AddExpression(args, ExprContext.ACCEPT_SUB_QUERY)
+     (
+        <RPAREN>
+     |
+        <COMMA>
+        <JSON_SCOPE>
+        <NAMED_ARGUMENT_ASSIGNMENT> e = Expression(ExprContext.ACCEPT_SUB_QUERY)  { args.add(e); }
+        <RPAREN>
+     ) { return SqlLibraryOperators.CONTAINS_SUBSTR.createCall(s.end(this), args); }
+ }
 
 /**
  * Parses a call to BigQuery's DATE_DIFF.
@@ -7538,6 +7566,12 @@ SqlNode JdbcFunctionCall() :
     }
     (
         LOOKAHEAD(1)
+        call = ContainsSubstrFunctionCall() {
+            name = call.getOperator().getName();
+            args = new SqlNodeList(call.getOperandList(), getPos());
+        }
+    |
+        LOOKAHEAD(1)
         call = DateDiffFunctionCall() {
             name = call.getOperator().getName();
             args = new SqlNodeList(call.getOperandList(), getPos());
@@ -7924,6 +7958,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < CONSTRAINTS: "CONSTRAINTS" >
 |   < CONSTRUCTOR: "CONSTRUCTOR" >
 |   < CONTAINS: "CONTAINS" >
+|   < CONTAINS_SUBSTR: "CONTAINS_SUBSTR" >
 |   < CONTINUE: "CONTINUE" >
 |   < CONVERT: "CONVERT" >
 |   < CORR: "CORR" >
@@ -8110,6 +8145,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < JSON_OBJECT: "JSON_OBJECT">
 |   < JSON_OBJECTAGG: "JSON_OBJECTAGG">
 |   < JSON_QUERY: "JSON_QUERY" >
+|   < JSON_SCOPE: "JSON_SCOPE" >
 |   < JSON_VALUE: "JSON_VALUE" >
 |   < K: "K" >
 |   < KEY: "KEY" >

--- a/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlFunction.java
@@ -228,7 +228,7 @@ public class SqlFunction extends SqlOperator {
       SqlValidator validator,
       SqlValidatorScope scope,
       SqlCall call) {
-    return deriveType(validator, scope, call, true);
+    return deriveType(validator, scope, call, false);
   }
 
   private RelDataType deriveType(
@@ -288,8 +288,6 @@ public class SqlFunction extends SqlOperator {
             }
           }
           return deriveType(validator, scope, call, false);
-        } else if (function != null) {
-          validator.validateColumnListParams(function, argTypes, args);
         }
       }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -851,6 +851,9 @@ public enum SqlKind {
    * TABLE(udx(CURSOR(SELECT ...), x, y, z))</code>. */
   CURSOR,
 
+  /** {@code CONTAINS_SUBSTR} function (BigQuery semantics). */
+  CONTAINS_SUBSTR,
+
   // internal operators (evaluated in validator) 200-299
 
   /** The {@code LITERAL_AGG} aggregate function that always returns the same

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -785,6 +785,15 @@ public abstract class SqlLibraryOperators {
           ReturnTypes.INTEGER_NULLABLE, OperandTypes.DATE,
           SqlFunctionCategory.TIMEDATE);
 
+  /** "CONTAINS_SUBSTR(expression, string[, json_scope &#61;&#62; json_scope_value ])"
+   * function; returns whether string exists as substring in expression, with optional
+   * json_scope argument. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction CONTAINS_SUBSTR =
+      SqlBasicFunction.create("CONTAINS_SUBSTR",
+          ReturnTypes.BOOLEAN_NULLABLE, OperandTypes.ANY_STRING_OPTIONAL_STRING,
+          SqlFunctionCategory.STRING);
+
   /** The "MONTHNAME(datetime)" function; returns the name of the month,
    * in the current locale, of a TIMESTAMP or DATE argument. */
   @LibraryOperator(libraries = {MYSQL})

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -878,6 +878,10 @@ public abstract class OperandTypes {
       family(SqlTypeFamily.ANY, SqlTypeFamily.NUMERIC, SqlTypeFamily.ANY);
   public static final SqlSingleOperandTypeChecker ANY_STRING_STRING =
       family(SqlTypeFamily.ANY, SqlTypeFamily.STRING, SqlTypeFamily.STRING);
+  public static final SqlSingleOperandTypeChecker ANY_STRING_OPTIONAL_STRING =
+      family(ImmutableList.of(SqlTypeFamily.ANY, SqlTypeFamily.STRING, SqlTypeFamily.STRING),
+          // Third operand optional (operand index 0, 1, 2)
+          number -> number == 2);
 
   /**
    * Operand type-checking strategy used by {@code ARG_MIN(value, comp)} and

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -327,18 +327,6 @@ public interface SqlValidator {
       SqlValidatorScope scope);
 
   /**
-   * Validates a COLUMN_LIST parameter.
-   *
-   * @param function function containing COLUMN_LIST parameter
-   * @param argTypes function arguments
-   * @param operands operands passed into the function call
-   */
-  void validateColumnListParams(
-      SqlFunction function,
-      List<RelDataType> argTypes,
-      List<SqlNode> operands);
-
-  /**
    * If an identifier is a legitimate call to a function that has no
    * arguments and requires no parentheses (for example "CURRENT_USER"),
    * returns a call to that function, otherwise returns null.

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -6388,13 +6388,6 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
         });
   }
 
-  @Override public void validateColumnListParams(
-      SqlFunction function,
-      List<RelDataType> argTypes,
-      List<SqlNode> operands) {
-    throw new UnsupportedOperationException();
-  }
-
   private static boolean isPhysicalNavigation(SqlKind kind) {
     return kind == SqlKind.PREV || kind == SqlKind.NEXT;
   }

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -513,6 +513,7 @@ CONSTRAINT_NAME,
 CONSTRAINT_SCHEMA,
 CONSTRUCTOR,
 **CONTAINS**,
+CONTAINS_SUBSTR,
 CONTINUE,
 **CONVERT**,
 **CORR**,
@@ -699,6 +700,7 @@ JSON,
 **JSON_OBJECT**,
 **JSON_OBJECTAGG**,
 **JSON_QUERY**,
+**JSON_SCOPE**,
 **JSON_VALUE**,
 K,
 KEY,
@@ -2688,6 +2690,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | m p | CONCAT_WS(separator, str1 [, string ]*)      | Concatenates one or more strings, returns null only when separator is null, otherwise treats null arguments as empty strings
 | q | CONCAT_WS(separator, str1, str2 [, string ]*)  | Concatenates two or more strings, requires at least 3 arguments (up to 254), treats null arguments as empty strings
 | m | COMPRESS(string)                               | Compresses a string using zlib compression and returns the result as a binary string
+| b | CONTAINS_SUBSTR(expression, string [ , json_scope&#61;&#62;json_scope_value ]) | Returns whether *string* exists as a substring in *expression*. Optional *json_scope* argument specifies what scope to search if *expression* is in JSON format. Returns NULL if a NULL exists in *expression* that does not result in a match
 | q | CONVERT(type, expression [ , style ])          | Equivalent to `CAST(expression AS type)`; ignores the *style* operand
 | p | CONVERT_TIMEZONE(tz1, tz2, datetime)           | Converts the timezone of *datetime* from *tz1* to *tz2*
 | * | COSH(numeric)                                  | Returns the hyperbolic cosine of *numeric*


### PR DESCRIPTION
BigQuery's `CONTAIN_SUBSTR` determines whether a string appears in an expression. This expression can be of many types, as seen in the docs [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#contains_substr).

Also removes some random extra whitespace. Let me know if this should be reverted.

Any comments, questions, or suggestions in the meantime are appreciated as always.