### PR TITLE
[CALCITE-4189] Simplify 'p OR (p IS NOT TRUE)' to 'TRUE'

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -2060,6 +2060,26 @@ public class RexSimplify {
           }
         }
         break;
+      case IS_NOT_TRUE:
+        RexNode arg = ((RexCall) term).getOperands().get(0);
+        if (isSafeExpression(arg) && terms.contains(arg)) {
+          return trueLiteral;
+        }
+        break;
+      case NOT:
+        RexNode x = ((RexCall) term).getOperands().get(0);
+        if (isSafeExpression(x) && terms.contains(x)) {
+          if (!x.getType().isNullable()) {
+            return trueLiteral;
+          }
+
+          final RexNode isNotNull =
+              rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, x);
+          terms.set(terms.indexOf(x), simplifyIs((RexCall) isNotNull, unknownAs));
+          terms.set(i, rexBuilder.makeNullLiteral(x.getType()));
+          i--;
+        }
+        break;
       default:
         break;
       }

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
@@ -320,6 +320,9 @@ public class GeodeFilter extends Filter implements GeodeRel {
         return translateBinary(">=", "<=", (RexCall) node);
       case INPUT_REF:
         return translateBinary2("=", node, rexBuilder.makeLiteral(true));
+      case IS_NOT_NULL:
+        child = ((RexCall) node).getOperands().get(0);
+        return translateBinary2("<>", child, rexBuilder.makeNullLiteral(node.getType()));
       case NOT:
         child = ((RexCall) node).getOperands().get(0);
         if (child.getKind() == SqlKind.CAST) {

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
@@ -41,6 +41,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import org.immutables.value.Value;
 
@@ -314,10 +315,7 @@ public class GeodeRules {
 
     private static boolean isBooleanColumnReference(RexNode node, List<String> fieldNames) {
       // FIXME Ignore casts for rel and assume they aren't really necessary
-      if (node.isA(SqlKind.CAST)) {
-        node = ((RexCall) node).getOperands().get(0);
-      }
-      if (node.isA(SqlKind.NOT)) {
+      while (node.isA(ImmutableList.of(SqlKind.NOT, SqlKind.CAST, SqlKind.IS_NOT_NULL))) {
         node = ((RexCall) node).getOperands().get(0);
       }
       if (node.isA(SqlKind.INPUT_REF)) {

--- a/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeAllDataTypesTest.java
+++ b/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeAllDataTypesTest.java
@@ -110,6 +110,16 @@ class GeodeAllDataTypesTest extends AbstractGeodeTest {
                 + "WHERE booleanValue = true"));
   }
 
+  @Test void testSqlBooleanColumnIsNotNullFilter() {
+    calciteAssert()
+        .query("SELECT booleanValue as booleanValue "
+            + "FROM geode.allDataTypesRegion WHERE booleanValue is not null")
+        .returnsCount(3)
+        .queryContains(
+            GeodeAssertions.query("SELECT booleanValue AS booleanValue FROM /allDataTypesRegion "
+                + "WHERE booleanValue <> null"));
+  }
+
   @Test void testSqlBooleanColumnFilter() {
     calciteAssert()
         .query("SELECT booleanValue as booleanValue "


### PR DESCRIPTION
Simplify 'p OR NOT p' to 'TRUE' (if p is not nullable), or to 'null AND p IS NOT NULL' (if p is nullable).
GeodeFilter support converting 'p IS NOT NULL' to 'p <> null'.