### PR TITLE
[CALCITE-6343] Fix AS alias operator stripping MEASUREness from measures

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -539,8 +539,10 @@ public abstract class SqlOperator {
       }
 
       // MEASURE wrapper should be removed, e.g. MEASURE<DOUBLE> should just be DOUBLE
-      if (isMeasure(returnType) && returnType.getMeasureElementType() != null) {
-        returnType = Objects.requireNonNull(returnType.getMeasureElementType());
+      if (opBinding.getOperator().kind != SqlKind.AS
+          && isMeasure(returnType)
+          && returnType.getMeasureElementType() != null) {
+        returnType = returnType.getMeasureElementType();
       }
 
       if (operandTypeInference != null

--- a/core/src/test/java/org/apache/calcite/sql/type/RelDataTypeSystemTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/RelDataTypeSystemTest.java
@@ -189,6 +189,17 @@ class RelDataTypeSystemTest {
     assertThat(dataType, is(innerType));
   }
 
+  /** <a href="https://issues.apache.org/jira/browse/CALCITE-6343">[CALCITE-6343]</a>
+   * Ensure that AS operator doesn't change return type of measures. */
+  @Test void testAsOperatorReturnTypeInferenceDoesNotRemoveMeasure() {
+    final SqlTypeFactoryImpl f = new Fixture().typeFactory;
+    RelDataType innerType = f.createSqlType(SqlTypeName.DOUBLE);
+    RelDataType measureType = f.createMeasureType(innerType);
+    RelDataType dataType =
+        SqlStdOperatorTable.AS.inferReturnType(f, Lists.newArrayList(measureType));
+    assertThat(dataType, is(measureType));
+  }
+
   @Test void testCustomDecimalPlusReturnTypeInference() {
     final SqlTypeFactoryImpl f = new Fixture().customTypeFactory;
     RelDataType operand1 = f.createSqlType(SqlTypeName.DECIMAL, 38, 10);

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4756,6 +4756,22 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         .ok();
   }
 
+  /** Regression test for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6343">[CALCITE-6343]
+   * AS alias operator stripping MEASUREness from measures</a>.
+   */
+  @Test void testMeasureRefWithAlias() {
+    final String sql = "select count_plus_100 as c\n"
+        + "from empm";
+    fixture()
+        .withFactory(c ->
+            c.withOperatorTable(t ->
+              SqlValidatorTest.operatorTableFor(SqlLibrary.CALCITE)))
+        .withCatalogReader(MockCatalogReaderExtended::create)
+        .withSql(sql)
+        .ok();
+  }
+
   /** Test case for:
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6013">[CALCITE-6013]
    * Unnecessary measures added as projects during rel construction</a>.

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -4575,6 +4575,18 @@ LogicalAggregate(group=[{0}], C=[AGGREGATE($1)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMeasureRefWithAlias">
+    <Resource name="sql">
+      <![CDATA[select count_plus_100 as c
+from empm]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(C=[$9])
+  LogicalTableScan(table=[[CATALOG, SALES, EMPM]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMerge">
     <Resource name="sql">
       <![CDATA[merge into empnullables e


### PR DESCRIPTION
When inferring the return type of an operator application, don't unwrap MEASURE types if the operator is an AS alias.