### PR TITLE
[CALCITE-6248] Illegal dates are accepted by casts

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -8203,7 +8203,7 @@ public class JdbcTest {
    * TIMESTAMP elements</a>. */
   @Test void testArrayOfDates() {
     CalciteAssert.that()
-        .query("select array[cast('1900-1-1' as date)]")
+        .query("select array[cast('1900-01-01' as date)]")
         .returns("EXPR$0=[1900-01-01]\n");
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -1320,7 +1320,7 @@ public class SqlOperatorTest {
     f.checkCastToString("DATE '1945-2-24'", null, "1945-02-24", castType);
 
     f.checkScalar("cast('1945-02-24' as DATE)", "1945-02-24", "DATE NOT NULL");
-    f.checkScalar("cast(' 1945-2-4 ' as DATE)", "1945-02-04", "DATE NOT NULL");
+    f.checkScalar("cast(' 1945-02-04 ' as DATE)", "1945-02-04", "DATE NOT NULL");
     f.checkScalar("cast('  1945-02-24  ' as DATE)",
         "1945-02-24", "DATE NOT NULL");
     if (castType == CastType.CAST) {


### PR DESCRIPTION
This PR is a pair to https://github.com/apache/calcite-avatica/pull/238 and should be merged before the other one can pass.
It only changes a few date literals in tests to conform to the expectation of the SQL standard.
Together these two PRs constitute a fix to [CALCITE-6248]
