### PR TITLE
Remove mentions of binary distribution from README

### DIFF
--- a/README
+++ b/README
@@ -1,15 +1,14 @@
 Apache Calcite release 1.34.0
 
-This is a source or binary distribution of Apache Calcite.
+This is a source distribution of Apache Calcite.
 
 Changes since the previous release are described in the
 site/_docs/history.md file.
 
 The LICENSE and NOTICE files contain license information.
 
-If this is a source distribution, you can find instructions how to
-build the release in the "Building from a source distribution" section
-in site/_docs/howto.md.
+Check "Building from a source distribution" section
+in site/_docs/howto.md for instructions on how to build the project.
 
 Further information about Apache Calcite is available at its web site,
 http://calcite.apache.org.


### PR DESCRIPTION
The project does not make binary releases at the moment so mentioning binary distribution in the README is misleading.