### PR TITLE
[CALCITE-6162] Add rule(s) to remove joins with constant single tuple…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptRules.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.rules.DateRangeRules;
 import org.apache.calcite.rel.rules.JoinPushThroughJoinRule;
 import org.apache.calcite.rel.rules.PruneEmptyRules;
+import org.apache.calcite.rel.rules.SingleValuesOptimizationRules;
 import org.apache.calcite.rel.rules.materialize.MaterializedViewRules;
 
 import com.google.common.collect.ImmutableList;
@@ -106,6 +107,10 @@ public class RelOptRules {
           PruneEmptyRules.JOIN_RIGHT_INSTANCE,
           PruneEmptyRules.SORT_FETCH_ZERO_INSTANCE,
           PruneEmptyRules.EMPTY_TABLE_INSTANCE,
+          SingleValuesOptimizationRules.JOIN_LEFT_INSTANCE,
+          SingleValuesOptimizationRules.JOIN_RIGHT_INSTANCE,
+          SingleValuesOptimizationRules.JOIN_LEFT_PROJECT_INSTANCE,
+          SingleValuesOptimizationRules.JOIN_RIGHT_PROJECT_INSTANCE,
           CoreRules.UNION_MERGE,
           CoreRules.INTERSECT_MERGE,
           CoreRules.MINUS_MERGE,

--- a/core/src/main/java/org/apache/calcite/rel/core/Values.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Values.java
@@ -152,6 +152,10 @@ public abstract class Values extends AbstractRelNode implements Hintable {
     return !isEmpty(values);
   }
 
+  public static boolean isSingleValue(Values values) {
+    return values.tuples.size() == 1;
+  }
+
   public ImmutableList<ImmutableList<RexLiteral>> getTuples(RelInput input) {
     return input.getTuples("tuples");
   }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SingleValuesOptimizationRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SingleValuesOptimizationRules.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Collection of rules which simplify joins which have one of their input as constant relations
+ * {@link Values} that produce a single row.
+ *
+ * <p>Conventionally, the way to represent a single row constant relational expression is
+ * with a {@link Values} that has one tuple.
+ *
+ * @see LogicalValues#createOneRow
+ */
+public abstract class SingleValuesOptimizationRules {
+
+  public static final RelOptRule JOIN_LEFT_INSTANCE =
+      SingleValuesOptimizationRules.JoinLeftSingleRuleConfig.DEFAULT.toRule();
+
+  public static final RelOptRule JOIN_RIGHT_INSTANCE =
+      SingleValuesOptimizationRules.JoinRightSingleRuleConfig.DEFAULT.toRule();
+
+  public static final RelOptRule JOIN_LEFT_PROJECT_INSTANCE =
+      SingleValuesOptimizationRules.JoinLeftSingleValueRuleWithExprConfig.DEFAULT.toRule();
+
+  public static final RelOptRule JOIN_RIGHT_PROJECT_INSTANCE =
+      SingleValuesOptimizationRules.JoinRightSingleValueRuleWithExprConfig.DEFAULT.toRule();
+
+  /**
+   * Transformer class to transform a Join rel node tree with single constant row {@link Values}
+   * on either side of the Join to a simplified tree without a Join rel node.
+   */
+  private static class SingleValuesRelTransformer {
+
+    private final Join join;
+    private final RelNode relNode;
+    private final Predicate<Join> transformable;
+    private final BiFunction<RexNode, List<RexNode>, List<RexNode>> litTransformer;
+    private final boolean valuesAsLeftChild;
+    private final List<RexNode> literals;
+
+    /**
+     * A transformer object which transforms a Join rel node tree with constant relation
+     * node as one of its input to a rel node tree without a Join.
+     *
+     * @param join Join which is eligible for removal.
+     * @param rexNodes List of the expressions that are part of Project
+     * @param otherNode RelNode which is other side of the Join (apart from Values node)
+     * @param transformable Predicate to check if the given Join is transformable or not.
+     * @param isValuesLeftChild TRUE if Values is left child of join, FALSE otherwise.
+     * @param litTransformer A transformer function supplied by the caller.
+     *                       This function is specific to Join Type.
+     *                       LEFT/ RIGHT => has logic to produce null values for unmatched rows.
+     *                       INNER => produce the rexLiterals specified in the Values node.
+     */
+    protected SingleValuesRelTransformer(
+        Join join, List<RexNode> rexNodes, RelNode otherNode,
+        Predicate<Join> transformable, boolean isValuesLeftChild,
+        BiFunction<RexNode, List<RexNode>, List<RexNode>> litTransformer) {
+      this.relNode = otherNode;
+      this.join = join;
+      this.transformable = transformable;
+      this.litTransformer = litTransformer;
+      this.valuesAsLeftChild = isValuesLeftChild;
+      this.literals = rexNodes;
+    }
+
+    /**
+     * A transform function which simplifies the join tree when eligibility criteria is met.
+     * Refer to {@link PruneSingleValueRule#onMatch} function for details about the transformation.
+
+     * Another very subtle point is that this works even if the VALUES contain NULL entries.
+     * This is because this generates code with comparisons to NULL, and comparing a value to NULL
+     * using = always returns false, so the result is an empty collection, as expected.
+     *
+     * @param relBuilder Relation Builder supplied by the planner framework.
+     * @return Simplified relNode tree by replacing Join,
+     *          Otherwise returns null when criteria is not met.
+     */
+    public @Nullable RelNode transform(RelBuilder relBuilder) {
+      if (!transformable.test(join)) {
+        return null;
+      }
+      int end = valuesAsLeftChild
+          ? join.getLeft().getRowType().getFieldCount()
+          : join.getRowType().getFieldCount();
+
+      int start = valuesAsLeftChild
+          ? 0
+          : join.getLeft().getRowType().getFieldCount();
+      ImmutableBitSet bitSet = ImmutableBitSet.range(start, end);
+      RexNode trueNode = relBuilder.getRexBuilder().makeLiteral(true);
+      final RexNode filterCondition =
+          new RexNodeReplacer(bitSet,
+              literals,
+              (valuesAsLeftChild ? 0 : -1) * join.getLeft().getRowType().getFieldCount())
+              .go(join.getCondition());
+
+      RexNode fixedCondition =
+          valuesAsLeftChild
+              ? RexUtil.shift(filterCondition,
+              -1 * join.getLeft().getRowType().getFieldCount())
+              : filterCondition;
+
+      List<RexNode> rexLiterals = litTransformer.apply(fixedCondition, literals);
+      relBuilder.push(relNode)
+          .filter(join.getJoinType().isOuterJoin() ? trueNode : fixedCondition);
+
+      List<RexNode> rexNodes = relNode
+          .getRowType()
+          .getFieldList()
+          .stream()
+          .map(fld -> relBuilder.field(fld.getIndex()))
+          .collect(Collectors.toList());
+
+      List<RexNode> projects = new ArrayList<>();
+      projects.addAll(valuesAsLeftChild ? rexLiterals : rexNodes);
+      projects.addAll(valuesAsLeftChild ? rexNodes : rexLiterals);
+      return relBuilder.project(projects).build();
+    }
+  }
+
+  /**
+   * A rex shuttle to replace field refs with supplied rexNodes from a {@link Values} row.
+   */
+  private static class RexNodeReplacer extends RexShuttle {
+
+    private final ImmutableBitSet bitSet;
+    private final List<RexNode> fieldValues;
+    private final int offset;
+
+    /**
+     * A RexNode replacer which replaces an inputRef with a corresponding
+     * RexNode value supplied in values parameter of the constructor.
+     *
+     * @param bitSet A bitmap to track indices of the inputRef that get replaced.
+     * @param values RexNodes list that are used to replace inputRefs.
+     * @param offset offset to be applied for the inputRef index to get the corresponding
+     *              RexNode value.
+     */
+    RexNodeReplacer(ImmutableBitSet bitSet, List<RexNode> values, int offset) {
+      this.bitSet = bitSet;
+      this.fieldValues = values;
+      this.offset = offset;
+    }
+    @Override public RexNode visitInputRef(RexInputRef inputRef) {
+      if (bitSet.get(inputRef.getIndex())) {
+        return this.fieldValues.get(inputRef.getIndex() + offset);
+      }
+      return super.visitInputRef(inputRef);
+    }
+
+    public RexNode go(RexNode expression) {
+      return expression.accept(this);
+    }
+  }
+
+  /**
+   * Abstract class for all the SingleValuesOptimizationRules. All the specific
+   * SingleValuesOptimizationRules call the onMatch function to replace a Join
+   * with equivalent tree when eligible.
+   */
+  protected abstract static class PruneSingleValueRule
+      extends RelRule<PruneSingleValueRule.Config>
+      implements SubstitutionRule {
+    protected PruneSingleValueRule(PruneSingleValueRule.Config config) {
+      super(config);
+    }
+
+    protected BiFunction<RexNode, List<RexNode>, List<RexNode>>
+        getRexTransformer(RexBuilder rexBuilder,
+        JoinRelType joinRelType) {
+      switch (joinRelType) {
+      case LEFT:
+      case RIGHT:
+        return (condition, rexLiterals) -> rexLiterals.stream().map(lit ->
+            rexBuilder.makeCall(SqlStdOperatorTable.CASE, condition,
+                lit, rexBuilder.makeNullLiteral(lit.getType()))).collect(Collectors.toList());
+      default:
+        return (condition, rexLiterals) -> rexLiterals;
+      }
+    }
+
+    /**
+     * onMatch function contains common optimization logic for all the
+     * SingleValueOptimization rules. It simplifies the rel node tree by
+     * removing a Join node and creating a required filter as applicable.
+     * In case of the LEFT/RIGHT joins, a case expression which produce NULL
+     * values for non-matching rows will be created as part of a Project node.
+
+     * The transformation can be illustrated by following e.g.
+
+     *  TableScan(Emp) join (cond: Emp.empno = v.no) with Values(1010 as no) &rarr;
+     *  Filter(Emp.empno = 1010) on TableScan(Emp)
+     *
+     * @param call          A RelOptRuleCall object
+     * @param values        A constant relation node which produces a single row.
+     * @param project       A project node which has dynamic constants (can be null).
+     * @param join          A join node which will get removed.
+     * @param other         A node on the other side of the join (apart from Values)
+     * @param isOnLefSide   Whether a Values node is on the Left side or the right side
+     *                      of the Join.
+     */
+    protected void onMatch(RelOptRuleCall call, Values values,
+        @Nullable Project project, Join join,
+        RelNode other, boolean isOnLefSide) {
+      Predicate<Join> transformableCheck = isJoinTransformable(isOnLefSide);
+      List<RexNode> rexNodes;
+      if (project != null) {
+        ImmutableBitSet bitSet = ImmutableBitSet.range(0, values.getRowType().getFieldCount());
+        RexShuttle shuttle =
+            new RexNodeReplacer(bitSet,
+                    new ArrayList<>(values.tuples.get(0)),
+                0);
+
+        rexNodes = project.getProjects().stream()
+            .map(shuttle::apply)
+            .collect(Collectors.toList());
+      } else {
+        rexNodes = new ArrayList<>(values.tuples.get(0));
+      }
+      RelBuilder relBuilder = call.builder();
+
+      BiFunction<RexNode, List<RexNode>, List<RexNode>> transformer =
+          getRexTransformer(relBuilder.getRexBuilder(), join.getJoinType());
+
+      SingleValuesRelTransformer relTransformer =
+          new SingleValuesRelTransformer(join, rexNodes, other,
+              transformableCheck, isOnLefSide, transformer);
+
+      RelNode transformedRelNode =
+          relTransformer.transform(relBuilder);
+
+      if (transformedRelNode != null) {
+        call.transformTo(transformedRelNode);
+      }
+    }
+
+    static Predicate<Join> isJoinTransformable(boolean isLeft) {
+
+      Predicate<Join> isFullOrAntiJoin =
+          jn -> jn.getJoinType() == JoinRelType.ANTI
+          || jn.getJoinType() == JoinRelType.FULL;
+
+      if (isLeft) {
+        return jn -> !(jn.getJoinType() == JoinRelType.LEFT || isFullOrAntiJoin.test(jn));
+      } else {
+        return jn -> !(jn.getJoinType() == JoinRelType.RIGHT  || isFullOrAntiJoin.test(jn));
+      }
+    }
+
+    @Override public boolean autoPruneOld() {
+      return true;
+    }
+
+    /** Rule configuration. */
+    protected interface Config extends RelRule.Config {
+      @Override PruneSingleValueRule toRule();
+    }
+  }
+
+  /** Configuration for a rule that simplifies join node with constant row on its right input. */
+  @Value.Immutable
+  interface JoinRightSingleRuleConfig extends PruneSingleValueRule.Config {
+    JoinRightSingleRuleConfig DEFAULT = ImmutableJoinRightSingleRuleConfig.of()
+        .withOperandSupplier(b0 ->
+            b0.operand(Join.class).inputs(
+                b1 -> b1.operand(RelNode.class).anyInputs(),
+                b2 -> b2.operand(Values.class).predicate(Values::isSingleValue).noInputs()))
+        .withDescription("PruneJoinSingleValue(right)");
+
+    @Override default SingleValuesOptimizationRules.PruneSingleValueRule toRule() {
+      return new SingleValuesOptimizationRules.PruneSingleValueRule(this) {
+        @Override public void onMatch(RelOptRuleCall call) {
+          final Join join = call.rel(0);
+          final Values values = call.rel(2);
+          final RelNode other = call.rel(1);
+          onMatch(call, values, null, join, other, false);
+        }
+      };
+    }
+  }
+
+  /** Configuration for a rule that simplifies join node with constant row on its left input. */
+  @Value.Immutable
+  interface JoinLeftSingleRuleConfig extends PruneSingleValueRule.Config {
+    JoinLeftSingleRuleConfig DEFAULT = ImmutableJoinLeftSingleRuleConfig.of()
+        .withOperandSupplier(b0 ->
+            b0.operand(Join.class).inputs(
+                b1 -> b1.operand(Values.class).predicate(Values::isSingleValue).noInputs(),
+                b2 -> b2.operand(RelNode.class).anyInputs()))
+        .withDescription("PruneJoinSingleValueRule(left)");
+
+    @Override default SingleValuesOptimizationRules.PruneSingleValueRule toRule() {
+      return new SingleValuesOptimizationRules.PruneSingleValueRule(this) {
+        @Override public void onMatch(RelOptRuleCall call) {
+          final Join join = call.rel(0);
+          final Values values = call.rel(1);
+          final RelNode other = call.rel(2);
+          onMatch(call, values, null, join, other, true);
+        }
+      };
+    }
+  }
+
+  /** Configuration for a rule that simplifies join node with a project on a constant row
+   *  on its left input. A project node shows up for use cases with dynamic constants like
+   *  current_timestamp(dynamic constants are not RexLiteral so cannot be part of Values node).*/
+  @Value.Immutable
+  interface JoinLeftSingleValueRuleWithExprConfig extends PruneSingleValueRule.Config {
+    JoinLeftSingleValueRuleWithExprConfig DEFAULT =
+        ImmutableJoinLeftSingleValueRuleWithExprConfig.of().withOperandSupplier(b0 ->
+            b0.operand(Join.class).inputs(
+                b1 -> b1.operand(Project.class).inputs(
+                    b11 -> b11.operand(Values.class).predicate(Values::isSingleValue).noInputs()),
+                b2 -> b2.operand(RelNode.class).anyInputs()))
+        .withDescription("PruneJoinSingleValueRuleWithExpr(left)");
+
+    @Override default SingleValuesOptimizationRules.PruneSingleValueRule toRule() {
+      return new SingleValuesOptimizationRules.PruneSingleValueRule(this) {
+        @Override public void onMatch(RelOptRuleCall call) {
+          final Join join = call.rel(0);
+          final Project project = call.rel(1);
+          final Values values = call.rel(2);
+          final RelNode other = call.rel(3);
+          onMatch(call, values, project, join, other, true);
+        }
+      };
+    }
+  }
+
+  /** Configuration for a rule that simplifies join node with a project on a constant row
+   *  on its right input. A project node shows up for use cases with dynamic constants like
+   *  current_timestamp(dynamic constants are not RexLiteral so cannot be part of Values node).*/
+  @Value.Immutable
+  interface JoinRightSingleValueRuleWithExprConfig extends PruneSingleValueRule.Config {
+    JoinRightSingleValueRuleWithExprConfig DEFAULT =
+        ImmutableJoinRightSingleValueRuleWithExprConfig.of().withOperandSupplier(b0 ->
+            b0.operand(Join.class).inputs(
+                b1 -> b1.operand(RelNode.class).anyInputs(),
+                b2 -> b2.operand(Project.class).inputs(
+                    b21 -> b21.operand(Values.class).predicate(Values::isSingleValue).noInputs())))
+        .withDescription("PruneJoinSingleValueRuleWithExpr(right)");
+
+    @Override default SingleValuesOptimizationRules.PruneSingleValueRule toRule() {
+      return new SingleValuesOptimizationRules.PruneSingleValueRule(this) {
+        @Override public void onMatch(RelOptRuleCall call) {
+          final Join join = call.rel(0);
+          final RelNode other = call.rel(1);
+          final Project project = call.rel(2);
+          final Values values = call.rel(3);
+          onMatch(call, values, project, join, other, false);
+        }
+      };
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -2973,27 +2973,29 @@ public class JdbcTest {
     switch (format) {
     case "text":
       expected = "EnumerableAggregate(group=[{0, 3}])\n"
-          + "  EnumerableNestedLoopJoin(condition=[=(CAST($1):INTEGER NOT NULL, $2)], joinType=[inner])\n"
-          + "    EnumerableTableScan(table=[[SALES, EMPS]])\n"
-          + "    EnumerableCalc(expr#0..1=[{inputs}], expr#2=['SameName'], expr#3=[=($t1, $t2)], proj#0..1=[{exprs}], $condition=[$t3])\n"
-          + "      EnumerableValues(tuples=[[{ 10, 'SameName' }]])\n";
+          + "  EnumerableCalc(expr#0..1=[{inputs}], expr#2=[10], expr#3=['SameName'], expr#4=[CAST($t1):INTEGER NOT NULL], expr#5=[=($t4, $t2)], proj#0..3=[{exprs}], $condition=[$t5])\n"
+          + "    EnumerableTableScan(table=[[SALES, EMPS]])\n\n";
       extra = "";
       break;
     case "dot":
       expected = "PLAN=digraph {\n"
-          + "\"EnumerableNestedLoop\\nJoin\\ncondition = =(CAST($\\n1):INTEGER NOT NULL,\\n $2)"
-          + "\\njoinType = inner\\n\" -> \"EnumerableAggregate\\ngroup = {0, 3}\\n\" "
-          + "[label=\"0\"]\n"
-          + "\"EnumerableTableScan\\ntable = [SALES, EMPS\\n]\\n\" -> "
-          + "\"EnumerableNestedLoop\\nJoin\\ncondition = =(CAST($\\n1):INTEGER NOT NULL,\\n $2)"
-          + "\\njoinType = inner\\n\" [label=\"0\"]\n"
-          + "\"EnumerableCalc\\nexpr#0..1 = {inputs}\\nexpr#2 = 'SameName'\\nexpr#3 = =($t1, $t2)"
-          + "\\nproj#0..1 = {exprs}\\n$condition = $t3\" -> "
-          + "\"EnumerableNestedLoop\\nJoin\\ncondition = =(CAST($\\n1):INTEGER NOT NULL,\\n $2)"
-          + "\\njoinType = inner\\n\" [label=\"1\"]\n"
-          + "\"EnumerableValues\\ntuples = [{ 10, 'Sam\\neName' }]\\n\" -> "
-          + "\"EnumerableCalc\\nexpr#0..1 = {inputs}\\nexpr#2 = 'SameName'\\nexpr#3 = =($t1, $t2)"
-          + "\\nproj#0..1 = {exprs}\\n$condition = $t3\" [label=\"0\"]\n"
+          + "\"EnumerableCalc\\n"
+          + "expr#0..1 = {inputs}\\n"
+          + "expr#2 = 10\\n"
+          + "expr#3 = 'SameName'\\n"
+          + "expr#4 = CAST($t1):I\\n"
+          + "NTEGER NOT NULL\\n"
+          + "...\" -> \"EnumerableAggregate\\n"
+          + "group = {0, 3}\\n"
+          + "\" [label=\"0\"]\n"
+          + "\"EnumerableTableScan\\n"
+          + "table = [SALES, EMPS\\n]\\n"
+          + "\" -> \"EnumerableCalc\\n"
+          + "expr#0..1 = {inputs}\\n"
+          + "expr#2 = 10\\n"
+          + "expr#3 = 'SameName'\\n"
+          + "expr#4 = CAST($t1):I\\nNTEGER NOT NULL\\n"
+          + "...\" [label=\"0\"]\n"
           + "}\n"
           + "\n";
       extra = " as dot ";

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1817,6 +1817,48 @@ LogicalProject(EMPNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCrossJoinWithTimeStampSingleRowOnLeft">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from (select 5, current_timestamp) c cross join emp e ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], EXPR$0=[$0], CURRENT_TIMESTAMP=[$1])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalProject(EXPR$0=[5], CURRENT_TIMESTAMP=[CURRENT_TIMESTAMP])
+      LogicalValues(tuples=[[{ 0 }]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], EXPR$0=[$0], CURRENT_TIMESTAMP=[$1])
+  LogicalProject($f0=[5], $f1=[CURRENT_TIMESTAMP], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCrossJoinWithTimeStampSingleRowOnRight">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from emp e cross join (select 5, current_timestamp) c]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], EXPR$0=[$9], CURRENT_TIMESTAMP=[$10])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(EXPR$0=[5], CURRENT_TIMESTAMP=[CURRENT_TIMESTAMP])
+      LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], EXPR$0=[$9], CURRENT_TIMESTAMP=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[5], $f10=[CURRENT_TIMESTAMP])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCustomColumnResolvingInCorrelatedSubQuery">
     <Resource name="sql">
       <![CDATA[select *
@@ -4901,6 +4943,92 @@ LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testInnerJoinWithConstantRowOnLeft">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from (select 5 as nm) c inner join emp e on e.empno = c.nm]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$1], ENAME=[$2], NM=[$0])
+  LogicalJoin(condition=[=($1, $0)], joinType=[inner])
+    LogicalValues(tuples=[[{ 5 }]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$1], ENAME=[$2], NM=[$0])
+  LogicalProject($f0=[5], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[=($0, 5)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithConstantRowOnRight">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from emp e inner join (select 5 as nm) c  on e.empno = c.nm]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], NM=[$9])
+  LogicalJoin(condition=[=($0, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalValues(tuples=[[{ 5 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], NM=[$9])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[5])
+    LogicalFilter(condition=[=($0, 5)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithTimeStampSingleRowOnLeft">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.t from (select 7934 as ono, current_timestamp as t) c inner join emp e on e.empno=c.ono]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], T=[$1])
+  LogicalJoin(condition=[=($2, $0)], joinType=[inner])
+    LogicalProject(ONO=[7934], T=[CURRENT_TIMESTAMP])
+      LogicalValues(tuples=[[{ 0 }]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], T=[$1])
+  LogicalProject($f0=[7934], $f1=[CURRENT_TIMESTAMP], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalFilter(condition=[=($0, 7934)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithTimeStampSingleRowOnRight">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.t from emp e inner join (select 7934 as ono, current_timestamp as t) c on e.empno=c.ono]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], T=[$10])
+  LogicalJoin(condition=[=($0, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(ONO=[7934], T=[CURRENT_TIMESTAMP])
+      LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], T=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[7934], $f10=[CURRENT_TIMESTAMP])
+    LogicalFilter(condition=[=($0, 7934)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testIntersectToDistinct">
     <Resource name="sql">
       <![CDATA[select * from emp where deptno = 10
@@ -5880,6 +6008,46 @@ LogicalProject(DNAME=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinWithConstantRowOnLeft">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from (select 5, 5) c cross join emp e]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], EXPR$0=[$0], EXPR$1=[$1])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalValues(tuples=[[{ 5, 5 }]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], EXPR$0=[$0], EXPR$1=[$1])
+  LogicalProject($f0=[5], $f1=[5], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinWithConstantRowOnRight">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from emp e cross join (select 5, 5) c]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], EXPR$0=[$9], EXPR$1=[$10])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalValues(tuples=[[{ 5, 5 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], EXPR$0=[$9], EXPR$1=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[5], $f10=[5])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testLeftCorrelateWithBothEmpty1">
     <Resource name="planBefore">
       <![CDATA[
@@ -6077,6 +6245,47 @@ LogicalProject(EMPNO=[$0])
       <![CDATA[
 LogicalProject(EMPNO=[$0])
   LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinWithConstantRowOnRight">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from emp e left join (select 5 as nm) c  on e.empno = c.nm]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], NM=[$9])
+  LogicalJoin(condition=[=($0, $9)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalValues(tuples=[[{ 5 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], NM=[$9])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[CASE(=($0, 5), 5, null:INTEGER)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinWithTimeStampSingleRowOnRight">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.t from emp e left join (select 7934 as ono, current_timestamp as t) c   on e.empno = c.ono]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], T=[$10])
+  LogicalJoin(condition=[=($0, $9)], joinType=[left])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(ONO=[7934], T=[CURRENT_TIMESTAMP])
+      LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], T=[$10])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[CASE(=($0, 7934), 7934, null:INTEGER)], $f10=[CASE(=($0, 7934), CURRENT_TIMESTAMP, null:TIMESTAMP(0))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>
@@ -13071,6 +13280,47 @@ LogicalProject(EMPNO=[$0])
       <![CDATA[
 LogicalProject(EMPNO=[$0])
   LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightJoinWithConstantRowOnLeft">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.* from (select 5 as nm) c right join emp e on e.empno = c.nm]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$1], ENAME=[$2], NM=[$0])
+  LogicalJoin(condition=[=($1, $0)], joinType=[right])
+    LogicalValues(tuples=[[{ 5 }]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$1], ENAME=[$2], NM=[$0])
+  LogicalProject($f0=[CASE(=($0, 5), 5, null:INTEGER)], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightJoinWithTimeStampSingleRowOnLeft">
+    <Resource name="sql">
+      <![CDATA[select e.empno, e.ename, c.t from (select 7934 as ono, current_timestamp as t) c right join emp e   on e.empno = c.ono]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], T=[$1])
+  LogicalJoin(condition=[=($2, $0)], joinType=[right])
+    LogicalProject(ONO=[7934], T=[CURRENT_TIMESTAMP])
+      LogicalValues(tuples=[[{ 0 }]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$2], ENAME=[$3], T=[$1])
+  LogicalProject($f0=[CASE(=($0, 7934), 7934, null:INTEGER)], $f1=[CASE(=($0, 7934), CURRENT_TIMESTAMP, null:TIMESTAMP(0))], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/join.iq
+++ b/core/src/test/resources/sql/join.iq
@@ -637,4 +637,155 @@ select empno as two, * from emp natural join dept;
 
 !ok
 
+select emp.empno, s.sal from (select 7369 as empno, 10000 sal ) s inner join emp on emp.empno = s.empno;
++-------+-------+
+| EMPNO | SAL   |
++-------+-------+
+|  7369 | 10000 |
++-------+-------+
+(1 row)
+
+!ok
+EnumerableCalc(expr#0..7=[{inputs}], expr#8=[10000], expr#9=[CAST($t0):INTEGER NOT NULL], expr#10=[7369], expr#11=[=($t9, $t10)], EMPNO=[$t0], SAL=[$t8], $condition=[$t11])
+  EnumerableTableScan(table=[[scott, EMP]])
+!plan
+
+select e.empno, e.ename, c.ono from emp e
+left join (select 7934 as ono, current_timestamp as t) c on e.empno = c.ono;
++-------+--------+------+
+| EMPNO | ENAME  | ONO  |
++-------+--------+------+
+|  7369 | SMITH  |      |
+|  7499 | ALLEN  |      |
+|  7521 | WARD   |      |
+|  7566 | JONES  |      |
+|  7654 | MARTIN |      |
+|  7698 | BLAKE  |      |
+|  7782 | CLARK  |      |
+|  7788 | SCOTT  |      |
+|  7839 | KING   |      |
+|  7844 | TURNER |      |
+|  7876 | ADAMS  |      |
+|  7900 | JAMES  |      |
+|  7902 | FORD   |      |
+|  7934 | MILLER | 7934 |
++-------+--------+------+
+(14 rows)
+
+!ok
+
+EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t0):INTEGER NOT NULL], expr#9=[7934], expr#10=[=($t8, $t9)], expr#11=[null:INTEGER], expr#12=[CASE($t10, $t9, $t11)], proj#0..1=[{exprs}], ONO=[$t12])
+  EnumerableTableScan(table=[[scott, EMP]])
+!plan
+
+select e.empno, e.ename, c.ono from emp e
+left join (select 7935 as ono, current_timestamp as t) c on e.empno = c.ono;
++-------+--------+-----+
+| EMPNO | ENAME  | ONO |
++-------+--------+-----+
+|  7369 | SMITH  |     |
+|  7499 | ALLEN  |     |
+|  7521 | WARD   |     |
+|  7566 | JONES  |     |
+|  7654 | MARTIN |     |
+|  7698 | BLAKE  |     |
+|  7782 | CLARK  |     |
+|  7788 | SCOTT  |     |
+|  7839 | KING   |     |
+|  7844 | TURNER |     |
+|  7876 | ADAMS  |     |
+|  7900 | JAMES  |     |
+|  7902 | FORD   |     |
+|  7934 | MILLER |     |
++-------+--------+-----+
+(14 rows)
+
+!ok
+
+EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t0):INTEGER NOT NULL], expr#9=[7935], expr#10=[=($t8, $t9)], expr#11=[null:INTEGER], expr#12=[CASE($t10, $t9, $t11)], proj#0..1=[{exprs}], ONO=[$t12])
+  EnumerableTableScan(table=[[scott, EMP]])
+!plan
+
+select e.empno, e.ename, c.ono from emp e inner join (select 7934 as ono, current_timestamp as t) c on e.empno=c.ono;
++-------+--------+------+
+| EMPNO | ENAME  | ONO  |
++-------+--------+------+
+|  7934 | MILLER | 7934 |
++-------+--------+------+
+(1 row)
+
+!ok
+
+EnumerableCalc(expr#0..7=[{inputs}], expr#8=[7934], expr#9=[CAST($t0):INTEGER NOT NULL], expr#10=[=($t9, $t8)], proj#0..1=[{exprs}], ONO=[$t8], $condition=[$t10])
+  EnumerableTableScan(table=[[scott, EMP]])
+!plan
+
+select e.empno, e.ename, c.ono from emp e
+left join (select 7934 as ono, current_timestamp as t) c on e.empno = c.ono
+inner join (select 7566 as ono, current_timestamp as t) c1 on c.ono = c1.ono;
++-------+-------+-----+
+| EMPNO | ENAME | ONO |
++-------+-------+-----+
++-------+-------+-----+
+(0 rows)
+
+!ok
+
+EnumerableValues(tuples=[[]])
+!plan
+
+select e.empno, e.ename, c.ono from emp e
+left join (select 7934 as ono, current_timestamp as t) c on e.empno = c.ono
+left join (select 7566 as ono, current_timestamp as t) c1 on c.ono = c1.ono;
++-------+--------+------+
+| EMPNO | ENAME  | ONO  |
++-------+--------+------+
+|  7369 | SMITH  |      |
+|  7499 | ALLEN  |      |
+|  7521 | WARD   |      |
+|  7566 | JONES  |      |
+|  7654 | MARTIN |      |
+|  7698 | BLAKE  |      |
+|  7782 | CLARK  |      |
+|  7788 | SCOTT  |      |
+|  7839 | KING   |      |
+|  7844 | TURNER |      |
+|  7876 | ADAMS  |      |
+|  7900 | JAMES  |      |
+|  7902 | FORD   |      |
+|  7934 | MILLER | 7934 |
++-------+--------+------+
+(14 rows)
+
+!ok
+
+EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t0):INTEGER NOT NULL], expr#9=[7934], expr#10=[=($t8, $t9)], expr#11=[null:INTEGER], expr#12=[CASE($t10, $t9, $t11)], proj#0..1=[{exprs}], ONO=[$t12])
+  EnumerableTableScan(table=[[scott, EMP]])
+!plan
++-------+--------+------+
+| EMPNO | ENAME  | ONO  |
++-------+--------+------+
+|  7369 | SMITH  |      |
+|  7499 | ALLEN  |      |
+|  7521 | WARD   |      |
+|  7566 | JONES  |      |
+|  7654 | MARTIN |      |
+|  7698 | BLAKE  |      |
+|  7782 | CLARK  |      |
+|  7788 | SCOTT  |      |
+|  7839 | KING   |      |
+|  7844 | TURNER |      |
+|  7876 | ADAMS  |      |
+|  7900 | JAMES  |      |
+|  7902 | FORD   |      |
+|  7934 | MILLER | 7934 |
++-------+--------+------+
+(14 rows)
+
+!ok
+
+EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t0):INTEGER NOT NULL], expr#9=[7934], expr#10=[=($t8, $t9)], expr#11=[null:INTEGER], expr#12=[CASE($t10, $t9, $t11)], proj#0..1=[{exprs}], ONO=[$t12])
+  EnumerableTableScan(table=[[scott, EMP]])
+!plan
+
 # End join.iq

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -494,16 +494,28 @@ EnumerableCalc(expr#0..2=[{inputs}], proj#0..1=[{exprs}])
 # Uncorrelated
 with t (a, b) as (select * from (values (60, 'b')))
 select * from t where a in (select deptno from "scott".dept);
-EnumerableHashJoin(condition=[=($0, $2)], joinType=[semi])
-  EnumerableValues(tuples=[[{ 60, 'b' }]])
-  EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
-    EnumerableTableScan(table=[[scott, DEPT]])
+EnumerableCalc(expr#0..2=[{inputs}], expr#3=[60], expr#4=['b'], expr#5=[=($t3, $t0)], A=[$t3], B=[$t4], $condition=[$t5])
+  EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 +---+---+
 | A | B |
 +---+---+
 +---+---+
 (0 rows)
+
+!ok
+
+with t (a, b) as (select * from (values (30, 'b')))
+select * from t where a in (select deptno from "scott".dept);
+EnumerableCalc(expr#0..2=[{inputs}], expr#3=[30], expr#4=['b'], expr#5=[=($t3, $t0)], A=[$t3], B=[$t4], $condition=[$t5])
+  EnumerableTableScan(table=[[scott, DEPT]])
+!plan
++----+---+
+| A  | B |
++----+---+
+| 30 | b |
++----+---+
+(1 row)
 
 !ok
 
@@ -3509,11 +3521,8 @@ select (select (1, 2));
 
 !ok
 
-EnumerableCalc(expr#0..1=[{inputs}], EXPR$0=[$t1])
-  EnumerableNestedLoopJoin(condition=[true], joinType=[left])
-    EnumerableValues(tuples=[[{ 0 }]])
-    EnumerableCalc(expr#0=[{inputs}], expr#1=[1], expr#2=[2], expr#3=[ROW($t1, $t2)], EXPR$0=[$t3])
-      EnumerableValues(tuples=[[{ 0 }]])
+EnumerableCalc(expr#0=[{inputs}], expr#1=[1], expr#2=[2], expr#3=[ROW($t1, $t2)], expr#4=[CAST($t3):RecordType(INTEGER EXPR$0, INTEGER EXPR$1)], EXPR$0=[$t4])
+  EnumerableValues(tuples=[[{ 0 }]])
 !plan
 
 # Test case for correlated sub-query


### PR DESCRIPTION
… relations

This PR introduces four rules for simplifying joins with a single value row on either side of the input. Please find the information about this optimizations in the related [JIRA](https://issues.apache.org/jira/browse/CALCITE-6162).
**Testing**: Apart from the new tests added in RelOptRulesTest, these rules are enabled as part of the abstract rules and so they get triggered during the core quidem test suite. 