### PR TITLE
[CALCITE-3522] SqlValidator.validateLiteral rejects literals with a DECIMAL type that require more than 64 bits

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlNumericLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNumericLiteral.java
@@ -103,7 +103,7 @@ public class SqlNumericLiteral extends SqlLiteral {
           BigDecimal bd = getValueNonNull();
           SqlTypeName result;
           // Will throw if the number cannot be represented as a long.
-          long l = bd.longValue();
+          long l = bd.longValueExact();
           if ((l >= Integer.MIN_VALUE) && (l <= Integer.MAX_VALUE)) {
             result = SqlTypeName.INTEGER;
           } else {
@@ -115,7 +115,6 @@ public class SqlNumericLiteral extends SqlLiteral {
           // Fallback to DECIMAL.
         }
       }
-
       // else we have a decimal
       return typeFactory.createSqlType(
           SqlTypeName.DECIMAL,

--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -153,11 +153,6 @@ public abstract class Bug {
   public static final boolean CALCITE_2401_FIXED = false;
 
   /** Whether
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-2539">[CALCITE-2539]
-   * Several test case not passed in CalciteSqlOperatorTest.java</a> is fixed. */
-  public static final boolean CALCITE_2539_FIXED = false;
-
-  /** Whether
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2869">[CALCITE-2869]
    * JSON data type support</a> is fixed. */
   public static final boolean CALCITE_2869_FIXED = false;


### PR DESCRIPTION
The comment below is no longer accurate after the PR was split into two separate PRs.

--------------

I initially started with the goal of fixing just [CALCITE-3522], https://issues.apache.org/jira/browse/CALCITE-3522, which is limiting the size of decimal literals to 64 bits. The fix is to actually check the precision of the type system when rejecting a decimal literal. That's easy. I am not checking the scale, under the assumption that rounding is OK for literals but losing precision is not.

However, fixing this problem unmasked a bunch of other bugs in handling large values, so in order to make the tests pass I had to also fix [CALCITE-6169], which is about incorrect casts between numeric values. There is still one case which is not handled, which is casts between decimal values that change the scale of the result, but I plan to do that in a separate PR (because I also have to think about it more.)

You will notice that this fix re-enables some tests that were disabled a long time ago. I think that disabling failing tests is not a good practice, and should be avoided. There are still some disabled tests in these categories, but strictly fewer than before.

I couldn't make this into 2 separate PRs that both keep all tests running. 

I am not 100% happy with the code, in particular with the implementation of the new Expression `ConvertChecked`. The implementation (which is in the unparse method...) in fact just calls the existing code in `Primitive` which handles numeric casts. I think that's better than duplicating the code. There is already a very large number of places where these conversions are handled, which is shown by the many files that I had to patch.