### PR TITLE
[CALCITE-6195] Enable support for sql expression with qualified names

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -6667,14 +6667,20 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
       // Give precedence to namespace found, unless there
       // are no more identifier components.
-      if (type == null || id.names.size() == 1) {
-        // See if there's a column with the name we seek in
-        // precisely one of the namespaces in this scope.
-        RelDataType colType = scope.resolveColumn(id.names.get(0), id);
-        if (colType != null) {
-          type = colType;
+      if (type == null) {
+        if (id.names.size() == 1) {
+          RelDataType colType = scope.resolveColumn(id.names.get(0), id);
+          if (colType != null) {
+            type = colType;
+          }
+          ++i;
+        } else if (id.names.size() == 2) { // to cover qualified paths
+          RelDataType colType = scope.resolveColumn(id.names.get(0) + "." + id.names.get(1), id);
+          if (colType != null) {
+            type = colType;
+          }
+          i += 2; // BasicSqlType not needed to resolve rest of identifier
         }
-        ++i;
       }
 
       if (type == null) {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -5012,11 +5012,6 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).withTrim(true).ok();
   }
 
-  @Test void testInWithConstantList() {
-    String expr = "1 in (1,2,3)";
-    expr(expr).ok();
-  }
-
   @Test void testFunctionExprInOver() {
     String sql = "select ename, row_number() over(partition by char_length(ename)\n"
         + " order by deptno desc) as rn\n"
@@ -5110,5 +5105,40 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
   @Test void testDynamicParameterDoubleCast() {
     String sql = "SELECT CAST(CAST(? AS INTEGER) AS CHAR)";
     sql(sql).ok();
+  }
+
+  @Test void testInWithConstantList() {
+    String expr = "1 in (1,2,3)";
+    expr(expr).ok();
+  }
+
+  @Test void testExpression() {
+    String sql = "DEMO.A";
+    sql(sql).expression(true).withParameterizedExpression(true).ok();
+  }
+
+  @Test void testFilterExpression() {
+    String sql = "DEMO.A > 10";
+    sql(sql).expression(true).withParameterizedExpression(true).ok();
+  }
+
+  @Test void testProjectionExpression() {
+    String sql = "DEMO.A + 10";
+    sql(sql).expression(true).withParameterizedExpression(true).ok();
+  }
+
+  @Test void testInExpression() {
+    String sql = "DEMO.A IN (10, 20)";
+    sql(sql).expression(true).withParameterizedExpression(true).ok();
+  }
+
+  @Test void testIsNotNullExpression() {
+    String sql = "DEMO.A is not null";
+    sql(sql).expression(true).withParameterizedExpression(true).ok();
+  }
+
+  @Test void testIsNullExpression() {
+    String sql = "DEMO.A is null";
+    sql(sql).expression(true).withParameterizedExpression(true).ok();
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11753,6 +11753,23 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     assertThat(resultType, hasToString("INTEGER"));
   }
 
+  @Test void testValidateParameterizedExpressionQualifiedPaths() throws SqlParseException {
+    final SqlParser.Config config = SqlParser.config();
+    final SqlValidator validator = fixture().factory.createValidator();
+    final RelDataTypeFactory typeFactory = validator.getTypeFactory();
+    final RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    final RelDataType intTypeNull = typeFactory.createTypeWithNullability(intType, true);
+    final Map<String, RelDataType> nameToTypeMap = new HashMap<>();
+    nameToTypeMap.put("DEMO.A", intType);
+    nameToTypeMap.put("DEMO.B", intTypeNull);
+    final String expr = "DEMO.a + DEMO.b";
+    final SqlParser parser = SqlParser.create(expr, config);
+    final SqlNode sqlNode = parser.parseExpression();
+    final SqlNode validated = validator.validateParameterizedExpression(sqlNode, nameToTypeMap);
+    final RelDataType resultType = validator.getValidatedNodeType(validated);
+    assertThat(resultType, hasToString("INTEGER"));
+  }
+
   @Test void testAccessingNestedFieldsOfNullableRecord() {
     sql("select ROW_COLUMN_ARRAY[0].NOT_NULL_FIELD from NULLABLEROWS.NR_T1")
         .withExtendedCatalog()

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2001,6 +2001,16 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExpression">
+    <Resource name="sql">
+      <![CDATA[DEMO.A]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+$1
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFakeStar">
     <Resource name="sql">
       <![CDATA[SELECT * FROM (VALUES (0, 0)) AS T(A, "*")]]>
@@ -2033,6 +2043,16 @@ LogicalSort(fetch=[5])
 LogicalSort(fetch=[?0])
   LogicalProject(EMPNO=[$0])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFilterExpression">
+    <Resource name="sql">
+      <![CDATA[DEMO.A > 10]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+>($1, 10)
 ]]>
     </Resource>
   </TestCase>
@@ -2790,6 +2810,16 @@ FROM dept, emp WHERE emp.deptno = dept.deptno AND emp.sal < (
 )]]>
     </Resource>
   </TestCase>
+  <TestCase name="testInExpression">
+    <Resource name="sql">
+      <![CDATA[DEMO.A IN (10, 20)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+OR(=($1, 10), =($1, 20))
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testInToSemiJoin">
     <Resource name="sql">
       <![CDATA[SELECT empno
@@ -3361,6 +3391,26 @@ LogicalProject(EXPR$0=[OR(AND(IS NULL($0), IS NULL($1)), IS TRUE(=($0, $1)))])
       <![CDATA[select empno is not distinct from deptno
 from (values (cast(null as int), 1),
              (2, cast(null as int))) as emp(empno, deptno)]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIsNotNullExpression">
+    <Resource name="sql">
+      <![CDATA[DEMO.A is not null]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+IS NOT NULL($1)
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIsNullExpression">
+    <Resource name="sql">
+      <![CDATA[DEMO.A is null]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+IS NULL($1)
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testJoinExpandAndDecorrelation">
@@ -6031,6 +6081,16 @@ LogicalProject(EXPR$0=[||($1, CAST($0):VARCHAR NOT NULL)])
             LogicalTableScan(table=[[CATALOG, SALES, EMP]])
         LogicalProject(ENAME=[$1], SAL=[$5], DEPTNO=[$7])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectionExpression">
+    <Resource name="sql">
+      <![CDATA[DEMO.A + 10]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
++($1, 10)
 ]]>
     </Resource>
   </TestCase>

--- a/testkit/src/main/java/org/apache/calcite/sql/test/AbstractSqlTester.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/AbstractSqlTester.java
@@ -513,7 +513,8 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
     diffRepos.assertEquals("plan", plan, actual);
   }
 
-  private RexNode convertExprToRex(SqlTestFactory factory, String expr, boolean parameterizedExpression) {
+  private RexNode convertExprToRex(SqlTestFactory factory, String expr,
+      boolean parameterizedExpression) {
     requireNonNull(expr, "expr");
     final SqlNode sqlQuery;
     try {
@@ -537,7 +538,8 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
       final RelDataType intTypeNull = typeFactory.createTypeWithNullability(intType, true);
       nameToTypeMap.put("DEMO.A", intType);
       nameToTypeMap.put("DEMO.B", intTypeNull);
-      final SqlNode validatedQuery = validator.validateParameterizedExpression(sqlQuery, nameToTypeMap);
+      final SqlNode validatedQuery =
+          validator.validateParameterizedExpression(sqlQuery, nameToTypeMap);
       Map<String, RexNode> nameToNodeMap = new HashMap<>();
       nameToNodeMap.put("DEMO.A", new RexInputRef(1, intType));
       nameToNodeMap.put("DEMO.B", new RexInputRef(2, intTypeNull));

--- a/testkit/src/main/java/org/apache/calcite/sql/test/AbstractSqlTester.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/AbstractSqlTester.java
@@ -20,7 +20,9 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.PairList;
 import org.apache.calcite.runtime.Utilities;
@@ -55,8 +57,10 @@ import org.hamcrest.Matcher;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.apache.calcite.test.Matchers.relIsValid;
@@ -457,18 +461,19 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
       String plan,
       boolean trim,
       boolean expression,
-      boolean decorrelate) {
+      boolean decorrelate,
+      boolean parameterizedExpression) {
     if (expression) {
-      assertExprConvertsTo(factory, diffRepos, sql, plan);
+      assertExprConvertsTo(factory, diffRepos, sql, plan, parameterizedExpression);
     } else {
       assertSqlConvertsTo(factory, diffRepos, sql, plan, trim, decorrelate);
     }
   }
 
   private void assertExprConvertsTo(SqlTestFactory factory,
-      DiffRepository diffRepos, String expr, String plan) {
+      DiffRepository diffRepos, String expr, String plan, boolean parameterizedExpression) {
     String expr2 = diffRepos.expand("sql", expr);
-    RexNode rex = convertExprToRex(factory, expr2);
+    RexNode rex = convertExprToRex(factory, expr2, parameterizedExpression);
     assertNotNull(rex);
     // NOTE jvs 28-Mar-2006:  insert leading newline so
     // that plans come out nicely stacked instead of first
@@ -508,7 +513,7 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
     diffRepos.assertEquals("plan", plan, actual);
   }
 
-  private RexNode convertExprToRex(SqlTestFactory factory, String expr) {
+  private RexNode convertExprToRex(SqlTestFactory factory, String expr, boolean parameterizedExpression) {
     requireNonNull(expr, "expr");
     final SqlNode sqlQuery;
     try {
@@ -521,8 +526,23 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
 
     final SqlToRelConverter converter = factory.createSqlToRelConverter();
     final SqlValidator validator = requireNonNull(converter.validator);
-    final SqlNode validatedQuery = validator.validate(sqlQuery);
-    return converter.convertExpression(validatedQuery);
+
+    if (!parameterizedExpression) {
+      final SqlNode validatedQuery = validator.validate(sqlQuery);
+      return converter.convertExpression(validatedQuery);
+    } else {
+      final RelDataTypeFactory typeFactory = validator.getTypeFactory();
+      final Map<String, RelDataType> nameToTypeMap = new HashMap<>();
+      final RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+      final RelDataType intTypeNull = typeFactory.createTypeWithNullability(intType, true);
+      nameToTypeMap.put("DEMO.A", intType);
+      nameToTypeMap.put("DEMO.B", intTypeNull);
+      final SqlNode validatedQuery = validator.validateParameterizedExpression(sqlQuery, nameToTypeMap);
+      Map<String, RexNode> nameToNodeMap = new HashMap<>();
+      nameToNodeMap.put("DEMO.A", new RexInputRef(1, intType));
+      nameToNodeMap.put("DEMO.B", new RexInputRef(2, intTypeNull));
+      return converter.convertExpression(validatedQuery, nameToNodeMap);
+    }
   }
 
   @Override public Pair<SqlValidator, RelRoot> convertSqlToRel2(

--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlTester.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlTester.java
@@ -312,7 +312,8 @@ public interface SqlTester extends AutoCloseable {
       String plan,
       boolean trim,
       boolean expression,
-      boolean decorrelate);
+      boolean decorrelate,
+      boolean parameterizedExpression);
 
   /** Trims a RelNode. */
   RelNode trimRelNode(SqlTestFactory factory, RelNode relNode);

--- a/testkit/src/main/java/org/apache/calcite/test/SqlToRelFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlToRelFixture.java
@@ -73,6 +73,7 @@ public class SqlToRelFixture {
   private final SqlTestFactory factory;
   private final boolean trim;
   private final boolean expression;
+  private final boolean parameterizedExpression;
 
   SqlToRelFixture(String sql, boolean decorrelate,
       SqlTester tester, SqlTestFactory factory, boolean trim,
@@ -88,6 +89,25 @@ public class SqlToRelFixture {
     this.decorrelate = decorrelate;
     this.trim = trim;
     this.expression = expression;
+    this.parameterizedExpression = false;
+  }
+
+  SqlToRelFixture(String sql, boolean decorrelate,
+      SqlTester tester, SqlTestFactory factory, boolean trim,
+      boolean expression,
+      @Nullable DiffRepository diffRepos,
+      boolean parameterizedExpression) {
+    this.sql = requireNonNull(sql, "sql");
+    this.tester = requireNonNull(tester, "tester");
+    this.factory = requireNonNull(factory, "factory");
+    this.diffRepos = diffRepos;
+    if (sql.contains(" \n")) {
+      throw new AssertionError("trailing whitespace");
+    }
+    this.decorrelate = decorrelate;
+    this.trim = trim;
+    this.expression = expression;
+    this.parameterizedExpression = parameterizedExpression;
   }
 
   public void ok() {
@@ -104,7 +124,7 @@ public class SqlToRelFixture {
 
   public void convertsTo(String plan) {
     tester.assertConvertsTo(factory, diffRepos(), sql, plan, trim, expression,
-        decorrelate);
+        decorrelate, parameterizedExpression);
   }
 
   public DiffRepository diffRepos() {
@@ -124,6 +144,15 @@ public class SqlToRelFixture {
     return this.expression == expression ? this
         : new SqlToRelFixture(sql, decorrelate, tester, factory, trim,
             expression, diffRepos);
+  }
+
+  /**
+   * Sets whether this is an parameterized  expression (as opposed to a whole query).
+   */
+  public SqlToRelFixture withParameterizedExpression(boolean parameterizedExpression) {
+    return this.parameterizedExpression == parameterizedExpression ? this
+        : new SqlToRelFixture(sql, decorrelate, tester, factory, trim,
+            expression, diffRepos, parameterizedExpression);
   }
 
   public SqlToRelFixture withConfig(


### PR DESCRIPTION
The SQLValidator.validateParameterizedExpression method can be used to validate parameterized SQL expressions.

It is possible to register [validateParameterizedExpression](https://github.com/apache/calcite/blob/1b11d99e65d03a15ae4b25c47250b6918ce9aa10/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java#L11421:L11435):
````
final Map<String, RelDataType> nameToTypeMap = new HashMap<>();
nameToTypeMap.put("A", intType);
nameToTypeMap.put("B", intTypeNull); 
final String expr = "a + b";
final SqlNode validated = validator.validateParameterizedExpression(sqlNode, nameToTypeMap);
````

Problems appear if we are trying to register qualified paths:
````
final Map<String, RelDataType> nameToTypeMap = new HashMap<>(); 
nameToTypeMap.put("DEMO.A", intType);
nameToTypeMap.put("DEMO.B", intTypeNull); 
final String expr = "DEMO.a + DEMO.b";
final SqlNode validated = validator.validateParameterizedExpression(sqlNode, nameToTypeMap); 
Error:
org.apache.calcite.runtime.CalciteContextException: From line 1, column 1 to line 1, column 3: Unknown identifier 'DEMO'
````

As part of this PR, we are trying to make changes to support qualified names in order to resolve SQL expressions such as:
````
String sqlExpression = "DEMO.A";
String sqlExpression = "DEMO.A > 10";
String sqlExpression = "DEMO.A + 10";
String sqlExpression = "DEMO.A IN (10, 20)";
String sqlExpression = "DEMO.A is not null";
String sqlExpression = "DEMO.A is null";
````
