### PR TITLE
[CALCITE-6460] SortRemoveConstantKeysRule fails with AssertionError due to mismatched collation on resulting Sort

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveConstantKeysRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveConstantKeysRule.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -77,8 +78,13 @@ public class SortRemoveConstantKeysRule
       return;
     }
 
+    final RelCollation collation =
+        RelCollationTraitDef.INSTANCE.canonize(RelCollations.of(collationsList));
     final Sort result =
-        sort.copy(sort.getTraitSet(), input, RelCollations.of(collationsList));
+        sort.copy(
+            sort.getTraitSet().replaceIf(RelCollationTraitDef.INSTANCE, () -> collation),
+            input,
+            collation);
     call.transformTo(result);
     call.getPlanner().prune(sort);
   }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1383,6 +1383,11 @@ class RelOptRulesTest extends RelOptTestBase {
         + "group by deptno, sal\n"
         + "order by deptno, sal desc nulls first";
     sql(sql)
+        // Use VolcanoPlanner with collation to ensure the correct creation of the new Sort
+        .withVolcanoPlanner(false,  p -> {
+          p.addRelTraitDef(RelCollationTraitDef.INSTANCE);
+          RelOptUtil.registerDefaultRules(p, false, false);
+        })
         .withRule(CoreRules.SORT_REMOVE_CONSTANT_KEYS)
         .check();
   }


### PR DESCRIPTION
See more info in [CALCITE-6460](https://issues.apache.org/jira/browse/CALCITE-6460)