### PR TITLE
[CALCITE-5865] ClassCastException with FLOOR and CEIL on conformances that are not builtin

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -7364,7 +7364,7 @@ SqlNode StandardFloorCeilOptions(Span s, boolean floorFlag) :
         }
     )?
     <RPAREN> {
-        SqlOperator op = SqlStdOperatorTable.floorCeil(floorFlag, (SqlConformanceEnum) this.conformance);
+        SqlOperator op = SqlStdOperatorTable.floorCeil(floorFlag, this.conformance);
         function =  op.createCall(s.end(this), args);
     }
     (

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -2701,11 +2701,10 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
 
   /** Returns the operator for {@code FLOOR} and {@code CEIL} with given floor flag
    * and library. */
-  public static SqlOperator floorCeil(boolean floor, SqlConformanceEnum conformance) {
-    switch (conformance) {
-    case BIG_QUERY:
+  public static SqlOperator floorCeil(boolean floor, SqlConformance conformance) {
+    if (SqlConformanceEnum.BIG_QUERY.equals(conformance)) {
       return floor ? SqlLibraryOperators.FLOOR_BIG_QUERY : SqlLibraryOperators.CEIL_BIG_QUERY;
-    default:
+    } else {
       return floor ? SqlStdOperatorTable.FLOOR : SqlStdOperatorTable.CEIL;
     }
   }


### PR DESCRIPTION
[CALCITE-5747](https://issues.apache.org/jira/browse/CALCITE-5747) introduced some BigQuery-specific logic for FLOOR and CEIL that is keyed off the conformance being `SqlConformanceEnum.BIG_QUERY`. However, it was implemented in such a way that implementations of `SqlConformance` that are not `SqlConformanceEnum` would throw `ClassCastException`.