### PR TITLE
[CALCITE-5773] Gradle show tasks fails when creating javadocAggregateIncludingTests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         with:
           job-id: jdk${{ matrix.jdk }}
           remote-build-cache-proxy-enabled: false
-          arguments: --scan --no-parallel --no-daemon -Pguava.version=${{ env.GUAVA }} build
+          arguments: --scan --no-parallel --no-daemon -Pguava.version=${{ env.GUAVA }} tasks build
 
   linux-jdk11-tz:
     if: github.event.action != 'labeled'
@@ -244,7 +244,7 @@ jobs:
         with:
           job-id: jdk${{ matrix.jdk }}
           remote-build-cache-proxy-enabled: false
-          arguments: --scan --no-parallel --no-daemon -Pguava.version=${{ env.GUAVA }} build
+          arguments: --scan --no-parallel --no-daemon -Pguava.version=${{ env.GUAVA }} tasks build
 
   linux-avatica:
     if: github.event.action != 'labeled'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -202,6 +202,7 @@ val javadocAggregateIncludingTests by tasks.registering(Javadoc::class) {
     description = "Generates aggregate javadoc for all the artifacts"
 
     val sourceSets = subprojects
+        .filter { it.name != "bom" }
         .mapNotNull { it.extensions.findByType<SourceSetContainer>() }
         .flatMap { listOf(it.named("main"), it.named("test")) }
 


### PR DESCRIPTION
1. Exclude "bom" project from the javadoc aggregation since it does not have "main" and "test" objects causing "tasks" to fail.

2. Include "tasks" when building with newest & oldest JDK in CI to ensure it remains functional.