### PR TITLE
[CALCITE-5992] Avoid comparing root Relsubset's TraitSet with itself

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -565,6 +565,9 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
       }
     }
     for (RelSubset subset : root.set.subsets) {
+      if (subset == root) {
+        continue;
+      }
       final ImmutableList<RelTrait> difference =
           root.getTraitSet().difference(subset.getTraitSet());
       if (difference.size() == 1 && subsets.add(subset)) {


### PR DESCRIPTION
jira: [CALCITE-5992](https://issues.apache.org/jira/browse/CALCITE-5992)

Since VolcanoPlanner#root will definitely exist in the subsets collection of the Relset related to it, we can skip the comparison between the root Relsubset and itself.

