### PR TITLE
[CALCITE-5811] Error messages produced for constant out-of-bounds arg…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
@@ -29,7 +29,7 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
-import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
@@ -44,11 +44,15 @@ import java.util.Objects;
  * Definition of the "SUBSTRING" builtin SQL function.
  */
 public class SqlSubstringFunction extends SqlFunction {
-  /** Type checker for 3 argument calls. Put the STRING_INTEGER_INTEGER checker
-   * first because almost every other type can be coerced to STRING. */
-  private static final SqlSingleOperandTypeChecker CHECKER3 =
-      OperandTypes.STRING_INTEGER_INTEGER
-          .or(OperandTypes.STRING_STRING_STRING);
+  /** Type checker for 3 argument calls. */
+  private static final SqlOperandTypeChecker CHECKER3 =
+      OperandTypes.sequence("<CHARACTER> <INTEGER> <INTEGER>",
+          OperandTypes.STRING,
+          OperandTypes.typeName(SqlTypeName.INTEGER),
+          OperandTypes.typeName(SqlTypeName.INTEGER));
+      // The variant of substring(string FROM regexp FOR regexp)
+      // is not implemented.
+          // .or(OperandTypes.STRING_STRING_STRING);
 
   //~ Constructors -----------------------------------------------------------
 

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -3298,6 +3298,25 @@ public class SqlOperatorTest {
     f.setFor(SqlStdOperatorTable.DESC, VM_EXPAND);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5811">[CALCITE-5811]
+   * Error messages produced for constant out-of-bounds arguments are confusing</a>.
+   */
+  @Test void testIndexOutOfBounds() {
+    final SqlOperatorFixture f = fixture();
+    f.checkFails("^substring('abc' from 2 for 2147483650)^",
+        "Cannot apply 'SUBSTRING' to arguments of type "
+            + "'SUBSTRING\\(<CHAR\\(3\\)> FROM <INTEGER> FOR <BIGINT>\\)'\\. "
+            + "Supported form\\(s\\): 'SUBSTRING\\(<CHAR> FROM <INTEGER>\\)'\n"
+            + "'SUBSTRING\\(<CHAR> FROM <INTEGER> FOR <INTEGER>\\)'\n"
+            + "'SUBSTRING\\(<VARCHAR> FROM <INTEGER>\\)'\n"
+            + "'SUBSTRING\\(<VARCHAR> FROM <INTEGER> FOR <INTEGER>\\)'\n"
+            + "'SUBSTRING\\(<BINARY> FROM <INTEGER>\\)'\n"
+            + "'SUBSTRING\\(<BINARY> FROM <INTEGER> FOR <INTEGER>\\)'\n"
+            + "'SUBSTRING\\(<VARBINARY> FROM <INTEGER>\\)'\n"
+            + "'SUBSTRING\\(<VARBINARY> FROM <INTEGER> FOR <INTEGER>\\)'", false);
+  }
+
   @Test void testIsNotNullOperator() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.IS_NOT_NULL, VmName.EXPAND);


### PR DESCRIPTION
…uments are confusing

This turned out to be a bug in the type inference for the arguments of the `substring` function.
The type inference allowed BIGINT arguments.
The `SqlFunctions.substring` method only supports integers as arguments.