### PR TITLE
[CALCITE-6033] Fix broken links on adapter page

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -36,8 +36,8 @@ apiRoot: /javadocAggregate
 # apiRoot: http://calcite.apache.org/javadocAggregate
 
 # The URL where Avatica's Javadocs are located
-avaticaApiRoot: /avatica/apidocs
-# avaticaApiRoot: http://calcite.apache.org/avatica/apidocs
+avaticaApiRoot: /avatica/javadocAggregate
+# avaticaApiRoot: http://calcite.apache.org/avatica/javadocAggregate
 
 # The URL where the JDK's Javadocs are located
 jdkApiRoot: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/

--- a/site/_docs/adapter.md
+++ b/site/_docs/adapter.md
@@ -48,7 +48,7 @@ presenting the data as tables within a schema.
 
 ### Other language interfaces
 
-* Piglet (<a href="{{ site.apiRoot }}/org/apache/calcite/piglet/package-summary.html">calcite-piglet</a>) runs queries in a subset of <a href="https://pig.apache.org/docs/r0.7.0/piglatin_ref1.html">Pig Latin</a>
+* Piglet (<a href="{{ site.apiRoot }}/org/apache/calcite/piglet/package-summary.html">calcite-piglet</a>) runs queries in a subset of <a href="https://pig.apache.org/docs/latest/basic.html">Pig Latin</a>
 
 ## Engines
 
@@ -343,7 +343,7 @@ Grouped window functions are functions that operate the `GROUP BY` clause
 to gather together records into sets. The built-in grouped window functions
 are `HOP`, `TUMBLE` and `SESSION`.
 You can define additional functions by implementing
-[<code>interface SqlGroupedWindowFunction</code>]({{ site.apiRoot }}/org/apache/calcite/sql/fun/SqlGroupedWindowFunction.html).
+[<code>interface SqlGroupedWindowFunction</code>]({{ site.apiRoot }}/org/apache/calcite/sql/SqlGroupedWindowFunction.html).
 
 ### Table functions and table macros
 
@@ -497,7 +497,7 @@ Each of these has a "pure" logical sub-class,
 [<code>LogicalProject</code>]({{ site.apiRoot }}/org/apache/calcite/rel/logical/LogicalProject.html)
 and so forth. Any given adapter will have counterparts for the operations that
 its engine can implement efficiently; for example, the Cassandra adapter has
-[<code>CassandraProject</code>]({{ site.apiRoot }}/org/apache/calcite/rel/cassandra/CassandraProject.html)
+[<code>CassandraProject</code>]({{ site.apiRoot }}/org/apache/calcite/adapter/cassandra/CassandraProject.html)
 but there is no `CassandraJoin`.
 
 You can define your own sub-class of `RelNode` to add a new operator, or
@@ -590,7 +590,7 @@ Each kind of metadata has an interface with (usually) one method.
 For example, selectivity is defined by
 [<code>class RelMdSelectivity</code>]({{ site.apiRoot }}/org/apache/calcite/rel/metadata/RelMdSelectivity.html)
 and the method
-[<code>getSelectivity(RelNode rel, RexNode predicate)</code>]({{ site.apiRoot }}/org/apache/calcite/rel/metadata/RelMetadataQuery.html#getSelectivity-org.apache.calcite.rel.RelNode-org.apache.calcite.rex.RexNode-).
+[<code>getSelectivity(RelNode rel, RexNode predicate)</code>]({{ site.apiRoot }}/org/apache/calcite/rel/metadata/RelMetadataQuery.html#getSelectivity(org.apache.calcite.rel.RelNode,org.apache.calcite.rex.RexNode)).
 
 There are many built-in kinds of metadata, including
 [collation]({{ site.apiRoot }}/org/apache/calcite/rel/metadata/RelMdCollation.html),


### PR DESCRIPTION
- fix following broken links on adapter page:
https://calcite.apache.org/avatica/apidocs/org/apache/calcite/avatica/ConnectStringParser.html
https://calcite.apache.org/javadocAggregate/org/apache/calcite/sql/fun/SqlGroupedWindowFunction.html
https://pig.apache.org/docs/r0.7.0/piglatin_ref1.html
https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/cassandra/CassandraProject.html
https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/metadata/RelMetadataQuery.html#getSelectivity-org.apache.calcite.rel.RelNode-org.apache.calcite.rex.RexNode-