### PR TITLE
[CALCITE-6007] CTE as subquery without alias doesn't have correct alias setup

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2350,7 +2350,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       case PIVOT:
       case UNPIVOT:
       case MATCH_RECOGNIZE:
-
+      case WITH:
         // give this anonymous construct a name since later
         // query processing stages rely on it
         alias = SqlValidatorUtil.alias(node, nextGeneratedId++);

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7993,6 +7993,18 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             + "FROM `DEPT`");
   }
 
+  @Test void testSubQueryWithoutAlias() {
+    sql("select a from (select 1 as a)")
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo("SELECT `EXPR$0`.`A`\n"
+            + "FROM (SELECT 1 AS `A`) AS `EXPR$0`");
+    sql("select a from (with sub as (select 1 as a) select a from sub)")
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo("SELECT `EXPR$0`.`A`\n"
+            + "FROM (WITH `SUB` AS (SELECT 1 AS `A`) SELECT `SUB`.`A`\n"
+            + "FROM `SUB` AS `SUB`) AS `EXPR$0`");
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1238">[CALCITE-1238]
    * Unparsing LIMIT without ORDER BY after validation</a>. */


### PR DESCRIPTION
Support CTE as the subquery without alias same as regular SELECT subquery without alias.  It generate alias EXPR$num and register it during the SQL validation. 