### PR TITLE
[CALCITE-5949] RexExecutable should return unchanged original expressions when it fails

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexExecutable.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutable.java
@@ -88,7 +88,7 @@ public class RexExecutable {
         values = new Object[constExps.size()];
       } else {
         assert values.length == constExps.size();
-        final List<RexNode> successfullyReduced = new ArrayList<>();
+        final List<RexNode> successfullyReduced = new ArrayList<>(constExps.size());
         final List<@Nullable Object> valueList = Arrays.asList(values);
         for (Pair<RexNode, @Nullable Object> value : Pair.zip(constExps, valueList)) {
           successfullyReduced.add(

--- a/core/src/main/java/org/apache/calcite/rex/RexExecutable.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexExecutable.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
 import java.io.StringReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -87,11 +88,14 @@ public class RexExecutable {
         values = new Object[constExps.size()];
       } else {
         assert values.length == constExps.size();
+        final List<RexNode> successfullyReduced = new ArrayList<>();
         final List<@Nullable Object> valueList = Arrays.asList(values);
         for (Pair<RexNode, @Nullable Object> value : Pair.zip(constExps, valueList)) {
-          reducedValues.add(
+          successfullyReduced.add(
               rexBuilder.makeLiteral(value.right, value.left.getType(), true));
         }
+        assert successfullyReduced.size() == constExps.size();
+        reducedValues.addAll(successfullyReduced);
       }
     } catch (RuntimeException e) {
       // One or more of the expressions failed.

--- a/core/src/test/java/org/apache/calcite/rex/RexExecutorTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexExecutorTest.java
@@ -378,4 +378,28 @@ class RexExecutorTest {
   interface Action {
     void check(RexBuilder rexBuilder, RexExecutorImpl executor);
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5949">[CALCITE-5949]
+   * RexExecutable should properly handle invalid constant expressions in reduction</a>.
+   */
+  @Test void testInvalidExpressionInList() {
+    check((rexBuilder, executor) -> {
+      final List<RexNode> reducedValues = new ArrayList<>();
+      final RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+      final RelDataType integer =
+          typeFactory.createSqlType(SqlTypeName.INTEGER);
+      final RexCall first =
+          (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.LN,
+          rexBuilder.makeLiteral(3, integer, true));
+      final RexCall second =
+          (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.LN,
+          rexBuilder.makeLiteral(-2, integer, true));
+      executor.reduce(rexBuilder, ImmutableList.of(first, second),
+          reducedValues);
+      assertThat(reducedValues, hasSize(2));
+      assertThat(reducedValues.get(0), instanceOf(RexCall.class));
+      assertThat(reducedValues.get(1), instanceOf(RexCall.class));
+    });
+  }
 }


### PR DESCRIPTION
While reducing, when encountering an invalid expression in the list of constant expressions, RexExecutor is meant to return all initial expressions unchanged.

It fails to do so, because already handled correct expressions have already been added to the returned list, which can be greater than the input list.

For instance, when given the list `{ LN(2), LN(-2) }`, the RexExecutor will output a list of length 3.

This PR corrects this problem, and adds a corresponding test case.
