### PR TITLE
[CALCITE-5640] Add SAFE_ADD function (enabled in BigQuery library)

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -601,6 +601,74 @@ FROM t;
 !}
 
 #####################################################################
+# SAFE_ADD
+#
+# SAFE_ADD(value1, value2)
+#
+# Equivalent to the addition operator (+), but returns NULL if overflow/underflow occurs.
+SELECT SAFE_ADD(5, 4) as result;
++--------+
+| result |
++--------+
+|      9 |
++--------+
+(1 row)
+
+!ok
+
+# Overflow occurs if result is greater than 2^63 - 1
+SELECT SAFE_ADD(9223372036854775807, 2) as overflow_result;
++-----------------+
+| overflow_result |
++-----------------+
+|                 |
++-----------------+
+(1 row)
+
+!ok
+
+# Underflow occurs if result is less than -2^63
+SELECT SAFE_ADD(-9223372036854775806, -3) as underflow_result;
++------------------+
+| underflow_result |
++------------------+
+|                  |
++------------------+
+(1 row)
+
+!ok
+
+SELECT SAFE_ADD(CAST(1.7e308 as DOUBLE), CAST(1.7e308 as DOUBLE)) as double_overflow;
++-----------------+
+| double_overflow |
++-----------------+
+|                 |
++-----------------+
+(1 row)
+
+!ok
+
+SELECT SAFE_ADD(9, cast(9.999999999999999999e75 as DECIMAL(38, 19))) as decimal_overflow;
++------------------+
+| decimal_overflow |
++------------------+
+|                  |
++------------------+
+(1 row)
+
+!ok
+
+# NaN arguments should return NaN
+SELECT SAFE_ADD(CAST('NaN' AS DOUBLE), CAST(3 as BIGINT)) as NaN_result;
++------------+
+| NaN_result |
++------------+
+|        NaN |
++------------+
+(1 row)
+
+!ok
+#####################################################################
 # SAFE_MULTIPLY
 #
 # SAFE_MULTIPLY(value1, value2)

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -221,6 +221,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.REVERSE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.RIGHT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.RLIKE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.RPAD;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.SAFE_ADD;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SAFE_CAST;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SAFE_MULTIPLY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SAFE_OFFSET;
@@ -621,7 +622,8 @@ public class RexImpTable {
       defineMethod(TRUNC, "struncate", NullPolicy.STRICT);
       defineMethod(TRUNCATE, "struncate", NullPolicy.STRICT);
 
-      map.put(SAFE_MULTIPLY, new SafeArithmeticImplementor());
+      map.put(SAFE_ADD, new SafeArithmeticImplementor("safeAdd"));
+      map.put(SAFE_MULTIPLY, new SafeArithmeticImplementor("safeMultiply"));
 
       map.put(PI, new PiImplementor());
       return populate2();
@@ -2391,15 +2393,15 @@ public class RexImpTable {
 
   /** Implementor for the {@code SAFE_MULTIPLY} function. */
   private static class SafeArithmeticImplementor extends MethodNameImplementor {
-    SafeArithmeticImplementor() {
-      super("safeMultiply", NullPolicy.STRICT, false);
+    SafeArithmeticImplementor(String methodName) {
+      super(methodName, NullPolicy.STRICT, false);
     }
 
     @Override Expression implementSafe(final RexToLixTranslator translator,
         final RexCall call, final List<Expression> argValueList) {
       Expression arg0 = convertType(argValueList.get(0), call.operands.get(0));
       Expression arg1 = convertType(argValueList.get(1), call.operands.get(1));
-      return Expressions.call(SqlFunctions.class, "safeMultiply", arg0, arg1);
+      return Expressions.call(SqlFunctions.class, methodName, arg0, arg1);
     }
 
     // Because BigQuery treats all int types as aliases for BIGINT (Java's long)

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1714,6 +1714,61 @@ public class SqlFunctions {
     throw notArithmetic("*", b0, b1);
   }
 
+  /** SQL <code>SAFE_ADD</code> function applied to long values. */
+  public static @Nullable Long safeAdd(long b0, long b1) {
+    try {
+      return Math.addExact(b0, b1);
+    } catch (ArithmeticException e) {
+      return null;
+    }
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to long and BigDecimal values. */
+  public static @Nullable BigDecimal safeAdd(long b0, BigDecimal b1) {
+    BigDecimal ans = BigDecimal.valueOf(b0).add(b1);
+    return safeDecimal(ans) ? ans : null;
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to BigDecimal and long values. */
+  public static @Nullable BigDecimal safeAdd(BigDecimal b0, long b1) {
+    return safeAdd(b1, b0);
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to BigDecimal values. */
+  public static @Nullable BigDecimal safeAdd(BigDecimal b0, BigDecimal b1) {
+    BigDecimal ans = b0.add(b1);
+    return safeDecimal(ans) ? ans : null;
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to double and long values. */
+  public static @Nullable Double safeAdd(double b0, long b1) {
+    double ans = b0 + b1;
+    return safeDouble(ans) || !Double.isFinite(b0) ? ans : null;
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to long and double values. */
+  public static @Nullable Double safeAdd(long b0, double b1) {
+    return safeAdd(b1, b0);
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to double and BigDecimal values. */
+  public static @Nullable Double safeAdd(double b0, BigDecimal b1) {
+    double ans = b0 + b1.doubleValue();
+    return safeDouble(ans) || !Double.isFinite(b0) ? ans : null;
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to BigDecimal and double values. */
+  public static @Nullable Double safeAdd(BigDecimal b0, double b1) {
+    return safeAdd(b1, b0);
+  }
+
+  /** SQL <code>SAFE_ADD</code> function applied to double values. */
+  public static @Nullable Double safeAdd(double b0, double b1) {
+    double ans = b0 + b1;
+    boolean isFinite = Double.isFinite(b0) && Double.isFinite(b1);
+    return safeDouble(ans) || !isFinite ? ans : null;
+  }
+
   /** SQL <code>SAFE_MULTIPLY</code> function applied to long values. */
   public static @Nullable Long safeMultiply(long b0, long b1) {
     try {
@@ -1731,8 +1786,7 @@ public class SqlFunctions {
 
   /** SQL <code>SAFE_MULTIPLY</code> function applied to BigDecimal and long values. */
   public static @Nullable BigDecimal safeMultiply(BigDecimal b0, long b1) {
-    BigDecimal ans = b0.multiply(BigDecimal.valueOf(b1));
-    return safeDecimal(ans) ? ans : null;
+    return safeMultiply(b1, b0);
   }
 
   /** SQL <code>SAFE_MULTIPLY</code> function applied to BigDecimal values. */
@@ -1749,8 +1803,7 @@ public class SqlFunctions {
 
   /** SQL <code>SAFE_MULTIPLY</code> function applied to long and double values. */
   public static @Nullable Double safeMultiply(long b0, double b1) {
-    double ans = b0 * b1;
-    return safeDouble(ans) || !Double.isFinite(b1) ? ans : null;
+    return safeMultiply(b1, b0);
   }
 
   /** SQL <code>SAFE_MULTIPLY</code> function applied to double and BigDecimal values. */
@@ -1761,8 +1814,7 @@ public class SqlFunctions {
 
   /** SQL <code>SAFE_MULTIPLY</code> function applied to BigDecimal and double values. */
   public static @Nullable Double safeMultiply(BigDecimal b0, double b1) {
-    double ans = b0.doubleValue() * b1;
-    return safeDouble(ans) || !Double.isFinite(b1) ? ans : null;
+    return safeMultiply(b1, b0);
   }
 
   /** SQL <code>SAFE_MULTIPLY</code> function applied to double values. */

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1651,6 +1651,15 @@ public abstract class SqlLibraryOperators {
           OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.TIMESTAMP,
               SqlTypeFamily.ANY));
 
+  /** The "SAFE_ADD(numeric1, numeric2)" function; equivalent to the {@code +} operator but
+   * returns null if overflow occurs. */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction SAFE_ADD =
+      SqlBasicFunction.create("SAFE_ADD",
+          ReturnTypes.SUM_FORCE_NULLABLE,
+          OperandTypes.NUMERIC_NUMERIC,
+          SqlFunctionCategory.NUMERIC);
+
   /** The "SAFE_MULTIPLY(numeric1, numeric2)" function; equivalent to the {@code *} operator but
    * returns null if overflow occurs. */
   @LibraryOperator(libraries = {BIG_QUERY})

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -844,6 +844,15 @@ public abstract class ReturnTypes {
       DECIMAL_SUM.andThen(SqlTypeTransforms.TO_NULLABLE);
 
   /**
+   * Same as {@link #DECIMAL_SUM_NULLABLE} but returns with nullability if any of
+   * the operands is nullable or the operation results in overflow by using
+   * {@link org.apache.calcite.sql.type.SqlTypeTransforms#FORCE_NULLABLE}. Also handles
+   * addition for integers, not just decimals.
+   */
+  public static final SqlReturnTypeInference SUM_FORCE_NULLABLE =
+      DECIMAL_SUM_NULLABLE.orElse(LEAST_RESTRICTIVE).andThen(SqlTypeTransforms.FORCE_NULLABLE);
+
+  /**
    * Type-inference strategy whereby the result type of a call is
    * {@link #DECIMAL_SUM_NULLABLE} with a fallback to {@link #LEAST_RESTRICTIVE}
    * These rules are used for addition and subtraction.

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2786,6 +2786,7 @@ BigQuery's type system uses confusingly different names for types and functions:
 | h s | string1 NOT RLIKE string2                    | Whether *string1* does not match regex pattern *string2* (similar to `NOT LIKE`, but uses Java regex)
 | b o | RPAD(string, length[, pattern ])             | Returns a string or bytes value that consists of *string* appended to *length* with *pattern*
 | b o | RTRIM(string)                                | Returns *string* with all blanks removed from the end
+| b | SAFE_ADD(numeric1, numeric2)                   | Returns *numeric1* + *numeric2*, or NULL on overflow
 | b | SAFE_CAST(value AS type)                       | Converts *value* to *type*, returning NULL if conversion fails
 | b | SAFE_MULTIPLY(numeric1, numeric2)              | Returns *numeric1* * *numeric2*, or NULL on overflow
 | b | SAFE_OFFSET(index)                             | Similar to `OFFSET` except null is returned if *index* is out of bounds


### PR DESCRIPTION
This PR continues working towards the goal of implementing all BigQuery safe arithmetic functions, captured in [CALCITE-5591](https://issues.apache.org/jira/browse/CALCITE-5591). SAFE_MULTIPLY was merged recently in [1b8dc6](https://github.com/apache/calcite/commit/1b8dc60b7673d83445f06ecaebd5f89dfd5781f6) and this PR follows a very similar structure, except of course using addition rather than multiplication. 

Any questions or suggestions would be appreciated as always!