### PR TITLE
[CALCITE-5836] Implement Rel2Sql for MERGE

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1882,7 +1882,7 @@ SqlInsert WhenNotMatchedClause(SqlNode table) :
     final List<SqlLiteral> keywords = new ArrayList<SqlLiteral>();
     final SqlNodeList keywordList;
     final SqlNodeList insertColumnList;
-    SqlNode rowConstructor;
+    List<SqlNode> valueList;
     SqlNode insertValues;
 }
 {
@@ -1899,17 +1899,19 @@ SqlInsert WhenNotMatchedClause(SqlNode table) :
     )
     (
         <LPAREN>
-        <VALUES> { valuesSpan = span(); } rowConstructor = RowConstructor()
+        <VALUES> { valuesSpan = span(); }
+        valueList = ParenthesizedQueryOrCommaListWithDefault(ExprContext.ACCEPT_NONCURSOR)
         <RPAREN>
     |
-        <VALUES> { valuesSpan = span(); } rowConstructor = RowConstructor()
+        <VALUES> { valuesSpan = span(); }
+        valueList = ParenthesizedQueryOrCommaListWithDefault(ExprContext.ACCEPT_NONCURSOR)
     )
     {
         // TODO zfong 5/26/06: note that extra parentheses are accepted above
         // around the VALUES clause as a hack for unparse, but this is
         // actually invalid SQL; should fix unparse
         insertValues = SqlStdOperatorTable.VALUES.createCall(
-            valuesSpan.end(this), rowConstructor);
+            valuesSpan.end(this), valueList);
         return new SqlInsert(insertSpan.end(this), keywordList,
             table, insertValues, insertColumnList);
     }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -2138,6 +2138,7 @@ public abstract class RelOptUtil {
     case INSERT:
     case DELETE:
     case UPDATE:
+    case MERGE:
       return typeFactory.createStructType(
           PairList.of(AvaticaConnection.ROWCOUNT_COLUMN_NAME,
               typeFactory.createSqlType(SqlTypeName.BIGINT)));

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -591,6 +591,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
     case INSERT:
     case DELETE:
     case UPDATE:
+    case MERGE:
       return Meta.StatementType.IS_DML;
     default:
       return Meta.StatementType.SELECT;
@@ -668,6 +669,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
       case DELETE:
       case UPDATE:
       case EXPLAIN:
+      case MERGE:
         // FIXME: getValidatedNodeType is wrong for DML
         x = RelOptUtil.createDmlRowType(sqlNode.getKind(), typeFactory);
         break;

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -1063,6 +1063,7 @@ public class RelToSqlConverter extends SqlImplementor
       final RelDataType targetRowType = modify.getTable().getRowType();
       final List<String> updateColumnList = (modify.getUpdateColumnList() != null)
           ? modify.getUpdateColumnList() : Collections.emptyList();
+      assert updateColumnList != null;
 
       // Convert input into a SELECT which contains the join condition
       final SqlSelect select = visitInput(modify, 0).asSelect();

--- a/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql;
 
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
@@ -211,7 +212,12 @@ public class SqlMerge extends SqlCall {
       if (targetColumnList != null) {
         targetColumnList.unparse(writer, opLeft, opRight);
       }
-      insertCall.getSource().unparse(writer, 0, 0);
+      if (insertCall.getSource().getKind() == SqlKind.VALUES) {
+        SqlUtil.unparseFunctionSyntax(SqlStdOperatorTable.VALUES, writer,
+            (SqlCall) insertCall.getSource(), false);
+      } else {
+        insertCall.getSource().unparse(writer, 0, 0);
+      }
 
       writer.endList(frame);
     }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -108,11 +108,6 @@ public class BigQuerySqlDialect extends SqlDialect {
         || RESERVED_KEYWORDS.contains(val.toUpperCase(Locale.ROOT));
   }
 
-  @Override public @Nullable SqlNode emulateNullDirection(SqlNode node,
-      boolean nullsFirst, boolean desc) {
-    return emulateNullDirectionWithIsNull(node, nullsFirst, desc);
-  }
-
   @Override public boolean supportsImplicitTypeCoercion(RexCall call) {
     return super.supportsImplicitTypeCoercion(call)
             && RexUtil.isLiteral(call.getOperands().get(0), false)

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1611,14 +1611,12 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // Source for the insert call is a select of the source table
     // reference with the select list being the value expressions;
     // note that the values clause has already been converted to a
-    // select on the values row constructor; so we need to extract
-    // that via the from clause on the select
+    // select; so we need to extract that via the from clause on the select
     if (insertCall != null) {
-      SqlCall valuesCall = (SqlCall) insertCall.getSource();
-      SqlCall rowCall = valuesCall.operand(0);
+      SqlCall values = (SqlCall) insertCall.getSource();
       selectList =
           new SqlNodeList(
-              rowCall.getOperandList(),
+              values.getOperandList(),
               SqlParserPos.ZERO);
       final SqlNode insertSource = SqlNode.clone(sourceTableRef);
       select =

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3180,7 +3180,7 @@ class RelToSqlConverterTest {
     // BigQuery uses LIMIT/OFFSET, and nulls sort low by default
     final String expectedBigQuery = "SELECT product_id\n"
         + "FROM foodmart.product\n"
-        + "ORDER BY net_weight IS NULL, net_weight\n"
+        + "ORDER BY net_weight NULLS LAST\n"
         + "LIMIT 100\n"
         + "OFFSET 10";
     sql(query).ok(expected)
@@ -7074,7 +7074,7 @@ class RelToSqlConverterTest {
         + "FROM SCOTT.EMP\n"
         + "GROUP BY DEPTNO\n"
         + "HAVING COUNT(DISTINCT EMPNO) > 0\n"
-        + "ORDER BY COUNT(DISTINCT EMPNO) IS NULL DESC, 2 DESC";
+        + "ORDER BY 2 DESC NULLS FIRST";
 
     // Convert rel node to SQL with BigQuery dialect,
     // in which "isHavingAlias" is true.

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7107,6 +7107,65 @@ class RelToSqlConverterTest {
     sql(query).withMssql().ok(expectedMssql);
   }
 
+  @Test void testMerge() {
+    final String sql = "merge into \"account\"\n"
+        + "using \"sales_fact_1997\"\n"
+        + "on \"account\".\"account_id\" = \"sales_fact_1997\".\"product_id\"\n"
+        + "when matched then update\n"
+        + "set \"account_rollup\" = \"account\".\"account_type\"\n"
+        + "when not matched then insert (\"account_id\", \"account_parent\",\n"
+        + "\"account_type\", \"account_rollup\")\n"
+        + "values (\"sales_fact_1997\".\"product_id\", NULL, ?, ?)";
+    final String expected = "MERGE INTO \"foodmart\".\"account\"\n"
+        + "USING \"foodmart\".\"sales_fact_1997\"\n"
+        + "ON \"sales_fact_1997\".\"product_id\" = \"account\".\"account_id\"\n"
+        + "WHEN MATCHED THEN UPDATE "
+        + "SET \"account_rollup\" = \"account\".\"account_type\"\n"
+        + "WHEN NOT MATCHED THEN INSERT (\"account_id\", \"account_parent\", "
+        + "\"account_description\", \"account_type\", \"account_rollup\", "
+        + "\"Custom_Members\") "
+        + "VALUES(\"sales_fact_1997\".\"product_id\", CAST(NULL AS INTEGER), "
+        + "CAST(NULL AS VARCHAR(30) CHARACTER SET \"ISO-8859-1\"), ?, ?, "
+        + "CAST(NULL AS VARCHAR(255) CHARACTER SET \"ISO-8859-1\"))";
+    sql(sql)
+        .ok(expected);
+  }
+
+  @Test void testMergeWhenMatched() {
+    final String sql = "merge into \"account\"\n"
+        + "using \"sales_fact_1997\"\n"
+        + "on \"account\".\"account_id\" = \"sales_fact_1997\".\"product_id\"\n"
+        + "when matched then update\n"
+        + "set \"account_rollup\" = \"account\".\"account_type\"";
+    final String expected = "MERGE INTO \"foodmart\".\"account\"\n"
+        + "USING \"foodmart\".\"sales_fact_1997\"\n"
+        + "ON \"sales_fact_1997\".\"product_id\" = \"account\".\"account_id\"\n"
+        + "WHEN MATCHED THEN UPDATE "
+        + "SET \"account_rollup\" = \"account\".\"account_type\"";
+    sql(sql)
+        .ok(expected);
+  }
+
+  @Test void testMergeWhenNotMatched() {
+    final String sql = "merge into \"account\"\n"
+        + "using \"sales_fact_1997\"\n"
+        + "on \"account\".\"account_id\" = \"sales_fact_1997\".\"product_id\"\n"
+        + "when not matched then insert (\"account_id\", \"account_parent\",\n"
+        + "\"account_type\", \"account_rollup\")\n"
+        + "values (\"sales_fact_1997\".\"product_id\", NULL, ?, ?)";
+    final String expected = "MERGE INTO \"foodmart\".\"account\"\n"
+        + "USING \"foodmart\".\"sales_fact_1997\"\n"
+        + "ON \"sales_fact_1997\".\"product_id\" = \"account\".\"account_id\"\n"
+        + "WHEN NOT MATCHED THEN INSERT (\"account_id\", \"account_parent\", "
+        + "\"account_description\", \"account_type\", \"account_rollup\", "
+        + "\"Custom_Members\") "
+        + "VALUES(\"sales_fact_1997\".\"product_id\", CAST(NULL AS INTEGER), "
+        + "CAST(NULL AS VARCHAR(30) CHARACTER SET \"ISO-8859-1\"), ?, ?, "
+        + "CAST(NULL AS VARCHAR(255) CHARACTER SET \"ISO-8859-1\"))";
+    sql(sql)
+        .ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final CalciteAssert.SchemaSpec schemaSpec;

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -1106,6 +1106,47 @@ class JdbcAdapterTest {
         .returns("C=null\nC=null\nC=null\nC=null\nC=null\nC=null\nC=null\n");
   }
 
+  @Test void testMerge() throws Exception {
+    final String sql = "merge into \"foodmart\".\"expense_fact\"\n"
+        + "using (values(666, 42)) as vals(store_id, amount)\n"
+        + "on \"expense_fact\".\"store_id\" = vals.store_id\n"
+        + "when matched then update\n"
+        + "set \"amount\" = vals.amount\n"
+        + "when not matched then insert\n"
+        + "values (vals.store_id, 666, TIMESTAMP '1997-01-01 00:00:00', 666, '666', 666,"
+        + " vals.amount)";
+    final String explain = "PLAN=JdbcToEnumerableConverter\n"
+        + "  JdbcTableModify(table=[[foodmart, expense_fact]], operation=[MERGE],"
+        + " updateColumnList=[[amount]], flattened=[false])\n"
+        + "    JdbcProject(STORE_ID=[$0], $f1=[666], $f2=[1997-01-01 00:00:00], $f3=[666],"
+        + " $f4=['666'], $f5=[666], AMOUNT=[CAST($1):DECIMAL(10, 4) NOT NULL], store_id=[$2],"
+        + " account_id=[$3], exp_date=[$4], time_id=[$5], category_id=[$6], currency_id=[$7],"
+        + " amount=[$8], AMOUNT0=[$1])\n"
+        + "      JdbcJoin(condition=[=($2, $0)], joinType=[left])\n"
+        + "        JdbcValues(tuples=[[{ 666, 42 }]])\n"
+        + "        JdbcTableScan(table=[[foodmart, expense_fact]])\n";
+    final String jdbcSql = "MERGE INTO \"foodmart\".\"expense_fact\"\n"
+        + "USING (VALUES (666, 42)) AS \"t\" (\"STORE_ID\", \"AMOUNT\")\n"
+        + "ON \"t\".\"STORE_ID\" = \"expense_fact\".\"store_id\"\n"
+        + "WHEN MATCHED THEN UPDATE SET \"amount\" = \"t\".\"AMOUNT\"\n"
+        + "WHEN NOT MATCHED THEN INSERT (\"store_id\", \"account_id\", \"exp_date\", \"time_id\","
+        + " \"category_id\", \"currency_id\", \"amount\") VALUES(\"t\".\"STORE_ID\", 666,"
+        + " TIMESTAMP '1997-01-01 00:00:00', 666, '666', 666,"
+        + " CAST(\"t\".\"AMOUNT\" AS DECIMAL(10, 4)))";
+    final AssertThat that =
+        CalciteAssert.model(FoodmartSchema.FOODMART_MODEL)
+            .enable(CalciteAssert.DB == DatabaseInstance.HSQLDB);
+    that.doWithConnection(connection -> {
+      try (LockWrapper ignore = exclusiveCleanDb(connection)) {
+        that.query(sql)
+            .explainContains(explain)
+            .planUpdateHasSql(jdbcSql, 1);
+      } catch (SQLException e) {
+        throw TestUtil.rethrow(e);
+      }
+    });
+  }
+
   /** Acquires a lock, and releases it when closed. */
   static class LockWrapper implements AutoCloseable {
     private final Lock lock;

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -177,9 +177,13 @@ import static org.junit.jupiter.api.Assertions.fail;
  * for details on the schema.
  *
  * <li>Run the test. It should fail. Inspect the output in
- * {@code build/resources/.../RelOptRulesTest_actual.xml}
- * (e.g., {@code diff src/test/resources/.../RelOptRulesTest.xml
- * build/resources/.../RelOptRulesTest_actual.xml}).
+ * {@code build/diffrepo/test/org/apache/calcite/test/RelOptRulesTest_actual.xml},
+ * e.g.
+ *
+ * <blockquote>{@code
+ * diff core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+ * build/diffrepo/test/org/apache/calcite/test/RelOptRulesTest_actual.xml
+ * }</blockquote>
  *
  * <li>Verify that the "planBefore" is the correct translation of your SQL,
  * and that it contains the pattern on which your rule is supposed to fire.

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1732,6 +1732,97 @@ EnumerableValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelatedFilterWithoutVariable">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalFilter(condition=[EXISTS({
+LogicalProject(DEPTNO=[$7])
+  LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), >($5, 100))])
+    LogicalTableScan(table=[[scott, EMP]])
+})])
+  LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], DNAME=[$1], LOC=[$2])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+    LogicalTableScan(table=[[scott, DEPT]])
+    LogicalAggregate(group=[{0}])
+      LogicalProject(i=[true])
+        LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), >($5, 100))])
+          LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCorrelatedVariableAtSecondLevel">
+    <Resource name="sql">
+      <![CDATA[SELECT d1.name, d1.deptno +(
+SELECT e1.empno
+FROM emp e1
+WHERE e1.sal = (SELECT max(sal)
+                FROM emp e2
+                WHERE e1.sal = e2.sal and
+                    e1.deptno = e2.deptno and
+                    d1.deptno < e2.deptno))
+FROM dept d1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[=($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))], variablesSet=[[$cor0]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $2)])
+  LogicalCorrelate(correlation=[$cor2], joinType=[left], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+      LogicalProject(EMPNO=[$0])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+          LogicalFilter(condition=[=($5, $9)])
+            LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{5, 7}])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+              LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+                LogicalProject(SAL=[$5])
+                  LogicalFilter(condition=[AND(=($cor0.SAL, $5), =($cor0.DEPTNO, $7), <($cor2.DEPTNO, $7))])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $3)])
+  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
+      LogicalProject(DEPTNO00=[$11], EMPNO=[$0])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], SAL0=[CAST($9):INTEGER], DEPTNO0=[CAST($10):INTEGER], DEPTNO00=[CAST($11):INTEGER], EXPR$0=[CAST($12):INTEGER])
+          LogicalJoin(condition=[AND(=($5, $9), =($7, $10))], joinType=[inner])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+            LogicalFilter(condition=[=($0, $3)])
+              LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
+                LogicalProject(SAL0=[$9], DEPTNO0=[$10], DEPTNO00=[$11], SAL=[$5])
+                  LogicalJoin(condition=[AND(=($9, $5), =($10, $7), <($11, $7))], joinType=[inner])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                    LogicalJoin(condition=[true], joinType=[inner])
+                      LogicalAggregate(group=[{0, 1}])
+                        LogicalProject(SAL=[$5], DEPTNO=[$7])
+                          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                      LogicalProject(DEPTNO=[$0])
+                        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCorrelationScalarAggAndFilter">
     <Resource name="sql">
       <![CDATA[SELECT e1.empno
@@ -14940,6 +15031,75 @@ LogicalProject(DEPTNO=[$0], DEPTNO0=[$1])
             LogicalTableScan(table=[[CATALOG, SALES, EMP]])
         LogicalProject(DEPTNO=[$7])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTwoLevelDecorrelate">
+    <Resource name="sql">
+      <![CDATA[SELECT d1.name, d1.deptno + (
+SELECT e1.empno
+FROM emp e1
+WHERE d1.deptno = e1.deptno and
+    e1.sal = (SELECT max(sal)
+              FROM emp e2
+              WHERE e1.sal = e2.sal and
+                  e1.deptno = e2.deptno and
+                  d1.deptno < e2.deptno))
+FROM dept d1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $SCALAR_QUERY({
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+  LogicalProject(SAL=[$5])
+    LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})))], variablesSet=[[$cor1]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+}))])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planMid">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $2)])
+  LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+      LogicalProject(EMPNO=[$0])
+        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+          LogicalFilter(condition=[AND(=($cor0.DEPTNO, $7), =($5, $9))])
+            LogicalCorrelate(correlation=[$cor1], joinType=[left], requiredColumns=[{5, 7}])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+              LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+                LogicalProject(SAL=[$5])
+                  LogicalFilter(condition=[AND(=($cor1.SAL, $5), =($cor1.DEPTNO, $7), <($cor0.DEPTNO, $7))])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(NAME=[$1], EXPR$1=[+($0, $3)])
+  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
+      LogicalProject(DEPTNO0=[$10], EMPNO=[$0])
+        LogicalFilter(condition=[AND(=($10, $7), =($5, $9))])
+          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EXPR$0=[$12], DEPTNO0=[$9])
+            LogicalJoin(condition=[AND(=($5, $10), =($7, $11))], joinType=[left])
+              LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+              LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
+                LogicalProject(DEPTNO0=[$9], SAL0=[$10], DEPTNO00=[$11], SAL=[$5])
+                  LogicalJoin(condition=[AND(=($10, $5), =($11, $7), <($9, $7))], joinType=[inner])
+                    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+                    LogicalJoin(condition=[true], joinType=[inner])
+                      LogicalProject(DEPTNO=[$0])
+                        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+                      LogicalAggregate(group=[{0, 1}])
+                        LogicalProject(SAL=[$5], DEPTNO=[$7])
+                          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -777,6 +777,25 @@ having exists
 
 !ok
 
