### PR TITLE
[CALCITE-6448] FilterReduceExpressionsRule returns empty RelNode for R…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Filter.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Filter.java
@@ -86,8 +86,6 @@ public abstract class Filter extends SingleRel implements Hintable {
       RexNode condition) {
     super(cluster, traits, child);
     this.condition = requireNonNull(condition, "condition");
-    assert SqlTypeName.BOOLEAN == condition.getType().getSqlTypeName()
-        : "condition should be of BOOLEAN type, but was " + condition.getType();
     assert RexUtil.isFlat(condition) : "RexUtil.isFlat should be true for condition " + condition;
     assert isValid(Litmus.THROW, null);
     this.hints = ImmutableList.copyOf(hints);
@@ -146,6 +144,9 @@ public abstract class Filter extends SingleRel implements Hintable {
   }
 
   @Override public boolean isValid(Litmus litmus, @Nullable Context context) {
+    if (condition.getType().getSqlTypeName() != SqlTypeName.BOOLEAN) {
+      return litmus.fail("condition must be boolean: {}", condition.getType());
+    }
     if (RexUtil.isNullabilityCast(getCluster().getTypeFactory(), condition)) {
       return litmus.fail("Cast for just nullability not allowed");
     }

--- a/core/src/main/java/org/apache/calcite/rel/core/Filter.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Filter.java
@@ -34,6 +34,7 @@ import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Litmus;
 
 import com.google.common.collect.ImmutableList;
@@ -85,6 +86,8 @@ public abstract class Filter extends SingleRel implements Hintable {
       RexNode condition) {
     super(cluster, traits, child);
     this.condition = requireNonNull(condition, "condition");
+    assert SqlTypeName.BOOLEAN == condition.getType().getSqlTypeName()
+        : "condition should be of BOOLEAN type, but was " + condition.getType();
     assert RexUtil.isFlat(condition) : "RexUtil.isFlat should be true for condition " + condition;
     assert isValid(Litmus.THROW, null);
     this.hints = ImmutableList.copyOf(hints);

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -100,12 +100,11 @@ public abstract class Join extends BiRel implements Hintable {
       JoinRelType joinType) {
     super(cluster, traitSet, left, right);
     this.condition = Objects.requireNonNull(condition, "condition");
-    assert SqlTypeName.BOOLEAN == condition.getType().getSqlTypeName()
-        : "condition should be of BOOLEAN type, but was " + condition.getType();
     this.variablesSet = ImmutableSet.copyOf(variablesSet);
     this.joinType = Objects.requireNonNull(joinType, "joinType");
     this.joinInfo = JoinInfo.of(left, right, condition);
     this.hints = ImmutableList.copyOf(hints);
+    assert isValid(Litmus.THROW, null);
   }
 
   @Deprecated // to be removed before 2.0

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -100,6 +100,8 @@ public abstract class Join extends BiRel implements Hintable {
       JoinRelType joinType) {
     super(cluster, traitSet, left, right);
     this.condition = Objects.requireNonNull(condition, "condition");
+    assert SqlTypeName.BOOLEAN == condition.getType().getSqlTypeName()
+        : "condition should be of BOOLEAN type, but was " + condition.getType();
     this.variablesSet = ImmutableSet.copyOf(variablesSet);
     this.joinType = Objects.requireNonNull(joinType, "joinType");
     this.joinInfo = JoinInfo.of(left, right, condition);

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -215,7 +216,7 @@ public final class LogicalJoin extends Join {
   }
 
   @Override public List<RelDataTypeField> getSystemFieldList() {
-    return systemFieldList;
+    return systemFieldList != null ? systemFieldList : Collections.emptyList();
   }
 
   @Override public RelNode withHints(List<RelHint> hintList) {

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -2650,19 +2650,17 @@ public class RelBuilderTest {
         b.scan("EMP")
             .scan("DEPT")
             .join(JoinRelType.INNER,
-                b.or(b.literal(null),
-                    b.and(b.equals(b.field(2, 0, "DEPTNO"), b.literal(1)),
-                        b.equals(b.field(2, 0, "DEPTNO"), b.literal(2)),
-                        b.equals(b.field(2, 1, "DEPTNO"),
-                            b.field(2, 0, "DEPTNO")))))
+                b.and(b.equals(b.field(2, 0, "DEPTNO"), b.literal(1)),
+                    b.equals(b.field(2, 0, "DEPTNO"), b.literal(2)),
+                    b.equals(b.field(2, 1, "DEPTNO"),
+                        b.field(2, 0, "DEPTNO"))))
             .build();
     final String expected = ""
         + "LogicalJoin(condition=[false], joinType=[inner])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
     final String expectedWithoutSimplify = ""
-        + "LogicalJoin(condition=[OR(null:NULL, "
-        + "AND(=($7, 1), =($7, 2), =($8, $7)))], joinType=[inner])\n"
+        + "LogicalJoin(condition=[AND(=($7, 1), =($7, 2), =($8, $7))], joinType=[inner])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
     assertThat(f.apply(createBuilder()), hasTree(expected));
@@ -4512,13 +4510,12 @@ public class RelBuilderTest {
     Function<RelBuilder, RelNode> f = b ->
         b.scan("EMP")
             .filter(
-                b.or(b.literal(null),
-                     b.and(b.equals(b.field(2), b.literal(1)),
-                         b.equals(b.field(2), b.literal(2)))))
+                b.and(b.equals(b.field(2), b.literal(1)),
+                    b.equals(b.field(2), b.literal(2))))
             .build();
     final String expected = "LogicalValues(tuples=[[]])\n";
     final String expectedWithoutSimplify = ""
-        + "LogicalFilter(condition=[OR(null:NULL, AND(=($2, 1), =($2, 2)))])\n"
+        + "LogicalFilter(condition=[AND(=($2, 1), =($2, 2))])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(f.apply(createBuilder()), hasTree(expected));
     assertThat(f.apply(createBuilder(c -> c.withSimplify(false))),

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelExTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelExTest.java
@@ -145,76 +145,76 @@ class PigRelExTest extends PigRelTestBase {
   }
 
   @Test void testAdd() {
-    checkTranslation("b + 3", inTree("+($1, 3)"));
+    checkTranslation("(boolean)(b + 3)", inTree("+($1, 3)"));
   }
 
   @Test void testSubtract() {
-    checkTranslation("b - 3", inTree("-($1, 3)"));
+    checkTranslation("(boolean)(b - 3)", inTree("-($1, 3)"));
   }
 
   @Test void testMultiply() {
-    checkTranslation("b * 3", inTree("*($1, 3)"));
+    checkTranslation("(boolean)(b * 3)", inTree("*($1, 3)"));
   }
 
   @Test void testMod() {
-    checkTranslation("b % 3", inTree("MOD($1, 3)"));
+    checkTranslation("(boolean)(b % 3)", inTree("MOD($1, 3)"));
   }
 
   @Test void testDivide() {
-    checkTranslation("b / 3", inTree("/($1, 3)"));
-    checkTranslation("c / 3.1", inTree("/($2, 3.1E0:DOUBLE)"));
+    checkTranslation("(boolean)(b / 3)", inTree("/($1, 3)"));
+    checkTranslation("(boolean)(c / 3.1)", inTree("/($2, 3.1E0:DOUBLE)"));
   }
 
   @Test void testBinCond() {
-    checkTranslation("(b == 1 ? 2 : 3)", inTree("CASE(=($1, 1), 2, 3)"));
+    checkTranslation("(boolean)(b == 1 ? 2 : 3)", inTree("CASE(=($1, 1), 2, 3)"));
   }
 
   @Test void testTupleDereference() {
-    checkTranslation("k2.k21", inTree("[$11.k21]"));
-    checkTranslation("k2.(k21, k22)", inTree("[ROW($11.k21, $11.k22)]"));
-    checkTranslation("k2.k22.(k221,k222)",
-        inTree("[ROW($11.k22.k221, $11.k22.k222)]"));
+    checkTranslation("(boolean)k2.k21", inTree("$11.k21"));
+    checkTranslation("(boolean)k2.(k21, k22)", inTree("ROW($11.k21, $11.k22)"));
+    checkTranslation("(boolean)k2.k22.(k221,k222)",
+        inTree("ROW($11.k22.k221, $11.k22.k222)"));
   }
 
   @Test void testBagDereference() {
-    checkTranslation("l2.l22", inTree("[MULTISET_PROJECTION($13, 1)]"));
-    checkTranslation("l2.(l21, l22)", inTree("[MULTISET_PROJECTION($13, 0, 1)]"));
+    checkTranslation("(boolean)l2.l22", inTree("MULTISET_PROJECTION($13, 1)"));
+    checkTranslation("(boolean)l2.(l21, l22)", inTree("MULTISET_PROJECTION($13, 0, 1)"));
   }
 
   @Test void testMapLookup() {
-    checkTranslation("m2#'testKey'", inTree("ITEM($15, 'testKey')"));
+    checkTranslation("(boolean)(m2#'testKey')", inTree("ITEM($15, 'testKey')"));
   }
 
   @Test void testCast() {
-    checkTranslation("(int) b", inTree("CAST($1):INTEGER"));
-    checkTranslation("(long) a", inTree("CAST($0):BIGINT"));
-    checkTranslation("(float) b", inTree("CAST($1):REAL"));
-    checkTranslation("(double) b", inTree("CAST($1):DOUBLE"));
-    checkTranslation("(chararray) b", inTree("CAST($1):VARCHAR"));
-    checkTranslation("(bytearray) b", inTree("CAST($1):BINARY"));
-    checkTranslation("(boolean) c", inTree("CAST($2):BOOLEAN"));
-    checkTranslation("(biginteger) b", inTree("CAST($1):DECIMAL(19, 0)"));
-    checkTranslation("(bigdecimal) b", inTree("CAST($1):DECIMAL(19, 0)"));
-    checkTranslation("(tuple()) b", inTree("CAST($1):(DynamicRecordRow[])"));
-    checkTranslation("(tuple(int, float)) b",
+    checkTranslation("(boolean)(int) b", inTree("CAST($1):INTEGER"));
+    checkTranslation("(boolean)(long) a", inTree("CAST($0):BIGINT"));
+    checkTranslation("(boolean)(float) b", inTree("CAST($1):REAL"));
+    checkTranslation("(boolean)(double) b", inTree("CAST($1):DOUBLE"));
+    checkTranslation("(boolean)(chararray) b", inTree("CAST($1):VARCHAR"));
+    checkTranslation("(boolean)(bytearray) b", inTree("CAST($1):BINARY"));
+    checkTranslation("(boolean)(boolean) c", inTree("CAST($2):BOOLEAN"));
+    checkTranslation("(boolean)(biginteger) b", inTree("CAST($1):DECIMAL(19, 0)"));
+    checkTranslation("(boolean)(bigdecimal) b", inTree("CAST($1):DECIMAL(19, 0)"));
+    checkTranslation("(boolean)(tuple()) b", inTree("CAST($1):(DynamicRecordRow[])"));
+    checkTranslation("(boolean)(tuple(int, float)) b",
         inTree("CAST($1):RecordType(INTEGER $0, REAL $1)"));
-    checkTranslation("(bag{}) b",
+    checkTranslation("(boolean)(bag{}) b",
         inTree("CAST($1):(DynamicRecordRow[]) NOT NULL MULTISET"));
-    checkTranslation("(bag{tuple(int)}) b",
+    checkTranslation("(boolean)(bag{tuple(int)}) b",
         inTree("CAST($1):RecordType(INTEGER $0) MULTISET"));
-    checkTranslation("(bag{tuple(int, float)}) b",
+    checkTranslation("(boolean)(bag{tuple(int, float)}) b",
         inTree("CAST($1):RecordType(INTEGER $0, REAL $1) MULTISET"));
-    checkTranslation("(map[]) b",
+    checkTranslation("(boolean)(map[]) b",
         inTree("CAST($1):(VARCHAR NOT NULL, BINARY(1) NOT NULL) MAP"));
-    checkTranslation("(map[int]) b", inTree("CAST($1):(VARCHAR NOT NULL, INTEGER"));
-    checkTranslation("(map[tuple(int, float)]) b",
+    checkTranslation("(boolean)(map[int]) b", inTree("CAST($1):(VARCHAR NOT NULL, INTEGER"));
+    checkTranslation("(boolean)(map[tuple(int, float)]) b",
         inTree("CAST($1):(VARCHAR NOT NULL, RecordType(INTEGER val_0, REAL val_1)) MAP"));
   }
 
   @Test void testPigBuiltinFunctions() {
-    checkTranslation("ABS(-5)", inTree("ABS(-5)"));
-    checkTranslation("AddDuration(h, 'P1D')",
+    checkTranslation("(boolean)ABS(-5)", inTree("ABS(-5)"));
+    checkTranslation("(boolean)AddDuration(h, 'P1D')",
         inTree("AddDuration(PIG_TUPLE($7, 'P1D'))"));
-    checkTranslation("CEIL(1.2)", inTree("CEIL(1.2E0:DOUBLE)"));
+    checkTranslation("(boolean)CEIL(1.2)", inTree("CEIL(1.2E0:DOUBLE)"));
   }
 }


### PR DESCRIPTION
…exLiterals

Add a check in Join and Filter to require conditions to be of type BOOLEAN