### PR TITLE
[CALCITE-5508] Allow no-op versions of DATETIME and TIMESTAMP

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -2708,6 +2708,18 @@ SELECT TIMESTAMP(DATE "2008-12-25") AS timestamp_date;
 
 !ok
 
+# This tests the no-op TIMESTAMP and DATETIME functions.
+select TIMESTAMP(TIMESTAMP "2008-01-01 01:03:05") as ts,
+       DATETIME(DATETIME "2008-01-01 01:03:05") as dt;
++---------------------+---------------------+
+| ts                  | dt                  |
++---------------------+---------------------+
+| 2008-01-01 01:03:05 | 2008-01-01 01:03:05 |
++---------------------+---------------------+
+(1 row)
+
+!ok
+
 # All these timestamps should be equal.
 # This tests the BQ timestamp literal string formatter
 # (optional 'T', optional leading zeros, optional offset with conversion).

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -772,7 +772,9 @@ public abstract class SqlLibraryOperators {
               // DATETIME(timestampLtz, timeZone)
               OperandTypes.sequence(
                   "DATETIME(TIMESTAMP WITH LOCAL TIME ZONE, VARCHAR)",
-                  OperandTypes.TIMESTAMP_LTZ, OperandTypes.CHARACTER)),
+                  OperandTypes.TIMESTAMP_LTZ, OperandTypes.CHARACTER),
+              // DATETIME(timestamp) -- This is a no-op.
+              OperandTypes.TIMESTAMP_NTZ),
           SqlFunctionCategory.TIMEDATE);
 
   /** The "TIME" function. It has the following overloads:
@@ -827,7 +829,9 @@ public abstract class SqlLibraryOperators {
               OperandTypes.TIMESTAMP_NTZ,
               // TIMESTAMP(timestamp, timeZone)
               OperandTypes.sequence("TIMESTAMP(TIMESTAMP, VARCHAR)",
-                  OperandTypes.TIMESTAMP_NTZ, OperandTypes.CHARACTER)),
+                  OperandTypes.TIMESTAMP_NTZ, OperandTypes.CHARACTER),
+              // TIMESTAMP(timestampLtz) -- This is a no-op.
+              OperandTypes.TIMESTAMP_LTZ),
           SqlFunctionCategory.TIMEDATE);
 
   /** The "CURRENT_DATETIME([timezone])" function. */

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -5055,4 +5055,24 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     String sql = "SELECT CAST(CAST(? AS INTEGER) AS CHAR)";
     sql(sql).ok();
   }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5508">DATETIME and TIMESTAMP constructor
