### PR TITLE
[CALCITE-5674] CAST expr to target type should respect nullable when it is complex type (follow-up)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -147,7 +147,7 @@ public class SqlCastFunction extends SqlFunction {
       RelDataType newElementType =
           createTypeWithNullabilityFromExpr(
               typeFactory, expressionElementType, targetElementType, safe);
-      return isArray(expressionType)
+      return isArray(targetType)
           ? SqlTypeUtil.createArrayType(typeFactory, newElementType, isNullable)
           : SqlTypeUtil.createMultisetType(typeFactory, newElementType, isNullable);
     }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -6990,6 +6990,8 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .columnType("VARCHAR(5) ARRAY NOT NULL");
     sql("select cast(multiset[1,null,2] as int multiset) from (values (1))")
         .columnType("INTEGER MULTISET NOT NULL");
+    sql("select cast(array[1,null,2] as int multiset) from (values (1))")
+        .columnType("INTEGER MULTISET NOT NULL");
 
     // test array type.
     sql("select cast(\"intArrayType\" as int array) from COMPLEXTYPES.CTC_T1")


### PR DESCRIPTION
Fixes minor regression introduced by https://github.com/apache/calcite/pull/3189