### PR TITLE
[CALCITE-6295] Support IS NOT NULL in Arrow adapter

### DIFF
--- a/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowTranslator.java
+++ b/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowTranslator.java
@@ -129,6 +129,8 @@ class ArrowTranslator {
       return translateBinary("greater_than_or_equal_to", "<=", (RexCall) node);
     case IS_NULL:
       return translateUnary("isnull", (RexCall) node);
+    case IS_NOT_NULL:
+      return translateUnary("isnotnull", (RexCall) node);
     default:
       throw new UnsupportedOperationException("Unsupported operator " + node);
     }

--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -231,11 +231,6 @@ public abstract class Bug {
    * [CALCITE-6294] Support IN filter in Arrow adapter</a> is fixed. */
   public static final boolean CALCITE_6294_FIXED = false;
 
-  /** Whether
-   * <a href="https://issues.apache.org/jira/browse/CALCITE/issues/CALCITE-6295">
-   * [CALCITE-6295] Support IS NOT NULL in Arrow adapter</a> is fixed. */
-  public static final boolean CALCITE_6295_FIXED = false;
-
   /**
    * Use this to flag temporary code.
    */


### PR DESCRIPTION
Analogous change to [[CALCITE-6296] Support IS NULL in Arrow adapter](https://github.com/apache/calcite/commit/e371b336a8b404ed36955f517196a5e8606455d7). I've adjusted the test cases to align with what we've merged for `IS NULL` support in the arrow adapter to make this part of the test code a bit more predictable.