### PR TITLE
[CALCITE-6274] Two Elasticsearch index join return empty result

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
@@ -113,8 +113,7 @@ class ElasticsearchRules {
     return SqlValidatorUtil.uniquify(
         new AbstractList<String>() {
           @Override public String get(int index) {
-            final String name = rowType.getFieldList().get(index).getName();
-            return name.startsWith("$") ? "_" + name.substring(2) : name;
+            return rowType.getFieldList().get(index).getName();
           }
 
           @Override public int size() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/JoinTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/JoinTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.test.CalciteAssert;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Testing Elasticsearch join query.
+ */
+@ResourceLock(value = "elasticsearch-scrolls", mode = ResourceAccessMode.READ)
+public class JoinTest {
+
+  public static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
+
+  private static final String NAME_LEFT = "lt";
+
+  private static final String NAME_RIGHT = "rt";
+
+
+  @BeforeAll
+  public static void setupInstance() throws Exception {
+    final Map<String, String> ltMappings = ImmutableMap.<String, String>builder()
+        .put("doc_id", "keyword")
+        .put("val1", "long")
+        .build();
+
+    final Map<String, String> rtMappings = ImmutableMap.<String, String>builder()
+        .put("doc_id", "keyword")
+        .put("val2", "long")
+        .build();
+
+    NODE.createIndex(NAME_LEFT, ltMappings);
+    NODE.createIndex(NAME_RIGHT, rtMappings);
+    final ObjectMapper mapper = new ObjectMapper()
+        .enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES) // user-friendly settings to
+        .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES); // avoid too much quoting
+
+    String ldoc1 = "{doc_id:'1', val1:1}";
+    String ldoc2 = "{doc_id:'2', val1:2}";
+    final List<ObjectNode> docs = new ArrayList<>();
+    for (String text : Arrays.asList(ldoc1, ldoc2)) {
+      docs.add((ObjectNode) mapper.readTree(text));
+    }
+    NODE.insertBulk(NAME_LEFT, docs);
+
+
+    String rdoc1 = "{doc_id:'1', val2:1}";
+    String rdoc2 = "{doc_id:'2', val2:2}";
+    final List<ObjectNode> rdocs = new ArrayList<>();
+    for (String text : Arrays.asList(rdoc1, rdoc2)) {
+      rdocs.add((ObjectNode) mapper.readTree(text));
+    }
+    NODE.insertBulk(NAME_RIGHT, rdocs);
+  }
+
+  private static Connection createConnection() throws SQLException {
+    final Connection connection = DriverManager.getConnection("jdbc:calcite:");
+    final SchemaPlus root =
+        connection.unwrap(CalciteConnection.class).getRootSchema();
+
+    root.add("elastic0", new ElasticsearchSchema(NODE.restClient(), NODE.mapper(), NAME_LEFT));
+    root.add("elastic1", new ElasticsearchSchema(NODE.restClient(), NODE.mapper(), NAME_RIGHT));
+
+    return connection;
+  }
+
+  /**
+   * Test two elasticserch index join.
+   */
+  @Test void join() {
+    CalciteAssert.that()
+        .with(JoinTest::createConnection)
+        .query(
+            String.format(Locale.ROOT,
+                "select t._MAP['doc_id'] AS \"doc_id\", t._MAP['val1'] AS \"val1\" "
+            + " from \"elastic0\".\"%s\" t "
+            + " join \"elastic1\".\"%s\" s"
+            + " on cast(t._MAP['doc_id'] as varchar) = cast(s._MAP['doc_id'] as varchar)",
+                NAME_LEFT, NAME_RIGHT))
+        .returnsUnordered("doc_id=1; val1=1",
+            "doc_id=2; val1=2");
+
+  }
+
+}


### PR DESCRIPTION
[CALCITE-6274](https://issues.apache.org/jira/browse/CALCITE-6274)
Two index of Elasticsearch join return empty result even if the data from both indexes can match。

create index test_01:
`
PUT /test_01/_doc/1
{
  "doc_id" : 1,
  "doc_desc" : "doc01"
} 
`

create index test_02:
`
PUT /test_02/_doc/1
{
  "doc_id" : 1,
  "doc_score" : 90
} 
`

execute sql:
`
select * from es.test_01 t1 join es.test_02 t2 on cast(t1._MAP['doc_id'] as bigint) = cast(t2._MAP['doc_id'] as bigint) 
`

the code generate by ElasticsearchToEnumerableConverter like this:
subquery of index test_01:
`
{
  return ((org.apache.calcite.adapter.elasticsearch.ElasticsearchTable.ElasticsearchQueryable) org.apache.calcite.schema.Schemas.queryable(root, root.getRootSchema().getSubSchema("es"), java.lang.Object[].class, "test_01")).find(java.util.Collections.EMPTY_LIST, java.util.Arrays.asList(new org.apache.calcite.util.Pair[] {
      new org.apache.calcite.util.Pair(
        "_MAP",
        java.util.Map.class),
      new org.apache.calcite.util.Pair(
        "_1",
        java.lang.Long.class)}), java.util.Arrays.asList(new org.apache.calcite.util.Pair[] {
      new org.apache.calcite.util.Pair(
        "doc_id",
        org.apache.calcite.rel.RelFieldCollation.Direction.ASCENDING)}), java.util.Collections.EMPTY_LIST, java.util.Arrays.asList(new org.apache.calcite.util.Pair[] {}), com.google.common.collect.ImmutableMap.of("$f1", "doc_id"), null, null);
}
`
project field names: `"_MAP", "_1"`

subquery of index test_02:
`
{
  return ((org.apache.calcite.adapter.elasticsearch.ElasticsearchTable.ElasticsearchQueryable) org.apache.calcite.schema.Schemas.queryable(root, root.getRootSchema().getSubSchema("es"), java.lang.Object[].class, "test_02")).find(java.util.Collections.EMPTY_LIST, java.util.Arrays.asList(new org.apache.calcite.util.Pair[] {
      new org.apache.calcite.util.Pair(
        "_MAP",
        java.util.Map.class),
      new org.apache.calcite.util.Pair(
        "_1",
        java.lang.Long.class)}), java.util.Arrays.asList(new org.apache.calcite.util.Pair[] {
      new org.apache.calcite.util.Pair(
        "doc_id",
        org.apache.calcite.rel.RelFieldCollation.Direction.ASCENDING)}), java.util.Collections.EMPTY_LIST, java.util.Arrays.asList(new org.apache.calcite.util.Pair[] {}), com.google.common.collect.ImmutableMap.of("$f1", "doc_id"), null, null);
}
`
project field names: `"_MAP", "_1"`

This org.apache.calcite.adapter.elasticsearch.ElasticsearchTable.ElasticsearchQueryable#find function actually execute request, subq-query result  projected according to second paramter fields. Field "_1" can not find from subq-query result.  "_1" not in mappings {"$f1":"doc_id"}, cause two sub-query join condition value is null, so the result of sql is empty.

This PR fix the problem, the sub-query project field names is: `"_MAP", "$f1"`. join condition field `$f1` can be find in mappings. The result of sql match expectations. 
 


