### PR TITLE
[CALCITE-6275] Parser for data types ignores element nullability in collections

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -2353,15 +2353,13 @@ void AddColumnType(List<SqlNode> list) :
 {
     final SqlIdentifier name;
     final SqlDataTypeSpec type;
-    final boolean nullable;
 }
 {
     name = CompoundIdentifier()
-    type = DataType()
-    nullable = NotNullOpt()
+    type = DataTypeNullable()
     {
         list.add(name);
-        list.add(type.withNullable(nullable, getPos()));
+        list.add(type);
     }
 }
 
@@ -5715,10 +5713,81 @@ SqlDataTypeSpec DataType() :
         s = Span.of(typeName.getParserPos());
     }
     (
-        typeName = CollectionsTypeName(typeName)
+        typeName = CollectionsTypeName(new SqlDataTypeSpec(typeName, s.add(typeName.getParserPos()).pos()))
     )*
     {
         return new SqlDataTypeSpec(typeName, s.add(typeName.getParserPos()).pos());
+    }
+}
+
+// Type name with optional scale, precision, and nullability.
+// Nullability of the type is specified as follows
+// - `NOT NULL` implies not nullable,
+// - nothing implies nullable
+// These rules are applied recursively for type components
+// in composite types, such as ARRAY and MAP.
+SqlDataTypeSpec DataTypeNullable() :
+{
+    SqlTypeNameSpec typeName;
+    Span s;
+    boolean nullable;
+    SqlDataTypeSpec type;
+}
+{
+    typeName = TypeName() {
+        s = Span.of(typeName.getParserPos());
+        type = new SqlDataTypeSpec(typeName, s.pos());
+    }
+    nullable = NotNullOpt() {
+        type = type.withNullable(nullable, getPos());
+        s = s.add(getPos());
+    }
+    (
+        typeName = CollectionsTypeName(type) {
+            type = new SqlDataTypeSpec(typeName, s.add(typeName.getParserPos()).pos());
+        }
+        nullable = NotNullOpt() {
+            type = type.withNullable(nullable, s.add(getPos()).pos());
+        }
+    )*
+    {
+        return type;
+    }
+}
+
+// Type name with optional scale, precision, and nullability.
+// Nullability of the type is specified as follows
+// - `NOT NULL` implies not nullable,
+// - `NULL` implies nullable
+// - nothing implies nullable
+// These rules are applied recursively for type components
+// in composite types, such as ARRAY and MAP.
+SqlDataTypeSpec DataTypeNullableOptDefaultTrue() :
+{
+    SqlTypeNameSpec typeName;
+    Span s;
+    boolean nullable;
+    SqlDataTypeSpec type;
+}
+{
+    typeName = TypeName() {
+        s = Span.of(typeName.getParserPos());
+        type = new SqlDataTypeSpec(typeName, s.pos());
+    }
+    nullable = NullableOptDefaultTrue() {
+        type = type.withNullable(nullable, getPos());
+        s = s.add(getPos());
+    }
+    (
+        typeName = CollectionsTypeName(type) {
+            type = new SqlDataTypeSpec(typeName, s.add(typeName.getParserPos()).pos());
+        }
+        nullable = NullableOptDefaultTrue() {
+            type = type.withNullable(nullable, s.add(getPos()).pos());
+        }
+    )*
+    {
+        return type;
     }
 }
 
@@ -5917,7 +5986,7 @@ SqlLiteral JdbcOdbcDataType() :
 * Parse a collection type name, the input element type name may
 * also be a collection type.
 */
-SqlTypeNameSpec CollectionsTypeName(SqlTypeNameSpec elementTypeName) :
+SqlTypeNameSpec CollectionsTypeName(SqlDataTypeSpec elementTypeSpec) :
 {
     final SqlTypeName collectionTypeName;
 }
