### PR TITLE
[CALCITE-6438] Add optimization to returns empty when the filter operator is a false instance

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -4667,6 +4667,14 @@ class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(PruneEmptyRules.SORT_FETCH_ZERO_INSTANCE).check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6438">[CALCITE-6438]
+   * Add optimization to returns empty when the filter operator is a false instance</a>. */
+  @Test void testFilterFalse() {
+    final String sql = "select * from emp where false";
+    sql(sql).withRule(PruneEmptyRules.FILETER_FALSE_INSTANCE).check();
+  }
+
   @Test void testEmptyAggregate() {
     final String sql = "select sum(empno) from emp where false group by deptno";
     sql(sql)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4516,6 +4516,24 @@ MultiJoin(joinFilter=[true], isFullOuterJoin=[false], joinTypes=[[INNER, LEFT]],
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFilterFalse">
+    <Resource name="sql">
+      <![CDATA[select * from emp where false]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalFilter(condition=[false])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalValues(tuples=[[]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFilterJoinRuleAndIsNotNull">
     <Resource name="sql">
       <![CDATA[select * from


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6438