### PR TITLE
[CALCITE-5974] Elasticsearch adapter throws ClassCastException when index mapping sets dynamic_templates without properties

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
@@ -98,7 +98,9 @@ final class ElasticsearchJson {
       BiConsumer<String, String> consumer) {
     Objects.requireNonNull(mapping, "mapping");
     Objects.requireNonNull(consumer, "consumer");
-    visitMappingProperties(new ArrayDeque<>(), mapping, consumer);
+    if (mapping.has("properties")) {
+      visitMappingProperties(new ArrayDeque<>(), mapping, consumer);
+    }
   }
 
   private static void visitMappingProperties(Deque<String> path,

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJsonTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJsonTest.java
@@ -197,4 +197,21 @@ class ElasticsearchJsonTest {
     assertThat(result.get("keyword"), is("keyword"));
     assertThat(result.get("properties"), is("long"));
   }
+
+
+  /**
+   * Validate that ES index sets dynamic_templates without properties.
+   */
+  @Test void reservedEmptyPropertiesMapping() throws Exception {
+    // have special property names: type and properties
+    ObjectNode mapping = mapper.readValue("{dynamic_templates:["
+        + "{integers:"
+        + "{match_mapping_type:'long',mapping:{type:'integer'}}"
+        + "}]}", ObjectNode.class);
+
+    Map<String, String> result = new HashMap<>();
+    ElasticsearchJson.visitMappingProperties(mapping, result::put);
+
+    assertThat(result.isEmpty(), is(true));
+  }
 }


### PR DESCRIPTION
when use  es-adapter, A index set dynamic_templates  bug no  mappings causing exceptions:

java.lang.ClassCastException: com.fasterxml.jackson.databind.node.ArrayNode cannot be cast to com.fasterxml.jackson.databind.node.ObjectNode
        at org.apache.calcite.adapter.elasticsearch.ElasticsearchJson.visitMappingProperties(ElasticsearchJson.java:133)

this pr fix it.