+# Having with correlation anded with normal condition.
+with src (key, "value")
+  as (select * from (values (1, 'a'), (2, 'z')) as t(key, "value"))
+select b.key, count(*) as c
+from src b
+group by b.key
+having exists
+  (select a.key
+  from src a
+  where a.key = b.key and a."value" > 'val_9') and b.key > 0;
++-----+---+
+| KEY | C |
++-----+---+
+|   2 | 1 |
++-----+---+
+(1 row)
+
+!ok
+
 # [CALCITE-411] Duplicate aliases
 select 1 as a, 2 as a from (values (true));
 +---+---+

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -3611,4 +3611,78 @@ from emp;
 
 !ok
 
+# Test case for [CALCITE-5789]
+select deptno from dept d1 where exists (
+ select 1 from dept d2 where d2.deptno = d1.deptno and exists (
+  select 1 from dept d3 where d3.deptno = d2.deptno and d3.dname = d1.dname));
++--------+
+| DEPTNO |
++--------+
+|     10 |
+|     20 |
+|     30 |
+|     40 |
++--------+
+(4 rows)
+
+!ok
+EnumerableCalc(expr#0..3=[{inputs}], DEPTNO=[$t2])
+  EnumerableHashJoin(condition=[AND(=($0, $2), =($1, $3))], joinType=[inner])
+    EnumerableCalc(expr#0..2=[{inputs}], proj#0..1=[{exprs}])
+      EnumerableMergeJoin(condition=[=($0, $2)], joinType=[inner])
+        EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
+          EnumerableTableScan(table=[[scott, DEPT]])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[IS NOT NULL($t1)], DNAME=[$t1], DEPTNO=[$t0], $condition=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
+    EnumerableCalc(expr#0..2=[{inputs}], proj#0..1=[{exprs}])
+      EnumerableTableScan(table=[[scott, DEPT]])
+!plan
+
+# Test case for CALCITE-5683 which throws an exception during the de-correlation phase
+SELECT d1.dname, d1.deptno + (
+  SELECT max(e1.empno)
+  FROM emp e1
+  WHERE d1.deptno = e1.deptno and
+        e1.sal = (
+          SELECT max(sal)
+          FROM emp e2
+          WHERE e1.sal = e2.sal and
+                e1.deptno = e2.deptno and
+                d1.deptno <= e2.deptno))
+FROM dept d1;
++------------+--------+
+| DNAME      | EXPR$1 |
++------------+--------+
+| ACCOUNTING |   7944 |
+| OPERATIONS |        |
+| RESEARCH   |   7922 |
+| SALES      |   7930 |
++------------+--------+
+(4 rows)
+
+!ok
+
+# Test case for CALCITE-5683 which throws an exception during the de-correlation phase
+SELECT d1.dname, d1.deptno + (
+  SELECT max(e1.empno)
+  FROM emp e1
+  WHERE d1.deptno = e1.deptno and
+        e1.sal = (SELECT max(sal)
+                  FROM emp e2
+                  WHERE e1.sal = e2.sal and
+                        e1.deptno = e2.deptno and
+                        d1.deptno < e2.deptno))
+FROM dept d1;
++------------+--------+
+| DNAME      | EXPR$1 |
++------------+--------+
+| ACCOUNTING |        |
+| OPERATIONS |        |
+| RESEARCH   |        |
+| SALES      |        |
++------------+--------+
+(4 rows)
+
+!ok
+
 # End sub-query.iq

--- a/site/_data/contributors.yml
+++ b/site/_data/contributors.yml
@@ -327,6 +327,12 @@
   pronouns: he/him
   org: Hikvision
   role: Committer
+- name: Yong Liu
+  apacheId: jackylau
+  githubId: liuyongvs
+  pronouns: he/him
+  org: Ant Financial
+  role: Committer
 - name: Zhaohui Xu
   apacheId: zhaohui
   githubId: xy2953396112

--- a/site/_data/contributors.yml
+++ b/site/_data/contributors.yml
@@ -338,6 +338,12 @@
   githubId: xy2953396112
   org: Ant Financial
   role: Committer
+- name: Zhe Hu
+  apacheId: zhehu
+  githubId: ILuffZhe
+  pronouns: he/him
+  org: Hikvision
+  role: Committer
 - name: Zhen Wang
   apacheId: zhenw
   githubId: zinking

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -880,7 +880,7 @@ public class SqlParserTest {
         + " salary = (t.salary * 0.1)\n"
         + "WHEN NOT MATCHED THEN"
         + " INSERT (name, dept, salary)"
-        + " VALUES (t.name, 10, (t.salary * 0.15))";
+        + " VALUES(t.name, 10, (t.salary * 0.15))";
     sql(mergeSql)
         .fails("(?s)Encountered \"-\" at .*")
         .withDialect(BIG_QUERY)
@@ -4849,7 +4849,7 @@ public class SqlParserTest {
         + ", `DEPTNO` = `T`.`DEPTNO`"
         + ", `SALARY` = (`T`.`SALARY` * 0.1)\n"
         + "WHEN NOT MATCHED THEN INSERT (`NAME`, `DEPT`, `SALARY`) "
-        + "VALUES (ROW(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15)))";
+        + "VALUES(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15))";
     sql(sql).ok(expected)
         .node(not(isDdl()));
   }
@@ -4872,7 +4872,7 @@ public class SqlParserTest {
         + ", `E`.`DEPTNO` = `T`.`DEPTNO`"
         + ", `E`.`SALARY` = (`T`.`SALARY` * 0.1)\n"
         + "WHEN NOT MATCHED THEN INSERT (`NAME`, `DEPT`, `SALARY`) "
-        + "VALUES (ROW(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15)))";
+        + "VALUES(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15))";
     sql(sql).ok(expected)
         .node(not(isDdl()));
   }
@@ -4892,7 +4892,7 @@ public class SqlParserTest {
         + ", `DEPTNO` = `T`.`DEPTNO`"
         + ", `SALARY` = (`T`.`SALARY` * 0.1)\n"
         + "WHEN NOT MATCHED THEN INSERT (`NAME`, `DEPT`, `SALARY`) "
-        + "VALUES (ROW(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15)))";
+        + "VALUES(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15))";
     sql(sql).ok(expected);
   }
 
@@ -4912,7 +4912,7 @@ public class SqlParserTest {
         + ", `E`.`DEPTNO` = `T`.`DEPTNO`"
         + ", `E`.`SALARY` = (`T`.`SALARY` * 0.1)\n"
         + "WHEN NOT MATCHED THEN INSERT (`NAME`, `DEPT`, `SALARY`) "
-        + "VALUES (ROW(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15)))";
+        + "VALUES(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15))";
     sql(sql).ok(expected);
   }
 
@@ -4939,7 +4939,7 @@ public class SqlParserTest {
     final String expected = "MERGE INTO `EMPS` AS `E`\n"
         + "USING `TEMPS` AS `T`\n"
         + "ON (`E`.`EMPNO` = `T`.`EMPNO`)\n"
-        + "WHEN NOT MATCHED THEN INSERT (`A`, `B`) VALUES (ROW(1, 2))";
+        + "WHEN NOT MATCHED THEN INSERT (`A`, `B`) VALUES(1, 2)";
     sql(sql2).ok(expected);
 
     // As sql1, removing unmatched '(', therefore valid
@@ -8926,7 +8926,7 @@ public class SqlParserTest {
         + ", `DEPTNO` = `T`.`DEPTNO`"
         + ", `SALARY` = (`T`.`SALARY` * 0.1)\n"
         + "WHEN NOT MATCHED THEN INSERT (`NAME`, `DEPT`, `SALARY`) "
-        + "VALUES (ROW(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15)))";
+        + "VALUES(`T`.`NAME`, 10, (`T`.`SALARY` * 0.15))";
     sql(sql).ok(expected);
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
+++ b/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
@@ -76,11 +76,11 @@ import static java.util.Objects.requireNonNull;
  *     return DiffRepository.lookup(MyTest.class);
  *   }
  * &nbsp;
- *   &#64;Test public void testToUpper() {
+ *   &#64;Test void testToUpper() {
  *     getDiffRepos().assertEquals("${result}", "${string}");
  *   }
  * &nbsp;
- *   &#64;Test public void testToLower() {
+ *   &#64;Test void testToLower() {
  *     getDiffRepos().assertEquals("Multi-line\nstring", "${string}");
  *   }
  * }
@@ -110,16 +110,18 @@ import static java.util.Objects.requireNonNull;
  * </code></pre></blockquote>
  *
  * <p>If any of the test cases fails, a log file is generated, called
- * <code>build/resources/test/com/acme/test/MyTest_actual.xml</code>, containing the actual
- * output.
+ * {@code build/diffrepo/test/com/acme/test/MyTest_actual.xml},
+ * containing the actual output.
  *
  * <p>The log
  * file is otherwise identical to the reference log, so once the log file has
  * been verified, it can simply be copied over to become the new reference
  * log:
  *
- * <blockquote><code>cp build/resources/test/com/acme/test/MyTest_actual.xml
- * src/test/resources/com/acme/test/MyTest.xml</code></blockquote>
+ * <blockquote>{@code
+ * cp build/diffrepo/test/com/acme/test/MyTest_actual.xml
+ * src/test/resources/com/acme/test/MyTest.xml
+ * }</blockquote>
  *
  * <p>If a resource or test case does not exist, <code>DiffRepository</code>
  * creates them in the log file. Because DiffRepository is so forgiving, it is
@@ -128,7 +130,7 @@ import static java.util.Objects.requireNonNull;
  * <p>The {@link #lookup} method ensures that all test cases share the same
  * instance of the repository. This is important more than one test case fails.
  * The shared instance ensures that the generated
- * <code>build/resources/test/com/acme/test/MyTest_actual.xml</code>
+ * {@code build/diffrepo/test/com/acme/test/MyTest_actual.xml}
  * file contains the actual for <em>both</em> test cases.
  */
 public class DiffRepository {
@@ -927,7 +929,9 @@ public class DiffRepository {
     DiffRepository toRepo() {
       final URL refFile = findFile(clazz, ".xml");
       final String refFilePath = Sources.of(refFile).file().getAbsolutePath();
-      final String logFilePath = refFilePath.replace(".xml", "_actual.xml");
+      final String logFilePath = refFilePath
+          .replace("resources", "diffrepo")
+          .replace(".xml", "_actual.xml");
       final File logFile = new File(logFilePath);
       assert !refFilePath.equals(logFile.getAbsolutePath());
       return new DiffRepository(refFile, logFile, baseRepository, filter,

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -39,6 +39,7 @@ import com.google.common.io.PatternFilenameFilter;
 import net.hydromatic.quidem.CommandHandler;
 import net.hydromatic.quidem.Quidem;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -61,6 +62,8 @@ import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Test that runs every Quidem file as a test.
  */
@@ -69,7 +72,7 @@ public abstract class QuidemTest {
 
   private static final Pattern PATTERN = Pattern.compile("\\.iq$");
 
-  private static Object getEnv(String varName) {
+  private static @Nullable Object getEnv(String varName) {
     switch (varName) {
     case "jdk18":
       return System.getProperty("java.version").startsWith("1.8");
@@ -99,7 +102,7 @@ public abstract class QuidemTest {
     }
   }
 
-  private Method findMethod(String path) {
+  private @Nullable Method findMethod(String path) {
     // E.g. path "sql/agg.iq" gives method "testSqlAgg"
     final String path1 = path.replace(File.separatorChar, '_');
     final String path2 = PATTERN.matcher(path1).replaceAll("");
@@ -113,11 +116,11 @@ public abstract class QuidemTest {
     return m;
   }
 
-  @SuppressWarnings("BetaApi")
+  @SuppressWarnings({"BetaApi", "UnstableApiUsage"})
   protected static Collection<String> data(String first) {
     // inUrl = "file:/home/fred/calcite/core/target/test-classes/sql/agg.iq"
     final URL inUrl = QuidemTest.class.getResource("/" + n2u(first));
-    final File firstFile = Sources.of(inUrl).file();
+    final File firstFile = Sources.of(requireNonNull(inUrl, "inUrl")).file();
     final int commonPrefixLength = firstFile.getAbsolutePath().length() - first.length();
     final File dir = firstFile.getParentFile();
     final List<String> paths = new ArrayList<>();
@@ -137,11 +140,14 @@ public abstract class QuidemTest {
       inFile = f;
       outFile = new File(path + ".out");
     } else {
-      // e.g. path = "sql/outer.iq"
-      // inUrl = "file:/home/fred/calcite/core/target/test-classes/sql/outer.iq"
+      // e.g. path = "sql/agg.iq"
+      // inUrl = "file:/home/fred/calcite/core/build/resources/test/sql/agg.iq"
+      // inFile = "/home/fred/calcite/core/build/resources/test/sql/agg.iq"
+      // outDir = "/home/fred/calcite/core/build/quidem/test/sql"
+      // outFile = "/home/fred/calcite/core/build/quidem/test/sql/agg.iq"
       final URL inUrl = QuidemTest.class.getResource("/" + n2u(path));
-      inFile = Sources.of(inUrl).file();
-      outFile = new File(inFile.getAbsoluteFile().getParent(), u2n("surefire/") + path);
+      inFile = Sources.of(requireNonNull(inUrl, "inUrl")).file();
+      outFile = replaceDir(inFile, "resources", "quidem");
     }
     Util.discard(outFile.getParentFile().mkdirs());
     try (Reader reader = Util.reader(inFile);
@@ -179,6 +185,18 @@ public abstract class QuidemTest {
     }
   }
 
+  /** Returns a file, replacing one directory with another.
+   *
+   * <p>For example, {@code replaceDir("/abc/str/astro.txt", "str", "xyz")}
+   * returns "{@code "/abc/xyz/astro.txt}".
+   * Note that the file name "astro.txt" does not become "axyzo.txt".
+   */
+  private static File replaceDir(File file, String target, String replacement) {
+    return new File(
+        file.getAbsolutePath().replace(n2u('/' + target + '/'),
+            n2u('/' + replacement + '/')));
+  }
+
   /** Creates a command handler. */
   protected CommandHandler createCommandHandler() {
     return Quidem.EMPTY_COMMAND_HANDLER;
@@ -189,14 +207,8 @@ public abstract class QuidemTest {
     return new QuidemConnectionFactory();
   }
 
-  /** Converts a path from Unix to native. On Windows, converts
-   * forward-slashes to back-slashes; on Linux, does nothing. */
-  private static String u2n(String s) {
-    return File.separatorChar == '\\'
-        ? s.replace('/', '\\')
-        : s;
-  }
-
+  /** Converts a path from native to Unix. On Windows, converts
+   * back-slashes to forward-slashes; on Linux, does nothing. */
   private static String n2u(String s) {
     return File.separatorChar == '\\'
         ? s.replace('\\', '/')


### PR DESCRIPTION
Adds support for MERGE operations in RelToSqlConverter.visit(TableModify) and verifies that it works with the JDBC adapter.