### PR TITLE
[CALCITE-6256] Incorrect rendering of HTML on InnoDB adapter page

### DIFF
--- a/site/_docs/innodb_adapter.md
+++ b/site/_docs/innodb_adapter.md
@@ -95,9 +95,8 @@ a MySQL "scott" database:
 }
 {% endhighlight %}
 
-`sqlFilePath` is a list of DDL files, you can generate table
-definitions by executing `mysqldump -d -u<username> -p<password> -h
-<hostname> <dbname>` in command-line.
+`sqlFilePath` is a list of DDL files, you can generate table definitions by executing
+`mysqldump -d -u<username> -p<password> -h <hostname> <dbname>` in command-line.
 
 The file content of `/path/scott.sql` is as follows:
 

--- a/site/_docs/innodb_adapter.md
+++ b/site/_docs/innodb_adapter.md
@@ -95,8 +95,12 @@ a MySQL "scott" database:
 }
 {% endhighlight %}
 
-`sqlFilePath` is a list of DDL files, you can generate table definitions by executing
-`mysqldump -d -u<username> -p<password> -h <hostname> <dbname>` in command-line.
+`sqlFilePath` is a list of DDL files, you can generate table
+definitions by executing `mysqldump` in command-line:
+
+{% highlight bash %}
+mysqldump -d -u<username> -p<password> -h <hostname> <dbname>
+{% endhighlight %}
 
 The file content of `/path/scott.sql` is as follows:
 


### PR DESCRIPTION
The new rendered HTML is as follows(IDEA Local preview without CSS style).

<img width="1774" alt="image" src="https://github.com/apache/calcite/assets/10829171/441fff2e-2c51-421a-862b-8f98cd9fb5ad">
