### PR TITLE
[CALCITE-6074] The size of REAL, DOUBLE, and FLOAT is not consistent

### DIFF
--- a/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/AggregateNode.java
@@ -218,10 +218,10 @@ public class AggregateNode extends AbstractSingleNode<Aggregate> {
     switch (call.getType().getSqlTypeName()) {
     case INTEGER:
       return max ? MaxInt.class : MinInt.class;
-    case FLOAT:
-      return max ? MaxFloat.class : MinFloat.class;
-    case DOUBLE:
     case REAL:
+      return max ? MaxFloat.class : MinFloat.class;
+    case FLOAT:
+    case DOUBLE:
       return max ? MaxDouble.class : MinDouble.class;
     case DECIMAL:
       return max ? MaxBigDecimal.class : MinBigDecimal.class;

--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -126,6 +126,7 @@ public class VisitorDataContext implements DataContext {
       switch (type.getSqlTypeName()) {
       case INTEGER:
         return Pair.of(index, rexLiteral.getValueAs(Integer.class));
+      case FLOAT:
       case DOUBLE:
         return Pair.of(index, rexLiteral.getValueAs(Double.class));
       case REAL:

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdSize.java
@@ -360,7 +360,6 @@ public class RelMdSize implements MetadataHandler<BuiltInMetadata.Size> {
     case SMALLINT:
       return 2d;
     case INTEGER:
-    case FLOAT:
     case REAL:
     case DATE:
     case TIME:
@@ -370,6 +369,7 @@ public class RelMdSize implements MetadataHandler<BuiltInMetadata.Size> {
     case INTERVAL_MONTH:
       return 4d;
     case BIGINT:
+    case FLOAT:  // sic
     case DOUBLE:
     case TIMESTAMP:
     case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -590,8 +590,7 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
       return createSqlType(SqlTypeName.DECIMAL, 38, 0);
     case REAL:
       return createSqlType(SqlTypeName.DECIMAL, 14, 7);
-    case FLOAT:
-      return createSqlType(SqlTypeName.DECIMAL, 14, 7);
+    case FLOAT: // sic
     case DOUBLE:
       // the default max precision is 19, so this is actually DECIMAL(19, 15)
       // but derived system can override the max precision/scale.

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -595,6 +595,7 @@ public class RexBuilder {
           case INTEGER:
           case SMALLINT:
           case TINYINT:
+          case DOUBLE:
           case FLOAT:
           case REAL:
           case DECIMAL:
@@ -1783,13 +1784,13 @@ public class RexBuilder {
               o.getClass().getCanonicalName(),
               type.getSqlTypeName());
       return new BigDecimal(((Number) o).longValue());
-    case FLOAT:
+    case REAL:
       if (o instanceof BigDecimal) {
         return o;
       }
       return new BigDecimal(((Number) o).doubleValue(), MathContext.DECIMAL32)
           .stripTrailingZeros();
-    case REAL:
+    case FLOAT:
     case DOUBLE:
       if (o instanceof BigDecimal) {
         return o;

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -406,6 +406,7 @@ public class RexLiteral extends RexNode {
       return SqlTypeName.DECIMAL;
     case REAL:
     case FLOAT:
+    case DOUBLE:
       return SqlTypeName.DOUBLE;
     case VARBINARY:
       return SqlTypeName.BINARY;
@@ -653,6 +654,7 @@ public class RexLiteral extends RexNode {
       sb.append(value.toString());
       break;
     case DOUBLE:
+    case FLOAT:
       assert value instanceof BigDecimal;
       sb.append(Util.toScientificNotation((BigDecimal) value));
       break;
@@ -806,6 +808,8 @@ public class RexLiteral extends RexNode {
       return new RexLiteral(b, type, typeName);
     case DECIMAL:
     case DOUBLE:
+    case REAL:
+    case FLOAT:
       BigDecimal d = new BigDecimal(literal);
       return new RexLiteral(d, type, typeName);
     case BINARY:

--- a/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -199,6 +199,8 @@ public class SqlLiteral extends SqlNode {
       return value == null;
     case DECIMAL:
     case DOUBLE:
+    case FLOAT:
+    case REAL:
       return value instanceof BigDecimal;
     case DATE:
       return value instanceof DateString;

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -340,6 +340,8 @@ public class BigQuerySqlDialect extends SqlDialect {
       case FLOAT:
       case DOUBLE:
         return createSqlDataTypeSpecByName("FLOAT64", typeName);
+      case REAL:
+        return createSqlDataTypeSpecByName("FLOAT32", typeName);
       case DECIMAL:
         return createSqlDataTypeSpecByName("NUMERIC", typeName);
       case BOOLEAN:

--- a/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
@@ -88,8 +88,9 @@ public class ClickHouseSqlDialect extends SqlDialect {
         return createSqlDataTypeSpecByName("Int32", typeName);
       case BIGINT:
         return createSqlDataTypeSpecByName("Int64", typeName);
-      case FLOAT:
+      case REAL:
         return createSqlDataTypeSpecByName("Float32", typeName);
+      case FLOAT:
       case DOUBLE:
         return createSqlDataTypeSpecByName("Float64", typeName);
       case DATE:

--- a/core/src/main/java/org/apache/calcite/sql/dialect/JethroDataSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/JethroDataSqlDialect.java
@@ -148,7 +148,7 @@ public class JethroDataSqlDialect extends SqlDialect {
       case "double":
         return SqlTypeName.DOUBLE;
       case "float":
-        return SqlTypeName.FLOAT;
+        return SqlTypeName.REAL;
       case "string":
         return SqlTypeName.VARCHAR;
       case "timestamp":

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRule.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRule.java
@@ -99,6 +99,7 @@ public class SqlTypeAssignmentRule implements SqlTypeMappingRule {
     rule.add(SqlTypeName.BIGINT);
     rule.add(SqlTypeName.DECIMAL);
     rule.add(SqlTypeName.FLOAT);
+    rule.add(SqlTypeName.DOUBLE);
     rules.add(SqlTypeName.FLOAT, rule);
 
     // REAL (32 bit floating point) is assignable from...
@@ -109,6 +110,7 @@ public class SqlTypeAssignmentRule implements SqlTypeMappingRule {
     rule.add(SqlTypeName.BIGINT);
     rule.add(SqlTypeName.DECIMAL);
     rule.add(SqlTypeName.FLOAT);
+    rule.add(SqlTypeName.DOUBLE);
     rule.add(SqlTypeName.REAL);
     rules.add(SqlTypeName.REAL, rule);
 
@@ -204,6 +206,7 @@ public class SqlTypeAssignmentRule implements SqlTypeMappingRule {
     rule.add(SqlTypeName.BIGINT);
     rule.add(SqlTypeName.DECIMAL);
     rule.add(SqlTypeName.FLOAT);
+    rule.add(SqlTypeName.DOUBLE);
     rule.add(SqlTypeName.REAL);
     rule.add(SqlTypeName.TIME);
     rule.add(SqlTypeName.DATE);

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeExplicitPrecedenceList.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeExplicitPrecedenceList.java
@@ -65,8 +65,14 @@ public class SqlTypeExplicitPrecedenceList
           .put(SqlTypeName.BIGINT, numeric(SqlTypeName.BIGINT))
           .put(SqlTypeName.DECIMAL, numeric(SqlTypeName.DECIMAL))
           .put(SqlTypeName.REAL, numeric(SqlTypeName.REAL))
-          .put(SqlTypeName.FLOAT, list(SqlTypeName.FLOAT, SqlTypeName.REAL, SqlTypeName.DOUBLE))
-          .put(SqlTypeName.DOUBLE, list(SqlTypeName.DOUBLE, SqlTypeName.DECIMAL))
+          .put(
+              SqlTypeName.FLOAT, list(
+                  SqlTypeName.FLOAT, SqlTypeName.REAL,
+                  SqlTypeName.DOUBLE,  SqlTypeName.DECIMAL))
+          .put(
+              SqlTypeName.DOUBLE, list(
+                  SqlTypeName.FLOAT, SqlTypeName.REAL,
+                  SqlTypeName.DOUBLE, SqlTypeName.DECIMAL))
           .put(SqlTypeName.CHAR, list(SqlTypeName.CHAR, SqlTypeName.VARCHAR))
           .put(SqlTypeName.VARCHAR, list(SqlTypeName.VARCHAR))
           .put(SqlTypeName.BINARY,

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -491,24 +491,6 @@ public abstract class SqlTypeUtil {
     return typeName == SqlTypeName.DECIMAL;
   }
 
-  /** Returns whether a type is DOUBLE. */
-  public static boolean isDouble(RelDataType type) {
-    SqlTypeName typeName = type.getSqlTypeName();
-    if (typeName == null) {
-      return false;
-    }
-    return typeName == SqlTypeName.DOUBLE;
-  }
-
-  /** Returns whether a type is BIGINT. */
-  public static boolean isBigint(RelDataType type) {
-    SqlTypeName typeName = type.getSqlTypeName();
-    if (typeName == null) {
-      return false;
-    }
-    return typeName == SqlTypeName.BIGINT;
-  }
-
   /** Returns whether a type is numeric with exact precision. */
   public static boolean isExactNumeric(RelDataType type) {
     SqlTypeName typeName = type.getSqlTypeName();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3330,6 +3330,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       break;
 
     case DOUBLE:
+    case FLOAT:
+    case REAL:
       validateLiteralAsDouble(literal);
       break;
 

--- a/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
@@ -762,7 +762,7 @@ class RexBuilderTest {
     final RelDataTypeFactory typeFactory =
             new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     final RexBuilder rexBuilder = new RexBuilder(typeFactory);
-    final RelDataType floatType = typeFactory.createSqlType(SqlTypeName.FLOAT);
+    final RelDataType floatType = typeFactory.createSqlType(SqlTypeName.REAL);
     RexNode left = rexBuilder.makeInputRef(floatType, 0);
     final RexNode literal1 = rexBuilder.makeLiteral(1.0f, floatType);
     final RexNode literal2 = rexBuilder.makeLiteral(2.0f, floatType);

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidType.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidType.java
@@ -21,7 +21,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /** Druid type. */
 public enum DruidType {
   LONG(SqlTypeName.BIGINT),
-  FLOAT(SqlTypeName.FLOAT),
+  FLOAT(SqlTypeName.REAL),
   DOUBLE(SqlTypeName.DOUBLE),
   STRING(SqlTypeName.VARCHAR),
   COMPLEX(SqlTypeName.OTHER),

--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvEnumerator.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvEnumerator.java
@@ -328,11 +328,12 @@ public class CsvEnumerator<E> implements Enumerator<E> {
           return null;
         }
         return Long.parseLong(string);
-      case FLOAT:
+      case REAL:
         if (string.length() == 0) {
           return null;
         }
         return Float.parseFloat(string);
+      case FLOAT:
       case DOUBLE:
         if (string.length() == 0) {
           return null;

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigTypes.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigTypes.java
@@ -116,7 +116,7 @@ class PigTypes {
     case DataType.LONG:
       return TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT, nullable);
     case DataType.FLOAT:
-      return TYPE_FACTORY.createSqlType(SqlTypeName.FLOAT, nullable);
+      return TYPE_FACTORY.createSqlType(SqlTypeName.REAL, nullable);
     case DataType.DOUBLE:
       return TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE, nullable);
     case DataType.DATETIME:

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelExTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelExTest.java
@@ -188,7 +188,7 @@ class PigRelExTest extends PigRelTestBase {
   @Test void testCast() {
     checkTranslation("(int) b", inTree("CAST($1):INTEGER"));
     checkTranslation("(long) a", inTree("CAST($0):BIGINT"));
-    checkTranslation("(float) b", inTree("CAST($1):FLOAT"));
+    checkTranslation("(float) b", inTree("CAST($1):REAL"));
     checkTranslation("(double) b", inTree("CAST($1):DOUBLE"));
     checkTranslation("(chararray) b", inTree("CAST($1):VARCHAR"));
     checkTranslation("(bytearray) b", inTree("CAST($1):BINARY"));
@@ -197,18 +197,18 @@ class PigRelExTest extends PigRelTestBase {
     checkTranslation("(bigdecimal) b", inTree("CAST($1):DECIMAL(19, 0)"));
     checkTranslation("(tuple()) b", inTree("CAST($1):(DynamicRecordRow[])"));
     checkTranslation("(tuple(int, float)) b",
-        inTree("CAST($1):RecordType(INTEGER $0, FLOAT $1)"));
+        inTree("CAST($1):RecordType(INTEGER $0, REAL $1)"));
     checkTranslation("(bag{}) b",
         inTree("CAST($1):(DynamicRecordRow[]) NOT NULL MULTISET"));
     checkTranslation("(bag{tuple(int)}) b",
         inTree("CAST($1):RecordType(INTEGER $0) MULTISET"));
     checkTranslation("(bag{tuple(int, float)}) b",
-        inTree("CAST($1):RecordType(INTEGER $0, FLOAT $1) MULTISET"));
+        inTree("CAST($1):RecordType(INTEGER $0, REAL $1) MULTISET"));
     checkTranslation("(map[]) b",
         inTree("CAST($1):(VARCHAR NOT NULL, BINARY(1) NOT NULL) MAP"));
     checkTranslation("(map[int]) b", inTree("CAST($1):(VARCHAR NOT NULL, INTEGER"));
     checkTranslation("(map[tuple(int, float)]) b",
-        inTree("CAST($1):(VARCHAR NOT NULL, RecordType(INTEGER val_0, FLOAT val_1)) MAP"));
+        inTree("CAST($1):(VARCHAR NOT NULL, RecordType(INTEGER val_0, REAL val_1)) MAP"));
   }
 
   @Test void testPigBuiltinFunctions() {


### PR DESCRIPTION
This is based on a code audit.
The assumption is that FLOAT=DOUBLE=64 bit and REAL=32 bit
I also deleted some deprecated functions instead of fixing them.