### PR TITLE
[CALCITE-6278] Add REGEXP, REGEXP_LIKE  function (enabled in Spark library)

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
@@ -131,6 +131,16 @@ class BabelQuidemTest extends QuidemTest {
                   SqlConformanceEnum.BABEL)
               .with(CalciteConnectionProperty.LENIENT_OPERATOR_LOOKUP, true)
               .connect();
+        case "scott-spark":
+          return CalciteAssert.that()
+              .with(CalciteAssert.SchemaSpec.SCOTT)
+              .with(CalciteConnectionProperty.FUN, "standard,spark")
+              .with(CalciteConnectionProperty.PARSER_FACTORY,
+                  BabelDdlExecutor.class.getName() + "#PARSER_FACTORY")
+              .with(CalciteConnectionProperty.CONFORMANCE,
+                  SqlConformanceEnum.BABEL)
+              .with(CalciteConnectionProperty.LENIENT_OPERATOR_LOOKUP, true)
+              .connect();
         default:
           return super.connect(name, reference);
         }

--- a/babel/src/test/resources/sql/spark.iq
+++ b/babel/src/test/resources/sql/spark.iq
@@ -1,0 +1,243 @@
+# spark.iq - Babel test for Spark dialect of SQL
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+!use scott-spark
+!set outputformat csv
+
+#####################################################################
+# String functions ######################
+
+#####################################################################
+# RLIKE
+#
+# string1 RLIKE string2
+# Returns true if str matches regexp, or false otherwise.
+#
+# Returns BOOLEAN
+
+select NULL RLIKE 'abc*';
+EXPR$0
+null
+!ok
+
+select 'abc' RLIKE NULL;
+EXPR$0
+null
+!ok
+
+select 'abc' RLIKE '';
+EXPR$0
+true
+!ok
+
+SELECT 'abc def ghi' RLIKE 'abc';
+EXPR$0
+true
+!ok
+
+SELECT 'abc def ghi' RLIKE 'abcd';
+EXPR$0
+false
+!ok
+
+select 'abc' RLIKE '^\abc$';
+EXPR$0
+false
+!ok
+
+select '\abc' RLIKE '\abc$';
+EXPR$0
+false
+!ok
+
+select '\abc' RLIKE '^\abc$';
+EXPR$0
+false
+!ok
+
+select '\abc' RLIKE '^\\abc$';
+EXPR$0
+true
+!ok
+
+select 'abc' RLIKE '^abc$';
+EXPR$0
+true
+!ok
+
+select 'abc' RLIKE 'abz*';
+EXPR$0
+true
+!ok
+
+SELECT '%SystemDrive%\\Users\\John' RLIKE '%SystemDrive%\\\\Users.*';
+EXPR$0
+true
+!ok
+
+select '%SystemDrive%\Users\John' RLIKE '%SystemDrive%\\Users.*';
+EXPR$0
+true
+!ok
+
+#####################################################################
+# REGEXP
+#
+# REGEXP(str, regexp)
+# Returns true if str matches regexp, or false otherwise.
+#
+# Returns BOOLEAN
+
+select REGEXP(NULL, 'abc*');
+EXPR$0
+null
+!ok
+
+select REGEXP('abc', NULL);
+EXPR$0
+null
+!ok
+
+select REGEXP('abc', '');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP('abc def ghi', 'abc');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP('abc def ghi', 'abcd');
+EXPR$0
+false
+!ok
+
+select REGEXP('abc', '^\abc$');
+EXPR$0
+false
+!ok
+
+select REGEXP('\abc', '\abc$');
+EXPR$0
+false
+!ok
+
+select REGEXP('\abc', '^\abc$');
+EXPR$0
+false
+!ok
+
+select REGEXP('\abc', '^\\abc$');
+EXPR$0
+true
+!ok
+
+select REGEXP('abc', '^abc$');
+EXPR$0
+true
+!ok
+
+select REGEXP('abc', 'abz*');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP('%SystemDrive%\\Users\\John', '%SystemDrive%\\\\Users.*');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP('%SystemDrive%\Users\John', '%SystemDrive%\\Users.*');
+EXPR$0
+true
+!ok
+
+#####################################################################
+# REGEXP_LIKE
+#
+# REGEXP_LIKE(str, regexp)
+# Returns true if str matches regexp, or false otherwise.
+#
+# Returns BOOLEAN
+
+select REGEXP_LIKE(NULL, 'abc*');
+EXPR$0
+null
+!ok
+
+select REGEXP_LIKE('abc', NULL);
+EXPR$0
+null
+!ok
+
+select REGEXP_LIKE('abc', '');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP_LIKE('abc def ghi', 'abc');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP_LIKE('abc def ghi', 'abcd');
+EXPR$0
+false
+!ok
+
+select REGEXP_LIKE('abc', '^\abc$');
+EXPR$0
+false
+!ok
+
+select REGEXP_LIKE('\abc', '\abc$');
+EXPR$0
+false
+!ok
+
+select REGEXP_LIKE('\abc', '^\abc$');
+EXPR$0
+false
+!ok
+
+select REGEXP_LIKE('\abc', '^\\abc$');
+EXPR$0
+true
+!ok
+
+select REGEXP_LIKE('abc', '^abc$');
+EXPR$0
+true
+!ok
+
+select REGEXP_LIKE('abc', 'abz*');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP_LIKE('%SystemDrive%\\Users\\John', '%SystemDrive%\\\\Users.*');
+EXPR$0
+true
+!ok
+
+SELECT REGEXP_LIKE('%SystemDrive%\Users\John', '%SystemDrive%\\Users.*');
+EXPR$0
+true
+!ok
+
+# End spark.iq

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -231,10 +231,12 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.PARSE_TIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.PARSE_TIMESTAMP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.PARSE_URL;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.POW;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_CONTAINS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_EXTRACT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_EXTRACT_ALL;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_INSTR;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_LIKE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_REPLACE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REPEAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.REVERSE;
@@ -596,6 +598,8 @@ public class RexImpTable {
       defineMethod(SPLIT, BuiltInMethod.SPLIT.method, NullPolicy.STRICT);
       defineReflective(PARSE_URL, BuiltInMethod.PARSE_URL2.method,
           BuiltInMethod.PARSE_URL3.method);
+      defineReflective(REGEXP, BuiltInMethod.RLIKE.method);
+      defineReflective(REGEXP_LIKE, BuiltInMethod.RLIKE.method);
       defineReflective(REGEXP_CONTAINS, BuiltInMethod.REGEXP_CONTAINS.method);
       defineReflective(REGEXP_EXTRACT, BuiltInMethod.REGEXP_EXTRACT2.method,
           BuiltInMethod.REGEXP_EXTRACT3.method, BuiltInMethod.REGEXP_EXTRACT4.method);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -549,6 +549,20 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction REGEXP_SUBSTR = REGEXP_EXTRACT.withName("REGEXP_SUBSTR");
 
+  /** The "REGEXP(value, regexp)" function, equivalent to {@link #RLIKE}. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction REGEXP =
+      SqlBasicFunction.create("REGEXP", ReturnTypes.BOOLEAN_NULLABLE,
+          OperandTypes.STRING_STRING,
+          SqlFunctionCategory.STRING);
+
+  /** The "REGEXP_LIKE(value, regexp)" function, equivalent to {@link #RLIKE}. */
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction REGEXP_LIKE =
+      SqlBasicFunction.create("REGEXP_LIKE", ReturnTypes.BOOLEAN_NULLABLE,
+          OperandTypes.STRING_STRING,
+          SqlFunctionCategory.STRING);
+
   @LibraryOperator(libraries = {MYSQL})
   public static final SqlFunction COMPRESS =
       SqlBasicFunction.create("COMPRESS",

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2812,10 +2812,12 @@ In the following:
 | b | PARSE_TIMESTAMP(format, string[, timeZone])    | Uses format specified by *format* to convert *string* representation of timestamp to a TIMESTAMP WITH LOCAL TIME ZONE value in *timeZone*
 | h s | PARSE_URL(urlString, partToExtract [, keyToExtract] ) | Returns the specified *partToExtract* from the *urlString*. Valid values for *partToExtract* include HOST, PATH, QUERY, REF, PROTOCOL, AUTHORITY, FILE, and USERINFO. *keyToExtract* specifies which query to extract
 | b s | POW(numeric1, numeric2)                      | Returns *numeric1* raised to the power *numeric2*
+| s | REGEXP(string, regexp)                         | Equivalent to `string1 RLIKE string2`
 | b | REGEXP_CONTAINS(string, regexp)                | Returns whether *string* is a partial match for the *regexp*
 | b | REGEXP_EXTRACT(string, regexp [, position [, occurrence]]) | Returns the substring in *string* that matches the *regexp*, starting search at *position* (default 1), and until locating the nth *occurrence* (default 1). Returns NULL if there is no match
 | b | REGEXP_EXTRACT_ALL(string, regexp)             | Returns an array of all substrings in *string* that matches the *regexp*. Returns an empty array if there is no match
 | b | REGEXP_INSTR(string, regexp [, position [, occurrence [, occurrence_position]]]) | Returns the lowest 1-based position of the substring in *string* that matches the *regexp*, starting search at *position* (default 1), and until locating the nth *occurrence* (default 1). Setting occurrence_position (default 0) to 1 returns the end position of substring + 1. Returns 0 if there is no match
+| s | REGEXP_LIKE(string, regexp)                    | Equivalent to `string1 RLIKE string2`
 | b m o | REGEXP_REPLACE(string, regexp, rep [, pos [, occurrence [, matchType]]]) | Replaces all substrings of *string* that match *regexp* with *rep* at the starting *pos* in expr (if omitted, the default is 1), *occurrence* specifies which occurrence of a match to search for (if omitted, the default is 1), *matchType* specifies how to perform matching
 | b | REGEXP_SUBSTR(string, regexp [, position [, occurrence]]) | Synonym for REGEXP_EXTRACT
 | b m p s | REPEAT(string, integer)                  | Returns a string consisting of *string* repeated of *integer* times; returns an empty string if *integer* is less than 1


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6278

1. Add Function [REGEXP](https://spark.apache.org/docs/latest/api/sql/index.html#regexp)、[REGEXP_LIKE](https://spark.apache.org/docs/latest/api/sql/index.html#regexp_like) enabled in the Spark library.
Since this function has the same implementation as the Spark [RLIKE](https://spark.apache.org/docs/latest/api/sql/index.html#rlike) function. 
The implementation can be reused.

[Source Code](https://github.com/apache/spark/blob/ee15cbd3ac3cc98ae262834b4f16e74fe54d82c3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala#L567C1-L569C54)
<img width="545" alt="image" src="https://github.com/apache/calcite/assets/7956306/9882931e-316d-4895-a89b-63056ee9f613">

[undo] Discuss results in Jira:
> 2. Since Spark 2.0, string literals (including regex patterns) are unescaped in SQL parser, also fix this bug in calcite.  

2. Add spark query tests in BabelQuidemTest to ensure the execution correctness.