### PR TITLE
[CALCITE-6169] EnumUtils.convert does not implement the correct SQL cast semantics

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -776,13 +776,8 @@ public class RexBuilder {
 
     if (SqlTypeName.INT_TYPES.contains(sqlType)) {
       final BigDecimal decimalValue = (BigDecimal) value;
-      final int s = decimalValue.scale();
-      if (s != 0) {
-        return false;
-      }
       try {
-        // will trigger ArithmeticException when the value
-        // cannot be represented exactly as a long
+        // Will throw ArithmeticException if the value cannot be represented using a 'long'
         long l = decimalValue.longValueExact();
         switch (sqlType) {
         case TINYINT:
@@ -799,7 +794,6 @@ public class RexBuilder {
         return false;
       }
     }
-
     return true;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlNumericLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNumericLiteral.java
@@ -99,15 +99,21 @@ public class SqlNumericLiteral extends SqlLiteral {
     if (isExact) {
       int scaleValue = requireNonNull(scale, "scale");
       if (0 == scaleValue) {
-        BigDecimal bd = getValueNonNull();
-        SqlTypeName result;
-        long l = bd.longValue();
-        if ((l >= Integer.MIN_VALUE) && (l <= Integer.MAX_VALUE)) {
-          result = SqlTypeName.INTEGER;
-        } else {
-          result = SqlTypeName.BIGINT;
+        try {
+          BigDecimal bd = getValueNonNull();
+          SqlTypeName result;
+          // Will throw if the number cannot be represented as a long.
+          long l = bd.longValue();
+          if ((l >= Integer.MIN_VALUE) && (l <= Integer.MAX_VALUE)) {
+            result = SqlTypeName.INTEGER;
+          } else {
+            result = SqlTypeName.BIGINT;
+          }
+          return typeFactory.createSqlType(result);
+        } catch (ArithmeticException ex) {
+          // This indicates that the value does not fit in any integer type.
+          // Fallback to DECIMAL.
         }
-        return typeFactory.createSqlType(result);
       }
 
       // else we have a decimal

--- a/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
@@ -140,11 +140,11 @@ LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[
     LogicalUnion(all=[false])
       LogicalUnion(all=[false])
         LogicalUnion(all=[false])
-          LogicalValues(tuples=[[{ 'a', 1, 1, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+          LogicalValues(tuples=[[{ 'a', 1, 1.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
           LogicalValues(tuples=[[{ 'b', 2, 2, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
-        LogicalValues(tuples=[[{ 'c', 3, 3, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
-      LogicalValues(tuples=[[{ 'd', 4, 4, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
-    LogicalValues(tuples=[[{ 'e', 5, 5, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+        LogicalValues(tuples=[[{ 'c', 3, 3.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+      LogicalValues(tuples=[[{ 'd', 4, 4.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+    LogicalValues(tuples=[[{ 'e', 5, 5.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
 ]]>
     </Resource>
   </TestCase>
@@ -155,7 +155,7 @@ LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[
     <Resource name="plan">
       <![CDATA[
 LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[false])
-  LogicalValues(tuples=[[{ 'a', 1, 1, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'b', 2, 2, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'c', 3, 3, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'd', 4, 4, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'e', 5, 5, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+  LogicalValues(tuples=[[{ 'a', 1, 1.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'b', 2, 2, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'c', 3, 3.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'd', 4, 4.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'e', 5, 5.0, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
 ]]>
     </Resource>
   </TestCase>

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/UnaryExpression.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/UnaryExpression.java
@@ -51,6 +51,24 @@ public class UnaryExpression extends Expression {
         expression.accept(writer, nodeType.rprec, rprec);
       }
       return;
+    case ConvertChecked:
+      // This is ugly, but Java does not seem to have any facilities
+      // to perform checked cast between scalar types!
+      // So we use the existing linq4j Primitive.numberValue method
+      // which does overflow checking.
+      if (!writer.requireParentheses(this, lprec, rprec)) {
+        // Generate Java code that looks like e.g.,
+        // ((Number)org.apache.calcite.linq4j.tree.Primitive.of(int.class)
+        //     .numberValue(literal_value)).intValue();
+        writer.append("((Number)")
+            .append("org.apache.calcite.linq4j.tree.Primitive.of(")
+            .append(type)
+            .append(".class)")
+            .append(".numberValue(");
+        expression.accept(writer, nodeType.rprec, rprec);
+        writer.append(")).").append(type).append("Value()");
+      }
+      return;
     default:
       break;
     }

--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
@@ -658,11 +658,13 @@ public interface SqlOperatorFixture extends AutoCloseable {
 
   default void checkCastFails(String value, String targetType,
       String expectedError, boolean runtime, CastType castType) {
-    final String query = getCastString(value, targetType, !runtime, castType);
-    if (castType == CastType.CAST || !runtime) {
-      checkFails(query, expectedError, runtime);
+    // Safe casts should never fail
+    boolean shouldFail = castType == CastType.CAST;
+    final String castString = getCastString(value, targetType, shouldFail && !runtime, castType);
+    if (shouldFail) {
+      checkFails(castString, expectedError, runtime);
     } else {
-      checkNull(query);
+      checkNull(castString);
     }
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -629,10 +629,10 @@ public class SqlOperatorTest {
         // Calcite cannot even represent a literal so large, so
         // for this query even the safe casts fail at compile-time
         // (runtime == false).
-        f.checkCastFails(numeric.maxOverflowNumericString,
-            type, LITERAL_OUT_OF_RANGE_MESSAGE, false, castType);
-        f.checkCastFails(numeric.minOverflowNumericString,
-            type, LITERAL_OUT_OF_RANGE_MESSAGE, false, castType);
+        f.checkFails("cast(^" + numeric.maxOverflowNumericString + "^ as BIGINT)",
+            LITERAL_OUT_OF_RANGE_MESSAGE, false);
+        f.checkFails("cast(^" + numeric.minOverflowNumericString + "^ as BIGINT)",
+            LITERAL_OUT_OF_RANGE_MESSAGE, false);
       } else {
         if (numeric != Numeric.DECIMAL5_2) {
           // This condition is for bug [CALCITE-6078], not yet fixed


### PR DESCRIPTION
This is a piece of https://github.com/apache/calcite/pull/3589 which only contains the fix to CALCITE-6169
This also fixes CALCITE-6366
The main part of the fix is implementing Expressions.convertChecked.
There was a recent implementation of this method, but we replace it in the generated Java code with a call to Primitive.numberValue, which covers more cases than the existing implementation.