### PR TITLE
[CALCITE-6255] Support BigQuery-style JSON_OBJECT invocation syntax

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6732,6 +6732,12 @@ List<SqlNode> JsonNameAndValue() :
     (
         <VALUE>
     |
+        <COMMA> {
+            if (kvMode) {
+                throw SqlUtil.newContextException(getPos(), RESOURCE.illegalComma());
+            }
+        }
+    |
         <COLON> {
             if (kvMode) {
                 throw SqlUtil.newContextException(getPos(), RESOURCE.illegalColon());

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -109,8 +109,11 @@ public interface CalciteResource {
   @BaseMessage("ROW expression encountered in illegal context")
   ExInst<CalciteException> illegalRowExpression();
 
-  @BaseMessage("Illegal identifier '':''. Was expecting ''VALUE''")
+  @BaseMessage("Unexpected symbol '':''. Was expecting ''VALUE''")
   ExInst<CalciteException> illegalColon();
+
+  @BaseMessage("Unexpected symbol '',''. Was expecting ''VALUE''")
+  ExInst<CalciteException> illegalComma();
 
   @BaseMessage("TABLESAMPLE percentage must be between 0 and 100, inclusive")
   @Property(name = "SQLSTATE", value = "2202H")

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -8815,6 +8815,16 @@ public class SqlParserTest {
         .ok("JSON_OBJECT(KEY 'foo' VALUE "
             + "JSON_OBJECT(KEY 'foo' VALUE 'bar' NULL ON NULL) "
             + "FORMAT JSON NULL ON NULL)");
+    expr("json_object('foo', 'bar')")
+        .ok("JSON_OBJECT(KEY 'foo' VALUE 'bar' NULL ON NULL)");
+    expr("json_object('foo', 'bar', 'baz', 'qux')")
+        .ok("JSON_OBJECT(KEY 'foo' VALUE 'bar', KEY 'baz' VALUE 'qux' NULL ON NULL)");
+    expr("json_object('foo', json_object('bar': 'baz') format json)")
+        .ok("JSON_OBJECT(KEY 'foo' VALUE "
+            + "JSON_OBJECT(KEY 'bar' VALUE 'baz' NULL ON NULL) "
+            + "FORMAT JSON NULL ON NULL)");
+    expr("json_object('foo', 'bar', 'baz'^)^")
+        .fails("(?s)Encountered \"\\)\".*Was expecting.*");
 
     if (!Bug.TODO_FIXED) {
       return;


### PR DESCRIPTION
[CALCITE-6255](https://issues.apache.org/jira/browse/CALCITE-6255)

Currently, Calcite has two styles for invoking `JSON_OBJECT`:

```
    JSON_OBJECT(KEY 'foo' VALUE 'bar', KEY 'foo2' VALUE 'bar2')
```

and:

```
    JSON_OBJECT('foo' : 'bar', 'foo2' : 'bar')
```

However, [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_object) uses a lighter-weight syntax resembling the MAP<> constructor, with an even numbered argument list where every odd item is a key and the following even item is a value:

```
    JSON_OBJECT('foo', 'bar', 'foo2', 'bar2')
```

This PR updates the grammar to allow `,` as well as `:` for separating key/value pairs in the invocation.

It does not prevent mixing `,` and `:`, but retains the prohibition from mixing with `KEY`/`VALUE` syntax.