### PR TITLE
[CALCITE-6238] Exception while evaluating ROUND/TRUNCATE functions

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1774,11 +1774,11 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           OperandTypes.NUMERIC,
           SqlFunctionCategory.NUMERIC);
 
-  /** The {@code ROUND(numeric [, numeric])} function. */
+  /** The {@code ROUND(numeric [, integer])} function. */
   public static final SqlFunction ROUND =
       SqlBasicFunction.create("ROUND",
           ReturnTypes.ARG0_NULLABLE,
-          OperandTypes.NUMERIC_OPTIONAL_INTEGER,
+          OperandTypes.NUMERIC.or(OperandTypes.NUMERIC_INT32),
           SqlFunctionCategory.NUMERIC);
 
   /** The {@code SIGN(numeric)} function. */
@@ -1802,11 +1802,11 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           OperandTypes.NUMERIC,
           SqlFunctionCategory.NUMERIC);
 
-  /** The {@code TRUNCATE(numeric [, numeric])} function. */
+  /** The {@code TRUNCATE(numeric [, integer])} function. */
   public static final SqlBasicFunction TRUNCATE =
       SqlBasicFunction.create("TRUNCATE",
           ReturnTypes.ARG0_NULLABLE,
-          OperandTypes.NUMERIC_OPTIONAL_INTEGER,
+          OperandTypes.NUMERIC.or(OperandTypes.NUMERIC_INT32),
           SqlFunctionCategory.NUMERIC);
 
   /** The {@code PI} function. */

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -267,6 +267,18 @@ public abstract class OperandTypes {
   }
 
   /**
+   * Creates an operand checker from a sequence of single-operand checkers,
+   * generating the signature from the components.
+   */
+  public static SqlOperandTypeChecker sequence(
+      BiFunction<SqlOperator, String, String> signatureGenerator,
+      SqlSingleOperandTypeChecker... rules) {
+    return new CompositeOperandTypeChecker(
+        CompositeOperandTypeChecker.Composition.SEQUENCE,
+        ImmutableList.copyOf(rules), null, signatureGenerator, null);
+  }
+
+  /**
    * Creates a checker that passes if all of the rules pass for each operand,
    * using a given operand count strategy.
    */
@@ -393,6 +405,13 @@ public abstract class OperandTypes {
       family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.INTEGER),
           // Second operand optional (operand index 0, 1)
           number -> number == 1);
+
+  public static final SqlOperandTypeChecker NUMERIC_INT32 =
+      sequence(
+          (operator, name) -> operator.getName() + "(<NUMERIC>, <INTEGER>)",
+          family(SqlTypeFamily.NUMERIC),
+          // Only 32-bit integer allowed for the second argument
+          new TypeNameChecker(SqlTypeName.INTEGER));
 
   public static final SqlSingleOperandTypeChecker NUMERIC_CHARACTER =
       family(SqlTypeFamily.NUMERIC, SqlTypeFamily.CHARACTER);


### PR DESCRIPTION
I had to modify a test in testJdbcFun which no longer passes in the original form.
I don't understand why it was passing beforehand. 
To the reviewers: please double check this.