### PR TITLE
 [CALCITE-5894] Add SortRemoveRedundantRule to remove redundant sort fields if they are functionally dependent on other sort fields

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/BuiltInMetadata.java
@@ -833,10 +833,32 @@ public abstract class BuiltInMetadata {
     }
   }
 
+  /** Metadata about the functional dependency of columns. */
+  public interface FunctionalDependency extends Metadata {
+    MetadataDef<FunctionalDependency> DEF =
+        MetadataDef.of(FunctionalDependency.class, FunctionalDependency.Handler.class,
+            BuiltInMethod.FUNCTIONAL_DEPENDENCY.method);
+
+    /**
+     * Returns whether column is functionally dependent on columns.
+     */
+    @Nullable Boolean functionallyDetermine(ImmutableBitSet columns, int column);
+
+    /** Handler API. */
+    interface Handler extends MetadataHandler<FunctionalDependency> {
+      @Nullable Boolean functionallyDetermine(RelNode r, RelMetadataQuery mq,
+          ImmutableBitSet columns, int column);
+
+      @Override default MetadataDef<FunctionalDependency> getDef() {
+        return DEF;
+      }
+    }
+  }
+
   /** The built-in forms of metadata. */
   interface All extends Selectivity, UniqueKeys, RowCount, DistinctRowCount,
       PercentageOriginalRows, ColumnUniqueness, ColumnOrigin, Predicates,
       Collation, Distribution, Size, Parallelism, Memory, AllPredicates,
