### PR TITLE
[CALCITE-6032] Multilevel correlated query is failing in RelDecorrela…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -271,7 +271,7 @@ public abstract class RelOptUtil {
   }
 
   /**
-   * Returns a set of variables used by a relational expression or its
+   * Returns the set of variables used by a relational expression or its
    * descendants.
    *
    * <p>The set may contain "duplicates" (variables with different ids that,
@@ -284,6 +284,24 @@ public abstract class RelOptUtil {
     CorrelationCollector visitor = new CorrelationCollector();
     rel.accept(visitor);
     return visitor.vuv.variables;
+  }
+
+  /**
+   * Returns the set of variables used by the given list of sub-queries and its descendants.
+   *
+   * @param subQueries The sub-queries containing correlation variables
+   * @return A list of correlation identifiers found within the sub-queries.
+   *          The type of the [CorrelationId] parameter corresponds to
+   *          {@link org.apache.calcite.rex.RexCorrelVariable#id}.
+   */
+  public static Set<CorrelationId> getVariablesUsed(List<RexSubQuery> subQueries) {
+    // Internally this function calls getVariablesUsed on a RelNode to get all the
+    // correlated variables in that RelNode
+    Set<CorrelationId> correlationIds = new HashSet<>();
+    for (RexSubQuery subQ : subQueries) {
+      correlationIds.addAll(getVariablesUsed(subQ.rel));
+    }
+    return correlationIds;
   }
 
   /** Finds which columns of a correlation variable are used within a

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -2854,6 +2854,29 @@ public class RexUtil {
     }
   }
 
+  /** Visitor that collects all the top level SubQueries {@link RexSubQuery}
+   *  in a projection list of a given {@link Project}.*/
+  public static class SubQueryCollector extends RexVisitorImpl<Void> {
+    private List<RexSubQuery> subQueries;
+    private SubQueryCollector() {
+      super(true);
+      this.subQueries = new ArrayList<>();
+    }
+
+    @Override public Void visitSubQuery(RexSubQuery subQuery) {
+      subQueries.add(subQuery);
+      return null;
+    }
+
+    public static List<RexSubQuery> collect(Project project) {
+      SubQueryCollector subQueryCollector = new SubQueryCollector();
+      for (RexNode node : project.getProjects()) {
+        node.accept(subQueryCollector);
+      }
+      return subQueryCollector.subQueries;
+    }
+  }
+
   /** Visitor that throws {@link org.apache.calcite.util.Util.FoundOne} if
    * applied to an expression that contains a {@link RexSubQuery}. */
   public static class SubQueryFinder extends RexVisitorImpl<Void> {

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -5491,18 +5491,25 @@ public class SqlToRelConverter {
               builder.add(convertExpression(node));
             }
             final ImmutableList<RexNode> list = builder.build();
+            RelNode rel = root.rel;
+            // Fix the correlation namespaces and de-duplicate the correlation variables.
+            CorrelationUse correlationUse = getCorrelationUse(this, root.rel);
+            if (correlationUse != null) {
+              rel = correlationUse.r;
+            }
+
             switch (kind) {
             case IN:
-              return RexSubQuery.in(root.rel, list);
+              return RexSubQuery.in(rel, list);
             case NOT_IN:
               return rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-                  RexSubQuery.in(root.rel, list));
+                  RexSubQuery.in(rel, list));
             case SOME:
-              return RexSubQuery.some(root.rel, list,
+              return RexSubQuery.some(rel, list,
                   (SqlQuantifyOperator) call.getOperator());
             case ALL:
               return rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-                  RexSubQuery.some(root.rel, list,
+                  RexSubQuery.some(rel, list,
                       negate((SqlQuantifyOperator) call.getOperator())));
             default:
               throw new AssertionError(kind);
@@ -5515,6 +5522,12 @@ public class SqlToRelConverter {
           query = Iterables.getOnlyElement(call.getOperandList());
           root = convertQueryRecursive(query, false, null);
           RelNode rel = root.rel;
+          // Fix the correlation namespaces and de-duplicate the correlation variables.
+          CorrelationUse correlationUse = getCorrelationUse(this, root.rel);
+          if (correlationUse != null) {
+            rel = correlationUse.r;
+          }
+
           while (rel instanceof Project
               || rel instanceof Sort
               && ((Sort) rel).fetch == null
@@ -5533,7 +5546,13 @@ public class SqlToRelConverter {
           call = (SqlCall) expr;
           query = Iterables.getOnlyElement(call.getOperandList());
           root = convertQueryRecursive(query, false, null);
-          return RexSubQuery.scalar(root.rel);
+          rel = root.rel;
+          // Fix the correlation namespaces and de-duplicate the correlation variables.
+          correlationUse = getCorrelationUse(this, root.rel);
+          if (correlationUse != null) {
+            rel = correlationUse.r;
+          }
+          return RexSubQuery.scalar(rel);
 
         case ARRAY_QUERY_CONSTRUCTOR:
           call = (SqlCall) expr;


### PR DESCRIPTION
…tor code path

This pull request includes the following modifications to address the Null Pointer Exception (NPE) when decorrelating a multi-level correlated subquery:

- Eliminated the TrimUnusedFields in the Prepare phase, as the optimize call (in the same function) handles the trimming of unused fields as part of the standard program. Additionally, this code path is brought in line with the Optimize code path in the PlannerImpl, where the TrimUnusedFields flag is set to False. This ensures consistency between both code paths.

- Implemented a call to the getCorrelationUse function in certain code paths. This call rectifies the rel node tree to standardize the correlated variables.

- The fix introduced in response to [CALCITE-5683](https://issues.apache.org/jira/browse/CALCITE-5683) also addresses the identified issue in this JIRA.

All of the aforementioned code changes are necessary to resolve the reported problem.

result from sqlfiddle postgresql: https://sqlfiddle.com/postgresql/online-compiler?id=98100522-acf6-46b3-9b19-eb14b7015078