### PR TITLE
[CALCITE-5679] HepPlanner#buildFinalPlan: do not clear metadata cache if RelNode has not changed

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/hep/HepPlanner.java
@@ -944,6 +944,7 @@ public class HepPlanner extends AbstractRelOptPlanner {
     // Recursively process children, replacing this rel's inputs
     // with corresponding child rels.
     List<RelNode> inputs = rel.getInputs();
+    boolean changed = false;
     for (int i = 0; i < inputs.size(); ++i) {
       RelNode child = inputs.get(i);
       if (!(child instanceof HepRelVertex)) {
@@ -952,9 +953,12 @@ public class HepPlanner extends AbstractRelOptPlanner {
       }
       child = buildFinalPlan((HepRelVertex) child);
       rel.replaceInput(i, child);
+      changed = true;
     }
-    RelMdUtil.clearCache(rel);
-    rel.recomputeDigest();
+    if (changed) {
+      RelMdUtil.clearCache(rel);
+      rel.recomputeDigest();
+    }
 
     return rel;
   }


### PR DESCRIPTION
[CALCITE-5679](https://issues.apache.org/jira/browse/CALCITE-5679) 
Minor optimization:
HepPlanner#buildFinalplan clears the metadata cache info of the impacted RelNode after replacing its inputs, but in the cases where the RelNode does not change (e.g. when it has no inputs) this clear cache should not be necessary (unless I'm missing something).
