### PR TITLE
[CALCITE-5713] Update Operator's operands to ensure consistency with the latest operandList references

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlBasicCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBasicCall.java
@@ -94,6 +94,7 @@ public class SqlBasicCall extends SqlCall {
 
   @Override public void setOperand(int i, @Nullable SqlNode operand) {
     operandList = set(operandList, i, operand);
+    operator.updateOperandsIfNeed(operandList);
   }
 
   /** Sets the operator (or function) that is being called.

--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.calcite.util.Static.RESOURCE;
@@ -461,6 +462,10 @@ public class SqlJdbcFunctionCall extends SqlFunction {
               .createCall(SqlParserPos.ZERO, requireNonNull(thisOperands, "thisOperands"));
     }
     return lookupCall;
+  }
+
+  @Override public void updateOperandsIfNeed(List<@Nullable SqlNode> operandList) {
+    thisOperands = operandList.toArray(SqlNode.EMPTY_ARRAY);
   }
 
   @Override public String getAllowedSignatures(String name) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -1086,4 +1086,10 @@ public abstract class SqlOperator {
   public boolean argumentMustBeScalar(int ordinal) {
     return true;
   }
+
+  /**
+   * When SqlBasicCall modifies operandList with deep copy, it also should be replaced with
+   * the latest operandList to ensure reference consistency.
+   */
+  public void updateOperandsIfNeed(List<@Nullable SqlNode> operandList) {}
 }

--- a/core/src/test/java/org/apache/calcite/sql/SqlBasicCallTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/SqlBasicCallTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.test.SqlTestFactory;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.calcite.test.MockRelOptPlanner;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SqlBasicCall}.
+ */
+public class SqlBasicCallTest {
+
+  @Test void testSqlBasicCallSetOperands() {
+    final String sql = "SELECT { fn TRUNCATE(\n"
+        + "        { fn QUARTER(\n"
+        + "                { fn TIMESTAMPADD(\n"
+        + "                        SQL_TSI_HOUR,\n"
+        + "                        1,\n"
+        + "                        { ts '1900-01-01 00:00:00' }\n"
+        + "                    ) }\n"
+        + "            ) },\n"
+        + "        0\n"
+        + "    ) }\n"
+        + "FROM EMP\n"
+        + "GROUP BY 1.1000000000000001";
+    try {
+      RelOptPlanner planner = new MockRelOptPlanner(Contexts.empty());
+      planner.addRule(CoreRules.PROJECT_REDUCE_EXPRESSIONS);
+      SqlTestFactory sqlTestFactory = SqlTestFactory.INSTANCE
+          .withPlannerFactory(context -> planner);
+      SqlParser parser = sqlTestFactory.createParser(sql);
+      final SqlNode sqlNode = parser.parseQuery();
+      SqlToRelConverter sqlToRelConverter = sqlTestFactory.createSqlToRelConverter();
+      RelRoot relRoot = sqlToRelConverter.convertQuery(sqlNode, true, true);
+      planner.setRoot(relRoot.rel);
+      planner.findBestExp();
+      // TRUNCATE(EXTRACT(FLAG(QUARTER), +(1900-01-01 00:00:00, *(3600000:INTERVAL HOUR, 1))), 0)
+      RexCall rexCall = (RexCall) ((LogicalProject) relRoot.rel).getProjects().get(0);
+      RexCall operand = (RexCall) rexCall.getOperands().get(0);
+      assert operand.getOperator().getName().equals(SqlStdOperatorTable.EXTRACT.getName());
+    } catch (SqlParseException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
The SqlBasicCall#set method uses a deep copy in order to modify immutable collections and returns a new operandList object when modified.

If the SQL contains an operation that requires a rewrite call, the deep copy logic will cause the operator and operandList to be different and eventually raise an exception.