### PR TITLE
Following [CALCITE-5688] Eliminate warnings in server parser

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1138,6 +1138,7 @@ SqlNode SqlStmt() :
     |
 </#if>
 <#if (parser.truncateStatementParserMethods!default.parser.truncateStatementParserMethods)?size != 0>
+        LOOKAHEAD(2)
         stmt = SqlTruncate()
     |
 </#if>


### PR DESCRIPTION
There are no warning.
- core
```
$ javacc core/build/fmpp/fmppMain/javacc/Parser.jj
Java Compiler Compiler Version 7.0.9 (Parser Generator)
(type "javacc" with no arguments for help)
Reading from file core/build/fmpp/fmppMain/javacc/Parser.jj . . .
Note: UNICODE_INPUT option is specified. Please make sure you create the parser/lexer using a Reader with the correct character encoding.
File "TokenMgrError.java" is being rebuilt.
File "ParseException.java" is being rebuilt.
File "Token.java" is being rebuilt.
File "SimpleCharStream.java" is being rebuilt.
Parser generated successfully.

```
- server

```
$ javacc server/build/fmpp/fmppMain/javacc/Parser.jj
Java Compiler Compiler Version 7.0.9 (Parser Generator)
(type "javacc" with no arguments for help)
Reading from file server/build/fmpp/fmppMain/javacc/Parser.jj . . .
Note: UNICODE_INPUT option is specified. Please make sure you create the parser/lexer using a Reader with the correct character encoding.
File "TokenMgrError.java" is being rebuilt.
File "ParseException.java" is being rebuilt.
File "Token.java" is being rebuilt.
File "SimpleCharStream.java" is being rebuilt.
Parser generated successfully.

```