### PR TITLE
[CALCITE-6385] LintTest fails when run in source distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -826,6 +826,7 @@ allprojects {
                 passProperty("user.country", "tr")
                 passProperty("user.timezone", "UTC")
                 passProperty("calcite.avatica.version", props.string("calcite.avatica.version"))
+                passProperty("gradle.rootDir", rootDir.toString())
                 val props = System.getProperties()
                 for (e in props.propertyNames() as `java.util`.Enumeration<String>) {
                     if (e.startsWith("calcite.") || e.startsWith("avatica.")) {

--- a/core/src/test/java/org/apache/calcite/test/LintTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LintTest.java
@@ -37,6 +37,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -45,10 +47,6 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-
-import static com.google.common.collect.Iterables.getOnlyElement;
-
-import static org.apache.calcite.util.Util.filter;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -64,6 +62,7 @@ class LintTest {
    * space. */
   private static final Pattern CALCITE_PATTERN =
       Pattern.compile("^(\\[CALCITE-[0-9]{1,4}][ ]).*");
+  private static final Path ROOT_PATH = Paths.get(System.getProperty("gradle.rootDir"));
 
   @SuppressWarnings("Convert2MethodRef") // JDK 8 requires lambdas
   private Puffin.Program<GlobalState> makeProgram() {
@@ -397,10 +396,7 @@ class LintTest {
   /** Ensures that the {@code contributors.yml} file is sorted by name. */
   @Test void testContributorsFileIsSorted() throws IOException {
     final ObjectMapper mapper = new YAMLMapper();
-    final List<File> files = TestUnsafe.getTextFiles();
-    final File contributorsFile =
-        getOnlyElement(
-            filter(files, f -> f.getName().equals("contributors.yml")));
+    final File contributorsFile = ROOT_PATH.resolve("site/_data/contributors.yml").toFile();
     JavaType listType =
         mapper.getTypeFactory()
             .constructCollectionType(List.class, Contributor.class);
@@ -416,12 +412,9 @@ class LintTest {
 
   /** Ensures that the {@code .mailmap} file is sorted. */
   @Test void testMailmapFile() {
-    final List<File> files = TestUnsafe.getTextFiles();
-    final File contributorsFile =
-        getOnlyElement(
-            filter(files, f -> f.getName().equals(".mailmap")));
+    final File mailmapFile = ROOT_PATH.resolve(".mailmap").toFile();
     final List<String> lines = new ArrayList<>();
-    forEachLineIn(contributorsFile, line -> {
+    forEachLineIn(mailmapFile, line -> {
       if (!line.startsWith("#")) {
         lines.add(line);
       }


### PR DESCRIPTION
The testContributorsFileIsSorted and testMailmapFile tests fail cause they rely on git and there is no git info available in source distribution.

In fact the tests don't really need git and the paths to the .mailmap and contributor.yml files can be specified explicitly. This removes the git requirement and also makes the tests more efficient since there is no process calls and lookup involved.