### PR TITLE
[CALCITE-6432] Infinite loop for JoinPushTransitivePredicatesRule

### DIFF
--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6012,27 +6012,6 @@ LogicalProject(SAL=[$5])
                   LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
 ]]>
     </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(SAL=[$5])
-  LogicalJoin(condition=[AND(=($5, $11), =($9, $12))], joinType=[inner])
-    LogicalFilter(condition=[>($5, 1000)])
-      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8], SAL0=[$5], $f9=[=($5, 4)])
-        LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
-          LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
-    LogicalFilter(condition=[=($1, $0)])
-      LogicalAggregate(group=[{0, 1, 2}])
-        LogicalProject(SAL=[$5], SAL0=[$8], $f9=[$9])
-          LogicalJoin(condition=[OR(=($8, $5), $9)], joinType=[inner])
-            LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8])
-              LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
-                LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
-            LogicalAggregate(group=[{0, 1}])
-              LogicalProject(SAL=[$5], $f9=[=($5, 4)])
-                LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
-                  LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
-]]>
-    </Resource>
   </TestCase>
   <TestCase name="testJoinToMultiJoinDoesNotMatchAntiJoin">
     <Resource name="sql">
@@ -8164,6 +8143,37 @@ from (
 LogicalProject(EXPR$0=[ROW_NUMBER() OVER (ORDER BY $0)], COL1=[$1])
   LogicalProject(DEPTNO=[$7], COL1=[SUM(100) OVER (PARTITION BY $7 ORDER BY $5)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectPredicatePull">
+    <Resource name="sql">
+      <![CDATA[select e.ename, d.dname
+from (select ename, deptno from emp where deptno = 10) e
+join (select name dname, deptno, * from dept) d
+on e.deptno = d.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ENAME=[$0], DNAME=[$2])
+  LogicalJoin(condition=[=($1, $3)], joinType=[inner])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalFilter(condition=[=($7, 10)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DNAME=[$1], DEPTNO=[$0], DEPTNO0=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(ENAME=[$0], DNAME=[$2])
+  LogicalJoin(condition=[=($1, $3)], joinType=[inner])
+    LogicalProject(ENAME=[$1], DEPTNO=[$7])
+      LogicalFilter(condition=[=($7, 10)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DNAME=[$1], DEPTNO=[$0], DEPTNO0=[$0], NAME=[$1])
+      LogicalFilter(condition=[=($0, 10)])
+        LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
jira: [CALCITE-6432](https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-6432)

Infinite loop for JoinPushTransitivePredicatesRule when there are multiple project expressions reference the same input field.