### PR TITLE
[CALCITE-5976] Use explicit casting if inserted element type in ArrayPrepend/ArrayAppend/ArrayInsert does not equal derived component type

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -5204,7 +5204,11 @@ public class SqlFunctions {
   public static List arrayAppend(List list, Object element) {
     final List result = new ArrayList(list.size() + 1);
     result.addAll(list);
-    result.add(element);
+    if (element instanceof Byte) {
+      result.add(((Byte) element).intValue());
+    } else {
+      result.add(element);
+    }
     return result;
   }
 
@@ -5248,7 +5252,11 @@ public class SqlFunctions {
   /** Support the ARRAY_PREPEND function. */
   public static List arrayPrepend(List list, Object element) {
     final List result = new ArrayList(list.size() + 1);
-    result.add(element);
+    if (element instanceof Byte) {
+      result.add(((Byte) element).intValue());
+    } else {
+      result.add(element);
+    }
     result.addAll(list);
     return result;
   }

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -6486,6 +6486,10 @@ public class SqlOperatorTest {
         "INTEGER NOT NULL ARRAY NOT NULL ARRAY NOT NULL");
     f.checkScalar("array_prepend(array[map[1, 'a']], map[2, 'b'])", "[{2=b}, {1=a}]",
         "(INTEGER NOT NULL, CHAR(1) NOT NULL) MAP NOT NULL ARRAY NOT NULL");
+    f.checkScalar("array_prepend(array[1], cast(2 as tinyint))", "[2, 1]",
+        "INTEGER NOT NULL ARRAY NOT NULL");
+    f.checkScalar("array_append(array[1], cast(2 as tinyint))", "[1, 2]",
+        "INTEGER NOT NULL ARRAY NOT NULL");
     f.checkNull("array_prepend(cast(null as integer array), 1)");
     f.checkType("array_prepend(cast(null as integer array), 1)", "INTEGER NOT NULL ARRAY");
     f.checkFails("^array_prepend(array[1, 2], true)^",
@@ -6742,7 +6746,6 @@ public class SqlOperatorTest {
         "The index 0 is invalid. "
             + "An index shall be either < 0 or > 0 \\(the first element has index 1\\) "
             + "and not exceeds the allowed limit.", true);
-
     f1.checkScalar("array_insert(array[1, 2, 3], 3, 4)",
         "[1, 2, 4, 3]", "INTEGER NOT NULL ARRAY NOT NULL");
     f1.checkScalar("array_insert(array[1, 2, 3], 3, cast(null as integer))",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-5976