### PR TITLE
Document MAP types in grammar

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -304,6 +304,12 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testCreateTableMapType() {
+    final String sql = "create table foo (bar map<integer, varchar>)";
+    final String expected = "CREATE TABLE `FOO` (`BAR` MAP< INTEGER, VARCHAR >)";
+    sql(sql).ok(expected);
+  }
+
   @Test void testCreateSetTable() {
     final String sql = "create set table foo (bar int not null, baz varchar(30))";
     final String expected = "CREATE SET TABLE `FOO` (`BAR` INTEGER NOT NULL, `BAZ` VARCHAR(30))";

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1205,12 +1205,12 @@ Note:
 
 ### Non-scalar types
 
-| Type     | Description                | Example literals
+| Type     | Description                | Example type
 |:-------- |:---------------------------|:---------------
 | ANY      | The union of all types |
 | UNKNOWN  | A value of an unknown type; used as a placeholder |
 | ROW      | Row with 1 or more columns | Example: row(f0 int null, f1 varchar)
-| MAP      | Collection of keys mapped to values | Example: (int, varchar) map
+| MAP      | Collection of keys mapped to values | Example: map &lt; int, varchar &gt;
 | MULTISET | Unordered collection that may contain duplicates | Example: int multiset
 | ARRAY    | Ordered, contiguous collection that may contain duplicates | Example: varchar(10) array
 | CURSOR   | Cursor over the result of executing a query |
@@ -1500,7 +1500,11 @@ type:
 typeName:
       sqlTypeName
   |   rowTypeName
+  |   mapTypeName
   |   compoundIdentifier
+
+mapTypeName:
+  MAP '<' type ',' type '>'
 
 sqlTypeName:
       char [ precision ] [ charSet ]


### PR DESCRIPTION
Calcite has been supporting MAP types for a long time, but they do not show up in the documentation.