### PR TITLE
[CALCITE-6055] Customize handling of type name based on type system

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
@@ -120,6 +120,7 @@ class BabelQuidemTest extends QuidemTest {
                   ConnectionFactories.addType("TIMESTAMP", typeFactory ->
                       typeFactory.createSqlType(
                           SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)))
+              .with(CalciteConnectionProperty.TIME_ZONE, "UTC")
               .connect();
         case "scott-postgresql":
           return CalciteAssert.that()

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6029,6 +6029,15 @@ SqlTypeNameSpec DateTimeTypeName() :
         return new SqlBasicTypeNameSpec(typeName, getPos());
     }
 |
+    // DATETIME is the BigQuery-specific name for ISO SQL's TIMESTAMP type.
+    // In order to support this, the schema UDT map must be properly configued.
+    // See the BigQuery Quidem tests in the babel component for an example.
+    <DATETIME> {
+        s = span();
+        return new SqlUserDefinedTypeNameSpec(
+            unquotedIdentifier(), precision, s.end(this));
+    }
+|
     LOOKAHEAD(2)
     <TIME> { s = span(); }
     precision = PrecisionOpt()
@@ -6051,7 +6060,12 @@ SqlTypeNameSpec DateTimeTypeName() :
         } else {
             typeName = SqlTypeName.TIMESTAMP;
         }
-        return new SqlBasicTypeNameSpec(typeName, precision, s.end(this));
+        // Like DATETIME above, TIMESTAMP may have a different meaning for
+        // certain SQL dialects (namely, BigQuery). Unlike DATETIME, TIMESTAMP
+        // types names have default standard types that will be used in the
+        // absence of a UDT mapping.
+        return new SqlUserDefinedTypeNameSpec(
+            typeName.getSpaceName(), precision, s.end(this));
     }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
