### PR TITLE
[CALCITE-6117] Converting SAFE_CAST from RexCall to SqlCall fails to add the type as an argument

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -814,6 +814,7 @@ public abstract class SqlImplementor {
       final List<SqlNode> nodeList = toSql(program, call.getOperands());
       switch (call.getKind()) {
       case CAST:
+      case SAFE_CAST:
         // CURSOR is used inside CAST, like 'CAST ($0): CURSOR NOT NULL',
         // convert it to sql call of {@link SqlStdOperatorTable#CURSOR}.
         final RelDataType dataType = call.getType();

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2251,6 +2251,15 @@ class RelToSqlConverterTest {
         .ok(expectedBqFormatDatetime);
   }
 
+  @Test void testBigQuerySafeCast() {
+    final String query = "select safe_cast(\"product_name\" as date) "
+        + "from \"foodmart\".\"product\"";
+    final String expected = "SELECT SAFE_CAST(\"product_name\" AS DATE)\n"
+        + "FROM \"foodmart\".\"product\"";
+
+    sql(query).withLibrary(SqlLibrary.BIG_QUERY).ok(expected);
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3220">[CALCITE-3220]
    * HiveSqlDialect should transform the SQL-standard TRIM function to TRIM,

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2251,6 +2251,10 @@ class RelToSqlConverterTest {
         .ok(expectedBqFormatDatetime);
   }
 
+  /**
+   * Test that the type of a SAFE_CAST rex call is converted to an argument of the SQL call.
+   * See <a href="https://issues.apache.org/jira/browse/CALCITE-6117">[CALCITE-6117]</a>.
+   */
   @Test void testBigQuerySafeCast() {
     final String query = "select safe_cast(\"product_name\" as date) "
         + "from \"foodmart\".\"product\"";


### PR DESCRIPTION
With the fix to `SqlImplementor.java`, the added test passes.

Without the fix, it triggers [this assertion](https://github.com/apache/calcite/blob/3843ede3d28783235780c0f81f725dc7e64a7828/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java#L254) because the type of the rex function is not converted to an argument of the sql function (which thus only has 1 argument).