### PR TITLE
[CALCITE-5971] Add the RelRule to rewrite the bernoulli sample as Filter

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
@@ -87,7 +87,8 @@ public class RelOptRules {
           CoreRules.SORT_REMOVE_CONSTANT_KEYS,
           CoreRules.SORT_UNION_TRANSPOSE,
           CoreRules.EXCHANGE_REMOVE_CONSTANT_KEYS,
-          CoreRules.SORT_EXCHANGE_REMOVE_CONSTANT_KEYS);
+          CoreRules.SORT_EXCHANGE_REMOVE_CONSTANT_KEYS,
+          CoreRules.SAMPLE_TO_FILTER);
 
   static final List<RelOptRule> ABSTRACT_RULES =
       ImmutableList.of(CoreRules.AGGREGATE_ANY_PULL_UP_CONSTANTS,

--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -747,8 +747,8 @@ public class CoreRules {
       UnionToDistinctRule.Config.DEFAULT.toRule();
 
   /** Rule that rewrite {@link Sample} which is bernoulli to the {@link Filter}. */
-  public static final RewriteSampleToFilterRule SAMPLE_TO_FILTER =
-      RewriteSampleToFilterRule.Config.DEFAULT.toRule();
+  public static final SampleToFilterRule SAMPLE_TO_FILTER =
+      SampleToFilterRule.Config.DEFAULT.toRule();
 
   /** Rule that applies an {@link Aggregate} to a {@link Values} (currently just
    * an empty {@code Values}). */

--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.core.Intersect;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Minus;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Sample;
 import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableScan;
@@ -744,6 +745,10 @@ public class CoreRules {
    * (<code>all</code> = <code>true</code>). */
   public static final UnionToDistinctRule UNION_TO_DISTINCT =
       UnionToDistinctRule.Config.DEFAULT.toRule();
+
+  /** Rule that rewrite {@link Sample} which is bernoulli to the {@link Filter}. */
+  public static final RewriteSampleToFilterRule SAMPLE_TO_FILTER =
+      RewriteSampleToFilterRule.Config.DEFAULT.toRule();
 
   /** Rule that applies an {@link Aggregate} to a {@link Values} (currently just
    * an empty {@code Values}). */

--- a/core/src/main/java/org/apache/calcite/rel/rules/RewriteSampleToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/RewriteSampleToFilterRule.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Sample;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+
+import org.immutables.value.Value;
+
+/**
+ * This rule rewrite {@link Sample} which is bernoulli to the {@link Filter}.
+ *
+ * <p> For example:
+ * <blockquote><pre>{@code
+ *    select deptno from "scott".dept tablesample bernoulli(50);
+ * }</pre></blockquote>
+ *
+ * <p> will convert to:
+ * <blockquote><pre>{@code
+ *    select deptno from "scott".dept where rand() < 0.5;
+ * }</pre></blockquote>
+ *
+ * <p> The sql:
+ * <blockquote><pre>{@code
+ *    select deptno from "scott".dept tablesample bernoulli(50) REPEATABLE(10);
+ * }</pre></blockquote>
+ *
+ * <p> will convert to:
+ * <blockquote><pre>{@code
+ *    select deptno from "scott".dept where rand(10) < 0.5;
+ * }</pre></blockquote>
+ *
+ * @see CoreRules#SAMPLE_TO_FILTER
+ */
+@Value.Enclosing
+public class RewriteSampleToFilterRule
+    extends RelRule<RewriteSampleToFilterRule.Config>
+    implements TransformationRule {
+
+  protected RewriteSampleToFilterRule(final RewriteSampleToFilterRule.Config config) {
+    super(config);
+  }
+
+  @Override public void onMatch(final RelOptRuleCall call) {
+    final Sample sample = call.rel(0);
+    final RelBuilder relBuilder = call.builder();
+    relBuilder.push(sample.getInput());
+
+    RexNode randFunc = sample.getSamplingParameters().isRepeatable()
+        ? relBuilder.call(SqlStdOperatorTable.RAND,
+        relBuilder.literal(sample.getSamplingParameters().getRepeatableSeed()))
+        : relBuilder.call(SqlStdOperatorTable.RAND);
+
+    relBuilder.filter(
+        relBuilder.lessThan(randFunc,
+            relBuilder.literal(sample.getSamplingParameters().sampleRate)));
+    call.transformTo(relBuilder.build());
+  }
+
+  /** Rule configuration. */
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    RewriteSampleToFilterRule.Config DEFAULT = ImmutableRewriteSampleToFilterRule.Config.of()
+        .withOperandFor(Sample.class);
+
+    @Override default RewriteSampleToFilterRule toRule() {
+      return new RewriteSampleToFilterRule(this);
+    }
+
+    /** Defines an operand tree for the given classes. */
+    default RewriteSampleToFilterRule.Config withOperandFor(Class<? extends Sample> sampleClass) {
+      return withOperandSupplier(b ->
+          b.operand(sampleClass)
+              .predicate(sample -> sample.getSamplingParameters().isBernoulli()).anyInputs())
+          .as(RewriteSampleToFilterRule.Config.class);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/rules/SampleToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SampleToFilterRule.java
@@ -52,11 +52,11 @@ import org.immutables.value.Value;
  * @see CoreRules#SAMPLE_TO_FILTER
  */
 @Value.Enclosing
-public class RewriteSampleToFilterRule
-    extends RelRule<RewriteSampleToFilterRule.Config>
+public class SampleToFilterRule
+    extends RelRule<SampleToFilterRule.Config>
     implements TransformationRule {
 
-  protected RewriteSampleToFilterRule(final RewriteSampleToFilterRule.Config config) {
+  protected SampleToFilterRule(final SampleToFilterRule.Config config) {
     super(config);
   }
 
@@ -79,19 +79,19 @@ public class RewriteSampleToFilterRule
   /** Rule configuration. */
   @Value.Immutable
   public interface Config extends RelRule.Config {
-    RewriteSampleToFilterRule.Config DEFAULT = ImmutableRewriteSampleToFilterRule.Config.of()
+    SampleToFilterRule.Config DEFAULT = ImmutableSampleToFilterRule.Config.of()
         .withOperandFor(Sample.class);
 
-    @Override default RewriteSampleToFilterRule toRule() {
-      return new RewriteSampleToFilterRule(this);
+    @Override default SampleToFilterRule toRule() {
+      return new SampleToFilterRule(this);
     }
 
     /** Defines an operand tree for the given classes. */
-    default RewriteSampleToFilterRule.Config withOperandFor(Class<? extends Sample> sampleClass) {
+    default SampleToFilterRule.Config withOperandFor(Class<? extends Sample> sampleClass) {
       return withOperandSupplier(b ->
           b.operand(sampleClass)
               .predicate(sample -> sample.getSamplingParameters().isBernoulli()).anyInputs())
-          .as(RewriteSampleToFilterRule.Config.class);
+          .as(SampleToFilterRule.Config.class);
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -263,6 +263,26 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5971">[CALCITE-5971]
+   * Add the RelRule to rewrite the bernoulli sample as Filter</a>. */
+  @Test void testSampleToFilter() {
+    final String sql = "select deptno from emp tablesample bernoulli(50)";
+    sql(sql)
+        .withRule(CoreRules.SAMPLE_TO_FILTER)
+        .check();
+  }
+
+  /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5971">[CALCITE-5971]
+   * Add the RelRule to rewrite the bernoulli sample as Filter</a>. */
+  @Test void testSampleToFilterWithSeed() {
+    final String sql = "select deptno from emp tablesample bernoulli(50) REPEATABLE(10)";
+    sql(sql)
+        .withRule(CoreRules.SAMPLE_TO_FILTER)
+        .check();
+  }
+
+  /**
    * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5813">[CALCITE-5813]
    * Type inference for sql functions REPEAT, SPACE, XML_TRANSFORM,
    * and XML_EXTRACT is incorrect</a>. */

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -12577,6 +12577,44 @@ LogicalProject(EXPR$0=[1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSampleToFilter">
+    <Resource name="sql">
+      <![CDATA[select deptno from emp tablesample bernoulli(50)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  Sample(mode=[bernoulli], rate=[0.5], repeatableSeed=[-])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalFilter(condition=[<(RAND(), 0.5:DECIMAL(2, 1))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSampleToFilterWithSeed">
+    <Resource name="sql">
+      <![CDATA[select deptno from emp tablesample bernoulli(50) REPEATABLE(10)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  Sample(mode=[bernoulli], rate=[0.5], repeatableSeed=[10])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7])
+  LogicalFilter(condition=[<(RAND(10), 0.5:DECIMAL(2, 1))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSelectAnyCorrelated">
     <Resource name="sql">
       <![CDATA[select empno > ANY (


### PR DESCRIPTION
![image](https://github.com/apache/calcite/assets/8057451/0c7616b9-1419-4e0a-ba75-f3664d78f593)

The logic is same as presto/trino's [ImplementBernoulliSampleAsFilter](https://github.com/prestodb/presto/blob/0ab7d55d04296999e2e4ccaee424b720d576dd59/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementBernoulliSampleAsFilter.java#L47C1-L47C46) rule
