### PR TITLE
[CALCITE-5732] EnumerableHashJoin and EnumerableMergeJoin on composite key return rows matching condition 'null = null'

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableHashJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableHashJoin.java
@@ -218,8 +218,8 @@ public class EnumerableHashJoin extends Join implements EnumerableRel {
                 Expressions.list(
                     leftExpression,
                     rightExpression,
-                    leftResult.physType.generateAccessor(joinInfo.leftKeys),
-                    rightResult.physType.generateAccessor(joinInfo.rightKeys),
+                    leftResult.physType.generateAccessorWithoutNulls(joinInfo.leftKeys),
+                    rightResult.physType.generateAccessorWithoutNulls(joinInfo.rightKeys),
                     Util.first(keyPhysType.comparer(),
                         Expressions.constant(null)),
                     predicate)))
@@ -264,8 +264,8 @@ public class EnumerableHashJoin extends Join implements EnumerableRel {
                 BuiltInMethod.HASH_JOIN.method,
                 Expressions.list(
                     rightExpression,
-                    leftResult.physType.generateAccessor(joinInfo.leftKeys),
-                    rightResult.physType.generateAccessor(joinInfo.rightKeys),
+                    leftResult.physType.generateAccessorWithoutNulls(joinInfo.leftKeys),
+                    rightResult.physType.generateAccessorWithoutNulls(joinInfo.rightKeys),
                     EnumUtils.joinSelector(joinType,
                         physType,
                         ImmutableList.of(

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -492,7 +492,7 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
               RelFieldCollation.NullDirection.LAST));
     }
     final RelCollation collation = RelCollations.of(fieldCollations);
-    final Expression comparator = leftKeyPhysType.generateComparator(collation);
+    final Expression comparator = leftKeyPhysType.generateMergeJoinComparator(collation);
 
     return implementor.result(
         physType,
@@ -512,6 +512,9 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
                         ImmutableList.of(
                             leftResult.physType, rightResult.physType)),
                     Expressions.constant(EnumUtils.toLinq4jJoinType(joinType)),
-                    comparator))).toBlock());
+                    comparator,
+                    Util.first(
+                        leftKeyPhysType.comparer(),
+                        Expressions.constant(null))))).toBlock());
   }
 }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysType.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysType.java
@@ -112,10 +112,27 @@ public interface PhysType {
    *    public Object[] apply(Employee v1) {
    *        return FlatLists.of(v1.&lt;fieldN&gt;, v1.&lt;fieldM&gt;);
    *    }
-   * }
    * }</pre></blockquote>
    */
   Expression generateAccessor(List<Integer> fields);
+
+  /** Similar to {@link #generateAccessor(List)}, but if one of the fields is <code>null</code>,
+   * it will return <code>null</code>.
+   *
+   * <p>For example:
+   *
+   * <blockquote><pre>
+   * new Function1&lt;Employee, Object[]&gt; {
+   *    public Object[] apply(Employee v1) {
+   *        return v1.&lt;fieldN&gt; == null
+   *            ? null
+   *            : v1.&lt;fieldM&gt; == null
+   *                ? null
+   *                : FlatLists.of(v1.&lt;fieldN&gt;, v1.&lt;fieldM&gt;);
+   *    }
+   * }</pre></blockquote>
+   */
+  Expression generateAccessorWithoutNulls(List<Integer> fields);
 
   /** Generates a selector for the given fields from an expression, with the
    * default row format. */
