### PR TITLE
[CALCITE-5862] Incorrect semantics of ARRAY function (Spark library) when elements have Numeric and Character types

### DIFF
--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -9941,6 +9941,14 @@ public class SqlOperatorTest {
         "[null, foo]", "CHAR(3) ARRAY NOT NULL");
     f2.checkScalar("array(null)",
         "[null]", "NULL ARRAY NOT NULL");
+    f2.checkScalar("array(1, 2, 'Hi')",
+        "[1, 2, Hi]", "CHAR(2) NOT NULL ARRAY NOT NULL");
+    f2.checkScalar("array(1, 2, 'Hi', 'Hello')",
+        "[1, 2, Hi, Hello]", "CHAR(5) NOT NULL ARRAY NOT NULL");
+    f2.checkScalar("array(1, 2, 'Hi', null)",
+        "[1, 2, Hi, null]", "CHAR(2) ARRAY NOT NULL");
+    f2.checkScalar("array(1, 2, 'Hi', cast(null as char(10)))",
+        "[1, 2, Hi, null]", "CHAR(10) ARRAY NOT NULL");
   }
 
   /**


### PR DESCRIPTION
# What is the purpose of the change

https://issues.apache.org/jira/browse/CALCITE-5862

# Brief change log
Fix incorrect spark semantics of array function when array elements have Numeric and Character types.

# Verifying this change

SqlOperatorTests#testArrayFunc()
