### PR TITLE
CALCITE-5647 Use mq.getRowCount(rel) instead of rel.estimateRowCount(mq)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPopulationSize.java
@@ -113,7 +113,7 @@ public class RelMdPopulationSize
   public Double getPopulationSize(Values rel, RelMetadataQuery mq,
       ImmutableBitSet groupKey) {
     // assume half the rows are duplicates
-    return rel.estimateRowCount(mq) / 2;
+    return mq.getRowCount(rel) / 2;
   }
 
   public @Nullable Double getPopulationSize(Project rel, RelMetadataQuery mq,


### PR DESCRIPTION
This PR corrects a row count call to use the RelMetadataQuery instead of going directly to rel.estimateRowCount.

Using rel.estimateRowCount directly will behave incorrectly when using a cardinality estimator that is implemented entirely in a MetadataHandler<RowCount> class, as it will evade the metadata handler's implementation of getRowCount and fall through to the underlying default method for Values.

This corrects the problem by using mq.getRowCount instead of rel.estimateRowCount. In the default case this results in the same value but in the custom cardinality model case the expected handler is called.