### PR TITLE
[CALCITE-5736] Add ARRAY_REVERSE function (enabled in Spark library)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -868,7 +868,7 @@ public abstract class SqlLibraryOperators {
               OperandTypes.ANY, OperandTypes.typeName(SqlTypeName.INTEGER)));
 
   /** The "ARRAY_REVERSE(array)" function. */
-  @LibraryOperator(libraries = {BIG_QUERY})
+  @LibraryOperator(libraries = {BIG_QUERY, SPARK})
   public static final SqlFunction ARRAY_REVERSE =
       SqlBasicFunction.create(SqlKind.ARRAY_REVERSE,
           ReturnTypes.ARG0_NULLABLE,

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -5377,17 +5377,22 @@ public class SqlOperatorTest {
     f.checkNull("array_repeat(1, null)");
   }
 
-  /** Tests {@code ARRAY_REVERSE} function from BigQuery. */
+  /** Tests {@code ARRAY_REVERSE} function from BigQuery and Spark. */
   @Test void testArrayReverseFunc() {
-    SqlOperatorFixture f = fixture()
-        .setFor(SqlLibraryOperators.ARRAY_REVERSE)
-        .withLibrary(SqlLibrary.BIG_QUERY);
-    f.checkScalar("array_reverse(array[1])", "[1]",
-        "INTEGER NOT NULL ARRAY NOT NULL");
-    f.checkScalar("array_reverse(array[1, 2])", "[2, 1]",
-        "INTEGER NOT NULL ARRAY NOT NULL");
-    f.checkScalar("array_reverse(array[null, 1])", "[1, null]",
-        "INTEGER ARRAY NOT NULL");
+    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.ARRAY_REVERSE);
+    f0.checkFails("^array_reverse(array[1])^",
+        "No match found for function signature ARRAY_REVERSE\\(<INTEGER ARRAY>\\)",
+        false);
+    final Consumer<SqlOperatorFixture> consumer = f -> {
+      f.checkScalar("array_reverse(array[1])", "[1]",
+          "INTEGER NOT NULL ARRAY NOT NULL");
+      f.checkScalar("array_reverse(array[1, 2])", "[2, 1]",
+          "INTEGER NOT NULL ARRAY NOT NULL");
+      f.checkScalar("array_reverse(array[null, 1])", "[1, null]",
+          "INTEGER ARRAY NOT NULL");
+      f.checkNull("array_reverse(null)");
+    };
+    f0.forEachLibrary(list(SqlLibrary.BIG_QUERY, SqlLibrary.SPARK), consumer);
   }
 
   /** Tests {@code ARRAY_SIZE} function from Spark. */


### PR DESCRIPTION

spark doesn't support the array_reverse.

it supports reverse, which not only can reverse string, but also can reverse array
so close this PR

```
reverse(array) - Returns a reversed string or an array with reverse order of elements.

Examples:

> SELECT reverse('Spark SQL');
 LQS krapS
> SELECT reverse(array(2, 1, 4, 3));
 [3,4,1,2]
```
