### PR TITLE
[CALCITE-6060] Rename the named parameter OFFSET in window functions to avoid conflicts with reserved keywords

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlWindowTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWindowTableFunction.java
@@ -56,7 +56,7 @@ public class SqlWindowTableFunction extends SqlFunction
   protected static final String PARAM_SIZE = "SIZE";
 
   /** The optional align offset for each window. */
-  protected static final String PARAM_OFFSET = "OFFSET";
+  protected static final String PARAM_OFFSET = "OFFSETSIZE";
 
   /** The session key(s), only used for SESSION window. */
   protected static final String PARAM_KEY = "KEY";

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2258,6 +2258,7 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         + "  DATA => table Shipments,\n"
         + "  SLIDE => INTERVAL '1' MINUTE,\n"
         + "  TIMECOL => descriptor(rowtime),\n"
+        + "  OFFSETSIZE => INTERVAL '1' MINUTE,\n"
         + "  SIZE => INTERVAL '2' MINUTE))";
     sql(sql).ok();
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -10155,7 +10155,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "data => table orders,\n"
         + "timecol => descriptor(rowtime),\n"
         + "size => interval '2' hour,\n"
-        + "\"OFFSET\" => interval '1' hour))").ok();
+        + "OFFSETSIZE => interval '1' hour))").ok();
     // negative tests.
     sql("select rowtime, productid, orderid, 'window_start', 'window_end'\n"
         + "from table(\n"
@@ -10235,7 +10235,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "timecol => descriptor(rowtime),\n"
         + "slide => interval '2' hour,\n"
         + "size => interval '1' hour,\n"
-        + "\"OFFSET\" => interval '20' minute))").ok();
+        + "OFFSETSIZE => interval '20' minute))").ok();
     // negative tests.
     sql("select rowtime, productid, orderid, 'window_start', 'window_end'\n"
         + "from table(\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -7289,12 +7289,13 @@ hop(
   DATA => table Shipments,
   SLIDE => INTERVAL '1' MINUTE,
   TIMECOL => descriptor(rowtime),
+  OFFSETSIZE => INTERVAL '1' MINUTE,
   SIZE => INTERVAL '2' MINUTE))]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
 LogicalProject(ORDERID=[$0], ROWTIME=[$1], window_start=[$2], window_end=[$3])
-  LogicalTableFunctionScan(invocation=[HOP(DESCRIPTOR($1), 60000:INTERVAL MINUTE, 120000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER ORDERID, TIMESTAMP(0) ROWTIME, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end)])
+  LogicalTableFunctionScan(invocation=[HOP(DESCRIPTOR($1), 60000:INTERVAL MINUTE, 120000:INTERVAL MINUTE, 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER ORDERID, TIMESTAMP(0) ROWTIME, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end)])
     LogicalProject(ORDERID=[$0], ROWTIME=[$1])
       LogicalTableScan(table=[[CATALOG, SALES, SHIPMENTS]])
 ]]>


### PR DESCRIPTION
This is a breaking change. Users should change the named parameter in window table function from ``OFFSET`` to `OFFSETSIZE`.
More details: https://issues.apache.org/jira/browse/CALCITE-6060