+   * functions</a> that take single arguments with the same type as the function's return type.
+   *
+   * <p>The function counts as a no-op in this case.
+   */
+  @Test void testNoOpTimeDateFunctions() {
+    String sql = "SELECT TIMESTAMP(TIMESTAMP WITH LOCAL TIME ZONE '2023-12-21 12:34:56'), "
+        + "DATETIME(TIMESTAMP '2023-12-21 12:34:56') "
+        + "FROM emp";
+
+    fixture()
+        .withFactory(c ->
+            c.withOperatorTable(t ->
+                SqlValidatorTest.operatorTableFor(SqlLibrary.BIG_QUERY)))
+        .withSql(sql)
+        .ok();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -4886,6 +4886,17 @@ LogicalProject(SKILL=[ROW($0)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNoOpTimeDateFunctions">
+    <Resource name="sql">
+      <![CDATA[SELECT TIMESTAMP(TIMESTAMP WITH LOCAL TIME ZONE '2023-12-21 12:34:56'), DATETIME(TIMESTAMP '2023-12-21 12:34:56') FROM emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[TIMESTAMP(2023-12-21 12:34:56:TIMESTAMP_WITH_LOCAL_TIME_ZONE(0))], EXPR$1=[DATETIME(2023-12-21 12:34:56)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNotCaseInMoreClause">
     <Resource name="sql">
       <![CDATA[select empno from emp where not case when true then deptno in (10,20) when false then false else deptno in (30,40) end]]>

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2711,9 +2711,11 @@ BigQuery's type system uses confusingly different names for types and functions:
 | p q | DATEADD(timeUnit, integer, datetime)         | Equivalent to `TIMESTAMPADD(timeUnit, integer, datetime)`
 | p q | DATEDIFF(timeUnit, datetime, datetime2)      | Equivalent to `TIMESTAMPDIFF(timeUnit, datetime, datetime2)`
 | q | DATEPART(timeUnit, datetime)                   | Equivalent to `EXTRACT(timeUnit FROM  datetime)`
+| b | DATETIME(timestamp)                            | Returns its argument unchanged (no-op)
 | b | DATETIME(date, time)                           | Converts *date* and *time* to a TIMESTAMP
 | b | DATETIME(date)                                 | Converts *date* to a TIMESTAMP value (at midnight)
-| b | DATETIME(date, timeZone)                       | Converts *date* to a TIMESTAMP value (at midnight), in *timeZone*
+| b | DATETIME(timestampLtz)                         | Converts *timestampLtz* to a TIMESTAMP value, with no conversion for local time zone
+| b | DATETIME(timestampLtz, timeZone)               | Converts *timestampLtz* to a TIMESTAMP value, converting from the given local time zone
 | b | DATETIME(year, month, day, hour, minute, second) | Creates a TIMESTAMP for *year*, *month*, *day*, *hour*, *minute*, *second* (all of type INTEGER)
 | b | DATETIME_ADD(timestamp, interval)              | Returns the TIMESTAMP value that occurs *interval* after *timestamp*
 | b | DATETIME_DIFF(timestamp, timestamp2, timeUnit) | Returns the whole number of *timeUnit* between *timestamp* and *timestamp2*
@@ -2833,12 +2835,13 @@ BigQuery's type system uses confusingly different names for types and functions:
 | b | TIME(timestamp)                                | Extracts the TIME from *timestamp* (a local time; BigQuery's DATETIME type)
 | b | TIME(instant)                                  | Extracts the TIME from *timestampLtz* (an instant; BigQuery's TIMESTAMP type), assuming UTC
 | b | TIME(instant, timeZone)                        | Extracts the time from *timestampLtz* (an instant; BigQuery's TIMESTAMP type), in *timeZone*
+| b | TIMESTAMP(timestampLtz)                        | Returns its argument unchanged (no-op)
 | b | TIMESTAMP(string)                              | Equivalent to `CAST(string AS TIMESTAMP WITH LOCAL TIME ZONE)`
 | b | TIMESTAMP(string, timeZone)                    | Equivalent to `CAST(string AS TIMESTAMP WITH LOCAL TIME ZONE)`, converted to *timeZone*
 | b | TIMESTAMP(date)                                | Converts *date* to a TIMESTAMP WITH LOCAL TIME ZONE value (at midnight)
 | b | TIMESTAMP(date, timeZone)                      | Converts *date* to a TIMESTAMP WITH LOCAL TIME ZONE value (at midnight), in *timeZone*
-| b | TIMESTAMP(timestamp)                           | Converts *timestamp* to a TIMESTAMP WITH LOCAL TIME ZONE, assuming a UTC
-| b | TIMESTAMP(timestamp, timeZone)                 | Converts *timestamp* to a TIMESTAMP WITH LOCAL TIME ZONE, in *timeZone*
+| b | TIMESTAMP(timestamp)                           | Converts *timestamp* to a TIMESTAMP WITH LOCAL TIME ZONE, with no time zone conversion
+| b | TIMESTAMP(timestamp, timeZone)                 | Converts *timestamp* to a TIMESTAMP WITH LOCAL TIME ZONE, converting to *timeZone*
 | b | TIMESTAMP_ADD(timestamp, interval)             | Returns the TIMESTAMP value that occurs *interval* after *timestamp*
 | b | TIMESTAMP_DIFF(timestamp, timestamp2, timeUnit) | Returns the whole number of *timeUnit* between *timestamp* and *timestamp2*. Equivalent to `TIMESTAMPDIFF(timeUnit, timestamp2, timestamp)` and `(timestamp - timestamp2) timeUnit`
 | b | TIMESTAMP_MICROS(integer)                      | Returns the TIMESTAMP that is *integer* microseconds after 1970-01-01 00:00:00


### PR DESCRIPTION
This is a bit of unfinished work from CALCITE-5508. BigQuery supports calling the `TIMESTAMP()` function with a `TIMESTAMP`-typed argument, and the `DATETIME()` function with a `DATETIME`-typed argument. Both functions should simply return their argument in these cases, which is functionality we get for free from the existing implementations.

The problem is that, without proper argument type checking, Calcite will try to coerce the argument types, which in the case of `DATETIME()` causes it to try casting as `DATE` and eliminating the time component.