### PR TITLE
[WIP][CALCITE-6028] SqlToRelConverter#substituteSubQuery gives NullPointerException when convert expr JOIN ... ON ... AND ... IN ... and if size of IN exceeds IN_SUBQUERY_THRESHOLD

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4946,6 +4946,30 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
 
   /**
    * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6028">[CALCITE-6028]
+   * SqlToRelConverter#substituteSubQuery gives NullPointerException when convert
+   * expr JOIN ... ON ... AND ... IN ... and if size of IN exceeds IN_SUBQUERY_THRESHOLD</a>.
+   */
+  @Test void testInSubQueryWithinJoin0() {
+    String sql = "SELECT t1.x FROM (values (1, 'a')) as t1(x, y)\n"
+        + "left join (values (1, 'b')) as t2(x, y)\n"
+        + "ON t1.x=t2.x AND t1.x IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)";
+    sql(sql).ok();
+  }
+
+  /**
+   * As {@link #testInSubQueryWithinJoin0()} but value size of IN < 20.
+   */
+  @Test void testInSubQueryWithinJoin1() {
+    String sql = "SELECT t1.x FROM (values (1, 'a')) as t1(x, y)\n"
+        + "left join (values (1, 'b')) as t2(x, y)\n"
+        + "ON t1.x=t2.x AND t1.x IN (1,2,3,4,5)";
+    sql(sql).ok();
+  }
+
+
+  /**
+   * Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-4295">[CALCITE-4295]
    * Composite of two checker with SqlOperandCountRange throws IllegalArgumentException</a>.
    */

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2779,6 +2779,40 @@ FROM dept, emp WHERE emp.deptno = dept.deptno AND emp.sal < (
 )]]>
     </Resource>
   </TestCase>
+  <TestCase name="testInSubQueryWithinJoin0">
+    <Resource name="sql">
+      <![CDATA[SELECT t1.x FROM (values (1, 'a')) as t1(x, y)
+left join (values (1, 'b')) as t2(x, y)
+ON t1.x=t2.x AND t1.x IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(X=[$0])
+  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+    LogicalValues(tuples=[[{ 1, 'a' }]])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalValues(tuples=[[{ 1, 'b' }]])
+      LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+        LogicalAggregate(group=[{0}])
+          LogicalValues(tuples=[[{ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 }, { 11 }, { 12 }, { 13 }, { 14 }, { 15 }, { 16 }, { 17 }, { 18 }, { 19 }, { 20 }, { 21 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInSubQueryWithinJoin1">
+    <Resource name="sql">
+      <![CDATA[SELECT t1.x FROM (values (1, 'a')) as t1(x, y)
+left join (values (1, 'b')) as t2(x, y)
+ON t1.x=t2.x AND t1.x IN (1,2,3,4,5)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(X=[$0])
+  LogicalJoin(condition=[AND(=($0, $2), SEARCH($0, Sarg[1, 2, 3, 4, 5]))], joinType=[left])
+    LogicalValues(tuples=[[{ 1, 'a' }]])
+    LogicalValues(tuples=[[{ 1, 'b' }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testInToSemiJoin">
     <Resource name="sql">
       <![CDATA[SELECT empno

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -3721,4 +3721,41 @@ SELECT map(SELECT empno, deptno from emp where false);
 
 !ok
 
+# Test case for [CALCITE-6028] SqlToRelConverter#substituteSubQuery gives NullPointerException when convert
+# expr JOIN ... ON ... AND ... IN ... and if size of IN exceeds IN_SUBQUERY_THRESHOLD
+# IN value size < 20
+SELECT e1.empno FROM emp as e1 LEFT JOIN dept as d1 ON e1.deptno=d1.deptno
+WHERE e1.deptno IN (1,2,3,4,5,6,7,8,9,10);
++-------+
+| EMPNO |
++-------+
+|  7782 |
+|  7839 |
+|  7934 |
++-------+
+(3 rows)
+
+!ok
+
+# Test case for [CALCITE-6028] SqlToRelConverter#substituteSubQuery gives NullPointerException when convert
+# expr JOIN ... ON ... AND ... IN ... and if size of IN exceeds IN_SUBQUERY_THRESHOLD
+# IN value size > 20
+SELECT e1.empno FROM emp as e1 LEFT JOIN dept as d1 ON e1.deptno=d1.deptno
+WHERE e1.deptno IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21);
++-------+
+| EMPNO |
++-------+
+|  7369 |
+|  7566 |
+|  7782 |
+|  7788 |
+|  7839 |
+|  7876 |
+|  7902 |
+|  7934 |
++-------+
+(8 rows)
+
+!ok
+
 # End sub-query.iq


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6028

the PR only changed 2 lines, fix two exceptions.

1.the NPE is introduced by https://issues.apache.org/jira/browse/CALCITE-3292.
2.the assert in bb.register