### PR TITLE
Remove FENNEL VM; enable some disabled tests

### DIFF
--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlOperatorFixture.java
@@ -101,7 +101,7 @@ public interface SqlOperatorFixture extends AutoCloseable {
    * Name of a virtual machine that can potentially implement an operator.
    */
   enum VmName {
-    FENNEL, JAVA, EXPAND
+    JAVA, EXPAND
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/testkit/src/main/java/org/apache/calcite/sql/test/SqlTester.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/test/SqlTester.java
@@ -55,7 +55,7 @@ public interface SqlTester extends AutoCloseable {
    * Name of a virtual machine that can potentially implement an operator.
    */
   enum VmName {
-    FENNEL, JAVA, EXPAND
+    JAVA, EXPAND
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/testkit/src/main/java/org/apache/calcite/util/TestUtil.java
+++ b/testkit/src/main/java/org/apache/calcite/util/TestUtil.java
@@ -217,7 +217,8 @@ public abstract class TestUtil {
         .replace("(", "\\(")
         .replace(")", "\\)")
         .replace("[", "\\[")
-        .replace("]", "\\]");
+        .replace("]", "\\]")
+        .replace("^", "\\^");
   }
 
   /** Removes floating-point rounding errors from the end of a string.


### PR DESCRIPTION
The VmName.FENNEL does not seem to be used anywhere, so I deleted it.
I also re-enabled a few SqlOperatorTest tests that work given recent fixes.
And fixed a tiny bug in the regex quoting code.

There are many more disabled tests that should be audited. I audited some of them, and they still fail (or I would have enabled them).