### PR TITLE
[CALCITE-6466] Add benchmark for SQL parser instantiation

### DIFF
--- a/ubenchmark/README.md
+++ b/ubenchmark/README.md
@@ -38,7 +38,7 @@ following task:
 
 ```kotlin
 jmh {
-    include = listOf("removeAllVertices.*Benchmark")
+    includes = listOf("removeAllVertices.*Benchmark")
 }
 ```
 

--- a/ubenchmark/build.gradle.kts
+++ b/ubenchmark/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 
 dependencies {
     jmhImplementation(platform(project(":bom")))
+    jmhImplementation(project(":babel"))
     jmhImplementation(project(":core"))
     jmhImplementation(project(":linq4j"))
     jmhImplementation("com.google.guava:guava")

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.babel.SqlBabelParserImpl;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks JavaCC-generated SqlBabelParserImpl and ImmutableSqlParser instantiation.
+ * The instantiation time of parsers should not depend on the call stack depth.
+ * See https://lists.apache.org/thread/xw35sdy1w1k8lvn1q1lr7xb93bkj0lpq
+ */
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 7, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 7, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ParserInstantiationBenchmark {
+
+  int callStackDepth;
+  SqlParser.Config babelConfig;
+  SqlParser.Config coreConfig;
+  String sqlExpression;
+
+  @Setup
+  public void setup() throws SqlParseException {
+    babelConfig = SqlParser.config().withParserFactory(SqlBabelParserImpl.FACTORY);
+    coreConfig = SqlParser.config();
+    // not important in this benchmark, see ParserBenchmark for varying string length
+    sqlExpression = "SELECT 1";
+    callStackDepth = 100;
+  }
+
+  @Benchmark
+  public void instantiateBabelParser(Blackhole bh) {
+    bh.consume(SqlParser.create(sqlExpression, babelConfig));
+  }
+
+  @Benchmark
+  public void instantiateBabelParserInDeepCallStack(Blackhole bh) {
+    recursiveCall(
+        () -> bh.consume(SqlParser.create(sqlExpression, babelConfig)),
+        callStackDepth
+    );
+  }
+
+  @Benchmark
+  public void instantiateCoreParser(Blackhole bh) {
+    bh.consume(SqlParser.create(sqlExpression, coreConfig));
+  }
+
+  @Benchmark
+  public void instantiateCoreParserInDeepCallStack(Blackhole bh) {
+    recursiveCall(
+        () -> bh.consume(SqlParser.create(sqlExpression, babelConfig)),
+        callStackDepth
+    );
+  }
+
+  // used to increase the stack depth
+  private void recursiveCall(final Runnable r, final int callStackSize) {
+    if (callStackSize == 0) {
+      r.run();
+      return;
+    }
+    recursiveCall(r, callStackSize - 1);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(ParserInstantiationBenchmark.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .addProfiler(FlightRecorderProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
@@ -74,6 +74,8 @@ public class ParserInstantiationBenchmark {
     case "babel":
       config = SqlParser.config().withParserFactory(SqlBabelParserImpl.FACTORY);
       break;
+    default:
+      throw new RuntimeException("Unsupported parser: " + parser);
     }
   }
 

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
@@ -16,9 +16,6 @@
  */
 package org.apache.calcite.benchmarks;
 
-import java.util.concurrent.TimeUnit;
-
-import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.babel.SqlBabelParserImpl;
 
@@ -34,11 +31,12 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Benchmarks JavaCC-generated SqlBabelParserImpl and ImmutableSqlParser instantiation.

--- a/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
+++ b/ubenchmark/src/jmh/java/org/apache/calcite/benchmarks/ParserInstantiationBenchmark.java
@@ -105,8 +105,6 @@ public class ParserInstantiationBenchmark {
 
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder().include(ParserInstantiationBenchmark.class.getSimpleName())
-        .addProfiler(GCProfiler.class)
-        .addProfiler(FlightRecorderProfiler.class)
         .detectJvmArgs()
         .build();
 


### PR DESCRIPTION
This benchmark will help to measure the progress on the discussion here:
https://lists.apache.org/thread/xw35sdy1w1k8lvn1q1lr7xb93bkj0lpq
As of today the parsers instantiation is pretty slow and the speed depends on the call stack depth. This is an issue caused by JavaCC. The issue is fixed in newer version of JavaCC.

Once JavaCC is upgraded to 7.0.13 (https://issues.apache.org/jira/browse/CALCITE-5541), this benchmark can be re-run. 
Expected improvements are: 
- a minor speed improvement of ~10% for `instantiateBabelParser` and `instantiateCoreParser`
- the instantiation of parsers should not depend on the call stack depth anymore: 
  - `instantiateBabelParser` ~= `instantiateBabelParserInDeepCallStack`
  - `instantiateCoreParser` ~= `instantiateCoreParserInDeepCallStack`

## Current Results: 
```
Benchmark                                       (parser)  (stackDepth)  Mode  Cnt   Score   Error  Units
ParserInstantiationBenchmark.instantiateParser      core             0  avgt    7   6.887 ± 0.357  us/op
ParserInstantiationBenchmark.instantiateParser      core           100  avgt    7  13.425 ± 0.395  us/op
ParserInstantiationBenchmark.instantiateParser     babel             0  avgt    7  15.224 ± 0.272  us/op
ParserInstantiationBenchmark.instantiateParser     babel           100  avgt    7  21.652 ± 0.169  us/op
```

(temurin 17, intel macbook)

## How to run: 
Add: 
```
jmh {
    includes = listOf("ParserInstantiationBenchmark")
}
```
To `ubenchmark/build.gradle.kts`  
Then `./gradlew :ubenchmark:jmh`
This will run the new `ParserInstantiationBenchmark` and the existing `ParserBenchmark`.