### PR TITLE
[CALCITE-6208] update JSON_VALUE return type inference to make explicit array return types be nullable with nullable elements

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11413,6 +11413,14 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("json_value('{\"foo\":100}', 'lax $.foo' returning boolean"
         + " default 100 on empty)")
         .columnType("BOOLEAN");
+
+    expr("json_value('{\"foo\":[100, null, 200]}', 'lax $.foo'"
+        + "returning integer array)")
+        .columnType("INTEGER ARRAY");
+
+    expr("json_value('{\"foo\":[[100, null, 200]]}', 'lax $.foo'"
+        + "returning integer array array)")
+        .columnType("INTEGER ARRAY ARRAY");
   }
 
   @Test void testJsonQuery() {


### PR DESCRIPTION
From [CALCITE-6208](https://issues.apache.org/jira/browse/CALCITE-6208)

This PR modifies the `SqlJsonValueFunction` return type inference to special handle explicit array syntax so that the arrays are returned with nullable elements.

The added tests fail with:
```
Expected: is "INTEGER ARRAY"
     but: was "INTEGER NOT NULL ARRAY"
```
and
```
Expected: is "INTEGER ARRAY ARRAY"
     but: was "INTEGER NOT NULL ARRAY NOT NULL ARRAY"
```

without the changes in this PR.