### PR TITLE
[CALCITE-5607] Datetime MINUS throws ArrayIndexOutOfBounds error when…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
+++ b/core/src/main/java/org/apache/calcite/rel/externalize/RelJson.java
@@ -622,6 +622,7 @@ public class RelJson {
         }
         map.put("operands", list);
         switch (node.getKind()) {
+        case MINUS:
         case CAST:
           map.put("type", toJson(node.getType()));
           break;

--- a/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/RelWriterTest.java
@@ -786,7 +786,8 @@ class RelWriterTest {
       throw TestUtil.rethrow(e);
     }
     final RelJson relJson = RelJson.create()
-        .withInputTranslator(RelWriterTest::translateInput);
+        .withInputTranslator(RelWriterTest::translateInput)
+        .withLibraryOperatorTable();
     final RexNode e = relJson.toRex(cluster, o);
     assertThat(e, hasToString(matcher));
   }
@@ -1048,6 +1049,39 @@ class RelWriterTest {
     String result = deserializeAndDumpToTextFormat(getSchema(rel), relJson);
     final String expected = ""
         + "LogicalProject(JOB=[$2], $f1=[CURRENT_DATETIME])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(result, isLinux(expected));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5607">[CALCITE-5607]
+   * Datetime MINUS throws ArrayIndexOutOfBounds error when serializing toRex</a>
+   */
+  @Test void testDeserializeMinusDateOperator() {
+    final FrameworkConfig config = RelBuilderTest.config().build();
+    final RelBuilder builder = RelBuilder.create(config);
+    final RexBuilder rb = builder.getRexBuilder();
+    final RelDataTypeFactory typeFactory = rb.getTypeFactory();
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.MONTH, null, SqlParserPos.ZERO);
+    final RexNode op1 = rb.makeTimestampLiteral(new TimestampString("2012-12-03 12:34:44"), 0);
+    final RexNode op2 = rb.makeTimestampLiteral(new TimestampString("2014-12-23 12:34:44"), 0);
+    final RelDataType intervalType =
+        typeFactory.createTypeWithNullability(
+            typeFactory.createSqlIntervalType(qualifier),
+            op1.getType().isNullable() || op2.getType().isNullable());
+    final RelNode rel = builder
+        .scan("EMP")
+        .project(builder.field("JOB"),
+            rb.makeCall(intervalType, SqlStdOperatorTable.MINUS_DATE,
+                ImmutableList.of(op2, op1))).build();
+    final RelJsonWriter jsonWriter =
+        new RelJsonWriter(new JsonBuilder(), RelJson::withLibraryOperatorTable);
+    rel.explain(jsonWriter);
+    String relJson = jsonWriter.asString();
+    String result = deserializeAndDumpToTextFormat(getSchema(rel), relJson);
+    final String expected =
+        "LogicalProject(JOB=[$2], $f1=[-(2014-12-23 12:34:44, 2012-12-03 12:34:44)])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(result, isLinux(expected));
   }


### PR DESCRIPTION
… serializing toRex

Uncovered a bug in RelJson#toRex for the TIMESTAMP_DIFF call for Big Query dialect which is translated to Datetime MINUS. MINUS_DATE uses an ARG2_NULLABLE return type inference which requires 3 operands, however there are only 2 operands for BQ. The solution is to add in "type" when serializing to JSON in RelJson.toJson(RexNode node) [like we do for CAST] so that jsonType will be defined in toRex and it doesn't rely on the operands.

Co-authored-by: TJ Banghart <tjbanghart@gmail.com>