### PR TITLE
[CALCITE-6437]For druid sql JSON_OBJECT() function results in RUNTIME_FAILURE when querying INFORMATION_SCHEMA.COLUMNS

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -6474,7 +6474,8 @@ public class SqlToRelConverter {
     }
 
     @Override public RexNode visitCall(RexCall call) {
-      if (call.getOperator() == SqlStdOperatorTable.JSON_OBJECT) {
+      if (call.getOperator().getName().equals(SqlStdOperatorTable.JSON_OBJECT.getName())
+          && call.getOperator().getKind() == SqlStdOperatorTable.JSON_OBJECT.getKind()) {
         final ImmutableList.Builder<RexNode> builder = ImmutableList.builder();
         for (int i = 0; i < call.operands.size(); ++i) {
           if ((i & 1) == 0 && i != 0) {
@@ -6485,7 +6486,8 @@ public class SqlToRelConverter {
         }
         return rexBuilder.makeCall(SqlStdOperatorTable.JSON_OBJECT, builder.build());
       }
-      if (call.getOperator() == SqlStdOperatorTable.JSON_ARRAY) {
+      if (call.getOperator().getName().equals(SqlStdOperatorTable.JSON_ARRAY.getName())
+          && call.getOperator().getKind() == SqlStdOperatorTable.JSON_ARRAY.getKind()) {
         final ImmutableList.Builder<RexNode> builder = ImmutableList.builder();
         builder.add(call.operands.get(0));
         for (int i = 1; i < call.operands.size(); ++i) {

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3247,7 +3247,7 @@ select json_object('deptno': deptno, 'employees': json_arrayagg(json_object('ena
 +-------------------------------------------------------------------------------------------+
 (6 rows)
 
-!ok2
+!ok
 
 # [CALCITE-2786] Add order by clause support for JSON_ARRAYAGG
 select gender,

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3247,7 +3247,7 @@ select json_object('deptno': deptno, 'employees': json_arrayagg(json_object('ena
 +-------------------------------------------------------------------------------------------+
 (6 rows)
 
-!ok
+!ok2
 
 # [CALCITE-2786] Add order by clause support for JSON_ARRAYAGG
 select gender,
@@ -3776,6 +3776,23 @@ select distinct sum(deptno + '1') as deptsum from dept order by 1;
 |     104 |
 +---------+
 (1 row)
+
+!ok
+
+# Test cases for [CALCITE-6437] For druid sql JSON_OBJECT() function results in RUNTIME_FAILURE when querying
+# INFORMATION_SCHEMA.COLUMNS
+select json_object('name': job, 'value': deptno) as options
+from "scott".emp
+where deptno = 10
+group by deptno, job;
++---------------------------------+
+| OPTIONS                         |
++---------------------------------+
+| {"name":"CLERK","value":10}     |
+| {"name":"MANAGER","value":10}   |
+| {"name":"PRESIDENT","value":10} |
++---------------------------------+
+(3 rows)
 
 !ok
 # End agg.iq

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -6330,6 +6330,12 @@ public class SqlOperatorTest {
         "{\"foo\":{\"foo\":\"bar\"}}", "VARCHAR(2000) NOT NULL");
     f.checkString("json_object('foo': json_object('foo': 'bar') format json)",
         "{\"foo\":{\"foo\":\"bar\"}}", "VARCHAR(2000) NOT NULL");
+    final SqlOperatorFixture f1 = SqlOperatorFixtureImpl.DEFAULT.withTester(t -> TESTER);
+    f1.check(
+        "select json_object('key':x, 'value':y)\n"
+        + "from (select 1 as x, 2 as y\n"
+        + "  from (values (true)))",
+        SqlTests.ANY_TYPE_CHECKER, "{\"value\":2,\"key\":1}");
   }
 
   @Test void testJsonObjectAgg() {


### PR DESCRIPTION
# Fix the druid json_object issue.
# Description 
jira: [CALCITE-6437](https://issues.apache.org/jira/browse/CALCITE-6437)
druid issue: https://github.com/apache/druid/issues/16356
1. Now in druid, we will construct the SqlFunction instance as following:

```
private static final SqlFunction SQL_FUNCTION = OperatorConversions
        .operatorBuilder(FUNCTION_NAME)
        .operandTypeChecker(OperandTypes.variadic(SqlOperandCountRanges.from(1)))
        .operandTypeInference((callBinding, returnType, operandTypes) -> {
          RelDataTypeFactory typeFactory = callBinding.getTypeFactory();
          for (int i = 0; i < operandTypes.length; i++) {
            if (i % 2 == 0) {
              operandTypes[i] = typeFactory.createSqlType(SqlTypeName.VARCHAR);
              continue;
            }
            operandTypes[i] = typeFactory.createTypeWithNullability(
                typeFactory.createSqlType(SqlTypeName.ANY),
                true
            );
          }
        })
        .returnTypeInference(NESTED_RETURN_TYPE_INFERENCE)
        .functionCategory(SqlFunctionCategory.SYSTEM)
        .build();
```

2. We try to get SqlJsonObjectFunction as following:
```
 public @Nullable RexCallImplementor get(final SqlOperator operator) {
    if (operator instanceof SqlUserDefinedFunction) {
      org.apache.calcite.schema.Function udf =
          ((SqlUserDefinedFunction) operator).getFunction();
      if (!(udf instanceof ImplementableFunction)) {
        throw new IllegalStateException("User defined function " + operator
            + " must implement ImplementableFunction");
      }
      CallImplementor implementor =
          ((ImplementableFunction) udf).getImplementor();
      return wrapAsRexCallImplementor(implementor);
    } else if (operator instanceof SqlTypeConstructorFunction) {
      return map.get(SqlStdOperatorTable.ROW);
    }
    return map.get(operator);
  }
```
3. Here is issue, the operator is SqlFunction, but in the map, the key instance is SqlJsonObjectFunction, the type is not equals, so we can naver get from the map
4. So i try to fix this in this cr as following in SqlToRelConverter.
We can overwrite to be SqlJsonObjectFunction
5. And also probably there is other way to fix:
add one more construction of SqlJsonObjectFunction as following 
```
public SqlJsonObjectFunction(SqlFunction baseFunction)
```
and  update JsonObjectOperatorConversion in druid as following:
```
SQL_FUNCTION = SqlJsonObjectFunction(OperatorConversions
        .operatorBuilder(FUNCTION_NAME)
        .operandTypeChecker(OperandTypes.variadic(SqlOperandCountRanges.from(1)))
        .operandTypeInference((callBinding, returnType, operandTypes) -> {
          RelDataTypeFactory typeFactory = callBinding.getTypeFactory();
          for (int i = 0; i < operandTypes.length; i++) {
            if (i % 2 == 0) {
              operandTypes[i] = typeFactory.createSqlType(SqlTypeName.VARCHAR);
              continue;
            }
            operandTypes[i] = typeFactory.createTypeWithNullability(
                typeFactory.createSqlType(SqlTypeName.ANY),
                true
            );
          }
        })
        .returnTypeInference(NESTED_RETURN_TYPE_INFERENCE)
        .functionCategory(SqlFunctionCategory.SYSTEM)
        .build());
```
6. I am not sure which one is better, could you guy help to look, or better solution?
