### PR TITLE
[CALCITE-5892] Add support for unparseSqlIntervalLiteral with SnowflakeSQLDialect

### DIFF
--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -97,6 +97,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -7158,6 +7159,35 @@ class RelToSqlConverterTest {
 
     sql(query).withSpark().withLibrary(SqlLibrary.SPARK).ok(expectedSql);
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5892">[CALCITE-5892]
+   * SnowflakeSqlDialect doesn't provide custom unparseSqlIntervalLiteral support </a>.
+   *
+   * <p>Calcite's Snowflake dialect should ensure the SQL literal
+   * places the qualifier inside the string literal and not as a keyword.
+   */
+  @Test void testSnowflakeInterval() {
+    // TODO: Support millisecond, microsecond, and nanosecond in parsing
+    String[] qualifiers = {"YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"};
+    for (String qualifier: qualifiers) {
+      checkSnowflakeIntevalLiteral(1, qualifier);
+    }
+  }
+
+  private void checkSnowflakeIntevalLiteral(int count, String qualifier) {
+    String original = String.format(Locale.ROOT, "INTERVAL '%d' %s", count, qualifier);
+    String expected = String.format(Locale.ROOT, "INTERVAL '%d %s'", count, qualifier);
+    checkSnowflakeIntevalLiteral2(original, expected);
+  }
+
+  private void checkSnowflakeIntevalLiteral2(String expression, String expected) {
+    String expectedSnowflakedb = "SELECT *\n"
+        + "FROM (VALUES (" + expected + ")) AS \"t\" (\"EXPR$0\")";
+    sql("VALUES " + expression)
+        .withSnowflake().ok(expectedSnowflakedb);
+  }
+
 
   /** Fluid interface to run tests. */
   static class Sql {


### PR DESCRIPTION
Updates the SnowflakeSQLDialect to fix the unparse implementation for SQL Literals. In Snowflake the qualifier is not a keyword and is instead included as part of the string literal that contains the integer: https://docs.snowflake.com/en/sql-reference/data-types-datetime#interval-constants.

This doesn't attempt to implement any additional interval parsing support for Snowflake, so there are still gaps that remain (e.g. sub-second intervals and multiple intervals). 