### PR TITLE
[CALCITE-3959] Implement INSTR function (Enabled for BigQuery, MySql, Oracle)

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -1020,10 +1020,10 @@ public interface CalciteResource {
   @BaseMessage("No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization")
   ExInst<CalciteException> noOperator(String name, String kind, String syntax);
 
-  @BaseMessage("Invalid input for position function from operand value must not be zero")
+  @BaseMessage("Invalid input for POSITION function: from operand value must not be zero")
   ExInst<CalciteException> fromNotZero();
 
-  @BaseMessage("Invalid input for position function occurrence operand value must not be zero")
+  @BaseMessage("Invalid input for POSITION function: occurrence operand value must be positive")
   ExInst<CalciteException> occurrenceNotZero();
 
   @BaseMessage("Only tables with set semantics may be partitioned. Invalid PARTITION BY clause in the {0,number,#}-th operand of table function ''{1}''")
@@ -1034,6 +1034,4 @@ public interface CalciteResource {
 
   @BaseMessage("A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics")
   ExInst<SqlValidatorException> multipleRowSemanticsTables(String funcName);
-
-
 }

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -1020,6 +1020,12 @@ public interface CalciteResource {
   @BaseMessage("No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization")
   ExInst<CalciteException> noOperator(String name, String kind, String syntax);
 
+  @BaseMessage("Invalid input for position function from operand value must not be zero")
+  ExInst<CalciteException> fromNotZero();
+
+  @BaseMessage("Invalid input for position function occurrence operand value must not be zero")
+  ExInst<CalciteException> occurrenceNotZero();
+
   @BaseMessage("Only tables with set semantics may be partitioned. Invalid PARTITION BY clause in the {0,number,#}-th operand of table function ''{1}''")
   ExInst<SqlValidatorException> invalidPartitionKeys(int idx, String funcName);
 
@@ -1028,4 +1034,6 @@ public interface CalciteResource {
 
   @BaseMessage("A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics")
   ExInst<SqlValidatorException> multipleRowSemanticsTables(String funcName);
+
+
 }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -3104,23 +3104,89 @@ public class SqlFunctions {
 
   /** SQL {@code POSITION(seek IN string FROM integer)} function. */
   public static int position(String seek, String s, int from) {
-    final int from0 = from - 1; // 0-based
-    if (from0 > s.length() || from0 < 0) {
+    if (from > 0) {
+      final int from0 = from - 1; // 0-based
+      if (from0 > s.length() || from0 < 0) {
+        return 0;
+      }
+
+      return s.indexOf(seek, from0) + 1;
+    }
+    final int rightIndex = from + s.length(); // negative position to positive index
+    if (rightIndex <= 0) {
       return 0;
     }
-
-    return s.indexOf(seek, from0) + 1;
+    return s.substring(0, rightIndex).lastIndexOf(seek) + 1;
   }
 
   /** SQL {@code POSITION(seek IN string FROM integer)} function for byte
    * strings. */
   public static int position(ByteString seek, ByteString s, int from) {
-    final int from0 = from - 1;
-    if (from0 > s.length() || from0 < 0) {
+    if (from > 0) {
+      final int from0 = from - 1; // 0-based
+      if (from0 > s.length() || from0 < 0) {
+        return 0;
+      }
+
+      return s.indexOf(seek, from0) + 1;
+    }
+    final int rightIndex = from + s.length();
+    if (rightIndex <= 0) {
       return 0;
     }
+    return -1;
+    //s.lastIndexOf(seek, rightIndex) + 1;
+  }
 
-    return s.indexOf(seek, from0) + 1;
+  /** SQL {@code POSITION(seek, string, from, occurrence)} function. */
+  public static int position(String seek, String s, int from, int occurrence) {
+    if (from > 0){
+      int rollingFrom = from;
+      for (int i = 0; i< occurrence; i++) {
+        rollingFrom = position(seek, s, rollingFrom);
+        if (rollingFrom == 0) {
+          return 0;
+        }
+      }
+      return rollingFrom;
+    }
+    int rollingFromNeg = from;
+    int rollingFromPos = 0;
+    for (int i = 0; i< occurrence; i++) {
+      rollingFromPos = position(seek, s, rollingFromNeg);
+      if (rollingFromPos == 0) {
+        return 0;
+      }
+      rollingFromNeg = rollingFromPos - s.length();
+    }
+    return rollingFromPos;
+
+  }
+
+  /** SQL {@code POSITION(seek, string, from, occurrence)} function for byte
+   * strings. */
+  public static int position(ByteString seek, ByteString s, int from, int occurrence) {
+    if (from > 0){
+      int rollingFrom = from;
+      for (int i = 0; i< occurrence; i++) {
+        rollingFrom = position(seek, s, rollingFrom);
+        if (rollingFrom == 0) {
+          return 0;
+        }
+      }
+      return rollingFrom;
+    }
+    int rollingFromNeg = from;
+    int rollingFromPos = 0;
+    for (int i = 0; i< occurrence; i++) {
+      rollingFromPos = position(seek, s, rollingFromNeg);
+      if (rollingFromPos == 0) {
+        return 0;
+      }
+      rollingFromNeg = rollingFromPos - s.length();
+    }
+    return rollingFromPos;
+
   }
 
   /** Helper for rounding. Truncate(12345, 1000) returns 12000. */

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -3104,45 +3104,57 @@ public class SqlFunctions {
 
   /** SQL {@code POSITION(seek IN string FROM integer)} function. */
   public static int position(String seek, String s, int from) {
-    if (from == 0) throw RESOURCE.fromNotZero().ex();
+    if (from == 0) {
+      throw RESOURCE.fromNotZero().ex();
+    }
     // Case when from is positive
     if (from > 0) {
       final int from0 = from - 1; // 0-based
       if (from0 >= s.length() || from0 < 0) {
         return 0;
+      } else {
+        return s.indexOf(seek, from0) + 1;
       }
-
-      return s.indexOf(seek, from0) + 1;
     }
     // Case when from is negative
     final int rightIndex = from + s.length(); // negative position to positive index
     if (rightIndex <= 0) {
       return 0;
     }
-    return s.substring(0, rightIndex+1).lastIndexOf(seek) + 1;
+    int lastIndex = s.lastIndexOf(seek) + 1;
+    while (lastIndex > rightIndex + 1) {
+      lastIndex = s.substring(0, lastIndex - 1).lastIndexOf(seek) + 1;
+      if (lastIndex == 0) {
+        return 0;
+      }
+    }
+    return lastIndex;
   }
 
   /** SQL {@code POSITION(seek IN string FROM integer)} function for byte
    * strings. */
   public static int position(ByteString seek, ByteString s, int from) {
-    if (from == 0) throw RESOURCE.fromNotZero().ex();
+    if (from == 0) {
+      throw RESOURCE.fromNotZero().ex();
+    }
     // Case when from is positive
     if (from > 0) {
       final int from0 = from - 1; // 0-based
       if (from0 >= s.length() || from0 < 0) {
         return 0;
+      } else {
+        return s.indexOf(seek, from0) + 1;
       }
-      return s.indexOf(seek, from0) + 1;
     }
     // Case when from is negative
-    final int rightIndex = from + s.length();
+    final int rightIndex = from + s.length(); // negative position to positive index
     if (rightIndex <= 0) {
       return 0;
     }
     int lastIndex = 0;
     while (lastIndex < rightIndex) {
-      int indexOf = s.substring(lastIndex, rightIndex + 1).indexOf(seek) + 1;
-      if (indexOf == 0) {
+      int indexOf = s.substring(lastIndex).indexOf(seek) + 1;
+      if (indexOf == 0 || lastIndex + indexOf > rightIndex + 1) {
         break;
       }
       lastIndex += indexOf;
@@ -3152,47 +3164,57 @@ public class SqlFunctions {
 
   /** SQL {@code POSITION(seek, string, from, occurrence)} function. */
   public static int position(String seek, String s, int from, int occurrence) {
-    if (occurrence == 0) throw RESOURCE.occurrenceNotZero().ex();
-    for (int i = 0; i < occurrence; i++){
-      if (from > 0){
+    if (occurrence == 0) {
+      throw RESOURCE.occurrenceNotZero().ex();
+    }
+    if (from > 0) {
+      for (int i = 0; i < occurrence; i++) {
         from = position(seek, s, from + (i == 0 ? 0 : 1));
         if (from == 0) {
           return 0;
         }
-      } else {
+      }
+    } else {
+      for (int i = 0; i < occurrence; i++) {
         from = position(seek, s, from);
         if (from == 0) {
           return 0;
         }
-        from -= (s.length() + 2);
+        from -= s.length() + 2;
       }
     }
-    if (from < 0) from += s.length() + 2;
+    if (from < 0) {
+      from += s.length() + 2;
+    }
     return from;
   }
 
   /** SQL {@code POSITION(seek, string, from, occurrence)} function for byte
    * strings. */
   public static int position(ByteString seek, ByteString s, int from, int occurrence) {
-    if (occurrence == 0) throw RESOURCE.occurrenceNotZero().ex();
-    for (int i = 0; i < occurrence; i++){
-      if (from > 0){
+    if (occurrence == 0) {
+      throw RESOURCE.occurrenceNotZero().ex();
+    }
+    if (from > 0) {
+      for (int i = 0; i < occurrence; i++) {
         from = position(seek, s, from + (i == 0 ? 0 : 1));
         if (from == 0) {
           return 0;
         }
       }
-      else {
+    } else {
+      for (int i = 0; i < occurrence; i++) {
         from = position(seek, s, from);
         if (from == 0) {
           return 0;
         }
-        from -= (s.length() + 2);
+        from -= s.length() + 2;
       }
     }
-    if (from < 0) from += s.length() + 2;
+    if (from < 0) {
+      from += s.length() + 2;
+    }
     return from;
-
   }
 
   /** Helper for rounding. Truncate(12345, 1000) returns 12000. */

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -150,16 +150,36 @@ public class BigQuerySqlDialect extends SqlDialect {
       final int rightPrec) {
     switch (call.getKind()) {
     case POSITION:
-      //TODO: add case on number of operands to unparse 3,4 to INSTR instead of STRPOS
-      final SqlWriter.Frame frame = writer.startFunCall("STRPOS");
-      writer.sep(",");
-      call.operand(1).unparse(writer, leftPrec, rightPrec);
-      writer.sep(",");
-      call.operand(0).unparse(writer, leftPrec, rightPrec);
-      if (3 == call.operandCount()) {
-        throw new RuntimeException("3rd operand Not Supported for Function STRPOS in Big Query");
+      if (2 == call.operandCount()) {
+        final SqlWriter.Frame frame = writer.startFunCall("STRPOS");
+        writer.sep(",");
+        call.operand(1).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",");
+        call.operand(0).unparse(writer, leftPrec, rightPrec);
+        writer.endFunCall(frame);
       }
-      writer.endFunCall(frame);
+      if (3 == call.operandCount()) {
+        final SqlWriter.Frame frame = writer.startFunCall("INSTR");
+        writer.sep(",");
+        call.operand(1).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",");
+        call.operand(0).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",");
+        call.operand(2).unparse(writer, leftPrec, rightPrec);
+        writer.endFunCall(frame);
+      }
+      if (4 == call.operandCount()) {
+        final SqlWriter.Frame frame = writer.startFunCall("INSTR");
+        writer.sep(",");
+        call.operand(1).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",");
+        call.operand(0).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",");
+        call.operand(2).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",");
+        call.operand(3).unparse(writer, leftPrec, rightPrec);
+        writer.endFunCall(frame);
+      }
       break;
     case UNION:
       if (((SqlSetOperator) call.getOperator()).isAll()) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -150,26 +150,23 @@ public class BigQuerySqlDialect extends SqlDialect {
       final int rightPrec) {
     switch (call.getKind()) {
     case POSITION:
-      if (2 == call.operandCount()) {
-        final SqlWriter.Frame frame = writer.startFunCall("STRPOS");
+      final SqlWriter.Frame frame = writer.startFunCall("INSTR");
+      switch (call.operandCount()) {
+      case 2:
         writer.sep(",");
         call.operand(1).unparse(writer, leftPrec, rightPrec);
         writer.sep(",");
         call.operand(0).unparse(writer, leftPrec, rightPrec);
-        writer.endFunCall(frame);
-      }
-      if (3 == call.operandCount()) {
-        final SqlWriter.Frame frame = writer.startFunCall("INSTR");
+        break;
+      case 3:
         writer.sep(",");
         call.operand(1).unparse(writer, leftPrec, rightPrec);
         writer.sep(",");
         call.operand(0).unparse(writer, leftPrec, rightPrec);
         writer.sep(",");
         call.operand(2).unparse(writer, leftPrec, rightPrec);
-        writer.endFunCall(frame);
-      }
-      if (4 == call.operandCount()) {
-        final SqlWriter.Frame frame = writer.startFunCall("INSTR");
+        break;
+      case 4:
         writer.sep(",");
         call.operand(1).unparse(writer, leftPrec, rightPrec);
         writer.sep(",");
@@ -178,8 +175,12 @@ public class BigQuerySqlDialect extends SqlDialect {
         call.operand(2).unparse(writer, leftPrec, rightPrec);
         writer.sep(",");
         call.operand(3).unparse(writer, leftPrec, rightPrec);
-        writer.endFunCall(frame);
+        break;
+      default:
+        throw new RuntimeException("BigQuery does not support " + call.operandCount()
+            + " operands in the position function");
       }
+      writer.endFunCall(frame);
       break;
     case UNION:
       if (((SqlSetOperator) call.getOperator()).isAll()) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -150,6 +150,7 @@ public class BigQuerySqlDialect extends SqlDialect {
       final int rightPrec) {
     switch (call.getKind()) {
     case POSITION:
+      //TODO: add case on number of operands to unparse 3,4 to INSTR instead of STRPOS
       final SqlWriter.Frame frame = writer.startFunCall("STRPOS");
       writer.sep(",");
       call.operand(1).unparse(writer, leftPrec, rightPrec);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -218,6 +218,14 @@ public class MysqlSqlDialect extends SqlDialect {
   @Override public void unparseCall(SqlWriter writer, SqlCall call,
       int leftPrec, int rightPrec) {
     switch (call.getKind()) {
+    case POSITION:
+      final SqlWriter.Frame frame = writer.startFunCall("INSTR");
+      writer.sep(",");
+      call.operand(1).unparse(writer, leftPrec, rightPrec);
+      writer.sep(",");
+      call.operand(0).unparse(writer, leftPrec, rightPrec);
+      writer.endFunCall(frame);
+      break;
     case FLOOR:
       if (call.operandCount() != 2) {
         super.unparseCall(writer, call, leftPrec, rightPrec);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -150,6 +150,24 @@ public class OracleSqlDialect extends SqlDialect {
           call, false);
     } else {
       switch (call.getKind()) {
+      case POSITION:
+        final SqlWriter.Frame frame = writer.startFunCall("INSTR");
+        writer.sep(",");
+        call.operand(1).unparse(writer, leftPrec, rightPrec);
+        writer.sep(",");
+        call.operand(0).unparse(writer, leftPrec, rightPrec);
+        if (3 == call.operandCount()) {
+          writer.sep(",");
+          call.operand(2).unparse(writer, leftPrec, rightPrec);
+        }
+        if (4 == call.operandCount()) {
+          writer.sep(",");
+          call.operand(2).unparse(writer, leftPrec, rightPrec);
+          writer.sep(",");
+          call.operand(3).unparse(writer, leftPrec, rightPrec);
+        }
+        writer.endFunCall(frame);
+        break;
       case FLOOR:
         if (call.operandCount() != 2) {
           super.unparseCall(writer, call, leftPrec, rightPrec);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -333,7 +333,7 @@ public abstract class SqlLibraryOperators {
   public static final SqlFunction STRPOS = new SqlPositionFunction("STRPOS");
 
   /** The "INSTR(string, substring [, position [, occurrence]])" function. */
-  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
+  @LibraryOperator(libraries = {BIG_QUERY, MYSQL, ORACLE})
   public static final SqlFunction INSTR = new SqlPositionFunction("INSTR");
 
   /** Generic "SUBSTR(string, position [, substringLength ])" function. */
@@ -341,7 +341,6 @@ public abstract class SqlLibraryOperators {
       SqlBasicFunction.create("SUBSTR", ReturnTypes.ARG0_NULLABLE_VARYING,
           OperandTypes.STRING_INTEGER_OPTIONAL_INTEGER,
           SqlFunctionCategory.STRING);
-
 
   /** The "ENDS_WITH(value1, value2)" function (BigQuery). */
   @LibraryOperator(libraries = {BIG_QUERY})

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -332,11 +332,16 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY, POSTGRESQL})
   public static final SqlFunction STRPOS = new SqlPositionFunction("STRPOS");
 
+  /** The "INSTR(string, substring [, position [, occurrence]])" function. */
+  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
+  public static final SqlFunction INSTR = new SqlPositionFunction("INSTR");
+
   /** Generic "SUBSTR(string, position [, substringLength ])" function. */
   private static final SqlBasicFunction SUBSTR =
       SqlBasicFunction.create("SUBSTR", ReturnTypes.ARG0_NULLABLE_VARYING,
           OperandTypes.STRING_INTEGER_OPTIONAL_INTEGER,
           SqlFunctionCategory.STRING);
+
 
   /** The "ENDS_WITH(value1, value2)" function (BigQuery). */
   @LibraryOperator(libraries = {BIG_QUERY})

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlPositionFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlPositionFunction.java
@@ -25,6 +25,8 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+
 
 /**
  * The <code>POSITION</code> function.
@@ -37,8 +39,10 @@ public class SqlPositionFunction extends SqlFunction {
   // as part of rtiDyadicStringSumPrecision
 
   private static final SqlOperandTypeChecker OTC_CUSTOM =
-      OperandTypes.STRING_SAME_SAME
-          .or(OperandTypes.STRING_SAME_SAME_INTEGER);
+//      OperandTypes.STRING_SAME_SAME
+//          .or(OperandTypes.STRING_SAME_SAME_INTEGER)
+          (OperandTypes.STRING_SAME_SAME_INTEGER_INTEGER);
+//          .or(OperandTypes.STRING_SAME_SAME_INTEGER_INTEGER);
 
   public SqlPositionFunction(String name) {
     super(name, SqlKind.POSITION, ReturnTypes.INTEGER_NULLABLE, null,
@@ -60,6 +64,10 @@ public class SqlPositionFunction extends SqlFunction {
       writer.sep("FROM");
       call.operand(2).unparse(writer, leftPrec, rightPrec);
     }
+    if (4 == call.operandCount()) {
+      writer.sep(", ");
+      call.operand(3).unparse(writer, leftPrec, rightPrec);
+    }
     writer.endFunCall(frame);
   }
 
@@ -69,6 +77,8 @@ public class SqlPositionFunction extends SqlFunction {
       return "{0}({1} IN {2})";
     case 3:
       return "{0}({1} IN {2} FROM {3})";
+    case 4:
+      return "{0}({1}, {2}, {3}, {4})";
     default:
       throw new AssertionError();
     }
@@ -88,6 +98,9 @@ public class SqlPositionFunction extends SqlFunction {
       return OperandTypes.SAME_SAME_INTEGER.checkOperandTypes(
           callBinding, throwOnFailure)
           && super.checkOperandTypes(callBinding, throwOnFailure);
+    case 4:
+      return true;
+          //OperandTypes.and(OperandTypes.SAME_SAME_INTEGER, OperandTypes.INTEGER).checkOperandTypes(callBinding, throwOnFailure) && super.checkOperandTypes(callBinding, throwOnFailure);
     default:
       throw new AssertionError();
     }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlPositionFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlPositionFunction.java
@@ -39,7 +39,10 @@ public class SqlPositionFunction extends SqlFunction {
   private static final SqlOperandTypeChecker OTC_CUSTOM =
       OperandTypes.STRING_SAME_SAME
           .or(OperandTypes.STRING_SAME_SAME_INTEGER)
-          .or(OperandTypes.sequence("INSTR(<STRING>, <STRING>, <INTEGER>, <INTEGER>)", OperandTypes.STRING, OperandTypes.STRING, OperandTypes.INTEGER, OperandTypes.INTEGER));
+          .or(
+              OperandTypes.sequence("INSTR(<STRING>, <STRING>, <INTEGER>, <INTEGER>)",
+              OperandTypes.STRING, OperandTypes.STRING, OperandTypes.INTEGER,
+              OperandTypes.INTEGER));
 
   public SqlPositionFunction(String name) {
     super(name, SqlKind.POSITION, ReturnTypes.INTEGER_NULLABLE, null,
@@ -54,16 +57,16 @@ public class SqlPositionFunction extends SqlFunction {
       int leftPrec,
       int rightPrec) {
     final SqlWriter.Frame frame = writer.startFunCall(getName());
-    if (2 == call.operandCount() || 3 == call.operandCount()) {
+    if (call.operandCount() == 2 || call.operandCount() == 3) {
       call.operand(0).unparse(writer, leftPrec, rightPrec);
       writer.sep("IN");
       call.operand(1).unparse(writer, leftPrec, rightPrec);
-      if (3 == call.operandCount()) {
+      if (call.operandCount() == 3) {
         writer.sep("FROM");
         call.operand(2).unparse(writer, leftPrec, rightPrec);
       }
     }
-    if (4 == call.operandCount()) {
+    if (call.operandCount() == 4) {
       call.operand(0).unparse(writer, leftPrec, rightPrec);
       writer.sep(",");
       call.operand(1).unparse(writer, leftPrec, rightPrec);
@@ -103,9 +106,11 @@ public class SqlPositionFunction extends SqlFunction {
           callBinding, throwOnFailure)
           && super.checkOperandTypes(callBinding, throwOnFailure);
     case 4:
-          return OperandTypes.sequence("INSTR(<STRING>, <STRING>, <INTEGER>, <INTEGER>)", OperandTypes.STRING, OperandTypes.STRING, OperandTypes.INTEGER, OperandTypes.INTEGER).checkOperandTypes(
-              callBinding, throwOnFailure)
-              && super.checkOperandTypes(callBinding, throwOnFailure);
+      return OperandTypes.sequence("INSTR(<STRING>, <STRING>, <INTEGER>, <INTEGER>)",
+          OperandTypes.STRING, OperandTypes.STRING, OperandTypes.INTEGER,
+          OperandTypes.INTEGER).checkOperandTypes(
+          callBinding, throwOnFailure)
+          && super.checkOperandTypes(callBinding, throwOnFailure);
     default:
       throw new AssertionError();
     }

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -597,8 +597,6 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker SAME_SAME_INTEGER =
       new SameOperandTypeExceptLastOperandChecker(3, "INTEGER");
 
-  public static final SqlSingleOperandTypeChecker SAME_SAME_INTEGER_INTEGER =
-      SAME_SAME_INTEGER.and(family(ImmutableList.of(SqlTypeFamily.INTEGER,SqlTypeFamily.INTEGER,SqlTypeFamily.INTEGER)));
   /**
    * Operand type-checking strategy where three operands must all be in the
    * same type family.
@@ -717,9 +715,6 @@ public abstract class OperandTypes {
    */
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_INTEGER =
       STRING_STRING_INTEGER.and(SAME_SAME_INTEGER);
-
-  public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_INTEGER_INTEGER =
-      STRING_STRING_INTEGER_INTEGER.and(SAME_SAME_INTEGER_INTEGER);
 
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_OR_ARRAY_SAME_SAME =
       or(STRING_SAME_SAME,

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -597,6 +597,8 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker SAME_SAME_INTEGER =
       new SameOperandTypeExceptLastOperandChecker(3, "INTEGER");
 
+  public static final SqlSingleOperandTypeChecker SAME_SAME_INTEGER_INTEGER =
+      SAME_SAME_INTEGER.and(family(ImmutableList.of(SqlTypeFamily.INTEGER,SqlTypeFamily.INTEGER,SqlTypeFamily.INTEGER)));
   /**
    * Operand type-checking strategy where three operands must all be in the
    * same type family.
@@ -715,6 +717,9 @@ public abstract class OperandTypes {
    */
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_INTEGER =
       STRING_STRING_INTEGER.and(SAME_SAME_INTEGER);
+
+  public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_INTEGER_INTEGER =
+      STRING_STRING_INTEGER_INTEGER.and(SAME_SAME_INTEGER_INTEGER);
 
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_OR_ARRAY_SAME_SAME =
       or(STRING_SAME_SAME,

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -279,6 +279,13 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
             SqlStdOperatorTable.POSITION.createCall(SqlParserPos.ZERO,
                 call.operand(1), call.operand(0))));
 
+    // "INSTR(string, substring, position, occurrence) is equivalent to
+    // "POSITION(substring, string, position, occurrence)"
+    registerOp(SqlLibraryOperators.INSTR,
+        (cx, call) -> cx.convertExpression(
+            SqlStdOperatorTable.POSITION.createCall(SqlParserPos.ZERO,
+                call.operand(1), call.operand(0), call.operand(2), call.operand(3))));
+
     // REVIEW jvs 24-Apr-2006: This only seems to be working from within a
     // windowed agg.  I have added an optimizer rule
     // org.apache.calcite.rel.rules.AggregateReduceFunctionsRule which handles

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -281,10 +281,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
 
     // "INSTR(string, substring, position, occurrence) is equivalent to
     // "POSITION(substring, string, position, occurrence)"
-    registerOp(SqlLibraryOperators.INSTR,
-        (cx, call) -> cx.convertExpression(
-            SqlStdOperatorTable.POSITION.createCall(SqlParserPos.ZERO,
-                call.operand(1), call.operand(0), call.operand(2), call.operand(3))));
+    registerOp(SqlLibraryOperators.INSTR, StandardConvertletTable::convertInstr);
+
 
     // REVIEW jvs 24-Apr-2006: This only seems to be working from within a
     // windowed agg.  I have added an optimizer rule
@@ -407,6 +405,24 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
                 cx.getTypeFactory()
                     .createTypeWithNullability(type, operand1.getType().isNullable()),
                 operand1)));
+  }
+
+  /** Converts a call to the INSTR function. */
+  private static RexNode convertInstr(SqlRexContext cx, SqlCall call) {
+    SqlNode callToConvert = null;
+    if (call.operandCount() == 2) {
+      callToConvert =
+          SqlStdOperatorTable.POSITION.createCall(SqlParserPos.ZERO, call.operand(1), call.operand(0));
+    }
+    if (call.operandCount() == 3) {
+      callToConvert =
+          SqlStdOperatorTable.POSITION.createCall(SqlParserPos.ZERO, call.operand(1), call.operand(0), call.operand(2));
+    }
+    if (call.operandCount() == 4) {
+      callToConvert =
+          SqlStdOperatorTable.POSITION.createCall(SqlParserPos.ZERO, call.operand(1), call.operand(0), call.operand(2), call.operand(3));
+    }
+    return cx.convertExpression(callToConvert);
   }
 
   /** Converts a call to the DECODE function. */

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -336,6 +336,6 @@ InvalidPartitionKeys=Only tables with set semantics may be partitioned. Invalid 
 InvalidOrderBy=Only tables with set semantics may be ordered. Invalid ORDER BY clause in the {0,number,#}-th operand of table function ''{1}''
 MultipleRowSemanticsTables=A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics
 NoOperator=No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization
-FromNotZero=Invalid input for position function: from operand value must not be zero
-OccurrenceNotZero=Invalid input for position function: occurrence operand value must not be zero
+FromNotZero=Invalid input for POSITION function: from operand value must not be zero
+OccurrenceNotZero=Invalid input for POSITION function: occurrence operand value must be positive
 # End CalciteResource.properties

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -336,4 +336,6 @@ InvalidPartitionKeys=Only tables with set semantics may be partitioned. Invalid 
 InvalidOrderBy=Only tables with set semantics may be ordered. Invalid ORDER BY clause in the {0,number,#}-th operand of table function ''{1}''
 MultipleRowSemanticsTables=A table function at most has one input table with row semantics. Table function ''{0}'' has multiple input tables with row semantics
 NoOperator=No operator for ''{0}'' with kind: ''{1}'', syntax: ''{2}'' during JSON deserialization
+FromNotZero=Invalid input for position function: from operand value must not be zero
+OccurrenceNotZero=Invalid input for position function: occurrence operand value must not be zero
 # End CalciteResource.properties

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2230,14 +2230,14 @@ class RelToSqlConverterTest {
 
   @Test void testPositionFunctionForBigQuery() {
     final String query = "select position('A' IN 'ABC') from \"product\"";
-    final String expected = "SELECT STRPOS('ABC', 'A')\n"
+    final String expected = "SELECT INSTR('ABC', 'A')\n"
         + "FROM foodmart.product";
     sql(query).withBigQuery().ok(expected);
   }
 
   @Test void testInstrFunction4Operands() {
     final String query = "SELECT INSTR('ABC', 'A', 1, 1) from \"product\"";
-    final String expectedBQ= "SELECT INSTR('ABC', 'A', 1, 1)\n"
+    final String expectedBQ = "SELECT INSTR('ABC', 'A', 1, 1)\n"
         + "FROM foodmart.product";
     final String expected_oracle = "SELECT INSTR('ABC', 'A', 1, 1)\n"
         + "FROM \"foodmart\".\"product\"";

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2228,6 +2228,15 @@ class RelToSqlConverterTest {
     sql(query).withBigQuery().ok(expected);
   }
 
+  @Test void testBigQueryInstrFunction() {
+    final String query = "SELECT INSTR('A', 'ABC', 1, 1) from \"product\"";
+    final String expected = "SELECT INSTR('A', 'ABC', 1, 1)\n"
+        + "FROM foodmart.product";
+    final Sql sql = fixture().withBigQuery().withLibrary(SqlLibrary.BIG_QUERY);
+    sql.withSql(query).withBigQuery().ok(expected);
+  }
+
+
   /** Tests that we escape single-quotes in character literals using back-slash
    * in BigQuery. The norm is to escape single-quotes with single-quotes. */
   @Test void testCharLiteralForBigQuery() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2221,6 +2221,13 @@ class RelToSqlConverterTest {
     sql(query).withHive().ok(expected);
   }
 
+  @Test void testPositionFunctionForMySql() {
+    final String query = "select position('A' IN 'ABC') from \"product\"";
+    final String expected = "SELECT INSTR('ABC', 'A')\n"
+        + "FROM `foodmart`.`product`";
+    sql(query).withMysql().ok(expected);
+  }
+
   @Test void testPositionFunctionForBigQuery() {
     final String query = "select position('A' IN 'ABC') from \"product\"";
     final String expected = "SELECT STRPOS('ABC', 'A')\n"
@@ -2228,14 +2235,29 @@ class RelToSqlConverterTest {
     sql(query).withBigQuery().ok(expected);
   }
 
-  @Test void testBigQueryInstrFunction() {
-    final String query = "SELECT INSTR('A', 'ABC', 1, 1) from \"product\"";
-    final String expected = "SELECT INSTR('A', 'ABC', 1, 1)\n"
+  @Test void testInstrFunction4Operands() {
+    final String query = "SELECT INSTR('ABC', 'A', 1, 1) from \"product\"";
+    final String expectedBQ= "SELECT INSTR('ABC', 'A', 1, 1)\n"
         + "FROM foodmart.product";
-    final Sql sql = fixture().withBigQuery().withLibrary(SqlLibrary.BIG_QUERY);
-    sql.withSql(query).withBigQuery().ok(expected);
+    final String expected_oracle = "SELECT INSTR('ABC', 'A', 1, 1)\n"
+        + "FROM \"foodmart\".\"product\"";
+    final Sql sqlOracle = fixture().withOracle().withLibrary(SqlLibrary.ORACLE);
+    sqlOracle.withSql(query).withOracle().ok(expected_oracle);
+    final Sql sqlBQ = fixture().withBigQuery().withLibrary(SqlLibrary.BIG_QUERY);
+    sqlBQ.withSql(query).withBigQuery().ok(expectedBQ);
   }
 
+  @Test void testInstrFunction3Operands() {
+    final String query = "SELECT INSTR('ABC', 'A', 1) from \"product\"";
+    final String expectedBQ = "SELECT INSTR('ABC', 'A', 1)\n"
+        + "FROM foodmart.product";
+    final String expectedOracle = "SELECT INSTR('ABC', 'A', 1)\n"
+        + "FROM \"foodmart\".\"product\"";
+    final Sql sqlOracle = fixture().withOracle().withLibrary(SqlLibrary.ORACLE);
+    sqlOracle.withSql(query).withOracle().ok(expectedOracle);
+    final Sql sqlBQ = fixture().withBigQuery().withLibrary(SqlLibrary.BIG_QUERY);
+    sqlBQ.withSql(query).withBigQuery().ok(expectedBQ);
+  }
 
   /** Tests that we escape single-quotes in character literals using back-slash
    * in BigQuery. The norm is to escape single-quotes with single-quotes. */

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -1055,51 +1055,54 @@ class SqlFunctionsTest {
       // ok
     }
   }
+
   @Test void testPosition() {
-    assertThat(3, is(position("c", "abcdec")));
-    assertThat(3, is(position("c", "abcdec", 2)));
-    assertThat(3, is(position("c", "abcdec", -2)));
-    assertThat(6, is(position("c", "abcdec", 4)));
-    assertThat(6, is(position("c", "abcdec",1 , 2)));
-    assertThat(3, is(position("c", "abcdec", -1, 2)));
-    assertThat(0, is(position("f", "abcdec", 1, 1)));
-    assertThat(0, is(position("c", "abcdec", 1, 3)));
+    assertThat(position("c", "abcdec"), is(3));
+    assertThat(position("c", "abcdec", 2), is(3));
+    assertThat(position("c", "abcdec", -2), is(3));
+    assertThat(position("c", "abcdec", 4), is(6));
+    assertThat(position("c", "abcdec", 1, 2), is(6));
+    assertThat(position("cde", "abcdecde", -2, 1), is(6));
+    assertThat(position("c", "abcdec", -1, 2), is(3));
+    assertThat(position("f", "abcdec", 1, 1), is(0));
+    assertThat(position("c", "abcdec", 1, 3), is(0));
     try {
       int i = position("c", "abcdec", 0, 1);
       fail("expected error, got: " + i);
     } catch (CalciteException e) {
       assertThat(e.getMessage(),
-          is("Invalid input for position function: from operand value must not be zero"));
+          is("Invalid input for POSITION function: from operand value must not be zero"));
     }
     try {
       int i = position("c", "abcdec", 1, 0);
       fail("expected error, got: " + i);
     } catch (CalciteException e) {
       assertThat(e.getMessage(),
-          is("Invalid input for position function: occurrence operand value must not be zero"));
+          is("Invalid input for POSITION function: occurrence operand value must be positive"));
     }
     final ByteString abc = ByteString.of("aabbccddeecc", 16);
-    assertThat(3, is(position(ByteString.of("cc", 16), abc)));
-    assertThat(3, is(position(ByteString.of("cc", 16), abc, 2)));
-    assertThat(3, is(position(ByteString.of("cc", 16), abc, -2)));
-    assertThat(6, is(position(ByteString.of("cc", 16), abc, 4)));
-    assertThat(6, is(position(ByteString.of("cc", 16), abc,1 , 2)));
-    assertThat(3, is(position(ByteString.of("cc", 16), abc, -1, 2)));
-    assertThat(0, is(position(ByteString.of("ff", 16), abc, 1, 1)));
-    assertThat(0, is(position(ByteString.of("cc", 16), abc, 1, 3)));
+    assertThat(position(ByteString.of("cc", 16), abc), is(3));
+    assertThat(position(ByteString.of("cc", 16), abc, 2), is(3));
+    assertThat(position(ByteString.of("cc", 16), abc, -2), is(3));
+    assertThat(position(ByteString.of("cc", 16), abc, 4), is(6));
+    assertThat(position(ByteString.of("ddeecc", 16), abc, -2), is(4));
+    assertThat(position(ByteString.of("cc", 16), abc, 1, 2), is(6));
+    assertThat(position(ByteString.of("cc", 16), abc, -1, 2), is(3));
+    assertThat(position(ByteString.of("ff", 16), abc, 1, 1), is(0));
+    assertThat(position(ByteString.of("cc", 16), abc, 1, 3), is(0));
     try {
       int i = position(ByteString.of("cc", 16), abc, 0, 1);
       fail("expected error, got: " + i);
     } catch (CalciteException e) {
       assertThat(e.getMessage(),
-          is("Invalid input for position function: from operand value must not be zero"));
+          is("Invalid input for POSITION function: from operand value must not be zero"));
     }
     try {
       int i = position(ByteString.of("cc", 16), abc, 1, 0);
       fail("expected error, got: " + i);
     } catch (CalciteException e) {
       assertThat(e.getMessage(),
-          is("Invalid input for position function: occurrence operand value must not be zero"));
+          is("Invalid input for POSITION function: occurrence operand value must be positive"));
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -53,6 +53,7 @@ import static org.apache.calcite.runtime.SqlFunctions.lesser;
 import static org.apache.calcite.runtime.SqlFunctions.lower;
 import static org.apache.calcite.runtime.SqlFunctions.ltrim;
 import static org.apache.calcite.runtime.SqlFunctions.md5;
+import static org.apache.calcite.runtime.SqlFunctions.position;
 import static org.apache.calcite.runtime.SqlFunctions.posixRegex;
 import static org.apache.calcite.runtime.SqlFunctions.regexpReplace;
 import static org.apache.calcite.runtime.SqlFunctions.rtrim;
@@ -1054,6 +1055,54 @@ class SqlFunctionsTest {
       // ok
     }
   }
+  @Test void testPosition() {
+    assertThat(3, is(position("c", "abcdec")));
+    assertThat(3, is(position("c", "abcdec", 2)));
+    assertThat(3, is(position("c", "abcdec", -2)));
+    assertThat(6, is(position("c", "abcdec", 4)));
+    assertThat(6, is(position("c", "abcdec",1 , 2)));
+    assertThat(3, is(position("c", "abcdec", -1, 2)));
+    assertThat(0, is(position("f", "abcdec", 1, 1)));
+    assertThat(0, is(position("c", "abcdec", 1, 3)));
+    try {
+      int i = position("c", "abcdec", 0, 1);
+      fail("expected error, got: " + i);
+    } catch (CalciteException e) {
+      assertThat(e.getMessage(),
+          is("Invalid input for position function: from operand value must not be zero"));
+    }
+    try {
+      int i = position("c", "abcdec", 1, 0);
+      fail("expected error, got: " + i);
+    } catch (CalciteException e) {
+      assertThat(e.getMessage(),
+          is("Invalid input for position function: occurrence operand value must not be zero"));
+    }
+    final ByteString abc = ByteString.of("aabbccddeecc", 16);
+    assertThat(3, is(position(ByteString.of("cc", 16), abc)));
+    assertThat(3, is(position(ByteString.of("cc", 16), abc, 2)));
+    assertThat(3, is(position(ByteString.of("cc", 16), abc, -2)));
+    assertThat(6, is(position(ByteString.of("cc", 16), abc, 4)));
+    assertThat(6, is(position(ByteString.of("cc", 16), abc,1 , 2)));
+    assertThat(3, is(position(ByteString.of("cc", 16), abc, -1, 2)));
+    assertThat(0, is(position(ByteString.of("ff", 16), abc, 1, 1)));
+    assertThat(0, is(position(ByteString.of("cc", 16), abc, 1, 3)));
+    try {
+      int i = position(ByteString.of("cc", 16), abc, 0, 1);
+      fail("expected error, got: " + i);
+    } catch (CalciteException e) {
+      assertThat(e.getMessage(),
+          is("Invalid input for position function: from operand value must not be zero"));
+    }
+    try {
+      int i = position(ByteString.of("cc", 16), abc, 1, 0);
+      fail("expected error, got: " + i);
+    } catch (CalciteException e) {
+      assertThat(e.getMessage(),
+          is("Invalid input for position function: occurrence operand value must not be zero"));
+    }
+  }
+
 
   /**
    * Tests that a date in the local time zone converts to a Unix timestamp in

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2693,6 +2693,8 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b o | GREATEST(expr [, expr ]*)                    | Returns the greatest of the expressions
 | b h s | IF(condition, value1, value2)              | Returns *value1* if *condition* is TRUE, *value2* otherwise
 | b | IFNULL(value1, value2)                         | Equivalent to `NVL(value1, value2)`
+| b o | INSTR(string, substring[, from, occurrence]) | Returns the position of substring in string, searching starting at from, and until locating the nth occurrence of substring.
+| m | INSTR(string, substring)                       | Equivalent to `POSITION(substring IN string)`
 | p | string1 ILIKE string2 [ ESCAPE string3 ]       | Whether *string1* matches pattern *string2*, ignoring case (similar to `LIKE`)
 | p | string1 NOT ILIKE string2 [ ESCAPE string3 ]   | Whether *string1* does not match pattern *string2*, ignoring case (similar to `NOT LIKE`)
 | m | JSON_TYPE(jsonValue)                           | Returns a string value indicating the type of *jsonValue*

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2693,7 +2693,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b o | GREATEST(expr [, expr ]*)                    | Returns the greatest of the expressions
 | b h s | IF(condition, value1, value2)              | Returns *value1* if *condition* is TRUE, *value2* otherwise
 | b | IFNULL(value1, value2)                         | Equivalent to `NVL(value1, value2)`
-| b o | INSTR(string, substring[, from, occurrence]) | Returns the position of substring in string, searching starting at from, and until locating the nth occurrence of substring.
+| b o | INSTR(string, substring[, from, occurrence]) | Returns the position of *substring* in *string*, searching starting at *from* (default 1), and until locating the nth *occurrence* (default 1) of substring
 | m | INSTR(string, substring)                       | Equivalent to `POSITION(substring IN string)`
 | p | string1 ILIKE string2 [ ESCAPE string3 ]       | Whether *string1* matches pattern *string2*, ignoring case (similar to `LIKE`)
 | p | string1 NOT ILIKE string2 [ ESCAPE string3 ]   | Whether *string1* does not match pattern *string2*, ignoring case (similar to `NOT LIKE`)

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -6225,7 +6225,11 @@ public class SqlOperatorTest {
   }
 
   @Test void testInstrFunction() {
-    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.INSTR);
+    final SqlOperatorFixture f0 = fixture()
+        .setFor(SqlLibraryOperators.CHR, VM_FENNEL, VM_JAVA);
+    f0.checkFails("^INSTR('abc', 'a', 1, 1)^",
+        "No match found for function signature INSTR\\(<CHARACTER>, <CHARACTER>,"
+            + " <NUMERIC>, <NUMERIC>\\)", false);
 
     final Consumer<SqlOperatorFixture> consumer = f -> {
 

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -3677,7 +3677,7 @@ public class SqlOperatorTest {
     f.checkScalarExact("position('b' in 'abcabc' FROM 3)", 5);
     f.checkScalarExact("position('b' in 'abcabc' FROM 5)", 5);
     f.checkScalarExact("position('b' in 'abcabc' FROM 6)", 0);
-    f.checkScalarExact("position('b' in 'abcabc' FROM -5)", 0);
+    f.checkScalarExact("position('b' in 'abcabc' FROM -5)", 2);
     f.checkScalarExact("position('' in 'abc' FROM 3)", 3);
     f.checkScalarExact("position('' in 'abc' FROM 10)", 0);
 
@@ -3686,7 +3686,7 @@ public class SqlOperatorTest {
     f.checkScalarExact("position(x'bb' in x'aabbccaabbcc' FROM 3)", 5);
     f.checkScalarExact("position(x'bb' in x'aabbccaabbcc' FROM 5)", 5);
     f.checkScalarExact("position(x'bb' in x'aabbccaabbcc' FROM 6)", 0);
-    f.checkScalarExact("position(x'bb' in x'aabbccaabbcc' FROM -5)", 0);
+    f.checkScalarExact("position(x'bb' in x'aabbccaabbcc' FROM -5)", 2);
     f.checkScalarExact("position(x'cc' in x'aabbccdd' FROM 2)", 3);
     f.checkScalarExact("position(x'' in x'aabbcc' FROM 3)", 3);
     f.checkScalarExact("position(x'' in x'aabbcc' FROM 10)", 0);
@@ -6222,6 +6222,33 @@ public class SqlOperatorTest {
     f.checkScalar("STRPOS(x'', x'12')", "0", "INTEGER NOT NULL");
     f.checkNull("STRPOS(null, x'')");
     f.checkNull("STRPOS(x'', null)");
+  }
+
+  @Test void testInstrFunction() {
+    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.INSTR);
+
+    final Consumer<SqlOperatorFixture> consumer = f -> {
+
+      f.checkScalar("INSTR('abc', 'a', 1, 1)", "1", "INTEGER NOT NULL");
+      f.checkScalar("INSTR('abcabc', 'bc', 1, 2)", "5", "INTEGER NOT NULL");
+      f.checkScalar("INSTR('abcabc', 'd', 1, 1)", "0", "INTEGER NOT NULL");
+      f.checkScalar("INSTR('dabcabcd', 'd', 4, 1)", "8", "INTEGER NOT NULL");
+      f.checkScalar("INSTR('abc', '', 1, 1)", "1", "INTEGER NOT NULL");
+      f.checkScalar("INSTR('', 'a', 1, 1)", "0", "INTEGER NOT NULL");
+      f.checkNull("INSTR(null, 'a', 1, 1)");
+      f.checkNull("INSTR('a', null, 1, 1)");
+
+      // test for BINARY
+      f.checkScalar("INSTR(x'2212', x'12', -1, 1)", "2", "INTEGER NOT NULL");
+      f.checkScalar("INSTR(x'2122', x'12', 1, 1)", "0", "INTEGER NOT NULL");
+      f.checkScalar("INSTR(x'122212', x'12', -1, 2)", "1", "INTEGER NOT NULL");
+      f.checkScalar("INSTR(x'1111', x'22', 1, 1)", "0", "INTEGER NOT NULL");
+      f.checkScalar("INSTR(x'2122', x'', 1, 1)", "1", "INTEGER NOT NULL");
+      f.checkScalar("INSTR(x'', x'12', 1, 1)", "0", "INTEGER NOT NULL");
+      f.checkNull("INSTR(null, x'', 1, 1)");
+      f.checkNull("INSTR(x'', null, 1, 1)");
+    };
+    f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE), consumer);
   }
 
   @Test void testStartsWithFunction() {


### PR DESCRIPTION
[BiqQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#instr) and [Oracle](https://docs.oracle.com/cd/B13789_01/server.101/b10759/functions058.htm) both support functionally identical INSTR(source_value, search_value[, position[, occurrence]]) functions which accepts 2 (character strings or binary strings), 1 optional int representing position, and 1 optional int representing occurrence.

Occurrence and position are assigned a default value of 1 if not specified.

The function returns the 1-based position of the nth occurrence of the 2nd operand in the 1st operand where n is defined by the 4th operand. The function begins searching at the 1-based position specified in the 3rd operand.

The function also supports negative position values, with -1 indicating the last character, and will search backwards from the position specified in that case. 

Returns 0 if:

No match is found.
If occurrence is greater than the number of matches found.
If position is greater than the length of source_value.
Returns NULL if:

Any input argument is NULL.
Returns an error if:

position is 0.
occurrence is 0 or negative.
EXAMPLE: INSTR("abc", "bc") would return 2.

EXAMPLE: INSTR("abcabc", "bc", 3) would return 5.

EXAMPLE: INSTR("abcabc", "bc", -1, 1) would return 5.

EXAMPLE: INSTR("abcabc", "bc", -1, 2) would return 2.

 

MySQL also has an  [INSTR](https://www.w3schools.com/sql/func_mysql_instr.asp) function, the functionality of which is a subset of the INSTR present in BQ and Oracle. MySQL INSTR only takes 2 parameters and returns the first occurrence of the search value in the source value.

[Jira Case](https://issues.apache.org/jira/browse/CALCITE-3959)