### PR TITLE
[CALCITE-6145] Function 'TRIM' without parameters throw NullPointerEx…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
@@ -131,7 +131,7 @@ public class SqlTrimFunction extends SqlFunction {
         operands[1] = SqlLiteral.createCharString(" ", pos);
       }
       if (operands[2] == null) {
-        throw new IllegalArgumentException("String to trim cannot be null");
+        throw new IllegalArgumentException("trim cannot be called without arguments");
       }
       break;
     default:

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
@@ -130,6 +130,9 @@ public class SqlTrimFunction extends SqlFunction {
       if (operands[1] == null) {
         operands[1] = SqlLiteral.createCharString(" ", pos);
       }
+      if (operands[2] == null) {
+        throw new IllegalArgumentException("String to trim cannot be null");
+      }
       break;
     default:
       throw new IllegalArgumentException(

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
@@ -134,7 +134,8 @@ public class SqlTrimFunction extends SqlFunction {
         // This variant occurs, when someone writes TRIM() without any arguments as the first two
         // absent arguments are set to default values and the third argument (string to trim)
         // stays null
-        throw new IllegalArgumentException("Invalid number of arguments to function 'TRIM'. Was expecting at least 2 arguments");
+        throw new IllegalArgumentException(
+            "Invalid number of arguments to function 'TRIM'. Was expecting at least 2 arguments");
       }
       break;
     default:

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
@@ -131,7 +131,10 @@ public class SqlTrimFunction extends SqlFunction {
         operands[1] = SqlLiteral.createCharString(" ", pos);
       }
       if (operands[2] == null) {
-        throw new IllegalArgumentException("trim cannot be called without arguments");
+        // This variant occurs, when someone writes TRIM() without any arguments as the first two
+        // absent arguments are set to default values and the third argument (string to trim)
+        // was absent, too
+        throw new IllegalArgumentException("Invalid number of arguments to function 'TRIM'. Was expecting at least 2 arguments");
       }
       break;
     default:

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
@@ -133,7 +133,7 @@ public class SqlTrimFunction extends SqlFunction {
       if (operands[2] == null) {
         // This variant occurs, when someone writes TRIM() without any arguments as the first two
         // absent arguments are set to default values and the third argument (string to trim)
-        // was absent, too
+        // stays null
         throw new IllegalArgumentException("Invalid number of arguments to function 'TRIM'. Was expecting at least 2 arguments");
       }
       break;

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -10857,6 +10857,7 @@ public class SqlOperatorTest {
     f.checkFails("trim('' from 'abcde')",
         "Trim error: trim character must be exactly 1 character",
         true);
+    f.checkFails("trim()", "String to trim cannot be null", false);
 
     final SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.MYSQL_5);
     f1.checkString("trim(leading 'eh' from 'hehe__hehe')", "__hehe",

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -10858,7 +10858,7 @@ public class SqlOperatorTest {
     f.checkFails("trim('' from 'abcde')",
         "Trim error: trim character must be exactly 1 character",
         true);
-    f.checkFails("trim()", "String to trim cannot be null", false);
+    f.checkFails("trim()", "trim cannot be called without arguments", false);
 
     final SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.MYSQL_5);
     f1.checkString("trim(leading 'eh' from 'hehe__hehe')", "__hehe",

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -10843,6 +10843,7 @@ public class SqlOperatorTest {
     f.checkString("trim(trailing 'a' from 'aAa')", "aA", "VARCHAR(3) NOT NULL");
     f.checkNull("trim(cast(null as varchar(1)) from 'a')");
     f.checkNull("trim('a' from cast(null as varchar(1)))");
+    f.checkNull("trim(null)");
 
     // SQL:2003 6.29.9: trim string must have length=1. Failure occurs
     // at runtime.

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -10858,7 +10858,7 @@ public class SqlOperatorTest {
     f.checkFails("trim('' from 'abcde')",
         "Trim error: trim character must be exactly 1 character",
         true);
-    f.checkFails("trim()", "trim cannot be called without arguments", false);
+    f.checkFails("trim()", "Invalid number of arguments to function 'TRIM'. Was expecting at least 2 arguments", false);
 
     final SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.MYSQL_5);
     f1.checkString("trim(leading 'eh' from 'hehe__hehe')", "__hehe",


### PR DESCRIPTION
Added an explicit check at parsing time to make sure that the string to trim is not `null`