### PR TITLE
[CALCITE-6037] The function category of ARRAY/EXTRACT_VALUE/XML_TRANSFORM/EXTRACT_XML/EXISTSNODE is incorrect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -532,26 +532,30 @@ public abstract class SqlLibraryOperators {
   public static final SqlFunction EXTRACT_VALUE =
       SqlBasicFunction.create("EXTRACTVALUE",
           ReturnTypes.VARCHAR_2000.andThen(SqlTypeTransforms.FORCE_NULLABLE),
-          OperandTypes.STRING_STRING);
+          OperandTypes.STRING_STRING,
+          SqlFunctionCategory.STRING);
 
   @LibraryOperator(libraries = {ORACLE})
   public static final SqlFunction XML_TRANSFORM =
       SqlBasicFunction.create("XMLTRANSFORM",
           ReturnTypes.VARCHAR.andThen(SqlTypeTransforms.FORCE_NULLABLE),
-          OperandTypes.STRING_STRING);
+          OperandTypes.STRING_STRING,
+          SqlFunctionCategory.STRING);
 
   @LibraryOperator(libraries = {ORACLE})
   public static final SqlFunction EXTRACT_XML =
       SqlBasicFunction.create("EXTRACT",
           ReturnTypes.VARCHAR.andThen(SqlTypeTransforms.FORCE_NULLABLE),
-          OperandTypes.STRING_STRING_OPTIONAL_STRING);
+          OperandTypes.STRING_STRING_OPTIONAL_STRING,
+          SqlFunctionCategory.STRING);
 
   @LibraryOperator(libraries = {ORACLE})
   public static final SqlFunction EXISTS_NODE =
       SqlBasicFunction.create("EXISTSNODE",
           ReturnTypes.INTEGER_NULLABLE
               .andThen(SqlTypeTransforms.FORCE_NULLABLE),
-          OperandTypes.STRING_STRING_OPTIONAL_STRING);
+          OperandTypes.STRING_STRING_OPTIONAL_STRING,
+          SqlFunctionCategory.STRING);
 
   /** The "BOOL_AND(condition)" aggregate function, PostgreSQL and Redshift's
    * equivalent to {@link SqlStdOperatorTable#EVERY}. */
@@ -1075,7 +1079,8 @@ public abstract class SqlLibraryOperators {
   public static final SqlFunction ARRAY =
       SqlBasicFunction.create("ARRAY",
           SqlLibraryOperators::arrayReturnType,
-          OperandTypes.SAME_VARIADIC);
+          OperandTypes.SAME_VARIADIC,
+          SqlFunctionCategory.SYSTEM);
 
   @SuppressWarnings("argument.type.incompatible")
   private static RelDataType arrayAppendPrependReturnType(SqlOperatorBinding opBinding) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6037

the definition of function category in ANSI-SQL(not very sure this is the sql standard, but the implementation of calcite is similar to it): 
https://www.oreilly.com/library/view/sql-in-a/9780596155322/ch04s04.html.