### PR TITLE
[CALCITE-5784] Generate the same correlationId for the same query

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4996,4 +4996,16 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     String sql = "SELECT CAST(CAST(? AS INTEGER) AS CHAR)";
     sql(sql).ok();
   }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5784">[CALCITE-5784]
+   * Generate the same correlationId for the same query</a>.
+   */
+  @Test void testCorrelationId() {
+    String sql = "WITH a AS (SELECT ename, job, empno, r FROM emp, "
+        + "LATERAL TABLE (ramp(empno)) as T(r))"
+        + " SELECT * from a a1, a a2 WHERE a1.r = a2.empno";
+    sql(sql).ok();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -1063,9 +1063,9 @@ LogicalProject(EMPNO=[$0])
       <![CDATA[
 LogicalProject(DEPTNO=[$7], DEPTNO0=[$9])
   LogicalFilter(condition=[EXISTS({
-LogicalFilter(condition=[AND(=($7, $cor2.DEPTNO0), =($7, $cor2.DEPTNO0), OR(=($7, $cor2.DEPTNO0), =($7, $cor2.DEPTNO0)))])
+LogicalFilter(condition=[AND(=($7, $cor0.DEPTNO0), =($7, $cor0.DEPTNO0), =($7, $cor0.DEPTNO0))])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-})], variablesSet=[[$cor2]])
+})], variablesSet=[[$cor0]])
     LogicalJoin(condition=[true], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -1078,6 +1078,25 @@ where exists (select * from emp
   where emp.deptno = dept.deptno
   and emp.deptno = dept.deptno
   and emp.deptno in (dept.deptno, dept.deptno))]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCorrelationId">
+    <Resource name="sql">
+      <![CDATA[WITH a AS (SELECT ename, job, empno, r FROM emp, LATERAL TABLE (ramp(empno)) as T(r)) SELECT * from a a1, a a2 WHERE a1.r = a2.empno]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ENAME=[$0], JOB=[$1], EMPNO=[$2], R=[$3], ENAME0=[$4], JOB0=[$5], EMPNO0=[$6], R0=[$7])
+  LogicalJoin(condition=[=($3, $6)], joinType=[inner])
+    LogicalProject(ENAME=[$1], JOB=[$2], EMPNO=[$0], R=[$9])
+      LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableFunctionScan(invocation=[RAMP($cor0.EMPNO)], rowType=[RecordType(INTEGER I)])
+    LogicalProject(ENAME=[$1], JOB=[$2], EMPNO=[$0], R=[$9])
+      LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableFunctionScan(invocation=[RAMP($cor0.EMPNO)], rowType=[RecordType(INTEGER I)])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testCorrelationInProjectionWithCorrelatedProjection">
@@ -1193,7 +1212,7 @@ LogicalProject(DEPTNO=[$0], ENAME=[$1])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
     LogicalSort(sort0=[$1], dir0=[DESC], fetch=[3])
       LogicalProject(ENAME=[$1], SAL=[$5])
-        LogicalFilter(condition=[AND(OR(=($7, $cor0.DEPTNO), =($7, $cor0.DEPTNO)), =($7, $cor0.DEPTNO))])
+        LogicalFilter(condition=[AND(=($7, $cor0.DEPTNO), =($7, $cor0.DEPTNO))])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
@@ -1327,11 +1346,11 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()], EXPR$1=[SUM($0)])
       <![CDATA[
 LogicalProject(C=[$0], D=[$1], C0=[$2], F=[$3])
   LogicalProject(C=[$0], D=[$1], C0=[$4], F=[$5])
-    LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{2, 3}])
+    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2, 3}])
       LogicalProject(C=[$0], D=[$1], C0=[$0], $f3=[+($0, $1)])
         LogicalValues(tuples=[[{ 4, 5 }]])
-      LogicalProject(C=[$cor3.C], F=[*($0, $cor3.C)])
-        LogicalFilter(condition=[=($cor3.$f3, *($0, $cor3.C))])
+      LogicalProject(C=[$cor0.C], F=[*($0, $cor0.C)])
+        LogicalFilter(condition=[=($cor0.$f3, *($0, $cor0.C))])
           LogicalValues(tuples=[[{ 2 }]])
 ]]>
     </Resource>
@@ -1957,7 +1976,7 @@ LogicalProject(EMPNO=[$0])
   LogicalFilter(condition=[IS NOT NULL($9)])
     LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f0=[$11])
       LogicalJoin(condition=[=($9, $10)], joinType=[left])
-        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[CASE(IS NOT NULL($1), $1, 'M':VARCHAR(20))])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[CASE(IS NOT NULL($1), CAST($1):VARCHAR(20) NOT NULL, 'M':VARCHAR(20))])
           LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
         LogicalAggregate(group=[{0}], agg#0=[MIN($1)])
           LogicalProject($f9=[CASE(IS NOT NULL($1), CAST($1):VARCHAR(20) NOT NULL, 'M':VARCHAR(20))], $f0=[true])
@@ -4723,18 +4742,18 @@ from (select 2+deptno d2, 3+deptno d3 from emp) e
       <![CDATA[
 LogicalProject(D2=[$0], D3=[$1])
   LogicalFilter(condition=[IS NOT NULL($2)])
-    LogicalCorrelate(correlation=[$cor3], joinType=[left], requiredColumns=[{0, 1}])
+    LogicalCorrelate(correlation=[$cor2], joinType=[left], requiredColumns=[{0, 1}])
       LogicalProject(D2=[+(2, $7)], D3=[+(3, $7)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalAggregate(group=[{}], agg#0=[MIN($0)])
         LogicalProject($f0=[true])
-          LogicalFilter(condition=[AND(=($0, $cor3.D2), IS NOT NULL($1))])
+          LogicalFilter(condition=[AND(=($0, $cor2.D2), IS NOT NULL($1))])
             LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
               LogicalProject(D1=[+($0, 1)])
                 LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
               LogicalAggregate(group=[{}], agg#0=[MIN($0)])
                 LogicalProject($f0=[true])
-                  LogicalFilter(condition=[AND(=($0, $cor0.D1), =($1, $cor0.D1), =($2, $cor3.D3))])
+                  LogicalFilter(condition=[AND(=($0, $cor0.D1), =($1, $cor0.D1), =($2, $cor2.D3))])
                     LogicalProject(D4=[+($0, 4)], D5=[+($0, 5)], D6=[+($0, 6)])
                       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -2216,7 +2216,7 @@ where exists
 # following plan (two scans of EMP table instead of three).
 EnumerableCalc(expr#0..2=[{inputs}], ENAME=[$t1])
   EnumerableHashJoin(condition=[=($2, $3)], joinType=[semi])
-    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NOT NULL($t3)], expr#9=[CAST($t3):INTEGER], expr#10=[0], expr#11=[CASE($t8, $t9, $t10)], proj#0..1=[{exprs}], $f3=[$t11])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NOT NULL($t3)], expr#9=[CAST($t3):INTEGER NOT NULL], expr#10=[0], expr#11=[CASE($t8, $t9, $t10)], proj#0..1=[{exprs}], $f3=[$t11])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NOT NULL($t3)], expr#9=[CAST($t3):INTEGER NOT NULL], expr#10=[0], expr#11=[CASE($t8, $t9, $t10)], $f8=[$t11])
       EnumerableTableScan(table=[[scott, EMP]])


### PR DESCRIPTION
Add a map to cache the correlarionId in the `SqlToRelConverter` to deduplicate correlationId for the same scope of identifier