### PR TITLE
[CALCITE-5895] TABLESAMPLE(0) should return empty result

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2288,12 +2288,6 @@ SqlNode Tablesample(SqlNode tableRef) :
         {
             final BigDecimal ONE_HUNDRED = BigDecimal.valueOf(100L);
             BigDecimal rate = samplePercentage.bigDecimalValue();
-            if (rate.compareTo(BigDecimal.ZERO) < 0
-                || rate.compareTo(ONE_HUNDRED) > 0)
-            {
-                throw SqlUtil.newContextException(getPos(), RESOURCE.invalidSampleSize());
-            }
-
             // Treat TABLESAMPLE(0) and TABLESAMPLE(100) as no table
             // sampling at all.  Not strictly correct: TABLESAMPLE(0)
             // should produce no output, but it simplifies implementation
@@ -2301,18 +2295,15 @@ SqlNode Tablesample(SqlNode tableRef) :
             // In practice values less than ~1E-43% are treated as 0.0 and
             // values greater than ~99.999997% are treated as 1.0
             float fRate = rate.divide(ONE_HUNDRED).floatValue();
-            if (fRate > 0.0f && fRate < 1.0f) {
-                SqlSampleSpec tableSampleSpec =
-                    isRepeatable
-                        ? SqlSampleSpec.createTableSample(
-                            isBernoulli, fRate, repeatableSeed)
-                        : SqlSampleSpec.createTableSample(isBernoulli, fRate);
-
+            SqlSampleSpec tableSampleSpec =
+                isRepeatable
+                    ? SqlSampleSpec.createTableSample(
+                        isBernoulli, fRate, repeatableSeed)
+                    : SqlSampleSpec.createTableSample(isBernoulli, fRate);
                 SqlLiteral tableSampleLiteral =
                     SqlLiteral.createSample(tableSampleSpec, s.end(this));
                 tableRef = SqlStdOperatorTable.TABLESAMPLE.createCall(
                     s.end(this), tableRef, tableSampleLiteral);
-            }
         }
     )
     { return tableRef; }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2294,7 +2294,7 @@ SqlNode Tablesample(SqlNode tableRef) :
             // to know that some amount of sampling will occur.
             // In practice values less than ~1E-43% are treated as 0.0 and
             // values greater than ~99.999997% are treated as 1.0
