### PR TITLE
[CALCITE-5665] Reducing ineffective matches for MaterializedViewRules

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewRule.java
@@ -56,6 +56,9 @@ import org.apache.calcite.util.graph.DirectedGraph;
 import org.apache.calcite.util.mapping.IntPair;
 import org.apache.calcite.util.mapping.Mapping;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -76,6 +79,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
 
@@ -92,6 +96,16 @@ import static java.util.Objects.requireNonNull;
 public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config>
     extends RelRule<C> {
 
+  /**
+   * Cache of RelMetadataQuery to MaterializationMetadata.
+   */
+  private final LoadingCache<RelMetadataQuery, MaterializationMetadata>
+      materializationMetadataCache =
+      CacheBuilder.newBuilder()
+          .expireAfterAccess(5, TimeUnit.MINUTES)
+          .maximumSize(1_024)
+          .build(CacheLoader.from(MaterializationMetadata::new));
+
   //~ Constructors -----------------------------------------------------------
 
   /** Creates a MaterializedViewRule. */
@@ -100,7 +114,20 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
   }
 
   @Override public boolean matches(RelOptRuleCall call) {
-    return !call.getPlanner().getMaterializations().isEmpty();
+    final List<RelOptMaterialization> materializations =
+        call.getPlanner().getMaterializations();
+    if (materializations.isEmpty()) {
+      return false;
+    }
+    RelMetadataQuery mq = call.getMetadataQuery();
+    MaterializationMetadata materializationMetadata =
+        materializationMetadataCache.getUnchecked(mq);
+    for (RelOptMaterialization materialization : materializations) {
+      if (materializationMetadata.isValidMaterialization(mq, materialization)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -197,7 +224,15 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
 
       // 3. We iterate through all applicable materializations trying to
       // rewrite the given query
+      MaterializationMetadata materializationMetadata =
+          materializationMetadataCache.getUnchecked(mq);
       for (RelOptMaterialization materialization : materializations) {
+        // 3.1. View checks before proceeding
+        if (!materializationMetadata.isValidMaterialization(mq, materialization)) {
+          // Skip it
+          continue;
+        }
+
         RelNode view = materialization.tableRel;
         Project topViewProject;
         RelNode viewNode;
@@ -210,11 +245,8 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
         }
 
         // Extract view table references
-        final Set<RelTableRef> viewTableRefs = mq.getTableReferences(viewNode);
-        if (viewTableRefs == null) {
-          // Skip it
-          continue;
-        }
+        final Set<RelTableRef> viewTableRefs =
+            materializationMetadata.viewTableRefsMap.get(materialization);
 
         // Filter relevant materializations. Currently, we only check whether
         // the materialization contains any table that is used by the query
@@ -231,21 +263,11 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
           continue;
         }
 
-        // 3.1. View checks before proceeding
-        if (!isValidPlan(topViewProject, viewNode, mq)) {
-          // Skip it
-          continue;
-        }
-
         // 3.2. Initialize all query related auxiliary data structures
         // that will be used throughout query rewriting process
         // Extract view predicates
         final RelOptPredicateList viewPredicateList =
-            mq.getAllPredicates(viewNode);
-        if (viewPredicateList == null) {
-          // Skip it
-          continue;
-        }
+            materializationMetadata.viewPredicateListMap.get(materialization);
         final RexNode viewPred =
             simplify.simplifyUnknownAsFalse(
                 RexUtil.composeConjunction(rexBuilder,
@@ -1424,6 +1446,61 @@ public abstract class MaterializedViewRule<C extends MaterializedViewRule.Config
     COMPLETE,
     VIEW_PARTIAL,
     QUERY_PARTIAL
+  }
+
+  /**
+   * Check if the materialization is valid for this rule.
+   * If it does, cache the materialization's RelTableRef and RelOptPredicateList.
+   */
+  protected class MaterializationMetadata {
+    private final Set<RelOptMaterialization> notValidMaterializations = new HashSet<>();
+    private final Map<RelOptMaterialization, Set<RelTableRef>> viewTableRefsMap = new HashMap<>();
+    private final Map<RelOptMaterialization, RelOptPredicateList>
+        viewPredicateListMap = new HashMap<>();
+
+    protected boolean isValidMaterialization(
+        RelMetadataQuery mq, RelOptMaterialization materialization) {
+      if (notValidMaterializations.contains(materialization)) {
+        return false;
+      } else if (viewTableRefsMap.containsKey(materialization)) {
+        return true;
+      } else {
+        Project topViewProject;
+        RelNode viewNode;
+        if (materialization.queryRel instanceof Project) {
+          topViewProject = (Project) materialization.queryRel;
+          viewNode = topViewProject.getInput();
+        } else {
+          topViewProject = null;
+          viewNode = materialization.queryRel;
+        }
+
+        final Set<RelTableRef> viewTableRefs = mq.getTableReferences(viewNode);
+        if (viewTableRefs == null) {
+          // Skip it
+          notValidMaterializations.add(materialization);
+          return false;
+        }
+
+        if (!isValidPlan(topViewProject, viewNode, mq)) {
+          // Skip it
+          notValidMaterializations.add(materialization);
+          return false;
+        }
+
+        final RelOptPredicateList viewPredicateList =
+            mq.getAllPredicates(viewNode);
+        if (viewPredicateList == null) {
+          // Skip it
+          notValidMaterializations.add(materialization);
+          return false;
+        }
+
+        viewTableRefsMap.put(materialization, viewTableRefs);
+        viewPredicateListMap.put(materialization, viewPredicateList);
+        return true;
+      }
+    }
   }
 
   /** Rule configuration. */

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewRelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewRelOptRulesTest.java
@@ -157,6 +157,19 @@ class MaterializedViewRelOptRulesTest {
         .noMat();
   }
 
+  @Test void testMultiMaterializationsNoAggregateFuncs() {
+    fixture("select \"empid\", \"deptno\" from \"emps\" group by \"empid\", \"deptno\"")
+        .withMaterializations(
+            ImmutableList.of(
+                Pair.of(
+                    "select \"empid\", \"deptno\" from \"emps\" group by \"empid\", \"deptno\"",
+                    "MV0"),
+                Pair.of(
+                    "select \"empid\" from \"emps\" group by \"empid\", \"deptno\"",
+                "MV1")))
+        .ok();
+  }
+
   @Test void testAggregateMaterializationAggregateFuncs1() {
     sql("select \"empid\", \"deptno\", count(*) as c, sum(\"empid\") as s\n"
             + "from \"emps\" group by \"empid\", \"deptno\"",


### PR DESCRIPTION
jira: [CALCITE-5665](https://issues.apache.org/jira/browse/CALCITE-5665)

1. Reduce the number of MaterializedViewRule matches
2. Reduce RelOptMaterialization metadata recalculation

For example, in the test MaterializedViewRelOptRulesTest#testJoinAggregateMaterializationNoAggregateFuncs9, MaterializedViewRule#perform was triggered 489 times in the original implementation, but in this pr, it was only triggered 23 times.

I did a simple test on my personal computer and added a timer to the MaterializedViewRelOptRulesTest#TESTER#optimize method. Here are the milliseconds this method executes before and after optimization.

before: 237 237 229 250 241 227 258 239 253 267 256 244 228 228 241 245 245 238 273 243
after:   199  202 191 190 243 206 207 204 213 239 239 205 192 200 215 196 195 200 193 217
before avg: 243.95 ms
after    avg: 207.3   ms 

before: 225 239 244 236 240 225 281 239 240 236 238 236 228 239 241 238 237 265 256 233
after:    204 201 187 196 192 213 197 186 200 194 189 200 207 199 210 213 188 214 201 206
before avg: 240.8   ms
after    avg: 199.85 ms 
