### PR TITLE
[CALCITE-5757] BigQuery DATE_TRUNC return type should be ARG0 and TIMESTAMP_TRUNC/DATETIME_TRUNC should return TIMESTAMP for DATE/TIMESTAMPs and TIMESTAMP_LTZ for TIMESTAMP_LTZ

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -2462,6 +2462,14 @@ FROM Dates;
 
 !ok
 
+# Show that the return type matches the operand type
+SELECT
+    DATE_TRUNC(TIMESTAMP "2008-12-25 15:30:00", MONTH) AS timestamp_result,
+    DATE_TRUNC(DATETIME "2008-12-25 15:30:00", MONTH) AS datetime_result;
+timestamp_result TIMESTAMP_WITH_LOCAL_TIME_ZONE NOT NULL
+datetime_result TIMESTAMP NOT NULL
+!type
+
 # In the following example, the original date falls on a
 # Sunday. Because the date_part is WEEK(MONDAY), DATE_TRUNC returns
 # the DATE for the preceding Monday.
@@ -2549,6 +2557,15 @@ SELECT
 (1 row)
 
 !ok
+
+# Show that the return type matches the operand type, unless it is a date
+# in which case a TIMESTAMP is returned.
+SELECT
+    DATETIME_TRUNC(TIMESTAMP "2008-12-25 15:30:00", MONTH) AS timestamp_result,
+    DATETIME_TRUNC(DATETIME "2008-12-25 15:30:00", MONTH) AS datetime_result;
+timestamp_result TIMESTAMP_WITH_LOCAL_TIME_ZONE NOT NULL
+datetime_result TIMESTAMP NOT NULL
+!type
 
 
 # In the following example, the original DATETIME falls on a
@@ -2678,6 +2695,15 @@ SELECT
 # that TIMESTAMP. While this provides intuitive results in most cases,
 # the result is non-intuitive near daylight savings transitions that
 # are not hour aligned.
+
+# Show that the return type matches the operand type, unless it is a date
+# in which case a TIMESTAMP is returned.
+SELECT
+    TIMESTAMP_TRUNC(TIMESTAMP "2008-12-25 15:30:00", MONTH) AS timestamp_result,
+    TIMESTAMP_TRUNC(DATETIME "2008-12-25 15:30:00", MONTH) AS datetime_result;
+timestamp_result TIMESTAMP_WITH_LOCAL_TIME_ZONE NOT NULL
+datetime_result TIMESTAMP NOT NULL
+!type
 
 # Display of results may differ, depending upon the environment and
 # time zone where this query was executed.

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1148,9 +1148,9 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction DATE_TRUNC =
       SqlBasicFunction.create("DATE_TRUNC",
-          ReturnTypes.DATE_NULLABLE,
+          ReturnTypes.ARG0_NULLABLE,
           OperandTypes.sequence("'DATE_TRUNC(<DATE>, <DATETIME_INTERVAL>)'",
-              OperandTypes.DATE, OperandTypes.dateInterval()),
+              OperandTypes.DATE_OR_TIMESTAMP, OperandTypes.dateInterval()),
           SqlFunctionCategory.TIMEDATE)
           .withOperandHandler(OperandHandlers.OPERAND_1_MIGHT_BE_TIME_FRAME);
 
