### PR TITLE
[CALCITE-5984] Allow disabling field trim via `SqlToRelConverter` config

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -293,10 +293,12 @@ public abstract class Prepare {
       root = root.withRel(decorrelate(sqlToRelConverter, sqlQuery, root.rel));
     }
 
-    // Trim unused fields.
-    root = trimUnusedFields(root);
+    if (configHolder.get().isTrimUnusedFields()) {
+      // Trim unused fields.
+      root = trimUnusedFields(root);
 
-    Hook.TRIMMED.run(root.rel);
+      Hook.TRIMMED.run(root.rel);
+    }
 
     // Display physical plan after decorrelation.
     if (sqlExplain != null) {

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -250,11 +250,12 @@ public class Programs {
 
   /** Returns the standard program used by Prepare. */
   public static Program standard() {
-    return standard(DefaultRelMetadataProvider.INSTANCE);
+    return standard(DefaultRelMetadataProvider.INSTANCE, true);
   }
 
   /** Returns the standard program with user metadata provider. */
-  public static Program standard(RelMetadataProvider metadataProvider) {
+  public static Program standard(RelMetadataProvider metadataProvider,
+      boolean enableFieldTrimming) {
     final Program program1 =
         (planner, rel, requiredOutputTraits, materializations, lattices) -> {
           for (RelOptMaterialization materialization : materializations) {
@@ -278,7 +279,8 @@ public class Programs {
           return rootRel3;
         };
 
-    return sequence(subQuery(metadataProvider),
+    List<Program> programs =
+        Lists.newArrayList(subQuery(metadataProvider),
         new DecorrelateProgram(),
         new TrimFieldsProgram(),
         program1,
@@ -286,6 +288,10 @@ public class Programs {
         // Second planner pass to do physical "tweaks". This the first time
         // that EnumerableCalcRel is introduced.
         calc(metadataProvider));
+
+    programs.removeIf(program -> !enableFieldTrimming && program instanceof TrimFieldsProgram);
+
+    return new SequenceProgram(ImmutableList.copyOf(programs));
   }
 
   /** Program backed by a {@link RuleSet}. */

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -254,6 +254,11 @@ public class Programs {
   }
 
   /** Returns the standard program with user metadata provider. */
+  public static Program standard(RelMetadataProvider metadataProvider) {
+    return standard(metadataProvider, true);
+  }
+
+  /** Returns the standard program with user metadata provider and enableFieldTrimming config. */
   public static Program standard(RelMetadataProvider metadataProvider,
       boolean enableFieldTrimming) {
     final Program program1 =

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3127,7 +3127,8 @@ public class JdbcTest {
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program. */
+   * Disabling trimming of unused fields via config and program.
+   * Case: trimmingByProgram: false ; trimmingByConfig: false. */
   @Test void testJoinWithTrimmingDisabled() {
     CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
                 + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")
@@ -3148,7 +3149,8 @@ public class JdbcTest {
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program. */
+   * Disabling trimming of unused fields via config and program.
+   * Case: trimmingByProgram: false ; trimmingByConfig: true. */
   @Test void testJoinWithTrimmingEnabledByConfig() {
     CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
                 + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")
@@ -3171,7 +3173,8 @@ public class JdbcTest {
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program. */
+   * Disabling trimming of unused fields via config and program.
+   * Case: trimmingByProgram: true ; trimmingByConfig: false. */
   @Test void testJoinWithTrimmingEnabledByProgram() {
     CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
                 + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")
@@ -3194,7 +3197,8 @@ public class JdbcTest {
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program. */
+   * Disabling trimming of unused fields via config and program.
+   * Case: trimmingByProgram: true ; trimmingByConfig: true. */
   @Test void testJoinWithTrimmingEnabledByProgramAndConfig() {
     CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
                 + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -109,6 +109,7 @@ import org.hsqldb.jdbcDriver;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
@@ -171,6 +172,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * Tests for using Calcite via JDBC.
@@ -249,6 +251,45 @@ public class JdbcTest {
 
   static Stream<String> explainFormats() {
     return Stream.of("text", "dot");
+  }
+
+  static Stream<Arguments> disableTrimmingConfigsTestArguments() {
+    /** enableTrimmingByConfig, enableTrimmingByProgram, expectedLogicalPlan. */
+    return Stream.of(
+        arguments(true, true,
+            ""
+                + "LogicalProject(name=[$1])\n"
+                + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
+                + "    LogicalProject(deptno=[$0], name=[$1])\n"
+                + "      LogicalTableScan(table=[[hr, depts]])\n"
+                + "    LogicalProject(deptno=[$1])\n"
+                + "      LogicalTableScan(table=[[hr, emps]])\n"
+                + ""),
+        arguments(true, false,
+            ""
+                + "LogicalProject(name=[$1])\n"
+                + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
+                + "    LogicalProject(deptno=[$0], name=[$1])\n"
+                + "      LogicalTableScan(table=[[hr, depts]])\n"
+                + "    LogicalProject(deptno=[$1])\n"
+                + "      LogicalTableScan(table=[[hr, emps]])\n"
+                + ""),
+        arguments(false, true,
+            ""
+                + "LogicalProject(name=[$1])\n"
+                + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
+                + "    LogicalProject(deptno=[$0], name=[$1])\n"
+                + "      LogicalTableScan(table=[[hr, depts]])\n"
+                + "    LogicalProject(deptno=[$1])\n"
+                + "      LogicalTableScan(table=[[hr, emps]])\n"
+                + ""),
+        arguments(false, false,
+            ""
+                + "LogicalProject(name=[$1])\n"
+                + "  LogicalJoin(condition=[=($0, $5)], joinType=[inner])\n"
+                + "    LogicalTableScan(table=[[hr, depts]])\n"
+                + "    LogicalTableScan(table=[[hr, emps]])\n"
+                + ""));
   }
 
   /** Runs a task (such as a test) with and without expansion. */
@@ -3122,98 +3163,26 @@ public class JdbcTest {
             "deptno=10; name=Sales; employees=[{100, 10, Bill, 10000.0, 1000}, {150, 10, Sebastian, 7000.0, null}]; location={-122, 38}");
   }
 
-  /** Test case for
+  /** Test cases for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program.
-   * Case: trimmingByProgram: false ; trimmingByConfig: false. */
-  @Test void testJoinWithTrimmingDisabled() {
+   * Disabling trimming of unused fields via config and program. */
+  @ParameterizedTest
+  @MethodSource("disableTrimmingConfigsTestArguments")
+  void testJoinWithTrimmingConfigs(boolean enableTrimmingByConfig,
+      boolean enableTrimmingByProgram,
+      String expectedLogicalPlan) {
     CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
                 + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")
         .withHook(Hook.SQL2REL_CONVERTER_CONFIG_BUILDER,
             (Consumer<Holder<Config>>) configHolder ->
-            configHolder.set(configHolder.get().withTrimUnusedFields(false)))
+            configHolder.set(configHolder.get().withTrimUnusedFields(enableTrimmingByConfig)))
         .withHook(Hook.PROGRAM,
             (Consumer<Holder<Program>>)
             programHolder -> programHolder
-                    .set(Programs.standard(DefaultRelMetadataProvider.INSTANCE, false)))
-        .convertContains(""
-                + "LogicalProject(name=[$1])\n"
-                + "  LogicalJoin(condition=[=($0, $5)], joinType=[inner])\n"
-                + "    LogicalTableScan(table=[[hr, depts]])\n"
-                + "    LogicalTableScan(table=[[hr, emps]])\n"
-                + "");
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program.
-   * Case: trimmingByProgram: false ; trimmingByConfig: true. */
-  @Test void testJoinWithTrimmingEnabledByConfig() {
-    CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
-                + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")
-        .withHook(Hook.SQL2REL_CONVERTER_CONFIG_BUILDER,
-            (Consumer<Holder<Config>>) configHolder ->
-            configHolder.set(configHolder.get().withTrimUnusedFields(true)))
-        .withHook(Hook.PROGRAM,
-            (Consumer<Holder<Program>>)
-            programHolder -> programHolder
-                    .set(Programs.standard(DefaultRelMetadataProvider.INSTANCE, false)))
-        .convertContains(""
-                + "LogicalProject(name=[$1])\n"
-                + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
-                + "    LogicalProject(deptno=[$0], name=[$1])\n"
-                + "      LogicalTableScan(table=[[hr, depts]])\n"
-                + "    LogicalProject(deptno=[$1])\n"
-                + "      LogicalTableScan(table=[[hr, emps]])\n"
-                + "");
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program.
-   * Case: trimmingByProgram: true ; trimmingByConfig: false. */
-  @Test void testJoinWithTrimmingEnabledByProgram() {
-    CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
-                + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")
-        .withHook(Hook.SQL2REL_CONVERTER_CONFIG_BUILDER,
-            (Consumer<Holder<Config>>) configHolder ->
-            configHolder.set(configHolder.get().withTrimUnusedFields(false)))
-        .withHook(Hook.PROGRAM,
-            (Consumer<Holder<Program>>)
-            programHolder -> programHolder
-                    .set(Programs.standard()))
-        .convertContains(""
-                + "LogicalProject(name=[$1])\n"
-                + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
-                + "    LogicalProject(deptno=[$0], name=[$1])\n"
-                + "      LogicalTableScan(table=[[hr, depts]])\n"
-                + "    LogicalProject(deptno=[$1])\n"
-                + "      LogicalTableScan(table=[[hr, emps]])\n"
-                + "");
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5984">[CALCITE-5984]</a>
-   * Disabling trimming of unused fields via config and program.
-   * Case: trimmingByProgram: true ; trimmingByConfig: true. */
-  @Test void testJoinWithTrimmingEnabledByProgramAndConfig() {
-    CalciteAssert.hr().query("select \"d\".\"name\" from \"hr\".\"depts\" as \"d\" \n"
-                + "  join \"hr\".\"emps\" as \"e\" on \"d\".\"deptno\" = \"e\".\"deptno\" \n")
-        .withHook(Hook.SQL2REL_CONVERTER_CONFIG_BUILDER,
-            (Consumer<Holder<Config>>) configHolder ->
-                configHolder.set(configHolder.get().withTrimUnusedFields(true)))
-        .withHook(Hook.PROGRAM,
-            (Consumer<Holder<Program>>)
-            programHolder -> programHolder
-                    .set(Programs.standard()))
-        .convertContains(""
-                + "LogicalProject(name=[$1])\n"
-                + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
-                + "    LogicalProject(deptno=[$0], name=[$1])\n"
-                + "      LogicalTableScan(table=[[hr, depts]])\n"
-                + "    LogicalProject(deptno=[$1])\n"
-                + "      LogicalTableScan(table=[[hr, emps]])\n"
-                + "");
+                    .set(
+                        Programs.standard(
+                        DefaultRelMetadataProvider.INSTANCE, enableTrimmingByProgram)))
+        .convertContains(expectedLogicalPlan);
   }
 
   /** A difficult query: an IN list so large that the planner promotes it

--- a/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
+++ b/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
@@ -679,6 +679,16 @@ public class CalciteAssert {
       Connection connection,
       String sql,
       boolean materializationsEnabled,
+      final Consumer<RelNode> convertChecker,
+      final Consumer<RelNode> substitutionChecker) {
+    assertPrepare(connection, sql, materializationsEnabled, ImmutableList.of(),
+        convertChecker, substitutionChecker);
+  }
+
+  static void assertPrepare(
+      Connection connection,
+      String sql,
+      boolean materializationsEnabled,
       List<Pair<Hook, Consumer>> hooks,
       final Consumer<RelNode> convertChecker,
       final Consumer<RelNode> substitutionChecker) {


### PR DESCRIPTION
[CALCITE-5984](https://issues.apache.org/jira/browse/CALCITE-5984) Allow disabling field trim via `SqlToRelConverter` config

Use the value of `isTrimUnusedFields` set to  `SqlToRelConverter.Config` to determine whether to trim unused fields, making it possible to completely disable trimming. 

As seen [here](https://github.com/apache/calcite/blob/454899a451d90726affdddfa75b1de24904d3072/core/src/main/java/org/apache/calcite/prepare/Prepare.java#L376), the Prepare#trim function creates a new instance of `SqlToRelConverter.Config`, overwriting existing `isTrimUnusedFields` settings.

This PR fixes this by checking the boolean `trimUnusedFields` before calling `#trim`.

Unit tests were added to ensure that trimming can be completely disabled by controlling:
1. Disabling `isTrimUnusedFields` on  `SqlToRelConverter.Config`.
2. Removing `TrimFieldsProgram` from the initialization of the optimization program.