@@ -5928,7 +5997,7 @@ SqlTypeNameSpec CollectionsTypeName(SqlTypeNameSpec elementTypeName) :
         <ARRAY> { collectionTypeName = SqlTypeName.ARRAY; }
     )
     {
-        return new SqlCollectionTypeNameSpec(elementTypeName,
+        return new SqlCollectionTypeNameSpec(elementTypeSpec,
                 collectionTypeName, getPos());
     }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
@@ -55,35 +55,35 @@ import java.util.Objects;
  * name of this {@code SqlCollectionTypeNameSpec} is also a {@code SqlCollectionTypeNameSpec}.
  */
 public class SqlCollectionTypeNameSpec extends SqlTypeNameSpec {
-  private final SqlTypeNameSpec elementTypeName;
+  private final SqlDataTypeSpec elementTypeSpec;
   private final SqlTypeName collectionTypeName;
 
   /**
    * Creates a {@code SqlCollectionTypeNameSpec}.
    *
-   * @param elementTypeName    Type of the collection element
+   * @param elementTypeSpec    Type of the collection element
    * @param collectionTypeName Collection type name
    * @param pos                Parser position, must not be null
    */
-  public SqlCollectionTypeNameSpec(SqlTypeNameSpec elementTypeName,
+  public SqlCollectionTypeNameSpec(SqlDataTypeSpec elementTypeSpec,
       SqlTypeName collectionTypeName,
       SqlParserPos pos) {
     super(new SqlIdentifier(collectionTypeName.name(), pos), pos);
-    this.elementTypeName = Objects.requireNonNull(elementTypeName, "elementTypeName");
+    this.elementTypeSpec = Objects.requireNonNull(elementTypeSpec, "elementTypeSpec");
     this.collectionTypeName = Objects.requireNonNull(collectionTypeName, "collectionTypeName");
   }
 
-  public SqlTypeNameSpec getElementTypeName() {
-    return elementTypeName;
+  public SqlDataTypeSpec getElementTypeSpec() {
+    return elementTypeSpec;
   }
 
   @Override public RelDataType deriveType(SqlValidator validator) {
-    final RelDataType type = elementTypeName.deriveType(validator);
+    final RelDataType type = elementTypeSpec.deriveType(validator);
     return createCollectionType(type, validator.getTypeFactory());
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    elementTypeName.unparse(writer, leftPrec, rightPrec);
+    elementTypeSpec.unparse(writer, leftPrec, rightPrec);
     writer.keyword(collectionTypeName.name());
   }
 
@@ -92,7 +92,7 @@ public class SqlCollectionTypeNameSpec extends SqlTypeNameSpec {
       return litmus.fail("{} != {}", this, spec);
     }
     SqlCollectionTypeNameSpec that = (SqlCollectionTypeNameSpec) spec;
-    if (!this.elementTypeName.equalsDeep(that.elementTypeName, litmus)) {
+    if (!this.elementTypeSpec.equalsDeep(that.elementTypeSpec, litmus)) {
       return litmus.fail("{} != {}", this, spec);
     }
     if (!Objects.equals(this.collectionTypeName, that.collectionTypeName)) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
@@ -181,13 +181,34 @@ public class SqlDataTypeSpec extends SqlNode {
    */
   public SqlDataTypeSpec getComponentTypeSpec() {
     assert typeNameSpec instanceof SqlCollectionTypeNameSpec;
-    SqlTypeNameSpec elementTypeName =
-        ((SqlCollectionTypeNameSpec) typeNameSpec).getElementTypeName();
-    return new SqlDataTypeSpec(elementTypeName, timeZone, getParserPosition());
+    return ((SqlCollectionTypeNameSpec) typeNameSpec).getElementTypeSpec();
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     typeNameSpec.unparse(writer, leftPrec, rightPrec);
+    SqlWriter.TypeNullabilityStyle style = writer.getTypeNullabilityStyle();
+    switch (style) {
+    case SHOW_NULLABLE:
+      if (Boolean.TRUE.equals(this.getNullable())) {
+        writer.keyword("NULL");
+      }
+      break;
+    case SHOW_NON_NULLABLE:
+      if (Boolean.FALSE.equals(this.getNullable())) {
+        writer.keyword("NOT NULL");
+      }
+      break;
+    case SHOW_EVERYTHING:
+      if (Boolean.TRUE.equals(this.getNullable())) {
+        writer.keyword("NULL");
+      }
+      if (Boolean.FALSE.equals(this.getNullable())) {
+        writer.keyword("NOT NULL");
+      }
+      break;
+    case SHOW_NOTHING:
+      break;
+    }
   }
 
   @Override public void validate(SqlValidator validator, SqlValidatorScope scope) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -63,6 +63,26 @@ public interface SqlWriter {
   }
 
   /**
+   * Controls how type nullability is displayed.
+   * This depends on the context where a type appears.
+   */
+  enum TypeNullabilityStyle {
+    /** If a type is nullable, write NULL, otherwise do nothing. */
+    SHOW_NULLABLE,
+    /** If a type is not nullable, write NOT NULL, otherwise do nothing. */
+    SHOW_NON_NULLABLE,
+    /** Show the nullability explicitly. */
+    SHOW_EVERYTHING,
+    /** Nullability should not be displayed at all. */
+    SHOW_NOTHING,
+  }
+
+  /** Set the style of the nullability for the next type that will be unparsed. */
+  void setTypeNullabilityStyle(TypeNullabilityStyle style);
+  /** Get the style of the nullability used for the next type that will be unparsed. */
+  TypeNullabilityStyle getTypeNullabilityStyle();
+
+  /**
    * Enumerates the types of frame.
    */
   enum FrameTypeEnum implements FrameType {

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlColumnDeclaration.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlColumnDeclaration.java
@@ -68,10 +68,8 @@ public class SqlColumnDeclaration extends SqlCall {
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     name.unparse(writer, 0, 0);
+    writer.setTypeNullabilityStyle(SqlWriter.TypeNullabilityStyle.SHOW_NON_NULLABLE);
     dataType.unparse(writer, 0, 0);
-    if (Boolean.FALSE.equals(dataType.getNullable())) {
-      writer.keyword("NOT NULL");
-    }
     SqlNode expression = this.expression;
     if (expression != null) {
       switch (strategy) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -258,6 +258,7 @@ public class SqlCastFunction extends SqlFunction {
     if (call.operand(1) instanceof SqlIntervalQualifier) {
       writer.sep("INTERVAL");
     }
+    writer.setTypeNullabilityStyle(SqlWriter.TypeNullabilityStyle.SHOW_NOTHING);
     call.operand(1).unparse(writer, 0, 0);
     writer.endFunCall(frame);
   }

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -281,6 +281,7 @@ public class SqlPrettyWriter implements SqlWriter {
   private SqlWriterConfig config;
   private @Nullable Bean bean;
   private int currentIndent;
+  private TypeNullabilityStyle typeNullabilityStyle = TypeNullabilityStyle.SHOW_NOTHING;
 
   private int lineStart;
 
@@ -558,6 +559,14 @@ public class SqlPrettyWriter implements SqlWriter {
   @Deprecated
   public void setQuoteAllIdentifiers(boolean quoteAllIdentifiers) {
     this.config = config.withQuoteAllIdentifiers(quoteAllIdentifiers);
+  }
+
+  @Override public void setTypeNullabilityStyle(TypeNullabilityStyle style) {
+    typeNullabilityStyle = style;
+  }
+
+  @Override public TypeNullabilityStyle getTypeNullabilityStyle() {
+    return typeNullabilityStyle;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -1117,7 +1117,7 @@ public abstract class SqlTypeUtil {
     } else if (isCollection(type)) {
       typeNameSpec =
           new SqlCollectionTypeNameSpec(
-              convertTypeToSpec(getComponentTypeOrThrow(type)).getTypeNameSpec(),
+              convertTypeToSpec(getComponentTypeOrThrow(type)),
               typeName, SqlParserPos.ZERO);
     } else if (isRow(type)) {
       RelRecordType recordType = (RelRecordType) type;

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -171,12 +171,12 @@ class SqlTypeUtilTest {
     SqlCollectionTypeNameSpec arraySpec =
         (SqlCollectionTypeNameSpec) convertTypeToSpec(f.arrayBigInt).getTypeNameSpec();
     assertThat(arraySpec.getTypeName().getSimple(), is("ARRAY"));
-    assertThat(arraySpec.getElementTypeName().getTypeName().getSimple(), is("BIGINT"));
+    assertThat(arraySpec.getElementTypeSpec().getTypeName().getSimple(), is("BIGINT"));
 
     SqlCollectionTypeNameSpec multisetSpec =
         (SqlCollectionTypeNameSpec) convertTypeToSpec(f.multisetBigInt).getTypeNameSpec();
     assertThat(multisetSpec.getTypeName().getSimple(), is("MULTISET"));
-    assertThat(multisetSpec.getElementTypeName().getTypeName().getSimple(), is("BIGINT"));
+    assertThat(multisetSpec.getElementTypeSpec().getTypeName().getSimple(), is("BIGINT"));
 
     SqlRowTypeNameSpec rowSpec =
         (SqlRowTypeNameSpec) convertTypeToSpec(f.structOfInt).getTypeNameSpec();

--- a/server/src/main/codegen/includes/parserImpls.ftl
+++ b/server/src/main/codegen/includes/parserImpls.ftl
@@ -119,7 +119,6 @@ void TableElement(List<SqlNode> list) :
 {
     final SqlIdentifier id;
     final SqlDataTypeSpec type;
-    final boolean nullable;
     final SqlNode e;
     SqlIdentifier name = null;
     final SqlNodeList columnList;
@@ -129,8 +128,7 @@ void TableElement(List<SqlNode> list) :
 {
     LOOKAHEAD(2) id = SimpleIdentifier()
     (
-        type = DataType()
-        nullable = NullableOptDefaultTrue()
+        type = DataTypeNullableOptDefaultTrue()
         (
             [ <GENERATED> <ALWAYS> ] <AS> <LPAREN>
             e = Expression(ExprContext.ACCEPT_SUB_QUERY) <RPAREN>
@@ -148,14 +146,14 @@ void TableElement(List<SqlNode> list) :
         |
             {
                 e = null;
-                strategy = nullable ? ColumnStrategy.NULLABLE
+                strategy = type.getNullable() ? ColumnStrategy.NULLABLE
                     : ColumnStrategy.NOT_NULLABLE;
             }
         )
         {
             list.add(
                 SqlDdlNodes.column(s.add(id).end(this), id,
-                    type.withNullable(nullable), e, strategy));
+                    type, e, strategy));
         }
     |
         { list.add(id); }
@@ -204,20 +202,18 @@ void AttributeDef(List<SqlNode> list) :
 {
     final SqlIdentifier id;
     final SqlDataTypeSpec type;
-    final boolean nullable;
     SqlNode e = null;
     final Span s = Span.of();
 }
 {
     id = SimpleIdentifier()
     (
-        type = DataType()
-        nullable = NullableOptDefaultTrue()
+        type = DataTypeNullableOptDefaultTrue()
     )
     [ <DEFAULT_> e = Expression(ExprContext.ACCEPT_SUB_QUERY) ]
     {
         list.add(SqlDdlNodes.attribute(s.add(id).end(this), id,
-            type.withNullable(nullable), e, null));
+            type, e, null));
     }
 }
 

--- a/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
+++ b/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
  *
  * <li>during CREATE VIEW, check for a table and a materialized view
  * with the same name (they have the same namespace)
- *
  * </ul>
  */
 class ServerParserTest extends SqlParserTest {
@@ -114,6 +113,30 @@ class ServerParserTest extends SqlParserTest {
   @Test void testCreateTable() {
     sql("create table x (i int not null, j varchar(5) null)")
         .ok("CREATE TABLE `X` (`I` INTEGER NOT NULL, `J` VARCHAR(5))");
+  }
+
+  /**
+   * Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-6275">[CALCITE-6275]
+   * Parser for data types ignores element nullability in collections</a>. */
+  @Test void testCreateTableWithArray() {
+    sql("create table x ("
+        + "a int array, "
+        + "b int array not null, "
+        + "c int not null array, "
+        + "d int not null array not null, "
+        + "e int array null, " // same as column a
+        + "f int null array null, " // same as column a
+        + "g int null array not null, " // same as column b
+        + "h int not null array null)") // same as column c
+        .ok("CREATE TABLE `X` ("
+            + "`A` INTEGER ARRAY, "
+            + "`B` INTEGER ARRAY NOT NULL, "
+            + "`C` INTEGER NOT NULL ARRAY, "
+            + "`D` INTEGER NOT NULL ARRAY NOT NULL, "
+            + "`E` INTEGER ARRAY, "
+            + "`F` INTEGER ARRAY, "
+            + "`G` INTEGER ARRAY NOT NULL, "
+            + "`H` INTEGER NOT NULL ARRAY)");
   }
 
   @Test void testCreateTableAsSelect() {


### PR DESCRIPTION
This modifies the parser to accept types such as INTEGER NOT NULL ARRAY NULL for column types.
The only thing I don't like too much about this PR is the fact that this type is unparsed differently depending on where it appears: 

- in a column definition it is unparsed as INTEGER NOT NULL ARRAY
- in a CAST it is unparsed as INTEGER ARRAY (the type can appear in a cast due to type coercion, so this is a legal use case)

These two not the same type at all, but other databases, such as Postgres, also do not accept types with nullabilities in casts. Maybe that's a bug in Postgres as well, or maybe in the SQL handling of collection types in general? 

In order to provide this behavior I had to add some state to the SqlWriter which indicates the context where a type is being unparsed. Fortunately, types cannot contain other kinds of SqlNodes - e.g., expressions - so a stack of context is not necessary, a scalar will do.

