### PR TITLE
[CALCITE-6581] Incorrect INTERVAL math for WEEK and QUARTER

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
@@ -575,7 +575,7 @@ public class SqlIntervalQualifier extends SqlNode {
     return new BigDecimal("0." + secondFracStr).multiply(THOUSAND);
   }
 
-  private static int[] fillIntervalValueArray(
+  private static int[] fillYearMonthIntervalValueArray(
       int sign,
       BigDecimal year,
       BigDecimal month) {
@@ -588,7 +588,7 @@ public class SqlIntervalQualifier extends SqlNode {
     return ret;
   }
 
-  private static int[] fillIntervalValueArray(
+  private static int[] fillDayTimeIntervalValueArray(
       int sign,
       BigDecimal day,
       BigDecimal hour,
@@ -636,7 +636,7 @@ public class SqlIntervalQualifier extends SqlNode {
       checkLeadFieldInRange(typeSystem, sign, year, TimeUnit.YEAR, pos);
 
       // package values up for return
-      return fillIntervalValueArray(sign, year, ZERO);
+      return fillYearMonthIntervalValueArray(sign, year, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -676,7 +676,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(sign, year, month);
+      return fillYearMonthIntervalValueArray(sign, year, month);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -711,7 +711,7 @@ public class SqlIntervalQualifier extends SqlNode {
       checkLeadFieldInRange(typeSystem, sign, month, TimeUnit.MONTH, pos);
 
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, month);
+      return fillYearMonthIntervalValueArray(sign, ZERO, month);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -746,7 +746,8 @@ public class SqlIntervalQualifier extends SqlNode {
       checkLeadFieldInRange(typeSystem, sign, quarter, TimeUnit.QUARTER, pos);
 
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, quarter);
+      final BigDecimal months = quarter.multiply(BigDecimal.valueOf(3));
+      return fillYearMonthIntervalValueArray(sign, ZERO, months);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -781,7 +782,8 @@ public class SqlIntervalQualifier extends SqlNode {
       checkLeadFieldInRange(typeSystem, sign, week, TimeUnit.WEEK, pos);
 
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, week);
+      final BigDecimal days = week.multiply(BigDecimal.valueOf(7));
+      return fillDayTimeIntervalValueArray(sign, days, ZERO, ZERO, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -816,7 +818,7 @@ public class SqlIntervalQualifier extends SqlNode {
       checkLeadFieldInRange(typeSystem, sign, day, TimeUnit.DAY, pos);
 
       // package values up for return
-      return fillIntervalValueArray(sign, day, ZERO, ZERO, ZERO, ZERO);
+      return fillDayTimeIntervalValueArray(sign, day, ZERO, ZERO, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -856,7 +858,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(sign, day, hour, ZERO, ZERO, ZERO);
+      return fillDayTimeIntervalValueArray(sign, day, hour, ZERO, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -899,7 +901,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(sign, day, hour, minute, ZERO, ZERO);
+      return fillDayTimeIntervalValueArray(sign, day, hour, minute, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -969,7 +971,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(
+      return fillDayTimeIntervalValueArray(
           sign,
           day,
           hour,
@@ -1010,7 +1012,7 @@ public class SqlIntervalQualifier extends SqlNode {
       checkLeadFieldInRange(typeSystem, sign, hour, TimeUnit.HOUR, pos);
 
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, hour, ZERO, ZERO, ZERO);
+      return fillDayTimeIntervalValueArray(sign, ZERO, hour, ZERO, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -1051,7 +1053,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, hour, minute, ZERO, ZERO);
+      return fillDayTimeIntervalValueArray(sign, ZERO, hour, minute, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -1119,7 +1121,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(
+      return fillDayTimeIntervalValueArray(
           sign,
           ZERO,
           hour,
@@ -1160,7 +1162,7 @@ public class SqlIntervalQualifier extends SqlNode {
       checkLeadFieldInRange(typeSystem, sign, minute, TimeUnit.MINUTE, pos);
 
       // package values up for return
-      return fillIntervalValueArray(sign, ZERO, ZERO, minute, ZERO, ZERO);
+      return fillDayTimeIntervalValueArray(sign, ZERO, ZERO, minute, ZERO, ZERO);
     } else {
       throw invalidValueException(pos, originalValue);
     }
@@ -1224,7 +1226,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(
+      return fillDayTimeIntervalValueArray(
           sign,
           ZERO,
           ZERO,
@@ -1291,7 +1293,7 @@ public class SqlIntervalQualifier extends SqlNode {
       }
 
       // package values up for return
-      return fillIntervalValueArray(
+      return fillDayTimeIntervalValueArray(
           sign, ZERO, ZERO, ZERO, second, secondFrac);
     } else {
       throw invalidValueException(pos, originalValue);

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserUtilTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.parser;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests {@link SqlParserUtil}. Currently, this test focuses on tests for the methods that work
+ * with {@link SqlIntervalQualifier}. It may be expanded to test other functionality in the future.
+ */
+public class SqlParserUtilTest {
+  private static final SqlParserPos POSITION = SqlParserPos.ZERO;
+
+  @Test void testSecondIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.SECOND, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2.1", qualifier), equalTo(2_100L));
+  }
+
+  @Test void testMinuteIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.MINUTE, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2", qualifier), equalTo(120_000L));
+  }
+
+  @Test void testMinuteToSecondIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.MINUTE, TimeUnit.SECOND, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2:30", qualifier), equalTo(150_000L));
+  }
+
+  @Test void testHourIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.HOUR, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2", qualifier), equalTo(7_200_000L));
+  }
+
+  @Test void testHourToMinuteIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.HOUR, TimeUnit.MINUTE, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2:03", qualifier), equalTo(7_380_000L));
+  }
+
+  @Test void testHourToSecondIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.HOUR, TimeUnit.SECOND, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2:03:30", qualifier), equalTo(7_410_000L));
+  }
+
+  @Test void testDayIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.DAY, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2", qualifier), equalTo(172_800_000L));
+  }
+
+  @Test void testDayToHourIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.HOUR, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2 1", qualifier), equalTo(176_400_000L));
+  }
+
+  @Test void testDayToMinuteIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.MINUTE, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2 1:03", qualifier), equalTo(176_580_000L));
+  }
+
+  @Test void testDayToSecondIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.SECOND, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2 1:02:30", qualifier), equalTo(176_550_000L));
+  }
+
+  @Test void testWeekIntervalToMillis() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.WEEK, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2", qualifier), equalTo(1_209_600_000L));
+  }
+
+  @Test void testMonthIntervalToMonths() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.WEEK, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMillis("2", qualifier), equalTo(1_209_600_000L));
+  }
+
+  @Test void testQuarterIntervalToMonths() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.QUARTER, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMonths("2", qualifier), equalTo(6L));
+  }
+
+  @Test void testYearIntervalToMonths() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.YEAR, null, POSITION);
+    assertThat(SqlParserUtil.intervalToMonths("2", qualifier), equalTo(24L));
+  }
+
+  @Test void testYearToMonthIntervalToMonths() {
+    final SqlIntervalQualifier qualifier =
+        new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, POSITION);
+    assertThat(SqlParserUtil.intervalToMonths("2-3", qualifier), equalTo(27L));
+  }
+}

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -1522,6 +1522,18 @@ order by empno;
 
 !ok
 
+# [CALCITE-6581] INTERVAL with WEEK and QUARTER
+select timestamp '1970-01-01' + interval '2' week as w,
+  timestamp '1970-01-01 00:00:00' + interval '2' quarter as q;
++---------------------+---------------------+
+| W                   | Q                   |
++---------------------+---------------------+
+| 1970-01-15 00:00:00 | 1970-07-01 00:00:00 |
++---------------------+---------------------+
+(1 row)
+
+!ok
+
 # [CALCITE-1486] Invalid "Invalid literal" error for complex expression
 select 8388608/(60+27.39);
 +-------------------+


### PR DESCRIPTION
WEEK and QUARTER intervals were incorrectly treated like HOUR and MONTH respectively. This patch fixes the handling, and adds unit tests.

This patch also renames the two "fillIntervalValueArray" methods to "fillDayIntervalValueArray" (for INTERVAL_DAY_TIME type intervals) and "fillYearMonthIntervalValueArray" (for INTERVAL_YEAR_MONTH type intervals) to make it more clear which one is which.