### PR TITLE
[CALCITE-6584] Validate prefixed column identifiers in SET clause of UPDATE statement

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -653,7 +653,7 @@ public class SqlValidatorUtil {
     final Table t = table == null ? null : table.unwrap(Table.class);
     if (!(t instanceof CustomColumnResolvingTable)) {
       final SqlNameMatcher nameMatcher = catalogReader.nameMatcher();
-      return nameMatcher.field(rowType, id.getSimple());
+      return nameMatcher.field(rowType, Util.last(id.names));
     }
 
     final List<Pair<RelDataTypeField, List<String>>> entries =

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -4531,6 +4531,23 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("Table 'SALES.BAD' not found");
   }
 
+    /** Test case for
+     * <a href="https://issues.apache.org/jira/browse/CALCITE-6584">[CALCITE-6584]
+     * Validate prefixed column identifiers in SET clause of UPDATE statement</a>. */
+  @Test void testAliasInSetClauseOfUpdate() {
+    // good examples
+    sql("UPDATE sales.emp AS e SET e.deptno = 10").ok();
+    sql("UPDATE emp AS e SET e.deptno = 10").ok();
+
+    // bad examples
+    sql("UPDATE sales.emp AS emp SET ^sales.emp^.deptno = 10")
+        .fails("Unknown identifier 'SALES.EMP'");
+    sql("UPDATE sales.emp AS e SET ^emp^.deptno = 10").fails("Unknown identifier 'EMP'");
+    sql("UPDATE emp AS e SET ^emp^.deptno = 10").fails("Unknown identifier 'EMP'");
+    sql("UPDATE emp AS e SET ^a.b.c.d^.deptno = 10").fails("Unknown identifier 'A.B.C.D'");
+    sql("UPDATE emp AS e SET ^dept^.deptno = 10").fails("Unknown identifier 'DEPT'");
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-881">[CALCITE-881]
    * Allow schema.table.column references in GROUP BY</a>. */


### PR DESCRIPTION
This PR adds validation of prefixed column identifiers in SET clause of UPDATE statement (and in the UPDATE statement within a MERGE statement)

- This is a follow-up PR to https://github.com/apache/calcite/pull/3959
- I first had to change `SqlValidatorUtil.addFields()` to use the `Util.last()` method for getting the last element of a compound identifier instead of relying on simple identifiers
- I then implemented a validation logic in `SqlValidatorImpl.createTargetRowType()` which is being used for validating INSERT, UPDATE and MERGE
- in presence of the new `targetTableAlias` parameter the validation logic checks the prefix of any non-simple identifiers or in other words it checks that any prefixed column identifiers are prefixed with the target table alias
- I tried to check for any existing validation logic that I could reuse and it's possible I might have missed a utility method that I could have used.
- The validation logic supports a mix of prefixed and unprefixed columns in the SET clause. Not sure if I should only allow prefixed columns here.

Let me know your thoughts.