### PR TITLE
[CALCITE-6570] Add SCALAR_QUERY to sourceExpressionList of SqlUpdate

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2941,6 +2941,19 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
           SqlSelect.HAVING_OPERAND);
       registerSubQueries(selectScope2,
           SqlNonNullableAccessors.getSelectList(select));
+
+      if (enclosingNode.getKind() == SqlKind.UPDATE) {
+        registerSubQueries(selectScope2,
+            ((SqlUpdate) enclosingNode).getSourceExpressionList());
+      } else if (enclosingNode.getKind() == SqlKind.MERGE) {
+        SqlUpdate updateCall = ((SqlMerge) enclosingNode).getUpdateCall();
+
+        if (updateCall != null) {
+          registerSubQueries(selectScope2,
+              updateCall.getSourceExpressionList());
+        }
+      }
+
       final SqlNodeList orderList = select.getOrderList();
       if (orderList != null) {
         // If the query is 'SELECT DISTINCT', restrict the columns

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3121,6 +3121,18 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
 
   /**
    * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6570">[CALCITE-6570]
+   * UPDATE with sub-query that requires type cast gives AssertionError</a>.
+   */
+  @Test void testUpdateSubQueryWithCast() {
+    final String sql = "update emp\n"
+        + "set empno = (\n"
+        + "  select cast(min(empno) as BIGINT) from emp as e where e.deptno = emp.deptno)";
+    sql(sql).ok();
+  }
+
+  /**
+   * Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3229">[CALCITE-3229]
    * UnsupportedOperationException for UPDATE with IN query</a>.
    */
@@ -3210,6 +3222,20 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         + "set ename = t.ename, deptno = t.deptno, sal = t.sal * .1\n"
         + "when not matched then insert (empno, ename, deptno, sal)\n"
         + "values(t.empno, t.ename, 10, t.sal * .15)";
+    sql(sql).ok();
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6570">[CALCITE-6570]
+   * UPDATE with sub-query that requires type cast gives AssertionError</a>.
+   */
+  @Test void testMergeSubQueryWithCast() {
+    final String sql = "merge into emp t0\n"
+        + "using emp t1 ON t0.empno = t1.empno\n"
+        + "when matched then\n"
+        + "update set deptno = (select cast(deptno as BIGINT) from emp where deptno > 1)";
+
     sql(sql).ok();
   }
 

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -4711,6 +4711,28 @@ LogicalTableModify(table=[[CATALOG, SALES, EMPNULLABLES]], operation=[MERGE], up
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMergeSubQueryWithCast">
+    <Resource name="sql">
+      <![CDATA[merge into emp t0
+using emp t1 ON t0.empno = t1.empno
+when matched then
+update set deptno = (select cast(deptno as BIGINT) from emp where deptno > 1)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalTableModify(table=[[CATALOG, SALES, EMP]], operation=[MERGE], updateColumnList=[[DEPTNO]], flattened=[true])
+  LogicalProject($f0=[$18])
+    LogicalJoin(condition=[true], joinType=[left])
+      LogicalJoin(condition=[=($9, $0)], joinType=[inner])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
+        LogicalProject(EXPR$0=[CAST($7):BIGINT NOT NULL])
+          LogicalFilter(condition=[>($7, 1)])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testModeFunction">
     <Resource name="sql">
       <![CDATA[select mode(deptno)
@@ -8931,6 +8953,24 @@ LogicalTableModify(table=[[CATALOG, SALES, EMP]], operation=[UPDATE], updateColu
     LogicalJoin(condition=[=($7, $9)], joinType=[left])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalAggregate(group=[{0}], EXPR$0=[MIN($1)])
+        LogicalProject(DEPTNO=[$7], EMPNO=[$0])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateSubQueryWithCast">
+    <Resource name="sql">
+      <![CDATA[update emp
+set empno = (
+  select cast(min(empno) as BIGINT) from emp as e where e.deptno = emp.deptno)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalTableModify(table=[[CATALOG, SALES, EMP]], operation=[UPDATE], updateColumnList=[[EMPNO]], sourceExpressionList=[[CAST($0):INTEGER]], flattened=[true])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EXPR$0=[CAST($10):BIGINT])
+    LogicalJoin(condition=[=($7, $9)], joinType=[left])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{0}], agg#0=[MIN($1)])
         LogicalProject(DEPTNO=[$7], EMPNO=[$0])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>


### PR DESCRIPTION
Validation currently fails with an AssertionError on an UPDATE query with a sub-query that requires an implicit type cast. (See CALCITE-6570 for details).

Example
```sql
update emp set empno = (
    select cast(empno as BIGINT) from emp
)
```

During validation, when registering subqueries, Calcite wraps the sub-query in a SCALAR_QUERY call in `selectList` (`sqlUpdate.getSourceSelect().getSelectList()`).

But after that, `TypeCoersion` tries to coerce types for expressions in `sourceExpressionList` (see `TypeCoersionImpl.coerceSourceRowType()`), but it contains `SqlSelect` instead of `SCALAR_QUERY` call.

As a solution I added `SCALAR_QUERY` to `sourceExpressionList` as well.