### PR TITLE
Add .gitignore and .ratignore for jenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ nb-configuration.xml
 
 # Local configuration file (sdk path, etc)
 local.properties
+
+# jenv
+.java-version

--- a/.ratignore
+++ b/.ratignore
@@ -47,3 +47,6 @@ site/js/**
 # Images
 site/img/*.png
 site/favicon.ico
+
+# jenv
+.jenv-version


### PR DESCRIPTION
When using jenv to manage the local java environment, it will generate a `.java-version` file, we should ignore it.

See more details about jenv in https://github.com/jenv/jenv.