### PR TITLE
[CALCITE-5829] Add BYTE_LENGTH function (enabled in BigQuery Library)

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -144,6 +144,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.ASINH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.ATANH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.BOOL_AND;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.BOOL_OR;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.BYTE_LENGTH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CEIL_BIG_QUERY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CHAR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.CHR;
@@ -514,6 +515,8 @@ public class RexImpTable {
       defineMethod(CHAR_LENGTH, BuiltInMethod.CHAR_LENGTH.method,
           NullPolicy.STRICT);
       defineMethod(OCTET_LENGTH, BuiltInMethod.OCTET_LENGTH.method,
+          NullPolicy.STRICT);
+      defineMethod(BYTE_LENGTH, BuiltInMethod.BYTE_LENGTH.method,
           NullPolicy.STRICT);
       map.put(CONCAT, new ConcatImplementor());
       defineMethod(CONCAT_FUNCTION, BuiltInMethod.MULTI_STRING_CONCAT.method,

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -805,6 +805,16 @@ public class SqlFunctions {
     return s.length();
   }
 
+  /** SQL BYTE_LENGTH(string) function. */
+  public static long byteLength(String s) {
+    return s.getBytes(UTF_8).length;
+  }
+
+  /** SQL BYTE_LENGTH(binary) function. */
+  public static long byteLength(ByteString s) {
+    return s.length();
+  }
+
   /** SQL {@code string || string} operator. */
   public static String concat(String s0, String s1) {
     return s0 + s1;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1834,4 +1834,12 @@ public abstract class SqlLibraryOperators {
           ReturnTypes.BOOLEAN,
           InferTypes.FIRST_KNOWN,
           OperandTypes.COMPARABLE_UNORDERED_COMPARABLE_UNORDERED);
+
+  /** The "BYTE_LENGTH(string or binary)" function. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction BYTE_LENGTH =
+      SqlBasicFunction.create("BYTE_LENGTH",
+          ReturnTypes.INTEGER_NULLABLE,
+          OperandTypes.or(OperandTypes.CHARACTER, OperandTypes.BINARY),
+          SqlFunctionCategory.NUMERIC);
 }

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -425,6 +425,7 @@ public enum BuiltInMethod {
   ENDS_WITH(SqlFunctions.class, "endsWith", String.class, String.class),
   OCTET_LENGTH(SqlFunctions.class, "octetLength", ByteString.class),
   CHAR_LENGTH(SqlFunctions.class, "charLength", String.class),
+  BYTE_LENGTH(SqlFunctions.class, "byteLength", String.class),
   STRING_CONCAT(SqlFunctions.class, "concat", String.class, String.class),
   STRING_CONCAT_WITH_NULL(SqlFunctions.class, "concatWithNull", String.class,
       String.class),

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2676,6 +2676,8 @@ BigQuery's type system uses confusingly different names for types and functions:
 | s | SORT_ARRAY(array [, ascendingOrder])           | Sorts the *array* in ascending or descending order according to the natural ordering of the array elements. The default order is ascending if *ascendingOrder* is not specified. Null elements will be placed at the beginning of the returned array in ascending order or at the end of the returned array in descending order
 | * | ASINH(numeric)                                 | Returns the inverse hyperbolic sine of *numeric*
 | * | ATANH(numeric)                                 | Returns the inverse hyperbolic tangent of *numeric*
+| b | BYTE_LENGTH(binary)                            | Returns the byte length of *binary*
+| b | BYTE_LENGTH(string)                            | Returns the byte length of *string*
 | b | CEIL(value)                                    | Similar to standard `CEIL(value)` except if *value* is an integer type, the return type is a double
 | m s | CHAR(integer)                                | Returns the character whose ASCII code is *integer* % 256, or null if *integer* &lt; 0
 | b o p | CHR(integer)                               | Returns the character whose UTF-8 code is *integer*

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -3932,6 +3932,21 @@ public class SqlOperatorTest {
     f.checkNull("OCTET_LENGTH(cast(null as varbinary(1)))");
   }
 
+  @Test void testByteLengthFunc() {
+    final SqlOperatorFixture f0 = Fixtures.forOperators(true);
+    f0.setFor(SqlLibraryOperators.BYTE_LENGTH, VmName.EXPAND);
+    f0.checkFails("^byte_length('Apache Calcite')^",
+        "No match found for function signature BYTE_LENGTH\\(<CHARACTER>\\)", false);
+
+    final SqlOperatorFixture f1 = f0.withLibrary(SqlLibrary.BIG_QUERY);
+    // string
+    f1.checkScalarExact("BYTE_LENGTH('Apache Calcite')", 14);
+    f1.checkNull("BYTE_LENGTH(cast(null as varchar(1)))");
+    // binary string
+    f1.checkScalarExact("BYTE_LENGTH(x'4170616368652043616C63697465')", 14);
+    f1.checkNull("BYTE_LENGTH(cast(null as binary))");
+  }
+
   @Test void testAsciiFunc() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.ASCII, VmName.EXPAND);


### PR DESCRIPTION
# What is the purpose of the change

Returns the string or binary data bit numbers.

> SELECT byte_length('Apache Calcite');
14
> SELECT byte_length(x'4170616368652043616C63697465');
14
 
details pls see: https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#byte_length

# Brief change log
Add byte_length function (enabled in BigQuery Library)

# Verifying this change
SqlOperatorTests#testByteLength
