### PR TITLE
[CALCITE-6149] Unparse for CAST Nullable with ClickHouseSqlDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
@@ -79,25 +79,25 @@ public class ClickHouseSqlDialect extends SqlDialect {
       SqlTypeName typeName = type.getSqlTypeName();
       switch (typeName) {
       case VARCHAR:
-        return createSqlDataTypeSpecByName("String", typeName);
+        return createSqlDataTypeSpecByName("String", typeName, type.isNullable());
       case TINYINT:
-        return createSqlDataTypeSpecByName("Int8", typeName);
+        return createSqlDataTypeSpecByName("Int8", typeName, type.isNullable());
       case SMALLINT:
-        return createSqlDataTypeSpecByName("Int16", typeName);
+        return createSqlDataTypeSpecByName("Int16", typeName, type.isNullable());
       case INTEGER:
-        return createSqlDataTypeSpecByName("Int32", typeName);
+        return createSqlDataTypeSpecByName("Int32", typeName, type.isNullable());
       case BIGINT:
-        return createSqlDataTypeSpecByName("Int64", typeName);
+        return createSqlDataTypeSpecByName("Int64", typeName, type.isNullable());
       case REAL:
-        return createSqlDataTypeSpecByName("Float32", typeName);
+        return createSqlDataTypeSpecByName("Float32", typeName, type.isNullable());
       case FLOAT:
       case DOUBLE:
-        return createSqlDataTypeSpecByName("Float64", typeName);
+        return createSqlDataTypeSpecByName("Float64", typeName, type.isNullable());
       case DATE:
-        return createSqlDataTypeSpecByName("Date", typeName);
+        return createSqlDataTypeSpecByName("Date", typeName, type.isNullable());
       case TIMESTAMP:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-        return createSqlDataTypeSpecByName("DateTime", typeName);
+        return createSqlDataTypeSpecByName("DateTime", typeName, type.isNullable());
       default:
         break;
       }
@@ -107,11 +107,15 @@ public class ClickHouseSqlDialect extends SqlDialect {
   }
 
   private static SqlDataTypeSpec createSqlDataTypeSpecByName(String typeAlias,
-      SqlTypeName typeName) {
+      SqlTypeName typeName, boolean isNullable) {
+    if (isNullable) {
+      typeAlias = "Nullable(" + typeAlias + ")";
+    }
+    String finalTypeAlias = typeAlias;
     SqlBasicTypeNameSpec spec = new SqlBasicTypeNameSpec(typeName, SqlParserPos.ZERO) {
       @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
         // unparse as an identifier to ensure that type names are cased correctly
-        writer.identifier(typeAlias, true);
+        writer.identifier(finalTypeAlias, true);
       }
     };
     return new SqlDataTypeSpec(spec, SqlParserPos.ZERO);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7120,6 +7120,21 @@ class RelToSqlConverterTest {
         .withBigQuery().ok(expectedBiqquery);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6149">[CALCITE-6149]
+   * Unparse for CAST Nullable with ClickHouseSqlDialect</a>. */
+  @Test void testCastToNullableInClickhouse() {
+    final String query = ""
+        + "SELECT CASE WHEN \"product_id\" IS NULL "
+        + "THEN CAST(\"product_id\" AS TINYINT) END, CAST(\"product_id\" AS TINYINT)\n"
+        + "FROM \"foodmart\".\"product\"";
+    final String expectedSql = ""
+        + "SELECT CAST(NULL AS `Nullable(Int8)`), CAST(`product_id` AS `Int8`)\n"
+        + "FROM `foodmart`.`product`";
+
+    sql(query).withClickHouse().ok(expectedSql);
+  }
+
   @Test void testDialectQuoteStringLiteral() {
     dialects().forEach((dialect, databaseProduct) -> {
       assertThat(dialect.quoteStringLiteral(""), is("''"));


### PR DESCRIPTION
In ClickHouse, there is an issue with RelDataType of Nullable type when casting to a non-Nullable type. For example, `SELECT CAST(NULL, 'Int32')` will throw an error. In such cases, we should use `SELECT CAST(NULL, 'Nullable(Int32)')` instead.

```
CREATE TABLE default.test
(
    `id` Int64,
    `a` Nullable(Int64)
)
ENGINE = MergeTree
ORDER BY id
```
`insert into test(id,a) values(1,1);`
`insert into test(id,a) values(2,null);`
`SELECT CAST(a, 'String') FROM test;`

DB::Exception: Cannot convert NULL value to non-Nullable type
![image](https://github.com/apache/calcite/assets/67011523/9968152f-daf2-4db8-a1e0-7fbc815dbd36)
