### PR TITLE
[CALCITE-6337] Distinguish naked measure inside and outside aggregation

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/AggChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggChecker.java
@@ -106,7 +106,7 @@ class AggChecker extends SqlBasicVisitor<Void> {
       return null;
     }
 
-    if (!validator.config().nakedMeasures()
+    if (!validator.config().nakedMeasuresInAggregateQuery()
         && isMeasureExp(id)) {
       SqlNode originalExpr = validator.getOriginal(id);
       throw validator.newValidationError(originalExpr,

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -912,15 +912,39 @@ public interface SqlValidator {
      */
     Config withLenientOperatorLookup(boolean lenient);
 
-    /** Returns whether the validator allows measures to be used without the
-     * AGGREGATE function. Default is true. */
-    @Value.Default default boolean nakedMeasures() {
+    /** Returns whether the validator allows measures to be used without
+     * AGGREGATE function in a non-aggregate query. Default is true.
+     */
+    @Value.Default default boolean nakedMeasuresInNonAggregateQuery() {
       return true;
     }
 
+    /** Sets whether the validator allows measures to be used without AGGREGATE
+     * function in a non-aggregate query.
+     */
+    Config withNakedMeasuresInNonAggregateQuery(boolean value);
+
+    /** Returns whether the validator allows measures to be used without
+     * AGGREGATE function in an aggregate query. Default is true.
+     */
+    @Value.Default default boolean nakedMeasuresInAggregateQuery() {
+      return true;
+    }
+
+    /** Sets whether the validator allows measures to be used without AGGREGATE
+     * function in an aggregate query.
+     */
+    Config withNakedMeasuresInAggregateQuery(boolean value);
+
     /** Sets whether the validator allows measures to be used without the
-     * AGGREGATE function. */
-    Config withNakedMeasures(boolean nakedMeasures);
+     * AGGREGATE function inside or outside aggregate queries.
+     * Deprecated: use the inside / outside variants instead.
+     */
+    @Deprecated // to be removed before 1.38
+    default Config withNakedMeasures(boolean nakedMeasures) {
+      return withNakedMeasuresInAggregateQuery(nakedMeasures)
+              .withNakedMeasuresInNonAggregateQuery(nakedMeasures);
+    }
 
     /** Returns whether the validator supports implicit type coercion. */
     @Value.Default default boolean typeCoercionEnabled() {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2852,7 +2852,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
         }
       }
 
-      // If this is an aggregating query, the SELECT list and HAVING
+      // If this is an aggregate query, the SELECT list and HAVING
       // clause use a different scope, where you can only reference
       // columns which are in the GROUP BY clause.
       SqlValidatorScope aggScope = selectScope;
@@ -2888,7 +2888,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
         registerSubQueries(orderScope, orderList);
 
         if (!isAggregate(select)) {
-          // Since this is not an aggregating query,
+          // Since this is not an aggregate query,
           // there cannot be any aggregates in the ORDER BY clause.
           SqlNode agg = aggFinder.findAgg(orderList);
           if (agg != null) {
@@ -4826,10 +4826,10 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       }
     }
 
-    // Unless 'naked measures' are enabled, a non-aggregating query cannot
-    // reference measure columns. (An aggregating query can use them as
+    // Unless 'naked measures' are enabled, a non-aggregate query cannot
+    // reference measure columns. (An aggregate query can use them as
     // argument to the AGGREGATE function.)
-    if (!config.nakedMeasures()
+    if (!config.nakedMeasuresInNonAggregateQuery()
         && !(scope instanceof AggregatingScope)
         && scope.isMeasureRef(expr)) {
       throw newValidationError(expr,


### PR DESCRIPTION
Split nakedMeasures flag into two flags:
- nakedMeasuresInsideAggregatingQuery : allowed in group-by queries
- nakedMeasuresOutsideAggregatingQuery : allowed in non-group-by queries

The existing nakedMeasures flag is marked as deprecated. Its functionality is equivalent to setting the above two flags to the same value.