### PR TITLE
[MINOR] Add example for MAP type in reference docs

### DIFF
--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1199,8 +1199,8 @@ Note:
 |:-------- |:---------------------------|:---------------
 | ANY      | The union of all types |
 | UNKNOWN  | A value of an unknown type; used as a placeholder |
-| ROW      | Row with 1 or more columns | Example: Row(f0 int null, f1 varchar)
-| MAP      | Collection of keys mapped to values |
+| ROW      | Row with 1 or more columns | Example: row(f0 int null, f1 varchar)
+| MAP      | Collection of keys mapped to values | Example: (int, varchar) map
 | MULTISET | Unordered collection that may contain duplicates | Example: int multiset
 | ARRAY    | Ordered, contiguous collection that may contain duplicates | Example: varchar(10) array
 | CURSOR   | Cursor over the result of executing a query |


### PR DESCRIPTION
The background is that I was going to implement Spark's MAP function, and found that the MAP constructor embedded in calcite had no examples in docs. So try to add it here.

Background and context can be found at: https://issues.apache.org/jira/browse/CALCITE-5918