### PR TITLE
[CALCITE-5793] Use NULLS FIRST/LAST syntax for BigQuery

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -108,11 +108,6 @@ public class BigQuerySqlDialect extends SqlDialect {
         || RESERVED_KEYWORDS.contains(val.toUpperCase(Locale.ROOT));
   }
 
-  @Override public @Nullable SqlNode emulateNullDirection(SqlNode node,
-      boolean nullsFirst, boolean desc) {
-    return emulateNullDirectionWithIsNull(node, nullsFirst, desc);
-  }
-
   @Override public boolean supportsImplicitTypeCoercion(RexCall call) {
     return super.supportsImplicitTypeCoercion(call)
             && RexUtil.isLiteral(call.getOperands().get(0), false)

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7058,40 +7058,6 @@ class RelToSqlConverterTest {
         .withBigQuery().ok(expected);
   }
 
-  /**
-   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5775">[CALCITE-5775]</a>;
-   * make sure BigQuery uses {@code NULLS LAST} syntax.
-   */
-  @Test void testBigQueryUsesNullsLastInsteadOfEmulation() {
-    final Function<RelBuilder, RelNode> relFn = b ->
-        b.scan("EMP")
-            .project(
-                b.call(SqlStdOperatorTable.CASE,
-                    b.call(SqlStdOperatorTable.IS_NULL,
-                        b.field(4)),
-                    b.literal(0),
-                    b.literal(1)),
-                b.field(3))
-            .aggregate(
-                b.groupKey(
-                    ImmutableBitSet.of(0),
-                    ImmutableList.of(ImmutableBitSet.of(0))),
-                b.count(b.field(1)).as("cent"))
-            .sort(0)
-            .build();
-    final String expected = ""
-        + "SELECT CASE WHEN HIREDATE IS NULL THEN 0 ELSE 1 END AS `$f0`,"
-        + " COUNT(MGR) AS cent\n"
-        + "FROM SCOTT.EMP\n"
-        + "GROUP BY CASE WHEN HIREDATE IS NULL THEN 0 ELSE 1 END\n"
-        + "ORDER BY 1 NULLS LAST";
-
-    relFn(relFn)
-        .schema(CalciteAssert.SchemaSpec.JDBC_SCOTT)
-        .withBigQuery()
-        .ok(expected);
-  }
-
   /** Fluid interface to run tests. */
   static class Sql {
     private final CalciteAssert.SchemaSpec schemaSpec;


### PR DESCRIPTION
This may not be a complete solution to CALCITE-5775 but it fixes the issue for BigQuery by using the `NULLS FIRST` / `NULLS LAST` syntax introduced in 2020.