### PR TITLE
[CALCITE-6071] RexCall should carry source position information for runtime error reporting

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -4781,7 +4781,7 @@ public class RexImpTable {
       final ParameterExpression lambdaArg =
           Expressions.parameter(translator.typeFactory.getJavaClass(rightComponentType), "el");
       final RexCall binaryImplementorRexCall =
-          (RexCall) translator.builder.makeCall(binaryOperator, leftRex,
+          (RexCall) translator.builder.makeCall(call.getParserPosition(), binaryOperator, leftRex,
               translator.builder.makeDynamicParam(rightComponentType, 0));
       final List<RexToLixTranslator.Result> binaryImplementorArgs =
           ImmutableList.of(

--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -350,7 +350,7 @@ public class SubstitutionVisitor {
       if (newOperands.size() < 2) {
         return newOperands.values().iterator().next();
       }
-      return rexBuilder.makeCall(call.getOperator(),
+      return rexBuilder.makeCall(call.getParserPosition(), call.getOperator(),
           ImmutableList.copyOf(newOperands.values()));
     }
     case EQUALS:
@@ -362,7 +362,8 @@ public class SubstitutionVisitor {
       RexCall call = (RexCall) condition;
       RexNode left = canonizeNode(rexBuilder, call.getOperands().get(0));
       RexNode right = canonizeNode(rexBuilder, call.getOperands().get(1));
-      call = (RexCall) rexBuilder.makeCall(call.getOperator(), left, right);
+      call =
+          (RexCall) rexBuilder.makeCall(call.getParserPosition(), call.getOperator(), left, right);
 
       if (left.toString().compareTo(right.toString()) <= 0) {
         return call;
@@ -384,10 +385,11 @@ public class SubstitutionVisitor {
       RexNode right = canonizeNode(rexBuilder, call.getOperands().get(1));
 
       if (left.toString().compareTo(right.toString()) <= 0) {
-        return rexBuilder.makeCall(call.getOperator(), left, right);
+        return rexBuilder.makeCall(call.getParserPosition(), call.getOperator(), left, right);
       }
 
-      RexNode newCall = rexBuilder.makeCall(call.getOperator(), right, left);
+      RexNode newCall =
+          rexBuilder.makeCall(call.getParserPosition(), call.getOperator(), right, left);
       // new call should not be used if its inferred type is not same as old
       if (!newCall.getType().equals(call.getType())) {
         return call;
@@ -1973,7 +1975,8 @@ public class SubstitutionVisitor {
             final SqlAggFunction aggFunction = aggregateCall.getAggregation().getRollup();
             if (aggFunction != null) {
               newAggCall =
-                  AggregateCall.create(aggFunction, aggregateCall.isDistinct(),
+                  AggregateCall.create(aggregateCall.getParserPosition(),
+                      aggFunction, aggregateCall.isDistinct(),
                       aggregateCall.isApproximate(), aggregateCall.ignoreNulls(),
                       aggregateCall.rexList,
                       ImmutableList.of(target.groupSet.cardinality() + i), -1,
@@ -2044,7 +2047,7 @@ public class SubstitutionVisitor {
     if (!isAllowBuild) {
       return null;
     }
-    return AggregateCall.create(aggregation,
+    return AggregateCall.create(queryAggCall.getParserPosition(), aggregation,
         queryAggCall.isDistinct(), queryAggCall.isApproximate(),
         queryAggCall.ignoreNulls(), queryAggCall.rexList,
         newArgList, -1, queryAggCall.distinctKeys,

--- a/core/src/main/java/org/apache/calcite/rel/core/AggregateCall.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/AggregateCall.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Optionality;
@@ -50,6 +51,14 @@ import static java.util.Objects.requireNonNull;
 public class AggregateCall {
   //~ Instance fields --------------------------------------------------------
 
+  /**
+   * Some aggregate calls may produce runtime errors.  For these
+   * we need to keep around the original source position information
+   * so that the runtime can produce error messages pointing to
+   * the offending source operation.  For "safe" aggregations
+   * this field may be ZERO.
+   */
+  private final SqlParserPos pos;
   private final SqlAggFunction aggFunction;
 
   private final boolean distinct;
@@ -84,7 +93,7 @@ public class AggregateCall {
       List<Integer> argList,
       RelDataType type,
       String name) {
-    this(aggFunction, distinct, false, false,
+    this(SqlParserPos.ZERO, aggFunction, distinct, false, false,
         ImmutableList.of(), argList, -1, null,
         RelCollations.EMPTY, type, name);
   }
@@ -92,6 +101,9 @@ public class AggregateCall {
   /**
    * Creates an AggregateCall.
    *
+   * @param pos         Source position for this aggregate.
+   *                    Ideally it should only be ZERO when the aggregate
+   *                    can never fail at runtime.
    * @param aggFunction Aggregate function
    * @param distinct    Whether distinct
    * @param approximate Whether approximate
@@ -106,11 +118,12 @@ public class AggregateCall {
    * @param type        Result type
    * @param name        Name (may be null)
    */
-  private AggregateCall(SqlAggFunction aggFunction, boolean distinct,
+  private AggregateCall(SqlParserPos pos, SqlAggFunction aggFunction, boolean distinct,
       boolean approximate, boolean ignoreNulls,
       List<RexNode> rexList, List<Integer> argList,
       int filterArg, @Nullable ImmutableBitSet distinctKeys,
       RelCollation collation, RelDataType type, @Nullable String name) {
+    this.pos = pos;
     this.type = requireNonNull(type, "type");
     this.name = name;
     this.aggFunction = requireNonNull(aggFunction, "aggFunction");
@@ -187,6 +200,17 @@ public class AggregateCall {
       @Nullable ImmutableBitSet distinctKeys, RelCollation collation,
       int groupCount,
       RelNode input, @Nullable RelDataType type, @Nullable String name) {
+    return create(SqlParserPos.ZERO, aggFunction, distinct, approximate,
+        ignoreNulls, rexList, argList, filterArg, distinctKeys, collation, groupCount,
+        input, type, name);
+  }
+
+  public static AggregateCall create(SqlParserPos pos, SqlAggFunction aggFunction,
+      boolean distinct, boolean approximate, boolean ignoreNulls,
+      List<RexNode> rexList, List<Integer> argList, int filterArg,
+      @Nullable ImmutableBitSet distinctKeys, RelCollation collation,
+      int groupCount,
+      RelNode input, @Nullable RelDataType type, @Nullable String name) {
     if (type == null) {
       final RelDataTypeFactory typeFactory =
           input.getCluster().getTypeFactory();
@@ -198,7 +222,7 @@ public class AggregateCall {
               types, groupCount, filterArg >= 0);
       type = aggFunction.inferReturnType(callBinding);
     }
-    return create(aggFunction, distinct, approximate, ignoreNulls,
+    return create(pos, aggFunction, distinct, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -245,9 +269,18 @@ public class AggregateCall {
       List<RexNode> rexList, List<Integer> argList, int filterArg,
       @Nullable ImmutableBitSet distinctKeys, RelCollation collation,
       RelDataType type, @Nullable String name) {
+    return create(SqlParserPos.ZERO, aggFunction, distinct, approximate,
+        ignoreNulls, rexList, argList, filterArg, distinctKeys, collation, type, name);
+  }
+
+  public static AggregateCall create(SqlParserPos pos, SqlAggFunction aggFunction,
+      boolean distinct, boolean approximate, boolean ignoreNulls,
+      List<RexNode> rexList, List<Integer> argList, int filterArg,
+      @Nullable ImmutableBitSet distinctKeys, RelCollation collation,
+      RelDataType type, @Nullable String name) {
     final boolean distinct2 = distinct
         && (aggFunction.getDistinctOptionality() != Optionality.IGNORED);
-    return new AggregateCall(aggFunction, distinct2, approximate, ignoreNulls,
+    return new AggregateCall(pos, aggFunction, distinct2, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -264,7 +297,7 @@ public class AggregateCall {
   /** Withs {@link #isDistinct()}. */
   public AggregateCall withDistinct(boolean distinct) {
     return distinct == this.distinct ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -281,7 +314,7 @@ public class AggregateCall {
   /** Withs {@link #isApproximate()}. */
   public AggregateCall withApproximate(boolean approximate) {
     return approximate == this.approximate ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -297,7 +330,7 @@ public class AggregateCall {
   /** Withs {@link #ignoreNulls()}. */
   public AggregateCall withIgnoreNulls(boolean ignoreNulls) {
     return ignoreNulls == this.ignoreNulls ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -323,7 +356,7 @@ public class AggregateCall {
   /** Withs {@link #getCollation()}. */
   public AggregateCall withCollation(RelCollation collation) {
     return collation.equals(this.collation) ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -341,7 +374,7 @@ public class AggregateCall {
   /** Withs {@link #getArgList()}. */
   public AggregateCall withArgList(List<Integer> argList) {
     return argList.equals(this.argList) ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -349,7 +382,7 @@ public class AggregateCall {
   public AggregateCall withDistinctKeys(
       @Nullable ImmutableBitSet distinctKeys) {
     return Objects.equals(distinctKeys, this.distinctKeys) ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -374,7 +407,7 @@ public class AggregateCall {
   /** Withs {@link #name}. */
   public AggregateCall withName(@Nullable String name) {
     return Objects.equals(name, this.name) ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -435,11 +468,16 @@ public class AggregateCall {
   /** Withs {@link #filterArg}. */
   public AggregateCall withFilter(int filterArg) {
     return filterArg == this.filterArg ? this
-        : new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+        : new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
             rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
+  public SqlParserPos getParserPosition() {
+    return this.pos;
+  }
+
   @Override public boolean equals(@Nullable Object o) {
+    // Intentionally ignore the position
     return o == this
         || o instanceof AggregateCall
         && aggFunction.equals(((AggregateCall) o).aggFunction)
@@ -453,6 +491,7 @@ public class AggregateCall {
   }
 
   @Override public int hashCode() {
+    // Ignore the position!
     return Objects.hash(aggFunction, distinct, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation);
   }
@@ -492,7 +531,7 @@ public class AggregateCall {
   @Deprecated // to be removed before 2.0
   public AggregateCall copy(List<Integer> argList, int filterArg,
       @Nullable ImmutableBitSet distinctKeys, RelCollation collation) {
-    return new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+    return new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -500,21 +539,21 @@ public class AggregateCall {
   public AggregateCall copy(List<Integer> argList, int filterArg,
       RelCollation collation) {
     // ignoring distinctKeys is error-prone
-    return new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+    return new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
   @Deprecated // to be removed before 2.0
   public AggregateCall copy(List<Integer> argList, int filterArg) {
     // ignoring distinctKeys, collation is error-prone
-    return new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+    return new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
   @Deprecated // to be removed before 2.0
   public AggregateCall copy(List<Integer> argList) {
     // ignoring filterArg, distinctKeys, collation is error-prone
-    return new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+    return new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation, type, name);
   }
 
@@ -539,7 +578,7 @@ public class AggregateCall {
             && filterArg == this.filterArg
             ? type
             : null;
-    return create(aggFunction, distinct, approximate, ignoreNulls,
+    return create(pos, aggFunction, distinct, approximate, ignoreNulls,
         rexList, argList, filterArg, distinctKeys, collation,
         newGroupKeyCount, input, newType, getName());
   }
@@ -547,7 +586,7 @@ public class AggregateCall {
   /** Creates a copy of this aggregate call, applying a mapping to its
    * arguments. */
   public AggregateCall transform(Mappings.TargetMapping mapping) {
-    return new AggregateCall(aggFunction, distinct, approximate, ignoreNulls,
+    return new AggregateCall(pos, aggFunction, distinct, approximate, ignoreNulls,
         rexList, Mappings.apply2((Mapping) mapping, argList),
         hasFilter() ? Mappings.apply(mapping, filterArg) : -1,
         distinctKeys == null ? null : distinctKeys.permute(mapping),

--- a/core/src/main/java/org/apache/calcite/rel/core/Window.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Window.java
@@ -384,7 +384,7 @@ public abstract class Window extends SingleRel implements Hintable {
         @Override public AggregateCall get(int index) {
           final RexWinAggCall aggCall = aggCalls.get(index);
           final SqlAggFunction op = (SqlAggFunction) aggCall.getOperator();
-          return AggregateCall.create(op, aggCall.distinct, false,
+          return AggregateCall.create(aggCall.getParserPosition(), op, aggCall.distinct, false,
               aggCall.ignoreNulls, ImmutableList.of(),
               getProjectOrdinals(aggCall.getOperands()),
               -1, null, RelCollations.EMPTY,

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1697,7 +1697,7 @@ public abstract class SqlImplementor {
             && ((RexInputRef) op0).getIndex() >= leftContext.fieldCount) {
           // Arguments were of form 'op1 = op0'
           final SqlOperator op2 = requireNonNull(call.getOperator().reverse());
-          return (RexCall) rexBuilder.makeCall(op2, op1, op0);
+          return (RexCall) rexBuilder.makeCall(call.getParserPosition(), op2, op1, op0);
         }
         // fall through
       default:

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
@@ -334,7 +334,7 @@ public final class AggregateExpandDistinctAggregatesRule
       // as-is all the non-distinct aggregates
       if (!aggCall.isDistinct()) {
         final AggregateCall newCall =
-            AggregateCall.create(aggCall.getAggregation(), false,
+            AggregateCall.create(aggCall.getParserPosition(), aggCall.getAggregation(), false,
                 aggCall.isApproximate(), aggCall.ignoreNulls(), aggCall.rexList,
                 aggCall.getArgList(), -1, aggCall.distinctKeys,
                 aggCall.collation, bottomGroupSet.cardinality(),
@@ -360,7 +360,8 @@ public final class AggregateExpandDistinctAggregatesRule
           newArgList.add(bottomGroups.headSet(arg, false).size());
         }
         newCall =
-            AggregateCall.create(aggCall.getAggregation(),
+            AggregateCall.create(aggCall.getParserPosition(),
+                aggCall.getAggregation(),
                 false,
                 aggCall.isApproximate(),
                 aggCall.ignoreNulls(),
@@ -380,14 +381,16 @@ public final class AggregateExpandDistinctAggregatesRule
         final List<Integer> newArgs = ImmutableList.of(arg);
         if (aggCall.getAggregation().getKind() == SqlKind.COUNT) {
           newCall =
-              AggregateCall.create(new SqlSumEmptyIsZeroAggFunction(), false,
+              AggregateCall.create(aggCall.getParserPosition(),
+                  new SqlSumEmptyIsZeroAggFunction(), false,
                   aggCall.isApproximate(), aggCall.ignoreNulls(),
                   aggCall.rexList, newArgs, -1, aggCall.distinctKeys,
                   aggCall.collation, originalGroupSet.cardinality(),
                   relBuilder.peek(), null, aggCall.getName());
         } else {
           newCall =
-              AggregateCall.create(aggCall.getAggregation(), false,
+              AggregateCall.create(aggCall.getParserPosition(),
+                  aggCall.getAggregation(), false,
                   aggCall.isApproximate(), aggCall.ignoreNulls(),
                   aggCall.rexList, newArgs, -1, aggCall.distinctKeys,
                   aggCall.collation, originalGroupSet.cardinality(),
@@ -540,7 +543,7 @@ public final class AggregateExpandDistinctAggregatesRule
                 "filters.get(of(newGroupSet, aggCall.filterArg))");
       }
       final AggregateCall newCall =
-          AggregateCall.create(aggregation, false,
+          AggregateCall.create(aggCall.getParserPosition(), aggregation, false,
               aggCall.isApproximate(), aggCall.ignoreNulls(),
               aggCall.rexList, newArgList, newFilterArg,
               aggCall.distinctKeys, aggCall.collation,
@@ -755,7 +758,7 @@ public final class AggregateExpandDistinctAggregatesRule
         newArgs.add(requireNonNull(sourceOf.get(arg), () -> "sourceOf.get(" + arg + ")"));
       }
       final AggregateCall newAggCall =
-          AggregateCall.create(aggCall.getAggregation(), false,
+          AggregateCall.create(aggCall.getParserPosition(), aggCall.getAggregation(), false,
               aggCall.isApproximate(), aggCall.ignoreNulls(), aggCall.rexList,
               newArgs, -1, aggCall.distinctKeys, aggCall.collation,
               aggCall.getType(), aggCall.getName());
@@ -843,7 +846,7 @@ public final class AggregateExpandDistinctAggregatesRule
                 () -> "sourceOf.get(" + arg + ")"));
       }
       final AggregateCall newAggCall =
-          AggregateCall.create(aggCall.getAggregation(), false,
+          AggregateCall.create(aggCall.getParserPosition(), aggCall.getAggregation(), false,
               aggCall.isApproximate(), aggCall.ignoreNulls(),
               aggCall.rexList, newArgs, -1,
               aggCall.distinctKeys, aggCall.collation,

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandWithinDistinctRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandWithinDistinctRule.java
@@ -347,7 +347,7 @@ public class AggregateExpandWithinDistinctRule
     Ord.forEach(aggCallList, (c, i) -> {
       if (c.distinctKeys == null) {
         RelBuilder.AggCall aggCall =
-            b.aggregateCall(c.getAggregation(), b.fields(c.getArgList()));
+            b.aggregateCall(c.getParserPosition(), c.getAggregation(), b.fields(c.getArgList()));
         registrar.registerAgg(i,
             c.hasFilter()
                 ? aggCall.filter(b.field(c.filterArg))
@@ -411,7 +411,7 @@ public class AggregateExpandWithinDistinctRule
       RelBuilder.AggCall aggCall;
       if (c.distinctKeys == null) {
         aggCall =
-            b.aggregateCall(SqlStdOperatorTable.MIN,
+            b.aggregateCall(c.getParserPosition(), SqlStdOperatorTable.MIN,
                 b.field(registrar.getAgg(i)));
       } else {
         // The inputs to this aggregate are outputs from MIN() calls from the
@@ -423,7 +423,7 @@ public class AggregateExpandWithinDistinctRule
         // ignore null inputs, we add a filter based on a COUNT() in the inner
         // aggregate.
         aggCall =
-            b.aggregateCall(c.getAggregation(),
+            b.aggregateCall(c.getParserPosition(), c.getAggregation(),
                 b.fields(registrar.fields(c.getArgList(), c.filterArg)));
 
         if (mustBeCounted(c)) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateFilterTransposeRule.java
@@ -145,7 +145,8 @@ public class AggregateFilterTransposeRule
           return;
         }
         topAggCallList.add(
-            AggregateCall.create(rollup, aggregateCall.isDistinct(),
+            AggregateCall.create(aggregateCall.getParserPosition(),
+                rollup, aggregateCall.isDistinct(),
                 aggregateCall.isApproximate(), aggregateCall.ignoreNulls(),
                 aggregateCall.rexList, ImmutableList.of(i++), -1,
                 aggregateCall.distinctKeys, aggregateCall.collation,

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java
@@ -133,7 +133,7 @@ public class AggregateRemoveRule
                 aggregate.getGroupSet(), aggregate.groupSets, aggCall);
         if (constant != null) {
           final RexNode cast =
-              rexBuilder.ensureType(aggCall.type, constant, false);
+              rexBuilder.ensureType(aggCall.getParserPosition(), aggCall.type, constant, false);
           projects.add(cast);
           continue;
         }
@@ -143,7 +143,8 @@ public class AggregateRemoveRule
       final RexNode singleton =
           splitter.singleton(rexBuilder, input.getRowType(), aggCall);
       final RexNode cast =
-          rexBuilder.ensureType(aggCall.type, singleton, false);
+          rexBuilder.ensureType(
+              aggCall.getParserPosition(), aggCall.type, singleton, false);
       projects.add(cast);
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateStarTableRule.java
@@ -214,7 +214,7 @@ public class AggregateStarTableRule
       if (roll == null) {
         break tryRoll;
       }
-      return AggregateCall.create(roll, false, call.isApproximate(),
+      return AggregateCall.create(call.getParserPosition(), roll, false, call.isApproximate(),
           call.ignoreNulls(), call.rexList, ImmutableList.of(offset + i), -1,
           call.distinctKeys, call.collation,
           groupCount, relBuilder.peek(), null, call.name);
@@ -231,7 +231,7 @@ public class AggregateStarTableRule
         }
         newArgs.add(z);
       }
-      return AggregateCall.create(aggregation, false,
+      return AggregateCall.create(call.getParserPosition(), aggregation, false,
           call.isApproximate(), call.ignoreNulls(), call.rexList,
           newArgs, -1, call.distinctKeys, call.collation,
           groupCount, relBuilder.peek(), null, call.name);

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
@@ -213,7 +213,7 @@ public class AggregateUnionTransposeRule
         aggType = origCall.getType();
       }
       AggregateCall newCall =
-          AggregateCall.create(aggFun, origCall.isDistinct(),
+          AggregateCall.create(ord.e.getParserPosition(), aggFun, origCall.isDistinct(),
               origCall.isApproximate(), origCall.ignoreNulls(),
               origCall.rexList, ImmutableList.of(groupCount + ord.i), -1,
               origCall.distinctKeys, origCall.collation,

--- a/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ProjectAggregateMergeRule.java
@@ -164,7 +164,7 @@ public class ProjectAggregateMergeRule
   private static int findSum0(RelDataTypeFactory typeFactory, AggregateCall sum,
       List<AggregateCall> aggCallList) {
     final AggregateCall sum0 =
-        AggregateCall.create(SqlStdOperatorTable.SUM0, sum.isDistinct(),
+        AggregateCall.create(sum.getParserPosition(), SqlStdOperatorTable.SUM0, sum.isDistinct(),
             sum.isApproximate(), sum.ignoreNulls(), sum.rexList,
             sum.getArgList(), sum.filterArg, sum.distinctKeys, sum.collation,
             typeFactory.createTypeWithNullability(sum.type, false), null);

--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceDecimalsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceDecimalsRule.java
@@ -34,6 +34,7 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.tools.RelBuilderFactory;
@@ -414,7 +415,7 @@ public class ReduceDecimalsRule
      * @param scale a value from zero to max precision - 1
      * @return value * 10^scale as an exact numeric value
      */
-    protected RexNode scaleUp(RexNode value, int scale) {
+    protected RexNode scaleUp(SqlParserPos pos, RexNode value, int scale) {
       assert scale >= 0;
       assert scale
           < builder.getTypeFactory().getTypeSystem().getMaxNumericPrecision();
@@ -422,6 +423,7 @@ public class ReduceDecimalsRule
         return value;
       }
       return builder.makeCall(
+          pos,
           SqlStdOperatorTable.MULTIPLY,
           value,
           makeScaleFactor(scale));
@@ -438,7 +440,7 @@ public class ReduceDecimalsRule
      * @return value/10^scale, rounded away from zero and returned as an
      * exact numeric value
      */
-    protected RexNode scaleDown(RexNode value, int scale) {
+    protected RexNode scaleDown(SqlParserPos pos, RexNode value, int scale) {
       final int maxPrecision =
           builder.getTypeFactory().getTypeSystem().getMaxNumericPrecision();
       assert scale >= 0 && scale <= maxPrecision;
@@ -448,12 +450,12 @@ public class ReduceDecimalsRule
       if (scale == maxPrecision) {
         long half = BigInteger.TEN.pow(scale - 1).longValue() * 5;
         return makeCase(
-            builder.makeCall(
+            builder.makeCall(pos,
                 SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
                 value,
                 makeExactLiteral(half)),
             makeExactLiteral(1),
-            builder.makeCall(
+            builder.makeCall(pos,
                 SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
                 value,
                 makeExactLiteral(-half)),
@@ -463,13 +465,13 @@ public class ReduceDecimalsRule
       RexNode roundFactor = makeRoundFactor(scale);
       RexNode roundValue =
           makeCase(
-              builder.makeCall(
+              builder.makeCall(pos,
                   SqlStdOperatorTable.GREATER_THAN,
                   value,
                   makeExactLiteral(0)),
-              makePlus(value, roundFactor),
-              makeMinus(value, roundFactor));
-      return makeDivide(
+              makePlus(pos, value, roundFactor),
+              makeMinus(pos, value, roundFactor));
+      return makeDivide(pos,
           roundValue,
           makeScaleFactor(scale));
     }
@@ -483,15 +485,16 @@ public class ReduceDecimalsRule
      * @param scale a value from zero to max precision
      * @return value/10^scale as a double precision value
      */
-    protected RexNode scaleDownDouble(RexNode value, int scale) {
+    protected RexNode scaleDownDouble(SqlParserPos pos, RexNode value, int scale) {
       assert scale >= 0;
       assert scale
           <= builder.getTypeFactory().getTypeSystem().getMaxNumericPrecision();
-      RexNode cast = ensureType(real8, value);
+      RexNode cast = ensureType(pos, real8, value);
       if (scale == 0) {
         return cast;
       }
       return makeDivide(
+          pos,
           cast,
           makeApproxScaleFactor(scale));
     }
@@ -513,7 +516,7 @@ public class ReduceDecimalsRule
      * @return value * 10^scale, returned as an exact or approximate value
      * corresponding to the input value
      */
-    protected RexNode ensureScale(RexNode value, int scale, int required) {
+    protected RexNode ensureScale(SqlParserPos pos, RexNode value, int scale, int required) {
       final RelDataTypeSystem typeSystem =
           builder.getTypeFactory().getTypeSystem();
       final int maxPrecision = typeSystem.getMaxNumericPrecision();
@@ -525,6 +528,7 @@ public class ReduceDecimalsRule
       int scaleDiff = required - scale;
       if (SqlTypeUtil.isApproximateNumeric(value.getType())) {
         return makeMultiply(
+            pos,
             value,
             makeApproxScaleFactor(scaleDiff));
       }
@@ -537,7 +541,7 @@ public class ReduceDecimalsRule
             + "source type is too large to be encoded by the "
             + "target type");
       }
-      return scaleUp(value, scaleDiff);
+      return scaleUp(pos, value, scaleDiff);
     }
 
     /**
@@ -546,9 +550,9 @@ public class ReduceDecimalsRule
      * @param decimalNode the decimal value as an opaque type
      * @return an integer representation of the decimal value
      */
-    protected RexNode decodeValue(RexNode decimalNode) {
+    protected RexNode decodeValue(SqlParserPos pos, RexNode decimalNode) {
       assert SqlTypeUtil.isDecimal(decimalNode.getType());
-      return builder.decodeIntervalOrDecimal(decimalNode);
+      return builder.decodeIntervalOrDecimal(pos, decimalNode);
     }
 
     /**
@@ -562,7 +566,7 @@ public class ReduceDecimalsRule
     protected RexNode accessValue(RexNode node) {
       assert SqlTypeUtil.isNumeric(node.getType());
       if (SqlTypeUtil.isDecimal(node.getType())) {
-        return decodeValue(node);
+        return decodeValue(SqlParserPos.ZERO, node);
       }
       return node;
     }
@@ -577,8 +581,8 @@ public class ReduceDecimalsRule
      * @param decimalType type integer will be reinterpreted as
      * @return the integer representation reinterpreted as a decimal type
      */
-    protected RexNode encodeValue(RexNode value, RelDataType decimalType) {
-      return encodeValue(value, decimalType, false);
+    protected RexNode encodeValue(SqlParserPos pos, RexNode value, RelDataType decimalType) {
+      return encodeValue(pos, value, decimalType, false);
     }
 
     /**
@@ -598,11 +602,12 @@ public class ReduceDecimalsRule
      * @return the integer reinterpreted as an opaque decimal type
      */
     protected RexNode encodeValue(
+        SqlParserPos pos,
         RexNode value,
         RelDataType decimalType,
         boolean checkOverflow) {
       return builder.encodeIntervalOrDecimal(
-          value, decimalType, checkOverflow);
+          pos, value, decimalType, checkOverflow);
     }
 
     /**
@@ -616,8 +621,8 @@ public class ReduceDecimalsRule
      * @param node expression
      * @return a casted expression or the original expression
      */
-    protected RexNode ensureType(RelDataType type, RexNode node) {
-      return ensureType(type, node, true);
+    protected RexNode ensureType(SqlParserPos pos, RelDataType type, RexNode node) {
+      return ensureType(pos, type, node, true);
     }
 
     /**
@@ -633,10 +638,11 @@ public class ReduceDecimalsRule
      * @return a casted expression or the original expression
      */
     protected RexNode ensureType(
+        SqlParserPos pos,
         RelDataType type,
         RexNode node,
         boolean matchNullability) {
-      return builder.ensureType(type, node, matchNullability);
+      return builder.ensureType(pos, type, node, matchNullability);
     }
 
     protected RexNode makeCase(
@@ -666,36 +672,44 @@ public class ReduceDecimalsRule
     }
 
     protected RexNode makePlus(
+        SqlParserPos pos,
         RexNode a,
         RexNode b) {
       return builder.makeCall(
+          pos,
           SqlStdOperatorTable.PLUS,
           a,
           b);
     }
 
     protected RexNode makeMinus(
+        SqlParserPos pos,
         RexNode a,
         RexNode b) {
       return builder.makeCall(
+          pos,
           SqlStdOperatorTable.MINUS,
           a,
           b);
     }
 
     protected RexNode makeDivide(
+        SqlParserPos pos,
         RexNode a,
         RexNode b) {
       return builder.makeCall(
+          pos,
           SqlStdOperatorTable.DIVIDE_INTEGER,
           a,
           b);
     }
 
     protected RexNode makeMultiply(
+        SqlParserPos pos,
         RexNode a,
         RexNode b) {
       return builder.makeCall(
+          pos,
           SqlStdOperatorTable.MULTIPLY,
           a,
           b);
@@ -739,26 +753,27 @@ public class ReduceDecimalsRule
       assert SqlTypeUtil.isDecimal(fromType)
           || SqlTypeUtil.isDecimal(toType);
 
+      SqlParserPos pos = call.getParserPosition();
       if (SqlTypeUtil.isIntType(toType)) {
         // decimal to int
-        return ensureType(
+        return ensureType(pos,
             toType,
-            scaleDown(
-                decodeValue(operand),
+            scaleDown(pos,
+                decodeValue(pos, operand),
                 fromType.getScale()),
             false);
       } else if (SqlTypeUtil.isApproximateNumeric(toType)) {
         // decimal to floating point
-        return ensureType(
+        return ensureType(pos,
             toType,
-            scaleDownDouble(
-                decodeValue(operand),
+            scaleDownDouble(pos,
+                decodeValue(pos, operand),
                 fromType.getScale()),
             false);
       } else if (SqlTypeUtil.isApproximateNumeric(fromType)) {
         // real to decimal
-        return encodeValue(
-            ensureScale(
+        return encodeValue(pos,
+            ensureScale(pos,
                 operand,
                 0,
                 toType.getScale()),
@@ -784,8 +799,8 @@ public class ReduceDecimalsRule
 
       if (SqlTypeUtil.isIntType(fromType)) {
         // int to decimal
-        return encodeValue(
-            ensureScale(
+        return encodeValue(pos,
+            ensureScale(pos,
                 operand,
                 0,
                 toType.getScale()),
@@ -795,20 +810,20 @@ public class ReduceDecimalsRule
           SqlTypeUtil.isDecimal(fromType)
               && SqlTypeUtil.isDecimal(toType)) {
         // decimal to decimal
-        RexNode value = decodeValue(operand);
+        RexNode value = decodeValue(pos, operand);
         RexNode scaled;
         if (fromScale <= toScale) {
-          scaled = ensureScale(value, fromScale, toScale);
+          scaled = ensureScale(pos, value, fromScale, toScale);
         } else {
           if (toDigits == fromDigits) {
             // rounding away from zero may cause an overflow
             // for example: cast(9.99 as decimal(2,1))
             checkOverflow = true;
           }
-          scaled = scaleDown(value, fromScale - toScale);
+          scaled = scaleDown(pos, value, fromScale - toScale);
         }
 
-        return encodeValue(scaled, toType, checkOverflow);
+        return encodeValue(pos, scaled, toType, checkOverflow);
       } else {
         throw Util.needToImplement(
             "Reduce decimal cast from " + fromType + " to " + toType);
@@ -830,6 +845,7 @@ public class ReduceDecimalsRule
     }
 
     @Override public RexNode expand(RexCall call) {
+      final SqlParserPos pos = call.getParserPosition();
       List<RexNode> operands = call.operands;
       assert operands.size() == 2;
       RelDataType typeA = operands.get(0).getType();
@@ -843,13 +859,13 @@ public class ReduceDecimalsRule
         if (SqlTypeUtil.isApproximateNumeric(typeA)) {
           newOperands =
               ImmutableList.of(operands.get(0),
-                  ensureType(real8, operands.get(1)));
+                  ensureType(pos, real8, operands.get(1)));
         } else {
           newOperands =
-              ImmutableList.of(ensureType(real8, operands.get(0)),
+              ImmutableList.of(ensureType(pos, real8, operands.get(0)),
                   operands.get(1));
         }
-        return builder.makeCall(
+        return builder.makeCall(pos,
             call.getOperator(),
             newOperands);
       }
@@ -896,15 +912,16 @@ public class ReduceDecimalsRule
 
     private RexNode expandPlusMinus(RexCall call, List<RexNode> operands) {
       RelDataType outType = call.getType();
+      final SqlParserPos pos = call.getParserPosition();
       int outScale = outType.getScale();
-      return encodeValue(
-          builder.makeCall(
+      return encodeValue(pos,
+          builder.makeCall(pos,
               call.getOperator(),
-              ensureScale(
+              ensureScale(pos,
                   accessValue(operands.get(0)),
                   scaleA,
                   outScale),
-              ensureScale(
+              ensureScale(pos,
                   accessValue(operands.get(1)),
                   scaleB,
                   outScale)),
@@ -913,22 +930,24 @@ public class ReduceDecimalsRule
 
     private RexNode expandDivide(RexCall call, List<RexNode> operands) {
       RelDataType outType = call.getType();
+      final SqlParserPos pos = call.getParserPosition();
       RexNode dividend =
-          builder.makeCall(
+          builder.makeCall(pos,
               call.getOperator(),
-              ensureType(
+              ensureType(pos,
                   real8,
                   accessValue(operands.get(0))),
               ensureType(
+                  pos,
                   real8,
                   accessValue(operands.get(1))));
       int scaleDifference = outType.getScale() - scaleA + scaleB;
       RexNode rescale =
-          builder.makeCall(
+          builder.makeCall(pos,
               SqlStdOperatorTable.MULTIPLY,
               dividend,
               makeApproxScaleFactor(scaleDifference));
-      return encodeValue(rescale, outType);
+      return encodeValue(pos, rescale, outType);
     }
 
     private RexNode expandTimes(RexCall call, List<RexNode> operands) {
@@ -936,6 +955,7 @@ public class ReduceDecimalsRule
       // a number with scale = scaleA + scaleB. If the result type has
       // a lower scale, then the number should be scaled down.
       int divisor = scaleA + scaleB - call.getType().getScale();
+      final SqlParserPos pos = call.getParserPosition();
 
       if (builder.getTypeFactory().getTypeSystem().shouldUseDoubleMultiplication(
           builder.getTypeFactory(),
@@ -945,17 +965,17 @@ public class ReduceDecimalsRule
         // cast (a as double) * cast (b as double)
         //     / 10^divisor
         RexNode division =
-            makeDivide(
-                makeMultiply(
-                    ensureType(real8, accessValue(operands.get(0))),
-                    ensureType(real8, accessValue(operands.get(1)))),
+            makeDivide(pos,
+                makeMultiply(pos,
+                    ensureType(pos, real8, accessValue(operands.get(0))),
+                    ensureType(pos, real8, accessValue(operands.get(1)))),
                 makeApproxLiteral(BigDecimal.TEN.pow(divisor)));
-        return encodeValue(division, call.getType(), true);
+        return encodeValue(pos, division, call.getType(), true);
       } else {
         // Exact implementation: scaleDown(a * b)
-        return encodeValue(
-            scaleDown(
-                builder.makeCall(
+        return encodeValue(pos,
+            scaleDown(pos,
+                builder.makeCall(pos,
                     call.getOperator(),
                     accessValue(operands.get(0)),
                     accessValue(operands.get(1))),
@@ -965,20 +985,22 @@ public class ReduceDecimalsRule
     }
 
     private RexNode expandComparison(RexCall call, List<RexNode> operands) {
+      final SqlParserPos pos = call.getParserPosition();
       int commonScale = Math.max(scaleA, scaleB);
-      return builder.makeCall(
+      return builder.makeCall(pos,
           call.getOperator(),
-          ensureScale(
+          ensureScale(pos,
               accessValue(operands.get(0)),
               scaleA,
               commonScale),
-          ensureScale(
+          ensureScale(pos,
               accessValue(operands.get(1)),
               scaleB,
               commonScale));
     }
 
     private RexNode expandMod(RexCall call, List<RexNode> operands) {
+      final SqlParserPos pos = call.getParserPosition();
       assert SqlTypeUtil.isExactNumeric(requireNonNull(typeA, "typeA"));
       assert SqlTypeUtil.isExactNumeric(requireNonNull(typeB, "typeB"));
       if (scaleA != 0 || scaleB != 0) {
@@ -986,15 +1008,15 @@ public class ReduceDecimalsRule
             .ex();
       }
       RexNode result =
-          builder.makeCall(
+          builder.makeCall(pos,
               call.getOperator(),
               accessValue(operands.get(0)),
               accessValue(operands.get(1)));
       RelDataType retType = call.getType();
       if (SqlTypeUtil.isDecimal(retType)) {
-        return encodeValue(result, retType);
+        return encodeValue(pos, result, retType);
       }
-      return ensureType(
+      return ensureType(pos,
           call.getType(),
           result);
     }
@@ -1018,9 +1040,10 @@ public class ReduceDecimalsRule
 
     @Override public RexNode expand(RexCall call) {
       assert call.getOperator() == SqlStdOperatorTable.FLOOR;
+      final SqlParserPos pos = call.getParserPosition();
       RexNode decValue = call.operands.get(0);
       int scale = decValue.getType().getScale();
-      RexNode value = decodeValue(decValue);
+      RexNode value = decodeValue(pos, decValue);
       final RelDataTypeSystem typeSystem =
           builder.getTypeFactory().getTypeSystem();
 
@@ -1039,12 +1062,12 @@ public class ReduceDecimalsRule
         rewrite =
             makeCase(
                 makeIsNegative(value),
-                makeDivide(
-                    makePlus(value, round),
+                makeDivide(pos,
+                    makePlus(pos, value, round),
                     scaleFactor),
-                makeDivide(value, scaleFactor));
+                makeDivide(pos, value, scaleFactor));
       }
-      return encodeValue(
+      return encodeValue(pos,
           rewrite,
           call.getType());
     }
@@ -1068,9 +1091,10 @@ public class ReduceDecimalsRule
 
     @Override public RexNode expand(RexCall call) {
       assert call.getOperator() == SqlStdOperatorTable.CEIL;
+      final SqlParserPos pos = call.getParserPosition();
       RexNode decValue = call.operands.get(0);
       int scale = decValue.getType().getScale();
-      RexNode value = decodeValue(decValue);
+      RexNode value = decodeValue(pos, decValue);
       final RelDataTypeSystem typeSystem =
           builder.getTypeFactory().getTypeSystem();
 
@@ -1089,12 +1113,12 @@ public class ReduceDecimalsRule
         rewrite =
             makeCase(
                 makeIsPositive(value),
-                makeDivide(
-                    makePlus(value, round),
+                makeDivide(pos,
+                    makePlus(pos, value, round),
                     scaleFactor),
-                makeDivide(value, scaleFactor));
+                makeDivide(pos, value, scaleFactor));
       }
-      return encodeValue(
+      return encodeValue(pos,
           rewrite,
           call.getType());
     }
@@ -1118,7 +1142,8 @@ public class ReduceDecimalsRule
     }
 
     @Override public RexNode expand(RexCall call) {
-      RelDataType retType = call.getType();
+      final SqlParserPos pos = call.getParserPosition();
+      final RelDataType retType = call.getType();
       int argCount = call.operands.size();
       ImmutableList.Builder<RexNode> opBuilder = ImmutableList.builder();
 
@@ -1128,17 +1153,17 @@ public class ReduceDecimalsRule
           opBuilder.add(call.operands.get(i));
           continue;
         }
-        RexNode expr = ensureType(retType, call.operands.get(i), false);
+        RexNode expr = ensureType(pos, retType, call.operands.get(i), false);
         if (SqlTypeUtil.isDecimal(retType)) {
-          expr = decodeValue(expr);
+          expr = decodeValue(pos, expr);
         }
         opBuilder.add(expr);
       }
 
       RexNode newCall =
-          builder.makeCall(retType, call.getOperator(), opBuilder.build());
+          builder.makeCall(pos, retType, call.getOperator(), opBuilder.build());
       if (SqlTypeUtil.isDecimal(retType)) {
-        newCall = encodeValue(newCall, retType);
+        newCall = encodeValue(pos, newCall, retType);
       }
       return newCall;
     }
@@ -1159,6 +1184,7 @@ public class ReduceDecimalsRule
     }
 
     @Override public RexNode expand(RexCall call) {
+      final SqlParserPos pos = call.getParserPosition();
       ImmutableList.Builder<RexNode> opBuilder = ImmutableList.builder();
       for (RexNode operand : call.operands) {
         if (SqlTypeUtil.isNumeric(operand.getType())) {
@@ -1169,10 +1195,10 @@ public class ReduceDecimalsRule
       }
 
       RexNode newCall =
-          builder.makeCall(call.getType(), call.getOperator(),
+          builder.makeCall(pos, call.getType(), call.getOperator(),
               opBuilder.build());
       if (SqlTypeUtil.isDecimal(call.getType())) {
-        return encodeValue(
+        return encodeValue(pos,
             newCall,
             call.getType());
       } else {
@@ -1212,24 +1238,25 @@ public class ReduceDecimalsRule
     public abstract RelDataType getArgType(RexCall call, int ordinal);
 
     @Override public RexNode expand(RexCall call) {
+      final SqlParserPos pos = call.getParserPosition();
       ImmutableList.Builder<RexNode> opBuilder = ImmutableList.builder();
 
       for (Ord<RexNode> operand : Ord.zip(call.operands)) {
         RelDataType targetType = getArgType(call, operand.i);
         if (SqlTypeUtil.isDecimal(operand.e.getType())) {
-          opBuilder.add(ensureType(targetType, operand.e, true));
+          opBuilder.add(ensureType(pos, targetType, operand.e, true));
         } else {
           opBuilder.add(operand.e);
         }
       }
 
       RexNode ret =
-          builder.makeCall(
+          builder.makeCall(pos,
               call.getType(),
               call.getOperator(),
               opBuilder.build());
       ret =
-          ensureType(
+          ensureType(pos,
               call.getType(),
               ret,
               true);

--- a/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/materialize/MaterializedViewAggregateRule.java
@@ -348,7 +348,7 @@ public abstract class MaterializedViewAggregateRule<C extends MaterializedViewAg
           rexBuilder.makeInputRef(relBuilder.peek(),
               aggregate.getGroupCount() + i);
       aggregateCalls.add(
-          relBuilder.aggregateCall(rollupAgg, operand)
+          relBuilder.aggregateCall(aggCall.getParserPosition(), rollupAgg, operand)
               .distinct(aggCall.isDistinct())
               .approximate(aggCall.isApproximate())
               .as(aggCall.name));
@@ -606,7 +606,7 @@ public abstract class MaterializedViewAggregateRule<C extends MaterializedViewAg
             queryAggregate.getGroupCount() + aggregateCalls.size());
         final RexInputRef operand = rexBuilder.makeInputRef(input, k);
         aggregateCalls.add(
-            relBuilder.aggregateCall(rollupAgg, operand)
+            relBuilder.aggregateCall(queryAggCall.getParserPosition(), rollupAgg, operand)
                 .approximate(queryAggCall.isApproximate())
                 .distinct(queryAggCall.isDistinct())
                 .as(queryAggCall.name));

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -37,6 +37,7 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.fun.SqlCountAggFunction;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.MultisetSqlType;
@@ -257,33 +258,79 @@ public class RexBuilder {
       RelDataType returnType,
       SqlOperator op,
       List<RexNode> exprs) {
-    return new RexCall(returnType, op, exprs);
+    return makeCall(SqlParserPos.ZERO, returnType, op, exprs);
+  }
+
+  /**
+   * Creates a call with a list of arguments and a predetermined type.
+   *
+   * @param pos should be different from ZERO if the call can
+   *            fail at runtime.
+   */
+  public RexNode makeCall(
+      SqlParserPos pos,
+      RelDataType returnType,
+      SqlOperator op,
+      List<RexNode> exprs) {
+    return new RexCall(pos, returnType, op, exprs);
   }
 
   /**
    * Creates a call with an array of arguments.
    *
    * <p>If you already know the return type of the call, then
-   * {@link #makeCall(org.apache.calcite.rel.type.RelDataType, org.apache.calcite.sql.SqlOperator, java.util.List)}
+   * {@link #makeCall(SqlParserPos, RelDataType, SqlOperator, List)}
    * is preferred.
    */
   public RexNode makeCall(
       SqlOperator op,
       List<? extends RexNode> exprs) {
+    return makeCall(SqlParserPos.ZERO, op, exprs);
+  }
+
+  /**
+   * Creates a call with an array of arguments.
+   *
+   * @param pos should be different from ZERO if the call can
+   *            fail at runtime.
+   *
+   * <p>If you already know the return type of the call, then
+   * {@link #makeCall(SqlParserPos, RelDataType, SqlOperator, List)}
+   * is preferred.
+   */
+  public RexNode makeCall(
+      SqlParserPos pos, SqlOperator op,
+      List<? extends RexNode> exprs) {
     final RelDataType type = deriveReturnType(op, exprs);
-    return new RexCall(type, op, exprs);
+    return new RexCall(pos, type, op, exprs);
   }
 
   /**
    * Creates a call with a list of arguments.
    *
    * <p>Equivalent to
-   * <code>makeCall(op, exprList.toArray(new RexNode[exprList.size()]))</code>.
+   * <code>makeCall(ZERO, op, exprList.toArray(new RexNode[exprList.size()]))</code>.
    */
   public final RexNode makeCall(
       SqlOperator op,
       RexNode... exprs) {
-    return makeCall(op, ImmutableList.copyOf(exprs));
+    return makeCall(SqlParserPos.ZERO, op, exprs);
+  }
+
+  /**
+   * Creates a call with a list of arguments.
+   *
+   * @param pos should be different from ZERO if the call can
+   *            fail at runtime.
+   *
+   * <p>Equivalent to
+   * <code>makeCall(pos, op, exprList.toArray(new RexNode[exprList.size()]))</code>.
+   */
+  public final RexNode makeCall(
+      SqlParserPos pos,
+      SqlOperator op,
+      RexNode... exprs) {
+    return makeCall(pos, op, ImmutableList.copyOf(exprs));
   }
 
   /**
@@ -585,12 +632,52 @@ public class RexBuilder {
     return makeCast(type, exp, false, false, constantNull);
   }
 
+  /**
+   * Creates a call to the CAST operator.
+   *
+   * @param pos  Parser position of the cast.
+   * @param type Type to cast to
+   * @param exp  Expression being cast
+   * @return Call to CAST operator
+   */
+  public RexNode makeCast(
+      SqlParserPos pos,
+      RelDataType type,
+      RexNode exp) {
+    return makeCast(pos, type, exp, false, false, constantNull);
+  }
+
   @Deprecated // to be removed before 2.0
   public RexNode makeCast(
       RelDataType type,
       RexNode exp,
       boolean matchNullability) {
     return makeCast(type, exp, matchNullability, false, constantNull);
+  }
+
+  /**
+   * Creates a call to the CAST operator, expanding if possible, and optionally
+   * also preserving nullability, and optionally in safe mode.
+   *
+   * <p>Tries to expand the cast, and therefore the result may be something
+   * other than a {@link RexCall} to the CAST operator, such as a
+   * {@link RexLiteral}.
+   *
+   * @param pos  Parser position
+   * @param type Type to cast to
+   * @param exp  Expression being cast
+   * @param matchNullability Whether to ensure the result has the same
+   * nullability as {@code type}
+   * @param safe Whether to return NULL if cast fails
+   * @return Call to CAST operator
+   */
+  public RexNode makeCast(
+      SqlParserPos pos,
+      RelDataType type,
+      RexNode exp,
+      boolean matchNullability,
+      boolean safe) {
+    return makeCast(pos, type, exp, matchNullability, safe, constantNull);
   }
 
   /**
@@ -634,6 +721,33 @@ public class RexBuilder {
    * @return Call to CAST operator
    */
   public RexNode makeCast(
+      RelDataType type,
+      RexNode exp,
+      boolean matchNullability,
+      boolean safe,
+      RexLiteral format) {
+    return makeCast(SqlParserPos.ZERO, type, exp, matchNullability, safe, format);
+  }
+
+  /**
+   * Creates a call to the CAST operator, expanding if possible, and optionally
+   * also preserving nullability, and optionally in safe mode.
+   *
+   * <p>Tries to expand the cast, and therefore the result may be something
+   * other than a {@link RexCall} to the CAST operator, such as a
+   * {@link RexLiteral}.
+   *
+   * @param pos  Parser position
+   * @param type Type to cast to
+   * @param exp  Expression being cast
+   * @param matchNullability Whether to ensure the result has the same
+   * nullability as {@code type}
+   * @param safe Whether to return NULL if cast fails
+   * @param format Type Format to cast into
+   * @return Call to CAST operator
+   */
+  public RexNode makeCast(
+      SqlParserPos pos,
       RelDataType type,
       RexNode exp,
       boolean matchNullability,
@@ -705,13 +819,13 @@ public class RexBuilder {
         if (type.isNullable()
             && !literal2.getType().isNullable()
             && matchNullability) {
-          return makeAbstractCast(type, literal2, safe, format);
+          return makeAbstractCast(pos, type, literal2, safe, format);
         }
         return literal2;
       }
     } else if (SqlTypeUtil.isExactNumeric(type)
         && SqlTypeUtil.isInterval(exp.getType())) {
-      return makeCastIntervalToExact(type, exp);
+      return makeCastIntervalToExact(pos, type, exp);
     } else if (sqlType == SqlTypeName.BOOLEAN
         && SqlTypeUtil.isExactNumeric(exp.getType())) {
       return makeCastExactToBoolean(type, exp);
@@ -719,7 +833,7 @@ public class RexBuilder {
         && SqlTypeUtil.isExactNumeric(type)) {
       return makeCastBooleanToExact(type, exp);
     }
-    return makeAbstractCast(type, exp, safe, format);
+    return makeAbstractCast(pos, type, exp, safe, format);
   }
 
   /** Returns the lowest granularity unit for the given unit.
@@ -824,17 +938,22 @@ public class RexBuilder {
             casted, makeNullLiteral(toType)));
   }
 
-  private RexNode makeCastIntervalToExact(RelDataType toType, RexNode exp) {
+  private RexNode makeCastIntervalToExact(SqlParserPos pos, RelDataType toType, RexNode exp) {
     final TimeUnit endUnit = exp.getType().getSqlTypeName().getEndUnit();
     final TimeUnit baseUnit = baseUnit(exp.getType().getSqlTypeName());
     final BigDecimal multiplier = baseUnit.multiplier;
     final BigDecimal divider = endUnit.multiplier;
     RexNode value =
-        multiplyDivide(decodeIntervalOrDecimal(exp), multiplier, divider);
-    return ensureType(toType, value, false);
+        multiplyDivide(pos, decodeIntervalOrDecimal(pos, exp), multiplier, divider);
+    return ensureType(pos, toType, value, false);
   }
 
   public RexNode multiplyDivide(RexNode e, BigDecimal multiplier,
+      BigDecimal divider) {
+    return multiplyDivide(SqlParserPos.ZERO, e, multiplier, divider);
+  }
+
+  public RexNode multiplyDivide(SqlParserPos pos, RexNode e, BigDecimal multiplier,
       BigDecimal divider) {
     assert multiplier.signum() > 0;
     assert divider.signum() > 0;
@@ -843,12 +962,12 @@ public class RexBuilder {
       return e;
     case 1:
       // E.g. multiplyDivide(e, 1000, 10) ==> e * 100
-      return makeCall(SqlStdOperatorTable.MULTIPLY, e,
+      return makeCall(pos, SqlStdOperatorTable.MULTIPLY, e,
           makeExactLiteral(
               multiplier.divide(divider, RoundingMode.UNNECESSARY)));
     case -1:
       // E.g. multiplyDivide(e, 10, 1000) ==> e / 100
-      return makeCall(SqlStdOperatorTable.DIVIDE_INTEGER, e,
+      return makeCall(pos, SqlStdOperatorTable.DIVIDE_INTEGER, e,
           makeExactLiteral(
               divider.divide(multiplier, RoundingMode.UNNECESSARY)));
     default:
@@ -876,10 +995,18 @@ public class RexBuilder {
       RexNode value,
       RelDataType type,
       boolean checkOverflow) {
+    return encodeIntervalOrDecimal(SqlParserPos.ZERO, value, type, checkOverflow);
+  }
+
+  public RexNode encodeIntervalOrDecimal(
+      SqlParserPos pos,
+      RexNode value,
+      RelDataType type,
+      boolean checkOverflow) {
     RelDataType bigintType =
         typeFactory.createSqlType(SqlTypeName.BIGINT);
-    RexNode cast = ensureType(bigintType, value, true);
-    return makeReinterpretCast(type, cast, makeLiteral(checkOverflow));
+    RexNode cast = ensureType(pos, bigintType, value, true);
+    return makeReinterpretCast(pos, type, cast, makeLiteral(checkOverflow));
   }
 
   /**
@@ -889,10 +1016,14 @@ public class RexBuilder {
    * @return an integer representation of the decimal value
    */
   public RexNode decodeIntervalOrDecimal(RexNode node) {
+    return decodeIntervalOrDecimal(SqlParserPos.ZERO, node);
+  }
+
+  public RexNode decodeIntervalOrDecimal(SqlParserPos pos, RexNode node) {
     assert SqlTypeUtil.isDecimal(node.getType())
         || SqlTypeUtil.isInterval(node.getType());
     RelDataType bigintType = typeFactory.createSqlType(SqlTypeName.BIGINT);
-    return makeReinterpretCast(
+    return makeReinterpretCast(pos,
         matchNullability(bigintType, node), node, makeLiteral(false));
   }
 
@@ -910,10 +1041,24 @@ public class RexBuilder {
    * @return Call to CAST operator
    */
   public RexNode makeAbstractCast(RelDataType type, RexNode exp, boolean safe) {
+    return makeAbstractCast(SqlParserPos.ZERO, type, exp, safe);
+  }
+
+  /**
+   * Creates a call to CAST or SAFE_CAST operator.
+   *
+   * @param pos  Parser position.
+   * @param type Type to cast to
+   * @param exp  Expression being cast
+   * @param safe Whether to return NULL if cast fails
+   * @return Call to CAST operator
+   * Casts can fail at runtime, so we expect position information.
+   */
+  public RexNode makeAbstractCast(SqlParserPos pos, RelDataType type, RexNode exp, boolean safe) {
     final SqlOperator operator =
         safe ? SqlLibraryOperators.SAFE_CAST
             : SqlStdOperatorTable.CAST;
-    return new RexCall(type, operator, ImmutableList.of(exp));
+    return new RexCall(pos, type, operator, ImmutableList.of(exp));
   }
 
   /**
@@ -926,24 +1071,56 @@ public class RexBuilder {
    * @return Call to CAST operator
    */
   public RexNode makeAbstractCast(RelDataType type, RexNode exp, boolean safe, RexLiteral format) {
+    return makeAbstractCast(SqlParserPos.ZERO, type, exp, safe, format);
+  }
+
+  /**
+     * Creates a call to CAST or SAFE_CAST operator with a FORMAT clause.
+     *
+     * @param pos  Parser position
+     * @param type Type to cast to
+     * @param exp  Expression being cast
+     * @param safe Whether to return NULL if cast fails
+     * @param format Conversion format for target type
+     * @return Call to CAST operator
+     */
+  public RexNode makeAbstractCast(
+      SqlParserPos pos, RelDataType type, RexNode exp, boolean safe, RexLiteral format) {
     final SqlOperator operator =
         safe ? SqlLibraryOperators.SAFE_CAST
             : SqlStdOperatorTable.CAST;
     if (format.isNull()) {
-      return new RexCall(type, operator, ImmutableList.of(exp));
+      return new RexCall(pos, type, operator, ImmutableList.of(exp));
     }
-    return new RexCall(type, operator, ImmutableList.of(exp, format));
+    return new RexCall(pos, type, operator, ImmutableList.of(exp, format));
   }
 
   /**
    * Makes a reinterpret cast.
    *
    * @param type          type returned by the cast
+   * @param exp           expression to be casted
+   * @param checkOverflow whether an overflow check is required
+   * @return a RexCall with two operands and a special return type
+   */
+  public RexNode makeReinterpretCast(
+      RelDataType type,
+      RexNode exp,
+      RexNode checkOverflow) {
+    return makeReinterpretCast(SqlParserPos.ZERO, type, exp, checkOverflow);
+  }
+
+  /**
+   * Makes a reinterpret cast.
+   *
+   * @param pos           parser position
+   * @param type          type returned by the cast
    * @param exp           expression to be cast
    * @param checkOverflow whether an overflow check is required
    * @return a RexCall with two operands and a special return type
    */
   public RexNode makeReinterpretCast(
+      SqlParserPos pos,
       RelDataType type,
       RexNode exp,
       RexNode checkOverflow) {
@@ -954,6 +1131,7 @@ public class RexBuilder {
       args = ImmutableList.of(exp);
     }
     return new RexCall(
+        pos,
         type,
         SqlStdOperatorTable.REINTERPRET,
         args);
@@ -986,7 +1164,7 @@ public class RexBuilder {
     }
     final RelDataType type2 =
         typeFactory.createTypeWithNullability(type, nullability);
-    return makeAbstractCast(type2, exp, false);
+    return makeAbstractCast(SqlParserPos.ZERO, type2, exp, false);
   }
 
   /**
@@ -1319,6 +1497,27 @@ public class RexBuilder {
       RelDataType type,
       RexNode node,
       boolean matchNullability) {
+    return ensureType(SqlParserPos.ZERO, type, node, matchNullability);
+  }
+
+    /**
+     * Ensures expression is interpreted as a specified type. The returned
+     * expression may be wrapped with a cast.
+     *
+     * @param pos              parser position
+     * @param type             desired type
+     * @param node             expression
+     * @param matchNullability whether to correct nullability of specified
+     *                         type to match the expression; this usually should
+     *                         be true, except for explicit casts which can
+     *                         override default nullability
+     * @return a casted expression or the original expression
+     */
+  public RexNode ensureType(
+      SqlParserPos pos,
+      RelDataType type,
+      RexNode node,
+      boolean matchNullability) {
     RelDataType targetType = type;
     if (matchNullability) {
       targetType = matchNullability(type, node);
@@ -1331,7 +1530,7 @@ public class RexBuilder {
     }
 
     if (!node.getType().equals(targetType)) {
-      return makeCast(targetType, node);
+      return makeCast(pos, targetType, node);
     }
     return node;
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.Litmus;
@@ -56,6 +57,12 @@ public class RexCall extends RexNode {
 
   //~ Instance fields --------------------------------------------------------
 
+  /** In the calls which can produce runtime errors we carry
+   * the source position, so the backend can produce runtime error messages
+   * pointing to the original source position.
+   * For calls that are can never generate runtime failures, this field may
+   * be ZERO.  Note that some optimizations may "lost" position information. */
+  public final SqlParserPos pos;
   public final SqlOperator op;
   public final ImmutableList<RexNode> operands;
   public final RelDataType type;
@@ -74,15 +81,24 @@ public class RexCall extends RexNode {
   //~ Constructors -----------------------------------------------------------
 
   protected RexCall(
+      SqlParserPos pos,
       RelDataType type,
       SqlOperator operator,
       List<? extends RexNode> operands) {
+    this.pos = pos;
     this.type = requireNonNull(type, "type");
     this.op = requireNonNull(operator, "operator");
     this.operands = ImmutableList.copyOf(operands);
     this.nodeCount = RexUtil.nodeCount(1, this.operands);
     assert operator.validRexOperands(operands.size(), Litmus.THROW) : this;
     assert operator.kind != SqlKind.IN || this instanceof RexSubQuery;
+  }
+
+  protected RexCall(
+      RelDataType type,
+      SqlOperator operator,
+      List<? extends RexNode> operands) {
+    this(SqlParserPos.ZERO, type, operator, operands);
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -176,6 +192,10 @@ public class RexCall extends RexNode {
     return sb.toString();
   }
 
+  public SqlParserPos getParserPosition() {
+    return this.pos;
+  }
+
   @Override public final String toString() {
     return computeDigest(digestWithType());
   }
@@ -211,7 +231,7 @@ public class RexCall extends RexNode {
     case CAST:
       return operands.get(0).isAlwaysTrue();
     case SEARCH:
-      final Sarg sarg = ((RexLiteral) operands.get(1)).getValueAs(Sarg.class);
+      final Sarg<?> sarg = ((RexLiteral) operands.get(1)).getValueAs(Sarg.class);
       return requireNonNull(sarg, "sarg").isAll()
           && (sarg.nullAs == RexUnknownAs.TRUE
               || !operands.get(0).getType().isNullable());
@@ -233,7 +253,7 @@ public class RexCall extends RexNode {
     case CAST:
       return operands.get(0).isAlwaysFalse();
     case SEARCH:
-      final Sarg sarg = ((RexLiteral) operands.get(1)).getValueAs(Sarg.class);
+      final Sarg<?> sarg = ((RexLiteral) operands.get(1)).getValueAs(Sarg.class);
       return requireNonNull(sarg, "sarg").isNone()
           && (sarg.nullAs == RexUnknownAs.FALSE
               || !operands.get(0).getType().isNullable());
@@ -270,7 +290,7 @@ public class RexCall extends RexNode {
    * @return New call
    */
   public RexCall clone(RelDataType type, List<RexNode> operands) {
-    return new RexCall(type, op, operands);
+    return new RexCall(pos, type, op, operands);
   }
 
   private Pair<SqlOperator, List<RexNode>> getNormalized() {

--- a/core/src/main/java/org/apache/calcite/rex/RexCopier.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCopier.java
@@ -57,7 +57,7 @@ class RexCopier extends RexShuttle {
 
   @Override public RexNode visitCall(final RexCall call) {
     final boolean[] update = null;
-    return builder.makeCall(copy(call.getType()),
+    return builder.makeCall(call.getParserPosition(), copy(call.getType()),
         call.getOperator(),
         visitList(call.getOperands(), update));
   }

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1592,7 +1592,7 @@ public class RexUtil {
       final SqlOperator op = call.getOperator();
       final List<RexNode> flattenedOperands = flatten(call.getOperands(), op);
       if (!isFlat(call.getOperands(), op)) {
-        return rexBuilder.makeCall(call.getType(), op, flattenedOperands);
+        return rexBuilder.makeCall(call.getParserPosition(), call.getType(), op, flattenedOperands);
       }
     }
     return node;
@@ -2036,8 +2036,7 @@ public class RexUtil {
   }
 
   private static RexNode addNot(RexNode e) {
-    return new RexCall(e.getType(), SqlStdOperatorTable.NOT,
-        ImmutableList.of(e));
+    return new RexCall(e.getType(), SqlStdOperatorTable.NOT, ImmutableList.of(e));
   }
 
   @API(since = "1.27.0", status = API.Status.EXPERIMENTAL)
@@ -2114,7 +2113,7 @@ public class RexUtil {
     case LESS_THAN_OR_EQUAL:
     case GREATER_THAN_OR_EQUAL:
       final SqlOperator op = op(call.getKind().negateNullSafe());
-      return rexBuilder.makeCall(op, call.getOperands());
+      return rexBuilder.makeCall(call.getParserPosition(), op, call.getOperands());
     default:
       break;
     }
@@ -2130,7 +2129,7 @@ public class RexUtil {
     case LESS_THAN_OR_EQUAL:
     case GREATER_THAN_OR_EQUAL:
       final SqlOperator op = requireNonNull(call.getOperator().reverse());
-      return rexBuilder.makeCall(op, Lists.reverse(call.getOperands()));
+      return rexBuilder.makeCall(call.getParserPosition(), op, Lists.reverse(call.getOperands()));
     default:
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.mapping.Mappings;
@@ -114,7 +115,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
     @Override public @Nullable AggregateCall other(RelDataTypeFactory typeFactory,
         AggregateCall e) {
       final RelDataType type = typeFactory.createSqlType(SqlTypeName.BIGINT);
-      return AggregateCall.create(SqlStdOperatorTable.COUNT, false, false,
+      return AggregateCall.create(e.getParserPosition(), SqlStdOperatorTable.COUNT, false, false,
           false, ImmutableList.of(), ImmutableIntList.of(), -1, null,
           RelCollations.EMPTY, type, null);
     }
@@ -123,6 +124,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
         Registry<RexNode> extra, int offset, RelDataType inputRowType,
         AggregateCall aggregateCall, int leftSubTotal, int rightSubTotal) {
       final List<RexNode> merges = new ArrayList<>();
+      final SqlParserPos pos = aggregateCall.getParserPosition();
       if (leftSubTotal >= 0) {
         merges.add(
             rexBuilder.makeInputRef(aggregateCall.type, leftSubTotal));
@@ -137,13 +139,13 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
         node = merges.get(0);
         break;
       case 2:
-        node = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, merges);
+        node = rexBuilder.makeCall(pos, SqlStdOperatorTable.MULTIPLY, merges);
         break;
       default:
         throw new AssertionError("unexpected count " + merges);
       }
       int ordinal = extra.register(node);
-      return AggregateCall.create(SqlStdOperatorTable.SUM0, false, false,
+      return AggregateCall.create(pos, SqlStdOperatorTable.SUM0, false, false,
           false, aggregateCall.rexList, ImmutableList.of(ordinal), -1,
           aggregateCall.distinctKeys, aggregateCall.collation,
           aggregateCall.type, aggregateCall.name);
@@ -183,7 +185,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
       if (bottom.getAggregation().getKind() == SqlKind.COUNT
           && (top.getAggregation().getKind() == SqlKind.SUM
               || top.getAggregation().getKind() == SqlKind.SUM0)) {
-        return AggregateCall.create(bottom.getAggregation(),
+        return AggregateCall.create(top.getParserPosition(), bottom.getAggregation(),
             bottom.isDistinct(), bottom.isApproximate(), false,
             bottom.rexList, bottom.getArgList(), bottom.filterArg,
             bottom.distinctKeys, bottom.getCollation(),
@@ -228,7 +230,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
 
     @Override public @Nullable AggregateCall merge(AggregateCall top, AggregateCall bottom) {
       if (top.getAggregation().getKind() == bottom.getAggregation().getKind()) {
-        return AggregateCall.create(bottom.getAggregation(),
+        return AggregateCall.create(top.getParserPosition(), bottom.getAggregation(),
             bottom.isDistinct(), bottom.isApproximate(), false,
             bottom.rexList, bottom.getArgList(), bottom.filterArg,
             bottom.distinctKeys, bottom.getCollation(),
@@ -258,7 +260,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
     @Override public @Nullable AggregateCall other(RelDataTypeFactory typeFactory,
         AggregateCall e) {
       final RelDataType type = typeFactory.createSqlType(SqlTypeName.BIGINT);
-      return AggregateCall.create(SqlStdOperatorTable.COUNT, false, false,
+      return AggregateCall.create(e.getParserPosition(), SqlStdOperatorTable.COUNT, false, false,
           false, ImmutableList.of(), ImmutableIntList.of(), -1, null,
           RelCollations.EMPTY, type, null);
     }
@@ -267,6 +269,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
         Registry<RexNode> extra, int offset, RelDataType inputRowType,
         AggregateCall aggregateCall, int leftSubTotal, int rightSubTotal) {
       final List<RexNode> merges = new ArrayList<>();
+      final SqlParserPos pos = aggregateCall.getParserPosition();
       final List<RelDataTypeField> fieldList = inputRowType.getFieldList();
       if (leftSubTotal >= 0) {
         final RelDataType type = fieldList.get(leftSubTotal).getType();
@@ -282,14 +285,14 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
         node = merges.get(0);
         break;
       case 2:
-        node = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, merges);
-        node = rexBuilder.makeAbstractCast(aggregateCall.type, node, false);
+        node = rexBuilder.makeCall(pos, SqlStdOperatorTable.MULTIPLY, merges);
+        node = rexBuilder.makeAbstractCast(pos, aggregateCall.type, node, false);
         break;
       default:
         throw new AssertionError("unexpected count " + merges);
       }
       int ordinal = extra.register(node);
-      return AggregateCall.create(getMergeAggFunctionOfTopSplit(), false, false,
+      return AggregateCall.create(pos, getMergeAggFunctionOfTopSplit(), false, false,
           false, aggregateCall.rexList, ImmutableList.of(ordinal), -1,
           aggregateCall.distinctKeys, aggregateCall.collation,
           aggregateCall.type, aggregateCall.name);
@@ -300,7 +303,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
       if (topKind == bottom.getAggregation().getKind()
           && (topKind == SqlKind.SUM
               || topKind == SqlKind.SUM0)) {
-        return AggregateCall.create(bottom.getAggregation(),
+        return AggregateCall.create(top.getParserPosition(), bottom.getAggregation(),
             bottom.isDistinct(), bottom.isApproximate(), false,
             bottom.rexList, bottom.getArgList(), bottom.filterArg,
             bottom.distinctKeys, bottom.getCollation(),

--- a/core/src/main/java/org/apache/calcite/sql2rel/AggConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/AggConverter.java
@@ -539,6 +539,7 @@ class AggConverter implements SqlVisitor<Void> {
     }
     final AggregateCall aggCall =
         AggregateCall.create(
+            call.getParserPosition(),
             aggFunction,
             distinct,
             approximate,

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -1843,6 +1843,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
         }
         newCall =
             rexBuilder.makeCall(
+                call.getParserPosition(),
                 newType,
                 operator,
                 clonedOperands);

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -700,8 +700,9 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
         // NOTE jvs 10-Feb-2005:  This is a lame hack to keep special
         // functions which return row types working.
         RexNode newExp = exp;
-        List<RexNode> operands = ((RexCall) exp).getOperands();
-        SqlOperator operator = ((RexCall) exp).getOperator();
+        RexCall expCall = (RexCall) exp;
+        List<RexNode> operands = expCall.getOperands();
+        SqlOperator operator = expCall.getOperator();
 
         if (operator == SqlStdOperatorTable.ITEM
             && operands.get(0).getType().isStruct()
@@ -747,7 +748,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
           }
         } else {
           newExp =
-              rexBuilder.makeCall(exp.getType(), operator,
+              rexBuilder.makeCall(expCall.getParserPosition(), exp.getType(), operator,
                   shuttle.visitList(operands));
           // flatten call result type
           flattenResultTypeOfRexCall(newExp, fieldName, flattenedExps);
@@ -983,6 +984,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
         RexNode input = rexCall.getOperands().get(0).accept(this);
         RelDataType targetType = removeDistinct(rexCall.getType());
         return rexBuilder.makeCast(
+            rexCall.getParserPosition(),
             targetType,
             input);
       }

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -177,7 +177,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
               (RexCall) StandardConvertletTable.this.convertCall(cx, call);
           if (e.getOperands().size() == 1
               && SqlTypeUtil.isString(e.getOperands().get(0).getType())) {
-            return cx.getRexBuilder().makeCast(e.type, e.getOperands().get(0));
+            return cx.getRexBuilder().makeCast(
+                e.getParserPosition(), e.type, e.getOperands().get(0));
           }
           return e;
         });
@@ -403,7 +404,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         cx.getTypeFactory().createTypeWithNullability(
             cx.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN), right.getType().isNullable()
                 || left.getType().isNullable() || rightComponentType.isNullable());
-    return rexBuilder.makeCall(returnType, call.getOperator(), ImmutableList.of(left, right));
+    return rexBuilder.makeCall(call.getParserPosition(), returnType,
+        call.getOperator(), ImmutableList.of(left, right));
   }
 
   /** Converts a call to the {@code NVL} function (and also its synonym,
@@ -417,15 +419,15 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     final RelDataType type =
         cx.getValidator().getValidatedNodeType(call);
     // Preserve Operand Nullability
-    return rexBuilder.makeCall(type, SqlStdOperatorTable.CASE,
+    return rexBuilder.makeCall(call.getParserPosition(), type, SqlStdOperatorTable.CASE,
         ImmutableList.of(
-            rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL,
+            rexBuilder.makeCall(call.getParserPosition(), SqlStdOperatorTable.IS_NOT_NULL,
                 operand0),
-            rexBuilder.makeCast(
+            rexBuilder.makeCast(call.getParserPosition(),
                 cx.getTypeFactory()
                     .createTypeWithNullability(type, operand0.getType().isNullable()),
                 operand0),
-            rexBuilder.makeCast(
+            rexBuilder.makeCast(call.getParserPosition(),
                 cx.getTypeFactory()
                     .createTypeWithNullability(type, operand1.getType().isNullable()),
                 operand1)));
@@ -485,7 +487,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       throw new UnsupportedOperationException("Position does not accept "
           + call.operandCount() + " operands");
     }
-    return rexBuilder.makeCall(type, SqlStdOperatorTable.POSITION, exprs);
+    return rexBuilder.makeCall(call.getParserPosition(), type, SqlStdOperatorTable.POSITION, exprs);
   }
 
   /** Converts a call to the DECODE function. */
@@ -507,7 +509,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     } else {
       exprs.add(rexBuilder.makeNullLiteral(type));
     }
-    return rexBuilder.makeCall(type, SqlStdOperatorTable.CASE, exprs);
+    return rexBuilder.makeCall(call.getParserPosition(), type, SqlStdOperatorTable.CASE, exprs);
   }
 
   /** Converts a call to the IF function.
@@ -519,7 +521,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         convertOperands(cx, call, SqlOperandTypeChecker.Consistency.NONE);
     final RelDataType type =
         cx.getValidator().getValidatedNodeType(call);
-    return rexBuilder.makeCall(type, SqlStdOperatorTable.CASE, operands);
+    return rexBuilder.makeCall(call.getParserPosition(), type, SqlStdOperatorTable.CASE, operands);
   }
 
   /** Converts an interval expression to a numeric multiplied by an interval
@@ -560,22 +562,22 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     return rexBuilder.makeCall(SqlStdOperatorTable.AND, a0, a1);
   }
 
-  private static RexNode divideInt(RexBuilder rexBuilder, RexNode a0,
+  private static RexNode divideInt(SqlParserPos pos, RexBuilder rexBuilder, RexNode a0,
       RexNode a1) {
-    return rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE_INTEGER, a0, a1);
+    return rexBuilder.makeCall(pos, SqlStdOperatorTable.DIVIDE_INTEGER, a0, a1);
   }
 
-  private static RexNode plus(RexBuilder rexBuilder, RexNode a0, RexNode a1) {
-    return rexBuilder.makeCall(SqlStdOperatorTable.PLUS, a0, a1);
+  private static RexNode plus(SqlParserPos pos, RexBuilder rexBuilder, RexNode a0, RexNode a1) {
+    return rexBuilder.makeCall(pos, SqlStdOperatorTable.PLUS, a0, a1);
   }
 
-  private static RexNode minus(RexBuilder rexBuilder, RexNode a0, RexNode a1) {
-    return rexBuilder.makeCall(SqlStdOperatorTable.MINUS, a0, a1);
+  private static RexNode minus(SqlParserPos pos, RexBuilder rexBuilder, RexNode a0, RexNode a1) {
+    return rexBuilder.makeCall(pos, SqlStdOperatorTable.MINUS, a0, a1);
   }
 
-  private static RexNode multiply(RexBuilder rexBuilder, RexNode a0,
+  private static RexNode multiply(SqlParserPos pos, RexBuilder rexBuilder, RexNode a0,
       RexNode a1) {
-    return rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, a0, a1);
+    return rexBuilder.makeCall(pos, SqlStdOperatorTable.MULTIPLY, a0, a1);
   }
 
   private static RexNode case_(RexBuilder rexBuilder, RexNode... args) {
@@ -628,9 +630,10 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         rexBuilder.deriveReturnType(call.getOperator(), exprList);
     for (int i : elseArgs(exprList.size())) {
       exprList.set(i,
-          rexBuilder.ensureType(type, exprList.get(i), false));
+          rexBuilder.ensureType(
+              call.getParserPosition(), type, exprList.get(i), false));
     }
-    return rexBuilder.makeCall(type, SqlStdOperatorTable.CASE, exprList);
+    return rexBuilder.makeCall(call.getParserPosition(), type, SqlStdOperatorTable.CASE, exprList);
   }
 
   public RexNode convertMultiset(
@@ -662,7 +665,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       // then '$SLICE(<ms>) has type 'INTEGER MULTISET'.
       // This will be removed as the expression is translated.
       expr =
-          cx.getRexBuilder().makeCall(originalType, SqlStdOperatorTable.SLICE,
+          cx.getRexBuilder().makeCall(
+              call.getParserPosition(), originalType, SqlStdOperatorTable.SLICE,
               ImmutableList.of(expr));
     }
     return expr;
@@ -744,8 +748,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         RexLiteral castedInterval =
             rexBuilder.makeIntervalLiteral(sourceValue,
                 intervalQualifier);
-        return castToValidatedType(call, castedInterval, validator, rexBuilder,
-            safe);
+        return castToValidatedType(
+            call.getParserPosition(), call, castedInterval, validator, rexBuilder, safe);
       } else if (left instanceof SqlNumericLiteral) {
         RexLiteral sourceInterval =
             (RexLiteral) cx.convertExpression(left);
@@ -757,11 +761,12 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
             rexBuilder.makeIntervalLiteral(
                 SqlFunctions.multiply(sourceValue, multiplier),
                 intervalQualifier);
-        return castToValidatedType(call, castedInterval, validator, rexBuilder,
-            safe);
+        return castToValidatedType(
+            call.getParserPosition(), call, castedInterval, validator, rexBuilder, safe);
       }
       RexNode value = cx.convertExpression(left);
-      return castToValidatedType(call, value, validator, rexBuilder, safe);
+      return castToValidatedType(
+          call.getParserPosition(), call, value, validator, rexBuilder, safe);
     }
 
     final SqlDataTypeSpec dataType = (SqlDataTypeSpec) right;
@@ -799,11 +804,12 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         type = typeFactory.createTypeWithNullability(type, isn);
       }
     }
-    return rexBuilder.makeCast(type, arg, safe, safe, formatArg);
+    return rexBuilder.makeCast(call.getParserPosition(), type, arg, safe, safe, formatArg);
   }
 
   protected RexNode convertFloorCeil(SqlRexContext cx, SqlCall call) {
     final boolean floor = call.getKind() == SqlKind.FLOOR;
+    final SqlParserPos pos = call.getParserPosition();
     // Rewrite floor, ceil of interval
     if (call.operandCount() == 1
         && call.operand(0) instanceof SqlIntervalLiteral) {
@@ -821,19 +827,19 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       RexNode pad =
           rexBuilder.makeExactLiteral(val.subtract(BigDecimal.ONE));
       RexNode cast =
-          rexBuilder.makeReinterpretCast(rexInterval.getType(), pad,
+          rexBuilder.makeReinterpretCast(pos, rexInterval.getType(), pad,
               rexBuilder.makeLiteral(false));
       RexNode sum =
-          floor ? minus(rexBuilder, rexInterval, cast)
-              : plus(rexBuilder, rexInterval, cast);
+          floor ? minus(pos, rexBuilder, rexInterval, cast)
+              : plus(pos, rexBuilder, rexInterval, cast);
 
       RexNode kase = floor
           ? case_(rexBuilder, rexInterval, cond, sum)
           : case_(rexBuilder, sum, cond, rexInterval);
 
       RexNode factor = rexBuilder.makeExactLiteral(val);
-      RexNode div = divideInt(rexBuilder, kase, factor);
-      return multiply(rexBuilder, div, factor);
+      RexNode div = divideInt(pos, rexBuilder, kase, factor);
+      return multiply(pos, rexBuilder, div, factor);
     }
 
     // normal floor, ceil function
@@ -843,11 +849,12 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
   protected RexNode convertCharset(
       @UnknownInitialization StandardConvertletTable this,
       SqlRexContext cx, SqlCall call) {
+    final SqlParserPos pos = call.getParserPosition();
     final SqlNode expr = call.operand(0);
     final String srcCharset = call.operand(1).toString();
     final String destCharset = call.operand(2).toString();
     final RexBuilder rexBuilder = cx.getRexBuilder();
-    return rexBuilder.makeCall(SqlStdOperatorTable.CONVERT,
+    return rexBuilder.makeCall(pos, SqlStdOperatorTable.CONVERT,
         cx.convertExpression(expr),
         rexBuilder.makeLiteral(srcCharset),
         rexBuilder.makeLiteral(destCharset));
@@ -856,10 +863,11 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
   protected RexNode translateCharset(
       @UnknownInitialization StandardConvertletTable this,
       SqlRexContext cx, SqlCall call) {
+    final SqlParserPos pos = call.getParserPosition();
     final SqlNode expr = call.operand(0);
     final String transcodingName = call.operand(1).toString();
     final RexBuilder rexBuilder = cx.getRexBuilder();
-    return rexBuilder.makeCall(SqlStdOperatorTable.TRANSLATE,
+    return rexBuilder.makeCall(pos, SqlStdOperatorTable.TRANSLATE,
         cx.convertExpression(expr),
         rexBuilder.makeLiteral(transcodingName));
   }
@@ -877,16 +885,17 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
   }
 
   @SuppressWarnings("unused")
-  private static RexNode mod(RexBuilder rexBuilder, RelDataType resType, RexNode res,
+  private static RexNode mod(SqlParserPos pos, RexBuilder rexBuilder,
+      RelDataType resType, RexNode res,
       BigDecimal val) {
     if (val.equals(BigDecimal.ONE)) {
       return res;
     }
-    return rexBuilder.makeCall(SqlStdOperatorTable.MOD, res,
+    return rexBuilder.makeCall(pos, SqlStdOperatorTable.MOD, res,
         rexBuilder.makeExactLiteral(val, resType));
   }
 
-  private static RexNode divide(RexBuilder rexBuilder, RexNode res,
+  private static RexNode divide(SqlParserPos pos, RexBuilder rexBuilder, RexNode res,
       BigDecimal val) {
     if (val.equals(BigDecimal.ONE)) {
       return res;
@@ -898,13 +907,13 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       try {
         final BigDecimal reciprocal =
             BigDecimal.ONE.divide(val, RoundingMode.UNNECESSARY);
-        return multiply(rexBuilder, res,
+        return multiply(pos, rexBuilder, res,
             rexBuilder.makeExactLiteral(reciprocal));
       } catch (ArithmeticException e) {
         // ignore - reciprocal is not an integer
       }
     }
-    return divideInt(rexBuilder, res, rexBuilder.makeExactLiteral(val));
+    return divideInt(pos, rexBuilder, res, rexBuilder.makeExactLiteral(val));
   }
 
   public RexNode convertDatetimeMinus(
@@ -919,7 +928,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
 
     final RelDataType resType =
         cx.getValidator().getValidatedNodeType(call);
-    return rexBuilder.makeCall(resType, op, exprs.subList(0, 2));
+    return rexBuilder.makeCall(call.getParserPosition(), resType, op, exprs.subList(0, 2));
   }
 
   public RexNode convertFunction(
@@ -936,7 +945,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     if (returnType == null) {
       returnType = cx.getRexBuilder().deriveReturnType(fun, exprs);
     }
-    return cx.getRexBuilder().makeCall(returnType, fun, exprs);
+    return cx.getRexBuilder().makeCall(call.getParserPosition(), returnType, fun, exprs);
   }
 
   public RexNode convertWindowFunction(
@@ -953,7 +962,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     if (returnType == null) {
       returnType = cx.getRexBuilder().deriveReturnType(fun, exprs);
     }
-    return cx.getRexBuilder().makeCall(returnType, fun, exprs);
+    return cx.getRexBuilder().makeCall(call.getParserPosition(), returnType, fun, exprs);
   }
 
   public RexNode convertJsonValueFunction(
@@ -994,7 +1003,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         convertOperands(cx, call, operands, SqlOperandTypeChecker.Consistency.NONE);
     RelDataType returnType = cx.getValidator().getValidatedNodeTypeIfKnown(call);
     requireNonNull(returnType, () -> "Unable to get type of " + call);
-    return cx.getRexBuilder().makeCall(returnType, fun, exprs);
+    return cx.getRexBuilder().makeCall(call.getParserPosition(), returnType, fun, exprs);
   }
 
   public RexNode convertSequenceValue(
@@ -1008,7 +1017,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     final String key = Util.listToString(id.names);
     RelDataType returnType =
         cx.getValidator().getValidatedNodeType(call);
-    return cx.getRexBuilder().makeCall(returnType, fun,
+    return cx.getRexBuilder().makeCall(call.getParserPosition(), returnType, fun,
         ImmutableList.of(cx.getRexBuilder().makeLiteral(key)));
   }
 
@@ -1035,7 +1044,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
           };
       returnType = fun.inferReturnType(binding);
     }
-    return cx.getRexBuilder().makeCall(returnType, fun, exprs);
+    return cx.getRexBuilder().makeCall(call.getParserPosition(), returnType, fun, exprs);
   }
 
   private static RexNode makeConstructorCall(
@@ -1109,7 +1118,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       }
     }
     RelDataType type = rexBuilder.deriveReturnType(op, exprs);
-    return rexBuilder.makeCall(type, op, RexUtil.flatten(exprs, op));
+    return rexBuilder.makeCall(call.getParserPosition(), type, op, RexUtil.flatten(exprs, op));
   }
 
   /**
@@ -1146,11 +1155,11 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         final RexCall call1 = (RexCall) expr1;
         final List<RexNode> eqList = new ArrayList<>();
         Pair.forEach(call0.getOperands(), call1.getOperands(), (x, y) ->
-            eqList.add(rexBuilder.makeCall(op, x, y)));
+            eqList.add(rexBuilder.makeCall(call.getParserPosition(), op, x, y)));
         return RexUtil.composeConjunction(rexBuilder, eqList);
       }
     }
-    return rexBuilder.makeCall(type, op, RexUtil.flatten(exprs, op));
+    return rexBuilder.makeCall(call.getParserPosition(), type, op, RexUtil.flatten(exprs, op));
   }
 
   private static List<Integer> elseArgs(int count) {
@@ -1196,7 +1205,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       final List<RexNode> oldExprs = new ArrayList<>(exprs);
       exprs.clear();
       Pair.forEach(oldExprs, operandTypes, (expr, type) ->
-          exprs.add(cx.getRexBuilder().ensureType(type, expr, true)));
+          exprs.add(cx.getRexBuilder().ensureType(call.getParserPosition(), type, expr, true)));
     }
     if (exprs.size() > 1) {
       final RelDataType type =
@@ -1205,7 +1214,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         final List<RexNode> oldExprs = new ArrayList<>(exprs);
         exprs.clear();
         for (RexNode expr : oldExprs) {
-          exprs.add(cx.getRexBuilder().ensureType(type, expr, true));
+          exprs.add(cx.getRexBuilder().ensureType(call.getParserPosition(), type, expr, true));
         }
       }
     }
@@ -1289,7 +1298,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
           break;
         }
       }
-      return rexBuilder.makeCall(rex.getType(),
+      return rexBuilder.makeCall(call.getParserPosition(), rex.getType(),
           SqlStdOperatorTable.DATETIME_PLUS, operands);
     default:
       return rex;
@@ -1351,7 +1360,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     final SqlBetweenOperator betweenOp =
         (SqlBetweenOperator) call.getOperator();
     if (betweenOp.isNegated()) {
-      res = rexBuilder.makeCall(SqlStdOperatorTable.NOT, res);
+      res = rexBuilder.makeCall(call.getParserPosition(), SqlStdOperatorTable.NOT, res);
     }
     return res;
   }
@@ -1424,7 +1433,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     }
     final RelDataType type =
         rexBuilder.deriveReturnType(SqlStdOperatorTable.COLUMN_LIST, columns);
-    return rexBuilder.makeCall(type, SqlStdOperatorTable.COLUMN_LIST, columns);
+    return rexBuilder.makeCall(
+        call.getParserPosition(), type, SqlStdOperatorTable.COLUMN_LIST, columns);
   }
 
   /**
@@ -1516,14 +1526,14 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       SqlRexContext cx,
       SqlCall call,
       RexNode value) {
-    return castToValidatedType(call, value, cx.getValidator(),
+    return castToValidatedType(call.getParserPosition(), call, value, cx.getValidator(),
         cx.getRexBuilder(), false);
   }
 
   @Deprecated // to be removed before 2.0
   public static RexNode castToValidatedType(SqlNode node, RexNode e,
       SqlValidator validator, RexBuilder rexBuilder) {
-    return castToValidatedType(node, e, validator, rexBuilder, false);
+    return castToValidatedType(node.getParserPosition(), node, e, validator, rexBuilder, false);
   }
 
   /**
@@ -1531,13 +1541,13 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
    * was already of the validated type, then the value is returned without an
    * additional cast.
    */
-  public static RexNode castToValidatedType(SqlNode node, RexNode e,
+  public static RexNode castToValidatedType(SqlParserPos pos, SqlNode node, RexNode e,
       SqlValidator validator, RexBuilder rexBuilder, boolean safe) {
     final RelDataType type = validator.getValidatedNodeType(node);
     if (e.getType() == type) {
       return e;
     }
-    return rexBuilder.makeCast(type, e, safe, safe);
+    return rexBuilder.makeCast(pos, type, e, safe, safe);
   }
 
   /** Convertlet that handles {@code COVAR_POP}, {@code COVAR_SAMP},
@@ -1574,7 +1584,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         throw Util.unexpected(kind);
       }
       RexNode rex = cx.convertExpression(expr);
-      return cx.getRexBuilder().ensureType(type, rex, true);
+      return cx.getRexBuilder().ensureType(call.getParserPosition(), type, rex, true);
     }
 
     private static SqlNode expandRegrSzz(
@@ -1706,7 +1716,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         throw Util.unexpected(kind);
       }
       RexNode rex = cx.convertExpression(expr);
-      return cx.getRexBuilder().ensureType(type, rex, true);
+      return cx.getRexBuilder().ensureType(call.getParserPosition(), type, rex, true);
     }
 
     private static SqlNode expandAvg(
@@ -1856,7 +1866,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       final RexBuilder rexBuilder = cx.getRexBuilder();
       final RexNode operand =
           cx.convertExpression(call.getOperandList().get(0));
-      return rexBuilder.makeCall(SqlStdOperatorTable.TRIM,
+      return rexBuilder.makeCall(call.getParserPosition(), SqlStdOperatorTable.TRIM,
           rexBuilder.makeFlag(flag), rexBuilder.makeLiteral(" "), operand);
     }
   }
@@ -1897,7 +1907,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       final List<RexNode> list = new ArrayList<>();
       final List<RexNode> orList = new ArrayList<>();
       for (RexNode expr : exprs) {
-        orList.add(rexBuilder.makeCall(SqlStdOperatorTable.IS_NULL, expr));
+        orList.add(
+            rexBuilder.makeCall(call.getParserPosition(), SqlStdOperatorTable.IS_NULL, expr));
       }
       list.add(RexUtil.composeDisjunction(rexBuilder, orList));
       list.add(rexBuilder.makeNullLiteral(type));
@@ -1906,13 +1917,13 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         final List<RexNode> andList = new ArrayList<>();
         for (int j = i + 1; j < exprs.size(); j++) {
           final RexNode expr2 = exprs.get(j);
-          andList.add(rexBuilder.makeCall(op, expr, expr2));
+          andList.add(rexBuilder.makeCall(call.getParserPosition(), op, expr, expr2));
         }
         list.add(RexUtil.composeConjunction(rexBuilder, andList));
         list.add(expr);
       }
       list.add(exprs.get(exprs.size() - 1));
-      return rexBuilder.makeCall(type, SqlStdOperatorTable.CASE, list);
+      return rexBuilder.makeCall(call.getParserPosition(), type, SqlStdOperatorTable.CASE, list);
     }
   }
 
@@ -2040,6 +2051,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       //       FOR CASE WHEN length < 0 THEN 0 ELSE length END)
 
       final RexBuilder rexBuilder = cx.getRexBuilder();
+      final SqlParserPos pos = call.getParserPosition();
       final List<RexNode> exprs =
           convertOperands(cx, call, SqlOperandTypeChecker.Consistency.NONE);
       final RexNode value = exprs.get(0);
@@ -2049,10 +2061,10 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       final RexLiteral oneLiteral = rexBuilder.makeLiteral(1, startType);
       final RexNode valueLength =
           SqlTypeUtil.isBinary(value.getType())
-              ? rexBuilder.makeCall(SqlStdOperatorTable.OCTET_LENGTH, value)
-              : rexBuilder.makeCall(SqlStdOperatorTable.CHAR_LENGTH, value);
+              ? rexBuilder.makeCall(pos, SqlStdOperatorTable.OCTET_LENGTH, value)
+              : rexBuilder.makeCall(pos, SqlStdOperatorTable.CHAR_LENGTH, value);
       final RexNode valueLengthPlusOne =
-          rexBuilder.makeCall(SqlStdOperatorTable.PLUS, valueLength,
+          rexBuilder.makeCall(pos, SqlStdOperatorTable.PLUS, valueLength,
               oneLiteral);
 
       final RexNode newStart;
@@ -2060,8 +2072,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       case POSTGRESQL:
         if (call.operandCount() == 2) {
           newStart =
-              rexBuilder.makeCall(SqlStdOperatorTable.CASE,
-                  rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN, start,
+              rexBuilder.makeCall(pos, SqlStdOperatorTable.CASE,
+                  rexBuilder.makeCall(pos, SqlStdOperatorTable.LESS_THAN, start,
                       oneLiteral),
                   oneLiteral, start);
         } else {
@@ -2070,37 +2082,37 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         break;
       case BIG_QUERY:
         newStart =
-            rexBuilder.makeCall(SqlStdOperatorTable.CASE,
-                rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, start,
+            rexBuilder.makeCall(pos, SqlStdOperatorTable.CASE,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.EQUALS, start,
                     zeroLiteral),
                 oneLiteral,
-                rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN, start,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.LESS_THAN, start,
                     zeroLiteral),
-                rexBuilder.makeCall(SqlStdOperatorTable.PLUS, start,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.PLUS, start,
                     valueLengthPlusOne),
                 start);
         break;
       default:
         newStart =
-            rexBuilder.makeCall(SqlStdOperatorTable.CASE,
-                rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, start,
+            rexBuilder.makeCall(pos, SqlStdOperatorTable.CASE,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.EQUALS, start,
                     zeroLiteral),
                 library == SqlLibrary.MYSQL ? valueLengthPlusOne : oneLiteral,
-                rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN,
-                    rexBuilder.makeCall(SqlStdOperatorTable.PLUS, start,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.LESS_THAN,
+                    rexBuilder.makeCall(pos, SqlStdOperatorTable.PLUS, start,
                         valueLengthPlusOne),
                     oneLiteral),
                 valueLengthPlusOne,
-                rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN, start,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.LESS_THAN, start,
                     zeroLiteral),
-                rexBuilder.makeCall(SqlStdOperatorTable.PLUS, start,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.PLUS, start,
                     valueLengthPlusOne),
                 start);
         break;
       }
 
       if (call.operandCount() == 2) {
-        return rexBuilder.makeCall(SqlStdOperatorTable.SUBSTRING, value,
+        return rexBuilder.makeCall(pos, SqlStdOperatorTable.SUBSTRING, value,
             newStart);
       }
 
@@ -2113,19 +2125,19 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         break;
       default:
         newLength =
-            rexBuilder.makeCall(SqlStdOperatorTable.CASE,
-                rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN, length,
+            rexBuilder.makeCall(pos, SqlStdOperatorTable.CASE,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.LESS_THAN, length,
                     zeroLiteral),
                 zeroLiteral, length);
       }
       final RexNode substringCall =
-          rexBuilder.makeCall(SqlStdOperatorTable.SUBSTRING, value, newStart,
+          rexBuilder.makeCall(pos, SqlStdOperatorTable.SUBSTRING, value, newStart,
               newLength);
       switch (library) {
       case BIG_QUERY:
-        return rexBuilder.makeCall(SqlStdOperatorTable.CASE,
-            rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN,
-                rexBuilder.makeCall(SqlStdOperatorTable.PLUS, start,
+        return rexBuilder.makeCall(pos, SqlStdOperatorTable.CASE,
+            rexBuilder.makeCall(pos, SqlStdOperatorTable.LESS_THAN,
+                rexBuilder.makeCall(pos, SqlStdOperatorTable.PLUS, start,
                     valueLengthPlusOne), oneLiteral),
             value, substringCall);
       default:
@@ -2144,6 +2156,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       //  => timestamp + interval
       // "timestamp" may be of type TIMESTAMP or TIMESTAMP WITH LOCAL TIME ZONE.
       final RexBuilder rexBuilder = cx.getRexBuilder();
+      final SqlParserPos pos = call.getParserPosition();
       SqlIntervalQualifier qualifier;
       final RexNode op1;
       final RexNode op2;
@@ -2204,8 +2217,8 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         // If the TIMESTAMPADD call has type TIMESTAMP and op2 has type DATE
         // (which can happen for sub-day time frames such as HOUR), cast op2 to
         // TIMESTAMP.
-        final RexNode op2b = rexBuilder.makeCast(type, op2);
-        return rexBuilder.makeCall(type, SqlStdOperatorTable.TIMESTAMP_ADD,
+        final RexNode op2b = rexBuilder.makeCast(pos, type, op2);
+        return rexBuilder.makeCall(pos, type, SqlStdOperatorTable.TIMESTAMP_ADD,
             ImmutableList.of(timeFrameName, op1, op2b));
       }
 
@@ -2220,19 +2233,19 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       case MICROSECOND:
       case NANOSECOND:
         interval2Add =
-            divide(rexBuilder,
-                multiply(rexBuilder,
+            divide(pos, rexBuilder,
+                multiply(pos, rexBuilder,
                     rexBuilder.makeIntervalLiteral(BigDecimal.ONE, qualifier), op1),
                 BigDecimal.ONE.divide(unit.multiplier,
                     RoundingMode.UNNECESSARY));
         break;
       default:
         interval2Add =
-            multiply(rexBuilder,
+            multiply(pos, rexBuilder,
                 rexBuilder.makeIntervalLiteral(unit.multiplier, qualifier), op1);
       }
 
-      return rexBuilder.makeCall(SqlStdOperatorTable.DATETIME_PLUS,
+      return rexBuilder.makeCall(pos, SqlStdOperatorTable.DATETIME_PLUS,
           op2, interval2Add);
     }
   }
@@ -2243,13 +2256,14 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
   private static class TruncConvertlet implements SqlRexConvertlet {
     @Override public RexNode convertCall(SqlRexContext cx, SqlCall call) {
       final RexBuilder rexBuilder = cx.getRexBuilder();
+      final SqlParserPos pos = call.getParserPosition();
       RexNode op1 = cx.convertExpression(call.operand(0));
       RexNode op2 = cx.convertExpression(call.operand(1));
       if (op1.getType().getSqlTypeName() == SqlTypeName.DATE) {
         RelDataType type = cx.getValidator().getValidatedNodeType(call);
-        op1 = cx.getRexBuilder().makeCast(type, op1);
+        op1 = cx.getRexBuilder().makeCast(pos, type, op1);
       }
-      return rexBuilder.makeCall(call.getOperator(), op1, op2);
+      return rexBuilder.makeCall(pos, call.getOperator(), op1, op2);
     }
   }
 
@@ -2259,6 +2273,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       // TIMESTAMP_SUB(timestamp, interval)
       //  => timestamp - count * INTERVAL '1' UNIT
       final RexBuilder rexBuilder = cx.getRexBuilder();
+      final SqlParserPos pos = call.getParserPosition();
       final SqlBasicCall operandCall = call.operand(1);
       SqlIntervalQualifier qualifier = operandCall.operand(1);
       final RexNode op1 = cx.convertExpression(operandCall.operand(0));
@@ -2272,19 +2287,19 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       case MICROSECOND:
       case NANOSECOND:
         interval2Sub =
-            divide(rexBuilder,
-                multiply(rexBuilder,
+            divide(pos, rexBuilder,
+                multiply(pos, rexBuilder,
                     rexBuilder.makeIntervalLiteral(BigDecimal.ONE, qualifier), op1),
                 BigDecimal.ONE.divide(unit.multiplier,
                     RoundingMode.UNNECESSARY));
         break;
       default:
         interval2Sub =
-            multiply(rexBuilder,
+            multiply(pos, rexBuilder,
                 rexBuilder.makeIntervalLiteral(unit.multiplier, qualifier), op1);
       }
 
-      return rexBuilder.makeCall(SqlInternalOperators.MINUS_DATE2,
+      return rexBuilder.makeCall(pos, SqlInternalOperators.MINUS_DATE2,
           op2, interval2Sub);
     }
   }
@@ -2316,6 +2331,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       final boolean preTruncate;
       final RexNode op1;
       final RexNode op2;
+      final SqlParserPos pos = call.getParserPosition();
       if (call.operand(0).getKind() == SqlKind.INTERVAL_QUALIFIER) {
         qualifier = call.operand(0);
         preTruncate = false;
@@ -2342,11 +2358,11 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         // computing the difference.
         if (preTruncate) {
           truncateFn = e ->
-              rexBuilder.makeCall(e.getType(),
+              rexBuilder.makeCall(pos, e.getType(),
                   SqlLibraryOperators.TIMESTAMP_TRUNC,
                   ImmutableList.of(e, timeFrameName));
         }
-        return rexBuilder.makeCall(cx.getValidator().getValidatedNodeType(call),
+        return rexBuilder.makeCall(pos, cx.getValidator().getValidatedNodeType(call),
             SqlStdOperatorTable.TIMESTAMP_DIFF,
             ImmutableList.of(timeFrameName, truncateFn.apply(op1),
                 truncateFn.apply(op2)));
@@ -2358,7 +2374,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         // should be returned.
         final RexNode timeUnit = cx.convertExpression(qualifier);
         truncateFn = e ->
-            rexBuilder.makeCall(e.getType(),
+            rexBuilder.makeCall(call.getParserPosition(), e.getType(),
                 SqlLibraryOperators.TIMESTAMP_TRUNC,
                 ImmutableList.of(e, timeUnit));
       }
@@ -2399,15 +2415,15 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
               typeFactory.createSqlIntervalType(qualifier),
               op1.getType().isNullable() || op2.getType().isNullable());
       final RexNode call2 =
-          rexBuilder.makeCall(intervalType,
+          rexBuilder.makeCall(pos, intervalType,
               SqlStdOperatorTable.MINUS_DATE,
               ImmutableList.of(truncateFn.apply(op2), truncateFn.apply(op1)));
       final RelDataType intType =
           typeFactory.createTypeWithNullability(
               typeFactory.createSqlType(sqlTypeName),
               SqlTypeUtil.containsNullable(call2.getType()));
-      RexNode e = rexBuilder.makeCast(intType, call2);
-      return rexBuilder.multiplyDivide(e, multiplier, divider);
+      RexNode e = rexBuilder.makeCast(pos, intType, call2);
+      return rexBuilder.multiplyDivide(pos, e, multiplier, divider);
     }
   }
 }

--- a/core/src/test/java/org/apache/calcite/materialize/NormalizationTrimFieldTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/NormalizationTrimFieldTest.java
@@ -84,7 +84,7 @@ public class NormalizationTrimFieldTest extends SqlToRelTestBase {
     final ImmutableBitSet groupSet = ImmutableBitSet.of(4);
     final AggregateCall count = aggregate.getAggCallList().get(0);
     final AggregateCall call =
-        AggregateCall.create(count.getAggregation(),
+        AggregateCall.create(count.getParserPosition(), count.getAggregation(),
             count.isDistinct(), count.isApproximate(),
             count.ignoreNulls(), count.rexList, ImmutableList.of(3),
             count.filterArg, null, count.collation,

--- a/core/src/test/java/org/apache/calcite/test/fuzzer/RexShrinker.java
+++ b/core/src/test/java/org/apache/calcite/test/fuzzer/RexShrinker.java
@@ -76,7 +76,7 @@ public class RexShrinker extends RexShuttle {
       if (res != null) {
         didWork = true;
         if (!res.getType().equals(type)) {
-          return rexBuilder.makeCast(type, res);
+          return rexBuilder.makeCast(call.getParserPosition(), type, res);
         }
         return res;
       }


### PR DESCRIPTION
This PR adds source position (`SqlParserPos`) information to two kinds of nodes:
- RexCall
- AggregateCall

Not all RexCall nodes and AggregateCall operations need to have meaningful source position information. The most useful nodes are the ones that could lead to runtime errors. So operations like addition (which can overflow) or casts (which can fail when the target type is too narrow) need to carry such information. Nodes where the operation cannot fail dynamically (e.g., MAX, comparisons, or IS_NULL) may have the source position set to ZERO.

In this PR I have carefully audited the entire code base and tried to thread the flow of the position information everywhere, but there are a few places where I couldn't figure out where it should come from. There are, for example, a few casts inserted by the rewrite rules which have no direct correspondence to source constructs. Such casts have now a TODO comment wondering about their runtime safety.

In the process I have also removed a few `@Deprecated` functions which would have required a signature change. I figured that since they are deprecated there is no point to update them, since no one can call the variant with the new signature.

For methods where there are many calls where the position information may legitimately be ZERO I have left variants of the original methods without source position information (e.g., see RexBuilder.makeCall)

Currently there are no uses of this information, but I have inspected the IR with a debugger after optimizations to check that the information is present. A future commit (part of this PR or another one) should add an example runtime error that displays this information. This is not trivial to do for the Calcite Linq4j-based executor, so I haven't done it yet.

None of this should affect the behavior of any of the compiled programs, but I noticed that it's easy to mess up something in practice a few times. Currently no tests need to change.