### PR TITLE
[CALCITE-6543] Change the RelOptCostImpl toString method to be consistent with VolcanoCost

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCost.java
@@ -124,4 +124,18 @@ public interface RelOptCost {
    * good cost rendering to use during tracing.
    */
   @Override String toString();
+
+  static String toString(double value) {
+    if (value == Double.MAX_VALUE) {
+      return "{huge}";
+    } else if (value == Double.POSITIVE_INFINITY) {
+      return "{inf}";
+    } else if (value == 1.0) {
+      return "{tiny}";
+    } else if (value == 0.0) {
+      return "{0}";
+    } else {
+      return Double.toString(value);
+    }
+  }
 }

--- a/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptCostImpl.java
@@ -113,11 +113,7 @@ public class RelOptCostImpl implements RelOptCost {
 
   // implement RelOptCost
   @Override public String toString() {
-    if (value == Double.MAX_VALUE) {
-      return "huge";
-    } else {
-      return Double.toString(value);
-    }
+    return RelOptCost.toString(value);
   }
 
   /** Implementation of {@link RelOptCostFactory} that creates

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoCost.java
@@ -39,28 +39,28 @@ class VolcanoCost implements RelOptCost {
           Double.POSITIVE_INFINITY,
           Double.POSITIVE_INFINITY) {
         @Override public String toString() {
-          return "{inf}";
+          return  RelOptCost.toString(Double.POSITIVE_INFINITY);
         }
       };
 
   static final VolcanoCost HUGE =
       new VolcanoCost(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE) {
         @Override public String toString() {
-          return "{huge}";
+          return RelOptCost.toString(Double.MAX_VALUE);
         }
       };
 
   static final VolcanoCost ZERO =
       new VolcanoCost(0.0, 0.0, 0.0) {
         @Override public String toString() {
-          return "{0}";
+          return RelOptCost.toString(0.0);
         }
       };
 
   static final VolcanoCost TINY =
       new VolcanoCost(1.0, 1.0, 0.0) {
         @Override public String toString() {
-          return "{tiny}";
+          return RelOptCost.toString(1.0);
         }
       };
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/28420305-0d8f-45e4-a98a-861dc00fae9a)
