### PR TITLE
[CALCITE-6132] The exception thrown in the RelBuilderExample is not accurate

### DIFF
--- a/core/src/test/java/org/apache/calcite/examples/RelBuilderExample.java
+++ b/core/src/test/java/org/apache/calcite/examples/RelBuilderExample.java
@@ -66,7 +66,7 @@ public class RelBuilderExample {
     case 4:
       return example4(builder);
     default:
-      throw new AssertionError("unknown example " + i);
+      throw new AssertionError("unknown example" + i);
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6132