### PR TITLE
[CALCITE-6453] Simplify casts which are result of constant reduction

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -2272,8 +2272,14 @@ public class RexSimplify {
           (RexLiteral) e.getOperands().get(1))
           : rexBuilder.makeCast(e.getType(), operand, safe, safe);
       executor.reduce(rexBuilder, ImmutableList.of(simplifiedExpr), reducedValues);
-      return requireNonNull(
-          Iterables.getOnlyElement(reducedValues));
+      RexNode reducedRexNode = requireNonNull(Iterables.getOnlyElement(reducedValues));
+      if (reducedRexNode.isA(SqlKind.CAST)) {
+        RexNode reducedOperand = ((RexCall) reducedRexNode).getOperands().get(0);
+        if (sameTypeOrNarrowsNullability(reducedRexNode.getType(), reducedOperand.getType())) {
+          return reducedOperand;
+        }
+      }
+      return reducedRexNode;
     default:
       if (operand == e.getOperands().get(0)) {
         return e;

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -3837,4 +3837,12 @@ class RexProgramTest extends RexProgramTestBase {
     checkSimplify(add(zero, sub(nullInt, nullInt)), "null:INTEGER");
   }
 
+  @Test void testSimplifyCastWithConstantReduction() {
+    RexNode dateStr = literal("2020-10-30");
+    RelDataType nullableDateType =
+        typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DATE), true);
+    RexNode cast = rexBuilder.makeCast(nullableDateType, dateStr);
+    checkSimplify(cast, "2020-10-30");
+  }
+
 }


### PR DESCRIPTION
In `RexSimplify.simplifyCast` after constant reduction return the reduced expressions operand as result if the reduced expression and it's operand type is equal but different in nullability. 