-            float fRate = rate.divide(ONE_HUNDRED).floatValue();
+            BigDecimal fRate = rate.divide(ONE_HUNDRED);
             SqlSampleSpec tableSampleSpec =
                 isRepeatable
                     ? SqlSampleSpec.createTableSample(

--- a/core/src/main/java/org/apache/calcite/sql/SqlSampleSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSampleSpec.java
@@ -18,6 +18,8 @@ package org.apache.calcite.sql;
 
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 
+import java.math.BigDecimal;
+
 /**
  * Specification of a SQL sample.
  *
@@ -58,7 +60,7 @@ public abstract class SqlSampleSpec {
    */
   public static SqlSampleSpec createTableSample(
       boolean isBernoulli,
-      float samplePercentage) {
+      BigDecimal samplePercentage) {
     return new SqlTableSampleSpec(isBernoulli, samplePercentage);
   }
 
@@ -72,7 +74,7 @@ public abstract class SqlSampleSpec {
    */
   public static SqlSampleSpec createTableSample(
       boolean isBernoulli,
-      float samplePercentage,
+      BigDecimal samplePercentage,
       int repeatableSeed) {
     return new SqlTableSampleSpec(
         isBernoulli,
@@ -104,11 +106,11 @@ public abstract class SqlSampleSpec {
   /** Sample specification. */
   public static class SqlTableSampleSpec extends SqlSampleSpec {
     private final boolean isBernoulli;
-    private final float samplePercentage;
+    public final BigDecimal samplePercentage;
     private final boolean isRepeatable;
     private final int repeatableSeed;
 
-    private SqlTableSampleSpec(boolean isBernoulli, float samplePercentage) {
+    private SqlTableSampleSpec(boolean isBernoulli, BigDecimal samplePercentage) {
       this.isBernoulli = isBernoulli;
       this.samplePercentage = samplePercentage;
       this.isRepeatable = false;
@@ -117,7 +119,7 @@ public abstract class SqlSampleSpec {
 
     private SqlTableSampleSpec(
         boolean isBernoulli,
-        float samplePercentage,
+        BigDecimal samplePercentage,
         int repeatableSeed) {
       this.isBernoulli = isBernoulli;
       this.samplePercentage = samplePercentage;
@@ -136,7 +138,7 @@ public abstract class SqlSampleSpec {
      * Returns sampling percentage. Range is 0.0 to 1.0, exclusive
      */
     public float getSamplePercentage() {
-      return samplePercentage;
+      return samplePercentage.floatValue();
     }
 
     /**
@@ -157,7 +159,7 @@ public abstract class SqlSampleSpec {
       StringBuilder b = new StringBuilder();
       b.append(isBernoulli ? "BERNOULLI" : "SYSTEM");
       b.append('(');
-      b.append(samplePercentage * 100.0);
+      b.append(samplePercentage.multiply(new BigDecimal("100")));
       b.append(')');
 
       if (isRepeatable) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlSampleSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSampleSpec.java
@@ -137,6 +137,7 @@ public abstract class SqlSampleSpec {
     /**
      * Returns sampling percentage. Range is 0.0 to 1.0, exclusive
      */
+    @Deprecated
     public float getSamplePercentage() {
       return samplePercentage.floatValue();
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSampleSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSampleSpec.java
@@ -137,7 +137,6 @@ public abstract class SqlSampleSpec {
     /**
      * Returns sampling percentage. Range is 0.0 to 1.0, exclusive
      */
-    @Deprecated
     public float getSamplePercentage() {
       return samplePercentage.floatValue();
     }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1104,6 +1104,16 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       List<SqlNode> operands = ((SqlCall) node).getOperandList();
       SqlSampleSpec sampleSpec = SqlLiteral.sampleValue(operands.get(1));
       if (sampleSpec instanceof SqlSampleSpec.SqlTableSampleSpec) {
+        // The sampling percentage is between 0(0%) and 1(100%),1 is exclusive
+        float samplePercentage =
+            ((SqlSampleSpec.SqlTableSampleSpec) sampleSpec).getSamplePercentage();
+        // Because the rate is not exact numeric, so we need to convert it to BigDecimal to compare
+        BigDecimal dRate = new BigDecimal(Float.toString(samplePercentage));
+        // Check the samplePercentage whether is between 0 and 1
+        if (dRate.compareTo(BigDecimal.ZERO) < 0
+            || dRate.compareTo(BigDecimal.valueOf(1L)) > 0) {
+          throw SqlUtil.newContextException(node.getParserPosition(), RESOURCE.invalidSampleSize());
+        }
         validateFeature(RESOURCE.sQLFeature_T613(), node.getParserPosition());
       } else if (sampleSpec
           instanceof SqlSampleSpec.SqlSubstitutionSampleSpec) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1105,13 +1105,11 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       SqlSampleSpec sampleSpec = SqlLiteral.sampleValue(operands.get(1));
       if (sampleSpec instanceof SqlSampleSpec.SqlTableSampleSpec) {
         // The sampling percentage is between 0(0%) and 1(100%),1 is exclusive
-        float samplePercentage =
-            ((SqlSampleSpec.SqlTableSampleSpec) sampleSpec).getSamplePercentage();
-        // Because the rate is not exact numeric, so we need to convert it to BigDecimal to compare
-        BigDecimal dRate = new BigDecimal(Float.toString(samplePercentage));
+        BigDecimal samplePercentage =
+            ((SqlSampleSpec.SqlTableSampleSpec) sampleSpec).samplePercentage;
         // Check the samplePercentage whether is between 0 and 1
-        if (dRate.compareTo(BigDecimal.ZERO) < 0
-            || dRate.compareTo(BigDecimal.valueOf(1L)) > 0) {
+        if (samplePercentage.compareTo(BigDecimal.ZERO) < 0
+            || samplePercentage.compareTo(BigDecimal.valueOf(1L)) > 0) {
           throw SqlUtil.newContextException(node.getParserPosition(), RESOURCE.invalidSampleSize());
         }
         validateFeature(RESOURCE.sQLFeature_T613(), node.getParserPosition());

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2362,7 +2362,7 @@ public class SqlToRelConverter {
             (SqlSampleSpec.SqlTableSampleSpec) sampleSpec;
         convertFrom(bb, operands.get(0));
         // If the table sample percentage is 0, then the query should return empty.
-        if (tableSampleSpec.getSamplePercentage() == 0f) {
+        if (tableSampleSpec.samplePercentage.compareTo(BigDecimal.ZERO) == 0) {
           bb.setRoot(relBuilder.push(bb.root()).empty().build(), true);
         } else {
           RelOptSamplingParameters params =

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2368,7 +2368,7 @@ public class SqlToRelConverter {
           RelOptSamplingParameters params =
               new RelOptSamplingParameters(
                   tableSampleSpec.isBernoulli(),
-                  tableSampleSpec.getSamplePercentage(),
+                  tableSampleSpec.samplePercentage.floatValue(),
                   tableSampleSpec.isRepeatable(),
                   tableSampleSpec.getRepeatableSeed());
           bb.setRoot(new Sample(cluster, bb.root(), params), false);

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1522,6 +1522,11 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  @Test void testSampleBernoulliWithRateZero() {
+    final String sql = "select * from (select * from emp limit 10) as e tablesample bernoulli(0)";
+    sql(sql).ok();
+  }
+
   @Test void testSampleSystem() {
     final String sql =
         "select * from emp tablesample system(50) where empno > 5";
@@ -1533,6 +1538,15 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         + " select * from emp as e tablesample system(10) repeatable(1)\n"
         + " join dept on e.deptno = dept.deptno\n"
         + ") tablesample system(50) repeatable(99)\n"
+        + "where empno > 5";
+    sql(sql).ok();
+  }
+
+  @Test void testSampleSystemWithRateZero() {
+    final String sql = "select * from (\n"
+        + " select * from emp as e\n"
+        + " join dept on e.deptno = dept.deptno\n"
+        + ") tablesample system(0)\n"
         + "where empno > 5";
     sql(sql).ok();
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7965,6 +7965,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "    select * from emp\n"
         + "    join dept on emp.deptno = dept.deptno\n"
         + ") tablesample system(10)").ok();
+
+    sql("select * from ^emp TABLESAMPLE BERNOULLI(1000)^")
+        .fails("TABLESAMPLE percentage must be between 0 and 100, inclusive");
+
+    sql("select * from ^emp TABLESAMPLE SYSTEM(101)^")
+        .fails("TABLESAMPLE percentage must be between 0 and 100, inclusive");
   }
 
   @Test void testRewriteWithoutIdentifierExpansion() {

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6339,6 +6339,17 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSampleBernoulliWithRateZero">
+    <Resource name="sql">
+      <![CDATA[select * from (select * from emp limit 10) as e tablesample bernoulli(0)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSampleQuery">
     <Resource name="sql">
       <![CDATA[select * from (
@@ -6389,6 +6400,22 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
           Sample(mode=[system], rate=[0.1], repeatableSeed=[1])
             LogicalTableScan(table=[[CATALOG, SALES, EMP]])
           LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSampleSystemWithRateZero">
+    <Resource name="sql">
+      <![CDATA[select * from (
+ select * from emp as e
+ join dept on e.deptno = dept.deptno
+) tablesample system(0)
+where empno > 5]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], DEPTNO0=[$9], NAME=[$10])
+  LogicalFilter(condition=[>($0, 5)])
+    LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -2520,4 +2520,14 @@ EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t6):INTEGER], expr#9=[IS NOT 
   EnumerableTableScan(table=[[scott, EMP]])
 !plan
 
+# [CALCITE-5895] The result of table sample rate 0  is incorrect result and should return the empty result
+select comm from "scott".emp tablesample system(0);
++------+
+| COMM |
++------+
++------+
+(0 rows)
+
+!ok
+
 # End misc.iq

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -3341,14 +3341,14 @@ public class SqlParserTest {
     final String sql4 = "select * "
         + "from emp as x tablesample bernoulli(0)";
     final String expected4 = "SELECT *\n"
-        + "FROM `EMP` AS `X` TABLESAMPLE BERNOULLI(0.0)";
+        + "FROM `EMP` AS `X` TABLESAMPLE BERNOULLI(0)";
     sql(sql4).ok(expected4);
 
     // test system sample percentage with zero.
     final String sql5 = "select * "
         + "from emp as x tablesample system(0)";
     final String expected5 = "SELECT *\n"
-        + "FROM `EMP` AS `X` TABLESAMPLE SYSTEM(0.0)";
+        + "FROM `EMP` AS `X` TABLESAMPLE SYSTEM(0)";
     sql(sql5).ok(expected5);
   }
 

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -3336,6 +3336,20 @@ public class SqlParserTest {
         + "tablesample bernoulli(50) REPEATABLE(-^100000000000000000000^) ")
         .fails("Literal '100000000000000000000' "
             + "can not be parsed to type 'java\\.lang\\.Integer'");
+
+    // test bernoulli sample percentage with zero.
+    final String sql4 = "select * "
+        + "from emp as x tablesample bernoulli(0)";
+    final String expected4 = "SELECT *\n"
+        + "FROM `EMP` AS `X` TABLESAMPLE BERNOULLI(0.0)";
+    sql(sql4).ok(expected4);
+
+    // test system sample percentage with zero.
+    final String sql5 = "select * "
+        + "from emp as x tablesample system(0)";
+    final String expected5 = "SELECT *\n"
+        + "FROM `EMP` AS `X` TABLESAMPLE SYSTEM(0.0)";
+    sql(sql5).ok(expected5);
   }
 
   @Test void testLiteral() {


### PR DESCRIPTION
This PR is fixing the result of table sample rate 0 should return the empty result problem.

For The sql:
```sql
select * from emp tablesample bernoulli(0) where empno > 5
```
Its result should be empty.

This PR also takes Julian's advice and does the following:
1. Move the if (fRate > 0.0f && fRate < 1.0f) logic from Parser.jj to SqlToRelConverter.convertFrom.
2. In SqlToRelConverter, you should use RelBuilder.empty() to create an empty relation of the right type.
3. For extra credit, move the if (rate.compareTo(BigDecimal.ZERO) < 0 || rate.compareTo(ONE_HUNDRED) > 0) logic from Parser.jj to SqlValidatorImpl.validateQuery. The parser shouldn't be doing very much validation. (And add a negative test to SqlValidatorTest.) 
4. And also added some single test content