### PR TITLE
[CALCITE-5683] Two level nested correlated subquery throws an excepti…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -866,6 +866,8 @@ public class SubQueryRemoveRule
           LogicVisitor.find(RelOptUtil.Logic.TRUE, ImmutableList.of(c), e);
       final Set<CorrelationId>  variablesSet =
           RelOptUtil.getVariablesUsed(e.rel);
+      /* Only consider the correlated variables which originated from this sub-query level*/
+      variablesSet.retainAll(filter.getVariablesSet());
       final RexNode target =
           rule.apply(e, variablesSet, logic,
               builder, 1, builder.peek().getRowType().getFieldCount(), count);

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -866,10 +866,9 @@ public class SubQueryRemoveRule
           LogicVisitor.find(RelOptUtil.Logic.TRUE, ImmutableList.of(c), e);
       final Set<CorrelationId>  variablesSet =
           RelOptUtil.getVariablesUsed(e.rel);
-      // Only consider the correlated variables which originated from this sub-query level.
+      // Only retain when filter has non-empty correlated variables set to avoid removing
+      // all the correlated variables from parent scope.
       if (!filter.getVariablesSet().isEmpty()) {
-        // Only retain when filter has non-empty correlated variables set to avoid removing
-        // all the correlated variables from parent scope.
         variablesSet.retainAll(filter.getVariablesSet());
       }
       final RexNode target =

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -866,7 +866,7 @@ public class SubQueryRemoveRule
           LogicVisitor.find(RelOptUtil.Logic.TRUE, ImmutableList.of(c), e);
       final Set<CorrelationId>  variablesSet =
           RelOptUtil.getVariablesUsed(e.rel);
