### PR TITLE
Update project.copy() in RelBuilder.aggregate_ to reuse the traitSet()

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -2476,7 +2476,7 @@ public class RelBuilder {
           builder.add(project.getRowType().getFieldList().get(i));
         }
         r =
-            project.copy(cluster.traitSet(), project.getInput(), newProjects,
+            project.copy(project.getTraitSet(), project.getInput(), newProjects,
                 builder.build());
       } else {
         groupSet2 = groupSet;


### PR DESCRIPTION
I use Calcite in the project I work on, and I encountered a bug where pruning columns with aggregate_ was dropping trait information when attempting to do this project.copy(). I believe this is because rather than using the cluster traitSet, this call should reuse the traitSet of the original projection (as all this projection does is prune unused columns).

I'm not sure the best way to test this, so any suggestions would be greatly appreciated. In addition if I have any misconceptions/misunderstandings about how the traitSet should be used and this should not be changed, my apologies for taking your time.