### PR TITLE
[CALCITE-6440] SortRemoveConstantKeysRule should remove NULL literal sort keys (e.g. ORDER BY NULL)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -735,6 +735,14 @@ public class CoreRules {
   public static final SortRemoveConstantKeysRule SORT_REMOVE_CONSTANT_KEYS =
       SortRemoveConstantKeysRule.Config.DEFAULT.toRule();
 
+  /**
+   * Rule that removes empty litepal keys from a {@link Sort}.
+   * This rule is triggered if the litepal keys in the {@link Sort} operation are empty.
+   * The removal of empty litepal keys can optimize the {@link Sort} operation by eliminating unnecessary sorting on empty keys.
+   */
+  public static final SortRemoveEmptyLiteralKeysRule SORT_REMOVE_EMPTY_LITERAL_KEYS_RULE =
+      SortRemoveEmptyLiteralKeysRule.Config.DEFAULT.toRule();
+
   /** Rule that removes redundant {@code Order By} or {@code Limit} when its input RelNode's
    * max row count is less than or equal to specified row count.All of them
    * are represented by {@link Sort}*/

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveEmptyLiteralKeysRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveEmptyLiteralKeysRule.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
+
+import com.google.common.collect.ImmutableList;
+
+import org.immutables.value.Value;
+
+/**
+ * Planner rule that removes keys from a
+ * a {@link org.apache.calcite.rel.core.Sort} if those keys are empty litepal keys,
+ * or removes the entire Sort if all keys are empty litepal keys.
+ *
+ * <p>Requires {@link RelCollationTraitDef}.
+ */
+@Value.Enclosing
+public class SortRemoveEmptyLiteralKeysRule
+    extends RelRule<SortRemoveEmptyLiteralKeysRule.Config>
+    implements SubstitutionRule {
+
+  /** Creates a SortRemoveEmptyLiteralKeysRule. */
+  protected SortRemoveEmptyLiteralKeysRule(Config config) {
+    super(config);
+  }
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    Project project1 = call.rel(0);
+    Project project2 = call.rel(1);
+
+    final RelNode input1 = project1.getInput();
+    final RelNode input2 = project2.getInput();
+    final int size = input1.getRowType().getFieldList().size();
+
+    if (input1.getRowType().getFieldList().get(size - 1).getValue().isNullable()) {
+      Project newProject1 =
+          (Project) project1.copy(project1.getTraitSet(), ImmutableList.of(input2));
+      call.transformTo(newProject1);
+      return;
+    }
+  }
+
+  /** Rule configuration. */
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    Config DEFAULT = ImmutableSortRemoveEmptyLiteralKeysRule.Config.of()
+        .withOperandSupplier(b -> b.operand(Project.class)
+        .oneInput(b1 -> b1.operand(Project.class)
+        .anyInputs()));
+
+    @Override default SortRemoveEmptyLiteralKeysRule toRule() {
+      return new SortRemoveEmptyLiteralKeysRule(this);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -4679,6 +4679,14 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  @Test void testEmptyOrderBy() {
+    final String sql = "select * from emp order by null";
+    sql(sql)
+        .withRule(CoreRules.SORT_REMOVE_CONSTANT_KEYS,
+            CoreRules.SORT_REMOVE_EMPTY_LITERAL_KEYS_RULE)
+        .check();
+  }
+
   @Test void testEmptyAggregateEmptyKey() {
     final String sql = "select sum(empno) from emp where false";
     sql(sql)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -3212,6 +3212,25 @@ LogicalMinus(all=[false])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEmptyOrderBy">
+    <Resource name="sql">
+      <![CDATA[select * from emp order by null]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalSort(sort0=[$9], dir0=[ASC])
+    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EXPR$9=[null:NULL])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEmptyProject">
     <Resource name="sql">
       <![CDATA[select z + x from (


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6440