### PR TITLE
[CALCITE-6109] Avoid extra loops when optimizing statements with ternary expressions

### DIFF
--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/OptimizeShuttle.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/OptimizeShuttle.java
@@ -85,11 +85,15 @@ public class OptimizeShuttle extends Shuttle {
       Expression expression0,
       Expression expression1,
       Expression expression2) {
-    expression1 = skipNullCast(expression1);
-    expression2 = skipNullCast(expression2);
-    ternary =
-        new TernaryExpression(ternary.getNodeType(), ternary.getType(),
-            expression0, expression1, expression2);
+    Expression tmpExpression1 = skipNullCast(expression1);
+    Expression tmpExpression2 = skipNullCast(expression2);
+    if (tmpExpression1 != expression1 || tmpExpression2 != expression2) {
+      expression1 = tmpExpression1;
+      expression2 = tmpExpression2;
+      ternary =
+          new TernaryExpression(ternary.getNodeType(), ternary.getType(),
+              expression0, expression1, expression2);
+    }
     switch (ternary.getNodeType()) {
     case Conditional:
       Boolean always = always(expression0);


### PR DESCRIPTION
jira: [CALCITE-6109](https://issues.apache.org/jira/browse/CALCITE-6109)

When there are statements with ternary expressions in BlockBuilder#statements, the optimize method always returns true, causing the loop in the toBlock method to always be executed 10 times.

The reason is that when OptimizeShuttle traverses the statement, a new instance of TernaryExpression will always be created, regardless of whether the optimization is actually performed.