### PR TITLE
[CALCITE-5401] Rule fired by HepPlanner can return Volcano's RelSubset

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoinRule.java
@@ -140,9 +140,9 @@ public class EnumerableBatchNestedLoopJoinRule
 
     call.transformTo(
         EnumerableBatchNestedLoopJoin.create(
-            convert(join.getLeft(), join.getLeft().getTraitSet()
+            convert(call.getPlanner(), join.getLeft(), join.getLeft().getTraitSet()
                 .replace(EnumerableConvention.INSTANCE)),
-            convert(right, right.getTraitSet()
+            convert(call.getPlanner(), right, right.getTraitSet()
                 .replace(EnumerableConvention.INSTANCE)),
             join.getCondition(),
             requiredColumns.build(),

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitRule.java
@@ -57,7 +57,8 @@ public class EnumerableLimitRule
     }
     call.transformTo(
         EnumerableLimit.create(
-            convert(input, input.getTraitSet().replace(EnumerableConvention.INSTANCE)),
+            convert(call.getPlanner(), input,
+                input.getTraitSet().replace(EnumerableConvention.INSTANCE)),
             sort.offset,
             sort.fetch));
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitSortRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitSortRule.java
@@ -43,7 +43,7 @@ public class EnumerableLimitSortRule extends RelRule<EnumerableLimitSortRule.Con
     RelNode input = sort.getInput();
     final Sort o =
         EnumerableLimitSort.create(
-            convert(input,
+            convert(call.getPlanner(), input,
                 input.getTraitSet().replace(EnumerableConvention.INSTANCE)),
             sort.getCollation(), sort.offset, sort.fetch);
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeUnionRule.java
@@ -135,7 +135,8 @@ public class EnumerableMergeUnionRule extends RelRule<EnumerableMergeUnionRule.C
       final RelNode newInput =
           sort.copy(sort.getTraitSet(), unsortedInput, collation, null, inputFetch);
       inputs.add(
-          convert(newInput, newInput.getTraitSet().replace(EnumerableConvention.INSTANCE)));
+          convert(call.getPlanner(), newInput,
+              newInput.getTraitSet().replace(EnumerableConvention.INSTANCE)));
     }
 
     RelNode result = EnumerableMergeUnion.create(sort.getCollation(), inputs, union.all);

--- a/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRule.java
@@ -588,8 +588,10 @@ public abstract class RelOptRule {
    * @return a relational expression with the desired traits; never null
    */
   public static RelNode convert(RelNode rel, RelTraitSet toTraits) {
-    RelOptPlanner planner = rel.getCluster().getPlanner();
+    return convert(rel.getCluster().getPlanner(), rel, toTraits);
+  }
 
+  public static RelNode convert(RelOptPlanner planner, RelNode rel, RelTraitSet toTraits) {
     RelTraitSet outTraits = rel.getTraitSet();
     for (int i = 0; i < toTraits.size(); i++) {
       RelTrait toTrait = toTraits.getTrait(i);
@@ -614,7 +616,10 @@ public abstract class RelOptRule {
    * @return a relational expression with the desired trait; never null
    */
   public static RelNode convert(RelNode rel, @Nullable RelTrait toTrait) {
-    RelOptPlanner planner = rel.getCluster().getPlanner();
+    return convert(rel.getCluster().getPlanner(), rel, toTrait);
+  }
+
+  public static RelNode convert(RelOptPlanner planner, RelNode rel, @Nullable RelTrait toTrait) {
     RelTraitSet outTraits = rel.getTraitSet();
     if (toTrait != null) {
       outTraits = outTraits.replace(toTrait);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
@@ -118,7 +118,7 @@ public class AggregateRemoveRule
       projects.add(cast);
     }
 
-    final RelNode newInput = convert(input, aggregate.getTraitSet().simplify());
+    final RelNode newInput = convert(call.getPlanner(), input, aggregate.getTraitSet().simplify());
     relBuilder.push(newInput);
     if (!projects.isEmpty()) {
       projects.addAll(0, relBuilder.fields(aggregate.getGroupSet()));

--- a/core/src/main/java/org/apache/calcite/rel/rules/CalcRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CalcRemoveRule.java
@@ -59,6 +59,7 @@ public class CalcRemoveRule extends RelRule<CalcRemoveRule.Config>
     input = call.getPlanner().register(input, calc);
     call.transformTo(
         convert(
+            call.getPlanner(),
             input,
             calc.getTraitSet()));
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectRemoveRule.java
@@ -67,7 +67,7 @@ public class ProjectRemoveRule
               childProject.getInput(), childProject.getProjects(),
               project.getRowType());
     }
-    stripped = convert(stripped, project.getConvention());
+    stripped = convert(call.getPlanner(), stripped, project.getConvention());
     call.transformTo(stripped);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRule.java
@@ -70,7 +70,7 @@ public class SortRemoveRule
         .getTrait(RelCollationTraitDef.INSTANCE);
     final RelTraitSet traits = sort.getInput().getTraitSet()
         .replace(collation).replaceIf(ConventionTraitDef.INSTANCE, sort::getConvention);
-    call.transformTo(convert(sort.getInput(), traits));
+    call.transformTo(convert(call.getPlanner(), sort.getInput(), traits));
   }
 
   /** Rule configuration. */

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
@@ -225,7 +225,7 @@ public class GeodeRules {
 
       GeodeSort geodeSort =
           new GeodeSort(sort.getCluster(), traitSet,
-              convert(sort.getInput(), traitSet.replace(RelCollations.EMPTY)),
+              convert(call.getPlanner(), sort.getInput(), traitSet.replace(RelCollations.EMPTY)),
               sort.getCollation(), sort.fetch);
 
       call.transformTo(geodeSort);


### PR DESCRIPTION
See problem description in:
[CALCITE-5401](https://issues.apache.org/jira/browse/CALCITE-5401) Rule fired by HepPlanner can return Volcano's RelSubset.

Issue solved by  adding new `RelOptRule#convert` with an additional planner parameter, and use it in potentially sensitive locations for this issue to occur (basically rules' `onMatch`)