### PR TITLE
[CALCITE-5990] Explicit cast to numeric type doesn't check overflow

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -56,14 +56,6 @@ public abstract class Bug {
 
   public static final boolean DT785_FIXED = false;
 
-  // jhyde
-
-  /**
-   * Whether <a href="http://issues.eigenbase.org/browse/FNL-3">issue
-   * Fnl-3</a> is fixed.
-   */
-  public static final boolean FNL3_FIXED = false;
-
   /**
    * Whether <a href="http://issues.eigenbase.org/browse/FRG-327">issue
    * FRG-327: AssertionError while translating IN list that contains null</a>

--- a/core/src/test/java/org/apache/calcite/test/SqlOperatorUnparseTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlOperatorUnparseTest.java
@@ -80,7 +80,7 @@ public class SqlOperatorUnparseTest extends CalciteSqlOperatorTest {
     String rewrite(String sql) throws SqlParseException {
       final SqlParser parser = factory.createParser(sql);
       final SqlNode sqlNode = parser.parseStmt();
-      return sqlNode.toSqlString(c -> c).getSql();
+      return sqlNode.toSqlString(c -> c.withClauseStartsLine(false)).getSql();
     }
 
     @Override public void forEachQuery(
@@ -97,11 +97,6 @@ public class SqlOperatorUnparseTest extends CalciteSqlOperatorTest {
         throw new RuntimeException(e);
       }
     }
-  }
-
-  @Override @Disabled("Runtime error message differs after parsing and unparsing")
-  void testBitAndFuncRuntimeFails() {
-    super.testContainsSubstrFunc();
   }
 
   // Every test that is Disabled below corresponds to a bug.

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
@@ -22,6 +22,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.AbstractList;
@@ -367,28 +369,68 @@ public enum Primitive {
   }
 
   /**
-   * Converts a number into a value of the type
-   * specified by this primitive.
+   * Check if a value after rounding falls within a specified range.
+   *
+   * @param value  Value to compare.
+   * @param min    Minimum value allowed.
+   * @param max    Maximum value allowed.
+   */
+  static void checkRoundedRange(Number value, double min, double max) {
+    double dbl = value.doubleValue();
+    // The equivalent of DOWN rounding for BigDecimal
+    dbl = dbl > 0 ? Math.floor(dbl) : Math.ceil(dbl);
+    if (dbl < min || dbl > max) {
+      throw new ArithmeticException("Value " + value + " out of range");
+    }
+  }
+
+  /**
+   * Converts a number into a value of the type specified by this primitive
+   * using the SQL CAST rules.  If the value conversion causes loss of significant digits,
+   * an exception is thrown.
    *
    * @param value  Value to convert.
-   * @return       The converted value, or null if the
-   *               conversion cannot be performed.
+   * @return       The converted value, or null if the type of the result is not a number.
    */
   public @Nullable Object numberValue(Number value) {
     switch (this) {
     case BYTE:
+      checkRoundedRange(value, Byte.MIN_VALUE, Byte.MAX_VALUE);
       return value.byteValue();
     case CHAR:
+      // No overflow checks for char values.
+      // For example, Postgres has this behavior.
       return (char) value.intValue();
     case SHORT:
+      checkRoundedRange(value, Short.MIN_VALUE, Short.MAX_VALUE);
       return value.shortValue();
     case INT:
+      checkRoundedRange(value, Integer.MIN_VALUE, Integer.MAX_VALUE);
       return value.intValue();
     case LONG:
-      return value.longValue();
+      if (value instanceof Byte
+          || value instanceof Short
+          || value instanceof Integer
+          || value instanceof Long) {
+        return value.longValue();
+      }
+      if (value instanceof Float
+          || value instanceof Double) {
+        // The value Long.MAX_VALUE cannot be represented exactly as a double,
+        // so we cannot use checkRoundedRange.
+        BigDecimal decimal = BigDecimal.valueOf(value.doubleValue())
+            // Round to an integer
+            .setScale(0, RoundingMode.DOWN);
+        // longValueExact will throw ArithmeticException if out of range
+        return decimal.longValueExact();
+      }
+      throw new AssertionError("Unexpected Number type "
+          + value.getClass().getSimpleName());
     case FLOAT:
+      // out of range values will be represented as infinities
       return value.floatValue();
     case DOUBLE:
+      // out of range values will be represented as infinities
       return value.doubleValue();
     default:
       return null;

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1470,7 +1470,7 @@ Algorithms for implicit conversion are subject to change across Calcite releases
 
 | Operator syntax                         | Description
 |:----------------------------------------| :----------
-| CAST(value AS type)                     | Converts a value to a given type
+| CAST(value AS type)                     | Converts a value to a given type. Casts between integer types truncate towards 0
 | CONVERT(string, charSet1, charSet2)     | Converts *string* from *charSet1* to *charSet2*
 | CONVERT(value USING transcodingName)    | Alter *value* from one base character set to *transcodingName*
 | TRANSLATE(value USING transcodingName)  | Alter *value* from one base character set to *transcodingName*

--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
@@ -68,30 +68,19 @@ import static org.apache.calcite.sql.test.ResultCheckers.isSingle;
 public interface SqlOperatorFixture extends AutoCloseable {
   //~ Enums ------------------------------------------------------------------
 
-  // TODO: Change message when Fnl3Fixed to something like
-  // "Invalid character for cast: PC=0 Code=22018"
-  String INVALID_CHAR_MESSAGE =
-      Bug.FNL3_FIXED ? null : "(?s).*";
+  // TODO: Change message
+  String INVALID_CHAR_MESSAGE = "(?s).*";
 
-  // TODO: Change message when Fnl3Fixed to something like
-  // "Overflow during calculation or cast: PC=0 Code=22003"
-  String OUT_OF_RANGE_MESSAGE =
-      Bug.FNL3_FIXED ? null : "(?s).*";
+  String OUT_OF_RANGE_MESSAGE = ".* out of range";
 
-  // TODO: Change message when Fnl3Fixed to something like
-  // "Division by zero: PC=0 Code=22012"
-  String DIVISION_BY_ZERO_MESSAGE =
-      Bug.FNL3_FIXED ? null : "(?s).*";
+  // TODO: Change message
+  String DIVISION_BY_ZERO_MESSAGE = "(?s).*";
 
-  // TODO: Change message when Fnl3Fixed to something like
-  // "String right truncation: PC=0 Code=22001"
-  String STRING_TRUNC_MESSAGE =
-      Bug.FNL3_FIXED ? null : "(?s).*";
+  // TODO: Change message
+  String STRING_TRUNC_MESSAGE = "(?s).*";
 
-  // TODO: Change message when Fnl3Fixed to something like
-  // "Invalid datetime format: PC=0 Code=22007"
-  String BAD_DATETIME_MESSAGE =
-      Bug.FNL3_FIXED ? null : "(?s).*";
+  // TODO: Change message
+  String BAD_DATETIME_MESSAGE = "(?s).*";
 
   // Error messages when an invalid time unit is given as
   // input to extract for a particular input type.

--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlTests.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlTests.java
@@ -299,6 +299,10 @@ public abstract class SqlTests {
       }
     } else {
       actualMessage = ex.getMessage();
+      if (ex instanceof NumberFormatException) {
+        // The message from NumberFormatException is not very usable
+        actualMessage = "Number has wrong format " + actualMessage;
+      }
       if (actualMessage != null) {
         java.util.regex.Matcher matcher =
             LINE_COL_TWICE_PATTERN.matcher(actualMessage);


### PR DESCRIPTION
It turns out that in SQL casts are checked: a cast that cannot represent the resulting value in the destination type should report a runtime error. This PR adds range checking for Number values. The tests for this PR require https://github.com/apache/calcite/pull/3471 to fix a bug in the test fixture.