### PR TITLE
[CALCITE-6218] RelToSqlConverter fails to convert correlated lateral …

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -397,7 +397,7 @@ public class RelToSqlConverter extends SqlImplementor
   public Result visit(Correlate e) {
     final Result leftResult =
         visitInput(e, 0)
-            .resetAlias(e.getCorrelVariable(), e.getRowType());
+            .resetAlias(e.getCorrelVariable(), e.getInput(0).getRowType());
     parseCorrelTable(e, leftResult);
     final Result rightResult = visitInput(e, 1);
     final SqlNode rightLateral =

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -6640,7 +6640,7 @@ class RelToSqlConverterTest {
         + "       lateral (select d.\"department_id\" + 1 as d_plusOne"
         + "                from (values(true)))";
 
-    final String expected = "SELECT \"$cor0\".\"department_id\", \"$cor0\".\"D_PLUSONE\"\n"
+    final String expected = "SELECT \"$cor0\".\"department_id\", \"t1\".\"D_PLUSONE\"\n"
         + "FROM (SELECT \"department_id\", \"department_description\", \"department_id\" + 1 AS \"$f2\"\n"
         + "FROM \"foodmart\".\"department\") AS \"$cor0\",\n"
         + "LATERAL (SELECT \"$cor0\".\"$f2\" AS \"D_PLUSONE\"\n"

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -383,9 +383,9 @@ class PigRelOpTest extends PigRelTestBase {
         + "          LogicalValues(tuples=[[{ 0 }]])\n";
 
     final String sql = ""
-        + "SELECT $cor1.DEPTNO AS dept, $cor1.JOB AS job, $cor1.EMPNO,"
-        + " $cor1.ENAME, $cor1.JOB0 AS JOB, $cor1.MGR, $cor1.HIREDATE,"
-        + " $cor1.SAL, $cor1.COMM, $cor1.DEPTNO0 AS DEPTNO\n"
+        + "SELECT $cor1.DEPTNO AS dept, $cor1.JOB AS job, t30.EMPNO,"
+        + " t30.ENAME, t30.JOB, t30.MGR, t30.HIREDATE,"
+        + " t30.SAL, t30.COMM, t30.DEPTNO\n"
         + "FROM (SELECT DEPTNO, JOB, COLLECT(ROW(EMPNO, ENAME, JOB, MGR, "
         + "HIREDATE, SAL, COMM, DEPTNO)) AS $f2\n"
         + "    FROM scott.EMP\n"
@@ -470,11 +470,11 @@ class PigRelOpTest extends PigRelTestBase {
         + "(30,5,BLAKE,MANAGER,30,2850.00,2850.00)\n";
 
     final String sql = ""
-        + "SELECT $cor5.group, $cor5.cnt, $cor5.ENAME, $cor5.JOB, "
-        + "$cor5.DEPTNO, $cor5.SAL, $cor5.$f3\n"
+        + "SELECT $cor5.group, $cor5.cnt, t110.ENAME, t110.JOB, "
+        + "t110.DEPTNO, t110.SAL, $cor5.$f3\n"
         + "FROM (SELECT $cor4.DEPTNO AS group, "
-        + "COUNT(PIG_BAG($cor4.X)) AS cnt, $cor4.X, "
-        + "BigDecimalMax(PIG_BAG(MULTISET_PROJECTION($cor4.X, 3))) AS $f3\n"
+        + "COUNT(PIG_BAG(t8.X)) AS cnt, t8.X, "
+        + "BigDecimalMax(PIG_BAG(MULTISET_PROJECTION(t8.X, 3))) AS $f3\n"
         + "    FROM (SELECT DEPTNO, COLLECT(ROW(EMPNO, ENAME, JOB, MGR, "
         + "HIREDATE, SAL, COMM, DEPTNO)) AS A\n"
         + "        FROM scott.EMP\n"

--- a/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
+++ b/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
@@ -2191,6 +2191,7 @@ public class CalciteAssert {
        *            n12: STRUCT<c: BIGINT>
        *          >,
        *      n2: STRUCT<d: BIGINT>,
+       *      xs: ARRAY<BIGINT>,
        *      e: BIGINT)
        * }</pre>
        */
@@ -2204,6 +2205,7 @@ public class CalciteAssert {
                     .add("n12", typeFactory.builder().add("c", bigint).build())
                     .build())
             .add("n2", typeFactory.builder().add("d", bigint).build())
+            .add("xs", typeFactory.createArrayType(bigint, -1))
             .add("e", bigint)
             .build();
       }


### PR DESCRIPTION
```
SELECT 
  "a", "x"
FROM 
  "myDb"."myTable",
  unnest("xs") as "x";
```

original obtained sql:
```
SELECT
  "$cor0"."a",
  "$cor0"."xs0" AS "x" -- <-- xs0 ?
FROM 
  (
    SELECT "a", "n1"."n11"."b", "n1"."n12"."c", "n2"."d", "xs", "e" FROM "myDb"."myTable"
  ) AS "$cor0",
  LATERAL UNNEST (
   SELECT "$cor0"."xs" FROM (VALUES (0)) AS "t" ("ZERO")
  ) AS "t1" ("xs") AS "t10"
```


this PR fixed obtained sql:
```
SELECT
  "$cor0"."a",
  "t10."xs" AS "x"
FROM 
  (
    SELECT "a", "n1"."n11"."b", "n1"."n12"."c", "n2"."d", "xs", "e" FROM "myDb"."myTable"
  ) AS "$cor0",
  LATERAL UNNEST (
   SELECT "$cor0"."xs" FROM (VALUES (0)) AS "t" ("ZERO")
  ) AS "t1" ("xs") AS "t10"
```