@@ -1208,10 +1208,10 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction TIMESTAMP_TRUNC =
       SqlBasicFunction.create("TIMESTAMP_TRUNC",
-          ReturnTypes.TIMESTAMP_NULLABLE,
+          ReturnTypes.ARG0_EXCEPT_DATE_NULLABLE,
           OperandTypes.sequence(
               "'TIMESTAMP_TRUNC(<TIMESTAMP>, <DATETIME_INTERVAL>)'",
-              OperandTypes.TIMESTAMP, OperandTypes.timestampInterval()),
+              OperandTypes.DATE_OR_TIMESTAMP, OperandTypes.timestampInterval()),
           SqlFunctionCategory.TIMEDATE);
 
   /** The "DATETIME_TRUNC(timestamp, timeUnit)" function (BigQuery);
@@ -1222,10 +1222,10 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction DATETIME_TRUNC =
       SqlBasicFunction.create("DATETIME_TRUNC",
-          ReturnTypes.TIMESTAMP_NULLABLE,
+          ReturnTypes.ARG0_EXCEPT_DATE_NULLABLE,
           OperandTypes.sequence(
               "'DATETIME_TRUNC(<TIMESTAMP>, <DATETIME_INTERVAL>)'",
-              OperandTypes.TIMESTAMP, OperandTypes.timestampInterval()),
+              OperandTypes.DATE_OR_TIMESTAMP, OperandTypes.timestampInterval()),
           SqlFunctionCategory.TIMEDATE);
 
   /** The "TIMESTAMP_SECONDS(bigint)" function; returns a TIMESTAMP value

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -426,6 +426,9 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker TIMESTAMP =
       family(SqlTypeFamily.TIMESTAMP);
 
+  public static final SqlSingleOperandTypeChecker DATE_OR_TIMESTAMP =
+      DATE.or(TIMESTAMP);
+
   /** Type-checker that matches "TIMESTAMP WITH LOCAL TIME ZONE" but not other
    * members of the "TIMESTAMP" family (e.g. "TIMESTAMP"). */
   public static final SqlSingleOperandTypeChecker TIMESTAMP_LTZ =

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -303,6 +303,31 @@ public abstract class ReturnTypes {
       DATE.andThen(SqlTypeTransforms.TO_NULLABLE);
 
   /**
+   * Type-inference strategy that returns the type of the first operand,
+   * unless it is a DATE, in which case the return type is TIMESTAMP. Supports
+   * cases such as <a href="https://issues.apache.org/jira/browse/CALCITE-5757">[CALCITE-5757]
+   * Incorrect return type for BigQuery TRUNC functions </a>.
+   */
+  public static final SqlReturnTypeInference ARG0_EXCEPT_DATE = opBinding -> {
+    RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    SqlTypeName op = opBinding.getOperandType(0).getSqlTypeName();
+    switch (op) {
+    case DATE:
+      return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+    default:
+      return typeFactory.createSqlType(op);
+    }
+  };
+
+  /**
+   * Same as {@link #ARG0_EXCEPT_DATE} but returns with nullability if any of
+   * the operands is nullable by using
+   * {@link org.apache.calcite.sql.type.SqlTypeTransforms#TO_NULLABLE}.
+   */
+  public static final SqlReturnTypeInference ARG0_EXCEPT_DATE_NULLABLE =
+      ARG0_EXCEPT_DATE.andThen(SqlTypeTransforms.TO_NULLABLE);
+
+  /**
    * Type-inference strategy whereby the result type of a call is TIME(0).
    */
   public static final SqlReturnTypeInference TIME =

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -9534,6 +9534,14 @@ public class SqlOperatorTest {
         "2015-02-01 00:00:00", "TIMESTAMP(0) NOT NULL");
     f.checkScalar("timestamp_trunc(timestamp '2015-02-19 12:34:56', year)",
         "2015-01-01 00:00:00", "TIMESTAMP(0) NOT NULL");
+    // verify return type for dates
+    f.checkScalar("timestamp_trunc(date '2008-12-25', month)",
+        "2008-12-01 00:00:00", "TIMESTAMP(0) NOT NULL");
+    f.checkFails("^timestamp_trunc(time '15:30:00', hour)^",
+        "Cannot apply 'TIMESTAMP_TRUNC' to arguments of type "
+            + "'TIMESTAMP_TRUNC\\(<TIME\\(0\\)>, <INTERVAL HOUR>\\)'\\. "
+            + "Supported form\\(s\\): 'TIMESTAMP_TRUNC\\(<TIMESTAMP>, <DATETIME_INTERVAL>\\)'",
+        false);
   }
 
   @Test void testDatetimeTrunc() {
@@ -9572,6 +9580,14 @@ public class SqlOperatorTest {
         "2015-02-01 00:00:00", "TIMESTAMP(0) NOT NULL");
     f.checkScalar("datetime_trunc(timestamp '2015-02-19 12:34:56', year)",
         "2015-01-01 00:00:00", "TIMESTAMP(0) NOT NULL");
+    // verify return type for dates
+    f.checkScalar("datetime_trunc(date '2008-12-25', month)",
+        "2008-12-01 00:00:00", "TIMESTAMP(0) NOT NULL");
+    f.checkFails("^datetime_trunc(time '15:30:00', hour)^",
+        "Cannot apply 'DATETIME_TRUNC' to arguments of type "
+            + "'DATETIME_TRUNC\\(<TIME\\(0\\)>, <INTERVAL HOUR>\\)'\\. "
+            + "Supported form\\(s\\): 'DATETIME_TRUNC\\(<TIMESTAMP>, <DATETIME_INTERVAL>\\)'",
+        false);
   }
 
   @Test void testDateTrunc() {
@@ -9608,6 +9624,14 @@ public class SqlOperatorTest {
         "2015-01-01", "DATE NOT NULL");
     f.checkScalar("date_trunc(date '2015-02-19', isoyear)",
         "2014-12-29", "DATE NOT NULL");
+    // verifies return type for TIME & TIMESTAMP
+    f.checkScalar("date_trunc(timestamp '2008-12-25 15:30:00', month)",
+        "2008-12-01 00:00:00", "TIMESTAMP(0) NOT NULL");
+    f.checkFails("^date_trunc(time '15:30:00', hour)^",
+        "Cannot apply 'DATE_TRUNC' to arguments of type "
+            + "'DATE_TRUNC\\(<TIME\\(0\\)>, <INTERVAL HOUR>\\)'\\. "
+            + "Supported form\\(s\\): 'DATE_TRUNC\\(<DATE>, <DATETIME_INTERVAL>\\)'",
+        false);
   }
 
   @Test void testFormatTime() {


### PR DESCRIPTION
BigQuery TRUNC functions follow the return type behavior described in [CALCITE-5757](https://issues.apache.org/jira/browse/CALCITE-5757). This PR adjusts the return type for those functions such that it matches the described behavior. 

Notable changes include converting a `DATE` to a `TIMESTAMP` for the `TIMESTAMP_TRUNC` and `DATETIME_TRUNC` functions. It also ensures that `DATE_TRUNC` return type is equivalent to the operand type (aka `ReturnTypes.ARG0`). 

Prior to this PR, discrepancies included `DATETIME_TRUNC` incorrectly returning a `TIMESTAMP_LTZ` if given a `TIMESTAMP` argument and `DATE_TRUNC` having a `DATE` return type even if the argument was a `TIMESTAMP` or `TIMESTAMP_LTZ`.

@julianhyde I opted to just include the TRUNC functions in this PR to keep the review and scope fairly easy (hopefully).