### PR TITLE
[CALCITE-5840] Incorrect SOUNDEX function semantics in MySQL library

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -231,6 +231,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.SHA512;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SINH;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SORT_ARRAY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SOUNDEX;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.SOUNDEX_MYSQL;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SOUNDEX_SPARK;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPACE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPLIT;
@@ -545,6 +546,7 @@ public class RexImpTable {
       defineMethod(STRCMP, BuiltInMethod.STRCMP.method, NullPolicy.STRICT);
       defineMethod(SOUNDEX, BuiltInMethod.SOUNDEX.method, NullPolicy.STRICT);
       defineMethod(SOUNDEX_SPARK, BuiltInMethod.SOUNDEX_SPARK.method, NullPolicy.STRICT);
+      defineMethod(SOUNDEX_MYSQL, BuiltInMethod.SOUNDEX_MYSQL.method, NullPolicy.STRICT);
       defineMethod(DIFFERENCE, BuiltInMethod.DIFFERENCE.method, NullPolicy.STRICT);
       defineMethod(REVERSE, BuiltInMethod.REVERSE.method, NullPolicy.STRICT);
       defineMethod(LEVENSHTEIN, BuiltInMethod.LEVENSHTEIN.method, NullPolicy.STRICT);

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -222,6 +222,38 @@ public class SqlFunctions {
           .appendOffsetId()
           .toFormatter(Locale.ROOT);
 
+  // helper method for implementation non-standard soundex function
+  private static char soundexCode(char c) {
+    switch (Character.toUpperCase(c)) {
+    case 'B':
+    case 'F':
+    case 'P':
+    case 'V':
+      return '1';
+    case 'C':
+    case 'G':
+    case 'J':
+    case 'K':
+    case 'Q':
+    case 'S':
+    case 'X':
+    case 'Z':
+      return '2';
+    case 'D':
+    case 'T':
+      return '3';
+    case 'L':
+      return '4';
+    case 'M':
+    case 'N':
+      return '5';
+    case 'R':
+      return '6';
+    default:
+      return '0';
+    }
+  }
+
   /** Whether the current Java version is 8 (1.8). */
   private static final boolean IS_JDK_8 =
       System.getProperty("java.version").startsWith("1.8");
@@ -736,6 +768,32 @@ public class SqlFunctions {
     } catch (IllegalArgumentException ignore) {
       return s;
     }
+  }
+
+  /** SQL SOUNDEX(string) function.
+   *
+   * <p>If s is multibyte character it will return not reliable result either instead of throwing
+   * exception. And it returns an arbitrarily long string instead of standard 4 chars length.*/
+  public static String soundexMySQL(String s) {
+    if (s.length() == 0) {
+      return "";
+    }
+
+    StringBuilder result = new StringBuilder();
+    result.append(Character.toUpperCase(s.charAt(0)));
+
+    for (int i = 1; i < s.length(); i++) {
+      char code = soundexCode(s.charAt(i));
+      if (code != '0' && code != soundexCode(s.charAt(i - 1))) {
+        result.append(code);
+      }
+    }
+
+    while (result.length() < SOUNDEX_LENGTH) {
+      result.append('0');
+    }
+
+    return result.toString();
   }
 
   /** SQL DIFFERENCE(string, string) function. */

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -779,6 +779,9 @@ public enum SqlKind {
   /** {@code SOUNDEX} function (Spark semantics). */
   SOUNDEX_SPARK,
 
+  /** {@code SOUNDEX} function (MySQL semantics). */
+  SOUNDEX_MYSQL,
+
   /** {@code SUBSTR} function (BigQuery semantics). */
   SUBSTR_BIG_QUERY,
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -825,7 +825,7 @@ public abstract class SqlLibraryOperators {
           OperandTypes.STRING_STRING,
           SqlFunctionCategory.STRING);
 
-  @LibraryOperator(libraries = {BIG_QUERY, MYSQL, POSTGRESQL, ORACLE})
+  @LibraryOperator(libraries = {BIG_QUERY, POSTGRESQL, ORACLE})
   public static final SqlFunction SOUNDEX =
       SqlBasicFunction.create("SOUNDEX",
           ReturnTypes.VARCHAR_4_NULLABLE,
@@ -836,6 +836,12 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {SPARK})
   public static final SqlFunction SOUNDEX_SPARK =
       ((SqlBasicFunction) SOUNDEX).withKind(SqlKind.SOUNDEX_SPARK)
+          .withReturnTypeInference(ReturnTypes.VARCHAR_NULLABLE);
+
+  /** The variant of the SOUNDEX operator. */
+  @LibraryOperator(libraries = {MYSQL})
+  public static final SqlFunction SOUNDEX_MYSQL =
+      ((SqlBasicFunction) SOUNDEX).withKind(SqlKind.SOUNDEX_MYSQL)
           .withReturnTypeInference(ReturnTypes.VARCHAR_NULLABLE);
 
   @LibraryOperator(libraries = {POSTGRESQL})

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -358,6 +358,7 @@ public enum BuiltInMethod {
   SPACE(SqlFunctions.class, "space", int.class),
   SOUNDEX(SqlFunctions.class, "soundex", String.class),
   SOUNDEX_SPARK(SqlFunctions.class, "soundexSpark", String.class),
+  SOUNDEX_MYSQL(SqlFunctions.class, "soundexMySQL", String.class),
   STRCMP(SqlFunctions.class, "strcmp", String.class, String.class),
   DIFFERENCE(SqlFunctions.class, "difference", String.class, String.class),
   REVERSE(SqlFunctions.class, "reverse", String.class),

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7159,6 +7159,21 @@ class RelToSqlConverterTest {
     sql(query).withSpark().withLibrary(SqlLibrary.SPARK).ok(expectedSql);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5840">[CALCITE-5840]
+   * Incorrect SOUNDEX function semantics in MySQL library</a>.
+   *
+   * <p>Calcite's MySQL dialect SOUNDEX function should be SOUNDEX instead of SOUNDEX_MYSQL
+   * when unparsing it.
+   */
+  @Test void testMySQLSoundexFunction() {
+    final String query = "select soundex('Miller') from \"product\"\n";
+    final String expectedSql = "SELECT SOUNDEX('Miller')\n"
+        + "FROM foodmart.product";
+
+    sql(query).withSpark().withLibrary(SqlLibrary.MYSQL).ok(expectedSql);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final CalciteAssert.SchemaSpec schemaSpec;

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2794,8 +2794,9 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b p | SHA256(string)                               | Calculates a SHA-256 hash value of *string* and returns it as a hex string
 | b p | SHA512(string)                               | Calculates a SHA-512 hash value of *string* and returns it as a hex string
 | * | SINH(numeric)                                  | Returns the hyperbolic sine of *numeric*
-| b m o p | SOUNDEX(string)                          | Returns the phonetic representation of *string*; throws if *string* is encoded with multi-byte encoding such as UTF-8
+| b o p | SOUNDEX(string)                            | Returns the phonetic representation of *string*; throws if *string* is encoded with multi-byte encoding such as UTF-8
 | s | SOUNDEX(string)                                | Returns the phonetic representation of *string*; return original *string* if *string* is encoded with multi-byte encoding such as UTF-8
+| m | SOUNDEX(string)                                | Returns the phonetic representation of *string*; return not reliable result if *string* is encoded with multi-byte encoding such as UTF-8. Note this funtion is not standard soundex it returns an arbitrarily long string instead of 4-chars.
 | m | SPACE(integer)                                 | Returns a string of *integer* spaces; returns an empty string if *integer* is less than 1
 | b | SPLIT(string [, delimiter ])                   | Returns the string array of *string* split at *delimiter* (if omitted, default is comma)
 | b | STARTS_WITH(string1, string2)                  | Returns whether *string2* is a prefix of *string1*

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -4359,8 +4359,7 @@ public class SqlOperatorTest {
         "No match found for function signature SOUNDEX\\(<CHARACTER>\\)",
         false);
     final List<SqlLibrary> libraries =
-        ImmutableList.of(SqlLibrary.BIG_QUERY, SqlLibrary.MYSQL,
-            SqlLibrary.ORACLE, SqlLibrary.POSTGRESQL);
+        ImmutableList.of(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE, SqlLibrary.POSTGRESQL);
     final Consumer<SqlOperatorFixture> consumer = f -> {
       f.checkString("SOUNDEX('TECH ON THE NET')", "T253", "VARCHAR(4) NOT NULL");
       f.checkString("SOUNDEX('Miller')", "M460", "VARCHAR(4) NOT NULL");
@@ -4398,6 +4397,30 @@ public class SqlOperatorTest {
       f.checkNull("SOUNDEX(cast(null as varchar(1)))");
     };
     f0.forEachLibrary(list(SqlLibrary.SPARK), consumer);
+  }
+
+  @Test void testSoundexMySQLFunc() {
+    final SqlOperatorFixture f0 = fixture().setFor(SqlLibraryOperators.SOUNDEX_MYSQL);
+    f0.checkFails("^soundex('tech on the net')^",
+        "No match found for function signature SOUNDEX\\(<CHARACTER>\\)",
+        false);
+    final Consumer<SqlOperatorFixture> consumer = f -> {
+      f.checkString("SOUNDEX('TECH ON THE NET')", "T25353", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX('Miller')", "M460", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX('miler')", "M460", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX('myller')", "M460", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX('muller')", "M460", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX('m')", "M000", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX('mu')", "M000", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX('mile')", "M400", "VARCHAR NOT NULL");
+      // note: it's different with soundex for bigquery/mysql/oracle/pg
+      f.checkString("SOUNDEX(_UTF8'\u5B57\u5B57')",
+          "字000", "VARCHAR NOT NULL");
+      f.checkString("SOUNDEX(_UTF8'\u5B57\u5B57\u5B57\u5B57')",
+          "字000", "VARCHAR NOT NULL");
+      f.checkNull("SOUNDEX(cast(null as varchar(1)))");
+    };
+    f0.forEachLibrary(list(SqlLibrary.MYSQL), consumer);
   }
 
   @Test void testDifferenceFunc() {


### PR DESCRIPTION
# What is the purpose of the change

https://issues.apache.org/jira/browse/CALCITE-5840

The SqlFunctions#soundexMySQL rewrite the mysql's c++ soundex implementation. pls see:
https://github.com/mysql/mysql-server/blob/ea1efa9822d81044b726aab20c857d5e1b7e046a/sql/item_strfunc.cc#L2054


# Brief change log
Add a new mysql soundex implementation to correct current wrong behavior in calcite. 

# Verifying this change

SqlOperatorTests#testMysqlSoundex()