-      ExpressionLineage, TableReferences, NodeTypes {
+      ExpressionLineage, TableReferences, NodeTypes, FunctionalDependency {
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/DefaultRelMetadataProvider.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/DefaultRelMetadataProvider.java
@@ -62,6 +62,7 @@ public class DefaultRelMetadataProvider extends ChainedRelMetadataProvider {
             RelMdExplainVisibility.SOURCE,
             RelMdPredicates.SOURCE,
             RelMdAllPredicates.SOURCE,
-            RelMdCollation.SOURCE));
+            RelMdCollation.SOURCE,
+            RelMdFunctionalDependency.SOURCE));
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdFunctionalDependency.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdFunctionalDependency.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.metadata;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Default implementation of
+ * {@link RelMetadataQuery#functionallyDetermine(RelNode, ImmutableBitSet, int)}
+ * for the standard logical algebra.
+ *
+ * <p>The goal of this provider is to determine whether
+ * column is functionally dependent on columns.
+ *
+ * <p>If the functional dependency cannot be determined, we return false.
+ */
+public class RelMdFunctionalDependency
+    implements MetadataHandler<BuiltInMetadata.FunctionalDependency> {
+  public static final RelMetadataProvider SOURCE =
+      ReflectiveRelMetadataProvider.reflectiveSource(
+          new RelMdFunctionalDependency(), BuiltInMetadata.FunctionalDependency.Handler.class);
+
+  //~ Constructors -----------------------------------------------------------
+
+  protected RelMdFunctionalDependency() {}
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public MetadataDef<BuiltInMetadata.FunctionalDependency> getDef() {
+    return BuiltInMetadata.FunctionalDependency.DEF;
+  }
+
+  /** Catch-all implementation for
+   * {@link BuiltInMetadata.FunctionalDependency#functionallyDetermine(ImmutableBitSet, int)},
+   * invoked using reflection.
+   *
+   * @see org.apache.calcite.rel.metadata.RelMetadataQuery#areColumnsUnique(
+   * RelNode, ImmutableBitSet, boolean)
+   */
+  public @Nullable Boolean functionallyDetermine(RelNode rel, RelMetadataQuery mq,
+      ImmutableBitSet columns, int column) {
+    // This is a minimal implementation that needs to be gradually improved in the future.
+    // If columns contains a unique key, the column is functionally dependent on columns.
+    for (ImmutableBitSet subColumns : columns.powerSet()) {
+      if (Boolean.TRUE.equals(mq.areColumnsUnique(rel, subColumns, false))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -107,6 +107,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
   private BuiltInMetadata.Size.Handler sizeHandler;
   private BuiltInMetadata.UniqueKeys.Handler uniqueKeysHandler;
   private BuiltInMetadata.LowerBoundCost.Handler lowerBoundCostHandler;
+  private BuiltInMetadata.FunctionalDependency.Handler functionalDependencyHandler;
 
   /**
    * Creates the instance with {@link JaninoRelMetadataProvider} instance
@@ -151,6 +152,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     this.sizeHandler = provider.handler(BuiltInMetadata.Size.Handler.class);
     this.uniqueKeysHandler = provider.handler(BuiltInMetadata.UniqueKeys.Handler.class);
     this.lowerBoundCostHandler = provider.handler(BuiltInMetadata.LowerBoundCost.Handler.class);
+    this.functionalDependencyHandler =
+        provider.handler(BuiltInMetadata.FunctionalDependency.Handler.class);
   }
 
   /** Creates and initializes the instance that will serve as a prototype for
@@ -183,6 +186,8 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     this.sizeHandler = initialHandler(BuiltInMetadata.Size.Handler.class);
     this.uniqueKeysHandler = initialHandler(BuiltInMetadata.UniqueKeys.Handler.class);
     this.lowerBoundCostHandler = initialHandler(BuiltInMetadata.LowerBoundCost.Handler.class);
+    this.functionalDependencyHandler =
+        initialHandler(BuiltInMetadata.FunctionalDependency.Handler.class);
   }
 
   private RelMetadataQuery(
@@ -213,6 +218,7 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
     this.sizeHandler = prototype.sizeHandler;
     this.uniqueKeysHandler = prototype.uniqueKeysHandler;
     this.lowerBoundCostHandler = prototype.lowerBoundCostHandler;
+    this.functionalDependencyHandler = prototype.functionalDependencyHandler;
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -917,6 +923,26 @@ public class RelMetadataQuery extends RelMetadataQueryBase {
         return lowerBoundCostHandler.getLowerBoundCost(rel, this, planner);
       } catch (MetadataHandlerProvider.NoHandler e) {
         lowerBoundCostHandler = revise(BuiltInMetadata.LowerBoundCost.Handler.class);
+      }
+    }
+  }
+
+  /**
+   * Determines whether column is functionally dependent on columns.
+   *
+   * @param rel the relational expression
+   * @param columns the target columns
+   * @param column the source column
+   * @return whether column is functionally dependent on columns.
+   */
+  public @Nullable Boolean functionallyDetermine(RelNode rel,
+      ImmutableBitSet columns, int column) {
+    for (;;) {
+      try {
+        return functionalDependencyHandler.functionallyDetermine(rel, this,
+            columns, column);
+      } catch (MetadataHandlerProvider.NoHandler e) {
+        functionalDependencyHandler = revise(BuiltInMetadata.FunctionalDependency.Handler.class);
       }
     }
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -732,6 +732,11 @@ public class CoreRules {
   public static final SortRemoveRedundantRule SORT_REMOVE_REDUNDANT =
       SortRemoveRedundantRule.Config.DEFAULT.toRule();
 
+  /** Rule that removes keys from a {@link Sort}
+   * if those keys are known to be functionally dependent on other sort keys. */
+  public static final SortRemoveRedundantKeysRule SORT_REMOVE_REDUNDANT_KEYS =
+      SortRemoveRedundantKeysRule.Config.DEFAULT.toRule();
+
   /** Rule that pushes a {@link Sort} past a {@link Join}. */
   public static final SortJoinTransposeRule SORT_JOIN_TRANSPOSE =
       SortJoinTransposeRule.Config.DEFAULT.toRule();

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRedundantKeysRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRedundantKeysRule.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.ImmutableIntList;
+
+import org.immutables.value.Value;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Planner rule that removes keys from a
+ * a {@link org.apache.calcite.rel.core.Sort} if those keys functionally depend on
+ * other sort field.
+ *
+ * <p>Requires {@link org.apache.calcite.rel.metadata.RelMdFunctionalDependency}.
+ */
+@Value.Enclosing
+public class SortRemoveRedundantKeysRule extends RelRule<SortRemoveRedundantKeysRule.Config> {
+
+  /**
+   * Creates a SortRemoveRedundantRule.
+   */
+  protected SortRemoveRedundantKeysRule(Config config) {
+    super(config);
+  }
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    final Sort sort = call.rel(0);
+    final RelNode input = sort.getInput();
+    final RelMetadataQuery mq = call.getMetadataQuery();
+    final RelCollation collation = sort.getCollation();
+    final ImmutableIntList keys = collation.getKeys();
+    if (keys.isEmpty()) {
+      return;
+    }
+    ImmutableBitSet sortKeySet = ImmutableBitSet.of(keys);
+    final Set<Integer> needRemoveKeys = new HashSet<>();
+    // Remove redundant sort field by functional dependency
+    for (int keyIndex = keys.size() - 1; keyIndex >= 0; keyIndex--) {
+      Integer key = keys.get(keyIndex);
+      final ImmutableBitSet remainingSortKeySet = sortKeySet.except(ImmutableBitSet.of(key));
+      if (Boolean.TRUE.equals(mq.functionallyDetermine(input, remainingSortKeySet, key))) {
+        needRemoveKeys.add(key);
+        sortKeySet = remainingSortKeySet;
+      }
+    }
+    if (needRemoveKeys.isEmpty()) {
+      // No functional dependency, bail out.
+      return;
+    }
+    List<RelFieldCollation> remainingFieldCollationList = collation.getFieldCollations()
+        .stream()
+        .filter(fieldCollation -> !needRemoveKeys.contains(fieldCollation.getFieldIndex()))
+        .collect(Collectors.toList());
+    final Sort result =
+        sort.copy(sort.getTraitSet(), input, RelCollations.of(remainingFieldCollationList));
+    call.transformTo(result);
+  }
+
+  /**
+   * Rule configuration.
+   */
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    SortRemoveRedundantKeysRule.Config DEFAULT = ImmutableSortRemoveRedundantKeysRule.Config.of()
+        .withOperandSupplier(b -> b.operand(Sort.class).anyInputs());
+
+    @Override default SortRemoveRedundantKeysRule toRule() {
+      return new SortRemoveRedundantKeysRule(this);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -62,6 +62,7 @@ import org.apache.calcite.rel.metadata.BuiltInMetadata.DistinctRowCount;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.Distribution;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.ExplainVisibility;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.ExpressionLineage;
+import org.apache.calcite.rel.metadata.BuiltInMetadata.FunctionalDependency;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.LowerBoundCost;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.MaxRowCount;
 import org.apache.calcite.rel.metadata.BuiltInMetadata.Memory;
@@ -781,6 +782,8 @@ public enum BuiltInMethod {
       "cumulativeMemoryWithinPhaseSplit"),
   COLUMN_UNIQUENESS(ColumnUniqueness.class, "areColumnsUnique",
       ImmutableBitSet.class, boolean.class),
+  FUNCTIONAL_DEPENDENCY(FunctionalDependency.class, "functionallyDetermine",
+      ImmutableBitSet.class, int.class),
   COLLATIONS(Collation.class, "collations"),
   DISTRIBUTION(Distribution.class, "distribution"),
   NODE_TYPES(NodeTypes.class, "getNodeTypes"),

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -14167,6 +14167,119 @@ LogicalSort(fetch=[1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSortRemoveRedundantKeysForFilter">
+    <Resource name="sql">
+      <![CDATA[select *
+from sales.emp
+where comm = 1
+order by empno, empno, deptno, sal desc nulls first]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$0], sort1=[$7], sort2=[$5], dir0=[ASC], dir1=[ASC], dir2=[DESC])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[=($6, 1)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalSort(sort0=[$0], dir0=[ASC])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[=($6, 1)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortRemoveRedundantKeysOnAggregate0">
+    <Resource name="sql">
+      <![CDATA[select count(*) as c
+from sales.emp
+group by deptno, empno, sal
+order by empno, empno, deptno, sal desc nulls first]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(C=[$0])
+  LogicalSort(sort0=[$1], sort1=[$2], sort2=[$3], dir0=[ASC], dir1=[ASC], dir2=[DESC])
+    LogicalProject(C=[$3], EMPNO=[$1], DEPTNO=[$0], SAL=[$2])
+      LogicalAggregate(group=[{0, 1, 2}], C=[COUNT()])
+        LogicalProject(DEPTNO=[$7], EMPNO=[$0], SAL=[$5])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(C=[$0])
+  LogicalSort(sort0=[$1], dir0=[ASC])
+    LogicalProject(C=[$3], EMPNO=[$1], DEPTNO=[$0], SAL=[$2])
+      LogicalAggregate(group=[{0, 1, 2}], C=[COUNT()])
+        LogicalProject(DEPTNO=[$7], EMPNO=[$0], SAL=[$5])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortRemoveRedundantKeysOnAggregate1">
+    <Resource name="sql">
+      <![CDATA[select emp_agg.comm, emp_agg.sal_sum
+from (select comm, deptno, sum(sal) sal_sum
+        from sales.emp group by comm, deptno) emp_agg
+order by emp_agg.deptno, emp_agg.comm, emp_agg.sal_sum]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(COMM=[$0], SAL_SUM=[$1])
+  LogicalSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[ASC], dir1=[ASC], dir2=[ASC])
+    LogicalProject(COMM=[$0], SAL_SUM=[$2], DEPTNO=[$1])
+      LogicalAggregate(group=[{0, 1}], SAL_SUM=[SUM($2)])
+        LogicalProject(COMM=[$6], DEPTNO=[$7], SAL=[$5])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(COMM=[$0], SAL_SUM=[$1])
+  LogicalSort(sort0=[$2], sort1=[$0], dir0=[ASC], dir1=[ASC])
+    LogicalProject(COMM=[$0], SAL_SUM=[$2], DEPTNO=[$1])
+      LogicalAggregate(group=[{0, 1}], SAL_SUM=[SUM($2)])
+        LogicalProject(COMM=[$6], DEPTNO=[$7], SAL=[$5])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortRemoveRedundantKeysOnJoin">
+    <Resource name="sql">
+      <![CDATA[select emp_agg.comm, emp_agg.sal_sum
+from (select comm, deptno, sum(sal) sal_sum
+        from sales.emp group by comm, deptno) emp_agg
+left join sales.dept on dept.deptno = emp_agg.deptno
+order by emp_agg.deptno, emp_agg.comm, emp_agg.sal_sum, dept.name]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(COMM=[$0], SAL_SUM=[$1])
+  LogicalSort(sort0=[$2], sort1=[$0], sort2=[$1], sort3=[$3], dir0=[ASC], dir1=[ASC], dir2=[ASC], dir3=[ASC])
+    LogicalProject(COMM=[$0], SAL_SUM=[$2], DEPTNO=[$1], NAME=[$4])
+      LogicalJoin(condition=[=($3, $1)], joinType=[left])
+        LogicalAggregate(group=[{0, 1}], SAL_SUM=[SUM($2)])
+          LogicalProject(COMM=[$6], DEPTNO=[$7], SAL=[$5])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(COMM=[$0], SAL_SUM=[$1])
+  LogicalSort(sort0=[$2], sort1=[$0], dir0=[ASC], dir1=[ASC])
+    LogicalProject(COMM=[$0], SAL_SUM=[$2], DEPTNO=[$1], NAME=[$4])
+      LogicalJoin(condition=[=($3, $1)], joinType=[left])
+        LogicalAggregate(group=[{0, 1}], SAL_SUM=[SUM($2)])
+          LogicalProject(COMM=[$6], DEPTNO=[$7], SAL=[$5])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSortUnionTranspose">
     <Resource name="sql">
       <![CDATA[select a.name from dept a

--- a/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelMetadataFixture.java
@@ -524,6 +524,16 @@ public class RelMetadataFixture {
     return this;
   }
 
+  /** Checks {@link RelMetadataQuery#functionallyDetermine(RelNode, ImmutableBitSet, int)}. */
+  public RelMetadataFixture assertThatFunctionallyDetermine(ImmutableBitSet columns, int column,
+      Matcher<Boolean> matcher) {
+    RelNode rel = toRel();
+    final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
+    final Boolean isDependent = mq.functionallyDetermine(rel, columns, column);
+    assertThat(isDependent, matcher);
+    return this;
+  }
+
   /**
    * A configuration that describes how metadata should be configured.
    */


### PR DESCRIPTION
Sorting is an expensive operation, however. Therefore, it is imperative that sorting is optimized to avoid unnecessary sort field.

Add SortRemoveRedundantRule, it removes redundant sort fields if they are functionally dependent on other sort fields
RelMdFunctionalDependency is a minimal implementation that needs to be gradually improved in the future.