### PR TITLE
[CALCITE-6338] RelMdCollation#project can return an incomplete list of collations in the presence of aliasing

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
@@ -316,22 +316,32 @@ public class RelMdCollation
         targetsWithMonotonicity.put(project.i, call.getOperator().getMonotonicity(binding));
       }
     }
-    final List<RelFieldCollation> fieldCollations = new ArrayList<>();
+    List<List<RelFieldCollation>> fieldCollationsList = new ArrayList<>();
   loop:
     for (RelCollation ic : inputCollations) {
       if (ic.getFieldCollations().isEmpty()) {
         continue;
       }
-      fieldCollations.clear();
+      fieldCollationsList.clear();
+      fieldCollationsList.add(new ArrayList<>());
       for (RelFieldCollation ifc : ic.getFieldCollations()) {
         final Collection<Integer> integers = targets.get(ifc.getFieldIndex());
         if (integers.isEmpty()) {
           continue loop; // cannot do this collation
         }
-        fieldCollations.add(ifc.withFieldIndex(integers.iterator().next()));
+        fieldCollationsList = fieldCollationsList.stream()
+            .flatMap(fieldCollations -> integers.stream()
+                .map(integer -> {
+                  List<RelFieldCollation> newFieldCollations = new ArrayList<>(fieldCollations);
+                  newFieldCollations.add(ifc.withFieldIndex(integer));
+                  return newFieldCollations;
+                })).collect(Collectors.toList());
       }
-      assert !fieldCollations.isEmpty();
-      collations.add(RelCollations.of(fieldCollations));
+      assert !fieldCollationsList.isEmpty();
+      for (List<RelFieldCollation> fieldCollations : fieldCollationsList) {
+        assert !fieldCollations.isEmpty();
+        collations.add(RelCollations.of(fieldCollations));
+      }
     }
 
     final List<RelFieldCollation> fieldCollationsForRexCalls =

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -2260,9 +2260,8 @@ EnumerableCalc(expr#0..5=[{inputs}], expr#6=[<>($t2, $t1)], expr#7=[1], expr#8=[
   EnumerableMergeJoin(condition=[=($0, $5)], joinType=[left])
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0])
       EnumerableTableScan(table=[[scott, EMP]])
-    EnumerableSort(sort0=[$4], dir0=[ASC])
-      EnumerableCalc(expr#0..7=[{inputs}], expr#8=[1:BIGINT], expr#9=[true], c=[$t8], d=[$t8], m=[$t0], trueLiteral=[$t9], EMPNO1=[$t0])
-        EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[1:BIGINT], expr#9=[true], c=[$t8], d=[$t8], m=[$t0], trueLiteral=[$t9], EMPNO1=[$t0])
+      EnumerableTableScan(table=[[scott, EMP]])
 !plan
 +-------+
 | EMPNO |


### PR DESCRIPTION
More details in: [CALCITE-6338](https://issues.apache.org/jira/browse/CALCITE-6338)

Note: the quidem test that required an adjustment actually shows a good example of a side effect of this bug:
Notice how the original plan contained an unnecessary EnumerableSort:
```
old plan:
  EnumerableMergeJoin(condition=[=($0, $5)], joinType=[left])
    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0])
      EnumerableTableScan(table=[[scott, EMP]])
    EnumerableSort(sort0=[$4], dir0=[ASC]) <-- *** HERE! ***
      EnumerableCalc(expr#0..7=[{inputs}], expr#8=[1:BIGINT], expr#9=[true], c=[$t8], d=[$t8], m=[$t0], trueLiteral=[$t9], EMPNO1=[$t0])
        EnumerableTableScan(table=[[scott, EMP]])
=>
new plan:
  EnumerableMergeJoin(condition=[=($0, $5)], joinType=[left])
    EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0])
      EnumerableTableScan(table=[[scott, EMP]])
    EnumerableCalc(expr#0..7=[{inputs}], expr#8=[1:BIGINT], expr#9=[true], c=[$t8], d=[$t8], m=[$t0], trueLiteral=[$t9], EMPNO1=[$t0])
      EnumerableTableScan(table=[[scott, EMP]])
```
scott.EMP table scan is "by default" sorted by EMPNO ($0), for this reason there is no Sort on the first input of the MergeJoin. However, since the second input contains a Calc (this fix is for both Project and Calc) that was projecting EMPNO as $2 and $4, the planner was incorrectly assuming that we needed an EnumerableSort on $4 (i.e. the "second" EMPNO), when in fact this was not the case (the table scab on scott.EMP was already sorted by EMPNO). This was because the Project (or Calc in this case) collation calculation was [2], instead of [2][4].
Thus, the new plan seems both correct and more efficient.