### PR TITLE
[CALCITE-5996] TRANSLATE operator is incorrectly unparsed

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTranslateFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTranslateFunction.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlUtil;
+import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlTypeUtil;
@@ -108,5 +109,15 @@ public class SqlTranslateFunction extends SqlConvertFunction {
 
   @Override public SqlOperandCountRange getOperandCountRange() {
     return SqlOperandCountRanges.of(2);
+  }
+
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec,
+      int rightPrec) {
+    final SqlWriter.Frame frame = writer.startFunCall(getName());
+    List<SqlNode> operandList = call.getOperandList();
+    operandList.get(0).unparse(writer, leftPrec, rightPrec);
+    writer.keyword("USING");
+    operandList.get(1).unparse(writer, leftPrec, rightPrec);
+    writer.endFunCall(frame);
   }
 }

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -5491,16 +5491,25 @@ public class SqlParserTest {
             + "FROM `T`");
 
     expr("convert('abc' using utf8)")
-        .ok("TRANSLATE('abc', `UTF8`)");
+        .ok("TRANSLATE('abc' USING `UTF8`)");
     sql("select convert(name using gbk) as newName from t")
-        .ok("SELECT TRANSLATE(`NAME`, `GBK`) AS `NEWNAME`\n"
+        .ok("SELECT TRANSLATE(`NAME` USING `GBK`) AS `NEWNAME`\n"
             + "FROM `T`");
 
     expr("translate('abc' using lazy_translation)")
-        .ok("TRANSLATE('abc', `LAZY_TRANSLATION`)");
+        .ok("TRANSLATE('abc' USING `LAZY_TRANSLATION`)");
     sql("select translate(name using utf8) as newName from t")
-        .ok("SELECT TRANSLATE(`NAME`, `UTF8`) AS `NEWNAME`\n"
+        .ok("SELECT TRANSLATE(`NAME` USING `UTF8`) AS `NEWNAME`\n"
             + "FROM `T`");
+
+    // Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-5996">[CALCITE-5996]</a>
+    // TRANSLATE operator is incorrectly unparsed
+    sql("select translate(col using utf8)\n"
+        + "from (select 'a' as col\n"
+        + " from (values(true)))\n")
+        .ok("SELECT TRANSLATE(`COL` USING `UTF8`)\n"
+            + "FROM (SELECT 'a' AS `COL`\n"
+            + "FROM (VALUES (ROW(TRUE))))");
   }
 
   @Test void testTranslate3() {


### PR DESCRIPTION
@ILuffZhe this PR fixes a test which you recently wrote which I suspect was wrong.
Can you please take a look?