### PR TITLE
[CALCITE-6161] The equalsDeep of sqlCall should compare sqlOperator's sqlKind

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCall.java
@@ -181,6 +181,10 @@ public abstract class SqlCall extends SqlNode {
     if (!this.getOperator().getName().equalsIgnoreCase(that.getOperator().getName())) {
       return litmus.fail("{} != {}", this, node);
     }
+    // For same name but different kind
+    if (this.getOperator().getKind() != that.getOperator().getKind()) {
+      return litmus.fail("{} != {}", this, node);
+    }
     if (!equalDeep(this.getFunctionQuantifier(), that.getFunctionQuantifier(), litmus)) {
       return litmus.fail("{} != {} (function quantifier differs)", this, node);
     }

--- a/core/src/test/java/org/apache/calcite/sql/SqlNodeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/SqlNodeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql;
 
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -50,6 +51,22 @@ class SqlNodeTest {
         SqlNodeList.of(zero,
             Arrays.asList(SqlLiteral.createCharString("x", zero),
                 new SqlIdentifier("y", zero))));
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6161">[CALCITE-6161]
+   * The equalsDeep of sqlCall should compare sqlOperator's sqlKind</a>.
+   */
+  @Test void testSameNameButDifferent() {
+    final SqlParserPos zero = SqlParserPos.ZERO;
+    final List<SqlNode> operandList =
+        Arrays.asList(new SqlIdentifier("x", zero), new SqlIdentifier("y", zero));
+    final SqlNode unaryOperatorNode =
+        new SqlBasicCall(SqlStdOperatorTable.UNARY_MINUS, operandList, zero);
+    final SqlNode binaryOperatorNode =
+        new SqlBasicCall(SqlStdOperatorTable.MINUS, operandList, zero);
+    assertThat(unaryOperatorNode.equalsDeep(binaryOperatorNode, Litmus.IGNORE), is(false));
   }
 
   /**


### PR DESCRIPTION
fix for [CALCITE-6161](https://issues.apache.org/jira/browse/CALCITE-6161)