### PR TITLE
[CALCITE-5843] Constant expression with nested casts causes a compiler crash

### DIFF
--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Expressions.java
@@ -570,7 +570,15 @@ public abstract class Expressions {
           value = new BigInteger(stringValue);
         }
         if (primitive != null) {
-          value = primitive.parse(stringValue);
+          if (value instanceof Number) {
+            Number valueNumber = (Number) value;
+            value = primitive.numberValue(valueNumber);
+            if (value == null) {
+              value = primitive.parse(stringValue);
+            }
+          } else {
+            value = primitive.parse(stringValue);
+          }
         }
       }
     }

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
@@ -367,6 +367,35 @@ public enum Primitive {
   }
 
   /**
+   * Converts a number into a value of the type
+   * specified by this primitive.
+   *
+   * @param value  Value to convert.
+   * @return       The converted value, or null if the
+   *               conversion cannot be performed.
+   */
+  public @Nullable Object numberValue(Number value) {
+    switch (this) {
+    case BYTE:
+      return value.byteValue();
+    case CHAR:
+      return (char) value.intValue();
+    case SHORT:
+      return value.shortValue();
+    case INT:
+      return value.intValue();
+    case LONG:
+      return value.longValue();
+    case FLOAT:
+      return value.floatValue();
+    case DOUBLE:
+      return value.doubleValue();
+    default:
+      return null;
+    }
+  }
+
+  /**
    * Converts a collection of boxed primitives into an array of primitives.
    *
    * @param collection Collection of boxed primitives

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -687,6 +687,17 @@ public class SqlOperatorTest {
         "654342432412312");
   }
 
+  /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5843">
+   * Constant expression with nested casts causes a compiler crash</a>. */
+  @Test public void testConstantCast() {
+    SqlOperatorFixture f = fixture();
+    f.checkScalarExact("CAST(CAST('32767.4' AS FLOAT) AS SMALLINT)",
+        "SMALLINT NOT NULL", "32767");
+    f.checkScalarExact("CAST(CAST('32767.4' AS FLOAT) AS CHAR)",
+        "CHAR(1) NOT NULL", "3");
+  }
+
   @ParameterizedTest
   @MethodSource("safeParameters")
   void testCastStringToDecimal(CastType castType, SqlOperatorFixture f) {


### PR DESCRIPTION
I wasn't entirely sure how to handle conversions to other types than the numeric ones, so I left the previous behavior unchanged, but there may be other problems lurking.