### PR TITLE
[CALCITE-6236] EnumerableBatchNestedLoopJoin::estimateRowCount returns wrong value

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoinRule.java
@@ -32,6 +32,7 @@ import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Util;
 
 import org.immutables.value.Value;
 
@@ -137,6 +138,8 @@ public class EnumerableBatchNestedLoopJoinRule
     // Push a filter with batchSize disjunctions
     relBuilder.push(join.getRight()).filter(relBuilder.or(conditionList));
     final RelNode right = relBuilder.build();
+    final double originRowCount =
+        Util.first(call.getMetadataQuery().getRowCount(join), Double.MAX_VALUE);
 
     call.transformTo(
         EnumerableBatchNestedLoopJoin.create(
@@ -147,7 +150,8 @@ public class EnumerableBatchNestedLoopJoinRule
             join.getCondition(),
             requiredColumns.build(),
             correlationIds,
-            join.getJoinType()));
+            join.getJoinType(),
+            originRowCount));
   }
 
   /** Rule configuration. */

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.rel.metadata;
 
+import org.apache.calcite.adapter.enumerable.EnumerableBatchNestedLoopJoin;
 import org.apache.calcite.adapter.enumerable.EnumerableLimit;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.volcano.RelSubset;
@@ -183,6 +184,12 @@ public class RelMdRowCount
   }
 
   public @Nullable Double getRowCount(Join rel, RelMetadataQuery mq) {
+    if (rel instanceof EnumerableBatchNestedLoopJoin) {
+      Double originRowCount = ((EnumerableBatchNestedLoopJoin) rel).getOriginRowCount();
+      if (originRowCount != null) {
+        return originRowCount;
+      }
+    }
     return RelMdUtil.getJoinRowCount(mq, rel, rel.getCondition());
   }
 

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableBatchNestedLoopJoinTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableBatchNestedLoopJoinTest.java
@@ -226,6 +226,7 @@ class EnumerableBatchNestedLoopJoinTest {
             + "join locations l on e.empid <> l.empid and d.deptno = l.empid")
         .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner -> {
           planner.removeRule(EnumerableRules.ENUMERABLE_CORRELATE_RULE);
+          planner.removeRule(EnumerableRules.ENUMERABLE_JOIN_RULE);
           // Use a small batch size, otherwise we will run into Janino's
           // "InternalCompilerException: Code of method grows beyond 64 KB".
           planner.addRule(


### PR DESCRIPTION
This is another approach to fix [CALCITE-6236] using the rowCount of the original relation.