### PR TITLE
CALCITE-5648 SqlDelegatingConformance incorrectly delegates to SqlConformanceEnum.DEFAULT

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
@@ -23,12 +23,20 @@ import org.apache.calcite.sql.fun.SqlLibrary;
  * another object. You can create a sub-class that overrides particular
  * methods.
  */
-public class SqlDelegatingConformance extends SqlAbstractConformance {
+public class SqlDelegatingConformance implements SqlConformance {
   private final SqlConformance delegate;
 
   /** Creates a SqlDelegatingConformance. */
   protected SqlDelegatingConformance(SqlConformance delegate) {
     this.delegate = delegate;
+  }
+
+  @Override public boolean isLiberal() {
+    return delegate.isLiberal();
+  }
+
+  @Override public boolean allowCharLiteralAlias() {
+    return delegate.allowCharLiteralAlias();
   }
 
   @Override public boolean isGroupByAlias() {
@@ -40,7 +48,7 @@ public class SqlDelegatingConformance extends SqlAbstractConformance {
   }
 
   @Override public boolean isHavingAlias() {
-    return delegate.isGroupByAlias();
+    return delegate.isHavingAlias();
   }
 
   @Override public boolean isSortByOrdinal() {
@@ -59,24 +67,76 @@ public class SqlDelegatingConformance extends SqlAbstractConformance {
     return delegate.isFromRequired();
   }
 
+  @Override public boolean splitQuotedTableName() {
+    return delegate.splitQuotedTableName();
+  }
+
+  @Override public boolean allowHyphenInUnquotedTableName() {
+    return delegate.allowHyphenInUnquotedTableName();
+  }
+
   @Override public boolean isBangEqualAllowed() {
     return delegate.isBangEqualAllowed();
+  }
+
+  @Override public boolean isPercentRemainderAllowed() {
+    return delegate.isPercentRemainderAllowed();
   }
 
   @Override public boolean isMinusAllowed() {
     return delegate.isMinusAllowed();
   }
 
+  @Override public boolean isApplyAllowed() {
+    return delegate.isApplyAllowed();
+  }
+
   @Override public boolean isInsertSubsetColumnsAllowed() {
     return delegate.isInsertSubsetColumnsAllowed();
+  }
+
+  @Override public boolean allowAliasUnnestItems() {
+    return delegate.allowAliasUnnestItems();
   }
 
   @Override public boolean allowNiladicParentheses() {
     return delegate.allowNiladicParentheses();
   }
 
-  @Override public boolean allowAliasUnnestItems() {
-    return delegate.allowAliasUnnestItems();
+  @Override public boolean allowExplicitRowValueConstructor() {
+    return delegate.allowExplicitRowValueConstructor();
+  }
+
+  @Override public boolean allowExtend() {
+    return delegate.allowExtend();
+  }
+
+  @Override public boolean isLimitStartCountAllowed() {
+    return delegate.isLimitStartCountAllowed();
+  }
+
+  @Override public boolean isOffsetLimitAllowed() {
+    return delegate.isOffsetLimitAllowed();
+  }
+
+  @Override public boolean allowGeometry() {
+    return delegate.allowGeometry();
+  }
+
+  @Override public boolean shouldConvertRaggedUnionTypesToVarying() {
+    return delegate.shouldConvertRaggedUnionTypesToVarying();
+  }
+
+  @Override public boolean allowExtendedTrim() {
+    return delegate.allowExtendedTrim();
+  }
+
+  @Override public boolean allowPluralTimeUnits() {
+    return delegate.allowPluralTimeUnits();
+  }
+
+  @Override public boolean allowQualifyingCommonColumn() {
+    return delegate.allowQualifyingCommonColumn();
   }
 
   @Override public boolean isValueAllowed() {
@@ -85,6 +145,10 @@ public class SqlDelegatingConformance extends SqlAbstractConformance {
 
   @Override public SqlLibrary semantics() {
     return delegate.semantics();
+  }
+
+  @Override public boolean allowCoercionStringToArray() {
+    return delegate.allowCoercionStringToArray();
   }
 
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -5358,7 +5358,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test void testUserDefinedConformance() {
-    final SqlAbstractConformance custom =
+    final SqlConformance custom =
         new SqlDelegatingConformance(SqlConformanceEnum.DEFAULT) {
           public boolean isBangEqualAllowed() {
             return true;


### PR DESCRIPTION
This PR makes SqlDelegatingConformance a true delegation class that delegates all methods (and will break in future if new methods are added and it isn't update). Fixed a type expectation in the test script, but otherwise did not change anything in the tests because none of the tests covered the methods changing in a way that was a mismatch for the DEFAULT value.

With this change accidental oversights that fail to implement missing delegation methods cannot happen.