### PR TITLE
[CALCITE-6102] SqlWriter in SqlInsert's unparse start a list but does not end it

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlInsert.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlInsert.java
@@ -150,7 +150,7 @@ public class SqlInsert extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    writer.startList(SqlWriter.FrameTypeEnum.SELECT);
+    final SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.SELECT);
     writer.sep(isUpsert() ? "UPSERT INTO" : "INSERT INTO");
     final int opLeft = getOperator().getLeftPrec();
     final int opRight = getOperator().getRightPrec();
@@ -160,6 +160,7 @@ public class SqlInsert extends SqlCall {
     }
     writer.newlineAndIndent();
     source.unparse(writer, 0, 0);
+    writer.endList(frame);
   }
 
   @Override public void validate(SqlValidator validator, SqlValidatorScope scope) {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
@@ -18,6 +18,7 @@ package org.apache.calcite.sql.test;
 
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -484,6 +485,29 @@ class SqlPrettyWriterTest {
         .withWriter(w -> w.withUpdateSetListNewline(false)
             .withClauseStartsLine(false))
         .check();
+  }
+
+  @Test void testInsert() {
+    sql("insert into t1 select * from t2")
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6102">[CALCITE-6102]
+   * SqlWriter in SqlInsert's unparse start a list but does not end it</a>. */
+  @Test void testSqlWithBodyIsSqlInsert() throws SqlParseException {
+    final String withSql = "with tmp as (select * from t1) select 1";
+    final String insertSql = "insert into t2 select * from tmp";
+    final String expectedSql = "WITH `TMP` AS (SELECT *\n"
+        + "FROM `T1`) INSERT INTO `T2`\n"
+        + "SELECT *\n"
+        + "FROM `TMP`";
+    final SqlNode sqlInsert = SqlParser.create(insertSql).parseStmt();
+    final SqlNode sqlNode = SqlParser.create(withSql).parseQuery();
+    assertThat(sqlNode, instanceOf(SqlWith.class));
+    final SqlWith sqlWith = (SqlWith) sqlNode;
+    sqlWith.setOperand(1, sqlInsert);
+    assertThat(sqlWith, hasToString(isLinux(expectedSql)));
   }
 
   public static void main(String[] args) throws SqlParseException {

--- a/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
@@ -225,6 +225,13 @@ FROM `X`
     INNER JOIN `Y` ON `X`.`K` = `Y`.`K`]]>
     </Resource>
   </TestCase>
+  <TestCase name="testInsert">
+    <Resource name="formatted">
+      <![CDATA[INSERT INTO `T1`
+SELECT *
+    FROM `T2`]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinClauseToString">
     <Resource name="formatted">
       <![CDATA[SELECT `T`.`REGION_NAME`, `T0`.`O_TOTALPRICE`


### PR DESCRIPTION
fix of [CALCITE-6102](https://issues.apache.org/jira/browse/CALCITE-6102)
SqlWriter in SqlInsert's unparse() start a list but does not end it.

if we put a SqlInsert into a SqlWith's body, when we unparse the SqlWith , it will throw an Expception :

 
java.lang.IllegalArgumentException: Frame does not match current frame
 
at com.google.common.base.Preconditions.checkArgument(Preconditions.java:122)
at org.apache.calcite.sql.pretty.SqlPrettyWriter.endList(SqlPrettyWriter.java:884)
at org.apache.calcite.sql.SqlWith$SqlWithOperator.unparse(SqlWith.java:109)