### PR TITLE
[CALCITE-5653] AggChecker should look in the extended select list

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -5891,6 +5891,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + " order by upper(^eno^)")
         .failsIf(!conformance.isSortByAlias(),
             "Column 'ENO' not found in any table");
+
+    // Test case for [CALCITE-5653], order by on aggregate will fail when there is an implicit cast
+    // and IdentifierExpansion is off
+    sql("select distinct sum(deptno + '1') from dept order by 1")
+        .withValidatorIdentifierExpansion(false)
+        .ok();
   }
 
   /**

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3586,4 +3586,15 @@ from emp;
 (1 row)
 
 !ok
+
+# DISTINCT query with ORDER BY on aggregate when there is an implicit cast
+select distinct sum(deptno + '1') as deptsum from dept order by 1;
++---------+
+| DEPTSUM |
++---------+
+|     104 |
++---------+
+(1 row)
+
+!ok
 # End agg.iq


### PR DESCRIPTION
When validating aggregates, AggChecker checking the the aggregate expression is part of the select list.
But when the validator is changing the select list (for example by adding casts) this search will fail and the AggChecker will throw. 
This PR fixing that by searching for the expression in the extended select list instead of the unextended one.