@@ -180,6 +197,13 @@ public interface PhysType {
    * whole element. */
   Expression generateComparator(
       RelCollation collation);
+
+  /** Similar to {@link #generateComparator(RelCollation)}, but with some specificities for
+   * MergeJoin algorithm: it will not consider two <code>null</code> values as equal.
+   *
+   * @see org.apache.calcite.linq4j.EnumerableDefaults#compareNullsLastForMergeJoin
+   */
+  Expression generateMergeJoinComparator(RelCollation collation);
 
   /** Returns a expression that yields a comparer, or null if this type
    * is comparable. */

--- a/core/src/main/java/org/apache/calcite/runtime/Utilities.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Utilities.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.runtime;
 
+import org.apache.calcite.linq4j.EnumerableDefaults;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.text.Collator;
@@ -248,6 +250,15 @@ public class Utilities {
         : v0 == null ? 1
             : v1 == null ? -1
                 : FlatLists.ComparableListImpl.compare(v0, v1);
+  }
+
+  public static int compareNullsLastForMergeJoin(@Nullable Comparable v0, @Nullable Comparable v1) {
+    return EnumerableDefaults.compareNullsLastForMergeJoin(v0, v1);
+  }
+
+  public static int compareNullsLastForMergeJoin(@Nullable Comparable v0, @Nullable Comparable v1,
+      Comparator comparator) {
+    return EnumerableDefaults.compareNullsLastForMergeJoin(v0, v1, comparator);
   }
 
   /** Creates a pattern builder. */

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -205,7 +205,7 @@ public enum BuiltInMethod {
       List.class, int.class, Consumer.class),
   MERGE_JOIN(EnumerableDefaults.class, "mergeJoin", Enumerable.class,
       Enumerable.class, Function1.class, Function1.class, Predicate2.class, Function2.class,
-      JoinType.class, Comparator.class),
+      JoinType.class, Comparator.class, EqualityComparer.class),
   SLICE0(Enumerables.class, "slice0", Enumerable.class),
   SEMI_JOIN(EnumerableDefaults.class, "semiJoin", Enumerable.class,
       Enumerable.class, Function1.class, Function1.class,

--- a/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
@@ -414,7 +414,7 @@ class EnumerablesTest {
             e1 -> e1.name,
             e2 -> e2.name,
             (e1, e2) -> e1.deptno < e2.deptno,
-            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null).toList(),
+            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null, null).toList(),
         hasToString("["
             + "Emp(1, Fred)-Emp(2, Fred), "
             + "Emp(1, Fred)-Emp(3, Fred), "
@@ -430,7 +430,7 @@ class EnumerablesTest {
             e2 -> e2.name,
             e1 -> e1.name,
             (e2, e1) -> e2.deptno > e1.deptno,
-            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null).toList(),
+            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null, null).toList(),
         hasToString("["
             + "Emp(2, Fred)-Emp(1, Fred), "
             + "Emp(3, Fred)-Emp(1, Fred), "
@@ -446,7 +446,7 @@ class EnumerablesTest {
             e1 -> e1.name,
             e2 -> e2.name,
             (e1, e2) -> e1.deptno == e2.deptno * 2,
-            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null).toList(),
+            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null, null).toList(),
         hasToString("[]"));
 
     assertThat(
@@ -456,7 +456,7 @@ class EnumerablesTest {
             e2 -> e2.name,
             e1 -> e1.name,
             (e2, e1) -> e2.deptno == e1.deptno * 2,
-            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null).toList(),
+            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null, null).toList(),
         hasToString("[Emp(2, Fred)-Emp(1, Fred)]"));
 
     assertThat(
@@ -466,7 +466,7 @@ class EnumerablesTest {
             e2 -> e2.name,
             e1 -> e1.name,
             (e2, e1) -> e2.deptno == e1.deptno + 2,
-            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null).toList(),
+            (v0, v1) -> v0 + "-" + v1, JoinType.INNER, null, null).toList(),
         hasToString("[Emp(3, Fred)-Emp(1, Fred), Emp(5, Joe)-Emp(3, Joe)]"));
   }
 
@@ -493,7 +493,7 @@ class EnumerablesTest {
             null,
             (v0, v1) -> v0,
             JoinType.SEMI,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Dept(10, Marketing),"
             + " Dept(20, Sales),"
             + " Dept(30, Research)]"));
@@ -522,7 +522,7 @@ class EnumerablesTest {
             (d, e) -> e.name.contains("a"),
             (v0, v1) -> v0,
             JoinType.SEMI,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Dept(20, Sales)]"));
   }
 
@@ -550,7 +550,7 @@ class EnumerablesTest {
             (e, d) -> e.name.startsWith("T"),
             (v0, v1) -> v0,
             JoinType.SEMI,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Emp(30, Theodore)]"));
   }
 
@@ -578,7 +578,7 @@ class EnumerablesTest {
             null,
             (v0, v1) -> v0,
             JoinType.ANTI,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Dept(25, HR), Dept(40, Development)]"));
   }
 
@@ -605,7 +605,7 @@ class EnumerablesTest {
             (d, e) -> e.name.startsWith("F") || e.name.startsWith("S"),
             (v0, v1) -> v0,
             JoinType.ANTI,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Dept(25, HR), Dept(30, Research), "
             + "Dept(40, Development)]"));
   }
