### PR TITLE
[CALCITE-5387] Type-mismatch on nullability in JoinPushTransitivePredicatesRule RelRule

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -670,8 +670,8 @@ public class RelMdPredicates
      * As RexPermuteInputsShuttle, with one exception. When visiting an inputRef,
      * it will replace the type of the InputRef with the type found in the input fields,
      * instead of keeping the original type. This is used within
-     * generateLeftRightInferredPredicates, to avoid nullability mismatches between the types of
-     * the join and the types of the inputs.
+     * when generating the Left/RightInferredPredicates, to avoid nullability mismatches
+     * between the types of the join and the types of the inputs.
      */
     private class TypeChangingRexPermuteInputsShuttle
         extends org.apache.calcite.rex.RexPermuteInputsShuttle {

--- a/core/src/main/java/org/apache/calcite/rex/RexPermuteInputsShuttle.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexPermuteInputsShuttle.java
@@ -35,8 +35,8 @@ import java.util.List;
 public class RexPermuteInputsShuttle extends RexShuttle {
   //~ Instance fields --------------------------------------------------------
 
-  private final Mappings.TargetMapping mapping;
-  private final ImmutableList<RelDataTypeField> fields;
+  protected final Mappings.TargetMapping mapping;
+  protected final ImmutableList<RelDataTypeField> fields;
 
   //~ Constructors -----------------------------------------------------------
 

--- a/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
+++ b/core/src/test/java/org/apache/calcite/test/HepPlannerTest.java
@@ -291,6 +291,25 @@ class HepPlannerTest {
     assertThat(listener.getApplyTimes() == 1, is(true));
   }
 
+  @Test void testJoinPushTransitivePredicatesNullabilityIssue() {
+    // Tests an issue when a field in the output of the join
+    // has a different nullability the field in the input table
+    // See CALCITE-5387
+    final String sql = "WITH\n"
+        + "non_null_table AS (\n"
+        + "  SELECT DATE '2023-08-07' AS date_col_non_null FROM dept\n"
+        + "),\n"
+        + "null_table AS (\n"
+        + "  SELECT CAST(null as DATE) AS date_col_null FROM dept\n"
+        + ")\n"
+        + "SELECT *\n"
+        + "FROM non_null_table\n"
+        + "JOIN null_table\n"
+        + "ON null_table.date_col_null = non_null_table.date_col_non_null";
+
+    sql(sql).withRule(CoreRules.JOIN_PUSH_TRANSITIVE_PREDICATES).check();
+  }
+
   @Test void testSubprogram() {
     // Verify that subprogram gets re-executed until fixpoint.
     // In this case, the first time through we limit it to generate

--- a/core/src/test/resources/org/apache/calcite/test/HepPlannerTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/HepPlannerTest.xml
@@ -46,6 +46,41 @@ LogicalCalc(expr#0..1=[{inputs}], expr#2=[UPPER($t1)], expr#3=[20], expr#4=[=($t
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinPushTransitivePredicatesNullabilityIssue">
+    <Resource name="sql">
+      <![CDATA[WITH
+non_null_table AS (
+  SELECT DATE '2023-08-07' AS date_col_non_null FROM dept
+),
+null_table AS (
+  SELECT CAST(null as DATE) AS date_col_null FROM dept
+)
+SELECT *
+FROM non_null_table
+JOIN null_table
+ON null_table.date_col_null = non_null_table.date_col_non_null]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DATE_COL_NON_NULL=[$0], DATE_COL_NULL=[$1])
+  LogicalJoin(condition=[=($1, $0)], joinType=[inner])
+    LogicalProject(DATE_COL_NON_NULL=[2023-08-07])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalProject(DATE_COL_NULL=[null:DATE])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DATE_COL_NON_NULL=[$0], DATE_COL_NULL=[$1])
+  LogicalJoin(condition=[=($1, $0)], joinType=[inner])
+    LogicalValues(tuples=[[]])
+    LogicalFilter(condition=[=($0, 2023-08-07)])
+      LogicalProject(DATE_COL_NULL=[null:DATE])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMatchLimitOneBottomUp">
     <Resource name="sql">
       <![CDATA[(select name from dept union select ename from emp) union (select ename from bonus)]]>

--- a/core/src/test/resources/org/apache/calcite/test/HepPlannerTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/HepPlannerTest.xml
@@ -81,6 +81,45 @@ LogicalProject(DATE_COL_NON_NULL=[$0], DATE_COL_NULL=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinPushTransitivePredicatesUpcastingIssue">
+    <Resource name="sql">
+      <![CDATA[WITH
+bigint_table AS (
+  SELECT deptno AS bigint_col FROM dept WHERE deptno = 1
+),
+tinyint_table AS (
+  SELECT CAST(deptno as TINYINT) AS tinyint_col FROM dept
+)
+SELECT *
+FROM tinyint_table
+JOIN bigint_table
+ON bigint_col = tinyint_col
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(TINYINT_COL=[$0], BIGINT_COL=[$2])
+  LogicalJoin(condition=[=($2, $1)], joinType=[inner])
+    LogicalProject(TINYINT_COL=[CAST($0):TINYINT NOT NULL], DEPTNO=[CAST(CAST($0):TINYINT NOT NULL):INTEGER NOT NULL])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalProject(BIGINT_COL=[$0])
+      LogicalFilter(condition=[=($0, 1)])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(TINYINT_COL=[$0], BIGINT_COL=[$2])
+  LogicalJoin(condition=[=($2, $1)], joinType=[inner])
+    LogicalFilter(condition=[=($1, 1)])
+      LogicalProject(TINYINT_COL=[CAST($0):TINYINT NOT NULL], DEPTNO=[CAST(CAST($0):TINYINT NOT NULL):INTEGER NOT NULL])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+    LogicalProject(BIGINT_COL=[$0])
+      LogicalFilter(condition=[=($0, 1)])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMatchLimitOneBottomUp">
     <Resource name="sql">
       <![CDATA[(select name from dept union select ename from emp) union (select ename from bonus)]]>


### PR DESCRIPTION
Resolves an issue with the nullability of inputRefs in RexNodes returned by inferPredicates, which was causing JOIN_PUSH_TRANSITIVE_PREDICATES to throw errors.

The root issue was that the RexInputRefs in the left/rightInferredPredicates returned from the inferPredicates function were using the types of the join, instead of using the types from the left/right inputs respectively. When the type of the join node had a different nullability than the left/right inputs, the InputRefs would have the wrong nullability. In JOIN_PUSH_TRANSITIVE_PREDICATES, we use the left/right predicates in to construct filters on the left/right inputs. The relBuilder would throw an error because in the RexInputRefs in filter condition, have a different nullability than the input to the filter node.

Background and context can be found at: https://issues.apache.org/jira/browse/CALCITE-5387

I have just applied for JIRA access, I will update the ticket when I can.
