### PR TITLE
AbstractNamespace unwrap add isInstance judgments

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/AbstractNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AbstractNamespace.java
@@ -189,8 +189,11 @@ abstract class AbstractNamespace implements SqlValidatorNamespace {
     return true;
   }
 
-  @Override public <T> T unwrap(Class<T> clazz) {
-    return clazz.cast(this);
+  @Override public <T> @Nullable T unwrap(Class<T> clazz) {
+    if (clazz.isInstance(this)) {
+      return clazz.cast(this);
+    }
+    return null;
   }
 
   @Override public boolean isWrapperFor(Class<?> clazz) {


### PR DESCRIPTION
Some other classes add isInstance judgments before calling clazz.cast

![image](https://github.com/user-attachments/assets/3fcc1612-a0c3-4b6c-aedc-776eaaed4e98)
