### PR TITLE
[CALCITE-6262] CURRENT_TIMESTAMP(P) ignores DataTypeSystem#getMaxPrecision

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlAbstractTimeFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlAbstractTimeFunction.java
@@ -69,11 +69,12 @@ public class SqlAbstractTimeFunction extends SqlFunction {
       }
     }
     assert precision >= 0;
-    if (precision > SqlTypeName.MAX_DATETIME_PRECISION) {
+    final int maxPrecision = opBinding.getTypeFactory().getTypeSystem().getMaxPrecision(typeName);
+    if (precision > maxPrecision) {
       throw opBinding.newError(
           RESOURCE.argumentMustBeValidPrecision(
               opBinding.getOperator().getName(), 0,
-              SqlTypeName.MAX_DATETIME_PRECISION));
+              maxPrecision));
     }
     return opBinding.getTypeFactory().createSqlType(typeName, precision);
   }


### PR DESCRIPTION
Change datetime functions taking in a precision to validate against the max precision from the type system, rather than the SqlTypeName.