@@ -125,7 +125,7 @@ public class SqlDataTypeSpec extends SqlNode {
   //~ Methods ----------------------------------------------------------------
 
   @Override public SqlNode clone(SqlParserPos pos) {
-    return new SqlDataTypeSpec(typeNameSpec, timeZone, pos);
+    return new SqlDataTypeSpec(typeNameSpec, timeZone, nullable, pos);
   }
 
   @Override public SqlMonotonicity getMonotonicity(SqlValidatorScope scope) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlUserDefinedTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUserDefinedTypeNameSpec.java
@@ -18,8 +18,11 @@ package org.apache.calcite.sql;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
+
+import static org.apache.calcite.util.Static.RESOURCE;
 
 /**
  * A sql type name specification of user defined type.
@@ -29,28 +32,61 @@ import org.apache.calcite.util.Litmus;
  */
 public class SqlUserDefinedTypeNameSpec extends SqlTypeNameSpec {
 
+  /** Like {@link SqlBasicTypeNameSpec}, user-defined types may have precision in certain cases. */
+  private int precision;
+
   /**
    * Create a SqlUserDefinedTypeNameSpec instance.
    *
    * @param typeName Type name as SQL identifier
    * @param pos The parser position
    */
-  public SqlUserDefinedTypeNameSpec(SqlIdentifier typeName, SqlParserPos pos) {
+  public SqlUserDefinedTypeNameSpec(SqlIdentifier typeName, int precision, SqlParserPos pos) {
     super(typeName, pos);
+    this.precision = precision;
+  }
+
+  public SqlUserDefinedTypeNameSpec(SqlIdentifier typeName, SqlParserPos pos) {
+    this(typeName, -1, pos);
   }
 
   public SqlUserDefinedTypeNameSpec(String name, SqlParserPos pos) {
-    this(new SqlIdentifier(name, pos), pos);
+    this(new SqlIdentifier(name, pos), -1, pos);
+  }
+
+  public SqlUserDefinedTypeNameSpec(String name, int precision, SqlParserPos pos) {
+    this(new SqlIdentifier(name, pos), precision, pos);
   }
 
   @Override public RelDataType deriveType(SqlValidator validator) {
-    // The type name is a compound identifier, that means it is a UDT,
-    // use SqlValidator to deduce its type from the Schema.
-    return validator.getValidatedNodeType(getTypeName());
+    // The type name is a compound identifier. That means it is a UDT.
+    // Use SqlValidator to deduce its type from the Schema.
+    final SqlIdentifier identifier = getTypeName();
+    RelDataType type = validator.getValidatedNodeTypeIfKnown(identifier);
+    if (type != null) {
+      return type;
+    }
+
+    // If the type does not exist in the UDT map, try a sensible default.
+    try {
+      SqlTypeName defaultTypeName = SqlTypeName.lookup(identifier.toString());
+      return new SqlBasicTypeNameSpec(defaultTypeName, precision, getParserPos())
+          .deriveType(validator);
+    } catch (IllegalArgumentException e) {
+      throw validator.newValidationError(
+          identifier, RESOURCE.unknownIdentifier(identifier.toString()));
+    }
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     getTypeName().unparse(writer, leftPrec, rightPrec);
+
+    if (precision >= 0) {
+      final SqlWriter.Frame frame =
+          writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+      writer.print(precision);
+      writer.endList(frame);
+    }
   }
 
   @Override public boolean equalsDeep(SqlTypeNameSpec spec, Litmus litmus) {

--- a/core/src/test/java/org/apache/calcite/test/UdtTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdtTest.java
@@ -29,6 +29,14 @@ class UdtTest {
         + "     {\n"
         + "       name: 'foo',\n"
         + "       type: 'BIGINT'\n"
+        + "     },\n"
+        + "     {\n"
+        + "       name: 'TIMESTAMP',\n"
+        + "       type: 'TIMESTAMP_WITH_LOCAL_TIME_ZONE'\n"
+        + "     },\n"
+        + "     {\n"
+        + "       name: 'DATETIME',\n"
+        + "       type: 'TIMESTAMP'\n"
         + "     }"
         + "   ],\n"
         + "   schemas: [\n"
@@ -69,6 +77,15 @@ class UdtTest {
     final String sql = "select CAST(\"id\" AS foo) as ld "
         + "from (VALUES ROW(1, 'SameName')) AS \"t\" (\"id\", \"desc\")";
     withUdt().query(sql).returns("LD=1\n");
+  }
+
+  @Test void testAliasOnBasicType() {
+    final String sql1 = "select CAST(\"date\" AS TIMESTAMP) as ts "
+        + "from (VALUES ROW(DATE '2020-12-25', 'SameName')) AS \"t\" (\"date\", \"desc\")";
+    final String sql2 = "select CAST(\"date\" AS DATETIME) as ts "
+        + "from (VALUES ROW(DATE '2020-12-25', 'SameName')) AS \"t\" (\"date\", \"desc\")";
+    withUdt().query(sql1).typeIs("[TS TIMESTAMP_WITH_LOCAL_TIME_ZONE NOT NULL]");
+    withUdt().query(sql2).typeIs("[TS TIMESTAMP NOT NULL]");
   }
 
   /** Test case for

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1782,9 +1782,9 @@ public class SqlParserTest {
     expr("cast(x as time with local time zone)")
         .ok("CAST(`X` AS TIME WITH LOCAL TIME ZONE)");
     expr("cast(x as timestamp without time zone)")
-        .ok("CAST(`X` AS TIMESTAMP)");
+        .ok("CAST(`X` AS `TIMESTAMP`)");
     expr("cast(x as timestamp with local time zone)")
-        .ok("CAST(`X` AS TIMESTAMP WITH LOCAL TIME ZONE)");
+        .ok("CAST(`X` AS `TIMESTAMP WITH LOCAL TIME ZONE`)");
     expr("cast(x as time(0))")
         .ok("CAST(`X` AS TIME(0))");
     expr("cast(x as time(0) without time zone)")
@@ -1792,13 +1792,13 @@ public class SqlParserTest {
     expr("cast(x as time(0) with local time zone)")
         .ok("CAST(`X` AS TIME(0) WITH LOCAL TIME ZONE)");
     expr("cast(x as timestamp(0))")
-        .ok("CAST(`X` AS TIMESTAMP(0))");
+        .ok("CAST(`X` AS `TIMESTAMP`(0))");
     expr("cast(x as timestamp(0) without time zone)")
-        .ok("CAST(`X` AS TIMESTAMP(0))");
+        .ok("CAST(`X` AS `TIMESTAMP`(0))");
     expr("cast(x as timestamp(0) with local time zone)")
-        .ok("CAST(`X` AS TIMESTAMP(0) WITH LOCAL TIME ZONE)");
+        .ok("CAST(`X` AS `TIMESTAMP WITH LOCAL TIME ZONE`(0))");
     expr("cast(x as timestamp)")
-        .ok("CAST(`X` AS TIMESTAMP)");
+        .ok("CAST(`X` AS `TIMESTAMP`)");
     expr("cast(x as decimal(1,1))")
         .ok("CAST(`X` AS DECIMAL(1, 1))");
     expr("cast(x as char(1))")
@@ -6115,12 +6115,12 @@ public class SqlParserTest {
         + "f1 timestamp not null))")
         .ok("CAST(`A` AS ROW("
             + "`F0` ROW(`FF0` INTEGER, `FF1` VARCHAR NULL) NULL, "
-            + "`F1` TIMESTAMP))");
+            + "`F1` `TIMESTAMP`))");
     // test row type in collection data types.
     expr("cast(a as row(f0 bigint not null, f1 decimal null) array)")
         .ok("CAST(`A` AS ROW(`F0` BIGINT, `F1` DECIMAL NULL) ARRAY)");
     expr("cast(a as row(f0 varchar not null, f1 timestamp null) multiset)")
-        .ok("CAST(`A` AS ROW(`F0` VARCHAR, `F1` TIMESTAMP NULL) MULTISET)");
+        .ok("CAST(`A` AS ROW(`F0` VARCHAR, `F1` `TIMESTAMP` NULL) MULTISET)");
   }
 
   /**


### PR DESCRIPTION
Outline of the approach:
- Treat `TIMESTAMP`, `TIMESTAMP WITH LOCAL TIME ZONE`, and `DATETIME` type names as user-defined types during parsing.
- When deriving the types of these nodes, look for mappings in the schema model as before, but allow user-defined types to fall back on canonical types if no mapping is found, much like how `SqlUnknownLiteral` works. This is important so the `TIMESTAMP` and `TIMESTAMP WITH LOCAL TIME ZONE` types can still function when there is no UDT mapping for them.

There's still a lingering problem in how to unparse the `SqlUserDefinedTypeNameSpec` nodes. This is only relevant when a `SqlNode` AST is parsed and then unparsed without converting to `RelNode` form in between. I describe why I don't think this is a particularly important use-case in [this Jira comment](https://issues.apache.org/jira/browse/CALCITE-5526?focusedCommentId=17776449&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17776449), but it's how the `SqlParserTest` and it's various subclasses operate. Looking for feedback on how to better address this:

- The most obvious solution seems like implementing `unparse()` in a way similar to `deriveType()`: look up the UDT mapping and fall back on the standard types, thus preserving the existing default unparsing behavior for `TIMESTAMP`. However, this would require passing a `SqlValidator` to `unparse()`, which doesn't make a ton a sense.
- We could instead ignore the UDT map during unparsing, but still try to match the type name to the standard `SqlTypeName`, so `TIMESTAMP` unparsing is unaffected by default. However, this would mess up unparsing a dialect like BigQuery, since BigQuery timestamps would unparse as `TIMESTAMP WITH LOCAL TIME ZONE`, and datetimes would unparse as `` `DATETIME` `` (with backticks).

There are myriad details that could be tweaked in either case, and possibly other approached I'm not thinking of yet.