### PR TITLE
[CALCITE-6178] WITH RECURSIVE query when cloned using sqlshuttle loos…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlWithItem.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWithItem.java
@@ -58,7 +58,7 @@ public class SqlWithItem extends SqlCall {
 
   @SuppressWarnings("nullness")
   @Override public List<SqlNode> getOperandList() {
-    return ImmutableNullableList.of(name, columnList, query);
+    return ImmutableNullableList.of(name, columnList, query, recursive);
   }
 
   @SuppressWarnings("assignment.type.incompatible")
@@ -72,6 +72,9 @@ public class SqlWithItem extends SqlCall {
       break;
     case 2:
       query = operand;
+      break;
+    case 3:
+      recursive = (SqlLiteral) operand;
       break;
     default:
       throw new AssertionError(i);
@@ -114,10 +117,9 @@ public class SqlWithItem extends SqlCall {
     @Override public SqlCall createCall(@Nullable SqlLiteral functionQualifier,
         SqlParserPos pos, @Nullable SqlNode... operands) {
       assert functionQualifier == null;
-      assert operands.length == 3;
+      assert operands.length == 4;
       return new SqlWithItem(pos, (SqlIdentifier) operands[0],
-          (SqlNodeList) operands[1], operands[2],
-          SqlLiteral.createBoolean(false, SqlParserPos.ZERO));
+          (SqlNodeList) operands[1], operands[2], (SqlLiteral) operands[3]);
     }
   }
 }

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -43,6 +43,7 @@ import org.apache.calcite.test.IntervalTest;
 import org.apache.calcite.tools.Hoist;
 import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.ConversionUtil;
+import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
@@ -82,6 +83,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
@@ -1231,6 +1233,20 @@ public class SqlParserTest {
     // Therefore, we only support != with certain SQL conformance levels.
     expr("'abc'^!=^123")
         .fails("Bang equal '!=' is not allowed under the current SQL conformance level");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6178">[CALCITE-6178]
+   * WITH RECURSIVE query when cloned using sqlshuttle looses RECURSIVE property</a>. */
+  @Test void testRecursiveQueryCloned() throws Exception {
+    SqlNode sqlNode = sql("with RECURSIVE emp2 as "
+        + "(select * from emp union select * from emp2) select * from emp2").parser().parseStmt();
+    SqlNode sqlNode1 = sqlNode.accept(new SqlShuttle() {
+      @Override public SqlNode visit(SqlIdentifier identifier) {
+        return new SqlIdentifier(identifier.names, identifier.getParserPosition());
+      }
+    });
+    assertTrue(sqlNode.equalsDeep(sqlNode1, Litmus.IGNORE));
   }
 
   @Test void testBetween() {


### PR DESCRIPTION
…es RECURSIVE property

Fix the getters and setters of SqlWithItem to pass recursive flag as one of the operand.