### PR TITLE
[CALCITE-5768] Fix early return in hasSortByOrdinal

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1898,12 +1898,14 @@ public abstract class SqlImplementor {
           return false;
         }
         for (SqlNode sqlNode : orderList) {
-          if (!(sqlNode instanceof SqlBasicCall)) {
-            return sqlNode instanceof SqlNumericLiteral;
+          if (sqlNode instanceof SqlNumericLiteral) {
+            return true;
           }
-          for (SqlNode operand : ((SqlBasicCall) sqlNode).getOperandList()) {
-            if (operand instanceof SqlNumericLiteral) {
-              return true;
+          if (sqlNode instanceof SqlBasicCall) {
+            for (SqlNode operand : ((SqlBasicCall) sqlNode).getOperandList()) {
+              if (operand instanceof SqlNumericLiteral) {
+                return true;
+              }
             }
           }
         }


### PR DESCRIPTION
The unit test pretty much sums it up. Without the logic fix, the resulting SQL would be this:

```
SELECT "JOB"
FROM "scott"."EMP"
GROUP BY "JOB"
ORDER BY "JOB", 2
```

which is of course wrong because it's ordering by `2` and there's only one expression in the `SELECT` list.