### PR TITLE
[CALCITE-5986] The typeFamily property of SqlTypeName is used inconsistently

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -612,7 +612,7 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
     case INTERVAL_MINUTE_SECOND:
     case INTERVAL_SECOND:
       final SqlTypeFamily family =
-          requireNonNull(sourceType.getSqlTypeName().getFamily(),
+          requireNonNull(sourceType.getSqlTypeName().getPrimaryOrSecondaryFamily(),
               () -> "null SqlTypeFamily for " + sourceType + ", SqlTypeName "
                   + sourceType.getSqlTypeName());
       switch (family) {
@@ -976,8 +976,8 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
       RelDataType sourceType,
       RelDataType targetType,
       Expression operand) {
-    final SqlTypeFamily targetFamily = targetType.getSqlTypeName().getFamily();
-    final SqlTypeFamily sourceFamily = sourceType.getSqlTypeName().getFamily();
+    final SqlTypeFamily targetFamily = targetType.getSqlTypeName().getPrimaryOrSecondaryFamily();
+    final SqlTypeFamily sourceFamily = sourceType.getSqlTypeName().getPrimaryOrSecondaryFamily();
     if (targetFamily == SqlTypeFamily.NUMERIC
         && (sourceFamily == SqlTypeFamily.INTERVAL_YEAR_MONTH
             || sourceFamily == SqlTypeFamily.INTERVAL_DAY_TIME)) {

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -310,7 +310,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
         typeFactory -> argTypesFactory.apply(typeFactory)
             .stream()
             .map(type ->
-                Util.first(type.getSqlTypeName().getFamily(),
+                Util.first(type.getSqlTypeName().getPrimaryOrSecondaryFamily(),
                     SqlTypeFamily.ANY))
             .collect(Util.toImmutableList());
     final Function<RelDataTypeFactory, List<RelDataType>> paramTypesFactory =

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1553,7 +1553,7 @@ public abstract class SqlImplementor {
     @Override public SqlNode toSql(@Nullable RexProgram program, RexNode rex) {
       if (rex.getKind() == SqlKind.LITERAL) {
         final RexLiteral literal = (RexLiteral) rex;
-        if (literal.getTypeName().getFamily() == SqlTypeFamily.CHARACTER) {
+        if (literal.getTypeName().getPrimaryFamily() == SqlTypeFamily.CHARACTER) {
           return new SqlIdentifier(castNonNull(RexLiteral.stringValue(literal)), POS);
         }
       }

--- a/core/src/main/java/org/apache/calcite/rel/type/DynamicRecordTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/DynamicRecordTypeImpl.java
@@ -86,7 +86,7 @@ public class DynamicRecordTypeImpl extends DynamicRecordType {
   }
 
   @Override public RelDataTypeFamily getFamily() {
-    SqlTypeFamily family = getSqlTypeName().getFamily();
+    SqlTypeFamily family = getSqlTypeName().getPrimaryOrSecondaryFamily();
     return family != null ? family : this;
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
@@ -211,7 +211,7 @@ public abstract class RelDataTypeSystemImpl implements RelDataTypeSystem {
   }
 
   @Override public int getNumTypeRadix(SqlTypeName typeName) {
-    if (typeName.getFamily() == SqlTypeFamily.NUMERIC
+    if (typeName.getPrimaryFamily() == SqlTypeFamily.NUMERIC
         && getDefaultPrecision(typeName) != -1) {
       return 10;
     }

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -417,9 +417,9 @@ public class RexSimplify {
   }
 
   private RexNode simplifyArithmetic(RexCall e) {
-    if (e.getType().getSqlTypeName().getFamily() != SqlTypeFamily.NUMERIC
+    if (e.getType().getSqlTypeName().getPrimaryFamily() != SqlTypeFamily.NUMERIC
         || e.getOperands().stream().anyMatch(
-          o -> e.getType().getSqlTypeName().getFamily() != SqlTypeFamily.NUMERIC)) {
+          o -> e.getType().getSqlTypeName().getPrimaryFamily() != SqlTypeFamily.NUMERIC)) {
       // we only support simplifying numeric types.
       return simplifyGenericNode(e);
     }

--- a/core/src/main/java/org/apache/calcite/rex/RexToSqlNodeConverterImpl.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexToSqlNodeConverterImpl.java
@@ -129,7 +129,7 @@ public class RexToSqlNodeConverterImpl implements RexToSqlNodeConverter {
     }
 
     // Null
-    if (SqlTypeFamily.NULL == literal.getTypeName().getFamily()) {
+    if (SqlTypeFamily.NULL == literal.getTypeName().getSecondaryFamily()) {
       return SqlLiteral.createNull(SqlParserPos.ZERO);
     }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -490,10 +490,10 @@ public class RexUtil {
     final SqlTypeName name2 = type2.getSqlTypeName();
     final RelDataType type1Final = type1;
     SqlTypeFamily family =
-        requireNonNull(name1.getFamily(),
+        requireNonNull(name1.getPrimaryOrSecondaryFamily(),
             () -> "SqlTypeFamily is null for type " + type1Final
                 + ", SqlTypeName " + name1);
-    if (family == name2.getFamily()) {
+    if (family == name2.getPrimaryOrSecondaryFamily()) {
       switch (family) {
       case NUMERIC:
         if (SqlTypeUtil.isExactNumeric(type1)

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1689,8 +1689,8 @@ public class RexUtil {
           && source.getPrecision() <= target.getPrecision();
     }
     // 3) From NUMERIC family to CHARACTER family: it depends on the precision/scale
-    if (sourceSqlTypeName.getFamily() == SqlTypeFamily.NUMERIC
-        && targetSqlTypeName.getFamily() == SqlTypeFamily.CHARACTER) {
+    if (sourceSqlTypeName.getPrimaryFamily() == SqlTypeFamily.NUMERIC
+        && targetSqlTypeName.getPrimaryFamily() == SqlTypeFamily.CHARACTER) {
       int sourceLength = source.getPrecision() + 1; // include sign
       if (source.getScale() != -1 && source.getScale() != 0) {
         sourceLength += source.getScale() + 1; // include decimal mark

--- a/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -455,7 +455,7 @@ public class SqlLiteral extends SqlNode {
         return (Enum<?>) literal.value;
       }
       // Literals always have non-null family
-      switch (requireNonNull(literal.getTypeName().getFamily())) {
+      switch (requireNonNull(literal.getTypeName().getPrimaryOrSecondaryFamily())) {
       case CHARACTER:
         return (NlsString) literal.value;
       case NUMERIC:

--- a/core/src/main/java/org/apache/calcite/sql/SqlWindow.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWindow.java
@@ -620,7 +620,7 @@ public class SqlWindow extends SqlCall {
             validator.deriveType(
                 operandScope,
                 orderList.get(0));
-        orderTypeFam = orderType.getSqlTypeName().getFamily();
+        orderTypeFam = orderType.getSqlTypeName().getPrimaryOrSecondaryFamily();
       } else {
         // requires an ORDER BY clause if frame is logical(RANGE)
         // We relax this requirement if the table appears to be
@@ -709,7 +709,7 @@ public class SqlWindow extends SqlCall {
       if (orderTypeFam != null && !isRows) {
         final RelDataType boundType = validator.deriveType(scope, boundVal);
         final SqlTypeFamily boundTypeFamily =
-            boundType.getSqlTypeName().getFamily();
+            boundType.getSqlTypeName().getPrimaryOrSecondaryFamily();
         final List<SqlTypeFamily> allowableBoundTypeFamilies =
             orderTypeFam.allowableDifferenceTypes();
         if (allowableBoundTypeFamilies.isEmpty()) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlItemOperator.java
@@ -120,7 +120,7 @@ public class SqlItemOperator extends SqlSpecialOperator {
           requireNonNull(operandType.getKeyType(), "operandType.getKeyType()");
       SqlTypeName sqlTypeName = keyType.getSqlTypeName();
       return OperandTypes.family(
-          requireNonNull(sqlTypeName.getFamily(),
+          requireNonNull(sqlTypeName.getPrimaryOrSecondaryFamily(),
               () -> "keyType.getSqlTypeName().getFamily() null, type is " + sqlTypeName));
     case ROW:
     case ANY:

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1033,7 +1033,7 @@ public abstract class SqlLibraryOperators {
     boolean hasCharacter = false;
     boolean hasOthers = false;
     for (RelDataType type : operandTypes) {
-      SqlTypeFamily family = type.getSqlTypeName().getFamily();
+      SqlTypeFamily family = type.getSqlTypeName().getPrimaryOrSecondaryFamily();
       requireNonNull(family, "array element type family");
       switch (family) {
       case NUMERIC:
@@ -1057,7 +1057,7 @@ public abstract class SqlLibraryOperators {
       List<RelDataType> characterTypes =
           // may include NULL literal
           operandTypes.stream().filter(
-              t -> t.getSqlTypeName().getFamily() != SqlTypeFamily.NUMERIC)
+              t -> t.getSqlTypeName().getPrimaryOrSecondaryFamily() != SqlTypeFamily.NUMERIC)
               .collect(Collectors.toList());
       type = opBinding.getTypeFactory().leastRestrictive(characterTypes);
     } else {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -266,7 +266,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           true,
           ReturnTypes.ARG0.andThen((opBinding, typeToTransform) -> {
             SqlReturnTypeInference returnType =
-                typeToTransform.getSqlTypeName().getFamily() == SqlTypeFamily.ARRAY
+                typeToTransform.getSqlTypeName().getSecondaryFamily() == SqlTypeFamily.ARRAY
                     ? ReturnTypes.LEAST_RESTRICTIVE
                     : ReturnTypes.DYADIC_STRING_SUM_PRECISION_NULLABLE;
 

--- a/core/src/main/java/org/apache/calcite/sql/type/AbstractSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/AbstractSqlType.java
@@ -68,7 +68,7 @@ public abstract class AbstractSqlType
   }
 
   @Override public RelDataTypeFamily getFamily() {
-    SqlTypeFamily family = typeName.getFamily();
+    SqlTypeFamily family = typeName.getPrimaryOrSecondaryFamily();
     // If typename does not have family, treat the current type as the only member its family
     return family != null ? family : this;
   }

--- a/core/src/main/java/org/apache/calcite/sql/type/ExplicitOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ExplicitOperandTypeChecker.java
@@ -55,7 +55,7 @@ public class ExplicitOperandTypeChecker implements SqlOperandTypeChecker {
         }
       } else {
         families.add(
-            requireNonNull(sqlTypeName.getFamily(),
+            requireNonNull(sqlTypeName.getPrimaryOrSecondaryFamily(),
                 () -> "keyType.getSqlTypeName().getFamily() null, type is " + sqlTypeName));
       }
     }

--- a/core/src/main/java/org/apache/calcite/sql/type/FamilyOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FamilyOperandTypeChecker.java
@@ -128,7 +128,7 @@ public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
     SqlTypeName typeName = type.getSqlTypeName();
 
     // Pass type checking for operators if it's of type 'ANY'.
-    if (typeName.getFamily() == SqlTypeFamily.ANY) {
+    if (typeName.getSecondaryFamily() == SqlTypeFamily.ANY) {
       return true;
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -1289,7 +1289,7 @@ public abstract class OperandTypes {
     }
 
     @Override public SqlTypeFamily getOperandSqlTypeFamily(int iFormalOperand) {
-      return requireNonNull(typeName.getFamily(), "family");
+      return requireNonNull(typeName.getPrimaryOrSecondaryFamily(), "family");
     }
 
     @Override public String getAllowedSignatures(SqlOperator op, String opName) {

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
@@ -50,36 +50,42 @@ import java.util.Map;
  */
 public enum SqlTypeFamily implements RelDataTypeFamily {
   // Primary families.
-  CHARACTER,
-  BINARY,
-  NUMERIC,
-  DATE,
-  TIME,
-  TIMESTAMP,
-  BOOLEAN,
-  INTERVAL_YEAR_MONTH,
-  INTERVAL_DAY_TIME,
+  CHARACTER(true),
+  BINARY(true),
+  NUMERIC(true),
+  DATE(true),
+  TIME(true),
+  TIMESTAMP(true),
+  BOOLEAN(true),
+  INTERVAL_YEAR_MONTH(true),
+  INTERVAL_DAY_TIME(true),
 
   // Secondary families.
 
-  STRING,
-  APPROXIMATE_NUMERIC,
-  EXACT_NUMERIC,
-  DECIMAL,
-  INTEGER,
-  DATETIME,
-  DATETIME_INTERVAL,
-  MULTISET,
-  ARRAY,
-  MAP,
-  NULL,
-  ANY,
-  CURSOR,
-  COLUMN_LIST,
-  GEO,
+  STRING(false),
+  APPROXIMATE_NUMERIC(false),
+  EXACT_NUMERIC(false),
+  DECIMAL(false),
+  INTEGER(false),
+  DATETIME(false),
+  DATETIME_INTERVAL(false),
+  MULTISET(false),
+  ARRAY(false),
+  MAP(false),
+  NULL(false),
+  ANY(false),
+  CURSOR(false),
+  COLUMN_LIST(false),
+  GEO(false),
   /** Like ANY, but do not even validate the operand. It may not be an
    * expression. */
-  IGNORE;
+  IGNORE(false);
+
+  private final boolean primary;
+
+  SqlTypeFamily(boolean primary) {
+    this.primary = primary;
+  }
 
   private static final Map<Integer, SqlTypeFamily> JDBC_TYPE_TO_FAMILY =
       ImmutableMap.<Integer, SqlTypeFamily>builder()
@@ -128,6 +134,10 @@ public enum SqlTypeFamily implements RelDataTypeFamily {
    */
   public static @Nullable SqlTypeFamily getFamilyForJdbcType(int jdbcType) {
     return JDBC_TYPE_TO_FAMILY.get(jdbcType);
+  }
+
+  public boolean isPrimary() {
+    return primary;
   }
 
   /** For this type family, returns the allow types of the difference between

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
@@ -47,6 +47,11 @@ import java.util.Map;
  * with the primary categorization. It is used in type strategies for more
  * specific or more general categorization than the primary families. Secondary
  * families are never returned by RelDataType.getFamily().
+ *
+ * <p>Note: there are several incorrect facts in this comment, but it
+ * is not entirely clear how the comment should be fixed:
+ * - there are types that have no primary SqlTypeFamily
+ * - RelDataType.getFamily() does not have the type SqlTypeFamily.
  */
 public enum SqlTypeFamily implements RelDataTypeFamily {
   // Primary families.

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -289,7 +289,7 @@ public enum SqlTypeName {
    * types that have a 'null' primary family). */
   private final @Nullable SqlTypeFamily family;
   /**
-   * The secondary type family of tis type.
+   * The secondary type family of this type.
    * The secondary family encodes useful properties of a type that
    * are useful in some analyses; it is independent on the primary family.
    */
@@ -414,21 +414,35 @@ public enum SqlTypeName {
   }
 
   /**
-   * Gets the SqlTypeFamily containing this SqlTypeName.
+   * If this SqlType has a primary family, return it.
+   * Otherwise, return the secondary family.
+   * For some types (SYMBOL, DISTINCT, STRUCTURED, ROW, OTHER)
+   * both families are 'null' as well, and in this case
+   * 'null' is returned.
    *
    * <p>This function is preserved for backwards-compatibility and should be removed
    * once all its uses have been eliminated.
-   * Use one of {@link SqlTypeName#getPrimaryFamily} or
-   * {@link SqlTypeName#getSecondaryFamily} instead.
-   *
-   * @return containing family, or null for none (SYMBOL, DISTINCT, STRUCTURED, ROW, OTHER)
+   * Instead, one should use one of {@link SqlTypeName#getPrimaryFamily} or
+   * {@link SqlTypeName#getSecondaryFamily}.
    */
-  public @Nullable SqlTypeFamily getFamily() {
+  public @Nullable SqlTypeFamily getPrimaryOrSecondaryFamily() {
     if (family != null) {
       return family;
     } else {
       return secondaryFamily;
     }
+  }
+
+  /**
+   * Get the type family of the type.
+   *
+   * @deprecated
+   * Use one of {@link SqlTypeName#getPrimaryFamily} or
+   * {@link SqlTypeName#getSecondaryFamily} instead.
+   */
+  @Deprecated
+  public @Nullable SqlTypeFamily getFamily() {
+    return getPrimaryOrSecondaryFamily();
   }
 
   /** The primary family of this type.  See {@link SqlTypeFamily}. */

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -52,82 +52,89 @@ import java.util.Set;
  * </ul>
  */
 public enum SqlTypeName {
-  BOOLEAN(PrecScale.NO_NO, false, Types.BOOLEAN, SqlTypeFamily.BOOLEAN),
-  TINYINT(PrecScale.NO_NO, false, Types.TINYINT, SqlTypeFamily.NUMERIC),
-  SMALLINT(PrecScale.NO_NO, false, Types.SMALLINT, SqlTypeFamily.NUMERIC),
-  INTEGER(PrecScale.NO_NO, false, Types.INTEGER, SqlTypeFamily.NUMERIC),
-  BIGINT(PrecScale.NO_NO, false, Types.BIGINT, SqlTypeFamily.NUMERIC),
+  BOOLEAN(PrecScale.NO_NO, false, Types.BOOLEAN, SqlTypeFamily.BOOLEAN, null),
+  TINYINT(PrecScale.NO_NO, false, Types.TINYINT,
+      SqlTypeFamily.NUMERIC, SqlTypeFamily.EXACT_NUMERIC),
+  SMALLINT(PrecScale.NO_NO, false, Types.SMALLINT,
+      SqlTypeFamily.NUMERIC, SqlTypeFamily.EXACT_NUMERIC),
+  INTEGER(PrecScale.NO_NO, false, Types.INTEGER,
+      SqlTypeFamily.NUMERIC, SqlTypeFamily.EXACT_NUMERIC),
+  BIGINT(PrecScale.NO_NO, false, Types.BIGINT,
+      SqlTypeFamily.NUMERIC, SqlTypeFamily.EXACT_NUMERIC),
   DECIMAL(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES, false,
-      Types.DECIMAL, SqlTypeFamily.NUMERIC),
-  FLOAT(PrecScale.NO_NO, false, Types.FLOAT, SqlTypeFamily.NUMERIC),
-  REAL(PrecScale.NO_NO, false, Types.REAL, SqlTypeFamily.NUMERIC),
-  DOUBLE(PrecScale.NO_NO, false, Types.DOUBLE, SqlTypeFamily.NUMERIC),
-  DATE(PrecScale.NO_NO, false, Types.DATE, SqlTypeFamily.DATE),
+      Types.DECIMAL, SqlTypeFamily.NUMERIC, SqlTypeFamily.EXACT_NUMERIC),
+  FLOAT(PrecScale.NO_NO, false, Types.FLOAT,
+      SqlTypeFamily.NUMERIC, SqlTypeFamily.APPROXIMATE_NUMERIC),
+  REAL(PrecScale.NO_NO, false, Types.REAL,
+      SqlTypeFamily.NUMERIC, SqlTypeFamily.APPROXIMATE_NUMERIC),
+  DOUBLE(PrecScale.NO_NO, false, Types.DOUBLE,
+      SqlTypeFamily.NUMERIC, SqlTypeFamily.APPROXIMATE_NUMERIC),
+  DATE(PrecScale.NO_NO, false, Types.DATE, SqlTypeFamily.DATE, SqlTypeFamily.DATETIME),
   TIME(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.TIME,
-      SqlTypeFamily.TIME),
+      SqlTypeFamily.TIME, SqlTypeFamily.DATETIME),
   TIME_WITH_LOCAL_TIME_ZONE(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.OTHER,
-      SqlTypeFamily.TIME),
+      SqlTypeFamily.TIME, SqlTypeFamily.DATETIME),
   TIMESTAMP(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.TIMESTAMP,
-      SqlTypeFamily.TIMESTAMP),
+      SqlTypeFamily.TIMESTAMP, SqlTypeFamily.DATETIME),
   TIMESTAMP_WITH_LOCAL_TIME_ZONE(PrecScale.NO_NO | PrecScale.YES_NO, false,
-      Types.TIMESTAMP, SqlTypeFamily.TIMESTAMP),
+      Types.TIMESTAMP, SqlTypeFamily.TIMESTAMP, SqlTypeFamily.DATETIME),
   INTERVAL_YEAR(PrecScale.NO_NO, false, Types.OTHER,
-      SqlTypeFamily.INTERVAL_YEAR_MONTH),
+      SqlTypeFamily.INTERVAL_YEAR_MONTH, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_YEAR_MONTH(PrecScale.NO_NO, false, Types.OTHER,
-      SqlTypeFamily.INTERVAL_YEAR_MONTH),
+      SqlTypeFamily.INTERVAL_YEAR_MONTH, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_MONTH(PrecScale.NO_NO, false, Types.OTHER,
-      SqlTypeFamily.INTERVAL_YEAR_MONTH),
+      SqlTypeFamily.INTERVAL_YEAR_MONTH, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_DAY(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_DAY_HOUR(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_DAY_MINUTE(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_DAY_SECOND(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_HOUR(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_HOUR_MINUTE(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_HOUR_SECOND(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_MINUTE(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_MINUTE_SECOND(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   INTERVAL_SECOND(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
-      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME),
+      false, Types.OTHER, SqlTypeFamily.INTERVAL_DAY_TIME, SqlTypeFamily.DATETIME_INTERVAL),
   CHAR(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.CHAR,
-      SqlTypeFamily.CHARACTER),
+      SqlTypeFamily.CHARACTER, SqlTypeFamily.STRING),
   VARCHAR(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARCHAR,
-      SqlTypeFamily.CHARACTER),
+      SqlTypeFamily.CHARACTER, SqlTypeFamily.STRING),
   BINARY(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.BINARY,
-      SqlTypeFamily.BINARY),
+      SqlTypeFamily.BINARY, SqlTypeFamily.STRING),
   VARBINARY(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARBINARY,
-      SqlTypeFamily.BINARY),
-  NULL(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
-  UNKNOWN(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
+      SqlTypeFamily.BINARY, SqlTypeFamily.STRING),
+  NULL(PrecScale.NO_NO, true, Types.NULL, null, SqlTypeFamily.NULL),
+  UNKNOWN(PrecScale.NO_NO, true, Types.NULL, null, SqlTypeFamily.NULL),
   ANY(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES, true,
-      Types.JAVA_OBJECT, SqlTypeFamily.ANY),
-  SYMBOL(PrecScale.NO_NO, true, Types.OTHER, null),
-  MULTISET(PrecScale.NO_NO, false, Types.ARRAY, SqlTypeFamily.MULTISET),
-  ARRAY(PrecScale.NO_NO, false, Types.ARRAY, SqlTypeFamily.ARRAY),
-  MAP(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.MAP),
-  DISTINCT(PrecScale.NO_NO, false, Types.DISTINCT, null),
-  STRUCTURED(PrecScale.NO_NO, false, Types.STRUCT, null),
-  ROW(PrecScale.NO_NO, false, Types.STRUCT, null),
-  OTHER(PrecScale.NO_NO, false, Types.OTHER, null),
-  CURSOR(PrecScale.NO_NO, false, ExtraSqlTypes.REF_CURSOR,
+      Types.JAVA_OBJECT, null, SqlTypeFamily.ANY),
+  SYMBOL(PrecScale.NO_NO, true, Types.OTHER, null, null),
+  MULTISET(PrecScale.NO_NO, false, Types.ARRAY, null, SqlTypeFamily.MULTISET),
+  ARRAY(PrecScale.NO_NO, false, Types.ARRAY, null, SqlTypeFamily.ARRAY),
+  MAP(PrecScale.NO_NO, false, Types.OTHER, null, SqlTypeFamily.MAP),
+  DISTINCT(PrecScale.NO_NO, false, Types.DISTINCT, null, null),
+  STRUCTURED(PrecScale.NO_NO, false, Types.STRUCT, null, null),
+  ROW(PrecScale.NO_NO, false, Types.STRUCT, null, null),
+  OTHER(PrecScale.NO_NO, false, Types.OTHER, null, null),
+  CURSOR(PrecScale.NO_NO, false, ExtraSqlTypes.REF_CURSOR, null,
       SqlTypeFamily.CURSOR),
-  COLUMN_LIST(PrecScale.NO_NO, false, Types.OTHER + 2,
+  COLUMN_LIST(PrecScale.NO_NO, false, Types.OTHER + 2, null,
       SqlTypeFamily.COLUMN_LIST),
   DYNAMIC_STAR(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES, true,
-      Types.JAVA_OBJECT, SqlTypeFamily.ANY),
+      Types.JAVA_OBJECT, null, SqlTypeFamily.ANY),
   /** Spatial type. Though not standard, it is common to several DBs, so we
    * do not flag it 'special' (internal). */
-  GEOMETRY(PrecScale.NO_NO, false, ExtraSqlTypes.GEOMETRY, SqlTypeFamily.GEO),
-  MEASURE(PrecScale.NO_NO, true, Types.OTHER, SqlTypeFamily.ANY),
-  SARG(PrecScale.NO_NO, true, Types.OTHER, SqlTypeFamily.ANY);
+  GEOMETRY(PrecScale.NO_NO, false, ExtraSqlTypes.GEOMETRY, null, SqlTypeFamily.GEO),
+  MEASURE(PrecScale.NO_NO, true, Types.OTHER, null, SqlTypeFamily.ANY),
+  SARG(PrecScale.NO_NO, true, Types.OTHER, null, SqlTypeFamily.ANY);
 
   public static final int MAX_DATETIME_PRECISION = 3;
 
@@ -271,19 +278,24 @@ public enum SqlTypeName {
   private final int signatures;
 
   /**
-   * Returns true if not of a "pure" standard sql type. "Inpure" types are
+   * True if not of a "pure" standard sql type. "Impure" types are
    * {@link #ANY}, {@link #NULL} and {@link #SYMBOL}
    */
   private final boolean special;
   private final int jdbcOrdinal;
+  /** The primary family of the type. */
   private final @Nullable SqlTypeFamily family;
+  private final @Nullable SqlTypeFamily secondaryFamily;
 
   SqlTypeName(int signatures, boolean special, int jdbcType,
-      @Nullable SqlTypeFamily family) {
+      @Nullable SqlTypeFamily family, @Nullable SqlTypeFamily secondaryFamily) {
     this.signatures = signatures;
     this.special = special;
     this.jdbcOrdinal = jdbcType;
     this.family = family;
+    this.secondaryFamily = secondaryFamily;
+    assert family == null || family.isPrimary();
+    assert secondaryFamily == null || !secondaryFamily.isPrimary();
   }
 
   /**
@@ -292,15 +304,6 @@ public enum SqlTypeName {
    * @return Type name, or null if not found
    */
   public static @Nullable SqlTypeName get(String name) {
-    if (false) {
-      // The following code works OK, but the spurious exceptions are
-      // annoying.
-      try {
-        return SqlTypeName.valueOf(name);
-      } catch (IllegalArgumentException e) {
-        return null;
-      }
-    }
     return VALUES_MAP.get(name);
   }
 
@@ -404,11 +407,28 @@ public enum SqlTypeName {
 
   /**
    * Gets the SqlTypeFamily containing this SqlTypeName.
+   * This function is preserved for backwards-compatibility and should be removed
+   * once all its uses have been eliminated.
+   * We recommend using one of getPrimaryFamily() or getSecondaryFamily() instead.
    *
    * @return containing family, or null for none (SYMBOL, DISTINCT, STRUCTURED, ROW, OTHER)
    */
   public @Nullable SqlTypeFamily getFamily() {
+    if (family != null) {
+      return family;
+    } else {
+      return secondaryFamily;
+    }
+  }
+
+  /** The primary family of this type.  See {@link SqlTypeFamily}. */
+  public @Nullable SqlTypeFamily getPrimaryFamily() {
     return family;
+  }
+
+  /** The secondary family of this type.  See {@link SqlTypeFamily}. */
+  public @Nullable SqlTypeFamily getSecondaryFamily() {
+    return secondaryFamily;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -283,8 +283,16 @@ public enum SqlTypeName {
    */
   private final boolean special;
   private final int jdbcOrdinal;
-  /** The primary family of the type. */
+  /** The primary family of this type.
+   * The primary family of a type is supposed to be a partitioning of the
+   * types into disjoint fundamental classes. (However, there are some
+   * types that have a 'null' primary family). */
   private final @Nullable SqlTypeFamily family;
+  /**
+   * The secondary type family of tis type.
+   * The secondary family encodes useful properties of a type that
+   * are useful in some analyses; it is independent on the primary family.
+   */
   private final @Nullable SqlTypeFamily secondaryFamily;
 
   SqlTypeName(int signatures, boolean special, int jdbcType,
@@ -407,9 +415,11 @@ public enum SqlTypeName {
 
   /**
    * Gets the SqlTypeFamily containing this SqlTypeName.
-   * This function is preserved for backwards-compatibility and should be removed
+   *
+   * <p>This function is preserved for backwards-compatibility and should be removed
    * once all its uses have been eliminated.
-   * We recommend using one of getPrimaryFamily() or getSecondaryFamily() instead.
+   * Use one of {@link SqlTypeName#getPrimaryFamily} or
+   * {@link SqlTypeName#getSecondaryFamily} instead.
    *
    * @return containing family, or null for none (SYMBOL, DISTINCT, STRUCTURED, ROW, OTHER)
    */

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -414,7 +414,7 @@ public abstract class SqlTypeUtil {
 
   /** Returns whether a type name is in SqlTypeFamily.Character. */
   public static boolean inCharFamily(SqlTypeName typeName) {
-    return typeName.getFamily() == SqlTypeFamily.CHARACTER;
+    return typeName.getPrimaryFamily() == SqlTypeFamily.CHARACTER;
   }
 
   /** Returns whether a type is in SqlTypeFamily.Boolean. */

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -1586,7 +1586,7 @@ public abstract class SqlTypeUtil {
     // the Saffron type system happy.
     RelDataTypeFamily family = null;
     if (type.getSqlTypeName() != null) {
-      family = type.getSqlTypeName().getFamily();
+      family = type.getSqlTypeName().getPrimaryOrSecondaryFamily();
     }
     if (family == null) {
       family = type.getFamily();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -6165,7 +6165,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
         SqlNode node = orderList.get(0);
         assert node != null;
         final RelDataType type = deriveType(scope, node);
-        final @Nullable SqlTypeFamily family = type.getSqlTypeName().getFamily();
+        final @Nullable SqlTypeFamily family = type.getSqlTypeName().getPrimaryOrSecondaryFamily();
         if (family == null
             || family.allowableDifferenceTypes().isEmpty()) {
           throw newValidationError(orderList,

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
@@ -797,7 +797,7 @@ class TypeCoercionTest {
       assertThat(reason,
           from.equals(castedType)
               || SqlTypeUtil.equalSansNullability(typeFactory, castedType, expected)
-              || expected.getSqlTypeName().getFamily().contains(castedType),
+              || expected.getSqlTypeName().getPrimaryOrSecondaryFamily().contains(castedType),
           is(true));
     }
 
@@ -818,9 +818,9 @@ class TypeCoercionTest {
     private void checkShouldCast(RelDataType checked, List<RelDataType> types) {
       for (RelDataType type : allTypes) {
         if (contains(types, type)) {
-          shouldCast(checked, type.getSqlTypeName().getFamily(), type);
+          shouldCast(checked, type.getSqlTypeName().getPrimaryOrSecondaryFamily(), type);
         } else {
-          shouldNotCast(checked, type.getSqlTypeName().getFamily());
+          shouldNotCast(checked, type.getSqlTypeName().getPrimaryOrSecondaryFamily());
         }
       }
     }
@@ -830,7 +830,8 @@ class TypeCoercionTest {
     private static boolean contains(List<RelDataType> types, RelDataType type) {
       for (RelDataType type1 : types) {
         if (type1.equals(type)
-            || type1.getSqlTypeName().getFamily() == type.getSqlTypeName().getFamily()) {
+            || type1.getSqlTypeName().getPrimaryOrSecondaryFamily()
+            == type.getSqlTypeName().getPrimaryOrSecondaryFamily()) {
           return true;
         }
       }

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
@@ -138,11 +138,11 @@ public class DruidExpressions {
       } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
         return DruidExpressions.numberLiteral((Number) RexLiteral
             .value(rexNode));
-      } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getPrimaryFamily()) {
+      } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getFamily()) {
         // Calcite represents DAY-TIME intervals in milliseconds.
         final long milliseconds = ((Number) RexLiteral.value(rexNode)).longValue();
         return DruidExpressions.numberLiteral(milliseconds);
-      } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getPrimaryFamily()) {
+      } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getFamily()) {
         // Calcite represents YEAR-MONTH intervals in months.
         final long months = ((Number) RexLiteral.value(rexNode)).longValue();
         return DruidExpressions.numberLiteral(months);

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
@@ -138,11 +138,11 @@ public class DruidExpressions {
       } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
         return DruidExpressions.numberLiteral((Number) RexLiteral
             .value(rexNode));
-      } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getFamily()) {
+      } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getPrimaryOrSecondaryFamily()) {
         // Calcite represents DAY-TIME intervals in milliseconds.
         final long milliseconds = ((Number) RexLiteral.value(rexNode)).longValue();
         return DruidExpressions.numberLiteral(milliseconds);
-      } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getFamily()) {
+      } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getPrimaryOrSecondaryFamily()) {
         // Calcite represents YEAR-MONTH intervals in months.
         final long months = ((Number) RexLiteral.value(rexNode)).longValue();
         return DruidExpressions.numberLiteral(months);

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
@@ -138,11 +138,11 @@ public class DruidExpressions {
       } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
         return DruidExpressions.numberLiteral((Number) RexLiteral
             .value(rexNode));
-      } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getFamily()) {
+      } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getPrimaryFamily()) {
         // Calcite represents DAY-TIME intervals in milliseconds.
         final long milliseconds = ((Number) RexLiteral.value(rexNode)).longValue();
         return DruidExpressions.numberLiteral(milliseconds);
-      } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getFamily()) {
+      } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getPrimaryFamily()) {
         // Calcite represents YEAR-MONTH intervals in months.
         final long months = ((Number) RexLiteral.value(rexNode)).longValue();
         return DruidExpressions.numberLiteral(months);

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -369,16 +369,16 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
       return false;
     }
     final SqlTypeName toTypeName = rexNode.getType().getSqlTypeName();
-    if (toTypeName.getFamily() == SqlTypeFamily.CHARACTER) {
+    if (toTypeName.getPrimaryFamily() == SqlTypeFamily.CHARACTER) {
       // CAST of input to character type
       return true;
     }
-    if (toTypeName.getFamily() == SqlTypeFamily.NUMERIC) {
+    if (toTypeName.getPrimaryFamily() == SqlTypeFamily.NUMERIC) {
       // CAST of input to numeric type, it is part of a bounded comparison
       return true;
     }
-    if (toTypeName.getFamily() == SqlTypeFamily.TIMESTAMP
-        || toTypeName.getFamily() == SqlTypeFamily.DATETIME) {
+    if (toTypeName.getPrimaryFamily() == SqlTypeFamily.TIMESTAMP
+        || toTypeName.getSecondaryFamily() == SqlTypeFamily.DATETIME) {
       // CAST of literal to timestamp type
       return true;
     }

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -369,20 +369,20 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
       return false;
     }
     final SqlTypeName toTypeName = rexNode.getType().getSqlTypeName();
-    if (toTypeName.getFamily() == SqlTypeFamily.CHARACTER) {
+    if (toTypeName.getPrimaryOrSecondaryFamily() == SqlTypeFamily.CHARACTER) {
       // CAST of input to character type
       return true;
     }
-    if (toTypeName.getFamily() == SqlTypeFamily.NUMERIC) {
+    if (toTypeName.getPrimaryOrSecondaryFamily() == SqlTypeFamily.NUMERIC) {
       // CAST of input to numeric type, it is part of a bounded comparison
       return true;
     }
-    if (toTypeName.getFamily() == SqlTypeFamily.TIMESTAMP
-        || toTypeName.getFamily() == SqlTypeFamily.DATETIME) {
+    if (toTypeName.getPrimaryOrSecondaryFamily() == SqlTypeFamily.TIMESTAMP
+        || toTypeName.getPrimaryOrSecondaryFamily() == SqlTypeFamily.DATETIME) {
       // CAST of literal to timestamp type
       return true;
     }
-    if (toTypeName.getFamily().contains(input.getType())) {
+    if (toTypeName.getPrimaryOrSecondaryFamily().contains(input.getType())) {
       // same type it is okay to push it
       return true;
     }

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidQuery.java
@@ -369,16 +369,16 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
       return false;
     }
     final SqlTypeName toTypeName = rexNode.getType().getSqlTypeName();
-    if (toTypeName.getPrimaryFamily() == SqlTypeFamily.CHARACTER) {
+    if (toTypeName.getFamily() == SqlTypeFamily.CHARACTER) {
       // CAST of input to character type
       return true;
     }
-    if (toTypeName.getPrimaryFamily() == SqlTypeFamily.NUMERIC) {
+    if (toTypeName.getFamily() == SqlTypeFamily.NUMERIC) {
       // CAST of input to numeric type, it is part of a bounded comparison
       return true;
     }
-    if (toTypeName.getPrimaryFamily() == SqlTypeFamily.TIMESTAMP
-        || toTypeName.getSecondaryFamily() == SqlTypeFamily.DATETIME) {
+    if (toTypeName.getFamily() == SqlTypeFamily.TIMESTAMP
+        || toTypeName.getFamily() == SqlTypeFamily.DATETIME) {
       // CAST of literal to timestamp type
       return true;
     }

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelBuilder.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelBuilder.java
@@ -655,7 +655,8 @@ public class PigRelBuilder extends RelBuilder {
         return false;
       }
     }
-    return t1.getSqlTypeName().getFamily() == t2.getSqlTypeName().getFamily();
+    return t1.getSqlTypeName().getPrimaryOrSecondaryFamily()
+        == t2.getSqlTypeName().getPrimaryOrSecondaryFamily();
   }
 
   /**

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelSqlUdfs.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelSqlUdfs.java
@@ -246,7 +246,7 @@ public class PigRelSqlUdfs {
   private static List<SqlTypeFamily> getTypeFamilies(ImmutableList<RexNode> operands) {
     List<SqlTypeFamily> ret = new ArrayList<>();
     for (RexNode operand : operands) {
-      SqlTypeFamily family = operand.getType().getSqlTypeName().getFamily();
+      SqlTypeFamily family = operand.getType().getSqlTypeName().getPrimaryOrSecondaryFamily();
       ret.add(family != null ? family : SqlTypeFamily.ANY);
     }
     return ret;

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -232,7 +232,7 @@ class PigRelOpTest extends PigRelTestBase {
     final String sql = ""
         + "SELECT *\n"
         + "FROM scott.DEPT\n"
-        + "WHERE RAND() < 0.5";
+        + "WHERE RAND() < 5E-1";
     pig(script).assertRel(hasTree(plan))
         .assertSql(is(sql));
   }


### PR DESCRIPTION
I have discovered that the notion of typeFamily for a type was ambiguous. There are two kinds of type families: primary families, and secondary families, as described in the JavaDoc [`core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java`](https://github.com/apache/calcite/blob/3aee0b86aa23476cbdecc75ad5d43b936a6fff7b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java#L38). Both kinds are bundled in the same Enum. I have added a Boolean flag to the enum which will enable us in the future to check for misuses. The `SqlTypeName` class used them interchangeably. 

With this change each `SqlTypeName` has both a primary and a secondary family. For backwards compatibility, the `getFamily()` function keeps its original behavior. But each field can be accessed independently, and ideally the original function should be eventually deprecated.

This confusion led to at least one bug in RelToSqlConverter, which would generate DECIMAL literals instead of DOUBLE literals. That bug has been fixed in this PR as well. There is one test case for Piglet which has a changed output, so I haven't added a new test.

The confusion described may have consequences (i.e. bugs) elsewhere in the codebase, but this will require auditing for other uses of getTypeFamily(). (There aren't too many.)