### PR TITLE
[CALCITE-6519] Non-aggregate query that uses measure in ORDER BY

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/MeasureRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MeasureRules.java
@@ -75,8 +75,8 @@ public abstract class MeasureRules {
   }
 
   /** Rule that matches an {@link Aggregate}
-   * that contains a {@code M2V} call
-   * and pushes down the {@code M2V} call into a {@link Project}. */
+   * that contains an {@code AGG_M2V} call
+   * and pushes down the {@code AGG_M2V} call into a {@link Project}. */
   public static final RelOptRule AGGREGATE =
       AggregateMeasureRuleConfig.DEFAULT
           .toRule();
@@ -197,8 +197,8 @@ public abstract class MeasureRules {
   }
 
   /** Rule that matches an {@link Aggregate}
-   * that contains a {@code M2V} call
-   * and pushes down the {@code M2V} call into a {@link Project}. */
+   * that contains an {@code AGG_M2V} call
+   * and pushes down the {@code AGG_M2V} call into a {@link Project}. */
   public static final RelOptRule AGGREGATE2 =
       AggregateMeasure2RuleConfig.DEFAULT
           .toRule();
@@ -460,7 +460,7 @@ public abstract class MeasureRules {
           .as(ProjectSortMeasureRuleConfig.class)
           .toRule();
 
-  /** Rule that matches a {@link Project} that contains a {@code M2V} call
+  /** Rule that matches a {@link Project} that contains an {@code M2V} call
    * on top of a {@link Sort} and pushes down the {@code M2V} call.
    *
    * @see MeasureRules#PROJECT_SORT */

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3726,7 +3726,6 @@ public class SqlToRelConverter {
       SqlNode orderItem, List<SqlNode> extraExprs,
       RelFieldCollation.Direction direction,
       RelFieldCollation.NullDirection nullDirection) {
-    assert select != null;
     // Handle DESC keyword, e.g. 'select a, b from t order by a desc'.
     switch (orderItem.getKind()) {
     case DESCENDING:
@@ -3754,11 +3753,10 @@ public class SqlToRelConverter {
       break;
     }
 
-    SqlNode converted = validator().expandOrderExpr(select, orderItem);
-
+    final SqlValidator validator = validator();
     switch (nullDirection) {
     case UNSPECIFIED:
-      nullDirection = validator().config().defaultNullCollation().last(desc(direction))
+      nullDirection = validator.config().defaultNullCollation().last(desc(direction))
           ? RelFieldCollation.NullDirection.LAST
           : RelFieldCollation.NullDirection.FIRST;
       break;
@@ -3766,9 +3764,11 @@ public class SqlToRelConverter {
       break;
     }
 
+    SqlNode converted = validator.expandOrderExpr(select, orderItem);
+
     // Scan the select list and order exprs for an identical expression.
     final SelectScope selectScope =
-        requireNonNull(validator().getRawSelectScope(select),
+        requireNonNull(validator.getRawSelectScope(select),
             () -> "getRawSelectScope is not found for " + select);
     int ordinal = -1;
     List<SqlNode> expandedSelectList = selectScope.getExpandedSelectList();

--- a/core/src/main/java/org/apache/calcite/tools/Programs.java
+++ b/core/src/main/java/org/apache/calcite/tools/Programs.java
@@ -263,7 +263,7 @@ public class Programs {
   private static boolean containsAggM2v(RelNode rel) {
     return RelNodes.contains(rel,
         aggCall -> aggCall.getAggregation().kind == SqlKind.AGG_M2V,
-        RexUtil.find(SqlKind.AGG_M2V));
+        RexUtil.find(ImmutableSet.of(SqlKind.AGG_M2V, SqlKind.M2V)));
   }
 
   @Deprecated

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -4764,6 +4764,8 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         .ok();
   }
 
+  /** A query that references a measure that does not contain any aggregate
+   * functions. The measure is fully expanded in the plan. */
   @Test void testMeasure1() {
     final String sql = "select * from (\n"
         + "  select deptno,\n"
@@ -4783,7 +4785,8 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
-  /** As {@link #testMeasure1()} but uses an aggregate measure. */
+  /** As {@link #testMeasure1()} but uses an aggregate measure. The plan
+   * contains a call to {@code AGG_M2V} on top of a call to {@code V2M}. */
   @Test void testMeasure3() {
     final String sql = "select deptno, count_plus_10, min(job) as min_job\n"
         + "from (\n"
@@ -4793,6 +4796,19 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         + "    count_plus_10 + deptno as measure e2\n"
         + "  from emp)\n"
         + "group by deptno";
+    sql(sql).ok();
+  }
+
+  /** As {@link #testMeasure3()} but no {@code GROUP BY}.
+   * The measure is expanded to {@code OVER}. */
+  @Test void testMeasure3b() {
+    final String sql = "select deptno, count_plus_10\n"
+        + "from (\n"
+        + "  select deptno,\n"
+        + "    job,\n"
+        + "    count(*) + 10 as measure count_plus_10,\n"
+        + "    count_plus_10 + deptno as measure e2\n"
+        + "  from emp)";
     sql(sql).ok();
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -6703,6 +6703,37 @@ LogicalProject(DEPTNO=[$0], C1=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMeasureJoin">
+    <Resource name="sql">
+      <![CDATA[select deptno, aggregate(m) as m
+from (select deptno, name, avg(char_length(name)) as measure m
+  from dept)
+join emp using (deptno)
+group by deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], M=[$1])
+  LogicalAggregate(group=[{0}], M=[AGG_M2V($1)])
+    LogicalProject($f0=[$0], M=[$2])
+      LogicalJoin(condition=[=($0, $10)], joinType=[inner])
+        LogicalProject(DEPTNO=[$0], NAME=[$1], M=[V2M(CAST(/(SUM(CHAR_LENGTH($1)), COUNT(CHAR_LENGTH($1)))):INTEGER NOT NULL)])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], M=[$1])
+  LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
+    LogicalProject($f0=[$0], $f2=[M2X($2, SAME_PARTITION($0))])
+      LogicalJoin(condition=[=($0, $10)], joinType=[inner])
+        LogicalProject(DEPTNO=[$0], NAME=[$1], M=[V2M(CAST(/(SUM(CHAR_LENGTH($1)), COUNT(CHAR_LENGTH($1)))):INTEGER NOT NULL)])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMeasureSort">
     <Resource name="sql">
       <![CDATA[select deptno, c1
@@ -6725,6 +6756,59 @@ LogicalProject(DEPTNO=[$0], C1=[$2])
     LogicalProject(DEPTNO=[$0], C1=[$1], $f2=[M2V($1)])
       LogicalProject(DEPTNO=[$7], C1=[V2M(+(COUNT(), 1))])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMeasureWithoutGroupBy">
+    <Resource name="sql">
+      <![CDATA[with empm as
+  (select *, avg(sal) as measure avgSal from emp)
+select deptno, avgSal
+from empm]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], AVGSAL=[CAST(/(SUM($5) OVER (), COUNT($5) OVER ())):INTEGER NOT NULL])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMeasureWithoutGroupBy2">
+    <Resource name="sql">
+      <![CDATA[with empm as
+  (select *, avg(sal) as measure avgSal from emp)
+select deptno, avgSal from empm]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], AVGSAL=[CAST(/(SUM($5) OVER (), COUNT($5) OVER ())):INTEGER NOT NULL])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMeasureWithoutGroupByWithOrderBy">
+    <Resource name="sql">
+      <![CDATA[with empm as
+  (select *, avg(sal) as measure avgSal from emp)
+select deptno, avgSal
+from empm
+order by 2 desc limit 3]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], AVGSAL=[$1])
+  LogicalProject(DEPTNO=[$0], AVGSAL=[M2V($1)], EXPR$2=[$2])
+    LogicalSort(sort0=[$2], dir0=[DESC], fetch=[3])
+      LogicalProject(DEPTNO=[$7], AVGSAL=[V2M(CAST(/(SUM($5), COUNT($5))):INTEGER NOT NULL)], EXPR$2=[CAST(/(SUM($5) OVER (), COUNT($5) OVER ())):INTEGER NOT NULL])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], AVGSAL=[$3])
+  LogicalSort(sort0=[$2], dir0=[ASC], fetch=[3])
+    LogicalProject(DEPTNO=[$7], AVGSAL=[V2M(CAST(/(SUM($5), COUNT($5))):INTEGER NOT NULL)], EXPR$2=[CAST(/(SUM($5) OVER (), COUNT($5) OVER ())):INTEGER NOT NULL], $f3=[CAST(/(SUM($5) OVER (), COUNT($5) OVER ())):INTEGER NOT NULL])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -4611,6 +4611,23 @@ LogicalProject(DEPTNO=[$0], COUNT_PLUS_10=[$1], MIN_JOB=[$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMeasure3b">
+    <Resource name="sql">
+      <![CDATA[select deptno, count_plus_10
+from (
+  select deptno,
+    job,
+    count(*) + 10 as measure count_plus_10,
+    count_plus_10 + deptno as measure e2
+  from emp)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], COUNT_PLUS_10=[+(COUNT() OVER (), 10)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMeasure4">
     <Resource name="sql">
       <![CDATA[select deptno, count(*) as measure c,

--- a/core/src/test/resources/sql/measure.iq
+++ b/core/src/test/resources/sql/measure.iq
@@ -216,22 +216,110 @@ from empm;
 +---------+--------+
 | A       | DEPTNO |
 +---------+--------+
-| 1100.00 |     20 |
-| 1250.00 |     30 |
-| 1250.00 |     30 |
+| 2450.00 |     10 |
+| 5000.00 |     10 |
 | 1300.00 |     10 |
-| 1500.00 |     30 |
+| 1100.00 |     20 |
+| 3000.00 |     20 |
+| 2975.00 |     20 |
+| 3000.00 |     20 |
+|  800.00 |     20 |
 | 1600.00 |     30 |
+| 2850.00 |     30 |
+|  950.00 |     30 |
+| 1250.00 |     30 |
+| 1500.00 |     30 |
+| 1250.00 |     30 |
++---------+--------+
+(14 rows)
+
+!ok
+
+# Measure in query with ORDER BY and no GROUP BY.
+# (As above, but sorted.)
+select avg_sal as a, deptno
+from empm
+order by deptno, ename;
++---------+--------+
+| A       | DEPTNO |
++---------+--------+
+| 2450.00 |     10 |
+| 5000.00 |     10 |
+| 1300.00 |     10 |
+| 1100.00 |     20 |
+| 3000.00 |     20 |
+| 2975.00 |     20 |
+| 3000.00 |     20 |
+|  800.00 |     20 |
+| 1600.00 |     30 |
+| 2850.00 |     30 |
+|  950.00 |     30 |
+| 1250.00 |     30 |
+| 1500.00 |     30 |
+| 1250.00 |     30 |
++---------+--------+
+(14 rows)
+
+!ok
+
+# Measure in query with ORDER BY and LIMIT but no GROUP BY.
+select avg_sal as a, ename, deptno
+from empm
+order by ename limit 3;
++---------+-------+--------+
+| A       | ENAME | DEPTNO |
++---------+-------+--------+
+| 1100.00 | ADAMS |     20 |
+| 1600.00 | ALLEN |     30 |
+| 2850.00 | BLAKE |     30 |
++---------+-------+--------+
+(3 rows)
+
+!ok
+
+# Measure in query with ORDER BY and LIMIT but no GROUP BY, omitting sort key.
+# (As above, but not projecting ename.)
+select avg_sal as a, deptno
+from empm
+order by ename limit 3;
++---------+--------+
+| A       | DEPTNO |
++---------+--------+
+| 1100.00 |     20 |
+| 1600.00 |     30 |
+| 2850.00 |     30 |
++---------+--------+
+(3 rows)
+
+!ok
+
+# Measure in query with ORDER and LIMIT but no GROUP BY, sorting by measure.
+select avg_sal, deptno
+from empm
+order by avg_sal desc limit 3;
++---------+--------+
+| AVG_SAL | DEPTNO |
++---------+--------+
+| 1100.00 |     20 |
+|  950.00 |     30 |
+|  800.00 |     20 |
++---------+--------+
+(3 rows)
+
+!ok
+
+# Measure in query with WHERE but no GROUP BY
+select avg_sal as a, deptno
+from empm
+where job = 'MANAGER';
++---------+--------+
+| A       | DEPTNO |
++---------+--------+
 | 2450.00 |     10 |
 | 2850.00 |     30 |
 | 2975.00 |     20 |
-| 3000.00 |     20 |
-| 3000.00 |     20 |
-| 5000.00 |     10 |
-|  800.00 |     20 |
-|  950.00 |     30 |
 +---------+--------+
-(14 rows)
+(3 rows)
 
 !ok
 


### PR DESCRIPTION
As of [CALCITE-4496], a non-aggregate query can use measures in its `SELECT` clause; this change further allows a non-aggregate query to use measures in its `ORDER BY` clause. Example:
```
  WITH empm AS
    (SELECT *, avg(sal) AS MEASURE avgSal FROM emp)
  SELECT avgSal, deptno
  FROM empm
  ORDER BY avgSal DESC LIMIT 3;
```