### PR TITLE
Following [CALCITE-5570] Support nested map type for SqlDataTypeSpec

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlCollectionTypeNameSpec;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlMapTypeNameSpec;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlRowTypeNameSpec;
 import org.apache.calcite.sql.SqlTypeNameSpec;
@@ -1146,6 +1147,14 @@ public abstract class SqlTypeUtil {
           .map(f -> convertTypeToSpec(f.getType()))
           .collect(Collectors.toList());
       typeNameSpec = new SqlRowTypeNameSpec(SqlParserPos.ZERO, fieldNames, fieldTypes);
+    } else if (isMap(type)) {
+      final RelDataType keyType =
+          requireNonNull(type.getKeyType(), () -> "keyType of " + type);
+      final RelDataType valueType =
+          requireNonNull(type.getValueType(), () -> "valueType of " + type);
+      final SqlDataTypeSpec keyTypeSpec = convertTypeToSpec(keyType);
+      final SqlDataTypeSpec valueTypeSpec = convertTypeToSpec(valueType);
+      typeNameSpec = new SqlMapTypeNameSpec(keyTypeSpec, valueTypeSpec, SqlParserPos.ZERO);
     } else {
       throw new UnsupportedOperationException(
           "Unsupported type when convertTypeToSpec: " + typeName);
@@ -1212,7 +1221,7 @@ public abstract class SqlTypeUtil {
   public static RelDataType createRecordTypeFromMap(
       RelDataTypeFactory typeFactory, RelDataType type) {
     RelDataType keyType = requireNonNull(type.getKeyType(), () -> "keyType of " + type);
-    RelDataType valueType = requireNonNull(type.getValueType(), () -> "keyType of " + type);
+    RelDataType valueType = requireNonNull(type.getValueType(), () -> "valueType of " + type);
     return typeFactory.createStructType(
         Arrays.asList(keyType, valueType), Arrays.asList("f0", "f1"));
   }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -4016,6 +4016,25 @@ class RelToSqlConverterTest {
     sql(query).withSpark().ok(expected);
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5570">[CALCITE-5570]
+   * Support nested map type for SqlDataTypeSpec</a>.
+   */
+  @Test void testCastAsMapType() {
+    sql("SELECT CAST(MAP['A', 1.0] AS MAP<VARCHAR, DOUBLE>)")
+        .ok("SELECT CAST(MAP['A', 1.0] AS MAP< VARCHAR CHARACTER SET \"ISO-8859-1\", DOUBLE >)\n"
+            + "FROM (VALUES (0)) AS \"t\" (\"ZERO\")");
+    sql("SELECT CAST(MAP['A', ARRAY[1, 2, 3]] AS MAP<VARCHAR, INT ARRAY>)")
+        .ok("SELECT CAST(MAP['A', ARRAY[1, 2, 3]] AS "
+            + "MAP< VARCHAR CHARACTER SET \"ISO-8859-1\", INTEGER ARRAY >)\n"
+            + "FROM (VALUES (0)) AS \"t\" (\"ZERO\")");
+    sql("SELECT CAST(MAP[ARRAY['A'], MAP[1, 2]] AS MAP<VARCHAR ARRAY, MAP<INT, INT>>)")
+        .ok("SELECT CAST(MAP[ARRAY['A'], MAP[1, 2]] AS "
+            + "MAP< VARCHAR CHARACTER SET \"ISO-8859-1\" ARRAY, MAP< INTEGER, INTEGER > >)\n"
+            + "FROM (VALUES (0)) AS \"t\" (\"ZERO\")");
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-4674">[CALCITE-4674]
    * Excess quotes in generated SQL when STAR is a column alias</a>. */


### PR DESCRIPTION
```
[info]   java.lang.UnsupportedOperationException: Unsupported type when convertTypeToSpec: MAP
[info]   at org.apache.calcite.sql.type.SqlTypeUtil.convertTypeToSpec(SqlTypeUtil.java:1140)
[info]   at org.apache.calcite.sql.SqlDialect.getCastSpec(SqlDialect.java:848)
[info]   at io.narrative.nql.package$$anon$1.getCastSpec(package.scala:50)
[info]   at org.apache.calcite.rel.rel2sql.RelToSqlConverter.castNullType(RelToSqlConverter.java:486)
[info]   at org.apache.calcite.rel.rel2sql.RelToSqlConverter.visit(RelToSqlConverter.java:458)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[info]   at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info]   at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[info]   at org.apache.calcite.util.ReflectUtil$2.invoke(ReflectUtil.java:532)
```