### PR TITLE
[CALCITE-6248] Illegal dates are accepted by casts

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -200,6 +200,18 @@ public abstract class Bug {
    * Fix to be available with Avatica 1.24.0 [CALCITE-6053] */
   public static final boolean CALCITE_6092_FIXED = false;
 
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6053">[CALCITE-6053]
+   * Upgrade Calcite to Avatica 1.24.0</a> is fixed.
+   */
+  public static final boolean CALCITE_6053_FIXED = false;
+
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6248">[CALCITE-6248]
+   * Illegal dates are accepted by casts</a> is fixed.
+   * Fix to be available with Avatica 1.25.0 */
+  public static final boolean CALCITE_6248_FIXED = false;
+
   /**
    * Use this to flag temporary code.
    */

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -8256,7 +8256,7 @@ public class JdbcTest {
    * TIMESTAMP elements</a>. */
   @Test void testArrayOfDates() {
     CalciteAssert.that()
-        .query("select array[cast('1900-01-01' as date)]")
+        .query("select array[cast('1900-1-1' as date)]")
         .returns("EXPR$0=[1900-01-01]\n");
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -1273,7 +1273,6 @@ public class SqlOperatorTest {
     if (Bug.CALCITE_6282_FIXED) {
       f.checkScalar("cast('1945-02-24 12:42:25.34' as TIMESTAMP(2))",
           "1945-02-24 12:42:25.34", "TIMESTAMP(2) NOT NULL");
-
       if (castType == CastType.CAST) {
         f.checkFails("cast('1945-2-2 12:2:5' as TIMESTAMP)",
             "Invalid DATE value, '1945-2-2 12:2:5'", true);
@@ -1305,7 +1304,7 @@ public class SqlOperatorTest {
     f.checkCastToString("DATE '1945-2-24'", null, "1945-02-24", castType);
 
     f.checkScalar("cast('1945-02-24' as DATE)", "1945-02-24", "DATE NOT NULL");
-    f.checkScalar("cast(' 1945-02-04 ' as DATE)", "1945-02-04", "DATE NOT NULL");
+    f.checkScalar("cast(' 1945-2-4 ' as DATE)", "1945-02-04", "DATE NOT NULL");
     f.checkScalar("cast('  1945-02-24  ' as DATE)",
         "1945-02-24", "DATE NOT NULL");
     if (castType == CastType.CAST) {
@@ -1314,8 +1313,15 @@ public class SqlOperatorTest {
       f.checkNull("cast('notdate' as DATE)");
     }
 
-    f.checkScalar("cast('52534253' as DATE)", "7368-10-13", "DATE NOT NULL");
-    f.checkScalar("cast('1945-30-24' as DATE)", "1947-06-26", "DATE NOT NULL");
+    if (Bug.CALCITE_6248_FIXED) {
+      if (castType == CastType.CAST) {
+        f.checkFails("cast('52534253' as DATE)", BAD_DATETIME_MESSAGE, true);
+        f.checkFails("cast('1945-30-24' as DATE)", BAD_DATETIME_MESSAGE, true);
+      } else {
+        f.checkNull("cast('52534253' as DATE)");
+        f.checkNull("cast('1945-30-24' as DATE)");
+      }
+    }
 
     // cast null
     f.checkNull("cast(null as date)");


### PR DESCRIPTION
This is the second attempt to provide a partial fix for [CALCITE-6248].
The fix is partial, because the bug is in Avatica, but Avatica CI fails if this fix is not applied.
I have already merged a PR for this issue, but here I revert the changes in that prior PR.
I apologize for this change of mind, it has become apparent that the previous choice for the fix was incorrect.
The fix is about CAST(string to DATE). The assumption is that this cast should be more lenient than DATE literals in parsing the string, but should still require the date to be correct.
The plan is to merge this PR, then attempt to merge the corresponding Avatica PR: https://github.com/apache/calcite-avatica/pull/238. If that PR passes, it can be merged. Then some leftover code in Calcite can be cleaned-up when a new Calcite release picks up a new Avatica release.
Unfortunately I don't know of an easy way to test this PR before it's merged.