### PR TITLE
[CALCITE-5733][core]Simplification should also simplify for array type

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -54,6 +54,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
@@ -86,6 +87,8 @@ public class RexSimplify {
   private final RexExecutor executor;
 
   private static final Strong STRONG = new Strong();
+  
+  private Object[] recordedArray;
 
   /**
    * Creates a RexSimplify.
@@ -672,9 +675,28 @@ public class RexSimplify {
     RexSimplify simplify = this;
     for (int i = 0; i < terms.size(); i++) {
       RexNode t = terms.get(i);
-      if (Predicate.of(t) == null) {
+      Predicate predicate = Predicate.of(t); 
+      if (predicate == null) {
         continue;
       }
+      
+      //add for array-type
+      if (predicate instanceof Comparison) {
+        Comparison cmp = (Comparison) predicate;
+        if (cmp.rexCall != null && cmp.rexCall.getKind().equals(SqlKind.ARRAY_VALUE_CONSTRUCTOR)) {
+          RexCall arrayCall = cmp.rexCall;
+          if (i == 0) {
+            recordedArray = arrayCall.operands.toArray();
+            continue;
+          } else {
+            if (!Arrays.equals(arrayCall.operands.toArray(), recordedArray)) {
+              terms.set(i, rexBuilder.makeLiteral(false));
+              break;
+            }  
+          }
+        }
+      }
+      
       terms.set(i, simplify.simplify(t, unknownAs));
       RelOptPredicateList newPredicates =
           simplify.predicates.union(rexBuilder,
@@ -2622,21 +2644,34 @@ public class RexSimplify {
 
   /** Represents a simple Comparison.
    *
-   * <p>Left hand side is a {@link RexNode}, right hand side is a literal.
+   * <p>Left hand side is a {@link RexNode}, right hand side is a literal/array-call.
    */
   private static class Comparison implements Predicate {
     final RexNode ref;
     final SqlKind kind;
+    //RexCall or RexLiteral
     final RexLiteral literal;
+    final RexCall rexCall;
 
     private Comparison(RexNode ref, SqlKind kind, RexLiteral literal) {
       this.ref = requireNonNull(ref, "ref");
       this.kind = requireNonNull(kind, "kind");
       this.literal = requireNonNull(literal, "literal");
+      this.rexCall = null;
+    }
+    
+    /**
+     * Add for RexCall, such as ARRAY[...,...].
+     */
+    private Comparison(RexNode ref, SqlKind kind, RexCall arrayCall) {
+      this.ref = Objects.requireNonNull(ref);
+      this.kind = Objects.requireNonNull(kind);
+      this.rexCall = Objects.requireNonNull(arrayCall);
+      this.literal = null;
     }
 
     /** Creates a comparison, between a {@link RexInputRef} or {@link RexFieldAccess} or
-     * deterministic {@link RexCall} and a literal. */
+     * deterministic {@link RexCall} and a literal/array-call. */
     static @Nullable Comparison of(RexNode e) {
       return of(e, node -> RexUtil.isReferenceOrAccess(node, true)
           || RexUtil.isDeterministic(node));
@@ -2660,6 +2695,24 @@ public class RexSimplify {
             return new Comparison(left, e.getKind(), (RexLiteral) right);
           }
           break;
+        //add for RexCall like "CAST(ARRAY(..., ...))..."
+        case CAST:
+          final RexCall castCall = (RexCall) right;
+          final RexNode castLeft = castCall.getOperands().get(0);
+          switch (castLeft.getKind()) {
+            case ARRAY_VALUE_CONSTRUCTOR:
+              //array-type RexCall --> create a comparison of RexCall
+              if (nodePredicate.test(left)) {
+                return new Comparison(left, e.getKind(), (RexCall) castLeft);
+              }
+          }
+          break;
+        case ARRAY_VALUE_CONSTRUCTOR:
+          //array-type RexCall --> create a comparison of RexCall
+          if (nodePredicate.test(left)) {
+            return new Comparison(left, e.getKind(), (RexCall) right);
+          }
+          break;  
         default:
           break;
         }
@@ -2669,10 +2722,28 @@ public class RexSimplify {
             return new Comparison(right, e.getKind().reverse(), (RexLiteral) left);
           }
           break;
+        //add for RexCall like "CAST(ARRAY(..., ...))..."
+        case CAST:
+          final RexCall castCall = (RexCall) left;
+          final RexNode castLeft = castCall.getOperands().get(0);
+          switch (castLeft.getKind()) {
+            case ARRAY_VALUE_CONSTRUCTOR:
+              //array-type RexCall --> create a comparison of RexCall
+              if (nodePredicate.test(right)) {
+                return new Comparison(right, e.getKind().reverse(), (RexCall) castLeft);
+              }
+          }
+          break;
+        case ARRAY_VALUE_CONSTRUCTOR:
+          //array-type RexCall --> create a comparison of RexCall
+          if (nodePredicate.test(right)) {
+            return new Comparison(right, e.getKind().reverse(), (RexCall) left);
+          }
+          break;
         default:
           break;
         }
-        break;
+        break;    
       default:
         break;
       }


### PR DESCRIPTION
*Simplification seem to not take into account that the specified field is of array type. In other words，it can simplify "a = 1 AND a = 2" to "false"，but can not simplify “a = ARRAY[1,2] AND a = ARRAY[2,3]” to "false". This change can fix it.*
*Linked to https://issues.apache.org/jira/browse/FLINK-32188, when submitting an SQL task with Flink to test a customized data source connector, I specified to query an array-type field of a temporary table with a fixed-value array. For example, "select * from image-source where URL=ARRAY ['/flink. jpg', '/flink_1. jpg'] AND URL=ARRAY ['/f. jpg', '/f_1. jpg']" can obtain two predicate conditions, this is illogical. Generally speaking, simplifying this SQL condition should not result in any predicates. Changes related to “RexSimplify.java” can fix it.*