### PR TITLE
[CALCITE-5864] Convert interval weeks and quarters into the correct millisecond total

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
@@ -143,6 +143,10 @@ public class SqlIntervalQualifier extends SqlNode {
           "SQL_TSI_QUARTER",
           "SQL_TSI_YEAR");
 
+  private static final BigDecimal DAYS_IN_WEEK = BigDecimal.valueOf(7);
+
+  private static final BigDecimal MONTHS_IN_QUARTER = BigDecimal.valueOf(3);
+
   //~ Instance fields --------------------------------------------------------
 
   private final int startPrecision;
@@ -698,8 +702,11 @@ public class SqlIntervalQualifier extends SqlNode {
       // Validate individual fields
       checkLeadFieldInRange(typeSystem, sign, quarter, TimeUnit.QUARTER, pos);
 
+      // Convert into months
+      BigDecimal month = quarter.multiply(MONTHS_IN_QUARTER);
+
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, quarter);
+      return fillIntervalValueArray(sign, ZERO, month);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -733,8 +740,11 @@ public class SqlIntervalQualifier extends SqlNode {
       // Validate individual fields
       checkLeadFieldInRange(typeSystem, sign, week, TimeUnit.WEEK, pos);
 
+      // Convert into days
+      BigDecimal day = week.multiply(DAYS_IN_WEEK);
+
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, week);
+      return fillIntervalValueArray(sign, day, ZERO, ZERO, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -139,6 +139,20 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test void testIntervalLiteralWeek() {
+    final String sql = "select\n"
+        + " cast(empno as Integer) * (INTERVAL '1' WEEK)\n"
+        + "from emp";
+    sql(sql).ok();
+  }
+
+  @Test void testIntervalLiteralQuarter() {
+    final String sql = "select\n"
+        + " cast(empno as Integer) * (INTERVAL '1' QUARTER)\n"
+        + "from emp";
+    sql(sql).ok();
+  }
+
   @Test void testIntervalExpression() {
     sql("select interval mgr hour as h from emp").ok();
   }

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -3288,6 +3288,32 @@ LogicalProject(EXPR$0=[*($0, 3660000:INTERVAL HOUR TO MINUTE)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testIntervalLiteralQuarter">
+    <Resource name="sql">
+      <![CDATA[select
+ cast(empno as Integer) * (INTERVAL '1' QUARTER)
+from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[*($0, 3:INTERVAL QUARTER)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIntervalLiteralWeek">
+    <Resource name="sql">
+      <![CDATA[select
+ cast(empno as Integer) * (INTERVAL '1' WEEK)
+from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[*($0, 604800000:INTERVAL WEEK)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testIntervalLiteralYearToMonth">
     <Resource name="sql">
       <![CDATA[select


### PR DESCRIPTION
The week and quarter intervals were added but did not correctly convert
into the correct number of milliseconds when evaluated.

These now correctly translate a week to 7 days and a quarter to 3
months.