### PR TITLE
[CALCITE-5739] Add MAP_FROM_ARRAYS function (enabled in Spark library)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -173,6 +173,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_AND;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_OR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LPAD;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAP_ENTRIES;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAP_FROM_ARRAYS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAP_KEYS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAP_VALUES;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAX_BY;
@@ -697,6 +698,7 @@ public class RexImpTable {
       defineMethod(MAP_ENTRIES, BuiltInMethod.MAP_ENTRIES.method, NullPolicy.STRICT);
       defineMethod(MAP_KEYS, BuiltInMethod.MAP_KEYS.method, NullPolicy.STRICT);
       defineMethod(MAP_VALUES, BuiltInMethod.MAP_VALUES.method, NullPolicy.STRICT);
+      defineMethod(MAP_FROM_ARRAYS, BuiltInMethod.MAP_FROM_ARRAYS.method, NullPolicy.ANY);
       map.put(ARRAY_CONCAT, new ArrayConcatImplementor());
       final MethodImplementor isEmptyImplementor =
           new MethodImplementor(BuiltInMethod.IS_EMPTY.method, NullPolicy.NONE,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -172,6 +172,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOG;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_AND;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LOGICAL_OR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.LPAD;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAP_ENTRIES;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAP_KEYS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAP_VALUES;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.MAX_BY;
@@ -693,6 +694,7 @@ public class RexImpTable {
       defineMethod(ARRAY_REPEAT, BuiltInMethod.ARRAY_REPEAT.method, NullPolicy.NONE);
       defineMethod(ARRAY_REVERSE, BuiltInMethod.ARRAY_REVERSE.method, NullPolicy.STRICT);
       defineMethod(ARRAY_SIZE, BuiltInMethod.COLLECTION_SIZE.method, NullPolicy.STRICT);
+      defineMethod(MAP_ENTRIES, BuiltInMethod.MAP_ENTRIES.method, NullPolicy.STRICT);
       defineMethod(MAP_KEYS, BuiltInMethod.MAP_KEYS.method, NullPolicy.STRICT);
       defineMethod(MAP_VALUES, BuiltInMethod.MAP_VALUES.method, NullPolicy.STRICT);
       map.put(ARRAY_CONCAT, new ArrayConcatImplementor());

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -3898,6 +3898,15 @@ public class SqlFunctions {
     return Collections.nCopies(numberOfElement, element);
   }
 
+  /** Support the MAP_ENTRIES function. */
+  public static List mapEntries(Map<Object, Object> map) {
+    final List result = new ArrayList(map.size());
+    for (Map.Entry<Object, Object> entry : map.entrySet()) {
+      result.add(Arrays.asList(entry.getKey(), entry.getValue()));
+    }
+    return result;
+  }
+
   /** Support the MAP_KEYS function. */
   public static List mapKeys(Map map) {
     return new ArrayList<>(map.keySet());

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -92,6 +92,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -3915,6 +3916,23 @@ public class SqlFunctions {
   /** Support the MAP_VALUES function. */
   public static List mapValues(Map map) {
     return new ArrayList<>(map.values());
+  }
+
+  /** Support the MAP_FROM_ARRAYS function. */
+  public static Map mapFromArrays(List keysArray, List valuesArray) {
+    if (keysArray.size() != valuesArray.size()) {
+      throw new IllegalArgumentException(
+          "Invalid function MAP_FROM_ARRAYS call:\n"
+              + "The length of the keys array "
+              + keysArray.size()
+              + " is not equal to the length of the values array "
+              + valuesArray.size());
+    }
+    final Map map = new LinkedHashMap<>();
+    for (int i = 0; i < keysArray.size(); i++) {
+      map.put(keysArray.get(i), valuesArray.get(i));
+    }
+    return map;
   }
 
   /** Support the SLICE function. */

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -704,6 +704,9 @@ public enum SqlKind {
   /** {@code MAP_VALUES} function (Spark semantics). */
   MAP_VALUES,
 
+  /** {@code MAP_FROM_ARRAYS} function (Spark semantics). */
+  MAP_FROM_ARRAYS,
+
   /** {@code REVERSE} function (SQL Server, MySQL). */
   REVERSE,
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -695,6 +695,9 @@ public enum SqlKind {
   /** {@code ARRAY_SIZE} function (Spark semantics). */
   ARRAY_SIZE,
 
+  /** {@code MAP_ENTRIES} function (Spark semantics). */
+  MAP_ENTRIES,
+
   /** {@code MAP_KEYS} function (Spark semantics). */
   MAP_KEYS,
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -944,6 +944,24 @@ public abstract class SqlLibraryOperators {
           ReturnTypes.TO_MAP_VALUES_NULLABLE,
           OperandTypes.MAP);
 
+  private static RelDataType mapReturnType(SqlOperatorBinding opBinding) {
+    final RelDataType keysArrayType = opBinding.collectOperandTypes().get(0);
+    final RelDataType valuesArrayType = opBinding.collectOperandTypes().get(1);
+    final boolean nullable = keysArrayType.isNullable() || valuesArrayType.isNullable();
+    return SqlTypeUtil.createMapType(
+        opBinding.getTypeFactory(),
+        requireNonNull(keysArrayType.getComponentType(), "inferred key type"),
+        requireNonNull(valuesArrayType.getComponentType(), "inferred value type"),
+        nullable);
+  }
+
+  /** The "MAP_FROM_ARRAYS(keysArray, valuesArray)" function. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction MAP_FROM_ARRAYS =
+      SqlBasicFunction.create(SqlKind.MAP_FROM_ARRAYS,
+          SqlLibraryOperators::mapReturnType,
+          OperandTypes.ARRAY_ARRAY);
+
   @LibraryOperator(libraries = {BIG_QUERY, MYSQL})
   public static final SqlFunction REVERSE =
       SqlBasicFunction.create(SqlKind.REVERSE,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -923,6 +923,13 @@ public abstract class SqlLibraryOperators {
           ReturnTypes.LEAST_RESTRICTIVE,
           OperandTypes.AT_LEAST_ONE_SAME_VARIADIC);
 
+  /** The "MAP_ENTRIES(map)" function. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction MAP_ENTRIES =
+      SqlBasicFunction.create(SqlKind.MAP_ENTRIES,
+          ReturnTypes.TO_MAP_ENTRIES_NULLABLE,
+          OperandTypes.MAP);
+
   /** The "MAP_KEYS(map)" function. */
   @LibraryOperator(libraries = {SPARK})
   public static final SqlFunction MAP_KEYS =

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -466,6 +466,9 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker ARRAY =
       family(SqlTypeFamily.ARRAY);
 
+  public static final SqlSingleOperandTypeChecker ARRAY_ARRAY =
+      family(SqlTypeFamily.ARRAY, SqlTypeFamily.ARRAY);
+
   public static final SqlSingleOperandTypeChecker ARRAY_OR_MAP =
       OperandTypes.family(SqlTypeFamily.ARRAY)
           .or(OperandTypes.family(SqlTypeFamily.MAP))

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -537,6 +537,27 @@ public abstract class ReturnTypes {
       ARG0.andThen(SqlTypeTransforms.TO_MAP);
 
   /**
+   * Returns a ROW type.
+   *
+   * <p>For example, given {@code (INTEGER, DATE) MAP}, returns
+   * {@code Record(f0: INTEGER, f1: DATE)}.
+   */
+  public static final SqlReturnTypeInference TO_ROW =
+      ARG0.andThen(SqlTypeTransforms.TO_ROW);
+
+  /**
+   * Returns a ARRAY type.
+   *
+   * <p>For example, given {@code (INTEGER, DATE) MAP}, returns
+   * {@code Record(f0: INTEGER, f1: DATE) ARRAY}.
+   */
+  public static final SqlReturnTypeInference TO_MAP_ENTRIES =
+      TO_ROW.andThen(SqlTypeTransforms.TO_ARRAY);
+
+  public static final SqlReturnTypeInference TO_MAP_ENTRIES_NULLABLE =
+      TO_MAP_ENTRIES.andThen(SqlTypeTransforms.TO_NULLABLE);
+
+  /**
    * Returns a ARRAY type.
    *
    * <p>For example, given {@code (INTEGER, DATE) MAP}, returns

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeTransforms.java
@@ -230,6 +230,17 @@ public abstract class SqlTypeTransforms {
 
   /**
    * Parameter type-inference transform strategy that converts a MAP type
+   * to a two-field record type.
+   *
+   * @see org.apache.calcite.rel.type.RelDataTypeFactory#createStructType
+   */
+  public static final SqlTypeTransform TO_ROW =
+      (opBinding, typeToTransform) ->
+          SqlTypeUtil.createRecordTypeFromMap(opBinding.getTypeFactory(),
+              typeToTransform);
+
+  /**
+   * Parameter type-inference transform strategy that converts a MAP type
    * to a ARRAY type.
    *
    * @see org.apache.calcite.rel.type.RelDataTypeFactory#createArrayType

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -54,6 +54,7 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -1195,6 +1196,15 @@ public abstract class SqlTypeUtil {
         type.getFieldCount(), type);
     return createMapType(typeFactory, type.getFieldList().get(0).getType(),
         type.getFieldList().get(1).getType(), false);
+  }
+
+  /** Creates a ROW type from a map type. The record type will have two fields. */
+  public static RelDataType createRecordTypeFromMap(
+      RelDataTypeFactory typeFactory, RelDataType type) {
+    RelDataType keyType = requireNonNull(type.getKeyType(), () -> "keyType of " + type);
+    RelDataType valueType = requireNonNull(type.getValueType(), () -> "keyType of " + type);
+    return typeFactory.createStructType(
+        Arrays.asList(keyType, valueType), Arrays.asList("f0", "f1"));
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -635,6 +635,7 @@ public enum BuiltInMethod {
   MAP_ENTRIES(SqlFunctions.class, "mapEntries", Map.class),
   MAP_KEYS(SqlFunctions.class, "mapKeys", Map.class),
   MAP_VALUES(SqlFunctions.class, "mapValues", Map.class),
+  MAP_FROM_ARRAYS(SqlFunctions.class, "mapFromArrays", List.class, List.class),
   SELECTIVITY(Selectivity.class, "getSelectivity", RexNode.class),
   UNIQUE_KEYS(UniqueKeys.class, "getUniqueKeys", boolean.class),
   AVERAGE_ROW_SIZE(Size.class, "averageRowSize"),

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -632,6 +632,7 @@ public enum BuiltInMethod {
   ARRAY_DISTINCT(SqlFunctions.class, "distinct", List.class),
   ARRAY_REPEAT(SqlFunctions.class, "repeat", Object.class, Integer.class),
   ARRAY_REVERSE(SqlFunctions.class, "reverse", List.class),
+  MAP_ENTRIES(SqlFunctions.class, "mapEntries", Map.class),
   MAP_KEYS(SqlFunctions.class, "mapKeys", Map.class),
   MAP_VALUES(SqlFunctions.class, "mapValues", Map.class),
   SELECTIVITY(Selectivity.class, "getSelectivity", RexNode.class),

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableLimitSortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableLimitSortTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test.enumerable;
+
+import org.apache.calcite.adapter.enumerable.EnumerableRules;
+import org.apache.calcite.adapter.java.ReflectiveSchema;
+import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.runtime.Hook;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.test.schemata.hr.HrSchemaBig;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+/** Tests for
+ * {@link org.apache.calcite.adapter.enumerable.EnumerableLimitSort}. */
+public class EnumerableLimitSortTest {
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5730">[CALCITE-5730]
+   * First nulls can be dropped by EnumerableLimitSort with offset</a>. */
+  @Test void nullsFirstWithLimitAndOffset() {
+    tester("select commission from emps order by commission nulls first limit 1 offset 1 ")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4])\n"
+            + "  EnumerableLimitSort(sort0=[$4], dir0=[ASC-nulls-first], offset=[1], fetch=[1])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])")
+        .returnsOrdered("commission=null");
+  }
+
+  @Test void nullsLastWithLimitAndOffset() {
+    tester("select commission from emps order by commission desc nulls last limit 8 offset 10 ")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4])\n"
+            + "  EnumerableLimitSort(sort0=[$4], dir0=[DESC-nulls-last], offset=[10], fetch=[8])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])")
+        .returnsOrdered(
+            "commission=1000",
+            "commission=1000",
+            "commission=500",
+            "commission=500",
+            "commission=500",
+            "commission=500",
+            "commission=500",
+            "commission=500");
+  }
+
+  @Test void nullsFirstWithLimit() {
+    tester("select commission from emps order by commission nulls first limit 13 ")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4])\n"
+            + "  EnumerableLimitSort(sort0=[$4], dir0=[ASC-nulls-first], fetch=[13])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])")
+        .returnsOrdered(
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=null",
+            "commission=250");
+  }
+
+  @Test void nullsLastWithLimit() {
+    tester("select commission from emps order by commission nulls last limit 5 ")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4])\n"
+            + "  EnumerableLimitSort(sort0=[$4], dir0=[ASC], fetch=[5])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])")
+        .returnsOrdered(
+            "commission=250",
+            "commission=250",
+            "commission=250",
+            "commission=250",
+            "commission=250");
+  }
+
+  @Test void multiOrderByColumnsWithLimitAndOffset() {
+    tester("select commission, salary, empid from emps"
+        + " order by commission nulls first, salary asc, empid desc limit 4 offset 6 ")
+        .explainContains(
+            "EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4], salary=[$t3], empid=[$t0])\n"
+            + "  EnumerableLimitSort(sort0=[$4], sort1=[$3], sort2=[$0], dir0=[ASC-nulls-first], dir1=[ASC], dir2=[DESC], offset=[6], fetch=[4])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])")
+        .returnsOrdered(
+            "commission=null; salary=7000.0; empid=23",
+                    "commission=null; salary=7000.0; empid=19",
+                    "commission=null; salary=7000.0; empid=15",
+                    "commission=null; salary=7000.0; empid=11");
+  }
+
+  @Test void multiOrderByColumnsWithLimit() {
+    tester("select commission, deptno from emps"
+        + " order by commission desc nulls first, deptno asc limit 13 ")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4], deptno=[$t1])\n"
+            + "  EnumerableLimitSort(sort0=[$4], sort1=[$1], dir0=[DESC], dir1=[ASC], fetch=[13])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])\n")
+        .returnsOrdered(
+            "commission=null; deptno=8",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=10",
+            "commission=null; deptno=60",
+            "commission=null; deptno=80",
+            "commission=1000; deptno=10");
+  }
+
+  @Test void multiOrderByColumnsNullsLastWithLimitAndOffset() {
+    tester("select commission, salary from emps"
+        + " order by commission desc nulls last, salary limit 6 offset 12 ")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4], salary=[$t3])\n"
+            + "  EnumerableLimitSort(sort0=[$4], sort1=[$3], dir0=[DESC-nulls-last], dir1=[ASC], offset=[12], fetch=[6])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])")
+        .returnsOrdered(
+            "commission=500; salary=8000.0",
+            "commission=500; salary=8000.0",
+            "commission=500; salary=8000.0",
+            "commission=500; salary=8000.0",
+            "commission=500; salary=8000.0",
+            "commission=500; salary=8000.0");
+  }
+
+  @Test void multiOrderByColumnsNullsLastWithLimit() {
+    tester("select commission, empid from emps"
+        + " order by commission nulls last, empid desc limit 4 ")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], commission=[$t4], empid=[$t0])\n"
+            + "  EnumerableLimitSort(sort0=[$4], sort1=[$0], dir0=[ASC], dir1=[DESC], fetch=[4])\n"
+            + "    EnumerableTableScan(table=[[s, emps]])")
+        .returnsOrdered(
+            "commission=250; empid=48",
+            "commission=250; empid=44",
+            "commission=250; empid=40",
+            "commission=250; empid=36");
+  }
+
+  private CalciteAssert.AssertQuery tester(String sqlQuery) {
+    return CalciteAssert.that()
+        .with(CalciteConnectionProperty.LEX, Lex.JAVA)
+        .with(CalciteConnectionProperty.FORCE_DECORRELATE, false)
+        .withSchema("s", new ReflectiveSchema(new HrSchemaBig()))
+        .query(sqlQuery)
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner -> {
+          planner.removeRule(EnumerableRules.ENUMERABLE_SORT_RULE);
+          planner.addRule(EnumerableRules.ENUMERABLE_LIMIT_SORT_RULE);
+        });
+  }
+}

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -2735,7 +2735,7 @@ public abstract class EnumerableDefaults {
         if (offset > 0) {
           // search the key up to (but excluding) which we have to remove entries from the map
           int skipped = 0;
-          TKey until = null;
+          TKey until = (TKey) DUMMY;
           for (Map.Entry<TKey, List<TSource>> e : map.entrySet()) {
             skipped += e.getValue().size();
 
@@ -2751,7 +2751,7 @@ public abstract class EnumerableDefaults {
               break;
             }
           }
-          if (until == null) {
+          if (until == DUMMY) {
             // the offset is bigger than the number of rows in the map
             return Linq4j.emptyEnumerator();
           }

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2734,6 +2734,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | s | MAP_ENTRIES(map)                               | Returns the entries of the *map* as an array, the order of the entries is not defined
 | s | MAP_KEYS(map)                                  | Returns the keys of the *map* as an array, the order of the entries is not defined
 | s | MAP_VALUES(map)                                | Returns the values of the *map* as an array, the order of the entries is not defined
+| s | MAP_FROM_ARRAYS(array1, array2)                | Returns a map created from an *array1* and *array2*. Note that the lengths of two arrays should be the same
 | b m p | MD5(string)                                | Calculates an MD5 128-bit checksum of *string* and returns it as a hex string
 | m | MONTHNAME(date)                                | Returns the name, in the connection's locale, of the month in *datetime*; for example, it returns '二月' for both DATE '2020-02-10' and TIMESTAMP '2020-02-10 10:10:10'
 | o | NVL(value1, value2)                            | Returns *value1* if *value1* is not null, otherwise *value2*

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2731,6 +2731,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | m | TO_BASE64(string)                              | Converts the *string* to base-64 encoded form and returns a encoded string
 | b m | FROM_BASE64(string)                          | Returns the decoded result of a base-64 *string* as a string
 | b o | LTRIM(string)                                | Returns *string* with all blanks removed from the start
+| s | MAP_ENTRIES(map)                               | Returns the entries of the *map* as an array, the order of the entries is not defined
 | s | MAP_KEYS(map)                                  | Returns the keys of the *map* as an array, the order of the entries is not defined
 | s | MAP_VALUES(map)                                | Returns the values of the *map* as an array, the order of the entries is not defined
 | b m p | MD5(string)                                | Calculates an MD5 128-bit checksum of *string* and returns it as a hex string

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -5437,6 +5437,20 @@ public class SqlOperatorTest {
     f.checkNull("array_length(null)");
   }
 
+  /** Tests {@code MAP_ENTRIES} function from Spark. */
+  @Test void testMapEntriesFunc() {
+    final SqlOperatorFixture f0 = fixture();
+    f0.setFor(SqlLibraryOperators.MAP_ENTRIES);
+    f0.checkFails("^map_entries(map['foo', 1, 'bar', 2])^",
+        "No match found for function signature MAP_ENTRIES\\(<\\(CHAR\\(3\\), INTEGER\\) "
+            + "MAP>\\)", false);
+    final SqlOperatorFixture f = f0.withLibrary(SqlLibrary.SPARK);
+    f.checkScalar("map_entries(map['foo', 1, 'bar', 2])", "[{foo, 1}, {bar, 2}]",
+        "RecordType(CHAR(3) NOT NULL f0, INTEGER NOT NULL f1) NOT NULL ARRAY NOT NULL");
+    f.checkScalar("map_entries(map['foo', 1, null, 2])", "[{foo, 1}, {null, 2}]",
+        "RecordType(CHAR(3) f0, INTEGER NOT NULL f1) NOT NULL ARRAY NOT NULL");
+  }
+
   /** Tests {@code MAP_KEYS} function from Spark. */
   @Test void testMapKeysFunc() {
     final SqlOperatorFixture f0 = fixture();


### PR DESCRIPTION
MAP_FROM_ARRAYS (array1, array2)

Returns a map created from an array1 and *array2. Note that the lengths of two arrays should be the same

```
> SELECT map_from_arrays(array(1.0, 3.0), array('2', '4'));
 {1.0:"2",3.0:"4"} 
```