### PR TITLE
[Do not merge] Testing that gson LinkedTreeMaps instanceof Map evaluates to true

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ plugins {
 
 repositories {
     // At least for RAT
+    google()
     mavenCentral()
 }
 
@@ -329,6 +330,7 @@ allprojects {
 
     repositories {
         // RAT and Autostyle dependencies
+        google()
         mavenCentral()
     }
 
@@ -512,6 +514,7 @@ allprojects {
             if (enableMavenLocal) {
                 mavenLocal()
             }
+            google()
             mavenCentral()
         }
         val sourceSets: SourceSetContainer by project

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations")
     api("com.google.errorprone:error_prone_annotations")
     api("com.google.guava:guava")
+    implementation("com.google.code.gson:gson:2.10.1")
     api("org.apache.calcite.avatica:avatica-core")
     api("org.apiguardian:apiguardian-api")
     api("org.checkerframework:checker-qual")

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -82,6 +82,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Matcher;
@@ -103,6 +105,7 @@ import java.util.stream.Stream;
 
 import static org.apache.calcite.test.Matchers.isLinux;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -829,6 +832,25 @@ class RelWriterTest {
         + "  LogicalTableScan(table=[[scott, EMP]])\n";
     relFn(relFn)
         .assertThatPlan(isLinux(expected));
+  }
+
+  @Test void testGsonMapsAreInstanceOfJavaMap() {
+    GsonBuilder builder = new GsonBuilder();
+    Gson gson = builder.create();
+    final FrameworkConfig config = RelBuilderTest.config().build();
+    final RelBuilder b = RelBuilder.create(config);
+    final RexBuilder rexBuilder = b.getRexBuilder();
+
+    RexNode between =
+        rexBuilder.makeBetween(b.literal(45),
+            b.literal(20),
+            b.literal(30));
+
+    String gsonRepresentation = gson.toJson(between);
+    Object gsonObject = gson.fromJson(gsonRepresentation, Object.class);
+
+    // gsonObject is a class com.google.gson.internal.LinkedTreeMap
+    assertThat(gsonObject, instanceOf(Map.class));
   }
 
   @Test void testSearchOperator() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,7 @@ com.github.johnrengelman.shadow.version=5.1.0
 com.github.spotbugs.version=2.0.0
 com.github.vlsi.vlsi-release-plugins.version=1.84
 com.google.protobuf.version=0.8.10
+com.google.code.gson.version=2.10.1
 de.thetaphi.forbiddenapis.version=3.4
 jacoco.version=0.8.8
 kotlin.version=1.7.10


### PR DESCRIPTION
In that past when serializing/deserializing the `SEARCH` operator, I was encountering an issue where gsons's `LinkedHashMap` and `LinkedTreeMap` wasn't being evaluated as `instanceof Map`

I wanted to test internally within Calcite what happens when gson maps call `instanceof Map`, and it seems like it does evaluate to `true`.

The behavior I was seeing before must have been caused by something else. 

This PR is just to leave a record that this behavior has been tested, but since it adds a dependency, I wouldn't want it to be merged. 