### PR TITLE
[CALCITE-5649] Get row count statistics from ReflectiveSchema

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/MaterializedViewTester.java
+++ b/core/src/test/java/org/apache/calcite/test/MaterializedViewTester.java
@@ -18,7 +18,6 @@ package org.apache.calcite.test;
 
 import org.apache.calcite.DataContexts;
 import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
-import org.apache.calcite.adapter.java.ReflectiveSchema;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
@@ -114,7 +113,7 @@ public abstract class MaterializedViewTester {
         if (f.schemaSpec == null) {
           defaultSchema =
               rootSchema.add("hr",
-                  new ReflectiveSchema(new MaterializationTest.HrFKUKSchema()));
+                  new ReflectiveSchemaWithoutRowCount(new MaterializationTest.HrFKUKSchema()));
         } else {
           defaultSchema = CalciteAssert.addSchema(rootSchema, f.schemaSpec);
         }

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableCorrelateTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableCorrelateTest.java
@@ -18,7 +18,6 @@ package org.apache.calcite.test.enumerable;
 
 import org.apache.calcite.adapter.enumerable.EnumerableCorrelate;
 import org.apache.calcite.adapter.enumerable.EnumerableRules;
-import org.apache.calcite.adapter.java.ReflectiveSchema;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -26,6 +25,7 @@ import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.test.ReflectiveSchemaWithoutRowCount;
 import org.apache.calcite.test.schemata.hr.HrSchema;
 
 import org.junit.jupiter.api.Test;
@@ -283,6 +283,6 @@ class EnumerableCorrelateTest {
     return CalciteAssert.that()
         .with(CalciteConnectionProperty.LEX, Lex.JAVA)
         .with(CalciteConnectionProperty.FORCE_DECORRELATE, forceDecorrelate)
-        .withSchema("s", new ReflectiveSchema(schema));
+        .withSchema("s", new ReflectiveSchemaWithoutRowCount(schema));
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableHashJoinTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableHashJoinTest.java
@@ -17,13 +17,13 @@
 package org.apache.calcite.test.enumerable;
 
 import org.apache.calcite.adapter.enumerable.EnumerableRules;
-import org.apache.calcite.adapter.java.ReflectiveSchema;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.test.ReflectiveSchemaWithoutRowCount;
 import org.apache.calcite.test.schemata.hr.HrSchema;
 
 import org.junit.jupiter.api.Test;
@@ -306,6 +306,6 @@ class EnumerableHashJoinTest {
     return CalciteAssert.that()
         .with(CalciteConnectionProperty.LEX, Lex.JAVA)
         .with(CalciteConnectionProperty.FORCE_DECORRELATE, forceDecorrelate)
-        .withSchema("s", new ReflectiveSchema(schema));
+        .withSchema("s", new ReflectiveSchemaWithoutRowCount(schema));
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableRepeatUnionTest.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.rules.JoinToCorrelateRule;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.test.ReflectiveSchemaWithoutRowCount;
 import org.apache.calcite.test.schemata.hr.HierarchySchema;
 
 import org.junit.jupiter.api.Test;
@@ -266,7 +267,7 @@ class EnumerableRepeatUnionTest {
     CalciteAssert.that()
         .with(CalciteConnectionProperty.LEX, Lex.JAVA)
         .with(CalciteConnectionProperty.FORCE_DECORRELATE, false)
-        .withSchema("s", new ReflectiveSchema(new HierarchySchema()))
+        .withSchema("s", new ReflectiveSchemaWithoutRowCount(new HierarchySchema()))
         .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner -> {
           planner.addRule(JoinToCorrelateRule.Config.DEFAULT.toRule());
           planner.removeRule(JoinCommuteRule.Config.DEFAULT.toRule());
@@ -309,7 +310,7 @@ class EnumerableRepeatUnionTest {
     CalciteAssert.that()
         .with(CalciteConnectionProperty.LEX, Lex.JAVA)
         .with(CalciteConnectionProperty.FORCE_DECORRELATE, false)
-        .withSchema("s", new ReflectiveSchema(new HierarchySchema()))
+        .withSchema("s", new ReflectiveSchemaWithoutRowCount(new HierarchySchema()))
         .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner -> {
           planner.addRule(JoinToCorrelateRule.Config.DEFAULT.toRule());
           planner.removeRule(JoinCommuteRule.Config.DEFAULT.toRule());

--- a/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
+++ b/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
@@ -899,7 +899,7 @@ public class CalciteAssert {
       return s;
     case HR:
       return rootSchema.add(schema.schemaName,
-          new ReflectiveSchema(new HrSchema()));
+          new ReflectiveSchemaWithoutRowCount(new HrSchema()));
     case LINGUAL:
       return rootSchema.add(schema.schemaName,
           new ReflectiveSchema(new LingualSchema()));

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.test;
 
-import org.apache.calcite.adapter.java.ReflectiveSchema;
 import org.apache.calcite.avatica.AvaticaUtils;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteConnection;
@@ -326,7 +325,7 @@ public abstract class QuidemTest {
         return CalciteAssert.that()
             .with(CalciteConnectionProperty.TIME_ZONE, "UTC")
             .withSchema("s",
-                new ReflectiveSchema(
+                new ReflectiveSchemaWithoutRowCount(
                     new CatchallSchema()))
             .connect();
       case "orinoco":

--- a/testkit/src/main/java/org/apache/calcite/test/ReflectiveSchemaWithoutRowCount.java
+++ b/testkit/src/main/java/org/apache/calcite/test/ReflectiveSchemaWithoutRowCount.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.apache.calcite.adapter.java.ReflectiveSchema;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A ReflectiveSchema that does not return row count statistics.
+ * Intended to be used with tests written before row count statistics were supported
+ * by ReflectiveSchema that rely on legacy behavior.
+ */
+public class ReflectiveSchemaWithoutRowCount extends ReflectiveSchema  {
+  /**
+   * Creates a ReflectiveSchema.
+   *
+   * @param target Object whose fields will be sub-objects of the schema
+   */
+  public ReflectiveSchemaWithoutRowCount(Object target) {
+    super(target);
+  }
+
+  @Override protected @Nullable Double getRowCount(Object o) {
+    return null;
+  }
+}


### PR DESCRIPTION
(from #3154)
This PR adds row count statistics for simple reflective schemas with array and Collection field tables.

This small enhancement makes it a little easier to write tests for optimizer rules, particularly rules that might behave specially when the row count is 1 or 0.