### PR TITLE
[CALCITE-6457] The ARRAY_CONTAINS function wrongly returns false when arrayComponentType and op1 type are different

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/ArrayElementOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ArrayElementOperandTypeChecker.java
@@ -17,10 +17,12 @@
 package org.apache.calcite.sql.type;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
 
 import com.google.common.collect.ImmutableList;
 
@@ -94,6 +96,14 @@ public class ArrayElementOperandTypeChecker implements SqlOperandTypeChecker {
       }
 
       return false;
+    }
+
+    if (!arrayComponentType.equalsSansFieldNames(biggest)) {
+      SqlValidatorUtil.
+          adjustTypeForArrayFunctions(biggest, callBinding, 0);
+    } else {
+      SqlCall call =  callBinding.getCall();
+      call.setOperand(1, SqlValidatorUtil.castTo(op1, biggest));
     }
     return true;
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -1437,7 +1437,7 @@ public class SqlValidatorUtil {
    * @param type the target {@link RelDataType} to which 'node' should be cast
    * @return a new {@link SqlNode} representing the CAST operation
    */
-  private static SqlNode castTo(SqlNode node, RelDataType type) {
+  public static SqlNode castTo(SqlNode node, RelDataType type) {
     return SqlStdOperatorTable.CAST.createCall(
         SqlParserPos.ZERO,
         node,

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -7246,6 +7246,17 @@ public class SqlOperatorTest {
         "BOOLEAN NOT NULL");
     f.checkScalar("array_contains(array[map[1, 'a'], map[2, 'b']], map[1, 'a'])", true,
         "BOOLEAN NOT NULL");
+
+    f.checkScalar("array_contains(array(cast(1 as double), 2), cast(2 as double))", true,
+        "BOOLEAN NOT NULL");
+    f.checkScalar("array_contains(array(1, 2), cast(2 as double))", true,
+        "BOOLEAN NOT NULL");
+    f.checkScalar("array_contains(array(cast(1 as tinyint), 2), cast(2 as double))", true,
+        "BOOLEAN NOT NULL");
+    f.checkScalar("array_contains(array(cast(1 as double), 2), 1)", true,
+        "BOOLEAN NOT NULL");
+    f.checkScalar("array_contains(array(cast(1 as double), 2), cast(1 as tinyint))", true,
+        "BOOLEAN NOT NULL");
     f.checkNull("array_contains(cast(null as integer array), 1)");
     f.checkType("array_contains(cast(null as integer array), 1)", "BOOLEAN");
     // Flink and Spark differ on the following. The expression


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6457