### PR TITLE
[CALCITE-5824] Handle IndexCondition null pointQueryKey list in innodb

### DIFF
--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/IndexCondition.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/IndexCondition.java
@@ -95,7 +95,8 @@ public class IndexCondition {
         remainderConditions == null ? ImmutableList.of()
             : ImmutableList.copyOf(remainderConditions);
     this.queryType = queryType;
-    this.pointQueryKey = pointQueryKey;
+    this.pointQueryKey = pointQueryKey == null ? ImmutableList.of()
+            : ImmutableList.copyOf(pointQueryKey);
     this.rangeQueryLowerOp = Objects.requireNonNull(rangeQueryLowerOp, "rangeQueryLowerOp");
     this.rangeQueryUpperOp = Objects.requireNonNull(rangeQueryUpperOp, "rangeQueryUpperOp");
     this.rangeQueryLowerKey = ImmutableList.copyOf(rangeQueryLowerKey);

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbToEnumerableConverter.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbToEnumerableConverter.java
@@ -181,7 +181,7 @@ public class InnodbToEnumerableConverter extends ConverterImpl
    * {@code {ConstantExpression("x"), ConstantExpression("y")}}.
    */
   private static <T> List<Expression> constantList(List<T> values) {
-    if (values == null || values.isEmpty()) {
+    if (values.isEmpty()) {
       return Collections.emptyList();
     }
     return Util.transform(values, Expressions::constant);


### PR DESCRIPTION
# What is the purpose of the change
https://issues.apache.org/jira/browse/CALCITE-5824

# Brief change log
Refine constructor of IndexCondition, when pointQueryKey is null set an emptyList like other variables do.

# Verifying this change
This change is a trivial rework / code cleanup. Verifying by current total cases.