### PR TITLE
[CALCITE-5654] Support PostgreSQL's syntax for day-to-second intervals

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4848,7 +4848,7 @@ SqlLiteral IntervalLiteral() :
 SqlNode IntervalLiteralOrExpression() :
 {
     final String p;
-    final SqlIntervalQualifier intervalQualifier;
+    SqlIntervalQualifier intervalQualifier = null;
     int sign = 1;
     final Span s;
     SqlNode e;
@@ -4863,9 +4863,17 @@ SqlNode IntervalLiteralOrExpression() :
     (
         // literal (with quoted string)
         p = SimpleStringLiteral()
-        intervalQualifier = IntervalQualifier() {
-            return SqlParserUtil.parseIntervalLiteral(s.end(intervalQualifier),
-                sign, p, intervalQualifier);
+        [intervalQualifier = IntervalQualifier()] {
+            if (intervalQualifier == null) {
+                /* PostgreSQL interval literal without interval qualifier.
+                 * The quoted string contains components such as '3 days'.
+                 * Example: {@code INTERVAL '2 weeks 3 days 4 hours 5 minutes 6 seconds 7 milliseconds'}
+                 */
+                return SqlParserUtil.parseIntervalLiteralWithComponents(s.pos(), p);
+            } else {
+                return SqlParserUtil.parseIntervalLiteral(s.end(intervalQualifier),
+                    sign, p, intervalQualifier);
+            }
         }
     |
         // To keep parsing simple, any expressions besides numeric literal and

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -73,6 +73,9 @@ public interface CalciteResource {
   @Property(name = "SQLSTATE", value = "42000")
   ExInst<CalciteException> illegalIntervalLiteral(String a0, String a1);
 
+  @BaseMessage("Only DAY TO SECOND intervals are supported")
+  ExInst<CalciteException> illegalIntervalRange();
+
   @BaseMessage("Illegal expression. Was expecting \"(DATETIME - DATETIME) INTERVALQUALIFIER\"")
   ExInst<CalciteException> illegalMinusDate();
 

--- a/core/src/main/java/org/apache/calcite/sql/parser/PgInterval.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/PgInterval.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.parser;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+/**
+ * A parsed PostgreSQL interval.
+ */
+public class PgInterval {
+  boolean present;
+  int years;
+  int months;
+  int days;
+  int hours;
+  int minutes;
+  int seconds;
+  int milliseconds;
+
+  PgInterval(
+      boolean present,
+      int years,
+      int months,
+      int days,
+      int hours,
+      int minutes,
+      int seconds,
+      int milliseconds) {
+    this.present = present;
+    this.years = years;
+    this.months = months;
+    this.days = days;
+    this.hours = hours;
+    this.minutes = minutes;
+    this.seconds = seconds;
+    this.milliseconds = milliseconds;
+  }
+
+  @Override public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PgInterval that = (PgInterval) o;
+    return present == that.present
+        && years == that.years
+        && months == that.months
+        && days == that.days
+        && hours == that.hours
+        && minutes == that.minutes
+        && seconds == that.seconds
+        && milliseconds == that.milliseconds;
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(present, years, months, days, hours, minutes, seconds, milliseconds);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/parser/PgIntervalParser.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/PgIntervalParser.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.parser;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.math.BigDecimal;
+import java.util.StringTokenizer;
+
+/**
+ * Parser for PostgreSQL intervals.
+ *
+ * Based on <a href="https://github.com/crate/crate/blob/b8f5bfc1ae1d34b0426f2a01217fde663505225b/server/src/main/java/io/crate/interval/PGIntervalParser.java">Crate.io</a>.
+ */
+final class PgIntervalParser {
+  private PgIntervalParser() {}
+
+  static PgInterval parse(String value) {
+    boolean dataParsed = false;
+
+    int years = 0;
+    int months = 0;
+    int days = 0;
+    int weeks = 0;
+    int hours = 0;
+    int minutes = 0;
+    int seconds = 0;
+    int milliSeconds = 0;
+
+    try {
+      String valueToken = null;
+
+      value = value.replace('+', ' ').replace('@', ' ');
+      final StringTokenizer st = new StringTokenizer(value);
+      for (int i = 1; st.hasMoreTokens(); i++) {
+        String token = st.nextToken();
+
+        if ((i & 1) == 1) {
+          int endHours = token.indexOf(':');
+          if (endHours == -1) {
+            valueToken = token;
+            continue;
+          }
+          // This handles hours, minutes, seconds and microseconds for
+          // ISO intervals
+          int offset = (token.charAt(0) == '-') ? 1 : 0;
+
+          hours = nullSafeIntGet(token.substring(offset, endHours));
+          minutes = nullSafeIntGet(token.substring(endHours + 1, endHours + 3));
+
+          int endMinutes = token.indexOf(':', endHours + 1);
+          seconds = nullSafeIntGet(token.substring(endMinutes + 1));
+          milliSeconds = parseMilliSeconds(token.substring(endMinutes + 1));
+
+          if (offset == 1) {
+            hours = -hours;
+            minutes = -minutes;
+            seconds = -seconds;
+            milliSeconds = -milliSeconds;
+          }
+          valueToken = null;
+        } else {
+          // This handles years, months, days for both, ISO and
+          // non-ISO intervals. Hours, minutes, seconds and microseconds
+          // are handled for Non-ISO intervals here.
+          if (token.startsWith("year") || token.equals("yr")) {
+            years = nullSafeIntGet(valueToken);
+          } else if (token.startsWith("mon")) {
+            months = nullSafeIntGet(valueToken);
+          } else if (token.startsWith("day") || token.equals("d")) {
+            days = nullSafeIntGet(valueToken);
+          } else if (token.startsWith("week")) {
+            weeks = nullSafeIntGet(valueToken);
+          } else if (token.startsWith("hour") || token.startsWith("hr")) {
+            hours = nullSafeIntGet(valueToken);
+          } else if (token.startsWith("min")) {
+            minutes = nullSafeIntGet(valueToken);
+          } else if (token.startsWith("sec")) {
+            seconds = nullSafeIntGet(valueToken);
+            milliSeconds = parseMilliSeconds(valueToken);
+          } else if (token.startsWith("milli")) {
+            milliSeconds += nullSafeIntGet(valueToken);
+          } else {
+            throw new IllegalArgumentException("Unexpected token: " + token);
+          }
+          dataParsed = true;
+        }
+      }
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid interval format " + value);
+    }
+
+    if (!dataParsed) {
+      throw new IllegalArgumentException("Invalid interval format " + value);
+    }
+
+    boolean present = !value.endsWith(" ago");
+
+    return new PgInterval(
+        present,
+        years,
+        months,
+        weeks * 7 + days,
+        hours,
+        minutes,
+        seconds,
+        milliSeconds);
+  }
+
+  static int parseMilliSeconds(@Nullable String value) throws NumberFormatException {
+    if (value == null) {
+      return 0;
+    } else {
+      BigDecimal decimal = new BigDecimal(value);
+      return decimal
+          .subtract(new BigDecimal(decimal.intValue()))
+          .multiply(new BigDecimal(1000)).intValue();
+    }
+  }
+
+  static int nullSafeIntGet(@Nullable String value) {
+    return (value == null) ? 0 : Integer.parseInt(value);
+  }
+}

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -32,6 +32,7 @@ BetweenWithoutAnd=BETWEEN operator has no terminating AND
 GeometryDisabled=Geo-spatial extensions and the GEOMETRY data type are not enabled
 Proj4jEpsgIsMissing=Proj4J EPSG is missing from the classpath; to resolve this problem, download the EPSG data set and agree to its terms of use
 IllegalIntervalLiteral=Illegal INTERVAL literal {0}; at {1}
+IllegalIntervalRange=Only DAY TO SECOND intervals are supported
 IllegalMinusDate=Illegal expression. Was expecting "(DATETIME - DATETIME) INTERVALQUALIFIER"
 IllegalOverlaps=Illegal overlaps expression. Was expecting expression on the form "(DATETIME, EXPRESSION) OVERLAPS (DATETIME, EXPRESSION)"
 IllegalNonQueryExpression=Non-query expression encountered in illegal context

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3719,6 +3719,13 @@ class RelToSqlConverterTest {
     checkLiteral("123");
     checkLiteral("123.45");
     checkLiteral("-123.45");
+    checkLiteral2("INTERVAL '1 day'", "INTERVAL '1 00:00:00' DAY TO SECOND");
+    checkLiteral2("INTERVAL '-30 day'", "INTERVAL -'30 00:00:00' DAY TO SECOND");
+    checkLiteral2("INTERVAL '2 weeks 3 days 4 hours 5 minutes 6 seconds 7 milliseconds'",
+        "INTERVAL '17 04:05:06.007' DAY TO SECOND");
+    checkLiteral2("INTERVAL '13 hours 30 minutes 20 seconds 123 milliseconds'",
+        "INTERVAL '0 13:30:20.123' DAY TO SECOND");
+    checkLiteral2("INTERVAL '1 day ago'", "INTERVAL -'1 00:00:00' DAY TO SECOND");
     checkLiteral("INTERVAL '1-2' YEAR TO MONTH");
     checkLiteral("INTERVAL -'1-2' YEAR TO MONTH");
     checkLiteral("INTERVAL '12-11' YEAR TO MONTH");

--- a/core/src/test/java/org/apache/calcite/sql/parser/PgIntervalParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/PgIntervalParserTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.parser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit test for {@link PgIntervalParser}.
+ */
+class PgIntervalParserTest {
+  @Test void testParse() {
+    assertEquals(
+        PgIntervalParser.parse("10 milliseconds"),
+        new PgInterval(true, 0, 0, 0, 0, 0, 0, 10));
+
+    assertEquals(
+        PgIntervalParser.parse(
+            "1 year 2 months 3 weeks 4 days 5 hours 6 minutes 7 seconds 8 milliseconds"),
+        new PgInterval(true, 1, 2, 3 * 7 + 4, 5, 6, 7, 8));
+  }
+}

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -6040,26 +6040,8 @@ public class SqlParserTest {
 
   @Test void testUnparseableIntervalQualifiers() {
     // No qualifier
-    expr("interval '1^'^")
-        .fails("Encountered \"<EOF>\" at line 1, column 12\\.\n"
-            + "Was expecting one of:\n"
-            + "    \"DAY\" \\.\\.\\.\n"
-            + "    \"DAYS\" \\.\\.\\.\n"
-            + "    \"HOUR\" \\.\\.\\.\n"
-            + "    \"HOURS\" \\.\\.\\.\n"
-            + "    \"MINUTE\" \\.\\.\\.\n"
-            + "    \"MINUTES\" \\.\\.\\.\n"
-            + "    \"MONTH\" \\.\\.\\.\n"
-            + "    \"MONTHS\" \\.\\.\\.\n"
-            + "    \"QUARTER\" \\.\\.\\.\n"
-            + "    \"QUARTERS\" \\.\\.\\.\n"
-            + "    \"SECOND\" \\.\\.\\.\n"
-            + "    \"SECONDS\" \\.\\.\\.\n"
-            + "    \"WEEK\" \\.\\.\\.\n"
-            + "    \"WEEKS\" \\.\\.\\.\n"
-            + "    \"YEAR\" \\.\\.\\.\n"
-            + "    \"YEARS\" \\.\\.\\.\n"
-            + "    ");
+    expr("interval '1^'")
+        .fails(ANY);
 
     // illegal qualifiers, no precision in either field
     expr("interval '1' year ^to^ year")
@@ -6508,8 +6490,8 @@ public class SqlParserTest {
         .ok("INTERVAL -'1' DAY");
     expr("interval '-1' day")
         .ok("INTERVAL '-1' DAY");
-    expr("interval 'wael was here^'^")
-        .fails("(?s)Encountered \"<EOF>\".*");
+    expr("interval 'wael was here^'")
+        .fails(ANY);
 
     // ok in parser, not in validator
     expr("interval 'wael was here' HOUR")


### PR DESCRIPTION
Support day-to-second intervals using PostgreSQL's syntax:
```sql
select INTERVAL '2 weeks 3 days 4 hours 5 minutes 6 seconds 7 milliseconds'
select INTERVAL '-30 day'
```

These should be equivalent to:
```sql
select INTERVAL '17 04:05:06.007' DAY TO SECOND
select -INTERVAL '30 00:00:00.000' DAY TO SECOND
```