### PR TITLE
[CALCITE-5688] Support TRUNCATE TABLE DDL statement in Babel parser

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -447,6 +447,11 @@ class BabelParserTest extends SqlParserTest {
     assertThat(hoisted.substitute(SqlParserTest::varToStr), is(expected2));
   }
 
+  @Test void testTruncateTable() {
+    sql("truncate table x")
+        .ok("TRUNCATE TABLE `X`");
+  }
+
   /**
    * Babel parser's global {@code LOOKAHEAD} is larger than the core
    * parser's. This causes different parse error message between these two

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -100,6 +100,7 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
+import org.apache.calcite.sql.ddl.SqlTruncateTable;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlInternalOperators;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
@@ -1136,6 +1137,8 @@ SqlNode SqlStmt() :
         stmt = SqlDrop()
     |
 </#if>
+        stmt = SqlTruncateTable()
+    |
         stmt = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
     |
         stmt = SqlExplain()
@@ -4281,6 +4284,20 @@ SqlDrop SqlDrop() :
     }
 }
 </#if>
+
+/**
+ * Parses a TRUNCATE TABLE statement.
+ */
+SqlTruncateTable SqlTruncateTable() :
+{
+    final SqlIdentifier id;
+}
+{
+    <TRUNCATE> <TABLE> id = CompoundIdentifier()
+    {
+        return new SqlTruncateTable(getPos(), id);
+    }
+}
 
 /**
  * Parses a literal expression, allowing continued string literals.

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1060,6 +1060,9 @@ public enum SqlKind {
   /** {@code DROP TABLE} DDL statement. */
   DROP_TABLE,
 
+  /** {@code TRUNCATE TABLE} DDL statement. */
+  TRUNCATE_TABLE,
+
   /** {@code CREATE VIEW} DDL statement. */
   CREATE_VIEW,
 
@@ -1171,7 +1174,7 @@ public enum SqlKind {
   public static final EnumSet<SqlKind> DDL =
       EnumSet.of(COMMIT, ROLLBACK, ALTER_SESSION,
           CREATE_SCHEMA, CREATE_FOREIGN_SCHEMA, DROP_SCHEMA,
-          CREATE_TABLE, ALTER_TABLE, DROP_TABLE,
+          CREATE_TABLE, ALTER_TABLE, DROP_TABLE, TRUNCATE_TABLE,
           CREATE_FUNCTION, DROP_FUNCTION,
           CREATE_VIEW, ALTER_VIEW, DROP_VIEW,
           CREATE_MATERIALIZED_VIEW, ALTER_MATERIALIZED_VIEW,

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlDdlNodes.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlDdlNodes.java
@@ -101,6 +101,12 @@ public class SqlDdlNodes {
     return new SqlDropTable(pos, ifExists, name);
   }
 
+  /** Creates a TRUNCATE TABLE. */
+  public static SqlTruncateTable truncateTable(SqlParserPos pos,
+      SqlIdentifier name) {
+    return new SqlTruncateTable(pos, name);
+  }
+
   /** Creates a DROP VIEW. */
   public static SqlDrop dropView(SqlParserPos pos, boolean ifExists,
       SqlIdentifier name) {

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlTruncateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlTruncateTable.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql.ddl;
+
+import org.apache.calcite.sql.SqlDdl;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class SqlTruncateTable extends SqlDdl {
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("TRUNCATE TABLE", SqlKind.TRUNCATE_TABLE);
+  public final SqlIdentifier name;
+
+  /**
+   * Creates a SqlTruncateTable.
+   */
+  public SqlTruncateTable(SqlParserPos pos, SqlIdentifier name) {
+    super(OPERATOR, pos);
+    this.name = name;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return ImmutableList.of(name);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("TRUNCATE");
+    writer.keyword("TABLE");
+    name.unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlTruncateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlTruncateTable.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.calcite.sql.ddl;
 
 import org.apache.calcite.sql.SqlDdl;
@@ -30,6 +29,9 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
+/**
+ * Parse tree for {@code TRUNCATE TABLE} statement.
+ */
 public class SqlTruncateTable extends SqlDdl {
 
   private static final SqlOperator OPERATOR =
@@ -44,13 +46,11 @@ public class SqlTruncateTable extends SqlDdl {
     this.name = name;
   }
 
-  @Override
-  public List<SqlNode> getOperandList() {
+  @Override public List<SqlNode> getOperandList() {
     return ImmutableList.of(name);
   }
 
-  @Override
-  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.keyword("TRUNCATE");
     writer.keyword("TABLE");
     name.unparse(writer, leftPrec, rightPrec);

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -180,6 +180,9 @@ delete:
       DELETE FROM tablePrimary [ [ AS ] alias ]
       [ WHERE booleanExpression ]
 
+truncate:
+      TRUNCATE TABLE tablePrimary
+
 query:
       values
   |   WITH withItem [ , withItem ]* query


### PR DESCRIPTION
The PR adds support for TRUNCATE TABLE statement to the babel parser.