### PR TITLE
[CALCITE-6498] Elasticsearch multi-field mappings do not work

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
@@ -129,6 +129,7 @@ final class ElasticsearchJson {
     // "fields" is used for multi-mapped fields
     if (mapping.path("fields").isObject()
         && !isLeaf.test(mapping.path("fields"))) {
+      // recurse on multi-mapped field
       visitMappingProperties(path, (ObjectNode) mapping.get("fields"), consumer);
       return;
     }

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
@@ -93,6 +93,11 @@ final class ElasticsearchJson {
    * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html">mapping
    * properties</a> and calls consumer for each {@code field / type} pair.
    * Nested fields are represented as {@code foo.bar.qux}.
+   * Also supports
+   * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html">
+   * multi-field mappings</a>.
+   * These fields are also represented as {@code foo.bar} with the difference
+   * that the type of the parent cannot be "nested".
    */
   static void visitMappingProperties(ObjectNode mapping,
       BiConsumer<String, String> consumer) {
@@ -110,19 +115,26 @@ final class ElasticsearchJson {
       return;
     }
 
-    // check if we have reached actual field mapping (leaf of JSON tree)
+    // check if we've reached a leaf
     Predicate<JsonNode> isLeaf = node -> node.path("type").isValueNode();
 
+    // "properties" is present under the root or under "nested" fields
     if (mapping.path("properties").isObject()
         && !isLeaf.test(mapping.path("properties"))) {
-      // recurse
+      // recurse on "nested" field
       visitMappingProperties(path, (ObjectNode) mapping.get("properties"), consumer);
       return;
     }
 
+    // "fields" is used for multi-mapped fields
+    if (mapping.path("fields").isObject()
+        && !isLeaf.test(mapping.path("fields"))) {
+      visitMappingProperties(path, (ObjectNode) mapping.get("fields"), consumer);
+      return;
+    }
+
     if (isLeaf.test(mapping)) {
-      // this is leaf (register field / type mapping)
-      consumer.accept(String.join(".", path), mapping.get("type").asText());
+      // if we reached a leaf we can stop as we've already registered the type mapping
       return;
     }
 
@@ -132,6 +144,12 @@ final class ElasticsearchJson {
       final String name = entry.getKey();
       final ObjectNode node = (ObjectNode) entry.getValue();
       path.add(name);
+
+      // type is present
+      if (node.get("type") != null) {
+        consumer.accept(String.join(".", path), node.get("type").asText());
+      }
+
       visitMappingProperties(path, node, consumer);
       path.removeLast();
     }

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
@@ -126,10 +126,10 @@ final class ElasticsearchJson {
       return;
     }
 
-    // "fields" is used for multi-mapped fields
+    // "fields" is used for multi-fields
     if (mapping.path("fields").isObject()
         && !isLeaf.test(mapping.path("fields"))) {
-      // recurse on multi-mapped field
+      // recurse on multi-field
       visitMappingProperties(path, (ObjectNode) mapping.get("fields"), consumer);
       return;
     }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
@@ -177,8 +177,15 @@ class EmbeddedElasticsearchPolicy {
     final int index = key.indexOf('.');
     if (index > -1) {
       String prefix  = key.substring(0, index);
-      String suffix = key.substring(index + 1, key.length());
-      applyMapping(parent.withObject("/" + prefix).withObject("/properties"), suffix, type);
+      String suffix = key.substring(index + 1);
+
+      if ("nested".equals(parent.get(prefix).get("type").asText())) {
+        // Nested field mapping
+        applyMapping(parent.withObject("/" + prefix).withObject("/properties"), suffix, type);
+      } else {
+        // Multi-field mapping
+        applyMapping(parent.withObject("/" + prefix).withObject("/fields"), suffix, type);
+      }
     } else {
       parent.withObject("/" + key).put("type", type);
     }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicyTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicyTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.elasticsearch;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.util.EntityUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Set of tests for {@link EmbeddedElasticsearchPolicy}.
+ */
+@ResourceLock(value = "elasticsearch-scrolls", mode = ResourceAccessMode.READ)
+public class EmbeddedElasticsearchPolicyTest {
+
+  private static final EmbeddedElasticsearchPolicy NODE = EmbeddedElasticsearchPolicy.create();
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6498">[CALCITE-6498]
+   * Elasticsearch multi-field mappings do not work</a>. */
+  @Test void testCreateIndexWithSimpleFieldMappings() throws Exception {
+    final Map<String, String> mapping = ImmutableMap.of("a", "keyword", "b", "text", "c", "long");
+    final String simpleMappingIndex = "index_simple_mapping";
+
+    NODE.createIndex(simpleMappingIndex, mapping);
+
+    final JsonNode properties = getMappings(simpleMappingIndex);
+
+    assertThat(properties.path("a").path("type").asText(), is("keyword"));
+    assertThat(properties.path("b").path("type").asText(), is("text"));
+    assertThat(properties.path("c").path("type").asText(), is("long"));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6498">[CALCITE-6498]
+   * Elasticsearch multi-field mappings do not work</a>. */
+  @Test void testCreateIndexWithNestedFieldMappings() throws Exception {
+    final Map<String, String> mapping =
+        ImmutableMap.of("a", "nested", "a.b", "text", "a.c", "long");
+    final String index = "index_nested_field_mappings";
+
+    NODE.createIndex(index, mapping);
+
+    final JsonNode properties = getMappings(index);
+
+    assertThat(properties.path("a").path("type").asText(), is("nested"));
+    assertThat(properties.path("a")
+                          .path("properties")
+                            .path("b").path("type").asText(), is("text"));
+    assertThat(properties.path("a")
+                          .path("properties")
+                            .path("c").path("type").asText(), is("long"));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6498">[CALCITE-6498]
+   * Elasticsearch multi-field mappings do not work</a>. */
+  @Test void testCreateIndexWithMultiFieldMappings() throws Exception {
+    final Map<String, String> mapping =
+        ImmutableMap.of("a", "text", "a.keyword", "keyword");
+    final String index = "index_multi_field_mappings";
+
+    NODE.createIndex(index, mapping);
+
+    final JsonNode properties = getMappings(index);
+
+    assertThat(properties.path("a").path("type").asText(), is("text"));
+    assertThat(properties.path("a")
+                          .path("fields")
+                            .path("keyword").path("type").asText(), is("keyword"));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6498">[CALCITE-6498]
+   * Elasticsearch multi-field mappings do not work</a>. */
+  @Test void testCreateIndexWithNestedFieldMappingsAndMultiFieldMappings() throws Exception {
+    final Map<String, String> mapping =
+        ImmutableMap.of("a", "nested", "a.b", "text", "a.b.keyword", "keyword");
+    final String index = "index_nested_and_multi_field_mappings";
+
+    NODE.createIndex(index, mapping);
+
+    final JsonNode properties = getMappings(index);
+
+    assertThat(properties.path("a").path("type").asText(), is("nested"));
+    assertThat(properties.path("a")
+                          .path("properties")
+                            .path("b").path("type").asText(), is("text"));
+    assertThat(properties.path("a")
+                          .path("properties")
+                            .path("b").path("fields")
+                              .path("keyword")
+                                .path("type").asText(), is("keyword"));
+  }
+
+  private static JsonNode getMappings(String index) throws IOException {
+    Response indexMappingsResponse = NODE.restClient()
+        .performRequest(new Request("GET", "/" + index + "/_mapping"));
+    HttpEntity entity = indexMappingsResponse.getEntity();
+    String responseBody = EntityUtils.toString(entity);
+    JsonNode responseJson = new ObjectMapper().readTree(responseBody);
+
+    // It's more readable to assert on a JsonNode than on a map, where you need to cast a lot
+    return responseJson.path(index).path("mappings").path("properties");
+  }
+}

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
@@ -59,8 +59,14 @@ class Projection2Test {
   @BeforeAll
   public static void setupInstance() throws Exception {
     final Map<String, String> mappings =
-        ImmutableMap.of("a", "long",
-            "b", "nested", "b.a", "long", "b.b", "long", "b.c", "nested", "b.c.a", "keyword");
+        ImmutableMap.<String, String>builder()
+            .put("a", "long")
+            .put("b", "nested")
+            .put("b.a", "long")
+            .put("b.b", "long")
+            .put("b.c", "nested")
+            .put("b.c.a", "keyword")
+            .build();
 
     NODE.createIndex(NAME, mappings);
 

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/Projection2Test.java
@@ -60,7 +60,7 @@ class Projection2Test {
   public static void setupInstance() throws Exception {
     final Map<String, String> mappings =
         ImmutableMap.of("a", "long",
-            "b.a", "long", "b.b", "long", "b.c.a", "keyword");
+            "b", "nested", "b.a", "long", "b.b", "long", "b.c", "nested", "b.c.a", "keyword");
 
     NODE.createIndex(NAME, mappings);
 


### PR DESCRIPTION
A field identified by `a.b` can be either a [nested](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html) or a [multi-mapped field](https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html).

Multi-field mapped fields weren't handled in the current implementation in two places:
- When an existing mapping is visited
- When you want to create a mapping inside `EmbeddedElasticsearchPolicy`

This PR adds support for multi-mapped fields. This is important to work correctly for [[CALCITE-3027] Support LIKE operator in Elasticsearch](https://issues.apache.org/jira/browse/CALCITE-3027).`text` mapped fields are usually multi-mapped fields with a second `keyword` mapping, which you'll need for a wildcard query to have semantics like the SQL `LIKE` operator. Without this change we wouldn't be able to write tests we'll need for the `LIKE` operator.

I've added an explicit `EmbeddedElasticsearchPolicyTest` as the create mapping functionality was broken inside `EmbeddedElasticsearchPolicy`, which should work correctly as all ES tests depend on this.

I've created two separate commits to make reviewing easier:
- Visitor: [Handle visiting of multi-field and nested mappings correctly in Elast…](https://github.com/apache/calcite/pull/3885/commits/8420d9ff19f6539038aca8992f5dae3fd693cccf)
- Create mapping in tests: [Handle creation of multi-field and nested mappings correctly in Embed…](https://github.com/apache/calcite/pull/3885/commits/cb5e222c863a7bf320f4e3a4ff83b5bf257f8c79)

(force-pushed to remove `.` from the commit messages, which broke CI)