### PR TITLE
[CALCITE-5741] Add support for CONCAT_WS function(enabled in MSSQL, MySQL and Postgres)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -143,6 +143,8 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.COMPRESS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CONCAT2;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CONCAT_FUNCTION;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CONCAT_FUNCTION_WITH_NULL;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.CONCAT_WS;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.CONCAT_WS_MSSQL;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.COSH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.COTH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CSC;
@@ -496,6 +498,10 @@ public class RexImpTable {
       defineMethod(CONCAT_FUNCTION_WITH_NULL,
           BuiltInMethod.MULTI_STRING_CONCAT_WITH_NULL.method, NullPolicy.NONE);
       defineMethod(CONCAT2, BuiltInMethod.STRING_CONCAT_WITH_NULL.method, NullPolicy.ALL);
+      defineMethod(CONCAT_WS, BuiltInMethod.MULTI_STRING_CONCAT_WITH_SEPARATOR.method,
+          NullPolicy.ARG0);
+      defineMethod(CONCAT_WS_MSSQL, BuiltInMethod.MULTI_STRING_CONCAT_WITH_SEPARATOR.method,
+          NullPolicy.NONE);
       defineMethod(OVERLAY, BuiltInMethod.OVERLAY.method, NullPolicy.STRICT);
       defineMethod(POSITION, BuiltInMethod.POSITION.method, NullPolicy.STRICT);
       defineMethod(ASCII, BuiltInMethod.ASCII.method, NullPolicy.STRICT);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -802,6 +802,25 @@ public class SqlFunctions {
     return sb.toString();
   }
 
+  /** SQL {@code CONCAT_WS(sep, arg1, arg2, ...)} function,
+   * and null value will be treated as empty string. */
+  public static String concatMultiWithSeparator(String... args) {
+    // the separator arg could be null
+    final String sep = args[0] == null ? "" : args[0];
+    StringBuilder sb = new StringBuilder();
+    for (int i = 1; i < args.length; i++) {
+      if (args[i] != null) {
+        if (i < args.length - 1) {
+          sb.append(args[i]).append(sep);
+        } else {
+          // no separator after the last arg
+          sb.append(args[i]);
+        }
+      }
+    }
+    return sb.toString();
+  }
+
   /** SQL {@code CONVERT(s, src_charset, dest_charset)} function. */
   public static String convertWithCharset(String s, String srcCharset,
       String destCharset) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -427,6 +427,9 @@ public enum SqlKind {
   /** The {@code CONCAT} function (Postgresql and MSSQL) that ignores NULL. */
   CONCAT_WITH_NULL,
 
+  /** The {@code CONCAT_WS} function (MSSQL). */
+  CONCAT_WS_MSSQL,
+
   /** The "IF" function (BigQuery, Hive, Spark). */
   IF,
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -890,6 +890,50 @@ public abstract class SqlLibraryOperators {
           .withOperandTypeInference(InferTypes.RETURN_TYPE)
           .withKind(SqlKind.CONCAT2);
 
+  /** The "CONCAT_WS(separator, arg1, ...)" function that concatenates strings
+   * with separator, and null value is treated as empty string.
+   * For example:
+   *     "CONCAT_WS(',', 'a')" returns "a".
+   *     "CONCAT_WS(',', 'a', 'b')" returns "a,b".
+   *
+   * <p>Returns null if the separator arg is null.
+   * "CONCAT_WS(null, 'a', 'b')" returns null.
+   *
+   * <p>If all the arguments except the separator are null,
+   * it also returns empty string.
+   * "CONCAT_WS(',', null, null)" returns "". */
+  @LibraryOperator(libraries = {MYSQL, POSTGRESQL})
+  public static final SqlFunction CONCAT_WS =
+      SqlBasicFunction.create("CONCAT_WS",
+          ReturnTypes.MULTIVALENT_STRING_WITH_SEP_SUM_PRECISION_ARG0_NULLABLE,
+          OperandTypes.repeat(SqlOperandCountRanges.from(2),
+              OperandTypes.STRING),
+          SqlFunctionCategory.STRING)
+          .withOperandTypeInference(InferTypes.RETURN_TYPE);
+
+  /** The CONCAT_WS function in MSSQL has the following syntax:
+   * "CONCAT_WS(separator, arg1, arg2, ...)", which differs from
+   * {@link #CONCAT_WS} at
+   *     1)accepts arguments from 3 to 254
+   *     2)never returns null(even if the separator is null)
+   *
+   * <p>Hence, it is assigned {@link SqlKind#CONCAT_WS_MSSQL}.
+   *
+   * <p>For example:
+   *     "CONCAT_WS(',', 'a', 'b')" returns "a,b".
+   *     "CONCAT_WS(null, 'a', 'b')" returns "ab".
+   *     "CONCAT_WS(',', null, null)" returns "".
+   *     "CONCAT_WS(null, null, null)" returns "". */
+  @LibraryOperator(libraries = {MSSQL})
+  public static final SqlFunction CONCAT_WS_MSSQL =
+      SqlBasicFunction.create("CONCAT_WS",
+          ReturnTypes.MULTIVALENT_STRING_WITH_SEP_SUM_PRECISION_NOT_NULLABLE,
+          OperandTypes.repeat(SqlOperandCountRanges.between(3, 254),
+              OperandTypes.STRING),
+          SqlFunctionCategory.STRING)
+          .withOperandTypeInference(InferTypes.RETURN_TYPE)
+          .withKind(SqlKind.CONCAT_WS_MSSQL);
+
   private static RelDataType arrayReturnType(SqlOperatorBinding opBinding) {
     RelDataType type =
         opBinding.getOperandCount() > 0

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -422,6 +422,8 @@ public enum BuiltInMethod {
   STRING_CONCAT_WITH_NULL(SqlFunctions.class, "concatWithNull", String.class, String.class),
   MULTI_STRING_CONCAT(SqlFunctions.class, "concatMulti", String[].class),
   MULTI_STRING_CONCAT_WITH_NULL(SqlFunctions.class, "concatMultiWithNull", String[].class),
+  MULTI_STRING_CONCAT_WITH_SEPARATOR(SqlFunctions.class, "concatMultiWithSeparator",
+      String[].class),
   FLOOR_DIV(Math.class, "floorDiv", long.class, long.class),
   FLOOR_MOD(Math.class, "floorMod", long.class, long.class),
   ADD_MONTHS(DateTimeUtils.class, "addMonths", long.class, int.class),

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -177,6 +177,8 @@ class SqlFunctionsTest {
     assertThat(concatMultiWithSeparator(",", "a b", null, "cd", null, "e"), is("a b,cd,e"));
     assertThat(concatMultiWithSeparator(",", null, null), is(""));
     assertThat(concatMultiWithSeparator(",", "", ""), is(","));
+    assertThat(concatMultiWithSeparator("", "a", "b", null, "c"), is("abc"));
+    assertThat(concatMultiWithSeparator("", null, null), is(""));
     // The separator could be null, and it is treated as empty string
     assertThat(concatMultiWithSeparator(null, "a", "b", null, "c"), is("abc"));
     assertThat(concatMultiWithSeparator(null, null, null), is(""));

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -44,6 +44,7 @@ import static org.apache.calcite.runtime.SqlFunctions.charLength;
 import static org.apache.calcite.runtime.SqlFunctions.concat;
 import static org.apache.calcite.runtime.SqlFunctions.concatMulti;
 import static org.apache.calcite.runtime.SqlFunctions.concatMultiWithNull;
+import static org.apache.calcite.runtime.SqlFunctions.concatMultiWithSeparator;
 import static org.apache.calcite.runtime.SqlFunctions.concatWithNull;
 import static org.apache.calcite.runtime.SqlFunctions.fromBase64;
 import static org.apache.calcite.runtime.SqlFunctions.greater;
@@ -168,6 +169,17 @@ class SqlFunctionsTest {
     assertThat(concatMultiWithNull((String) null, ""), is(""));
     assertThat(concatMultiWithNull((String) null, null, null), is(""));
     assertThat(concatMultiWithNull("a", null, "b"), is("ab"));
+  }
+
+  @Test void testConcatMultiWithSeparator() {
+    assertThat(concatMultiWithSeparator(",", "a"), is("a"));
+    assertThat(concatMultiWithSeparator(",", "a b", "cd"), is("a b,cd"));
+    assertThat(concatMultiWithSeparator(",", "a b", null, "cd", null, "e"), is("a b,cd,e"));
+    assertThat(concatMultiWithSeparator(",", null, null), is(""));
+    assertThat(concatMultiWithSeparator(",", "", ""), is(","));
+    // The separator could be null, and it is treated as empty string
+    assertThat(concatMultiWithSeparator(null, "a", "b", null, "c"), is("abc"));
+    assertThat(concatMultiWithSeparator(null, null, null), is(""));
   }
 
   @Test void testPosixRegex() {

--- a/core/src/test/resources/sql/functions.iq
+++ b/core/src/test/resources/sql/functions.iq
@@ -103,6 +103,96 @@ from t;
 
 !ok
 
+# [CALCITE-5741] Add support for CONCAT_WS function(enabled in MSSQL, MySQL and Postgresql)
+# CONCAT_WS in Postgres and MySQL returns null only when the separator arg is null.
+select concat_ws(',', 'a');
++--------+
+| EXPR$0 |
++--------+
+| a      |
++--------+
+(1 row)
+
+!ok
+
+select concat_ws(',', 'a', 'b', 'c');
++--------+
+| EXPR$0 |
++--------+
+| a,b,c  |
++--------+
+(1 row)
+
+!ok
+
+select concat_ws(',', 'a', cast(null as varchar), 'b');
++--------+
+| EXPR$0 |
++--------+
+| a,b    |
++--------+
+(1 row)
+
+!ok
+
+select concat_ws(',', '', '', '');
++--------+
+| EXPR$0 |
++--------+
+| ,,     |
++--------+
+(1 row)
+
+!ok
+
+with t as (select concat_ws(',', '') as c)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | false     |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select concat_ws('', '', '') as c)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | false     |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select concat_ws(',', cast(null as varchar), cast(null as varchar)) as c)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | false     |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select concat_ws(cast(null as varchar), 'a', 'b') as c)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
 # Compression Functions
 
 SELECT COMPRESS('sample');
@@ -513,6 +603,83 @@ select CONVERT(INTEGER, NULL, NULL);
 select CONVERT(DATE, '05/01/2000', 103);
 !ok
 !}
+
+# CONCAT_WS in MSSQL
+select concat_ws(',', 'a', 'b');
++--------+
+| EXPR$0 |
++--------+
+| a,b    |
++--------+
+(1 row)
+
+!ok
+
+select concat_ws(',', 'a', cast(null as varchar), 'b');
++--------+
+| EXPR$0 |
++--------+
+| a,b    |
++--------+
+(1 row)
+
+!ok
+
+select concat_ws(',', '', '', '');
++--------+
+| EXPR$0 |
++--------+
+| ,,     |
++--------+
+(1 row)
+
+!ok
+
+with t as (select concat_ws('', '', '') as c)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | false     |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select concat_ws(',', cast(null as varchar), cast(null as varchar)) as c)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | false     |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select concat_ws(cast(null as varchar), '', '', '') as c)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | false     |
++---+-----------+
+(1 row)
+
+!ok
+
+select concat_ws(cast(null as varchar), 'a', cast(null as varchar), 'b');
++--------+
+| EXPR$0 |
++--------+
+| ab     |
++--------+
+(1 row)
+
+!ok
 
 # [CALCITE-5771] Apply two different NULL semantics for CONCAT function(enabled in MySQL, Postgresql, BigQuery and MSSQL)
 with t as (select concat(null) as c)

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2674,6 +2674,8 @@ BigQuery's type system uses confusingly different names for types and functions:
 | o | CONCAT(string, string)                         | Concatenates two strings, returns null only when both string arguments are null, otherwise treats null as empty string
 | b m | CONCAT(string [, string ]*)                  | Concatenates one or more strings, returns null if any of the arguments is null
 | p q | CONCAT(string [, string ]*)                  | Concatenates one or more strings, null is treated as empty string
+| m p | CONCAT_WS(separator, str1 [, string ]*)      | Concatenates one or more strings, returns null only when separator is null, otherwise treats null as empty string
+| q | CONCAT_WS(separator, str1, str2 [, string ]*)  | Concatenates two or more strings, accepts at least 3 arguments(at most 254), any of the null arguments is treated as empty string
 | m | COMPRESS(string)                               | Compresses a string using zlib compression and returns the result as a binary string
 | q | CONVERT(type, expression [ , style ])          | Equivalent to `CAST(expression AS type)`; ignores the *style* operand
 | p | CONVERT_TIMEZONE(tz1, tz2, datetime)           | Converts the timezone of *datetime* from *tz1* to *tz2*


### PR DESCRIPTION
CONCAT_WS function returns a string resulting from the concatenation, or joining, of two or more string values in an end-to-end manner.
It separates those concatenated string values with the delimiter specified in the **first function argument**. e.g:

- CONCAT_WS(',', 'c', 'h', 'a', 'r') returns 'c,h,a,r'

One thing need to be noted: this function has two NULL semantics for the separator argument in different Database products. Let's take CONCAT_WS(null, 'a', 'b') as an example:
- Postgres and MySQL: **it returns null when the separator is null**, otherwise treats null as empty string. So the above SQL returns null.

- MSSQL: never returns null and treats null as empty string, the above SQL returns "ab".