### PR TITLE
[CALCITE-6017] Update the GitHub link of released versions

### DIFF
--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -24,7 +24,7 @@ limitations under the License.
 -->
 
 For a full list of releases, see
-<a href="https://github.com/apache/calcite/releases">github</a>.
+<a href="https://github.com/apache/calcite/tags">github</a>.
 Downloads are available on the
 [downloads page]({{ site.baseurl }}/downloads/).
 


### PR DESCRIPTION
The old link is empty now, why we use old link and why we change to this new link can be found at
https://issues.apache.org/jira/browse/CALCITE-6017