### PR TITLE
[CALCITE-5767] No special treatment for GROUPING in MSSQL null direction emulation

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -91,16 +91,6 @@ public class MssqlSqlDialect extends SqlDialect {
       return null;
     }
 
-    // Null direction is technically irrelevant to GROUPING() since it never returns NULL,
-    // but adding a sort rex node with non-default null direction will later cause
-    // the insertion of a call to NULLS FIRST or NULLS LAST during SQL generation,
-    // which would *not* be expanded into a CASE statement by the logic below,
-    // causing a syntax error. Avoid this by always using the default null direction.
-    if (node.getKind() == SqlKind.GROUPING) {
-      // nullsFirst must be non-default since it failed the check above, so flip it.
-      nullsFirst = !nullsFirst;
-    }
-
     // Emulate nulls first/last with case ordering
     final SqlParserPos pos = SqlParserPos.ZERO;
     final SqlNodeList whenList =

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -3497,8 +3497,6 @@ public class RelBuilder {
     default:
       final int fieldIndex = extraNodes.size();
       extraNodes.add(node);
-      // direction.defaultNullDirection() is the NULLS-high default,
-      // which may cause unexpected behavior if used for a NULLS-low dialect.
       return new RelFieldCollation(fieldIndex, direction,
           Util.first(nullDirection, direction.defaultNullDirection()));
     }

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -3497,6 +3497,8 @@ public class RelBuilder {
     default:
       final int fieldIndex = extraNodes.size();
       extraNodes.add(node);
+      // direction.defaultNullDirection() is the NULLS-high default,
+      // which may cause unexpected behavior if used for a NULLS-low dialect.
       return new RelFieldCollation(fieldIndex, direction,
           Util.first(nullDirection, direction.defaultNullDirection()));
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7050,7 +7050,7 @@ class RelToSqlConverterTest {
     final String expectedMssql = "SELECT [product_class_id], [brand_name], GROUPING([brand_name])\n"
         + "FROM [foodmart].[product]\n"
         + "GROUP BY GROUPING SETS(([product_class_id], [brand_name]), [product_class_id])\n"
-        + "ORDER BY CASE WHEN GROUPING([brand_name]) IS NULL THEN 0 ELSE 1 END, 3,"
+        + "ORDER BY CASE WHEN GROUPING([brand_name]) IS NULL THEN 1 ELSE 0 END, 3,"
         + " CASE WHEN [brand_name] IS NULL THEN 1 ELSE 0 END, [brand_name],"
         + " CASE WHEN [product_class_id] IS NULL THEN 1 ELSE 0 END, [product_class_id]";
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7040,7 +7040,12 @@ class RelToSqlConverterTest {
         .withBigQuery().ok(expected);
   }
 
-  /** Test case for https://issues.apache.org/jira/browse/CALCITE-5767. */
+  /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5767">[CALCITE-5767]</a>.
+   *
+   * Calcite's MSSQL dialect should not give GROUPING special treatment when emulating NULL
+   * direction.
+   */
   @Test void testSortByGroupingInMssql() {
     final String query = "select \"product_class_id\", \"brand_name\", GROUPING(\"brand_name\")\n"
         + "from \"product\"\n"


### PR DESCRIPTION
This is a pretty weird problem, but this is the best solution I could muster for it. Ideally, we would use the proper default NULL direction in `RelBuilder` so that there is no constant `ORDER BY` expression, but then we would have to entangle `RelBuilder` with dialect-specific logic.