### PR TITLE
[CALCITE-6030] DATE_PART is not handled by the RexToLixTranslator

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelTest.java
@@ -232,6 +232,13 @@ class BabelTest {
         "EXPR$0=false\n");
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-6030">
+   * [CALCITE-6030] DATE_PART is not handled by the RexToLixTranslator</a>. */
+  @Test void testDatePart() {
+    checkSqlResult("postgresql", "SELECT DATE_PART(second, TIME '10:10:10')",
+        "EXPR$0=10\n");
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5816">[CALCITE-5816]
    * Query with LEFT SEMI JOIN should not refer to RHS columns</a>. */

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -169,6 +169,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATEADD;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATETIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATETIME_TRUNC;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_FROM_UNIX_DATE;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_PART;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_TRUNC;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DAYNAME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DIFFERENCE;
@@ -688,6 +689,7 @@ public class RexImpTable {
       map.put(DATETIME_PLUS, new DatetimeArithmeticImplementor());
       map.put(MINUS_DATE, new DatetimeArithmeticImplementor());
       map.put(EXTRACT, new ExtractImplementor());
+      map.put(DATE_PART, new ExtractImplementor());
       map.put(FLOOR,
           new FloorImplementor(BuiltInMethod.FLOOR.method,
               BuiltInMethod.UNIX_TIMESTAMP_FLOOR.method,


### PR DESCRIPTION
Please note that running this test requires #3445 to be merged first.
