### PR TITLE
[CALCITE-6576] SqlParser: allow using table alias with column identifiers in SET section of UPDATE statement

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1820,14 +1820,14 @@ SqlNode SqlUpdate() :
     ( tableRef = TableHints(tableName) | { tableRef = tableName; } )
     [ tableRef = ExtendTable(tableRef) ]
     ( [ <AS> ] alias = SimpleIdentifier() | { alias = null; } )
-    <SET> id = SimpleIdentifier() {
+    <SET> id = CompoundIdentifier() {
         targetColumnList.add(id);
     }
     // TODO:  support DEFAULT also
     <EQ> AddExpression(sourceExpressionList, ExprContext.ACCEPT_SUB_QUERY)
     (
         <COMMA>
-        id = SimpleIdentifier() { targetColumnList.add(id); }
+        id = CompoundIdentifier() { targetColumnList.add(id); }
         <EQ> AddExpression(sourceExpressionList, ExprContext.ACCEPT_SUB_QUERY)
     )*
     ( where = Where() | { where = null; } )

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -5102,6 +5102,17 @@ public class SqlParserTest {
             + "WHERE (`EMPNO` = 12)");
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6576">[CALCITE-6576]
+   * allow using table alias with column identifiers in SET section of UPDATE statement</a>.
+   */
+  @Test void testUpdateTableAlias() {
+    final String sql = "UPDATE mytable AS t SET t.ID=1";
+    final String expected = "UPDATE `MYTABLE` AS `T` SET `T`.`ID` = 1";
+    sql(sql).ok(expected);
+  }
+
   @Test void testMergeSelectSource() {
     final String sql = "merge into emps e "
         + "using (select * from tempemps where deptno is null) t "


### PR DESCRIPTION
Changing the column identifier from `SimpleIdentifier` to `CompoundIdentifier` allows using the table alias with the column identifiers in the SET section of an UPDATE statement.