### PR TITLE
[CALCITE-5786] Update QuidemTest and DiffRepository to write intermediate test files to directories other than build/resources/test. This addresses an incremental builds issue with the tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -812,6 +812,10 @@ allprojects {
                         passProperty(e)
                     }
                 }
+                jvmArgumentProviders.add(
+                    AdditionalTestSystemPropertiesProvider(
+                        layout.buildDirectory.dir("test-surefire").get().asFile.absolutePath,
+                        layout.buildDirectory.dir("test-diffrepo").get().asFile.absolutePath))
             }
             // Cannot be moved above otherwise configure each will override
             // also the specific configurations below.
@@ -822,6 +826,10 @@ allprojects {
                     includeTags("slow")
                 }
                 jvmArgs("-Xmx6g")
+                jvmArgumentProviders.add(
+                    AdditionalTestSystemPropertiesProvider(
+                        layout.buildDirectory.dir("test-surefire").get().asFile.absolutePath,
+                        layout.buildDirectory.dir("test-diffrepo").get().asFile.absolutePath))
             }
             configureEach<SpotBugsTask> {
                 group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -980,5 +988,18 @@ allprojects {
                 }
             }
         }
+    }
+}
+
+class AdditionalTestSystemPropertiesProvider(
+    @Internal val surefireTestDir: String,
+    @Internal val diffRepoTestDir: String
+) : CommandLineArgumentProvider {
+
+    override fun asArguments(): Iterable<String> {
+        return listOf(
+            "-Dtest.surefire.dir=$surefireTestDir",
+            "-Dtest.diffrepo.dir=$diffRepoTestDir"
+        )
     }
 }

--- a/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
+++ b/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
@@ -162,6 +162,7 @@ public class DiffRepository {
   private static final String TEST_CASE_OVERRIDES_ATTR = "overrides";
   private static final String RESOURCE_TAG = "Resource";
   private static final String RESOURCE_NAME_ATTR = "name";
+  private static final String DIFFREPO_TEST_DIR = System.getProperty("test.diffrepo.dir");
 
   /**
    * Holds one diff-repository per class. It is necessary for all test cases in
@@ -927,7 +928,10 @@ public class DiffRepository {
     DiffRepository toRepo() {
       final URL refFile = findFile(clazz, ".xml");
       final String refFilePath = Sources.of(refFile).file().getAbsolutePath();
-      final String logFilePath = refFilePath.replace(".xml", "_actual.xml");
+      final String logFilePath =
+          new File(DIFFREPO_TEST_DIR,
+              Sources.of(refFile).file().getName())
+              .getAbsolutePath().replace(".xml", "_actual.xml");
       final File logFile = new File(logFilePath);
       assert !refFilePath.equals(logFile.getAbsolutePath());
       return new DiffRepository(refFile, logFile, baseRepository, filter,

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -68,6 +68,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public abstract class QuidemTest {
 
   private static final Pattern PATTERN = Pattern.compile("\\.iq$");
+  private static final String SUREFIRE_TEST_DIR = System.getProperty("test.surefire.dir");
 
   private static Object getEnv(String varName) {
     switch (varName) {
@@ -141,7 +142,7 @@ public abstract class QuidemTest {
       // inUrl = "file:/home/fred/calcite/core/target/test-classes/sql/outer.iq"
       final URL inUrl = QuidemTest.class.getResource("/" + n2u(path));
       inFile = Sources.of(inUrl).file();
-      outFile = new File(inFile.getAbsoluteFile().getParent(), u2n("surefire/") + path);
+      outFile = new File(SUREFIRE_TEST_DIR, path);
     }
     Util.discard(outFile.getParentFile().mkdirs());
     try (Reader reader = Util.reader(inFile);

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -190,14 +190,6 @@ public abstract class QuidemTest {
     return new QuidemConnectionFactory();
   }
 
-  /** Converts a path from Unix to native. On Windows, converts
-   * forward-slashes to back-slashes; on Linux, does nothing. */
-  private static String u2n(String s) {
-    return File.separatorChar == '\\'
-        ? s.replace('/', '\\')
-        : s;
-  }
-
   private static String n2u(String s) {
     return File.separatorChar == '\\'
         ? s.replace('\\', '/')


### PR DESCRIPTION
Writing to build/resources/test causes issues with incremental build support, ideally these directories shouldn't be written to once the tests have started.

With this change the intermediate files used by tests are written to other directories in the build folder. These locations are passed to the tests through system properties which are marked internal - so they don't factor into input hash key creation for the tests.

I don't know if there was a specific reason why the files were being written to build/resources/test - I'm assuming it was an oversight. Please review this change with care to ensure there wasn't a reason why the behavior was this way.