### PR TITLE
[CALCITE-5822] Add BIT_LENGTH function (enabled in Spark library)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -142,6 +142,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.ARRAY_TO_STRING;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.ARRAY_UNION;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.ASINH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.ATANH;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.BIT_LENGTH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.BOOL_AND;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.BOOL_OR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CEIL_BIG_QUERY;
@@ -510,6 +511,8 @@ public class RexImpTable {
       defineMethod(CHAR_LENGTH, BuiltInMethod.CHAR_LENGTH.method,
           NullPolicy.STRICT);
       defineMethod(OCTET_LENGTH, BuiltInMethod.OCTET_LENGTH.method,
+          NullPolicy.STRICT);
+      defineMethod(BIT_LENGTH, BuiltInMethod.BIT_LENGTH.method,
           NullPolicy.STRICT);
       map.put(CONCAT, new ConcatImplementor());
       defineMethod(CONCAT_FUNCTION, BuiltInMethod.MULTI_STRING_CONCAT.method,

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -788,6 +788,16 @@ public class SqlFunctions {
     return s.length();
   }
 
+  /** SQL BIT_LENGTH(string) function. */
+  public static int bitLength(String s) {
+    return s.getBytes(UTF_8).length * 8;
+  }
+
+  /** SQL BIT_LENGTH(binary) function. */
+  public static int bitLength(ByteString s) {
+    return s.length() * 8;
+  }
+
   /** SQL {@code string || string} operator. */
   public static String concat(String s0, String s1) {
     return s0 + s1;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1814,4 +1814,12 @@ public abstract class SqlLibraryOperators {
           ReturnTypes.BOOLEAN,
           InferTypes.FIRST_KNOWN,
           OperandTypes.COMPARABLE_UNORDERED_COMPARABLE_UNORDERED);
+
+  /** The "BIT_LENGTH(string or binary)" function. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction BIT_LENGTH =
+      SqlBasicFunction.create("BIT_LENGTH",
+          ReturnTypes.INTEGER_NULLABLE,
+          OperandTypes.or(OperandTypes.CHARACTER, OperandTypes.BINARY),
+          SqlFunctionCategory.NUMERIC);
 }

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -423,6 +423,7 @@ public enum BuiltInMethod {
   ENDS_WITH(SqlFunctions.class, "endsWith", String.class, String.class),
   OCTET_LENGTH(SqlFunctions.class, "octetLength", ByteString.class),
   CHAR_LENGTH(SqlFunctions.class, "charLength", String.class),
+  BIT_LENGTH(SqlFunctions.class, "bitLength", String.class),
   STRING_CONCAT(SqlFunctions.class, "concat", String.class, String.class),
   STRING_CONCAT_WITH_NULL(SqlFunctions.class, "concatWithNull", String.class,
       String.class),

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2827,6 +2827,8 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b | UNIX_SECONDS(timestamp)                        | Returns the number of seconds since 1970-01-01 00:00:00
 | b | UNIX_DATE(date)                                | Returns the number of days since 1970-01-01
 | o | XMLTRANSFORM(xml, xslt)                        | Applies XSLT transform *xslt* to XML string *xml* and returns the result
+| s | BIT_LENGTH(string)                             | Returns the bit length of *string*
+| s | BIT_LENGTH(binary)                             | Returns the bit length of *binary*
 
 Note:
 

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2676,6 +2676,8 @@ BigQuery's type system uses confusingly different names for types and functions:
 | s | SORT_ARRAY(array [, ascendingOrder])           | Sorts the *array* in ascending or descending order according to the natural ordering of the array elements. The default order is ascending if *ascendingOrder* is not specified. Null elements will be placed at the beginning of the returned array in ascending order or at the end of the returned array in descending order
 | * | ASINH(numeric)                                 | Returns the inverse hyperbolic sine of *numeric*
 | * | ATANH(numeric)                                 | Returns the inverse hyperbolic tangent of *numeric*
+| s | BIT_LENGTH(binary)                             | Returns the bit length of *binary*
+| s | BIT_LENGTH(string)                             | Returns the bit length of *string*
 | b | CEIL(value)                                    | Similar to standard `CEIL(value)` except if *value* is an integer type, the return type is a double
 | m s | CHAR(integer)                                | Returns the character whose ASCII code is *integer* % 256, or null if *integer* &lt; 0
 | b o p | CHR(integer)                               | Returns the character whose UTF-8 code is *integer*
@@ -2827,8 +2829,6 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b | UNIX_SECONDS(timestamp)                        | Returns the number of seconds since 1970-01-01 00:00:00
 | b | UNIX_DATE(date)                                | Returns the number of days since 1970-01-01
 | o | XMLTRANSFORM(xml, xslt)                        | Applies XSLT transform *xslt* to XML string *xml* and returns the result
-| s | BIT_LENGTH(string)                             | Returns the bit length of *string*
-| s | BIT_LENGTH(binary)                             | Returns the bit length of *binary*
 
 Note:
 

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -3932,6 +3932,21 @@ public class SqlOperatorTest {
     f.checkNull("OCTET_LENGTH(cast(null as varbinary(1)))");
   }
 
+  @Test void testBitLengthFunc() {
+    final SqlOperatorFixture f0 = fixture();
+    f0.setFor(SqlLibraryOperators.BIT_LENGTH, VmName.EXPAND);
+    f0.checkFails("^bit_length('Apache Calcite')^",
+        "No match found for function signature BIT_LENGTH\\(<CHARACTER>\\)", false);
+
+    final SqlOperatorFixture f1 = f0.withLibrary(SqlLibrary.SPARK);
+    // string
+    f1.checkScalarExact("BIT_LENGTH('Apache Calcite')", 112);
+    f1.checkNull("BIT_LENGTH(cast(null as varchar(1)))");
+    // binary string
+    f1.checkScalarExact("BIT_LENGTH(x'4170616368652043616C63697465')", 112);
+    f1.checkNull("BIT_LENGTH(cast(null as binary))");
+  }
+
   @Test void testAsciiFunc() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.ASCII, VmName.EXPAND);


### PR DESCRIPTION
# What is the purpose of the change

Returns the string or binary data bit numbers.

> SELECT bit_length('Apache Calcite');
112
> SELECT bit_length(x'4170616368652043616C63697465');
112
 
details pls see: https://spark.apache.org/docs/latest/api/sql/index.html#bit_length

# Brief change log
Add bit_length (enabled in Spark library)

# Verifying this change
SqlOperatorTests#testBitLength
