### PR TITLE
CALCITE-5649 Produce row count statistics from ReflectiveSchema for array based tables

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/java/ReflectiveSchema.java
@@ -56,6 +56,7 @@ import com.google.common.collect.Multimap;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -205,7 +206,11 @@ public class ReflectiveSchema
     requireNonNull(o, () -> "field " + field + " is null for " + target);
     @SuppressWarnings("unchecked")
     final Enumerable<T> enumerable = toEnumerable(o);
-    return new FieldTable<>(field, elementType, enumerable);
+    final Double rows = toRowCount(o);
+    final Statistic statistic = rows == null
+        ? Statistics.UNKNOWN
+        : Statistics.of(rows, null);
+    return new FieldTable<>(field, elementType, enumerable, statistic);
   }
 
   /** Deduces the element type of a collection;
@@ -233,6 +238,13 @@ public class ReflectiveSchema
     }
     throw new RuntimeException(
         "Cannot convert " + o.getClass() + " into a Enumerable");
+  }
+
+  private static @Nullable Double toRowCount(final Object o) {
+    if (o.getClass().isArray()) {
+      return (double) Array.getLength(o);
+    }
+    return null;
   }
 
   /** Table that is implemented by reading from a Java object. */

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -29,6 +29,8 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.TableMacroImpl;
 import org.apache.calcite.schema.impl.ViewTable;
@@ -63,9 +65,7 @@ import java.util.Properties;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link ReflectiveSchema}.
@@ -915,5 +915,14 @@ public class ReflectiveSchemaTest {
         .returnsUnordered(
             "EXPR$0=0",
             "EXPR$0=null");
+  }
+
+  @Test void testFieldTableHasRowCount() {
+    ReflectiveSchema schema = new ReflectiveSchema(new HrSchema());
+    Table table = schema.getTable("emps");
+    assertNotNull(table);
+    Statistic statistic = table.getStatistic();
+    assertNotNull(statistic);
+    assertEquals(4, statistic.getRowCount());
   }
 }


### PR DESCRIPTION
This PR adds row count statistics for simple reflective schemas with array field tables.

This small enhancement makes it a little easier to write tests for optimizer rules, particularly rules that might behave specially when the row count is 1 or 0.