### PR TITLE
[CALCITE-5819] Bump commons-collections 3.x to commons-collections4

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
         apiv("org.apache.commons:commons-lang3")
         apiv("org.apache.commons:commons-math3")
         apiv("org.apache.commons:commons-pool2")
+        apiv("org.apache.commons:commons-collections4")
         apiv("org.apache.geode:geode-core")
         apiv("org.apache.hadoop:hadoop-client", "hadoop")
         apiv("org.apache.hadoop:hadoop-common", "hadoop")

--- a/gradle.properties
+++ b/gradle.properties
@@ -96,6 +96,7 @@ commons-io.version=2.11.0
 commons-lang3.version=3.8
 commons-math3.version=3.6.1
 commons-pool2.version=2.6.2
+commons-collections4.version=4.4
 dropwizard-metrics.version=4.0.5
 
 # do not upgrade this, new versions are Category X license.

--- a/innodb/build.gradle.kts
+++ b/innodb/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     }
     api("com.google.guava:guava")
 
-    implementation("commons-collections:commons-collections")
+    implementation("org.apache.commons:commons-collections4")
     implementation("org.apache.calcite.avatica:avatica-core")
     implementation("org.apache.commons:commons-lang3")
     implementation("org.slf4j:slf4j-api")

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/IndexCondition.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/IndexCondition.java
@@ -22,7 +22,7 @@ import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.alibaba.innodb.java.reader.comparator.ComparisonOperator;
 import com.google.common.collect.ImmutableList;

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilterTranslator.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilterTranslator.java
@@ -30,7 +30,7 @@ import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.alibaba.innodb.java.reader.comparator.ComparisonOperator;
 import com.alibaba.innodb.java.reader.schema.KeyMeta;

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbSchema.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbSchema.java
@@ -25,7 +25,7 @@ import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.alibaba.innodb.java.reader.TableReaderFactory;

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbTableScan.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbTableScan.java
@@ -30,7 +30,7 @@ import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.type.RelDataType;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.alibaba.innodb.java.reader.Constants;
 import com.alibaba.innodb.java.reader.schema.KeyMeta;

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbToEnumerableConverter.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbToEnumerableConverter.java
@@ -40,7 +40,7 @@ import org.apache.calcite.util.BuiltInMethod;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.alibaba.innodb.java.reader.comparator.ComparisonOperator;
 

--- a/innodb/src/test/java/org/apache/calcite/adapter/innodb/InnodbAdapterTest.java
+++ b/innodb/src/test/java/org/apache/calcite/adapter/innodb/InnodbAdapterTest.java
@@ -26,7 +26,7 @@ import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Sources;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.alibaba.innodb.java.reader.util.Utils;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
# What is the purpose of the change
Apache commons-collections 3.x is a Java 1.3 compatible version, and it does not use Java 5 generics. Apache commons-collections4 4.4 is an upgraded version of commons-collections and it built by Java 8.

# Brief change log
update kts dependency

# Verifying this change
This change is a trivial rework / code cleanup. Verifying by current total cases.