### PR TITLE
Bump 6 dependencies

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Sources.java
+++ b/core/src/main/java/org/apache/calcite/util/Sources.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.util;
 
-import org.apache.commons.io.input.ReaderInputStream;
-
 import com.google.common.io.CharSource;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -137,8 +135,7 @@ public abstract class Sources {
     }
 
     @Override public InputStream openStream() throws IOException {
-      // use charSource.asByteSource() once calcite can use guava v21+
-      return new ReaderInputStream(reader(), StandardCharsets.UTF_8);
+      return charSource.asByteSource(StandardCharsets.UTF_8).openStream();
     }
 
     @Override public String protocol() {

--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvStreamReader.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvStreamReader.java
@@ -28,6 +28,7 @@ import au.com.bytecode.opencsv.CSVReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
@@ -79,8 +80,15 @@ class CsvStreamReader extends CSVReader implements Closeable {
     contentQueue = new ArrayDeque<>();
     TailerListener listener = new CsvContentListener(contentQueue);
     tailer =
-        Tailer.create(source.file(), listener, DEFAULT_MONITOR_DELAY,
-            false, true, 4096);
+        Tailer.builder()
+            .setFile(source.file())
+            .setTailerListener(listener)
+            .setDelayDuration(Duration.ofMillis(DEFAULT_MONITOR_DELAY))
+            .setTailFromEnd(false)
+            .setReOpen(true)
+            .setBufferSize(4096)
+            .get();
+
     this.parser =
         new CSVParser(separator, quoteChar, escape, strictQuotes,
             ignoreLeadingWhiteSpace);

--- a/gradle.properties
+++ b/gradle.properties
@@ -90,14 +90,14 @@ cassandra-all.version=4.0.1
 cassandra-java-driver-core.version=4.13.0
 cassandra-unit.version=4.3.1.0
 chinook-data-hsqldb.version=0.2
-commons-codec.version=1.13
-commons-dbcp2.version=2.9.0
-commons-io.version=2.11.0
-commons-lang3.version=3.8
+commons-codec.version=1.16.0
+commons-dbcp2.version=2.11.0
+commons-io.version=2.15.0
+commons-lang3.version=3.13.0
 commons-math3.version=3.6.1
-commons-pool2.version=2.6.2
+commons-pool2.version=2.12.0
 commons-collections4.version=4.4
-commons-text.version=1.10.0
+commons-text.version=1.11.0
 dropwizard-metrics.version=4.0.5
 
 # do not upgrade this, new versions are Category X license.


### PR DESCRIPTION
bump commons-codec from 1.13 to 1.16.0
bump commons-dbcp2 from 2.9.0 to 2.11.0
bump commons-io from 2.11.0 to 2.15.0
bump commons-lang3 from 3.8 to 3.13.0
bump commons-pool2 from 2.6.2 to 2.12.0
bump commons-text from 1.10.0 to 1.11.0