### PR TITLE
[CALCITE-5875] Remove unnecessary NULL checks in Redis adapter

### DIFF
--- a/redis/src/test/java/org/apache/calcite/adapter/redis/RedisCaseBase.java
+++ b/redis/src/test/java/org/apache/calcite/adapter/redis/RedisCaseBase.java
@@ -113,7 +113,7 @@ public abstract class RedisCaseBase {
 
   @AfterAll
   public static void stopRedisContainer() {
-    if (REDIS_CONTAINER != null && REDIS_CONTAINER.isRunning()) {
+    if (REDIS_CONTAINER.isRunning()) {
       REDIS_CONTAINER.stop();
     }
   }


### PR DESCRIPTION
# What is the purpose of the change

code cleanup, remove some unnecessary null checks for redis adapter, because the static variable must be initialized successfully unless there is an exception.


# Brief change log
Remove some unnecessary null checks in redis adapter.

# Verifying this change

It's minor fix can be covered by current total cases.