### PR TITLE
[CALCITE-6111] Explicit cast from expression to numeric type doesn't check overflow

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -59,6 +59,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlWindowTableFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.util.BuiltInMethod;
@@ -533,6 +534,19 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
       default:
         return defaultExpression.get();
       }
+
+    case BIGINT:
+    case INTEGER:
+    case TINYINT:
+    case SMALLINT: {
+      if (SqlTypeName.NUMERIC_TYPES.contains(sourceType.getSqlTypeName())) {
+        return Expressions.call(
+            BuiltInMethod.INTEGER_CAST.method,
+            Expressions.constant(Primitive.of(typeFactory.getJavaClass(targetType))),
+            operand);
+      }
+      return defaultExpression.get();
+    }
 
     default:
       return defaultExpression.get();

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -291,6 +291,7 @@ public enum BuiltInMethod {
   ENUMERABLE_TO_LIST(ExtendedEnumerable.class, "toList"),
   ENUMERABLE_TO_MAP(ExtendedEnumerable.class, "toMap", Function1.class, Function1.class),
   AS_LIST(Primitive.class, "asList", Object.class),
+  INTEGER_CAST(Primitive.class, "integerCast", Primitive.class, Object.class),
   MEMORY_GET0(MemoryFactory.Memory.class, "get"),
   MEMORY_GET1(MemoryFactory.Memory.class, "get", int.class),
   ENUMERATOR_CURRENT(Enumerator.class, "current"),

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/Primitive.java
@@ -384,6 +384,10 @@ public enum Primitive {
     }
   }
 
+  public static @Nullable Object integerCast(Primitive primitive, final Object value) {
+    return requireNonNull(primitive, "primitive").numberValue((Number) value);
+  }
+
   /**
    * Converts a number into a value of the type specified by this primitive
    * using the SQL CAST rules.  If the value conversion causes loss of significant digits,
@@ -419,6 +423,13 @@ public enum Primitive {
         // The value Long.MAX_VALUE cannot be represented exactly as a double,
         // so we cannot use checkRoundedRange.
         BigDecimal decimal = BigDecimal.valueOf(value.doubleValue())
+            // Round to an integer
+            .setScale(0, RoundingMode.DOWN);
+        // longValueExact will throw ArithmeticException if out of range
+        return decimal.longValueExact();
+      }
+      if (value instanceof BigDecimal) {
+        BigDecimal decimal = ((BigDecimal) value)
             // Round to an integer
             .setScale(0, RoundingMode.DOWN);
         // longValueExact will throw ArithmeticException if out of range

--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
@@ -71,7 +71,9 @@ public interface SqlOperatorFixture extends AutoCloseable {
   // TODO: Change message
   String INVALID_CHAR_MESSAGE = "(?s).*";
 
-  String OUT_OF_RANGE_MESSAGE = ".* out of range";
+  String OUT_OF_RANGE_MESSAGE = ".* out of range.*";
+
+  String WRONG_FORMAT_MESSAGE = "Number has wrong format.*";
 
   // TODO: Change message
   String DIVISION_BY_ZERO_MESSAGE = "(?s).*";
@@ -643,8 +645,12 @@ public interface SqlOperatorFixture extends AutoCloseable {
 
   default void checkCastFails(String value, String targetType,
       String expectedError, boolean runtime, CastType castType) {
-    final String castString = getCastString(value, targetType, !runtime, castType);
-    checkFails(castString, expectedError, runtime);
+    final String query = getCastString(value, targetType, !runtime, castType);
+    if (castType == CastType.CAST || !runtime) {
+      checkFails(query, expectedError, runtime);
+    } else {
+      checkNull(query);
+    }
   }
 
   default void checkCastToString(String value, @Nullable String type,


### PR DESCRIPTION
This also fixes a few more tests which were disabled in SqlOperatorTests.
I still have to handle casts to decimal values, but hopefully this fixes the behavior of casts to integer types.
This behavior also has to be documented, so a future PR will describe in more details how Calcite evaluates casts.