### PR TITLE
[CALCITE-6278] Add REGEXP function (enabled in Spark library)

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
@@ -131,6 +131,16 @@ class BabelQuidemTest extends QuidemTest {
                   SqlConformanceEnum.BABEL)
               .with(CalciteConnectionProperty.LENIENT_OPERATOR_LOOKUP, true)
               .connect();
+        case "scott-spark":
+          return CalciteAssert.that()
+              .with(CalciteAssert.SchemaSpec.SCOTT)
+              .with(CalciteConnectionProperty.FUN, "standard,spark")
+              .with(CalciteConnectionProperty.PARSER_FACTORY,
+                  SqlBabelParserImpl.class.getName() + "#PARSER_FACTORY")
+              .with(CalciteConnectionProperty.CONFORMANCE,
+                  SqlConformanceEnum.BABEL)
+              .with(CalciteConnectionProperty.LENIENT_OPERATOR_LOOKUP, true)
+              .connect();
         default:
           return super.connect(name, reference);
         }

--- a/babel/src/test/resources/spark.iq
+++ b/babel/src/test/resources/spark.iq
@@ -1,0 +1,52 @@
+# spark.iq - Babel test for Spark dialect of SQL
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+!use scott-spark
+!set outputformat csv
+
+#####################################################################
+# String functions ######################
+
+#####################################################################
+# REGEXP
+#
+# REGEXP(str, regexp)
+# Returns true if str matches regexp, or false otherwise.
+#
+# Returns STRING
+
+SELECT REGEXP('%SystemDrive%\Users\John', '%SystemDrive%\\Users.*');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP('%SystemDrive%\\Users\\John', '%SystemDrive%\\\\Users.*');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP('abc def ghi', 'abc');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP('abc def ghi', 'abcd');
+EXPR$0
+false
+!ok
+
+# End spark.iq

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -231,6 +231,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.PARSE_TIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.PARSE_TIMESTAMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.PARSE_URL;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.POW;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_CONTAINS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_EXTRACT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_EXTRACT_ALL;
@@ -597,6 +598,7 @@ public class RexImpTable {
       defineReflective(PARSE_URL, BuiltInMethod.PARSE_URL2.method,
           BuiltInMethod.PARSE_URL3.method);
       defineReflective(REGEXP_CONTAINS, BuiltInMethod.REGEXP_CONTAINS.method);
+      defineReflective(REGEXP, BuiltInMethod.REGEXP_CONTAINS.method);
       defineReflective(REGEXP_EXTRACT, BuiltInMethod.REGEXP_EXTRACT2.method,
           BuiltInMethod.REGEXP_EXTRACT3.method, BuiltInMethod.REGEXP_EXTRACT4.method);
       defineReflective(REGEXP_EXTRACT_ALL, BuiltInMethod.REGEXP_EXTRACT_ALL.method);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -513,6 +513,11 @@ public abstract class SqlLibraryOperators {
           OperandTypes.STRING_STRING,
           SqlFunctionCategory.STRING);
 
+  /** The "REGEXP(value, regexp)" function. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction REGEXP = ((SqlBasicFunction) REGEXP_CONTAINS)
+      .withName("REGEXP");
+
   /** The "REGEXP_EXTRACT(value, regexp[, position[, occurrence]])" function.
    * Returns the substring in value that matches the regexp. Returns NULL if there is no match. */
   @LibraryOperator(libraries = {BIG_QUERY})

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -4907,25 +4907,38 @@ public class SqlOperatorTest {
   }
 
   @Test void testRegexpContainsFunc() {
-    final SqlOperatorFixture f = fixture().setFor(SqlLibraryOperators.REGEXP_CONTAINS)
-        .withLibrary(SqlLibrary.BIG_QUERY);
-    f.checkBoolean("regexp_contains('abc def ghi', 'abc')", true);
-    f.checkBoolean("regexp_contains('abc def ghi', '[a-z]+')", true);
-    f.checkBoolean("regexp_contains('foo@bar.com', '@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+')", true);
-    f.checkBoolean("regexp_contains('foo@.com', '@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+')", false);
-    f.checkBoolean("regexp_contains('5556664422', '^\\d{10}$')", true);
-    f.checkBoolean("regexp_contains('11555666442233', '^\\d{10}$')", false);
-    f.checkBoolean("regexp_contains('55566644221133', '\\d{10}')", true);
-    f.checkBoolean("regexp_contains('55as56664as422', '\\d{10}')", false);
-    f.checkBoolean("regexp_contains('55as56664as422', '')", true);
+    final SqlOperatorFixture f = fixture().setFor(SqlLibraryOperators.REGEXP_CONTAINS);
+    checkRegexpFunc(f, FunctionAlias.of(SqlLibraryOperators.REGEXP_CONTAINS));
+  }
 
-    f.checkQuery("select regexp_contains('abc def ghi', 'abc')");
-    f.checkQuery("select regexp_contains('foo@bar.com', '@[a-zA-Z0-9-]+\\\\.[a-zA-Z0-9-.]+')");
-    f.checkQuery("select regexp_contains('55as56664as422', '\\d{10}')");
+  @Test void testRegexpFunc() {
+    final SqlOperatorFixture f = fixture().setFor(SqlLibraryOperators.REGEXP);
+    checkRegexpFunc(f, FunctionAlias.of(SqlLibraryOperators.REGEXP));
+  }
 
-    f.checkNull("regexp_contains('abc def ghi', cast(null as varchar))");
-    f.checkNull("regexp_contains(cast(null as varchar), 'abc')");
-    f.checkNull("regexp_contains(cast(null as varchar), cast(null as varchar))");
+  void checkRegexpFunc(SqlOperatorFixture f0, FunctionAlias functionAlias) {
+    final SqlFunction function = functionAlias.function;
+    final String fn = function.getName();
+    final Consumer<SqlOperatorFixture> consumer = f -> {
+      f.checkBoolean(fn + "('abc def ghi', 'abc')", true);
+      f.checkBoolean(fn + "('abc def ghi', '[a-z]+')", true);
+      f.checkBoolean(fn + "('foo@bar.com', '@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+')", true);
+      f.checkBoolean(fn + "('foo@.com', '@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+')", false);
+      f.checkBoolean(fn + "('5556664422', '^\\d{10}$')", true);
+      f.checkBoolean(fn + "('11555666442233', '^\\d{10}$')", false);
+      f.checkBoolean(fn + "('55566644221133', '\\d{10}')", true);
+      f.checkBoolean(fn + "('55as56664as422', '\\d{10}')", false);
+      f.checkBoolean(fn + "('55as56664as422', '')", true);
+
+      f.checkQuery("select " + fn + "('abc def ghi', 'abc')");
+      f.checkQuery("select " + fn + "('foo@bar.com', '@[a-zA-Z0-9-]+\\\\.[a-zA-Z0-9-.]+')");
+      f.checkQuery("select " + fn + "('55as56664as422', '\\d{10}')");
+
+      f.checkNull(fn + "('abc def ghi', cast(null as varchar))");
+      f.checkNull(fn + "(cast(null as varchar), 'abc')");
+      f.checkNull(fn + "(cast(null as varchar), cast(null as varchar))");
+    };
+    f0.forEachLibrary(list(functionAlias.libraries), consumer);
   }
 
   @Test void testRegexpExtractAllFunc() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6278

1. Add Function [REGEXP](https://spark.apache.org/docs/latest/api/sql/index.html#regexp) enabled in Spark library.
Since this function has the same implementation as the Big Query [REGEXP_CONTAINS](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#regexp_contains) function. the implementation can be directly reused.
2. Add spark query tests in BabelQuidemTest to ensure the execution correctness.