### PR TITLE
[CALCITE-5874] Add  withReturnTypeInference copy method for SqlBasicFunction

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlBasicFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBasicFunction.java
@@ -200,6 +200,17 @@ public class SqlBasicFunction extends SqlFunction {
         getOperandTypeChecker(), callValidator,
         getFunctionType(), monotonicityInference);
   }
+
+  /** Returns a copy of this function with a given strategy for inferring
+   * returned type. */
+  public SqlBasicFunction withReturnTypeInference(
+      SqlReturnTypeInference returnTypeInference) {
+    return new SqlBasicFunction(getName(), kind, syntax, deterministic,
+        returnTypeInference, getOperandTypeInference(), operandHandler,
+        getOperandTypeChecker(), callValidator,
+        getFunctionType(), monotonicityInference);
+  }
+
   /** Returns a copy of this function with a given determinism. */
   public SqlBasicFunction withDeterministic(boolean deterministic) {
     return new SqlBasicFunction(getName(), kind, syntax, deterministic,


### PR DESCRIPTION
# What is the purpose of the change

https://issues.apache.org/jira/browse/CALCITE-5874

# Brief change log
Add a withReturnTypeInference helper method for creating SqlBasicFunction

# Verifying this change

SqlBasicFunctionTest#testWithReturnTypeInference
