### PR TITLE
[CALCITE-5742] SubstitutionVisitor Causes Infinite Loop when using AggregateOnCalcToAggregateUnifyRule

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -1499,7 +1499,7 @@ public class SubstitutionVisitor {
 
       final Mapping inverseMapping = mapping.inverse();
       final MutableAggregate aggregate2 =
-          permute(query, qInput.getInput(), inverseMapping);
+          permute(query, qInput.getInput().clone(), inverseMapping);
 
       final Mappings.TargetMapping mappingForQueryCond =
           Mappings.target(target.groupSet::indexOf,

--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewSubstitutionVisitorTest.java
@@ -654,6 +654,18 @@ public class MaterializedViewSubstitutionVisitorTest {
         .ok();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5742">[CALCITE-5742]
+   * AggregateOnCalcToAggregateUnifyRule may case Infinite Loop
+   * in SubstitutionVisitor</a>. */
+  @Test void testAggregateOnProject6() {
+    sql("select count(1) from (select \"empid\", \"deptno\", \"name\", count(*) from \"emps\""
+            + "group by \"empid\", \"deptno\", \"name\" limit 10)  ",
+        "select \"empid\", \"deptno\" from (select \"empid\", \"deptno\", \"name\", count(*) from \"emps\"\n"
+            + "group by \"empid\", \"deptno\", \"name\" limit 10) group by \"empid\", \"deptno\"")
+        .noMat();
+  }
+
   @Test void testAggregateOnProjectAndFilter() {
     String mv = ""
         + "select \"deptno\", sum(\"salary\"), count(1)\n"


### PR DESCRIPTION
The input of Calc Under Aggregate was changed when executing permute in AggregateOnCalcToAggregateUnifyRule, then If this match can't produce result, Visitor can not skip out because the condition "queryDescendant == r.after" is not met.
I changed it to use clone of input, when original input would not be changed when this result is null.