@@ -634,7 +634,7 @@ class EnumerablesTest {
             (e, d) -> d.deptno < 30,
             (v0, v1) -> v0,
             JoinType.ANTI,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Emp(30, Fred), Emp(20, Sebastian), Emp(20, Zoey)]"));
   }
 
@@ -661,7 +661,7 @@ class EnumerablesTest {
             null,
             (v0, v1) -> v0 + "-" + v1,
             JoinType.LEFT,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Dept(10, Marketing)-Emp(10, Fred),"
             + " Dept(20, Sales)-Emp(20, Theodore),"
             + " Dept(20, Sales)-Emp(20, Sebastian),"
@@ -694,7 +694,7 @@ class EnumerablesTest {
             (d, e) -> e.name.contains("a"),
             (v0, v1) -> v0 + "-" + v1,
             JoinType.LEFT,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Dept(10, Marketing)-null,"
             + " Dept(20, Sales)-Emp(20, Sebastian),"
             + " Dept(25, HR)-null,"
@@ -726,7 +726,7 @@ class EnumerablesTest {
             (e, d) -> e.name.startsWith("T"),
             (v0, v1) -> v0 + "-" + v1,
             JoinType.LEFT,
-            null).toList(),
+            null, null).toList(),
         hasToString("[Emp(30, Fred)-null,"
             + " Emp(20, Sebastian)-null,"
             + " Emp(30, Theodore)-Dept(30, Theodore),"

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableHashJoinTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableHashJoinTest.java
@@ -56,24 +56,6 @@ class EnumerableHashJoinTest {
             "empid=150; name=Sebastian; dept=Sales");
   }
 
-  @Test void innerJoinWithPredicate() {
-    tester(false, new HrSchema())
-        .query(
-            "select e.empid, e.name, d.name as dept from emps e join depts d"
-                + " on e.deptno=d.deptno and e.empid<150 and e.empid>d.deptno")
-        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], empid=[$t0], name=[$t2], "
-            + "dept=[$t4])\n"
-            + "  EnumerableHashJoin(condition=[AND(=($1, $3), >($0, $3))], joinType=[inner])\n"
-            + "    EnumerableCalc(expr#0..4=[{inputs}], expr#5=[150], expr#6=[<($t0, $t5)], "
-            + "proj#0..2=[{exprs}], $condition=[$t6])\n"
-            + "      EnumerableTableScan(table=[[s, emps]])\n"
-            + "    EnumerableCalc(expr#0..3=[{inputs}], proj#0..1=[{exprs}])\n"
-            + "      EnumerableTableScan(table=[[s, depts]])\n")
-        .returnsUnordered(
-            "empid=100; name=Bill; dept=Sales",
-            "empid=110; name=Theodore; dept=Sales");
-  }
-
   @Test void leftOuterJoin() {
     tester(false, new HrSchema())
         .query(
@@ -199,6 +181,124 @@ class EnumerableHashJoinTest {
         .returnsUnordered(
             "name=Bill; salary=10000.0",
             "name=Sebastian; salary=7000.0");
+  }
+
+  @Test void innerJoinWithPredicate() {
+    tester(false, new HrSchema())
+        .query(
+            "select e.empid, e.name, d.name as dept from emps e join depts d"
+                + " on e.deptno=d.deptno and e.empid<150 and e.empid>d.deptno")
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], empid=[$t0], name=[$t2], "
+            + "dept=[$t4])\n"
+            + "  EnumerableHashJoin(condition=[AND(=($1, $3), >($0, $3))], joinType=[inner])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], expr#5=[150], expr#6=[<($t0, $t5)], "
+            + "proj#0..2=[{exprs}], $condition=[$t6])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n"
+            + "    EnumerableCalc(expr#0..3=[{inputs}], proj#0..1=[{exprs}])\n"
+            + "      EnumerableTableScan(table=[[s, depts]])\n")
+        .returnsUnordered(
+            "empid=100; name=Bill; dept=Sales",
+            "empid=110; name=Theodore; dept=Sales");
+  }
+
+  @Test void innerJoinWithCompositeKeyAndNullValues() {
+    tester(false, new HrSchema())
+        .query(
+            "select e1.empid from emps e1 join emps e2 "
+                + "on e1.deptno=e2.deptno and e1.commission=e2.commission")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.removeRule(EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE))
+        .explainContains("EnumerableCalc(expr#0..4=[{inputs}], empid=[$t0])\n"
+            + "  EnumerableHashJoin(condition=[AND(=($1, $3), =($2, $4))], joinType=[inner])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], deptno=[$t1], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n")
+        .returnsUnordered(
+            "empid=100",
+            "empid=110",
+            "empid=200");
+  }
+
+  @Test void leftOuterJoinWithCompositeKeyAndNullValues() {
+    tester(false, new HrSchema())
+        .query(
+            "select e1.empid, e2.empid from emps e1 left outer join emps e2 "
+                + "on e1.deptno=e2.deptno and e1.commission=e2.commission")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.removeRule(EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE))
+        .explainContains("EnumerableCalc(expr#0..5=[{inputs}], empid=[$t0], empid0=[$t3])\n"
+            + "  EnumerableHashJoin(condition=[AND(=($1, $4), =($2, $5))], joinType=[left])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n")
+        .returnsUnordered(
+            "empid=100; empid=100",
+            "empid=110; empid=110",
+            "empid=150; empid=null",
+            "empid=200; empid=200");
+  }
+
+  @Test void rightOuterJoinWithCompositeKeyAndNullValues() {
+    tester(false, new HrSchema())
+        .query(
+            "select e1.empid, e2.empid from emps e1 right outer join emps e2 "
+                + "on e1.deptno=e2.deptno and e1.commission=e2.commission")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.removeRule(EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE))
+        .explainContains("EnumerableCalc(expr#0..5=[{inputs}], empid=[$t0], empid0=[$t3])\n"
+            + "  EnumerableHashJoin(condition=[AND(=($1, $4), =($2, $5))], joinType=[right])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n")
+        .returnsUnordered(
+            "empid=100; empid=100",
+            "empid=110; empid=110",
+            "empid=200; empid=200",
+            "empid=null; empid=150");
+  }
+
+  @Test void fullOuterJoinWithCompositeKeyAndNullValues() {
+    tester(false, new HrSchema())
+        .query(
+            "select e1.empid, e2.empid from emps e1 full outer join emps e2 "
+                + "on e1.deptno=e2.deptno and e1.commission=e2.commission")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner ->
+            planner.removeRule(EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE))
+        .explainContains("EnumerableCalc(expr#0..5=[{inputs}], empid=[$t0], empid0=[$t3])\n"
+            + "  EnumerableHashJoin(condition=[AND(=($1, $4), =($2, $5))], joinType=[full])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n")
+        .returnsUnordered(
+            "empid=100; empid=100",
+            "empid=110; empid=110",
+            "empid=150; empid=null",
+            "empid=200; empid=200",
+            "empid=null; empid=150");
+  }
+
+  @Test void semiJoinWithCompositeKeyAndNullValues() {
+    tester(true, new HrSchema())
+        .query(
+            "select e1.empid from emps e1 where exists (select 1 from emps e2 "
+                + "where e1.deptno=e2.deptno and e1.commission=e2.commission)")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner -> {
+          planner.removeRule(EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE);
+        })
+        .explainContains("EnumerableCalc(expr#0..2=[{inputs}], empid=[$t0])\n"
+            + "  EnumerableHashJoin(condition=[AND(=($1, $4), =($2, $7))], joinType=[semi])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], proj#0..1=[{exprs}], commission=[$t4])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n"
+            + "    EnumerableCalc(expr#0..4=[{inputs}], expr#5=[IS NOT NULL($t4)], proj#0..4=[{exprs}], $condition=[$t5])\n"
+            + "      EnumerableTableScan(table=[[s, emps]])\n")
+        .returnsUnordered(
+            "empid=100",
+            "empid=110",
+            "empid=200");
   }
 
   private CalciteAssert.AssertThat tester(boolean forceDecorrelate,


### PR DESCRIPTION
See Jira CALCITE-5732.

Proposed solution:
- For HashJoin: generate key with a new accessor that will return null if one of the fields is null (and the hashJoin algorithm will work as usual and will return the correct result).
- For MergeJoin: the previous approach could not be applied, since the current MergeJoin implementation works with keys sorted in ascending order, nulls last, so having a null means that the left/right input is exhausted, and that could have undesired effects (wrong results) in the MJ. Instead, use a new, dedicated key comparator that will NOT consider two null values as equal