### PR TITLE
CALCITE-6180 Append possibility to escape backslash in LIKE with ESCAPE operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/Like.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Like.java
@@ -96,6 +96,9 @@ public class Like {
             || (nextChar == escapeChar)) {
           javaPattern.append(nextChar);
           i++;
+        } else if (nextChar == '\\') {
+          javaPattern.append("\\\\");
+          i++;
         } else {
           throw invalidEscapeSequence(sqlPattern, i);
         }

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -3591,6 +3591,9 @@ public class SqlOperatorTest {
   @Test void testLikeEscape() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.LIKE, VmName.EXPAND);
+    f.checkBoolean("'a\\c' like 'a#\\c' escape '#'", true);
+    f.checkBoolean("'a\\\\c' like 'a#\\c' escape '#'", false);
+    f.checkBoolean("'a\\c' like 'a#\\\\c' escape '#'", false);
     f.checkBoolean("'a_c' like 'a#_c' escape '#'", true);
     f.checkBoolean("'axc' like 'a#_c' escape '#'", false);
     f.checkBoolean("'a_c' like 'a\\_c' escape '\\'", true);


### PR DESCRIPTION
fix possibility to execute:
`select 'Dev\ops' like 'Dev#\ops' escape '#';`