### PR TITLE
[CALCITE-5785] fmppMain tasks use absolute paths for input hashes and don't work with remote build caching

### DIFF
--- a/babel/build.gradle.kts
+++ b/babel/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 val fmppMain by tasks.registering(org.apache.calcite.buildtools.fmpp.FmppTask::class) {
-    inputs.dir("src/main/codegen")
+    inputs.dir("src/main/codegen").withPathSensitivity(PathSensitivity.RELATIVE)
     config.set(file("src/main/codegen/config.fmpp"))
     templates.set(file("$rootDir/core/src/main/codegen/templates"))
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 val fmppMain by tasks.registering(org.apache.calcite.buildtools.fmpp.FmppTask::class) {
-    inputs.dir("src/main/codegen")
+    inputs.dir("src/main/codegen").withPathSensitivity(PathSensitivity.RELATIVE)
     config.set(file("src/main/codegen/config.fmpp"))
     templates.set(file("$rootDir/core/src/main/codegen/templates"))
 }


### PR DESCRIPTION
The :babel:fmppMain and :server:fmppMain tasks currently do not work with remote build caching.

One of the inputs is a directory and currently it's configured to look at the absolute path instead of the relative path. This causes different input hashes to be computed on different machines, hence the tasks do not work correctly with remote build caching.

This PR addresses the issue by making the hashes for input directories look at the relative path.