### PR TITLE
[CALCITE-5881] Support to get foreign keys metadata in RelMetadataQuery

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptForeignKey.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptForeignKey.java
@@ -1,0 +1,411 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.InferredConstraintKey;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * ForeignKey represents the foreign and unique key constraint relationship
+ * on the current {@link org.apache.calcite.rel.RelNode}.
+ *
+ * <p><b>constraints</b> field {@link #constraints} are
+ * constraints that foreign key and unique key relationships in bottom-up derivation.
+ *
+ * <p><b>foreignColumns</b> field {@link #foreignColumns} indicates the
+ * position of the foreign key on the current {@link org.apache.calcite.rel.RelNode}
+ * if not or not be confirmed, it is an empty set.
+ *
+ * <p><b>uniqueColumns</b> field {@link #uniqueColumns} indicates the position of
+ * the unique key on the current {@link org.apache.calcite.rel.RelNode},
+ * if not or not be confirmed, it is an empty set, the position in uniqueColumns
+ * corresponds to foreignColumns.
+ *
+ * <p>The element positions in {@code uniqueColumns} and {@code foreignColumns}
+ * correspond to each other. The order of elements in {@code uniqueColumns}
+ * and {@code foreignColumns} is consistent with the order of constraints in
+ * the constraints list.
+ *
+ * <p>For instance,
+ * <blockquote>
+ * <pre>select e.deptno, e.ename, d.deptno
+ * from emp as e
+ * inner join dept as d
+ * on e.deptno = d.deptno</pre></blockquote>
+ *
+ * <p>the foreign key is the DEPTNO column of CATALOG.SALES.EMP table,
+ * reference the DEPTNO unique column of CATALOG.SALES.DEPT table.
+ *
+ * <p>Invoke the {@link RelMetadataQuery#getConfirmedForeignKeys} method which
+ * input param is the top {@link org.apache.calcite.rel.core.Project},
+ * the following results can be obtained.
+ *
+ * <p>{@code constraints} is
+ * [{left: [CATALOG, SALES, EMP].$7.#true, right: [CATALOG, SALES, DEPT].$0.#true}]
+ * {@code foreignColumns} is {0}
+ * {@code uniqueColumns} is {2}
+ *
+ * <p>For instance,
+ * <blockquote>
+ * <pre>select name, deptno
+ * from dept</pre></blockquote>
+ *
+ * <p>{@code constraints} is
+ * [{left: null.null.#false, right: [CATALOG, SALES, DEPT].$0.#false}]
+ * {@code foreignColumns} is {}
+ * {@code uniqueColumns} is {1}
+ *
+ * <p>For instance,
+ * <blockquote>
+ * <pre>select ename, sal, deptno
+ * from emp</pre></blockquote>
+ *
+ * <p>{@code constraints} is
+ * [{left: [CATALOG, SALES, EMP].$7.#false, right: [CATALOG, SALES, DEPT].$0.#false}]
+ * {@code foreignColumns} is {2}
+ * {@code uniqueColumns} is {}
+ *
+ * @see InferredConstraintKey
+ * @see org.apache.calcite.plan.RelOptForeignKey
+ */
+public class RelOptForeignKey {
+
+  /** Foreign key and unique key relationships in bottom-up derivation. */
+  private final List<Pair<InferredConstraintKey, InferredConstraintKey>> constraints;
+  /** Position of the foreign key on the current {@link org.apache.calcite.rel.RelNode}. */
+  private final ImmutableBitSet foreignColumns;
+  /** Position of the unique key on the current {@link org.apache.calcite.rel.RelNode}. */
+  private final ImmutableBitSet uniqueColumns;
+
+  private RelOptForeignKey(
+      List<Pair<InferredConstraintKey, InferredConstraintKey>> constraints,
+      ImmutableBitSet foreignColumns,
+      ImmutableBitSet uniqueColumns) {
+    this.constraints = constraints;
+    this.foreignColumns = foreignColumns;
+    this.uniqueColumns = uniqueColumns;
+  }
+
+  public static RelOptForeignKey of(List<Pair<InferredConstraintKey,
+      InferredConstraintKey>> constraints,
+      ImmutableBitSet foreignColumns,
+      ImmutableBitSet uniqueColumns) {
+    return new RelOptForeignKey(constraints, foreignColumns, uniqueColumns);
+  }
+
+  public ImmutableBitSet getForeignColumns() {
+    return foreignColumns;
+  }
+
+  public ImmutableBitSet getUniqueColumns() {
+    return uniqueColumns;
+  }
+
+  public List<Pair<InferredConstraintKey, InferredConstraintKey>> getConstraints() {
+    return constraints;
+  }
+
+  /** Returns the left side of a list of constraints. */
+  public static List<InferredConstraintKey> constraintsLeft(
+      List<Pair<InferredConstraintKey, InferredConstraintKey>> constraints) {
+    if (constraints.isEmpty()) {
+      return new ArrayList<>();
+    }
+    return constraints.stream()
+        .map(Pair::getKey)
+        .collect(Collectors.toList());
+  }
+
+  /** Returns the right side of a list of constraints. */
+  public static List<InferredConstraintKey> constraintsRight(
+      List<Pair<InferredConstraintKey, InferredConstraintKey>> constraints) {
+    if (constraints.isEmpty()) {
+      return new ArrayList<>();
+    }
+    return constraints.stream()
+        .map(Pair::getValue)
+        .collect(Collectors.toList());
+  }
+
+  /** Permutes relOptForeignKey set according to given mappings.
+   *
+   * <p>Example as follows:
+   * Simplified representation as foreignColumns and uniqueColumns
+   *
+   * <p>current relOptForeignKey:
+   * foreignColumns: {1, 3}
+   * uniqueColumns: {4}
+   *
+   * <p>permute params:
+   * foreignMapping: {1: [2, 6], 3: [7]}
+   * uniqueMapping: {4: [5, 8]}
+   *
+   * <p>result:
+   * [
+   *   {
+   *     foreignColumns: {2, 7}
+   *     uniqueColumns: {5}
+   *   },
+   *   {
+   *     foreignColumns: {2, 7}
+   *     uniqueColumns: {8}
+   *   },
+   *   {
+   *     foreignColumns: {6, 7}
+   *     uniqueColumns: {5}
+   *   },
+   *   {
+   *     foreignColumns: {6, 7}
+   *     uniqueColumns: {8}
+   *   }
+   * ]
+   *
+   * @param foreignMapping foreignKey mapping relationship
+   * @param uniqueMapping uniqueKey mapping relationship
+   * @return mapped relOptForeignKey set
+   */
+  public Set<RelOptForeignKey> permute(Map<Integer, List<Integer>> foreignMapping,
+      Map<Integer, List<Integer>> uniqueMapping) {
+    if (foreignMapping.isEmpty() && uniqueMapping.isEmpty()) {
+      return Sets.newHashSet(this);
+    }
+    final List<ImmutableBitSet> mappedForeignColumns = new ArrayList<>();
+    if (!foreignMapping.isEmpty()
+        && foreignMapping.keySet().containsAll(this.foreignColumns.asSet())) {
+      flatMappings(this.foreignColumns.toList(), foreignMapping)
+          .forEach(each -> mappedForeignColumns.add(this.foreignColumns.permute(each)));
+    }
+    if (mappedForeignColumns.isEmpty()) {
+      mappedForeignColumns.add(this.foreignColumns);
+    }
+    final List<ImmutableBitSet> mappedUniqueColumns = new ArrayList<>();
+    if (!uniqueMapping.isEmpty()
+        && uniqueMapping.keySet().containsAll(this.uniqueColumns.asSet())) {
+      flatMappings(this.uniqueColumns.toList(), uniqueMapping)
+          .forEach(each -> mappedUniqueColumns.add(this.uniqueColumns.permute(each)));
+    }
+    if (mappedUniqueColumns.isEmpty()) {
+      mappedUniqueColumns.add(this.uniqueColumns);
+    }
+    return Lists.newArrayList(
+            Linq4j.product(
+                Lists.newArrayList(mappedForeignColumns, mappedUniqueColumns))).stream()
+        .map(pair -> copy(pair.get(0), pair.get(1)))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Flatten the mapping based on the sources, which mapping can be one-to-many.
+   *
+   * <p>Example as follows:
+   * sources: [1, 2]
+   * mapping: {1: [3, 4], 2: [5, 6]}
+   * result: [{1:3, 2:5}, {1:3, 2:6}, {1:4, 2:5}, {1:4, 2:6}]
+   *
+   * @param sources the sources which will be mapped
+   * @param mapping the field mapping relationship which can potentially be one-to-many
+   * @return mapped sources
+   */
+  private static Set<Map<Integer, Integer>> flatMappings(List<Integer> sources,
+      Map<Integer, List<Integer>> mapping) {
+    List<List<Integer>> sourceMappings = new ArrayList<>();
+    for (int source : sources) {
+      List<Integer> sourceMapping = mapping.get(source);
+      if (sourceMapping == null || sourceMapping.isEmpty()) {
+        return new HashSet<>();
+      }
+      sourceMappings.add(sourceMapping);
+    }
+    Set<Map<Integer, Integer>> sourceTargetMappings = new HashSet<>();
+    Iterable<List<Integer>> targetMappingProducts = Linq4j.product(sourceMappings);
+    for (List<Integer> target : targetMappingProducts) {
+      // build map, key -> sources, value -> mapped targets
+      Iterator<Integer> sourceIterator = sources.iterator();
+      Iterator<Integer> targetIterator = target.iterator();
+      Map<Integer, Integer> sourceTargetMapping = new HashMap<>();
+      while (sourceIterator.hasNext() && targetIterator.hasNext()) {
+        sourceTargetMapping.put(sourceIterator.next(), targetIterator.next());
+      }
+      sourceTargetMappings.add(sourceTargetMapping);
+    }
+    return sourceTargetMappings;
+  }
+
+  /** Returns relOptForeignKey with every bit moved up {@code offset} positions.
+   * Offset may be negative, but throws if any bit ends up negative.
+   * Can control the shift side.
+   *
+   * <p>For instance,
+   * {@code constraints} is
+   * [{left: null.null.#false, right: [CATALOG, SALES, DEPT].$0.#false}]
+   * {@code foreignColumns} is {}
+   * {@code uniqueColumns} is {1}
+   *
+   * <p>It's inferred unique key, it will return as following when request params are
+   * offset = 2, shiftSides = [INFERRED_UNIQUE_TARGET]
+   * results:
+   * [{left: null.null.#false, right: [CATALOG, SALES, DEPT].$0.#false}]
+   * {@code foreignColumns} is {}
+   * {@code uniqueColumns} is {3}
+   *
+   * <p>It will return as following when request params are
+   * offset = 2,
+   * shiftSides = [INFERRED_UNIQUE_SOURCE, INFERRED_FOREIGN_SOURCE, INFERRED_FOREIGN_TARGET]
+   * results:
+   * [{left: null.null.#false, right: [CATALOG, SALES, DEPT].$0.#false}]
+   * {@code foreignColumns} is {}
+   * {@code uniqueColumns} is {1}
+   *
+   * @see org.apache.calcite.plan.RelOptForeignKey.ShiftSide */
+  public RelOptForeignKey shift(int offset, ShiftSide... shiftSides) {
+    if (offset == 0) {
+      return this;
+    }
+    ImmutableBitSet shiftedForeignColumns = ImmutableBitSet.of(this.foreignColumns);
+    ImmutableBitSet shiftedUniqueColumns = ImmutableBitSet.of(this.uniqueColumns);
+    for (ShiftSide shiftSide : shiftSides) {
+      if (ShiftSide.INFERRED_FOREIGN_SOURCE == shiftSide
+          && isInferredForeignKey()) {
+        shiftedForeignColumns = shiftedForeignColumns.shift(offset);
+      }
+      if (ShiftSide.INFERRED_FOREIGN_TARGET == shiftSide
+          && isInferredForeignKey()) {
+        shiftedUniqueColumns = shiftedUniqueColumns.shift(offset);
+      }
+      if (ShiftSide.INFERRED_UNIQUE_SOURCE == shiftSide
+          && isInferredUniqueKey()) {
+        shiftedForeignColumns = shiftedForeignColumns.shift(offset);
+      }
+      if (ShiftSide.INFERRED_UNIQUE_TARGET == shiftSide
+          && isInferredUniqueKey()) {
+        shiftedUniqueColumns = shiftedUniqueColumns.shift(offset);
+      }
+    }
+    return copy(shiftedForeignColumns, shiftedUniqueColumns);
+  }
+
+  /**
+   * The current constraint relationships consist only of foreign keys.
+   * These constraints need to be propagated to the top of the
+   * {@link org.apache.calcite.rel.RelNode} in order to be merged and confirmed
+   * in higher-level {@link org.apache.calcite.rel.RelNode} in the future.
+   */
+  public boolean isInferredForeignKey() {
+    return this.constraints.stream()
+        .allMatch(constraint -> !constraint.left.isNull()
+            && !constraint.right.isNull()
+            && !constraint.left.isConfirmed()
+            && !constraint.right.isConfirmed());
+  }
+
+  /**
+   * The current constraint relationships consist only of unique keys.
+   * These constraints need to be propagated to the top of the
+   * {@link org.apache.calcite.rel.RelNode} in order to be merged and confirmed
+   * in higher-level {@link org.apache.calcite.rel.RelNode} in the future.
+   */
+  public boolean isInferredUniqueKey() {
+    return this.constraints.stream()
+        .allMatch(constraint -> constraint.left.isNull()
+            && !constraint.right.isNull()
+            && !constraint.left.isConfirmed()
+            && !constraint.right.isConfirmed());
+  }
+
+  /** The inferred foreign key and unique key relationships have been determined,
+   * which typically occurs after a join operation. */
+  public boolean isConfirmed() {
+    return this.constraints.stream()
+        .allMatch(constraint -> !constraint.left.isNull()
+            && !constraint.right.isNull()
+            && constraint.left.isConfirmed()
+            && constraint.right.isConfirmed());
+  }
+
+  /** Deep copy based on foreignColumns and uniqueColumns. */
+  public RelOptForeignKey copy(ImmutableBitSet foreignColumns,
+      ImmutableBitSet uniqueColumns) {
+    List<Pair<InferredConstraintKey, InferredConstraintKey>> copiedConstraints =
+        this.constraints.stream()
+            .map(constraint -> Pair.of(constraint.left.copy(), constraint.right.copy()))
+            .collect(Collectors.toList());
+    return RelOptForeignKey.of(copiedConstraints, foreignColumns, uniqueColumns);
+  }
+
+  @Override public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    RelOptForeignKey that = (RelOptForeignKey) obj;
+    return constraints.equals(that.constraints)
+        && uniqueColumns.equals(that.uniqueColumns)
+        && foreignColumns.equals(that.foreignColumns);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(constraints, uniqueColumns, foreignColumns);
+  }
+
+  /** Represents the target bit set position to be shifted. */
+  public enum ShiftSide {
+    /**
+     * Shift constraint pair left when relOptForeignKey is inferred foreignKey.
+     *
+     * @see RelOptForeignKey#isInferredForeignKey()
+     */
+    INFERRED_FOREIGN_SOURCE,
+    /**
+     * Shift constraint pair right when relOptForeignKey is inferred foreignKey.
+     *
+     * @see RelOptForeignKey#isInferredForeignKey()
+     */
+    INFERRED_FOREIGN_TARGET,
+    /**
+     * Shift constraint pair left when relOptForeignKey is inferred uniqueKey.
+     *
+     * @see RelOptForeignKey#isInferredUniqueKey()
+     */
+    INFERRED_UNIQUE_SOURCE,
+    /**
+     * Shift constraint pair left when relOptForeignKey is inferred uniqueKey.
+     *
+     * @see RelOptForeignKey#isInferredUniqueKey()
+     */
+    INFERRED_UNIQUE_TARGET
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptForeignKey;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
@@ -100,6 +101,43 @@ public abstract class BuiltInMetadata {
           boolean ignoreNulls);
 
       @Override default MetadataDef<UniqueKeys> getDef() {
+        return DEF;
+      }
+    }
+  }
+
+  /**
+   * Metadata about which columns have foreign keys.
+   */
+  public interface ForeignKeys extends Metadata {
+    MetadataDef<ForeignKeys> DEF =
+        MetadataDef.of(ForeignKeys.class, ForeignKeys.Handler.class,
+            BuiltInMethod.FOREIGN_KEYS.method);
+
+    /**
+     * Extract foreign keys from {@link org.apache.calcite.rel.RelNode}.
+     * Foreign keys are represented as an {@link org.apache.calcite.util.ImmutableBitSet},
+     * where each bit position represents a 0-based output column ordinal.
+     *
+     * @param ignoreNulls if true, allow containing null values when determining
+     *                     whether the keys are foreign keys
+     *
+     * @return bit set of foreign keys(contains intermediate inferred foreign keys),
+     * or empty if not enough information is available to make that determination
+     */
+    Set<RelOptForeignKey> getForeignKeys(boolean ignoreNulls);
+
+    /**
+     * Handler API.
+     */
+    @FunctionalInterface
+    interface Handler extends MetadataHandler<ForeignKeys> {
+      Set<RelOptForeignKey> getForeignKeys(
+          RelNode rel,
+          RelMetadataQuery mq,
+          boolean ignoreNulls);
+
+      @Override default MetadataDef<ForeignKeys> getDef() {
         return DEF;
       }
     }
@@ -837,6 +875,6 @@ public abstract class BuiltInMetadata {
   interface All extends Selectivity, UniqueKeys, RowCount, DistinctRowCount,
       PercentageOriginalRows, ColumnUniqueness, ColumnOrigin, Predicates,
       Collation, Distribution, Size, Parallelism, Memory, AllPredicates,
-      ExpressionLineage, TableReferences, NodeTypes {
+      ExpressionLineage, TableReferences, NodeTypes, ForeignKeys {
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/DefaultRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/DefaultRelMetadataProvider.java
@@ -62,6 +62,7 @@ public class DefaultRelMetadataProvider extends ChainedRelMetadataProvider {
             RelMdExplainVisibility.SOURCE,
             RelMdPredicates.SOURCE,
             RelMdAllPredicates.SOURCE,
-            RelMdCollation.SOURCE));
+            RelMdCollation.SOURCE,
+            RelMdForeignKeys.SOURCE));
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdForeignKeys.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdForeignKeys.java
@@ -1,0 +1,348 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.plan.RelOptForeignKey;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelReferentialConstraint;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rel.core.Correlate;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.TableModify;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.InferredConstraintKey;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.apache.calcite.util.mapping.IntPair;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * RelMdForeignKeys supplies a default implementation of
+ * {@link RelMetadataQuery#getForeignKeys} for the standard logical algebra.
+ * The relNodes supported are same to {@link RelMetadataQuery#getUniqueKeys(RelNode)}
+ */
+public class RelMdForeignKeys
+    implements MetadataHandler<BuiltInMetadata.ForeignKeys> {
+  protected static final Set<RelOptForeignKey> EMPTY_BIT_SET = new HashSet<>();
+  public static final RelMetadataProvider SOURCE =
+      ReflectiveRelMetadataProvider.reflectiveSource(
+          new RelMdForeignKeys(), BuiltInMetadata.ForeignKeys.Handler.class);
+
+//~ Constructors -----------------------------------------------------------
+
+  private RelMdForeignKeys() {}
+
+//~ Methods ----------------------------------------------------------------
+
+  @Override public MetadataDef<BuiltInMetadata.ForeignKeys> getDef() {
+    return BuiltInMetadata.ForeignKeys.DEF;
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Filter rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getInput(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Sort rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getInput(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Correlate rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getLeft(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(TableModify rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return mq.getForeignKeys(rel.getInput(), ignoreNulls);
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Join rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    final RelNode left = rel.getLeft();
+    final RelNode right = rel.getRight();
+    if (!rel.getJoinType().projectsRight()) {
+      // Only return the foreign keys from the LHS since a semi or anti join only
+      // returns the LHS.
+      return mq.getForeignKeys(left, ignoreNulls);
+    }
+    int nLeftColumns = rel.getLeft().getRowType().getFieldList().size();
+    final Set<RelOptForeignKey> foreignKeys = new HashSet<>();
+    final Set<RelOptForeignKey> leftInputForeignKeys =
+        mq.getForeignKeys(left, ignoreNulls);
+    final Set<RelOptForeignKey> rightInputForeignKeys =
+        mq.getForeignKeys(right, ignoreNulls);
+
+    if (leftInputForeignKeys.isEmpty() && rightInputForeignKeys.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    // Shift right index.
+    Set<RelOptForeignKey> shiftedRightInputForeignKeys = rightInputForeignKeys.stream()
+        .map(
+            foreignKey -> foreignKey.shift(nLeftColumns,
+                RelOptForeignKey.ShiftSide.INFERRED_FOREIGN_SOURCE,
+                RelOptForeignKey.ShiftSide.INFERRED_UNIQUE_TARGET))
+        .collect(Collectors.toSet());
+    if (!rel.getJoinType().generatesNullsOnLeft() || ignoreNulls) {
+      foreignKeys.addAll(
+          tryMerge(leftInputForeignKeys, shiftedRightInputForeignKeys));
+    }
+    if (!rel.getJoinType().generatesNullsOnRight() || ignoreNulls) {
+      foreignKeys.addAll(
+          tryMerge(shiftedRightInputForeignKeys, leftInputForeignKeys));
+    }
+    return foreignKeys;
+  }
+
+  private Set<RelOptForeignKey> tryMerge(Set<RelOptForeignKey> foreignKeys,
+      Set<RelOptForeignKey> uniqueKeys) {
+    ImmutableMap.Builder<Set<InferredConstraintKey>, RelOptForeignKey>
+        inferredUniqueKeyMapBuilder = ImmutableMap.builder();
+    // The upper-level relational algebra may use constraints,
+    // so keep the unmerged foreign keys.
+    final Set<RelOptForeignKey> mixedForeignKeys = new HashSet<>(foreignKeys);
+    mixedForeignKeys.addAll(uniqueKeys);
+    if (foreignKeys.isEmpty() || uniqueKeys.isEmpty()) {
+      return mixedForeignKeys;
+    }
+    // Build unique keys map, key is unique key set, value is unique relOptForeignKey.
+    for (RelOptForeignKey uniqueKey : uniqueKeys) {
+      if (!uniqueKey.getConstraints().isEmpty()
+          && uniqueKey.isInferredUniqueKey()) {
+        inferredUniqueKeyMapBuilder.put(
+            Sets.newHashSet(RelOptForeignKey.constraintsRight(uniqueKey.getConstraints())),
+            uniqueKey);
+      }
+    }
+    ImmutableMap<Set<InferredConstraintKey>, RelOptForeignKey> inferredUniqueKeyMap =
+        inferredUniqueKeyMapBuilder.build();
+    for (RelOptForeignKey foreignKey : foreignKeys) {
+      if (foreignKey.getConstraints().isEmpty()
+          || !foreignKey.isInferredForeignKey()) {
+        continue;
+      }
+      // Try merge.
+      Set<InferredConstraintKey> foreignSideNeededUniqueSet =
+          Sets.newHashSet(RelOptForeignKey.constraintsRight(foreignKey.getConstraints()));
+      RelOptForeignKey inferredUniqueKey =
+          inferredUniqueKeyMap.get(foreignSideNeededUniqueSet);
+      if (inferredUniqueKey != null) {
+        mixedForeignKeys.add(
+            RelOptForeignKey.of(
+                foreignKey.getConstraints().stream()
+                    .map(
+                        constraint -> Pair.of(
+                        constraint.left.copy(true),
+                        constraint.right.copy(true)))
+                    .collect(Collectors.toList()),
+                ImmutableBitSet.of(foreignKey.getForeignColumns()),
+                ImmutableBitSet.of(inferredUniqueKey.getUniqueColumns())));
+      }
+    }
+    return mixedForeignKeys;
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Aggregate rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    final ImmutableBitSet groupSet = rel.getGroupSet();
+    if (groupSet.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    final Set<RelOptForeignKey> inputForeignKeys =
+        mq.getForeignKeys(rel.getInput(), ignoreNulls);
+    return inputForeignKeys.stream()
+        .filter(foreignKey -> filterValidateColumns(groupSet, foreignKey))
+        .collect(Collectors.toSet());
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Project rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    return getProjectForeignKeys(rel, mq, ignoreNulls, rel.getProjects());
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(Calc rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    RexProgram program = rel.getProgram();
+    return getProjectForeignKeys(rel, mq, ignoreNulls,
+        Util.transform(program.getProjectList(), program::expandLocalRef));
+  }
+
+  private static Set<RelOptForeignKey> getProjectForeignKeys(SingleRel rel,
+      RelMetadataQuery mq,
+      boolean ignoreNulls,
+      List<RexNode> projExprs) {
+
+    // Single input can be mapped to multiple outputs.
+    final ImmutableListMultimap.Builder<Integer, Integer> inToOutIndexBuilder =
+        ImmutableListMultimap.builder();
+    final ImmutableBitSet.Builder inColumnsBuilder = ImmutableBitSet.builder();
+    for (int i = 0; i < projExprs.size(); i++) {
+      RexNode projExpr = projExprs.get(i);
+      if (projExpr instanceof RexInputRef) {
+        int inputIndex = ((RexInputRef) projExpr).getIndex();
+        inToOutIndexBuilder.put(inputIndex, i);
+        inColumnsBuilder.set(inputIndex);
+      }
+    }
+    final ImmutableBitSet inColumnsUsed = inColumnsBuilder.build();
+    if (inColumnsUsed.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    final Map<Integer, List<Integer>> mapInToOutPos =
+        Maps.transformValues(inToOutIndexBuilder.build().asMap(), Lists::newArrayList);
+    final Set<RelOptForeignKey> inputForeignKeys =
+        mq.getForeignKeys(rel.getInput(), ignoreNulls);
+    if (inputForeignKeys.isEmpty()) {
+      return EMPTY_BIT_SET;
+    }
+    return inputForeignKeys.stream()
+        .filter(foreignKey -> filterValidateColumns(inColumnsUsed, foreignKey))
+        .flatMap(foreignKey -> foreignKey.permute(mapInToOutPos, mapInToOutPos).stream())
+        .collect(Collectors.toSet());
+  }
+
+  private static boolean filterValidateColumns(ImmutableBitSet columnsUsed,
+      RelOptForeignKey foreignKey) {
+    // used columns should contain all foreignColumns when is inferred foreign key
+    // used columns should contain all uniqueColumns when is inferred unique key
+    // used columns should contain both foreignColumns and uniqueColumns
+    // when is confirmed foreign key.
+    return (foreignKey.isInferredForeignKey()
+        && columnsUsed.contains(foreignKey.getForeignColumns()))
+        || (foreignKey.isInferredUniqueKey()
+        && columnsUsed.contains(foreignKey.getUniqueColumns()))
+        || (foreignKey.isConfirmed() && columnsUsed.contains(foreignKey.getForeignColumns())
+        && columnsUsed.contains(foreignKey.getUniqueColumns()));
+  }
+
+  public Set<RelOptForeignKey> getForeignKeys(TableScan rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    final RelOptTable table = rel.getTable();
+    final BuiltInMetadata.ForeignKeys.Handler handler =
+        table.unwrap(BuiltInMetadata.ForeignKeys.Handler.class);
+    if (handler != null) {
+      return handler.getForeignKeys(rel, mq, ignoreNulls);
+    }
+
+    final List<RelReferentialConstraint> referentialConstraints =
+        table.getReferentialConstraints();
+    final List<ImmutableBitSet> keys = table.getKeys();
+
+    final Set<RelOptForeignKey> foreignKeys = new HashSet<>();
+    if (referentialConstraints != null) {
+      foreignKeys.addAll(referentialConstraints.stream()
+          .map(constraint -> {
+            List<Pair<InferredConstraintKey, InferredConstraintKey>> constraints =
+                constraint.getColumnPairs().stream()
+                    .map(
+                        intPair -> Pair.of(
+                        InferredConstraintKey.of(constraint.getSourceQualifiedName(),
+                            intPair.source,
+                            false),
+                        InferredConstraintKey.of(constraint.getTargetQualifiedName(),
+                            intPair.target,
+                            false)))
+                    .collect(Collectors.toList());
+            return RelOptForeignKey.of(constraints,
+                ImmutableBitSet.of(IntPair.left(constraint.getColumnPairs())),
+                ImmutableBitSet.of());
+          })
+          .collect(Collectors.toSet()));
+    }
+    if (keys != null) {
+      foreignKeys.addAll(
+          // Unique keys can be combined, after combining still be unique keys
+          Sets.powerSet(Sets.newHashSet(keys)).stream()
+              .filter(keySet -> !keySet.isEmpty())
+              .map(ImmutableBitSet::union)
+              .map(keyBitSet -> {
+                List<Pair<InferredConstraintKey, InferredConstraintKey>> constraints =
+                    keyBitSet.asList().stream()
+                        .map(
+                            index -> Pair.of(
+                            InferredConstraintKey.of(),
+                            InferredConstraintKey.of(
+                                table.getQualifiedName(),
+                                index,
+                                false)))
+                        .collect(Collectors.toList());
+                return RelOptForeignKey.of(constraints, ImmutableBitSet.of(), keyBitSet);
+              })
+              .collect(Collectors.toList()));
+    }
+    if (!ignoreNulls) {
+      final List<RelDataTypeField> fieldList = rel.getRowType().getFieldList();
+      return foreignKeys.stream()
+          .filter(foreignKey -> foreignKey.getForeignColumns().asSet().stream()
+              .noneMatch(index -> fieldList.get(index).getType().isNullable())
+              && foreignKey.getUniqueColumns().asSet().stream()
+              .noneMatch(index -> fieldList.get(index).getType().isNullable()))
+          .collect(Collectors.toSet());
+    }
+    return foreignKeys;
+  }
+
+  /**
+   * The foreign keys of SetOp are precisely the intersection of its every
+   * input foreign keys.
+   */
+  public Set<RelOptForeignKey> getForeignKeys(SetOp rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+
+    Set<RelOptForeignKey> foreignKeys = new HashSet<>();
+    for (RelNode input : rel.getInputs()) {
+      Set<RelOptForeignKey> inputForeignKeys = mq.getForeignKeys(input, ignoreNulls);
+      if (inputForeignKeys.isEmpty()) {
+        return EMPTY_BIT_SET;
+      }
+      foreignKeys = foreignKeys.isEmpty()
+          ? inputForeignKeys : Sets.intersection(foreignKeys, inputForeignKeys);
+    }
+    return foreignKeys;
+  }
+
+  /** Catch-all rule when none of the others apply. */
+  public Set<RelOptForeignKey> getForeignKeys(RelNode rel, RelMetadataQuery mq,
+      boolean ignoreNulls) {
+    // No information available.
+    return EMPTY_BIT_SET;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.metadata;
 
 import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptForeignKey;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
@@ -40,6 +41,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
 
@@ -107,6 +109,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
   private BuiltInMetadata.Size.Handler sizeHandler;
   private BuiltInMetadata.UniqueKeys.Handler uniqueKeysHandler;
   private BuiltInMetadata.LowerBoundCost.Handler lowerBoundCostHandler;
+  private BuiltInMetadata.ForeignKeys.Handler foreignKeysHandler;
 
   /**
    * Creates the instance with {@link JaninoRelMetadataProvider} instance
@@ -151,6 +154,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     this.sizeHandler = provider.handler(BuiltInMetadata.Size.Handler.class);
     this.uniqueKeysHandler = provider.handler(BuiltInMetadata.UniqueKeys.Handler.class);
     this.lowerBoundCostHandler = provider.handler(BuiltInMetadata.LowerBoundCost.Handler.class);
+    this.foreignKeysHandler = provider.handler(BuiltInMetadata.ForeignKeys.Handler.class);
   }
 
   /** Creates and initializes the instance that will serve as a prototype for
@@ -183,6 +187,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     this.sizeHandler = initialHandler(BuiltInMetadata.Size.Handler.class);
     this.uniqueKeysHandler = initialHandler(BuiltInMetadata.UniqueKeys.Handler.class);
     this.lowerBoundCostHandler = initialHandler(BuiltInMetadata.LowerBoundCost.Handler.class);
+    this.foreignKeysHandler = initialHandler(BuiltInMetadata.ForeignKeys.Handler.class);
   }
 
   private RelMetadataQuery(
@@ -213,6 +218,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     this.sizeHandler = prototype.sizeHandler;
     this.uniqueKeysHandler = prototype.uniqueKeysHandler;
     this.lowerBoundCostHandler = prototype.lowerBoundCostHandler;
+    this.foreignKeysHandler = prototype.foreignKeysHandler;
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -506,6 +512,48 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
   }
 
   /**
+   * Extract foreign keys from {@link org.apache.calcite.rel.RelNode}.
+   * Foreign keys are represented as an {@link org.apache.calcite.plan.RelOptForeignKey},
+   * in which each bit position represents a 0-based output column ordinal.
+   *
+   * @param rel         the relational expression
+   * @param ignoreNulls if true, allow containing null values when determining
+   *                     whether the keys are foreign keys
+   *
+   * @return set of foreign keys(contains intermediate inferred foreign keys),
+   * or empty if not enough information is available to make that determination
+   */
+  public Set<RelOptForeignKey> getForeignKeys(RelNode rel, boolean ignoreNulls) {
+    for (;;) {
+      try {
+        return foreignKeysHandler.getForeignKeys(rel, this, ignoreNulls);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        foreignKeysHandler = revise(BuiltInMetadata.ForeignKeys.Handler.class);
+      }
+    }
+  }
+
+  /**
+   * Extract confirmed foreign keys from {@link org.apache.calcite.rel.RelNode}.
+   * Foreign keys are represented as an {@link org.apache.calcite.plan.RelOptForeignKey},
+   * in which each bit position represents a 0-based output column ordinal.
+   *
+   * @param rel         the relational expression
+   * @param ignoreNulls if true, allow containing null values when determining
+   *                     whether the keys are foreign keys
+   *
+   * @return confirmed set of foreign keys, or empty if not enough information
+   * is available to make that determination
+   *
+   * @see RelMetadataQuery#getForeignKeys(org.apache.calcite.rel.RelNode, boolean)
+   */
+  public Set<RelOptForeignKey> getConfirmedForeignKeys(RelNode rel, boolean ignoreNulls) {
+    return getForeignKeys(rel, ignoreNulls).stream()
+        .filter(RelOptForeignKey::isConfirmed)
+        .collect(Collectors.toSet());
+  }
+
+  /**
    * Returns whether the rows of a given relational expression are distinct,
    * optionally ignoring NULL values.
    *
@@ -587,6 +635,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
       }
     }
   }
+
 
   /**
    * Returns the

--- a/core/src/main/java/org/apache/calcite/rex/InferredConstraintKey.java
+++ b/core/src/main/java/org/apache/calcite/rex/InferredConstraintKey.java
@@ -103,7 +103,9 @@ public class InferredConstraintKey {
       return false;
     }
     InferredConstraintKey that = (InferredConstraintKey) obj;
-    return Objects.equals(qualifiedName, that.qualifiedName) && Objects.equals(index, that.index);
+    return Objects.equals(qualifiedName, that.qualifiedName)
+        && Objects.equals(index, that.index)
+        && this.confirmed == that.confirmed;
   }
 
   @Override public int hashCode() {

--- a/core/src/main/java/org/apache/calcite/rex/InferredConstraintKey.java
+++ b/core/src/main/java/org/apache/calcite/rex/InferredConstraintKey.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rex;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The inferred foreign and unique table and column.
+ * Within the same level of {@link org.apache.calcite.rel.RelNode},
+ * confirmed field is marked as ture when they are confirmed to be
+ * foreign key and unique key constraint.
+ * The propagation and confirmation are performed from bottom to top.
+ *
+ * <p>InferredConstraintKey#isNull() is true when the inferredConstraintKey
+ * is at the source side in RelOptForeignKey#constraints as it is inferred unique key.
+ *
+ * @see org.apache.calcite.plan.RelOptForeignKey
+ * @see org.apache.calcite.plan.RelOptForeignKey.ShiftSide
+ */
+public class InferredConstraintKey {
+
+  private final @Nullable List<String> qualifiedName;
+  private final @Nullable Integer index;
+  /**
+   * After join, this confirmed field become true when the constraints in
+   * {@link org.apache.calcite.plan.RelOptForeignKey} contains the corresponding
+   * foreign InferredConstraintKey and unique InferredConstraintKey.
+   */
+  private final boolean confirmed;
+  private final String digest;
+
+  private InferredConstraintKey(@Nullable List<String> qualifiedName,
+      @Nullable Integer index,
+      boolean confirmed) {
+    this.qualifiedName = qualifiedName;
+    this.index = index;
+    this.confirmed = confirmed;
+    this.digest = qualifiedName + ".$" + index + ".#" + confirmed;
+  }
+
+  public @Nullable List<String> getQualifiedName() {
+    return this.qualifiedName;
+  }
+
+  public @Nullable Integer getIndex() {
+    return this.index;
+  }
+
+  public boolean isConfirmed() {
+    return confirmed;
+  }
+
+  public static InferredConstraintKey of() {
+    return new InferredConstraintKey(null, null, false);
+  }
+
+  public static InferredConstraintKey of(@Nullable List<String> tableName,
+      @Nullable Integer index, boolean confirmed) {
+    return new InferredConstraintKey(tableName, index, confirmed);
+  }
+
+  public boolean isNull() {
+    return qualifiedName == null && index == null;
+  }
+
+  public InferredConstraintKey copy(boolean confirmed) {
+    return InferredConstraintKey.of(
+        this.qualifiedName == null ? null : new ArrayList<>(this.qualifiedName),
+        this.index,
+        confirmed);
+  }
+
+  public InferredConstraintKey copy() {
+    return InferredConstraintKey.of(
+        this.qualifiedName == null ? null : new ArrayList<>(qualifiedName),
+        this.index,
+        this.confirmed);
+  }
+
+  @Override public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    InferredConstraintKey that = (InferredConstraintKey) obj;
+    return Objects.equals(qualifiedName, that.qualifiedName) && Objects.equals(index, that.index);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(digest);
+  }
+
+  @Override public String toString() {
+    return digest;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -62,6 +62,7 @@ import org.apache.calcite.rel.metadata.BuiltInMetadata.DistinctRowCount;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.Distribution;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.ExplainVisibility;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.ExpressionLineage;
+import org.apache.calcite.rel.metadata.BuiltInMetadata.ForeignKeys;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCost;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.MaxRowCount;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.Memory;
@@ -668,6 +669,7 @@ public enum BuiltInMethod {
   STR_TO_MAP(SqlFunctions.class, "strToMap", String.class, String.class, String.class),
   SELECTIVITY(Selectivity.class, "getSelectivity", RexNode.class),
   UNIQUE_KEYS(UniqueKeys.class, "getUniqueKeys", boolean.class),
+  FOREIGN_KEYS(ForeignKeys.class, "getForeignKeys", boolean.class),
   AVERAGE_ROW_SIZE(Size.class, "averageRowSize"),
   AVERAGE_COLUMN_SIZES(Size.class, "averageColumnSizes"),
   IS_PHASE_TRANSITION(Parallelism.class, "isPhaseTransition"),

--- a/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.test;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptForeignKey;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
@@ -261,6 +262,18 @@ public class RelMetadataFixture {
     Double result = mq.getPercentageOriginalRows(rel);
     assertNotNull(result);
     assertThat(result, matcher);
+    return this;
+  }
+
+  public RelMetadataFixture assertForeignKeys(Matcher<Set<RelOptForeignKey>> matcher,
+      Matcher<Set<RelOptForeignKey>> confirmedMatcher,
+      boolean ignoreNulls) {
+    RelNode rel = toRel();
+    RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    Set<RelOptForeignKey> foreignKeys = mq.getForeignKeys(rel, ignoreNulls);
+    assertThat(foreignKeys, matcher);
+    Set<RelOptForeignKey> confirmedForeignKeys = mq.getConfirmedForeignKeys(rel, ignoreNulls);
+    assertThat(confirmedForeignKeys, confirmedMatcher);
     return this;
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReader.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReader.java
@@ -594,6 +594,11 @@ public abstract class MockCatalogReader extends CalciteCatalogReader {
       return referentialConstraints;
     }
 
+
+    public void setReferentialConstraints(List<RelReferentialConstraint> referentialConstraints) {
+      this.referentialConstraints.addAll(referentialConstraints);
+    }
+
     @Override public RelDataType getRowType() {
       return rowType;
     }

--- a/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
+++ b/testkit/src/main/java/org/apache/calcite/test/catalog/MockCatalogReaderSimple.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test.catalog;
 
+import org.apache.calcite.rel.RelReferentialConstraintImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -31,8 +32,10 @@ import org.apache.calcite.sql2rel.NullInitializerExpressionFactory;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
+import org.apache.calcite.util.mapping.IntPair;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -86,6 +89,15 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     empTable.addColumn("COMM", fixture.intType);
     empTable.addColumn("DEPTNO", fixture.intType);
     empTable.addColumn("SLACKER", fixture.booleanType);
+    // Mock the referentialConstraint,
+    // the foreign key is the DEPTNO column of CATALOG.SALES.EMP table,
+    // reference the DEPTNO unique column of CATALOG.SALES.DEPT table.
+    empTable.setReferentialConstraints(
+        Lists.newArrayList(
+            RelReferentialConstraintImpl.of(
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "EMP"),
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "DEPT"),
+        Lists.newArrayList(IntPair.of(7, 0)))));
     registerTable(empTable);
   }
 
@@ -99,6 +111,15 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     empNullablesTable.addColumn("COMM", fixture.intTypeNull);
     empNullablesTable.addColumn("DEPTNO", fixture.intTypeNull);
     empNullablesTable.addColumn("SLACKER", fixture.booleanTypeNull);
+    // Mock the referentialConstraint,
+    // the foreign key is the DEPTNO column of CATALOG.SALES.EMPNULLABLES table,
+    // reference the DEPTNO unique column of CATALOG.SALES.DEPT table.
+    empNullablesTable.setReferentialConstraints(
+        Lists.newArrayList(
+            RelReferentialConstraintImpl.of(
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "EMPNULLABLES"),
+        Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "DEPT"),
+        Lists.newArrayList(IntPair.of(7, 0)))));
     registerTable(empNullablesTable);
   }
 
@@ -115,6 +136,15 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
     empDefaultsTable.addColumn("COMM", fixture.intTypeNull);
     empDefaultsTable.addColumn("DEPTNO", fixture.intTypeNull);
     empDefaultsTable.addColumn("SLACKER", fixture.booleanTypeNull);
+    // Mock the referentialConstraint,
+    // the foreign key is combined, the ENAME and JOB column of CATALOG.SALES.EMPDEFAULTS table,
+    // reference the ENAME and JOB column of CATALOG.SALES.BONUS table.
+    empDefaultsTable.setReferentialConstraints(
+        Lists.newArrayList(
+            RelReferentialConstraintImpl.of(
+                Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "EMPDEFAULTS"),
+                Lists.newArrayList(DEFAULT_CATALOG, DEFAULT_SCHEMA, "BONUS"),
+                Lists.newArrayList(IntPair.of(1, 0), IntPair.of(2, 1)))));
     registerTable(empDefaultsTable);
   }
 
@@ -179,8 +209,8 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
   private void registerTableBonus(MockSchema salesSchema, Fixture fixture) {
     MockTable bonusTable =
         MockTable.create(this, salesSchema, "BONUS", false, 0);
-    bonusTable.addColumn("ENAME", fixture.varchar20Type);
-    bonusTable.addColumn("JOB", fixture.varchar10Type);
+    bonusTable.addColumn("ENAME", fixture.varchar20Type, true);
+    bonusTable.addColumn("JOB", fixture.varchar10Type, true);
     bonusTable.addColumn("SAL", fixture.intType);
     bonusTable.addColumn("COMM", fixture.intType);
     registerTable(bonusTable);
@@ -468,6 +498,9 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
             "customBigInt"),
         typeFactory -> typeFactory.createSqlType(SqlTypeName.BIGINT));
 
+    // Register "DEPT" table.
+    registerTableDept(salesSchema, fixture);
+
     // Register "EMP" table.
     final MockTable empTable =
         MockTable.create(this, salesSchema, "EMP", false, 14, null,
@@ -484,9 +517,6 @@ public class MockCatalogReaderSimple extends MockCatalogReader {
 
     // Register "EMP_B" table. As "EMP", birth with a "BIRTHDATE" column.
     registerTableEmpB(salesSchema, fixture);
-
-    // Register "DEPT" table.
-    registerTableDept(salesSchema, fixture);
 
     // Register "DEPTNULLABLES" table.
     registerTableDeptNullables(salesSchema, fixture);


### PR DESCRIPTION
We can get constraints by RelOptTable#getReferentialConstraints method, but maybe can't get appropriate constraints at top relNode.
Foreign keys metadata is very useful in many optimize scenes. Such as it can be used in join eliminate when join type is inner join and some other star schema query optimize.
So support to get foreign keys metadata in RelMetadataQuery, it support to get composite foreign keys and  get the corresponding unique key on the arbitrary relNode if you want.
Tests are added to `RelMetadataTest`, the test code takes up a large part of the PR.