-      /* Only consider the correlated variables which originated from this sub-query level*/
+      // Only consider the correlated variables which originated from this sub-query level
       variablesSet.retainAll(filter.getVariablesSet());
       final RexNode target =
           rule.apply(e, variablesSet, logic,

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -866,8 +866,10 @@ public class SubQueryRemoveRule
           LogicVisitor.find(RelOptUtil.Logic.TRUE, ImmutableList.of(c), e);
       final Set<CorrelationId>  variablesSet =
           RelOptUtil.getVariablesUsed(e.rel);
-      // Only consider the correlated variables which originated from this sub-query level
+      // Only consider the correlated variables which originated from this sub-query level.
       if (!filter.getVariablesSet().isEmpty()) {
+        // Only retain when filter has non-empty correlated variables set to avoid removing
+        // all the correlated variables from parent scope.
         variablesSet.retainAll(filter.getVariablesSet());
       }
       final RexNode target =

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -866,11 +866,8 @@ public class SubQueryRemoveRule
           LogicVisitor.find(RelOptUtil.Logic.TRUE, ImmutableList.of(c), e);
       final Set<CorrelationId>  variablesSet =
           RelOptUtil.getVariablesUsed(e.rel);
-      // Only retain when filter has non-empty correlated variables set to avoid removing
-      // all the correlated variables from parent scope.
-      if (!filter.getVariablesSet().isEmpty()) {
-        variablesSet.retainAll(filter.getVariablesSet());
-      }
+      // Only consider the correlated variables which originated from this sub-query level.
+      variablesSet.retainAll(filter.getVariablesSet());
       final RexNode target =
           rule.apply(e, variablesSet, logic,
               builder, 1, builder.peek().getRowType().getFieldCount(), count);

--- a/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SubQueryRemoveRule.java
@@ -867,7 +867,9 @@ public class SubQueryRemoveRule
       final Set<CorrelationId>  variablesSet =
           RelOptUtil.getVariablesUsed(e.rel);
       // Only consider the correlated variables which originated from this sub-query level
-      variablesSet.retainAll(filter.getVariablesSet());
+      if (!filter.getVariablesSet().isEmpty()) {
+        variablesSet.retainAll(filter.getVariablesSet());
+      }
       final RexNode target =
           rule.apply(e, variablesSet, logic,
               builder, 1, builder.peek().getRowType().getFieldCount(), count);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3549,7 +3549,17 @@ public class SqlToRelConverter {
     // implement HAVING (we have already checked that it is non-trivial)
     relBuilder.push(bb.root());
     if (havingExpr != null) {
-      relBuilder.filter(havingExpr);
+      /* Set the correlation variables used in this sub-query to the filter node,
+       * same logic is being used for the filter generated in where clause.
+       */
+      Set<CorrelationId> variableSet = new HashSet<>();
+      if (havingExpr instanceof RexSubQuery) {
+        CorrelationUse p = getCorrelationUse(bb, ((RexSubQuery) havingExpr).rel);
+        if (p != null) {
+          variableSet.add(p.id);
+        }
+      }
+      relBuilder.filter(variableSet, havingExpr);
     }
 
     // implement the SELECT list

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3549,9 +3549,8 @@ public class SqlToRelConverter {
     // implement HAVING (we have already checked that it is non-trivial)
     relBuilder.push(bb.root());
     if (havingExpr != null) {
-      /* Set the correlation variables used in this sub-query to the filter node,
-       * same logic is being used for the filter generated in where clause.
-       */
+      // Set the correlation variables used in this sub-query to the filter node,
+      // same logic is being used for the filter generated in where clause.
       Set<CorrelationId> variableSet = new HashSet<>();
       if (havingExpr instanceof RexSubQuery) {
         CorrelationUse p = getCorrelationUse(bb, ((RexSubQuery) havingExpr).rel);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3552,8 +3552,9 @@ public class SqlToRelConverter {
       // Set the correlation variables used in this sub-query to the filter node,
       // same logic is being used for the filter generated in where clause.
       Set<CorrelationId> variableSet = new HashSet<>();
-      if (havingExpr instanceof RexSubQuery) {
-        CorrelationUse p = getCorrelationUse(bb, ((RexSubQuery) havingExpr).rel);
+      RexSubQuery subQ = RexUtil.SubQueryFinder.find(havingExpr);
+      if (subQ != null) {
+        CorrelationUse p = getCorrelationUse(bb, subQ.rel);
         if (p != null) {
           variableSet.add(p.id);
         }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1933,8 +1933,8 @@ class RelOptRulesTest extends RelOptTestBase {
 
   @Test void testProjectCorrelateTransposeRuleLeftCorrelate() {
     final String sql = "SELECT e1.empno\n"
-        + "FROM emp e1 inner join dept d1 on e1.deptno = d1.deptno  "
-        + " and e1.deptno =  (select max(d2.deptno) from dept d2 where e1.deptno = d2.deptno)";
+        + "FROM emp e1 "
+        + "where exists (select empno, deptno from dept d2 where e1.deptno = d2.deptno)";
     sql(sql)
         .withDecorrelate(false)
         .withExpand(true)

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -6859,12 +6859,10 @@ class RelOptRulesTest extends RelOptTestBase {
         + "                         d1.deptno < e2.deptno))"
         + " FROM dept d1";
     sql(sql)
-        .withExpand(false)
-        .withLateDecorrelate(true)
         .withSubQueryRules()
+        .withLateDecorrelate(true)
         .withTrim(true)
-        .withRule()
-        .checkUnchanged();
+        .check();
   }
 
   /** Test case for

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -6839,6 +6839,7 @@ class RelOptRulesTest extends RelOptTestBase {
 
     sql(sql)
         .withExpand(false)
+        .withLateDecorrelate(true)
         .withSubQueryRules()
         .withTrim(true)
         .withRule()
@@ -6859,6 +6860,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + " FROM dept d1";
     sql(sql)
         .withExpand(false)
+        .withLateDecorrelate(true)
         .withSubQueryRules()
         .withTrim(true)
         .withRule()

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -6839,7 +6839,7 @@ class RelOptRulesTest extends RelOptTestBase {
 
     sql(sql)
         .withExpand(false)
-        .withLateDecorrelate(true)
+        .withSubQueryRules()
         .withTrim(true)
         .withRule()
         .checkUnchanged();
@@ -6859,7 +6859,7 @@ class RelOptRulesTest extends RelOptTestBase {
         + " FROM dept d1";
     sql(sql)
         .withExpand(false)
-        .withLateDecorrelate(true)
+        .withSubQueryRules()
         .withTrim(true)
         .withRule()
         .checkUnchanged();

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -133,7 +133,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -6838,20 +6837,12 @@ class RelOptRulesTest extends RelOptTestBase {
         + "                         d1.deptno < e2.deptno))"
         + " FROM dept d1";
 
-    final RelOptFixture fixture = sql(sql).withExpand(false);
-    final RelNode rel = fixture.toRel();
-    final RelOptPlanner planner = rel.getCluster().getPlanner();
-
-    final RelTraitSet desiredTraits = RelTraitSet.createEmpty();
-
-    final Program program = Programs.standard();
-    RelNode relNode =
-        program.run(planner, rel, desiredTraits,
-            new ArrayList<>(),
-            new ArrayList<>());
-
-    diffRepos.assertEquals("planAfter", "${planAfter}",
-        NL + RelOptUtil.toString(relNode));
+    sql(sql)
+        .withExpand(false)
+        .withLateDecorrelate(true)
+        .withTrim(true)
+        .withRule()
+        .checkUnchanged();
   }
 
   /** Test case for CALCITE-5683 for two level nested decorrelate with standard program
@@ -6866,21 +6857,12 @@ class RelOptRulesTest extends RelOptTestBase {
         + "                         e1.deptno = e2.deptno and"
         + "                         d1.deptno < e2.deptno))"
         + " FROM dept d1";
-
-    final RelOptFixture fixture = sql(sql).withExpand(false);
-    final RelNode rel = fixture.toRel();
-    final RelOptPlanner planner = rel.getCluster().getPlanner();
-
-    final RelTraitSet desiredTraits = RelTraitSet.createEmpty();
-
-    final Program program = Programs.standard();
-    RelNode relNode =
-        program.run(planner, rel, desiredTraits,
-            new ArrayList<>(),
-            new ArrayList<>());
-
-    diffRepos.assertEquals("planAfter", "${planAfter}",
-        NL + RelOptUtil.toString(relNode));
+    sql(sql)
+        .withExpand(false)
+        .withLateDecorrelate(true)
+        .withTrim(true)
+        .withRule()
+        .checkUnchanged();
   }
 
   /** Test case for

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -14686,6 +14686,63 @@ LogicalProject(DEPTNO=[$0], DEPTNO0=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTwoLevelDecorrelate">
+    <Resource name="sql">
+      <![CDATA[SELECT d1.name, d1.deptno +  ( SELECT e1.empno  FROM emp e1  WHERE d1.deptno = e1.deptno and        e1.sal = (SELECT max(sal)                  FROM emp e2                  WHERE   e1.sal = e2.sal and                         e1.deptno = e2.deptno and                         d1.deptno < e2.deptno)) FROM dept d1]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalCalc(expr#0..3=[{inputs}], expr#4=[+($t0, $t3)], NAME=[$t1], EXPR$1=[$t4])
+  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
+      LogicalCalc(expr#0..6=[{inputs}], expr#7=[=($t3, $t2)], expr#8=[=($t1, $t6)], expr#9=[AND($t7, $t8)], DEPTNO0=[$t3], EMPNO=[$t0], $condition=[$t9])
+        LogicalJoin(condition=[AND(=($1, $4), =($2, $5))], joinType=[left])
+          LogicalCalc(expr#0..8=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+          LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
+            LogicalCalc(expr#0..4=[{inputs}], DEPTNO0=[$t2], SAL0=[$t3], DEPTNO00=[$t4], SAL=[$t0])
+              LogicalJoin(condition=[AND(=($3, $0), =($4, $1), <($2, $1))], joinType=[inner])
+                LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
+                  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                LogicalJoin(condition=[true], joinType=[inner])
+                  LogicalCalc(expr#0..1=[{inputs}], DEPTNO=[$t0])
+                    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+                  LogicalAggregate(group=[{0, 1}])
+                    LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
+                      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTwoLevelDecorrelateSkipInBetween">
+    <Resource name="sql">
+      <![CDATA[SELECT d1.name, d1.deptno +  ( SELECT e1.empno  FROM emp e1  WHERE e1.sal = (SELECT max(sal)                  FROM emp e2                  WHERE   e1.sal = e2.sal and                         e1.deptno = e2.deptno and                         d1.deptno < e2.deptno)) FROM dept d1]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalCalc(expr#0..3=[{inputs}], expr#4=[+($t0, $t3)], NAME=[$t1], EXPR$1=[$t4])
+  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
+      LogicalCalc(expr#0..6=[{inputs}], expr#7=[CAST($t5):INTEGER], DEPTNO00=[$t7], EMPNO=[$t0])
+        LogicalJoin(condition=[AND(=($1, $3), =($2, $4))], joinType=[inner])
+          LogicalCalc(expr#0..8=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+          LogicalCalc(expr#0..3=[{inputs}], expr#4=[=($t0, $t3)], proj#0..3=[{exprs}], $condition=[$t4])
+            LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
+              LogicalCalc(expr#0..4=[{inputs}], SAL0=[$t2], DEPTNO0=[$t3], DEPTNO00=[$t4], SAL=[$t0])
+                LogicalJoin(condition=[AND(=($2, $0), =($3, $1), <($4, $1))], joinType=[inner])
+                  LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                  LogicalJoin(condition=[true], joinType=[inner])
+                    LogicalAggregate(group=[{0, 1}])
+                      LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
+                        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                    LogicalCalc(expr#0..1=[{inputs}], DEPTNO=[$t0])
+                      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUncorrelatedCallBelowNonComparisonOpIsNotFlattened">
     <Resource name="sql">
       <![CDATA[select * from emp e1 where exists (select * from emp e2 where (e1.deptno + (e2.deptno+30)) > 0)]]>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6943,7 +6943,7 @@ LogicalProject(EMPNO=[$0])
     </Resource>
     <Resource name="sql">
       <![CDATA[SELECT e1.empno
-FROM emp e1 inner join dept d1 on e1.deptno = d1.deptno   and e1.deptno =  (select max(d2.deptno) from dept d2 where e1.deptno = d2.deptno)]]>
+FROM emp e1 where exists (select empno, deptno from dept d2 where e1.deptno = d2.deptno)]]>
     </Resource>
   </TestCase>
   <TestCase name="testProjectCorrelateTransposeRuleSemiCorrelate">

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6883,7 +6883,7 @@ LogicalProject(EMPNO=[$0])
     </Resource>
     <Resource name="sql">
       <![CDATA[SELECT e1.empno
-FROM emp e1 where exists (select empno, deptno from dept d2 where e1.deptno = d2.deptno)]]>
+FROM emp e1 inner join dept d1 on e1.deptno = d1.deptno   and e1.deptno =  (select max(d2.deptno) from dept d2 where e1.deptno = d2.deptno)]]>
     </Resource>
   </TestCase>
   <TestCase name="testProjectCorrelateTransposeRuleSemiCorrelate">

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -14690,6 +14690,36 @@ LogicalProject(DEPTNO=[$0], DEPTNO0=[$1])
     <Resource name="sql">
       <![CDATA[SELECT d1.name, d1.deptno +  ( SELECT e1.empno  FROM emp e1  WHERE d1.deptno = e1.deptno and        e1.sal = (SELECT max(sal)                  FROM emp e2                  WHERE   e1.sal = e2.sal and                         e1.deptno = e2.deptno and                         d1.deptno < e2.deptno)) FROM dept d1]]>
     </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})))], variablesSet=[[$cor1]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})))], variablesSet=[[$cor1]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
     <Resource name="planAfter">
       <![CDATA[
 LogicalCalc(expr#0..3=[{inputs}], expr#4=[+($t0, $t3)], NAME=[$t1], EXPR$1=[$t4])
@@ -14717,6 +14747,36 @@ LogicalCalc(expr#0..3=[{inputs}], expr#4=[+($t0, $t3)], NAME=[$t1], EXPR$1=[$t4]
   <TestCase name="testTwoLevelDecorrelateSkipInBetween">
     <Resource name="sql">
       <![CDATA[SELECT d1.name, d1.deptno +  ( SELECT e1.empno  FROM emp e1  WHERE e1.sal = (SELECT max(sal)                  FROM emp e2                  WHERE   e1.sal = e2.sal and                         e1.deptno = e2.deptno and                         d1.deptno < e2.deptno)) FROM dept d1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[=($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))], variablesSet=[[$cor0]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[=($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))], variablesSet=[[$cor0]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1656,6 +1656,66 @@ MultiJoin(joinFilter=[true], isFullOuterJoin=[false], joinTypes=[[RIGHT, INNER]]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelatedVariableAtSecondLevel">
+    <Resource name="sql">
+      <![CDATA[SELECT d1.name, d1.deptno +  ( SELECT e1.empno  FROM emp e1  WHERE e1.sal = (SELECT max(sal)                  FROM emp e2                  WHERE   e1.sal = e2.sal and                         e1.deptno = e2.deptno and                         d1.deptno < e2.deptno)) FROM dept d1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[=($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))], variablesSet=[[$cor0]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $2)])
+  LogicalCorrelate(correlation=[$cor2], joinType=[left], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+      LogicalProject(EMPNO=[$0])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+          LogicalFilter(condition=[=($5, $9)])
+            LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{5, 7}])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+              LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+                LogicalProject(SAL=[$5])
+                  LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $3)])
+  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
+      LogicalProject(DEPTNO00=[$11], EMPNO=[$0])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], SAL0=[CAST($9):INTEGER], DEPTNO0=[CAST($10):INTEGER], DEPTNO00=[CAST($11):INTEGER], EXPR$0=[CAST($12):INTEGER])
+          LogicalJoin(condition=[AND(=($5, $9), =($7, $10))], joinType=[inner])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+            LogicalFilter(condition=[=($0, $3)])
+              LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
+                LogicalProject(SAL0=[$9], DEPTNO0=[$10], DEPTNO00=[$11], SAL=[$5])
+                  LogicalJoin(condition=[AND(=($9, $5), =($10, $7), <($11, $7))], joinType=[inner])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                    LogicalJoin(condition=[true], joinType=[inner])
+                      LogicalAggregate(group=[{0, 1}])
+                        LogicalProject(SAL=[$5], DEPTNO=[$7])
+                          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                      LogicalProject(DEPTNO=[$0])
+                        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCorrelationScalarAggAndFilter">
     <Resource name="sql">
       <![CDATA[SELECT e1.empno
@@ -14707,52 +14767,42 @@ LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
     </Resource>
     <Resource name="planMid">
       <![CDATA[
-LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
-LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
-  LogicalProject(SAL=[$5])
-    LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})))], variablesSet=[[$cor1]])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}))])
-  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $2)])
+  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+      LogicalProject(EMPNO=[$0])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+          LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $9))])
+            LogicalCorrelate(correlation=[$cor1], joinType=[left], requiredColumns=[{5, 7}])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+              LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+                LogicalProject(SAL=[$5])
+                  LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
-  </TestCase>
-  <TestCase name="testTwoLevelDecorrelateSkipInBetween">
-    <Resource name="sql">
-      <![CDATA[SELECT d1.name, d1.deptno +  ( SELECT e1.empno  FROM emp e1  WHERE e1.sal = (SELECT max(sal)                  FROM emp e2                  WHERE   e1.sal = e2.sal and                         e1.deptno = e2.deptno and                         d1.deptno < e2.deptno)) FROM dept d1]]>
-    </Resource>
-    <Resource name="planBefore">
+    <Resource name="planAfter">
       <![CDATA[
-LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
-LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[=($5, $SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
-  LogicalProject(SAL=[$5])
-    LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}))], variablesSet=[[$cor0]])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}))])
-  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-]]>
-    </Resource>
-    <Resource name="planMid">
-      <![CDATA[
-LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
-LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[=($5, $SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
-  LogicalProject(SAL=[$5])
-    LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}))], variablesSet=[[$cor0]])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}))])
-  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $3)])
+  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
+      LogicalProject(DEPTNO0=[$10], EMPNO=[$0])
+        LogicalFilter(condition=[AND(=($10, $7), =($5, $9))])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EXPR$0=[$12], DEPTNO0=[$9])
+            LogicalJoin(condition=[AND(=($5, $10), =($7, $11))], joinType=[left])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+              LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
+                LogicalProject(DEPTNO0=[$9], SAL0=[$10], DEPTNO00=[$11], SAL=[$5])
+                  LogicalJoin(condition=[AND(=($10, $5), =($11, $7), <($9, $7))], joinType=[inner])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                    LogicalJoin(condition=[true], joinType=[inner])
+                      LogicalProject(DEPTNO=[$0])
+                        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+                      LogicalAggregate(group=[{0, 1}])
+                        LogicalProject(SAL=[$5], DEPTNO=[$7])
+                          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -14720,21 +14720,6 @@ LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
   LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
-LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
-  LogicalProject(SAL=[$5])
-    LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})))], variablesSet=[[$cor1]])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-}))])
-  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-]]>
-    </Resource>
   </TestCase>
   <TestCase name="testTwoLevelDecorrelateSkipInBetween">
     <Resource name="sql">
@@ -14768,30 +14753,6 @@ LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 }))])
   LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalCalc(expr#0..3=[{inputs}], expr#4=[+($t0, $t3)], NAME=[$t1], EXPR$1=[$t4])
-  LogicalJoin(condition=[=($0, $2)], joinType=[left])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
-      LogicalCalc(expr#0..6=[{inputs}], expr#7=[CAST($t5):INTEGER], DEPTNO00=[$t7], EMPNO=[$t0])
-        LogicalJoin(condition=[AND(=($1, $3), =($2, $4))], joinType=[inner])
-          LogicalCalc(expr#0..8=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalCalc(expr#0..3=[{inputs}], expr#4=[=($t0, $t3)], proj#0..3=[{exprs}], $condition=[$t4])
-            LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
-              LogicalCalc(expr#0..4=[{inputs}], SAL0=[$t2], DEPTNO0=[$t3], DEPTNO00=[$t4], SAL=[$t0])
-                LogicalJoin(condition=[AND(=($2, $0), =($3, $1), <($4, $1))], joinType=[inner])
-                  LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
-                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-                  LogicalJoin(condition=[true], joinType=[inner])
-                    LogicalAggregate(group=[{0, 1}])
-                      LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
-                        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-                    LogicalCalc(expr#0..1=[{inputs}], DEPTNO=[$t0])
-                      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -14722,25 +14722,17 @@ LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalCalc(expr#0..3=[{inputs}], expr#4=[+($t0, $t3)], NAME=[$t1], EXPR$1=[$t4])
-  LogicalJoin(condition=[=($0, $2)], joinType=[left])
-    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
-      LogicalCalc(expr#0..6=[{inputs}], expr#7=[=($t3, $t2)], expr#8=[=($t1, $t6)], expr#9=[AND($t7, $t8)], DEPTNO0=[$t3], EMPNO=[$t0], $condition=[$t9])
-        LogicalJoin(condition=[AND(=($1, $4), =($2, $5))], joinType=[left])
-          LogicalCalc(expr#0..8=[{inputs}], EMPNO=[$t0], SAL=[$t5], DEPTNO=[$t7])
-            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-          LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
-            LogicalCalc(expr#0..4=[{inputs}], DEPTNO0=[$t2], SAL0=[$t3], DEPTNO00=[$t4], SAL=[$t0])
-              LogicalJoin(condition=[AND(=($3, $0), =($4, $1), <($2, $1))], joinType=[inner])
-                LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
-                  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-                LogicalJoin(condition=[true], joinType=[inner])
-                  LogicalCalc(expr#0..1=[{inputs}], DEPTNO=[$t0])
-                    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
-                  LogicalAggregate(group=[{0, 1}])
-                    LogicalCalc(expr#0..8=[{inputs}], SAL=[$t5], DEPTNO=[$t7])
-                      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})))], variablesSet=[[$cor1]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -777,6 +777,25 @@ having exists
 
 !ok
 
+# Having with correlation anded with normal condition.
+with src (key, "value")
+  as (select * from (values (1, 'a'), (2, 'z')) as t(key, "value"))
+select b.key, count(*) as c
+from src b
+group by b.key
+having exists
+  (select a.key
+  from src a
+  where a.key = b.key and a."value" > 'val_9') and b.key > 0;
++-----+---+
+| KEY | C |
++-----+---+
+|   2 | 1 |
++-----+---+
+(1 row)
+
+!ok
+
 # [CALCITE-411] Duplicate aliases
 select 1 as a, 2 as a from (values (true));
 +---+---+

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -3574,15 +3574,12 @@ or 20 in (
 !ok
 
 # Test case for CALCITE-5683 which throws an exception during the de-correlation phase
-SELECT d1.dname, d1.deptno +
-        (   SELECT max(e1.empno) FROM emp e1
-            WHERE   d1.deptno = e1.deptno and
-                    e1.sal = (  SELECT max(sal)
-                                FROM emp e2
-                                WHERE   e1.sal = e2.sal and
-                                        e1.deptno = e2.deptno and
-                                        d1.deptno <= e2.deptno))
-        FROM dept d1;
+SELECT d1.dname, d1.deptno + ( SELECT max(e1.empno)
+    FROM emp e1
+    WHERE   d1.deptno = e1.deptno and e1.sal = (  SELECT max(sal)
+        FROM emp e2
+        WHERE   e1.sal = e2.sal and e1.deptno = e2.deptno and d1.deptno <= e2.deptno))
+FROM dept d1;
 +------------+--------+
 | DNAME      | EXPR$1 |
 +------------+--------+
@@ -3596,15 +3593,12 @@ SELECT d1.dname, d1.deptno +
 !ok
 
 # Test case for CALCITE-5683 which throws an exception during the de-correlation phase
-SELECT d1.dname, d1.deptno +
-        (   SELECT max(e1.empno) FROM emp e1
-            WHERE   d1.deptno = e1.deptno and
-                    e1.sal = (  SELECT max(sal)
-                                FROM emp e2
-                                WHERE   e1.sal = e2.sal and
-                                        e1.deptno = e2.deptno and
-                                        d1.deptno < e2.deptno))
-        FROM dept d1;
+SELECT d1.dname, d1.deptno + (   SELECT max(e1.empno)
+    FROM emp e1
+    WHERE   d1.deptno = e1.deptno and e1.sal = (  SELECT max(sal)
+        FROM emp e2
+        WHERE   e1.sal = e2.sal and e1.deptno = e2.deptno and d1.deptno < e2.deptno))
+FROM dept d1;
 +------------+--------+
 | DNAME      | EXPR$1 |
 +------------+--------+

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -3611,4 +3611,22 @@ FROM dept d1;
 
 !ok
 
+SELECT dept.deptno, (SELECT Max(emp.empno)
+    FROM   emp
+    WHERE  empno = (SELECT Max(empno) AS maxDept
+        FROM   emp e2
+        WHERE  e2.deptno = dept.deptno) AND emp.deptno = dept.deptno), dept.dname
+FROM   dept;
++--------+--------+------------+
+| DEPTNO | EXPR$1 | DNAME      |
++--------+--------+------------+
+|     10 |   7934 | ACCOUNTING |
+|     20 |   7902 | RESEARCH   |
+|     30 |   7900 | SALES      |
+|     40 |        | OPERATIONS |
++--------+--------+------------+
+(4 rows)
+
+!ok
+
 # End sub-query.iq

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -3573,4 +3573,48 @@ or 20 in (
 
 !ok
 
+# Test case for CALCITE-5683 which throws an exception during the de-correlation phase
+SELECT d1.dname, d1.deptno +
+        (   SELECT max(e1.empno) FROM emp e1
+            WHERE   d1.deptno = e1.deptno and
+                    e1.sal = (  SELECT max(sal)
+                                FROM emp e2
+                                WHERE   e1.sal = e2.sal and
+                                        e1.deptno = e2.deptno and
+                                        d1.deptno <= e2.deptno))
+        FROM dept d1;
++------------+--------+
+| DNAME      | EXPR$1 |
++------------+--------+
+| ACCOUNTING |   7944 |
+| OPERATIONS |        |
+| RESEARCH   |   7922 |
+| SALES      |   7930 |
++------------+--------+
+(4 rows)
+
+!ok
+
+# Test case for CALCITE-5683 which throws an exception during the de-correlation phase
+SELECT d1.dname, d1.deptno +
+        (   SELECT max(e1.empno) FROM emp e1
+            WHERE   d1.deptno = e1.deptno and
+                    e1.sal = (  SELECT max(sal)
+                                FROM emp e2
+                                WHERE   e1.sal = e2.sal and
+                                        e1.deptno = e2.deptno and
+                                        d1.deptno < e2.deptno))
+        FROM dept d1;
++------------+--------+
+| DNAME      | EXPR$1 |
++------------+--------+
+| ACCOUNTING |        |
+| OPERATIONS |        |
+| RESEARCH   |        |
+| SALES      |        |
++------------+--------+
+(4 rows)
+
+!ok
+
 # End sub-query.iq


### PR DESCRIPTION
…on during decorrelation.

Currently two level correlated subqueries with more than one correlated variables are throwing exception, the fix is to track the correlated variables and then only consider those variables from the level which a logicalCorrelate node is created.

Added two test cases and checked for the expected plan in RelOptRulesTest.