### PR TITLE
Draft pr to simplify and fix ORDER BY ordinal issues

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -610,17 +610,7 @@ public abstract class SqlImplementor {
      */
     public SqlNode orderField(int ordinal) {
       final SqlNode node = field(ordinal);
-      if (node instanceof SqlNumericLiteral
-          && dialect.getConformance().isSortByOrdinal()) {
-        // An integer literal will be wrongly interpreted as a field ordinal.
-        // Convert it to a character literal, which will have the same effect.
-        final String strValue = ((SqlNumericLiteral) node).toValue();
-        return SqlLiteral.createCharString(strValue, node.getParserPosition());
-      }
-      if (node instanceof SqlCall
-          && dialect.getConformance().isSortByOrdinal()) {
-        // If the field is expression and sort by ordinal is set in dialect,
-        // convert it to ordinal.
+      if (dialect.getConformance().isSortByOrdinal()) {
         return SqlLiteral.createExactNumeric(
             Integer.toString(ordinal + 1), SqlParserPos.ZERO);
       }
@@ -1561,6 +1551,11 @@ public abstract class SqlImplementor {
       }
       throw new AssertionError(
           "field ordinal " + ordinal + " out of range " + aliases);
+    }
+
+    @Override public SqlNode orderField(int ordinal) {
+      final SqlNode node = field(ordinal);
+      return node;
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -192,7 +192,7 @@ class JdbcAdapterTest {
         .enable(CalciteAssert.DB == CalciteAssert.DatabaseInstance.HSQLDB)
         .planHasSql("SELECT \"ENAME\", \"EMPNO\"\n"
             + "FROM \"SCOTT\".\"EMP\"\n"
-            + "ORDER BY \"EMPNO\" NULLS LAST");
+            + "ORDER BY 2 NULLS LAST");
   }
 
   /** Test case for
@@ -211,7 +211,7 @@ class JdbcAdapterTest {
     final String sqlHsqldb = "SELECT \"DEPTNO\", \"JOB\", SUM(\"SAL\")\n"
         + "FROM \"SCOTT\".\"EMP\"\n"
         + "GROUP BY \"JOB\", \"DEPTNO\"\n"
-        + "ORDER BY \"DEPTNO\" NULLS LAST, \"JOB\" NULLS LAST";
+        + "ORDER BY 1 NULLS LAST, 2 NULLS LAST";
     CalciteAssert.model(JdbcTest.SCOTT_MODEL)
         .with(CalciteConnectionProperty.TOPDOWN_OPT.camelName(), false)
         .query(sql)

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -394,7 +394,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "  LATERAL UNNEST (SELECT $cor1.$f2 AS $f0\n"
         + "    FROM (VALUES (0)) AS t (ZERO)) AS t3 (EMPNO, ENAME, JOB,"
         + " MGR, HIREDATE, SAL, COMM, DEPTNO) AS t30\n"
-        + "ORDER BY $cor1.DEPTNO, $cor1.JOB";
+        + "ORDER BY 1, 2";
     pig(script).assertRel(hasTree(plan))
         .assertSql(is(sql));
 
@@ -479,18 +479,20 @@ class PigRelOpTest extends PigRelTestBase {
         + "HIREDATE, SAL, COMM, DEPTNO)) AS A\n"
         + "        FROM scott.EMP\n"
         + "        GROUP BY DEPTNO) AS $cor4,\n"
-        + "      LATERAL (SELECT X\n"
-        + "        FROM (SELECT 'all' AS $f0, COLLECT(ROW(ENAME, JOB, DEPTNO, SAL)) AS X\n"
+        + "      LATERAL (SELECT COLLECT"
+        + "(ROW(ENAME, JOB, DEPTNO, SAL)) AS X\n"
+        + "        FROM (SELECT ENAME, JOB, DEPTNO, SAL\n"
         + "            FROM UNNEST (SELECT $cor4.A AS $f0\n"
-        + "                FROM (VALUES (0)) AS t (ZERO)) "
-        + "AS t2 (EMPNO, ENAME, JOB, MGR, HIREDATE, SAL, COMM, DEPTNO)\n"
+        + "                FROM (VALUES (0)) AS t"
+        + " (ZERO)) AS t2 (EMPNO, ENAME, JOB, MGR, HIREDATE, SAL, COMM, DEPTNO)\n"
         + "            WHERE JOB <> 'CLERK'\n"
-        + "            GROUP BY 'all'\n"
-        + "            ORDER BY SAL) AS t7) AS t8) AS $cor5,\n"
+        + "            ORDER BY 4) AS t5\n"
+        + "        GROUP BY 'all') AS t8) "
+        + "AS $cor5,\n"
         + "  LATERAL UNNEST (SELECT $cor5.X AS $f0\n"
-        + "    FROM (VALUES (0)) AS t (ZERO)) "
-        + "AS t11 (ENAME, JOB, DEPTNO, SAL) AS t110\n"
-        + "ORDER BY $cor5.group";
+        + "    FROM (VALUES (0)) AS t "
+        + "(ZERO)) AS t11 (ENAME, JOB, DEPTNO, SAL) AS t110\n"
+        + "ORDER BY 1";
     pig(script).assertRel(hasTree(plan))
         .assertResult(is(result))
         .assertSql(is(sql));
@@ -1180,7 +1182,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "(13,7698,MANAGER,30)\n"
         + "(14,7900,CLERK,30)\n";
     final String sql = ""
-        + "SELECT RANK() OVER (ORDER BY DEPTNO, JOB DESC RANGE BETWEEN "
+        + "SELECT RANK() OVER (ORDER BY 3, 2 DESC RANGE BETWEEN "
         + "UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_B, EMPNO, JOB, DEPTNO\n"
         + "FROM scott.EMP";
     pig(script).assertRel(hasTree(plan))
@@ -1216,7 +1218,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "(8,7698,MANAGER,30)\n"
         + "(9,7900,CLERK,30)\n";
     final String sql2 = ""
-        + "SELECT DENSE_RANK() OVER (ORDER BY DEPTNO, JOB DESC RANGE BETWEEN "
+        + "SELECT DENSE_RANK() OVER (ORDER BY 3, 2 DESC RANGE BETWEEN "
         + "UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_B, EMPNO, JOB, DEPTNO\n"
         + "FROM scott.EMP";
     pig(script2).assertRel(hasTree(plan2))


### PR DESCRIPTION
Exploring what would have to change in ReltoSqlConverterTest in order to simplify SqlImplementor->Context->orderField. 

Current findings
Tests that seem to be caused by bugs
- testConvertWindowToSql
Put in fix for egregious issue of (group by 10) in query 1. Ignore ordinals when in an aliasContext was fix. Don’t know enough about what it’s doing in the rest to be sure if they’re correct. 6 & 8 definitely seem wrong
- testMySqlUnparseListAggCall
listagg() order by shouldn't be ordinals, seems needlessly confusing
- PigRelOpTest -> testForEachNested
Confusing change, doesn't seem to match anything else.
- PigRelOpTest -> testRank()
Inserts Ordinals that don't exist 

Tests that insert a pretty crazy select clause, not sure if it’s what we want
- testOrderByNotInSelectList
- testRewriteOrderByWithNumericConstants
- testSelectQueryWithAscDescOrderByClause
- testSelectQueryWithLimitOffsetClause
- testSelectQueryWithTwoOrderByClause