### PR TITLE
[CALCITE-5937] The parsing error should not be thrown even if there is empty Hint

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1335,7 +1335,7 @@ SqlSelect SqlSelect() :
 }
 {
     <SELECT> { s = span(); }
-    [ <HINT_BEG> AddHint(hints) ( <COMMA> AddHint(hints) )* <COMMENT_END> ]
+    [ <HINT_BEG> (AddHint(hints))? ( <COMMA> AddHint(hints) )* <COMMENT_END> ]
     SqlSelectKeywords(keywords)
     (
         <STREAM> {

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8886,6 +8886,16 @@ public class SqlParserTest {
         + "FROM `EMPS`\n"
         + "FETCH NEXT 2 ROWS ONLY";
     sql(sql3).ok(expected3);
+    // Hint statement without hints
+    final String sql4 = "select /*+*/ empno, ename, deptno from emps limit 2";
+    final String expected4 = "SELECT `EMPNO`, `ENAME`, `DEPTNO`\n"
+        + "FROM `EMPS`\n"
+        + "FETCH NEXT 2 ROWS ONLY";
+    sql(sql4).ok(expected4);
+    final String sql5 = "select /*  +*/ * from emps";
+    final String expected5 = "SELECT *\n"
+        + "FROM `EMPS`";
+    sql(sql5).ok(expected5);
   }
 
   @Test void testTableHintsInQuery() {


### PR DESCRIPTION
Now in the calcite,for the following sql query, it would throw an SQL parsing error:
```sql
select /*+ */ deptno, min(foo) as x from emp  
```
After this PR,above sql is successed to parse.
