### PR TITLE
[CALCITE-5668] When parsing SQL in PostgreSQL dialect, allow unquoted table names to contain dollar sign, letters with diacritical marks and non-Latin letters

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -578,9 +578,14 @@ data: {
     ]
 
     # Custom identifier token.
-    # Example: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >".
-    customIdentifierToken: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >"
-
+    # 
+    # PostgreSQL allows letters with diacritical marks and non-Latin letters 
+    # in the beginning of identifier and additionally dollar sign in the rest of identifier. 
+    # See https://github.com/postgres/postgres/blob/master/src/backend/parser/scan.l
+    #
+    # MySQL allows digit in the beginning of identifier
+    customIdentifierToken: "< IDENTIFIER: (<LETTER>|<DIGIT>|[\"\\200\"-\"\\377\"]) (<LETTER>|<DIGIT>|<DOLLAR>|[\"\\200\"-\"\\377\"])* >"
+    
     # Binary operators initialization.
     # Example: "InfixCast".
     extraBinaryExpressions: [

--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -577,6 +577,10 @@ data: {
       "< NULL_SAFE_EQUAL: \"<=>\" >"
     ]
 
+    # Custom identifier token.
+    # Example: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >".
+    customIdentifierToken: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >"
+
     # Binary operators initialization.
     # Example: "InfixCast".
     extraBinaryExpressions: [

--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -581,6 +581,9 @@ data: {
     # 
     # PostgreSQL allows letters with diacritical marks and non-Latin letters 
     # in the beginning of identifier and additionally dollar sign in the rest of identifier. 
+    # Letters with diacritical marks and non-Latin letters
+    # are represented by character codes 128 to 255 (or in octal \200 to \377).
+    # See https://learn.microsoft.com/en-gb/office/vba/language/reference/user-interface-help/character-set-128255
     # See https://github.com/postgres/postgres/blob/master/src/backend/parser/scan.l
     #
     # MySQL allows digit in the beginning of identifier

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -110,6 +110,13 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testIdentifierStartWithNumber() {
+    final String sql = "select 1 as 1_c1 from t";
+    final String expected = "SELECT 1 AS `1_C1`\n"
+        + "FROM `T`";
+    sql(sql).ok(expected);
+  }
+
   /** Tests that there are no reserved keywords. */
   @Disabled
   @Test void testKeywords() {

--- a/core/src/main/codegen/default_config.fmpp
+++ b/core/src/main/codegen/default_config.fmpp
@@ -439,7 +439,11 @@ parser: {
   # Example: "parserImpls.ftl".
   implementationFiles: [
   ]
-
+  
+  # Custom identifier token.
+  # Example: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >".
+  customIdentifierToken: ""
+      
   includePosixOperators: false
   includeCompoundIdentifier: true
   includeBraces: true

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -8803,7 +8803,7 @@ MORE :
 
 <DEFAULT, DQID, BTID, BQID> TOKEN :
 {
-    <#if parser.customIdentifierToken??>
+    <#if parser.customIdentifierToken?has_content>
         ${parser.customIdentifierToken}
     <#else>
         < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -8803,7 +8803,11 @@ MORE :
 
 <DEFAULT, DQID, BTID, BQID> TOKEN :
 {
-    < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >
+    <#if parser.customIdentifierToken??>
+        ${parser.customIdentifierToken}
+    <#else>
+        < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >
+    </#if>
 }
 
 <DEFAULT, DQID, BTID, BQID, BQHID> TOKEN :


### PR DESCRIPTION
Part of the work has been done inside #2737