### PR TITLE
[CALCITE-6378] Bump Redis Docker image from 2.8.19 to 7.2.4

### DIFF
--- a/redis/src/test/java/org/apache/calcite/adapter/redis/RedisCaseBase.java
+++ b/redis/src/test/java/org/apache/calcite/adapter/redis/RedisCaseBase.java
@@ -49,7 +49,7 @@ public abstract class RedisCaseBase {
    * <p>Uses the Redis 2.8.19 version to be aligned with the embedded server.
    */
   private static final GenericContainer<?> REDIS_CONTAINER =
-      new GenericContainer<>("redis:2.8.19").withExposedPorts(6379);
+      new GenericContainer<>("redis:7.2.4").withExposedPorts(6379);
 
   /**
    * The embedded Redis server.


### PR DESCRIPTION
Docker since 19.x deprecated image manifest v2 schema 1
and disabled since 26.x
it is also going to remove it since 27.x

as mentioned at https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1

for that reason need to bump redis docker image which uses deprecated version