### PR TITLE
[CALCITE-5722] RangeSets.isPoint incorrectly gives false for closed ranges with endpoints which are equal under `.compareTo` but not under `.equals` 

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/RangeSets.java
+++ b/core/src/main/java/org/apache/calcite/util/RangeSets.java
@@ -129,7 +129,7 @@ public class RangeSets {
   public static <C extends Comparable<C>> boolean isPoint(Range<C> range) {
     return range.hasLowerBound()
         && range.hasUpperBound()
-        && range.lowerEndpoint().equals(range.upperEndpoint())
+        && range.lowerEndpoint().compareTo(range.upperEndpoint()) == 0
         && !range.isEmpty();
   }
 

--- a/core/src/test/java/org/apache/calcite/util/RangeSetTest.java
+++ b/core/src/test/java/org/apache/calcite/util/RangeSetTest.java
@@ -155,6 +155,9 @@ class RangeSetTest {
     assertThat(RangeSets.isPoint(Range.atMost(0)), is(false));
     assertThat(RangeSets.isPoint(Range.greaterThan(0)), is(false));
     assertThat(RangeSets.isPoint(Range.atLeast(0)), is(false));
+
+    // Test situation where endpoints of closed range are equal under `Comparable.compareTo` but not `T.equals`
+    assertThat(RangeSets.isPoint(Range.closed(new BigDecimal("1"), new BigDecimal("1.0"))), is(true));
   }
 
   /** Tests {@link RangeSets#isOpenInterval(RangeSet)}. */


### PR DESCRIPTION
This PR fixes a peculiar issue where RangeSets.isPoint will return false when a closed range with endpoints that are equal under `Comparable.compareTo`, but not `T.equals`.

Using equality as determined by `Comparable.compareTo` is the most correct notion of equality in this situation.