### PR TITLE
[CALCITE-6026] MongoDB: Column is not quoted in "order by" clause and throws JsonParseException

### DIFF
--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSort.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoSort.java
@@ -66,7 +66,7 @@ public class MongoSort extends Sort implements MongoRel {
       for (RelFieldCollation fieldCollation : collation.getFieldCollations()) {
         final String name =
             fields.get(fieldCollation.getFieldIndex()).getName();
-        keys.add(name + ": " + direction(fieldCollation));
+        keys.add(MongoRules.maybeQuote(name) + ": " + direction(fieldCollation));
         if (false) {
           // TODO: NULLS FIRST and NULLS LAST
           switch (fieldCollation.nullDirection) {

--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -818,4 +818,14 @@ public class MongoAdapterTest implements SchemaFactory {
       }
     };
   }
+
+  @Test void testColumnQuoting() {
+    assertModel(MODEL)
+        .query("select state as \"STATE\", avg(pop) as \"AVG(pop)\" "
+            + "from zips "
+            + "group by \"STATE\" "
+            + "order by \"AVG(pop)\"")
+        .limit(2)
+        .returns("STATE=VT; AVG(pop)=26408\nSTATE=AK; AVG(pop)=26856\n");
+  }
 }


### PR DESCRIPTION
The following query fails with a `JsonParseException`:

```sql
select state as "STATE", avg(pop) as "AVG(pop)"
from zips
group by "STATE"
order by "AVG(pop)"
```

Stack trace:
```
org.bson.json.JsonParseException: JSON reader was expecting ':' but found '('.
	at org.bson.json.JsonReader.readBsonType(JsonReader.java:150)
	at org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:85)
	at org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:42)
	at org.bson.codecs.BsonDocumentCodec.readValue(BsonDocumentCodec.java:104)
	at org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:87)
	at org.bson.BsonDocument.parse(BsonDocument.java:66)
	at org.apache.calcite.adapter.mongodb.MongoTable.aggregate(MongoTable.java:138)
	at org.apache.calcite.adapter.mongodb.MongoTable.access$200(MongoTable.java:53)
	at org.apache.calcite.adapter.mongodb.MongoTable$MongoQueryable.aggregate(MongoTable.java:189)
```

This is caused by the column name in the `order by` clause not being escaped.