### PR TITLE
[CALCITE-6075] The git link to download the source code is incorrect

### DIFF
--- a/site/develop/index.md
+++ b/site/develop/index.md
@@ -54,7 +54,7 @@ Create a local copy of the Git repository, `cd` to its root directory,
 then build using Gradle:
 
 {% highlight bash %}
-$ git clone git://github.com/apache/calcite.git
+$ git clone https://github.com/apache/calcite.git
 $ cd calcite
 $ ./gradlew build
 {% endhighlight %}


### PR DESCRIPTION
git clone git://github.com/apache/calcite.git does not have this writing method. It should be https://github.com/apache/calcite.git or git@github.com:apache/calcite.git