### PR TITLE
[CALCITE-6149] Unparse for certain EXTRACT Unit with ClickHouseSqlDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
@@ -175,6 +175,29 @@ public class ClickHouseSqlDialect extends SqlDialect {
         super.unparseCall(writer, call, leftPrec, rightPrec);
       }
       break;
+    case EXTRACT:
+      SqlLiteral node = call.operand(0);
+      TimeUnitRange unit = node.getValueAs(TimeUnitRange.class);
+      String funName;
+      switch (unit){
+      case DOW:
+        funName = "DAYOFWEEK";
+        break;
+      case DOY:
+        funName = "DAYOFYEAR";
+        break;
+      case WEEK:
+        funName = "toWeek";
+        break;
+      default:
+        super.unparseCall(writer, call, leftPrec, rightPrec);
+        return;
+      }
+      writer.print(funName);
+      final SqlWriter.Frame frame = writer.startList("(", ")");
+      call.operand(1).unparse(writer, 0, 0);
+      writer.endList(frame);
+      break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7453,6 +7453,23 @@ class RelToSqlConverterTest {
     sql(query).withSpark().withLibrary(SqlLibrary.SPARK).ok(expectedSql);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6150">[CALCITE-6150]
+   * Clickhouse does not support certain EXTRACT Unit syntax.</a>. */
+  @Test void testClickhouseSpecialExtract() {
+    final String sql1 = "SELECT EXTRACT(DOW FROM Date '2023-12-01')";
+    final String expected1 = "SELECT DAYOFWEEK(toDate('2023-12-01'))";
+    sql(sql1).withClickHouse().ok(expected1);
+
+    final String sql2 = "SELECT EXTRACT(DOY FROM Date '2023-12-01')";
+    final String expected2 = "SELECT DAYOFYEAR(toDate('2023-12-01'))";
+    sql(sql2).withClickHouse().ok(expected2);
+
+    final String sql3 = "SELECT EXTRACT(WEEK FROM Date '2023-12-01')";
+    final String expected3 = "SELECT toWeek(toDate('2023-12-01'))";
+    sql(sql3).withClickHouse().ok(expected3);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final CalciteAssert.SchemaSpec schemaSpec;


### PR DESCRIPTION
Clickhouse does not support the following EXTRACT Unit syntax, and ClickHouseSqlDialect may need some adaptation.

`SELECT EXTRACT(DOW FROM Date '2023-12-01')`
![image](https://github.com/apache/calcite/assets/67011523/c56cda0f-26e2-40a3-b7ed-b871c87b384e)
`SELECT EXTRACT(DOY FROM Date '2023-12-01')`
![image](https://github.com/apache/calcite/assets/67011523/390a92e6-9e18-4226-bddf-6a7554e00bed)
`SELECT EXTRACT(WEEK FROM Date '2023-12-01')`
![image](https://github.com/apache/calcite/assets/67011523/d84ad5b3-33d0-4797-8709-fe0917eb99b4)
