### PR TITLE
[CALCITE-5756] Expand ProjectJoinRemoveRule to support inner join remove by the foreign-unique constraint in the catalog

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptForeignKey.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptForeignKey.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.InferredRexTableInputRef;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * ForeignKey represents the foreign and unique key constraint relationship
+ * on the current {@link org.apache.calcite.rel.RelNode}.
+ *
+ * <p><b>constraints</b> field {@link #constraints} are
+ * constraints that foreign key and unique key relationships in bottom-up derivation.
+ *
+ * <p><b>foreignColumns</b> field {@link #foreignColumns} indicates the
+ * position of the foreign key on the current {@link org.apache.calcite.rel.RelNode}
+ * if not or not be confirmed, it is an empty set.
+ *
+ * <p><b>uniqueColumns</b> field {@link #uniqueColumns} indicates the position of
+ * the unique key on the current {@link org.apache.calcite.rel.RelNode},
+ * if not or not be confirmed, it is an empty set.
+ *
+ * <p>The element positions in {@code uniqueColumns} and {@code foreignColumns}
+ * correspond to each other. The order of elements in {@code uniqueColumns}
+ * and {@code foreignColumns} is consistent with the order of constraints in
+ * the constraints list.
+ *
+ * <p>For instance,
+ * <blockquote>
+ * <pre>select e.deptno, e.ename, d.deptno
+ * from emp as e
+ * inner join dept as d
+ * on e.deptno = d.deptno</pre></blockquote>
+ *
+ * <p>Invoke the {@link RelMetadataQuery#getConfirmedForeignKeys} method for
+ * the aforementioned {@link org.apache.calcite.rel.RelNode}, the following
+ * results can be obtained.
+ *
+ * <p>{@code constraints} is
+ * [{left: [CATALOG, SALES, EMP].$7 right: [CATALOG, SALES, DEPT].$0}]
+ * {@code foreignColumns} is {0}
+ * {@code uniqueColumns} is {2}
+ *
+ * @see org.apache.calcite.rex.InferredRexTableInputRef
+ * @see org.apache.calcite.plan.RelOptForeignKey
+ */
+public class RelOptForeignKey {
+
+  /** Foreign key and unique key relationships in bottom-up derivation. */
+  private final List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> constraints;
+  /** Position of the foreign key on the current {@link org.apache.calcite.rel.RelNode}. */
+  private final ImmutableBitSet foreignColumns;
+  /** Position of the unique key on the current {@link org.apache.calcite.rel.RelNode}. */
+  private final ImmutableBitSet uniqueColumns;
+
+  private RelOptForeignKey(
+      List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> constraints,
+      ImmutableBitSet foreignColumns,
+      ImmutableBitSet uniqueColumns) {
+    this.constraints = constraints;
+    this.foreignColumns = foreignColumns;
+    this.uniqueColumns = uniqueColumns;
+  }
+
+  public static RelOptForeignKey of(List<Pair<InferredRexTableInputRef,
+      InferredRexTableInputRef>> constraints,
+      ImmutableBitSet foreignColumns,
+      ImmutableBitSet uniqueColumns) {
+    return new RelOptForeignKey(constraints, foreignColumns, uniqueColumns);
+  }
+
+  public ImmutableBitSet getForeignColumns() {
+    return foreignColumns;
+  }
+
+  public ImmutableBitSet getUniqueColumns() {
+    return uniqueColumns;
+  }
+
+  public List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> getConstraints() {
+    return constraints;
+  }
+
+  /** Returns the left side of a list of constraints. */
+  public static List<InferredRexTableInputRef> constraintsLeft(
+      List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> constraints) {
+    if (constraints.isEmpty()) {
+      return new ArrayList<>();
+    }
+    return constraints.stream()
+        .map(Pair::getKey)
+        .collect(Collectors.toList());
+  }
+
+  /** Returns the right side of a list of constraints. */
+  public static List<InferredRexTableInputRef> constraintsRight(
+      List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> constraints) {
+    if (constraints.isEmpty()) {
+      return new ArrayList<>();
+    }
+    return constraints.stream()
+        .map(Pair::getValue)
+        .collect(Collectors.toList());
+  }
+
+  /** Permutes relOptForeignKey set according to given mappings.
+   *
+   * <p>Example as follows:
+   * Simplified representation as foreignColumns and uniqueColumns
+   *
+   * <p>current relOptForeignKey:
+   * foreignColumns: {1, 3}
+   * uniqueColumns: {4}
+   *
+   * <p>permute params:
+   * foreignMapping: {1: [2, 6], 3: [7]}
+   * uniqueMapping: {4: [5, 8]}
+   *
+   * <p>result:
+   * [
+   *   {
+   *     foreignColumns: {2, 7}
+   *     uniqueColumns: {5}
+   *   },
+   *   {
+   *     foreignColumns: {2, 7}
+   *     uniqueColumns: {8}
+   *   },
+   *   {
+   *     foreignColumns: {6, 7}
+   *     uniqueColumns: {5}
+   *   },
+   *   {
+   *     foreignColumns: {6, 7}
+   *     uniqueColumns: {8}
+   *   }
+   * ]
+   *
+   * @param foreignMapping foreignKey mapping relationship
+   * @param uniqueMapping uniqueKey mapping relationship
+   * @return mapped relOptForeignKey set
+   */
+  public Set<RelOptForeignKey> permute(Map<Integer, List<Integer>> foreignMapping,
+      Map<Integer, List<Integer>> uniqueMapping) {
+    if (foreignMapping.isEmpty() && uniqueMapping.isEmpty()) {
+      return Sets.newHashSet(this);
+    }
+    final List<ImmutableBitSet> mappedForeignColumns = new ArrayList<>();
+    if (!foreignMapping.isEmpty()
+        && foreignMapping.keySet().containsAll(this.foreignColumns.asSet())) {
+      flatMappings(this.foreignColumns.toList(), foreignMapping)
+          .forEach(each -> mappedForeignColumns.add(this.foreignColumns.permute(each)));
+    }
+    if (mappedForeignColumns.isEmpty()) {
+      mappedForeignColumns.add(this.foreignColumns);
+    }
+    final List<ImmutableBitSet> mappedUniqueColumns = new ArrayList<>();
+    if (!uniqueMapping.isEmpty()
+        && uniqueMapping.keySet().containsAll(this.uniqueColumns.asSet())) {
+      flatMappings(this.uniqueColumns.toList(), uniqueMapping)
+          .forEach(each -> mappedUniqueColumns.add(this.uniqueColumns.permute(each)));
+    }
+    if (mappedUniqueColumns.isEmpty()) {
+      mappedUniqueColumns.add(this.uniqueColumns);
+    }
+    return Lists.newArrayList(
+            Linq4j.product(
+                Lists.newArrayList(mappedForeignColumns, mappedUniqueColumns))).stream()
+        .map(pair -> copyWith(pair.get(0), pair.get(1)))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Flatten the mapping based on the sources, which mapping can be one-to-many.
+   *
+   * <p>Example as follows:
+   * sources: [1, 2]
+   * mapping: {1: [3, 4], 2: [5, 6]}
+   * result: [{1:3, 2:5}, {1:3, 2:6}, {1:4, 2:5}, {1:4, 2:6}]
+   *
+   * @param sources the sources which will be mapped
+   * @param mapping the field mapping relationship which can potentially be one-to-many
+   * @return mapped sources
+   */
+  private static Set<Map<Integer, Integer>> flatMappings(List<Integer> sources,
+      Map<Integer, List<Integer>> mapping) {
+    List<List<Integer>> sourceMappings = new ArrayList<>();
+    for (int source : sources) {
+      List<Integer> sourceMapping = mapping.get(source);
+      if (sourceMapping == null || sourceMapping.isEmpty()) {
+        return new HashSet<>();
+      }
+      sourceMappings.add(sourceMapping);
+    }
+    Set<Map<Integer, Integer>> sourceTargetMappings = new HashSet<>();
+    Iterable<List<Integer>> targetMappingProducts = Linq4j.product(sourceMappings);
+    for (List<Integer> target : targetMappingProducts) {
+      // build map, key -> sources, value -> mapped targets
+      Iterator<Integer> sourceIterator = sources.iterator();
+      Iterator<Integer> targetIterator = target.iterator();
+      Map<Integer, Integer> sourceTargetMapping = new HashMap<>();
+      while (sourceIterator.hasNext() && targetIterator.hasNext()) {
+        sourceTargetMapping.put(sourceIterator.next(), targetIterator.next());
+      }
+      sourceTargetMappings.add(sourceTargetMapping);
+    }
+    return sourceTargetMappings;
+  }
+
+  /** Returns relOptForeignKey with every bit moved up {@code offset} positions.
+   * Offset may be negative, but throws if any bit ends up negative.
+   * Can control the shift side.
+   * @see ShiftSide */
+  public RelOptForeignKey shift(int offset, ShiftSide... shiftSides) {
+    if (offset == 0) {
+      return this;
+    }
+    ImmutableBitSet shiftedForeignColumns = ImmutableBitSet.of(this.foreignColumns);
+    ImmutableBitSet shiftedUniqueColumns = ImmutableBitSet.of(this.uniqueColumns);
+    for (ShiftSide shiftSide : shiftSides) {
+      if (ShiftSide.INFERRED_FOREIGN_SOURCE == shiftSide
+          && isInferredForeignKey()) {
+        shiftedForeignColumns = shiftedForeignColumns.shift(offset);
+      }
+      if (ShiftSide.INFERRED_FOREIGN_TARGET == shiftSide
+          && isInferredForeignKey()) {
+        shiftedUniqueColumns = shiftedUniqueColumns.shift(offset);
+      }
+      if (ShiftSide.INFERRED_UNIQUE_SOURCE == shiftSide
+          && isInferredUniqueKey()) {
+        shiftedForeignColumns = shiftedForeignColumns.shift(offset);
+      }
+      if (ShiftSide.INFERRED_UNIQUE_TARGET == shiftSide
+          && isInferredUniqueKey()) {
+        shiftedUniqueColumns = shiftedUniqueColumns.shift(offset);
+      }
+    }
+    return copyWith(shiftedForeignColumns, shiftedUniqueColumns);
+  }
+
+  /**
+   * The current constraint relationships consist only of foreign keys.
+   * These constraints need to be propagated to the top of the
+   * {@link org.apache.calcite.rel.RelNode} in order to be merged and confirmed
+   * in higher-level {@link org.apache.calcite.rel.RelNode} in the future.
+   */
+  public boolean isInferredForeignKey() {
+    return this.constraints.stream()
+        .allMatch(constraint -> !constraint.left.isConfirmed()
+            && !constraint.right.isConfirmed()
+            && !constraint.left.isNull()
+            && !constraint.right.isNull());
+  }
+
+  /**
+   * The current constraint relationships consist only of unique keys.
+   * These constraints need to be propagated to the top of the
+   * {@link org.apache.calcite.rel.RelNode} in order to be merged and confirmed
+   * in higher-level {@link org.apache.calcite.rel.RelNode} in the future.
+   */
+  public boolean isInferredUniqueKey() {
+    return this.constraints.stream()
+        .allMatch(constraint -> !constraint.left.isConfirmed()
+            && !constraint.right.isConfirmed()
+            && constraint.left.isNull()
+            && !constraint.right.isNull());
+  }
+
+  /** The inferred foreign key and unique key relationships have been determined,
+   * which typically occurs after a join operation. */
+  public boolean isConfirmed() {
+    return this.constraints.stream()
+        .allMatch(constraint -> constraint.left.isConfirmed()
+            && constraint.right.isConfirmed()
+            && !constraint.left.isNull()
+            && !constraint.right.isNull());
+  }
+
+  /** Deep copy based on foreignColumns and uniqueColumns. */
+  public RelOptForeignKey copyWith(ImmutableBitSet foreignColumns,
+      ImmutableBitSet uniqueColumns) {
+    List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> copiedConstraints =
+        this.constraints.stream()
+            .map(constraint -> Pair.of(constraint.left.copy(), constraint.right.copy()))
+            .collect(Collectors.toList());
+    return RelOptForeignKey.of(copiedConstraints, foreignColumns, uniqueColumns);
+  }
+
+  @Override public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    RelOptForeignKey that = (RelOptForeignKey) obj;
+    return constraints.equals(that.constraints)
+        && uniqueColumns.equals(that.uniqueColumns)
+        && foreignColumns.equals(that.foreignColumns);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(constraints, uniqueColumns, foreignColumns);
+  }
+
+  /** Represents the target bit set to be shifted. */
+  public enum ShiftSide {
+    /**
+     * Shift constraint pair left when relOptForeignKey is inferred foreignKey.
+     *
+     * @see RelOptForeignKey#isInferredForeignKey()
+     */
+    INFERRED_FOREIGN_SOURCE,
+    /**
+     * Shift constraint pair right when relOptForeignKey is inferred foreignKey.
+     *
+     * @see RelOptForeignKey#isInferredForeignKey()
+     */
+    INFERRED_FOREIGN_TARGET,
+    /**
+     * Shift constraint pair left when relOptForeignKey is inferred uniqueKey.
+     *
+     * @see RelOptForeignKey#isInferredUniqueKey()
+     */
+    INFERRED_UNIQUE_SOURCE,
+    /**
+     * Shift constraint pair left when relOptForeignKey is inferred uniqueKey.
+     *
+     * @see RelOptForeignKey#isInferredUniqueKey()
+     */
+    INFERRED_UNIQUE_TARGET
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptForeignKey;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
@@ -100,6 +101,43 @@ public abstract class BuiltInMetadata {
           boolean ignoreNulls);
 
       @Override default MetadataDef<UniqueKeys> getDef() {
+        return DEF;
+      }
+    }
+  }
+
+  /**
+   * Metadata about which columns have foreign keys.
+   */
+  public interface ForeignKeys extends Metadata {
+    MetadataDef<ForeignKeys> DEF =
+        MetadataDef.of(ForeignKeys.class, ForeignKeys.Handler.class,
+            BuiltInMethod.FOREIGN_KEYS.method);
+
+    /**
+     * Extract foreign keys from {@link org.apache.calcite.rel.RelNode}.
+     * Foreign keys are represented as an {@link org.apache.calcite.util.ImmutableBitSet},
+     * where each bit position represents a 0-based output column ordinal.
+     *
+     * @param ignoreNulls if true, allow containing null values when determining
+     *                     whether the keys are foreign keys
+     *
+     * @return bit set of foreign keys, or empty if not enough information is
+     * available to make that determination
+     */
+    Set<RelOptForeignKey> getForeignKeys(boolean ignoreNulls);
+
+    /**
+     * Handler API.
+     */
+    @FunctionalInterface
+    interface Handler extends MetadataHandler<ForeignKeys> {
+      Set<RelOptForeignKey> getForeignKeys(
+          RelNode rel,
+          RelMetadataQuery mq,
+          boolean ignoreNulls);
+
+      @Override default MetadataDef<ForeignKeys> getDef() {
         return DEF;
       }
     }
@@ -837,6 +875,6 @@ public abstract class BuiltInMetadata {
   interface All extends Selectivity, UniqueKeys, RowCount, DistinctRowCount,
       PercentageOriginalRows, ColumnUniqueness, ColumnOrigin, Predicates,
       Collation, Distribution, Size, Parallelism, Memory, AllPredicates,
-      ExpressionLineage, TableReferences, NodeTypes {
+      ExpressionLineage, TableReferences, NodeTypes, ForeignKeys {
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/DefaultRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/DefaultRelMetadataProvider.java
@@ -62,6 +62,7 @@ public class DefaultRelMetadataProvider extends ChainedRelMetadataProvider {
             RelMdExplainVisibility.SOURCE,
             RelMdPredicates.SOURCE,
             RelMdAllPredicates.SOURCE,
-            RelMdCollation.SOURCE));
+            RelMdCollation.SOURCE,
+            RelMdForeignKeys.SOURCE));
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdForeignKeys.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdForeignKeys.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.plan.RelOptForeignKey;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelReferentialConstraint;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rel.core.Correlate;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.TableModify;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.InferredRexTableInputRef;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.apache.calcite.util.mapping.IntPair;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * RelMdForeignKeys supplies a default implementation of
+ * {@link RelMetadataQuery#getForeignKeys} for the standard logical algebra.
+ * The relNodes supported are same to {@link RelMetadataQuery#getUniqueKeys(RelNode)}
+ */
+public class RelMdForeignKeys
+    implements MetadataHandler<BuiltInMetadata.ForeignKeys> {
+  protected static final Set<RelOptForeignKey> EMPTY_BIT_SET = new HashSet<>();
+  public static final RelMetadataProvider SOURCE =
+      ReflectiveRelMetadataProvider.reflectiveSource(
+          new RelMdForeignKeys(), BuiltInMetadata.ForeignKeys.Handler.class);
+
+//~ Constructors -----------------------------------------------------------
+
+  private RelMdForeignKeys() {}
+
+//~ Methods ----------------------------------------------------------------
+
+  @Override public MetadataDef<BuiltInMetadata.ForeignKeys> getDef() {
+    return BuiltInMetadata.ForeignKeys.DEF;
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Filter rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getInput(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Sort rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getInput(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Correlate rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getLeft(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(TableModify rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getInput(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Join rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    final RelNode left = rel.getLeft();
+    final RelNode right = rel.getRight();
+    if (!rel.getJoinType().projectsRight()) {
+      // only return the foreign keys from the LHS since a semi or anti join only
+      // returns the LHS
+      return mq.getForeignKeys(left, ignoreNulls);
+    }
+    int nLeftColumns = rel.getLeft().getRowType().getFieldList().size();
+    final Set<RelOptForeignKey> foreignKeys = new HashSet<>();
+    final Set<RelOptForeignKey> leftInputForeignKeys =
+        mq.getForeignKeys(left, ignoreNulls);
+    final Set<RelOptForeignKey> rightInputForeignKeys =
+        mq.getForeignKeys(right, ignoreNulls);
+
+    if (leftInputForeignKeys.isEmpty() && rightInputForeignKeys.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    // shift right index
+    Set<RelOptForeignKey> shiftedRightInputForeignKeys = rightInputForeignKeys.stream()
+        .map(
+            foreignKey -> foreignKey.shift(nLeftColumns,
+            RelOptForeignKey.ShiftSide.INFERRED_FOREIGN_SOURCE,
+            RelOptForeignKey.ShiftSide.INFERRED_UNIQUE_TARGET))
+        .collect(Collectors.toSet());
+    if (!rel.getJoinType().generatesNullsOnLeft() || ignoreNulls) {
+      foreignKeys.addAll(
+          tryMerge(leftInputForeignKeys, shiftedRightInputForeignKeys));
+    }
+    if (!rel.getJoinType().generatesNullsOnRight() || ignoreNulls) {
+      foreignKeys.addAll(
+          tryMerge(shiftedRightInputForeignKeys, leftInputForeignKeys));
+    }
+    return foreignKeys;
+  }
+
+  private Set<RelOptForeignKey> tryMerge(Set<RelOptForeignKey> foreignKeys,
+      Set<RelOptForeignKey> uniqueKeys) {
+    ImmutableMap.Builder<Set<InferredRexTableInputRef>, RelOptForeignKey>
+        inferredUniqueKeyMapBuilder = ImmutableMap.builder();
+    // The upper-level relational algebra may use constraints,
+    // so keep the unmerged foreign keys
+    final Set<RelOptForeignKey> mixedForeignKeys = new HashSet<>(foreignKeys);
+    mixedForeignKeys.addAll(uniqueKeys);
+    if (foreignKeys.isEmpty() || uniqueKeys.isEmpty()) {
+      return mixedForeignKeys;
+    }
+    // Build unique keys map, key -> unique table set, value -> unique relOptForeignKey
+    for (RelOptForeignKey uniqueKey : uniqueKeys) {
+      if (!uniqueKey.getConstraints().isEmpty()
+          && uniqueKey.isInferredUniqueKey()) {
+        inferredUniqueKeyMapBuilder.put(
+            Sets.newHashSet(RelOptForeignKey.constraintsRight(uniqueKey.getConstraints())),
+            uniqueKey);
+      }
+    }
+    ImmutableMap<Set<InferredRexTableInputRef>, RelOptForeignKey> inferredUniqueKeyMap =
+        inferredUniqueKeyMapBuilder.build();
+    for (RelOptForeignKey foreignKey : foreignKeys) {
+      if (foreignKey.getConstraints().isEmpty()
+          || !foreignKey.isInferredForeignKey()) {
+        continue;
+      }
+      // try merge
+      Set<InferredRexTableInputRef> foreignSideNeededUniqueSet =
+          Sets.newHashSet(RelOptForeignKey.constraintsRight(foreignKey.getConstraints()));
+      RelOptForeignKey inferredUniqueKey =
+          inferredUniqueKeyMap.get(foreignSideNeededUniqueSet);
+      if (inferredUniqueKey != null) {
+        mixedForeignKeys.add(
+            RelOptForeignKey.of(
+                foreignKey.getConstraints().stream()
+                    .map(
+                        constraint -> Pair.of(
+                        constraint.left.copy(true),
+                        constraint.right.copy(true)))
+                    .collect(Collectors.toList()),
+                ImmutableBitSet.of(foreignKey.getForeignColumns()),
+                ImmutableBitSet.of(inferredUniqueKey.getUniqueColumns())));
+      }
+    }
+    return mixedForeignKeys;
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Aggregate rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    final ImmutableBitSet groupSet = rel.getGroupSet();
+    if (groupSet.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    final Set<RelOptForeignKey> inputForeignKeys =
+        mq.getForeignKeys(rel.getInput(), ignoreNulls);
+    return inputForeignKeys.stream()
+        .filter(foreignKey -> filterValidateColumns(groupSet, foreignKey))
+        .collect(Collectors.toSet());
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Project rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return getProjectForeignKeys(rel, mq, ignoreNulls, rel.getProjects());
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Calc rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    RexProgram program = rel.getProgram();
+    return getProjectForeignKeys(rel, mq, ignoreNulls,
+        Util.transform(program.getProjectList(), program::expandLocalRef));
+  }
+
+  private static Set<RelOptForeignKey> getProjectForeignKeys(SingleRel rel,
+      RelMetadataQuery mq,
+      boolean ignoreNulls,
+      List<RexNode> projExprs) {
+
+    // Single input can be mapped to multiple outputs
+    final ImmutableListMultimap.Builder<Integer, Integer> inToOutIndexBuilder =
+        ImmutableListMultimap.builder();
+    final ImmutableBitSet.Builder inColumnsBuilder = ImmutableBitSet.builder();
+    for (int i = 0; i < projExprs.size(); i++) {
+      RexNode projExpr = projExprs.get(i);
+      if (projExpr instanceof RexInputRef) {
+        int inputIndex = ((RexInputRef) projExpr).getIndex();
+        inToOutIndexBuilder.put(inputIndex, i);
+        inColumnsBuilder.set(inputIndex);
+      }
+    }
+    final ImmutableBitSet inColumnsUsed = inColumnsBuilder.build();
+    if (inColumnsUsed.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    final Map<Integer, List<Integer>> mapInToOutPos =
+        Maps.transformValues(inToOutIndexBuilder.build().asMap(), Lists::newArrayList);
+    final Set<RelOptForeignKey> inputForeignKeys =
+        mq.getForeignKeys(rel.getInput(), ignoreNulls);
+    if (inputForeignKeys.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    return inputForeignKeys.stream()
+        .filter(foreignKey -> filterValidateColumns(inColumnsUsed, foreignKey))
+        .flatMap(foreignKey -> foreignKey.permute(mapInToOutPos, mapInToOutPos).stream())
+        .collect(Collectors.toSet());
+  }
+
+  private static boolean filterValidateColumns(ImmutableBitSet columnsUsed,
+      RelOptForeignKey foreignKey) {
+    return (!foreignKey.getForeignColumns().isEmpty()
+        && columnsUsed.contains(foreignKey.getForeignColumns()))
+        || (!foreignKey.getUniqueColumns().isEmpty()
+        && columnsUsed.contains(foreignKey.getUniqueColumns()));
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(TableScan rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    final RelOptTable table = rel.getTable();
+    final BuiltInMetadata.ForeignKeys.Handler handler =
+        table.unwrap(BuiltInMetadata.ForeignKeys.Handler.class);
+    if (handler != null) {
+      return handler.getForeignKeys(rel, mq, ignoreNulls);
+    }
+
+    final List<RelReferentialConstraint> referentialConstraints =
+        table.getReferentialConstraints();
+    final List<ImmutableBitSet> keys = table.getKeys();
+
+    final Set<RelOptForeignKey> foreignKeys = new HashSet<>();
+    if (referentialConstraints != null) {
+      foreignKeys.addAll(referentialConstraints.stream()
+          .map(constraint -> {
+            List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> constraints =
+                constraint.getColumnPairs().stream()
+                    .map(
+                        intPair -> Pair.of(
+                        InferredRexTableInputRef.of(constraint.getSourceQualifiedName(),
+                            intPair.source,
+                            false),
+                        InferredRexTableInputRef.of(constraint.getTargetQualifiedName(),
+                            intPair.target,
+                            false)))
+                    .collect(Collectors.toList());
+            return RelOptForeignKey.of(constraints,
+                ImmutableBitSet.of(IntPair.left(constraint.getColumnPairs())),
+                ImmutableBitSet.of());
+          })
+          .collect(Collectors.toSet()));
+    }
+    if (keys != null) {
+      foreignKeys.addAll(
+          keys.stream()
+              .map(keyBitSet -> {
+                List<Pair<InferredRexTableInputRef, InferredRexTableInputRef>> constraints =
+                    keyBitSet.asList().stream()
+                        .map(
+                            index -> Pair.of(
+                            InferredRexTableInputRef.of(),
+                            InferredRexTableInputRef.of(
+                                table.getQualifiedName(),
+                                index,
+                                false)))
+                        .collect(Collectors.toList());
+                return RelOptForeignKey.of(constraints, ImmutableBitSet.of(), keyBitSet);
+              })
+              .collect(Collectors.toList()));
+    }
+    if (!ignoreNulls) {
+      final List<RelDataTypeField> fieldList = rel.getRowType().getFieldList();
+      return foreignKeys.stream()
+          .filter(foreignKey -> foreignKey.getForeignColumns().asSet().stream()
+              .noneMatch(index -> fieldList.get(index).getType().isNullable())
+              && foreignKey.getUniqueColumns().asSet().stream()
+              .noneMatch(index -> fieldList.get(index).getType().isNullable()))
+          .collect(Collectors.toSet());
+    }
+    return foreignKeys;
+  }
+
+  /**
+   * The foreign keys of SetOp are precisely the intersection of its every
+   * input foreign keys.
+   */
+  public Set<RelOptForeignKey> getForeignKeys(SetOp rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+
+    Set<RelOptForeignKey> foreignKeys = new HashSet<>();
+    for (RelNode input : rel.getInputs()) {
+      Set<RelOptForeignKey> inputForeignKeys = mq.getForeignKeys(input, ignoreNulls);
+      if (inputForeignKeys.isEmpty()) {
+        return EMPTY_BIT_SET;
+      }
+      foreignKeys = foreignKeys.isEmpty()
+          ? inputForeignKeys : Sets.intersection(foreignKeys, inputForeignKeys);
+    }
+    return foreignKeys;
+  }
+
+  /** Catch-all rule when none of the others apply. */
+  public Set<RelOptForeignKey> getForeignKeys(RelNode rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    // no information available
+    return EMPTY_BIT_SET;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rex/InferredRexTableInputRef.java
+++ b/core/src/main/java/org/apache/calcite/rex/InferredRexTableInputRef.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rex;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The inferred foreign key and unique key relationships.
+ * Within the same level of {@link org.apache.calcite.rel.RelNode},
+ * confirmed field is marked as ture when they are confirmed to be
+ * foreign key and unique key relationships.
+ * The propagation and confirmation are performed from bottom to top.
+ *
+ * @see org.apache.calcite.plan.RelOptForeignKey
+ */
+public class InferredRexTableInputRef {
+
+  private final @Nullable List<String> qualifiedName;
+  private final @Nullable Integer index;
+  private final boolean confirmed;
+  private final String digest;
+
+  private InferredRexTableInputRef(@Nullable List<String> qualifiedName,
+      @Nullable Integer index,
+      boolean confirmed) {
+    this.qualifiedName = qualifiedName;
+    this.index = index;
+    this.confirmed = confirmed;
+    this.digest = qualifiedName + ".$" + index;
+  }
+
+  public @Nullable List<String> getQualifiedName() {
+    return this.qualifiedName;
+  }
+
+  public @Nullable Integer getIndex() {
+    return this.index;
+  }
+
+  public boolean isConfirmed() {
+    return confirmed;
+  }
+
+  public static InferredRexTableInputRef of() {
+    return new InferredRexTableInputRef(null, null, false);
+  }
+
+  public static InferredRexTableInputRef of(@Nullable List<String> tableName,
+      @Nullable Integer index, boolean confirmed) {
+    return new InferredRexTableInputRef(tableName, index, confirmed);
+  }
+
+  public boolean isNull() {
+    return qualifiedName == null && index == null;
+  }
+
+  public InferredRexTableInputRef copy(boolean confirmed) {
+    return InferredRexTableInputRef.of(
+        this.qualifiedName == null ? null : new ArrayList<>(this.qualifiedName),
+        this.index,
+        confirmed);
+  }
+
+  public InferredRexTableInputRef copy() {
+    return InferredRexTableInputRef.of(
+        this.qualifiedName == null ? null : new ArrayList<>(qualifiedName),
+        this.index,
+        this.confirmed);
+  }
+
+  @Override public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    InferredRexTableInputRef that = (InferredRexTableInputRef) obj;
+    return Objects.equals(qualifiedName, that.qualifiedName) && Objects.equals(index, that.index);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(digest);
+  }
+
+  @Override public String toString() {
+    return digest;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -62,6 +62,7 @@ import org.apache.calcite.rel.metadata.BuiltInMetadata.DistinctRowCount;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.Distribution;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.ExplainVisibility;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.ExpressionLineage;
+import org.apache.calcite.rel.metadata.BuiltInMetadata.ForeignKeys;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCost;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.MaxRowCount;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.Memory;
@@ -645,6 +646,7 @@ public enum BuiltInMethod {
   MAP_VALUES(SqlFunctions.class, "mapValues", Map.class),
   SELECTIVITY(Selectivity.class, "getSelectivity", RexNode.class),
   UNIQUE_KEYS(UniqueKeys.class, "getUniqueKeys", boolean.class),
+  FOREIGN_KEYS(ForeignKeys.class, "getForeignKeys", boolean.class),
   AVERAGE_ROW_SIZE(Size.class, "averageRowSize"),
   AVERAGE_COLUMN_SIZES(Size.class, "averageColumnSizes"),
   IS_PHASE_TRANSITION(Parallelism.class, "isPhaseTransition"),

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -22,6 +22,7 @@ import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptForeignKey;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptTable;
@@ -82,6 +83,7 @@ import org.apache.calcite.rel.metadata.UnboundMetadata;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.InferredRexTableInputRef;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;
@@ -105,11 +107,13 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
@@ -181,6 +185,14 @@ public class RelMetadataTest {
 
   private static final List<String> EMP_QNAME =
       ImmutableList.of("CATALOG", "SALES", "EMP");
+
+  private static final List<String> EMPNULLABLES_QNAME =
+      ImmutableList.of("CATALOG", "SALES", "EMPNULLABLES");
+
+  private static final List<String> DEPT_QNAME =
+      ImmutableList.of("CATALOG", "SALES", "DEPT");
+
+  private static final Set<RelOptForeignKey> EMPTY_FOREIGN_KEY_SET = new HashSet<>();
 
   /** Ensures that tests that use a lot of memory do not run at the same
    * time. */
@@ -271,6 +283,979 @@ public class RelMetadataTest {
         .assertPercentageOriginalRows(
             isAlmost(((EMP_SIZE * DEFAULT_EQUAL_SELECTIVITY) + DEPT_SIZE)
                 / (DEPT_SIZE + EMP_SIZE)));
+  }
+
+  // ----------------------------------------------------------------------
+  // Tests for getForeignKeys
+  // ----------------------------------------------------------------------
+
+  @Test void testForeignKeysAggregateEmpty() {
+    sql("select hiredate, sum(sal), count(deptno) from emp group by hiredate")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsAggregateEmpty() {
+    sql("select hiredate, sum(sal), count(deptno) from empnullables group by hiredate")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysAggregateKey() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select count(sal), deptno, count(deptno) from emp group by deptno")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsAggregateKey() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select count(sal), deptno, count(deptno) from empnullables group by deptno")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysTableOnly() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(EMP_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(0)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(3),
+                ImmutableBitSet.of()));
+    sql("select empno, deptno, ename, deptno from emp")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsTableOnly() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(0),
+                ImmutableBitSet.of()));
+    sql("select deptno, ename from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysTableOnlyEmpty() {
+    sql("select ename, job from emp")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsTableOnlyEmpty() {
+    sql("select ename, job from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysExpressionEmpty() {
+    sql("select deptno + 1, ename from emp")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsExpressionEmpty() {
+    sql("select deptno + 1, ename from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysFilter() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(0),
+                ImmutableBitSet.of()));
+    sql("select deptno, ename from emp where ename = 'lucy' and deptno = 1001")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsFilter() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(0),
+                ImmutableBitSet.of()));
+    sql("select deptno, ename from empnullables where ename = 'lucy' and deptno = 1001")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysFilterEmpty() {
+    sql("select ename from emp where deptno = 1001")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsFilterEmpty() {
+    sql("select ename from empnullables where deptno = 1001")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysInnerJoinLeft() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(0),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(2),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(0),
+                bitSetOf(3)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(2),
+                bitSetOf(3)));
+    foreignKeys.addAll(confirmedForeignKeys);
+    sql("select emp.deptno, dept.name, emp.deptno, dept.deptno from emp, dept")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(confirmedForeignKeys))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeys), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysIgnoreNullsInnerJoinLeft() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(0),
+                bitSetOf(3)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(2),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> foreignKeysIgnoreNulls =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(0),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(2),
+                ImmutableBitSet.of()));
+    foreignKeysIgnoreNulls.addAll(confirmedForeignKeys);
+    foreignKeysIgnoreNulls.addAll(foreignKeys);
+    sql("select empnullables.deptno, dept.name, empnullables.deptno, dept.deptno "
+        + "from empnullables, dept")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNulls), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysInnerJoinRight() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(2),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(3)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(2),
+                bitSetOf(3)));
+    foreignKeys.addAll(confirmedForeignKeys);
+    sql("select dept.name, emp.deptno, emp.deptno, dept.deptno from dept, emp")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(confirmedForeignKeys))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysIgnoreNullsInnerJoinRight() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(2)));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(2)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(3),
+                bitSetOf(2)));
+    Set<RelOptForeignKey> foreignKeysIgnoreNull =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(3),
+                ImmutableBitSet.of()));
+    foreignKeysIgnoreNull.addAll(confirmedForeignKeys);
+    foreignKeysIgnoreNull.addAll(foreignKeys);
+    sql("select dept.name, empnullables.deptno, dept.deptno, empnullables.deptno "
+        + "from dept, empnullables")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNull), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysLeftOuterJoin() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(3)));
+    foreignKeys.addAll(confirmedForeignKeys);
+    sql("select name as dname, emp.deptno, dept.name, dept.deptno "
+        + "from emp left outer join dept "
+        + "on emp.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(confirmedForeignKeys))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeys), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysIgnoreNullsLeftOuterJoin() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(1)));
+    Set<RelOptForeignKey> foreignKeysIgnoreNull =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(1)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(2),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeysIgnoreNull =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(2),
+                bitSetOf(1)));
+    foreignKeysIgnoreNull.addAll(confirmedForeignKeysIgnoreNull);
+    foreignKeysIgnoreNull.addAll(foreignKeys);
+    sql("select name as dname, dept.deptno, empnullables.deptno, dept.name "
+        + "from empnullables left outer join dept "
+        + "on empnullables.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNull), equalTo(confirmedForeignKeysIgnoreNull));
+  }
+
+  @Test void testForeignKeysRightOuterJoin() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(0)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(2),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(4),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(2),
+                bitSetOf(0)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(4),
+                bitSetOf(0)));
+    foreignKeys.addAll(confirmedForeignKeys);
+    sql("select dept.deptno, name as dname, emp.deptno, dept.name, emp.deptno "
+        + "from dept right outer join emp "
+        + "on emp.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(confirmedForeignKeys))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysIgnoreNullsRightOuterJoin() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(4)));
+    Set<RelOptForeignKey> foreignKeysIgnoreNulls =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(3),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(4)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(3),
+                bitSetOf(4)));
+    foreignKeysIgnoreNulls.addAll(foreignKeys);
+    foreignKeysIgnoreNulls.addAll(confirmedForeignKeys);
+    sql("select name as dname, empnullables.deptno, dept.name, "
+        + "empnullables.deptno, dept.deptno "
+        + "from dept right outer join empnullables "
+        + "on empnullables.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNulls), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysOuterJoinEmpty() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> foreignKeysIgnoreNull = Sets.newHashSet(foreignKeys);
+    foreignKeysIgnoreNull.addAll(confirmedForeignKeys);
+    sql("select name as dname, emp.deptno, dept.name, dept.deptno "
+        + "from dept left outer join emp "
+        + "on emp.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNull), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysIgnoreNullsOuterJoinEmpty() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> foreignKeysIgnoreNulls =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    foreignKeysIgnoreNulls.addAll(foreignKeys);
+    foreignKeysIgnoreNulls.addAll(confirmedForeignKeys);
+    sql("select name as dname, empnullables.deptno, dept.name, dept.deptno "
+        + "from dept left outer join empnullables "
+        + "on empnullables.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNulls), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysFullOuterJoinEmpty() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(2)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(2)));
+    foreignKeys.addAll(confirmedForeignKeys);
+    sql("select name as dname, emp.deptno, dept.deptno from emp full outer join dept"
+        + " on emp.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysIgnoreNullsFullOuterJoinEmpty() {
+    Set<RelOptForeignKey> foreignKeysIgnoreNulls =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(2)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                bitSetOf(2)));
+    foreignKeysIgnoreNulls.addAll(confirmedForeignKeys);
+    sql("select name as dname, empnullables.deptno, dept.deptno "
+        + "from empnullables full outer join dept "
+        + "on empnullables.deptno = dept.deptno")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNulls), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysJoinAggregateFilter() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)),
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                ImmutableBitSet.of(3)));
+    foreignKeys.addAll(confirmedForeignKeys);
+    sql("select dept.name, emp_agg.deptno, emp_agg.ename, dept.deptno "
+        + "from dept "
+        + "right join "
+        + "(select count(sal), deptno, ename from emp group by deptno, ename) emp_agg "
+        + "on dept.deptno = emp_agg.deptno "
+        + "where emp_agg.ename = 'job'")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(confirmedForeignKeys))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysIgnoreNullsJoinAggregateFilter() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(3)));
+    Set<RelOptForeignKey> foreignKeysIgnoreNulls =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    foreignKeysIgnoreNulls.addAll(foreignKeys);
+    Set<RelOptForeignKey> confirmedForeignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, true),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, true))),
+                bitSetOf(1),
+                ImmutableBitSet.of(3)));
+    foreignKeysIgnoreNulls.addAll(confirmedForeignKeys);
+    sql("select dept.name, emp_agg.deptno, emp_agg.ename, dept.deptno "
+        + "from dept "
+        + "right join "
+        + "(select count(sal), deptno, ename from empnullables group by deptno, ename) emp_agg "
+        + "on dept.deptno = emp_agg.deptno "
+        + "where emp_agg.ename = 'job'")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(foreignKeysIgnoreNulls), equalTo(confirmedForeignKeys));
+  }
+
+  @Test void testForeignKeysValuesEmpty() {
+    sql("values(1,2,3)")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysUnionAllEmpty() {
+    sql("select name, deptno from dept union all select ename, deptno from emp")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsUnionAllEmpty() {
+    sql("select name, deptno from dept union all select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysSelfUnionAll() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from emp union all select ename, deptno from emp")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreSelfUnionAll() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from empnullables union all select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysUnionEmpty() {
+    sql("select name, deptno from dept union select ename, deptno from emp")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsUnionEmpty() {
+    sql("select name, deptno from dept union select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysSelfUnion() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from emp union select ename, deptno from emp")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsSelfUnion() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from empnullables union select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysMinus() {
+    sql("select ename, deptno from emp except all select name, deptno from dept")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsMinus() {
+    sql("select ename, deptno from empnullables except all select name, deptno from dept")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysSelfMinus() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from emp except all select ename, deptno from emp")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsSelfMinus() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from empnullables except all select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysMinusEmpty() {
+    sql("select name, deptno from dept except all select ename, deptno from emp")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsMinusEmpty() {
+    sql("select name, deptno from dept except all select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIntersect() {
+    sql("select name, deptno from dept intersect all select ename, deptno from emp")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsIntersect() {
+    sql("select name, deptno from dept intersect all select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysSelfIntersect() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMP_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from emp intersect all select ename, deptno from emp")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysIgnoreNullsSelfIntersect() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(EMPNULLABLES_QNAME, 7, false),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                bitSetOf(1),
+                ImmutableBitSet.of()));
+    sql("select ename, deptno from emp intersect all select ename, deptno from empnullables")
+        .assertForeignKeys(equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(
+            equalTo(EMPTY_FOREIGN_KEY_SET), equalTo(EMPTY_FOREIGN_KEY_SET));
+  }
+
+  @Test void testForeignKeysSelfIntersectEmpty() {
+    Set<RelOptForeignKey> foreignKeys =
+        Sets.newHashSet(
+            RelOptForeignKey.of(
+                Lists.newArrayList(
+                    Pair.of(
+                        InferredRexTableInputRef.of(),
+                        InferredRexTableInputRef.of(DEPT_QNAME, 0, false))),
+                ImmutableBitSet.of(),
+                bitSetOf(1)));
+    sql("select name, deptno from dept intersect all select name, deptno from dept")
+        .assertForeignKeys(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET))
+        .assertForeignKeysIgnoreNulls(equalTo(foreignKeys), equalTo(EMPTY_FOREIGN_KEY_SET));
   }
 
   // ----------------------------------------------------------------------

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -6019,6 +6019,280 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Similar to {@link #testProjectJoinRemove4()};
+   * Should remove the right join since the join key is referential constraints
+   * and the right is unique. */
+  @Test void testProjectJoinRemove11() {
+    final String sql = "SELECT e.deptno\n"
+        + "FROM sales.emp e\n"
+        + "INNER JOIN sales.dept d ON e.deptno = d.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should not remove the right join since the join key is
+   * not referential constraints. */
+  @Test void testProjectJoinRemove12() {
+    final String sql = "SELECT e1.deptno\n"
+        + "FROM sales.emp e1\n"
+        + "INNER JOIN sales.emp e2 ON e1.deptno = e2.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should not remove the right join since the project use columns in the right
+   * input of the join. */
+  @Test void testProjectJoinRemove13() {
+    final String sql = "SELECT e.deptno, d.name\n"
+        + "FROM sales.emp e\n"
+        + "INNER JOIN sales.dept d ON e.deptno = d.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * The project references the last column of the left input.
+   * The rule should be fired and remove right.*/
+  @Test void testProjectJoinRemove14() {
+    final String sql = "SELECT e.deptno, e.slacker\n"
+        + "FROM sales.emp e\n"
+        + "INNER JOIN sales.dept d ON e.deptno = d.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Similar to {@link #testProjectJoinRemove11()};
+   * Should remove the left join since the join key of the left input is
+   * unique and the join key of the right input is foreign key, only use the right. */
+  @Test void testProjectJoinRemove15() {
+    final String sql = "SELECT e.slacker\n"
+        + "FROM sales.dept d\n"
+        + "INNER JOIN sales.emp e ON d.deptno = e.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Similar to {@link #testProjectJoinRemove15()};
+   * Should not remove the left join, even if the join key of the left input is
+   * unique and the join key of the right input is foreign key, but foreign key is nullable. */
+  @Test void testProjectJoinRemove16() {
+    final String sql = "SELECT e.slacker\n"
+        + "FROM sales.dept d\n"
+        + "INNER JOIN sales.empnullables e ON d.deptno = e.deptno";
+    sql(sql).withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should remove the left join, since the join key of the left input is
+   * unique and the join key of the right input is foreign key, only use the right. */
+  @Test void testProjectJoinRemove17() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM sales.dept d "
+        + "INNER JOIN "
+        + "   (SELECT ename, deptno, count(job)"
+        + "   FROM sales.emp"
+        + "   WHERE ename IN ('lucy', 'lily')"
+        + "   GROUP BY ename, deptno) e "
+        + "ON d.deptno = e.deptno "
+        + "WHERE e.deptno = 'd001'";
+    sql(sql)
+        .withPreRule(CoreRules.FILTER_INTO_JOIN)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should remove the right join, since the join key of the right input is
+   * unique and the join key of the left input is foreign key, only use the left. */
+  @Test void testProjectJoinRemove18() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT ename, deptno, count(job) "
+        + "   FROM sales.emp "
+        + "   WHERE ename IN ('lucy', 'lily') "
+        + "   GROUP BY ename, deptno) e "
+        + "INNER JOIN "
+        + "   (SELECT deptno, name "
+        + "   FROM sales.dept "
+        + "   WHERE deptno NOT IN (10003)) d "
+        + "ON d.deptno = e.deptno "
+        + "WHERE d.deptno IN (10001, 10002) and e.ename IN ('transportation', 'architecture')";
+    sql(sql)
+        .withPreRule(CoreRules.FILTER_INTO_JOIN)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should remove the right join, since the join key of the right input is
+   * unique and the join key of the left input is foreign key, only use the left. */
+  @Test void testProjectJoinRemove19() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT ename, deptno "
+        + "   FROM sales.emp "
+        + "   UNION ALL "
+        + "   SELECT ename, deptno FROM sales.emp "
+        + "   UNION "
+        + "   SELECT ename, deptno FROM sales.emp) e "
+        + "INNER JOIN "
+        + "(SELECT deptno, name FROM sales.dept) d "
+        + "ON d.deptno = e.deptno";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should not remove the right join, since the join key of left input is
+   * not foreign key. */
+  @Test void testProjectJoinRemove20() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT ename, deptno "
+        + "   FROM sales.emp "
+        + "   UNION ALL "
+        + "   SELECT name, deptno "
+        + "   FROM sales.dept) e "
+        + "INNER JOIN "
+        + "   (SELECT deptno, name FROM sales.dept) d "
+        + "ON d.deptno = e.deptno";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should not remove the right join, since the join key of left input is
+   * not foreign key. */
+  @Test void testProjectJoinRemove21() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT ename, deptno "
+        + "   FROM sales.emp "
+        + "   UNION "
+        + "   SELECT name, deptno "
+        + "   FROM sales.dept) e "
+        + "INNER JOIN "
+        + "(SELECT deptno, name FROM sales.dept) d "
+        + "ON d.deptno = e.deptno";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should remove the left join, since the join key of the left input is
+   * unique and the join key of the right input is foreign key, only use the right. */
+  @Test void testProjectJoinRemove22() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT deptno, name FROM sales.dept) d "
+        + "INNER JOIN "
+        + "   (SELECT ename, deptno "
+        + "   FROM sales.emp "
+        + "   EXCEPT ALL "
+        + "   SELECT ename, deptno "
+        + "   FROM sales.emp) e "
+        + "ON d.deptno = e.deptno";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should not remove the right join, since the join key of the right input is
+   * not foreign key. */
+  @Test void testProjectJoinRemove23() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT deptno, name FROM sales.dept) d "
+        + "INNER JOIN "
+        + "   (SELECT ename, deptno "
+        + "   FROM sales.emp "
+        + "   EXCEPT ALL "
+        + "   SELECT name, deptno "
+        + "   FROM sales.dept) e "
+        + "ON d.deptno = e.deptno";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should remove the left join, since the join key of the left input is
+   * unique and the join key of the right input is foreign key, only use the right. */
+  @Test void testProjectJoinRemove24() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT deptno, name FROM sales.dept) d "
+        + "INNER JOIN "
+        + "   (SELECT ename, deptno "
+        + "   FROM sales.emp "
+        + "   INTERSECT ALL "
+        + "   SELECT ename, deptno "
+        + "   FROM sales.emp) e "
+        + "ON d.deptno = e.deptno";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5756">[CALCITE-5756]
+   * Expand ProjectJoinRemoveRule to support inner join remove</a>.
+   * Should not remove the right join, since the join key of the right input is
+   * not foreign key. */
+  @Test void testProjectJoinRemove25() {
+    final String sql = "SELECT e.deptno, e.ename "
+        + "FROM "
+        + "   (SELECT deptno, name FROM sales.dept) d "
+        + "INNER JOIN "
+        + "   (SELECT ename, deptno "
+        + "   FROM sales.emp "
+        + "   INTERSECT ALL "
+        + "   SELECT name, deptno "
+        + "   FROM sales.dept) e "
+        + "ON d.deptno = e.deptno";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_JOIN_REMOVE)
+        .checkUnchanged();
+  }
+
   @Test void testSwapOuterJoin() {
     final HepProgram program = new HepProgramBuilder()
         .addMatchLimit(1)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -7235,6 +7235,205 @@ LogicalProject(DEPTNO=[$7], SLACKER=[$8])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectJoinRemove11">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno
+FROM sales.emp e
+INNER JOIN sales.dept d ON e.deptno = d.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove12">
+    <Resource name="sql">
+      <![CDATA[SELECT e1.deptno
+FROM sales.emp e1
+INNER JOIN sales.emp e2 ON e1.deptno = e2.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalJoin(condition=[=($7, $16)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove13">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, d.name
+FROM sales.emp e
+INNER JOIN sales.dept d ON e.deptno = d.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], NAME=[$10])
+  LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove14">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.slacker
+FROM sales.emp e
+INNER JOIN sales.dept d ON e.deptno = d.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], SLACKER=[$8])
+  LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], SLACKER=[$8])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove15">
+    <Resource name="sql">
+      <![CDATA[SELECT e.slacker
+FROM sales.dept d
+INNER JOIN sales.emp e ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(SLACKER=[$10])
+  LogicalJoin(condition=[=($0, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(SLACKER=[$8])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove16">
+    <Resource name="sql">
+      <![CDATA[SELECT e.slacker
+FROM sales.dept d
+INNER JOIN sales.empnullables e ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(SLACKER=[$10])
+  LogicalJoin(condition=[=($0, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove17">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM sales.dept d INNER JOIN    (SELECT ename, deptno, count(job)   FROM sales.emp   WHERE ename IN ('lucy', 'lily')   GROUP BY ename, deptno) e ON d.deptno = e.deptno WHERE e.deptno = 'd001']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$3], ENAME=[$2])
+  LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalFilter(condition=[=($1, CAST('d001'):INTEGER NOT NULL)])
+      LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+        LogicalProject(ENAME=[$1], DEPTNO=[$7], JOB=[$2])
+          LogicalFilter(condition=[OR(=($1, 'lucy'), =($1, 'lily'))])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalFilter(condition=[=($1, CAST('d001'):INTEGER NOT NULL)])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7], JOB=[$2])
+        LogicalFilter(condition=[OR(=($1, 'lucy'), =($1, 'lily'))])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove18">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT ename, deptno, count(job)    FROM sales.emp    WHERE ename IN ('lucy', 'lily')    GROUP BY ename, deptno) e INNER JOIN    (SELECT deptno, name    FROM sales.dept    WHERE deptno NOT IN (10003)) d ON d.deptno = e.deptno WHERE d.deptno IN (10001, 10002) and e.ename IN ('transportation', 'architecture')]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalJoin(condition=[=($3, $1)], joinType=[inner])
+    LogicalFilter(condition=[SEARCH($0, Sarg['architecture':CHAR(14), 'transportation']:CHAR(14))])
+      LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+        LogicalProject(ENAME=[$1], DEPTNO=[$7], JOB=[$2])
+          LogicalFilter(condition=[OR(=($1, 'lucy'), =($1, 'lily'))])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalFilter(condition=[SEARCH($0, Sarg[10001, 10002])])
+      LogicalProject(DEPTNO=[$0], NAME=[$1])
+        LogicalFilter(condition=[NOT(=($0, 10003))])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalFilter(condition=[SEARCH($0, Sarg['architecture':CHAR(14), 'transportation']:CHAR(14))])
+    LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7], JOB=[$2])
+        LogicalFilter(condition=[OR(=($1, 'lucy'), =($1, 'lily'))])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove19">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT ename, deptno    FROM sales.emp    UNION ALL    SELECT ename, deptno FROM sales.emp    UNION    SELECT ename, deptno FROM sales.emp) e INNER JOIN (SELECT deptno, name FROM sales.dept) d ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalJoin(condition=[=($2, $1)], joinType=[inner])
+    LogicalUnion(all=[false])
+      LogicalUnion(all=[true])
+        LogicalProject(ENAME=[$1], DEPTNO=[$7])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalProject(ENAME=[$1], DEPTNO=[$7])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalUnion(all=[false])
+    LogicalUnion(all=[true])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProjectJoinRemove2">
     <Resource name="sql">
       <![CDATA[SELECT e.deptno, d1.deptno
@@ -7260,6 +7459,134 @@ LogicalProject(DEPTNO=[$7], DEPTNO0=[$9])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove20">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT ename, deptno    FROM sales.emp    UNION ALL    SELECT name, deptno    FROM sales.dept) e INNER JOIN    (SELECT deptno, name FROM sales.dept) d ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalJoin(condition=[=($2, $1)], joinType=[inner])
+    LogicalUnion(all=[true])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(NAME=[$1], DEPTNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove21">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT ename, deptno    FROM sales.emp    UNION    SELECT name, deptno    FROM sales.dept) e INNER JOIN (SELECT deptno, name FROM sales.dept) d ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalJoin(condition=[=($2, $1)], joinType=[inner])
+    LogicalUnion(all=[false])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(NAME=[$1], DEPTNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove22">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT deptno, name FROM sales.dept) d INNER JOIN    (SELECT ename, deptno    FROM sales.emp    EXCEPT ALL    SELECT ename, deptno    FROM sales.emp) e ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$3], ENAME=[$2])
+  LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalMinus(all=[true])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalMinus(all=[true])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove23">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT deptno, name FROM sales.dept) d INNER JOIN    (SELECT ename, deptno    FROM sales.emp    EXCEPT ALL    SELECT name, deptno    FROM sales.dept) e ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$3], ENAME=[$2])
+  LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalMinus(all=[true])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(NAME=[$1], DEPTNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove24">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT deptno, name FROM sales.dept) d INNER JOIN    (SELECT ename, deptno    FROM sales.emp    INTERSECT ALL    SELECT ename, deptno    FROM sales.emp) e ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$3], ENAME=[$2])
+  LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalIntersect(all=[true])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$1], ENAME=[$0])
+  LogicalIntersect(all=[true])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinRemove25">
+    <Resource name="sql">
+      <![CDATA[SELECT e.deptno, e.ename FROM    (SELECT deptno, name FROM sales.dept) d INNER JOIN    (SELECT ename, deptno    FROM sales.emp    INTERSECT ALL    SELECT name, deptno    FROM sales.dept) e ON d.deptno = e.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$3], ENAME=[$2])
+  LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalIntersect(all=[true])
+      LogicalProject(ENAME=[$1], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(NAME=[$1], DEPTNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.test;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptForeignKey;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
@@ -261,6 +262,28 @@ public class RelMetadataFixture {
     Double result = mq.getPercentageOriginalRows(rel);
     assertNotNull(result);
     assertThat(result, matcher);
+    return this;
+  }
+
+  public RelMetadataFixture assertForeignKeys(Matcher<Set<RelOptForeignKey>> matcher,
+      Matcher<Set<RelOptForeignKey>> confirmedMatcher) {
+    RelNode rel = toRel();
+    RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    Set<RelOptForeignKey> foreignKeys = mq.getForeignKeys(rel, false);
+    assertThat(foreignKeys, matcher);
+    Set<RelOptForeignKey> confirmedForeignKeys = mq.getConfirmedForeignKeys(rel, false);
+    assertThat(confirmedForeignKeys, confirmedMatcher);
+    return this;
+  }
+
+  public RelMetadataFixture assertForeignKeysIgnoreNulls(
+      Matcher<Set<RelOptForeignKey>> matcher, Matcher<Set<RelOptForeignKey>> confirmedMatcher) {
+    RelNode rel = toRel();
+    RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    Set<RelOptForeignKey> foreignKeys = mq.getForeignKeys(rel, true);
+    assertThat(foreignKeys, matcher);
+    Set<RelOptForeignKey> confirmedForeignKeys = mq.getConfirmedForeignKeys(rel, true);
+    assertThat(confirmedForeignKeys, confirmedMatcher);
     return this;
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReader.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReader.java
@@ -593,6 +593,10 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
       return referentialConstraints;
     }
 
+    public void setReferentialConstraints(List<RelReferentialConstraint> referentialConstraints) {
+      this.referentialConstraints.addAll(referentialConstraints);
+    }
+
     @Override public RelDataType getRowType() {
       return rowType;
     }

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test.catalog;
 
+import org.apache.calcite.rel.RelReferentialConstraintImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -31,8 +32,10 @@ import org.apache.calcite.sql2rel.NullInitializerExpressionFactory;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
+import org.apache.calcite.util.mapping.IntPair;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -86,6 +89,15 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     empTable.addColumn("COMM", fixture.intType);
     empTable.addColumn("DEPTNO", fixture.intType);
     empTable.addColumn("SLACKER", fixture.booleanType);
+    // Mock the referentialConstraint,
+    // the foreign key is the DEPTNO column of CATALOG.SALES.EMP table,
+    // reference the DEPTNO unique column of CATALOG.SALES.DEPT table.
+    empTable.setReferentialConstraints(
+        Lists.newArrayList(
+            RelReferentialConstraintImpl.of(
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "EMP"),
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "DEPT"),
+        Lists.newArrayList(IntPair.of(7, 0)))));
     registerTable(empTable);
   }
 
@@ -99,6 +111,15 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     empNullablesTable.addColumn("COMM", fixture.intTypeNull);
     empNullablesTable.addColumn("DEPTNO", fixture.intTypeNull);
     empNullablesTable.addColumn("SLACKER", fixture.booleanTypeNull);
+    // Mock the referentialConstraint,
+    // the foreign key is the DEPTNO column of CATALOG.SALES.EMPNULLABLES table,
+    // reference the DEPTNO unique column of CATALOG.SALES.DEPT table.
+    empNullablesTable.setReferentialConstraints(
+        Lists.newArrayList(
+            RelReferentialConstraintImpl.of(
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "EMPNULLABLES"),
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "DEPT"),
+        Lists.newArrayList(IntPair.of(7, 0)))));
     registerTable(empNullablesTable);
   }
 
@@ -468,6 +489,9 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
             "customBigInt"),
         typeFactory -> typeFactory.createSqlType(SqlTypeName.BIGINT));
 
+    // Register "DEPT" table.
+    registerTableDept(salesSchema, fixture);
+
     // Register "EMP" table.
     final MockTable empTable =
         MockTable.create(this, salesSchema, "EMP", false, 14, null,
@@ -484,9 +508,6 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
 
     // Register "EMP_B" table. As "EMP", birth with a "BIRTHDATE" column.
     registerTableEmpB(salesSchema, fixture);
-
-    // Register "DEPT" table.
-    registerTableDept(salesSchema, fixture);
 
     // Register "DEPTNULLABLES" table.
     registerTableDeptNullables(salesSchema, fixture);


### PR DESCRIPTION
This feature is mainly about expanding ProjectJoinRemoveRule to support inner join remove
by the foreign-unique constraint in the catalog.

The main steps are as follows:
1. Analyse the column used by project, and then split them to left and right side.
2. Acccording to the project info above and outer join type, bail out in some scene.
3. Get join info such as join keys.
4. For inner join check foreign and unique keys, these may use
RelMetadataQuery#getForeignKeys(newly add, similar to RelMetadataQuery#getUniqueKeys),
RelOptTable#getReferentialConstraints.
5. Check removing side join keys are areColumnsUnique both for outer join and inner join.
6. If all done, calculate the fianl project and transform. 

Test cases are added to RelOptRulesTest and RelMetadataTest.