### PR TITLE
[CALCITE-6464] Type inference for DECIMAL division seems incorrect

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -259,7 +259,7 @@ public interface RelDataTypeSystem {
    * <li>Then the result type is a decimal with:
    *   <ul>
    *   <li>d = p1 - s1 + s2</li>
-   *   <li>s &lt; max(6, s1 + p2 + 1)</li>
+   *   <li>s = max(6, s1 + p2 + 1)</li>
    *   <li>p = d + s</li>
    *   </ul>
    * </li>
@@ -294,21 +294,11 @@ public interface RelDataTypeSystem {
         int s1 = type1.getScale();
         int s2 = type2.getScale();
 
-        final int maxNumericPrecision = getMaxNumericPrecision();
-        int dout =
-            Math.min(
-                p1 - s1 + s2,
-                maxNumericPrecision);
-
         int scale = Math.max(6, s1 + p2 + 1);
-        scale =
-            Math.min(
-                scale,
-                maxNumericPrecision - dout);
+        int precision = p1 - s1 + s2 + scale;
+        precision = Math.min(precision, getMaxNumericPrecision());
         scale = Math.min(scale, getMaxNumericScale());
 
-        int precision = dout + scale;
-        assert precision <= maxNumericPrecision;
         assert precision > 0;
 
         RelDataType ret;

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2650,7 +2650,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .columnType("DOUBLE");
 
     expr("cast(null as DECIMAL(5, 2)) / cast(1 as BIGINT)")
-        .columnType("DECIMAL(19, 16)");
+        .columnType("DECIMAL(19, 19)");
     expr("cast(1 as DECIMAL(5, 2)) / cast(1 as INTEGER)")
         .columnType("DECIMAL(16, 13) NOT NULL");
     expr("cast(1 as DECIMAL(5, 2)) / cast(1 as SMALLINT)")
@@ -2667,9 +2667,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("cast(null as DECIMAL(4, 2)) / cast(1 as DECIMAL(6, 4))")
         .columnType("DECIMAL(15, 9)");
     expr("cast(1 as DECIMAL(4, 10)) / cast(null as DECIMAL(6, 19))")
-        .columnType("DECIMAL(19, 6)");
+        .columnType("DECIMAL(19, 17)");
     expr("cast(1 as DECIMAL(19, 2)) / cast(1 as DECIMAL(19, 2))")
-        .columnType("DECIMAL(19, 0) NOT NULL");
+        .columnType("DECIMAL(19, 19) NOT NULL");
     expr("4/3")
         .columnType("INTEGER NOT NULL");
     expr("-4.0/3")

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
@@ -309,9 +309,9 @@ class TypeCoercionTest {
     expr("'12.3'/cast(5 as double)")
         .columnType("DOUBLE NOT NULL");
     expr("'12.3'/5.1")
-        .columnType("DECIMAL(19, 8) NOT NULL");
+        .columnType("DECIMAL(19, 12) NOT NULL");
     expr("12.3/'5.1'")
-        .columnType("DECIMAL(19, 8) NOT NULL");
+        .columnType("DECIMAL(19, 19) NOT NULL");
     // test binary arithmetic with two strings.
     expr("'12.3' + '5'")
         .columnType("DECIMAL(19, 9) NOT NULL");
@@ -320,7 +320,7 @@ class TypeCoercionTest {
     expr("'12.3' * '5'")
         .columnType("DECIMAL(19, 18) NOT NULL");
     expr("'12.3' / '5'")
-        .columnType("DECIMAL(19, 0) NOT NULL");
+        .columnType("DECIMAL(19, 19) NOT NULL");
   }
 
   /** Test cases for binary comparison expressions. */

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -2595,7 +2595,7 @@ public class SqlOperatorTest {
     }
     f.checkNull("1e1 / cast(null as float)");
 
-    f.checkScalarExact("100.1 / 0.00000000000000001", "DECIMAL(19, 0) NOT NULL",
+    f.checkScalarExact("100.1 / 0.00000000000000001", "DECIMAL(19, 19) NOT NULL",
         "1.001E+19");
   }
 
@@ -9420,9 +9420,9 @@ public class SqlOperatorTest {
     f.checkScalar("safe_divide(cast(2 as bigint), cast(4 as bigint))",
         "0.5", "DOUBLE");
     f.checkScalar("safe_divide(cast(15 as bigint), cast(1.2 as decimal(2,1)))",
-        "12.5", "DECIMAL(19, 0)");
+        "12.5", "DECIMAL(19, 6)");
     f.checkScalar("safe_divide(cast(4.5 as decimal(2,1)), cast(3 as bigint))",
-        "1.5", "DECIMAL(19, 18)");
+        "1.5", "DECIMAL(19, 19)");
     f.checkScalar("safe_divide(cast(4.5 as decimal(2,1)), "
         + "cast(1.5 as decimal(2, 1)))", "3", "DECIMAL(8, 6)");
     f.checkScalar("safe_divide(cast(3 as double), cast(3 as bigint))",


### PR DESCRIPTION
The javadocs of `RelDataTypeSystem.deriveDecimalDivideType` state the following algorithm for deriving the decimal type of a decimal division:
 
```
d = p1 - s1 + s2
s < max(6, s1 + p2 + 1)
p = d + s
```

The inequality here doesn't make 100% sense to me as the result of an inequality is not a number, but a boolean. Should it be the following?

```
d = p1 - s1 + s2
s = max(6, s1 + p2 + 1) 
p = d + s 
```

I don't have access to the original SQL standard from 2003, but this would align at least with how MS SQL Server defines type derivation for decimal division: [Precision, Scale and Length (Transact SQL)](https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-ver16).

If so I propose to fix and follow the docs and adjust the previous implementation from:

```
final int maxNumericPrecision = getMaxNumericPrecision();
int dout =
    Math.min(
        p1 - s1 + s2,
        maxNumericPrecision);

int scale = Math.max(6, s1 + p2 + 1);
scale =
    Math.min(
        scale,
        maxNumericPrecision - dout);
scale = Math.min(scale, getMaxNumericScale());

int precision = dout + scale; 
```
 
to:

```
int scale = Math.max(6, s1 + p2 + 1);
int precision = p1 - s1 + s2 + scale;
precision = Math.min(precision, getMaxNumericPrecision());
scale = Math.min(scale, getMaxNumericScale()); 
```

This also fixes the issue described in [[CALCITE-6464] Type inference for DECIMAL division seems incorrect](https://issues.apache.org/jira/browse/CALCITE-6464). I added an explicit regression test to check this. 

I've also adjusted one test case name to reflect that it tests subtraction and not addition and added an explicit test case for addition. I can also remove the test changes from this PR and open a separate one, if needed.