### PR TITLE
[CALCITE-5861] Optimization rules do not constant-fold expressions in window bounds

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectToWindowRule.java
@@ -283,7 +283,7 @@ public abstract class ProjectToWindowRule
         if (expr instanceof RexOver) {
           final RexOver over = (RexOver) expr;
 
-          // If we can found an existing cohort which satisfies the two conditions,
+          // If we can find an existing cohort which satisfies the two conditions,
           // we will add this RexOver into that cohort
           boolean isFound = false;
           for (Pair<RexWindow, Set<Integer>> pair : windowToIndices) {

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -4910,6 +4910,26 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5861">
+   * [CALCITE-5861] ReduceExpressionsRule rules should constant-fold
+   * expressions in window bounds</a>.
+   */
+  @Test void testExpressionPreceding() {
+    HepProgramBuilder preBuilder = new HepProgramBuilder();
+    preBuilder.addRuleInstance(CoreRules.PROJECT_REDUCE_EXPRESSIONS);
+    preBuilder.addRuleInstance(CoreRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW);
+
+    final String sql =
+        "select COUNT(*) over (\n"
+            + "ORDER BY empno\n"
+            + "ROWS BETWEEN 5 + 5 PRECEDING AND 1 PRECEDING) AS w_count from emp\n";
+    sql(sql)
+        .withPre(preBuilder.build())
+        .withRule(CoreRules.PROJECT_REDUCE_EXPRESSIONS)
+        .checkUnchanged();
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-750">[CALCITE-750]
    * Allow windowed aggregate on top of regular aggregate</a>. */

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4206,6 +4206,22 @@ LogicalProject(SUM1=[SUM($7) OVER (PARTITION BY $7 ORDER BY $5)], SUM2=[SUM(+($7
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExpressionPreceding">
+    <Resource name="sql">
+      <![CDATA[select COUNT(*) over (
+ORDER BY empno
+ROWS BETWEEN 5 + 5 PRECEDING AND 1 PRECEDING) AS w_count from emp
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject($0=[$1])
+  LogicalWindow(window#0=[window(order by [0] rows between $1 PRECEDING and $2 PRECEDING aggs [COUNT()])])
+    LogicalProject(EMPNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testExpressionSimplification1">
     <Resource name="sql">
       <![CDATA[select * from emp


### PR DESCRIPTION
With this change the PROJECT_REDUCE_EXPRESSIONS rule will also optimize constants that appear in window bound expressions. This makes it possible to compile programs that use (constant) expressions in window bounds.

However, I suspect that the rule PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW is still buggy, since it will move window bound expressions into separate projections, as described in the JIRA case. Unfortunately I could not figure out how to fix that rule - the code is very generic and treats all expressions in the same way, regardless where they appear in the RexNode. Perhaps I should file another JIRA issue about this?