### PR TITLE
[CALCITE-6586] Some Rules not firing due to RelMdPredicates returning…

### DIFF
--- a/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowTranslator.java
+++ b/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowTranslator.java
@@ -228,6 +228,8 @@ class ArrowTranslator {
       }
     } else if (String.class.equals(literal.getClass())) {
       return "string";
+    } else if (literal instanceof Double) {
+      return "float";
     }
     throw new UnsupportedOperationException("Unsupported literal " + literal);
   }

--- a/arrow/src/test/java/org/apache/calcite/adapter/arrow/ArrowAdapterTest.java
+++ b/arrow/src/test/java/org/apache/calcite/adapter/arrow/ArrowAdapterTest.java
@@ -373,7 +373,7 @@ class ArrowAdapterTest {
     String sql = "select * from arrowdata\n"
         + " where \"floatField\"=15.0";
     String plan = "PLAN=ArrowToEnumerableConverter\n"
-        + "  ArrowFilter(condition=[=(CAST($2):DOUBLE, 15.0)])\n"
+        + "  ArrowFilter(condition=[=(CAST($2):DOUBLE, 15.0E0)])\n"
         + "    ArrowTableScan(table=[[ARROW, ARROWDATA]], fields=[[0, 1, 2, 3]])\n\n";
     String result = "intField=15; stringField=15; floatField=15.0; longField=15\n";
 

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraRules.java
@@ -300,8 +300,7 @@ public class CassandraRules {
 
     public RelNode convert(Sort sort, CassandraFilter filter) {
       final RelTraitSet traitSet =
-          sort.getTraitSet().replace(CassandraRel.CONVENTION)
-              .replace(sort.getCollation());
+          sort.getTraitSet().replace(CassandraRel.CONVENTION);
       return new CassandraSort(sort.getCluster(), traitSet,
           convert(sort.getInput(), traitSet.replace(RelCollations.EMPTY)),
           sort.getCollation());

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSort.java
@@ -60,7 +60,7 @@ public class CassandraSort extends Sort implements CassandraRel {
 
   @Override public Sort copy(RelTraitSet traitSet, RelNode input,
       RelCollation newCollation, @Nullable RexNode offset, @Nullable RexNode fetch) {
-    return new CassandraSort(getCluster(), traitSet, input, collation);
+    return new CassandraSort(getCluster(), traitSet, input, newCollation);
   }
 
   @Override public void implement(Implementor implementor) {

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitSortRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimitSortRule.java
@@ -42,7 +42,9 @@ public class EnumerableLimitSortRule extends RelRule<EnumerableLimitSortRule.Con
     final Sort sort = call.rel(0);
     RelNode input = sort.getInput();
     final Sort o =
-        EnumerableLimitSort.create(
+        new EnumerableLimitSort(
+            sort.getCluster(),
+            sort.getTraitSet().replace(EnumerableConvention.INSTANCE),
             convert(call.getPlanner(), input,
                 input.getTraitSet().replace(EnumerableConvention.INSTANCE)),
             sort.getCollation(), sort.offset, sort.fetch);

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSort.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSort.java
@@ -58,6 +58,14 @@ public class EnumerableSort extends Sort implements EnumerableRel {
         fetch);
   }
 
+  /** Creates an EnumerableSort. */
+  public static EnumerableSort create(RelNode child, RelCollation collation,
+      RelTraitSet traitSet, @Nullable RexNode offset, @Nullable RexNode fetch) {
+    final RelOptCluster cluster = child.getCluster();
+    return new EnumerableSort(cluster, traitSet, child, collation, offset,
+        fetch);
+  }
+
   @Override public EnumerableSort copy(
       RelTraitSet traitSet,
       RelNode newInput,

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSortRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSortRule.java
@@ -52,6 +52,7 @@ class EnumerableSortRule extends ConverterRule {
             input,
             input.getTraitSet().replace(EnumerableConvention.INSTANCE)),
         sort.getCollation(),
+        sort.getTraitSet().replace(EnumerableConvention.INSTANCE),
         null,
         null);
   }

--- a/core/src/main/java/org/apache/calcite/plan/RelCompositeTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelCompositeTrait.java
@@ -63,8 +63,9 @@ class RelCompositeTrait<T extends RelMultipleTrait> implements RelTrait {
     } else if (traitList.size() == 1) {
       return def.canonize(traitList.get(0));
     } else {
+      // make sure traits in RelCompositeTrait is strictly ordered
       final RelMultipleTrait[] traits =
-          traitList.toArray(new RelMultipleTrait[0]);
+          traitList.stream().sorted().toArray(RelMultipleTrait[]::new);
       for (int i = 0; i < traits.length; i++) {
         traits[i] = (T) def.canonize(traits[i]);
       }

--- a/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTraitSet.java
@@ -562,6 +562,10 @@ public final class RelTraitSet extends AbstractList<RelTrait> {
   public boolean containsIfApplicable(RelTrait trait) {
     // Note that '==' is sufficient, because trait should be canonized.
     final RelTrait trait1 = getTrait(trait.getTraitDef());
+    if (trait1 instanceof RelCompositeTrait) {
+      List<RelMultipleTrait> traitList = ((RelCompositeTrait) trait1).traitList();
+      return traitList.contains(trait);
+    }
     return trait1 == null || trait1 == trait;
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Sort.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Sort.java
@@ -85,7 +85,7 @@ public abstract class Sort extends SingleRel implements Hintable {
     this.fetch = fetch;
     this.hints = ImmutableList.copyOf(hints);
 
-    assert traits.containsIfApplicable(collation)
+    assert collation.getFieldCollations().isEmpty() || traits.containsIfApplicable(collation)
             : "traits=" + traits + ", collation=" + collation;
     assert !(fetch == null
             && offset == null

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalSort.java
@@ -68,9 +68,13 @@ public final class LogicalSort extends Sort {
   public static LogicalSort create(RelNode input, RelCollation collation,
       @Nullable RexNode offset, @Nullable RexNode fetch) {
     RelOptCluster cluster = input.getCluster();
-    collation = RelCollationTraitDef.INSTANCE.canonize(collation);
-    RelTraitSet traitSet =
-        input.getTraitSet().replace(Convention.NONE).replace(collation);
+    final RelCollation canonize = RelCollationTraitDef.INSTANCE.canonize(collation);
+
+    RelTraitSet traitSet = input.getTraitSet().replace(Convention.NONE);
+    if (!canonize.getFieldCollations().isEmpty()) {
+      // Preserve input collation if only offset and fetch
+      traitSet = traitSet.replaceIf(RelCollationTraitDef.INSTANCE, () -> canonize);
+    }
     return new LogicalSort(cluster, traitSet, input, collation, offset, fetch);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdCollation.java
@@ -207,8 +207,10 @@ public class RelMdCollation
 
   public @Nullable ImmutableList<RelCollation> collations(Sort sort,
       RelMetadataQuery mq) {
-    return copyOf(
-        RelMdCollation.sort(sort.getCollation()));
+    List<RelCollation> collations =
+        Util.first(sort.getTraitSet().getTraits(RelCollationTraitDef.INSTANCE),
+            RelMdCollation.sort(sort.getCollation()));
+    return copyOf(collations);
   }
 
   public @Nullable ImmutableList<RelCollation> collations(SortExchange sort,

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdPredicates.java
@@ -607,7 +607,9 @@ public class RelMdPredicates
   public RelOptPredicateList getPredicates(RelSubset r,
       RelMetadataQuery mq) {
     if (!Bug.CALCITE_1048_FIXED) {
-      return RelOptPredicateList.EMPTY;
+      // FIXME: This is a short-term fix and may disable some applicable rules.
+      // A complete solution will come with [CALCITE-1048].
+      return mq.getPulledUpPredicates(r.stripped());
     }
     final RexBuilder rexBuilder = r.getCluster().getRexBuilder();
     RelOptPredicateList list = null;

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1498,7 +1498,7 @@ public abstract class SqlImplementor {
     case EXACT_NUMERIC: {
       if (SqlTypeName.APPROX_TYPES.contains(typeName)) {
         return SqlLiteral.createApproxNumeric(
-            castNonNull(literal.getValueAs(BigDecimal.class)).toPlainString(), POS);
+            castNonNull(literal.getValueAs(Double.class)).toString(), POS);
       } else {
         return SqlLiteral.createExactNumeric(
             castNonNull(literal.getValueAs(BigDecimal.class)).toPlainString(), POS);

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortRemoveRule.java
@@ -62,6 +62,11 @@ public class SortRemoveRule
       // Don't remove sort if would also remove OFFSET or LIMIT.
       return;
     }
+
+    // Composite trait not support in change trait
+    if (!sort.getTraitSet().allSimple()) {
+      return;
+    }
     // Express the "sortedness" requirement in terms of a collation trait and
     // we can get rid of the sort. This allows us to use rels that just happen
     // to be sorted but get the same effect.

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -480,7 +480,7 @@ public class RelBuilder {
       return rexBuilder.makeExactLiteral((BigDecimal) value);
     } else if (value instanceof Float || value instanceof Double) {
       return rexBuilder.makeApproxLiteral(
-          BigDecimal.valueOf(((Number) value).doubleValue()));
+          ((Number) value).doubleValue(), getTypeFactory().createSqlType(SqlTypeName.DOUBLE));
     } else if (value instanceof Number) {
       return rexBuilder.makeExactLiteral(
           BigDecimal.valueOf(((Number) value).longValue()));

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -535,6 +535,21 @@ public class Util {
   }
 
   /**
+   * Formats a double value to a String ensuring that the output
+   * is in scientific notation if the value is not "special".
+   * (Special values include infinities and NaN.)
+   */
+  public static String toScientificNotation(Double d) {
+    String repr = Double.toString(d);
+    if (!repr.toLowerCase(Locale.ENGLISH).contains("e")
+        && !d.isInfinite()
+        && !d.isNaN()) {
+      repr += "E0";
+    }
+    return repr;
+  }
+
+  /**
    * Formats a {@link BigDecimal} value to a string in scientific notation For
    * example<br>
    *
@@ -558,6 +573,10 @@ public class Util {
     int len = unscaled.length();
     int scale = bd.scale();
     int e = len - scale - 1;
+    if (bd.stripTrailingZeros().equals(BigDecimal.ZERO)) {
+      // Without this adjustment 0.0 generates 0E-1
+      e = 0;
+    }
 
     StringBuilder ret = new StringBuilder();
     if (bd.signum() < 0) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -407,7 +407,7 @@ class RelToSqlConverterTest {
         + "where \"net_weight\" <> 10 or \"net_weight\" is null";
     final String expected = "SELECT \"product_id\", \"shelf_width\"\n"
         + "FROM \"foodmart\".\"product\"\n"
-        + "WHERE \"net_weight\" <> 10 OR \"net_weight\" IS NULL";
+        + "WHERE \"net_weight\" <> CAST(10 AS DOUBLE) OR \"net_weight\" IS NULL";
     sql(query).ok(expected);
   }
 
@@ -4391,7 +4391,7 @@ class RelToSqlConverterTest {
         + "  select \"product_id\", 0 as \"net_weight\"\n"
         + "  from \"sales_fact_1997\") t0";
     final String expected = "SELECT SUM(CASE WHEN \"product_id\" = 0"
-        + " THEN \"net_weight\" ELSE 0 END) AS \"NET_WEIGHT\"\n"
+        + " THEN \"net_weight\" ELSE 0E0 END) AS \"NET_WEIGHT\"\n"
         + "FROM (SELECT \"product_id\", \"net_weight\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "UNION ALL\n"
@@ -6507,7 +6507,7 @@ class RelToSqlConverterTest {
         + "PATTERN (\"STRT\" \"DOWN\" + \"UP\" +)\n"
         + "DEFINE "
         + "\"DOWN\" AS PREV(\"DOWN\".\"net_weight\", 0) = "
-        + "0 OR PREV(\"DOWN\".\"net_weight\", 0) = 1, "
+        + "CAST(0 AS DOUBLE) OR PREV(\"DOWN\".\"net_weight\", 0) = CAST(1 AS DOUBLE), "
         + "\"UP\" AS PREV(\"UP\".\"net_weight\", 0) > "
         + "PREV(\"UP\".\"net_weight\", 1))";
     sql(sql).ok(expected);

--- a/core/src/test/java/org/apache/calcite/rex/RexExecutorTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexExecutorTest.java
@@ -389,9 +389,11 @@ class RexExecutorTest {
       final RexCall first =
           (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.LN,
           rexBuilder.makeLiteral(3, integer, true));
+      // Division by zero causes an exception during evaluation
       final RexCall second =
-          (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.LN,
-          rexBuilder.makeLiteral(-2, integer, true));
+          (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE_INTEGER,
+              rexBuilder.makeLiteral(-2, integer, true),
+              rexBuilder.makeLiteral(0, integer, true));
       executor.reduce(rexBuilder, ImmutableList.of(first, second),
           reducedValues);
       assertThat(reducedValues, hasSize(2));

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -389,7 +389,7 @@ public class JdbcTest {
               + "expr#7=[null:JavaType(class java.lang.Integer)], "
               + "empid=[$t3], deptno=[$t4], name=[$t5], salary=[$t6], "
               + "commission=[$t7])\n"
-              + "    EnumerableValues(tuples=[[{ 'Fred', 56, 123.4 }]])\n";
+              + "    EnumerableValues(tuples=[[{ 'Fred', 56, 123.4000015258789E0 }]])\n";
           assertThat(resultSet.getString(1), isLinux(expected));
 
           // With named columns

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3176,12 +3176,13 @@ public class JdbcTest {
         .enable(CalciteAssert.DB != CalciteAssert.DatabaseInstance.ORACLE)
         .explainContains(""
             + "EnumerableAggregate(group=[{0}], m0=[COUNT($1)])\n"
-            + "  EnumerableAggregate(group=[{1, 3}])\n"
-            + "    EnumerableHashJoin(condition=[=($0, $2)], joinType=[inner])\n"
-            + "      EnumerableCalc(expr#0..9=[{inputs}], expr#10=[CAST($t4):INTEGER], expr#11=[1997], expr#12=[=($t10, $t11)], time_id=[$t0], the_year=[$t4], $condition=[$t12])\n"
-            + "        EnumerableTableScan(table=[[foodmart2, time_by_day]])\n"
-            + "      EnumerableCalc(expr#0..7=[{inputs}], time_id=[$t1], unit_sales=[$t7])\n"
-            + "        EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])")
+            + "  EnumerableCalc(expr#0=[{inputs}], expr#1=[1997:SMALLINT], expr#2=[CAST($t1):SMALLINT], c0=[$t2], unit_sales=[$t0])\n"
+            + "    EnumerableAggregate(group=[{1}])\n"
+            + "      EnumerableHashJoin(condition=[=($0, $2)], joinType=[semi])\n"
+            + "        EnumerableCalc(expr#0..7=[{inputs}], time_id=[$t1], unit_sales=[$t7])\n"
+            + "          EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])\n"
+            + "        EnumerableCalc(expr#0..9=[{inputs}], expr#10=[CAST($t4):INTEGER], expr#11=[1997], expr#12=[=($t10, $t11)], time_id=[$t0], the_year=[$t4], $condition=[$t12])\n"
+            + "          EnumerableTableScan(table=[[foodmart2, time_by_day]])\n")
         .returns("c0=1997; m0=6\n");
   }
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1377,6 +1377,17 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  @Test void testSortRemoveAllKeysConstantInVolcano() {
+    final String sql = "select count(*) as c\n"
+        + "from sales.emp\n"
+        + "where deptno = 10\n"
+        + "group by deptno, sal\n"
+        + "order by deptno desc nulls last";
+    sql(sql)
+        .withVolcanoPlanner(false)
+        .check();
+  }
+
   @Test void testSortRemovalOneKeyConstant() {
     final String sql = "select count(*) as c\n"
         + "from sales.emp\n"

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3341,6 +3341,33 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-2067">
+   * [CALCITE-2067] RexLiteral cannot represent accurately floating point values,
+   * including NaN, Infinity</a>. */
+  @Test public void testDoubleReduction() {
+    // Without the fix for CALCITE-2067 the result returned below is
+    // 1008618.49.  Ironically, that result is more accurate; however
+    // it is not the result returned by the pow() function, which is
+    // 1008618.4899999999
+    final String sql = "SELECT power(1004.3, 2)";
+    sql(sql)
+        .withRule(CoreRules.PROJECT_REDUCE_EXPRESSIONS)
+        .check();
+  }
+
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-2067">
+   * [CALCITE-2067] RexLiteral cannot represent accurately floating point values,
+   * including NaN, Infinity</a>. */
+  @Test public void testDoubleReduction2() {
+    // Without the fix for CALCITE-2067 the following expression is not
+    // reduced to Infinity, since Infinity cannot be represented
+    // as a BigDecimal value.
+    final String sql2 = "SELECT 1.0 / 0.0e0";
+    sql(sql2)
+        .withRule(CoreRules.PROJECT_REDUCE_EXPRESSIONS)
+        .check();
+  }
+
   /** Tests that {@link UnionMergeRule} does nothing if its arguments have
    * are different set operators, {@link Union} and {@link Intersect}. */
   @Test void testMergeSetOpMixed() {

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -108,6 +108,7 @@ import java.util.function.UnaryOperator;
 
 import static org.apache.calcite.test.Matchers.isLinux;
 import static org.apache.calcite.util.ReflectUtil.isStatic;
+import static org.apache.calcite.util.TestUtil.assertThatScientific;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -161,6 +162,10 @@ class UtilTest {
   @Test void testScientificNotation() {
     BigDecimal bd;
 
+    bd = new BigDecimal("0.0");
+    TestUtil.assertEqualsVerbose(
+        "0E0",
+        Util.toScientificNotation(bd));
     bd = new BigDecimal("0.001234");
     TestUtil.assertEqualsVerbose(
         "1.234E-3",
@@ -207,6 +212,28 @@ class UtilTest {
     TestUtil.assertEqualsVerbose(
         "-1.2345678901234567890E0",
         Util.toScientificNotation(bd));
+  }
+
+  @Test void testDoubleScientificNotation() {
+    assertThatScientific("0.001234", is("0.001234E0"));
+    assertThatScientific("0.001", is("0.001E0"));
+    assertThatScientific("-0.001", is("-0.001E0"));
+    assertThatScientific("1", is("1.0E0"));
+    assertThatScientific("-1", is("-1.0E0"));
+    assertThatScientific("1.0", is("1.0E0"));
+    assertThatScientific("12345", is("12345.0E0"));
+    assertThatScientific("12345.00", is("12345.0E0"));
+    assertThatScientific("12345.001", is("12345.001E0"));
+
+    // test truncate
+    assertThatScientific("1.23456789012345678901", is("1.2345678901234567E0"));
+    assertThatScientific("-1.23456789012345678901", is("-1.2345678901234567E0"));
+
+    // special values
+    assertThatScientific("Infinity", is("Infinity"));
+    assertThatScientific("-Infinity", is("-Infinity"));
+    assertThatScientific("NaN", is("NaN"));
+    assertThatScientific("-0.0", is("-0.0E0"));
   }
 
   @Test void testToJavaId() throws UnsupportedEncodingException {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1566,7 +1566,7 @@ case when cast(ename as double) < 5 then 0.0
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(T=[CASE(<(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE, 5), 0.0:DOUBLE, CASE(IS NOT NULL(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE), CAST(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE):DOUBLE NOT NULL, 1.0:DOUBLE))])
+LogicalProject(T=[CASE(<(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE, 5), 0.0E0:DOUBLE, CASE(IS NOT NULL(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE), CAST(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE):DOUBLE NOT NULL, 1.0E0:DOUBLE))])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
@@ -3026,6 +3026,40 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM($3)], EXPR$2=[MIN($4)], EXPR$3=[COUNT(
 LogicalFilter(condition=[false])
   LogicalAggregate(group=[{}], agg#0=[COUNT()])
     LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDoubleReduction">
+    <Resource name="sql">
+      <![CDATA[SELECT power(1004.3, 2)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[POWER(1004.3:DECIMAL(5, 1), 2)])
+  LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[1008618.4899999999E0:DOUBLE])
+  LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDoubleReduction2">
+    <Resource name="sql">
+      <![CDATA[SELECT 1.0 / 0.0e0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[/(1.0:DECIMAL(2, 1), 0.0E0:DOUBLE)])
+  LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[Infinity:DOUBLE])
+  LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
   </TestCase>
@@ -12257,13 +12291,13 @@ from emp]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(NEWCOL=[CASE(false, 2.1:FLOAT, 1:FLOAT)])
+LogicalProject(NEWCOL=[CASE(false, CAST(2.1:DECIMAL(2, 1)):FLOAT NOT NULL, CAST(1):FLOAT NOT NULL)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(NEWCOL=[1E0:FLOAT])
+LogicalProject(NEWCOL=[1.0E0:FLOAT])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
@@ -16484,9 +16518,9 @@ LogicalProject(DEPTNO=[$0], NAME=[$1])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
     LogicalAggregate(group=[{0}])
       LogicalUnion(all=[true])
-        LogicalValues(tuples=[[{ 12 }]])
-        LogicalValues(tuples=[[{ 34 }]])
-        LogicalValues(tuples=[[{ 56.4 }]])
+        LogicalValues(tuples=[[{ 12.0E0 }]])
+        LogicalValues(tuples=[[{ 34.0E0 }]])
+        LogicalValues(tuples=[[{ 56.4E0 }]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -16496,7 +16530,7 @@ LogicalProject(DEPTNO=[$0], NAME=[$1])
     LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[CAST($0):DOUBLE NOT NULL])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
     LogicalAggregate(group=[{0}])
-      LogicalValues(tuples=[[{ 12 }, { 34 }, { 56.4 }]])
+      LogicalValues(tuples=[[{ 12.0E0 }, { 34.0E0 }, { 56.4E0 }]])
 ]]>
     </Resource>
   </TestCase>
@@ -16514,15 +16548,15 @@ LogicalProject(EXPR$0=[CAST(OR(AND(IS NOT NULL($6), <>($2, 0)), AND(<($3, $2), n
         LogicalAggregate(group=[{}], agg#0=[COUNT()], agg#1=[COUNT($0)])
           LogicalProject(EXPR$0=[$0], $f1=[true])
             LogicalUnion(all=[true])
-              LogicalValues(tuples=[[{ 12 }]])
-              LogicalValues(tuples=[[{ 34 }]])
-              LogicalValues(tuples=[[{ 56.4 }]])
+              LogicalValues(tuples=[[{ 12.0E0 }]])
+              LogicalValues(tuples=[[{ 34.0E0 }]])
+              LogicalValues(tuples=[[{ 56.4E0 }]])
     LogicalAggregate(group=[{0}], agg#0=[MIN($1)])
       LogicalProject(EXPR$0=[$0], $f1=[true])
         LogicalUnion(all=[true])
-          LogicalValues(tuples=[[{ 12 }]])
-          LogicalValues(tuples=[[{ 34 }]])
-          LogicalValues(tuples=[[{ 56.4 }]])
+          LogicalValues(tuples=[[{ 12.0E0 }]])
+          LogicalValues(tuples=[[{ 34.0E0 }]])
+          LogicalValues(tuples=[[{ 56.4E0 }]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -16534,10 +16568,10 @@ LogicalProject(EXPR$0=[CAST(OR(AND(IS NOT NULL($6), <>($2, 0)), AND(<($3, $2), n
         LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
         LogicalAggregate(group=[{}], agg#0=[COUNT()], agg#1=[COUNT($0)])
           LogicalProject(EXPR$0=[$0], $f1=[true])
-            LogicalValues(tuples=[[{ 12 }, { 34 }, { 56.4 }]])
+            LogicalValues(tuples=[[{ 12.0E0 }, { 34.0E0 }, { 56.4E0 }]])
     LogicalAggregate(group=[{0}], agg#0=[MIN($1)])
       LogicalProject(EXPR$0=[$0], $f1=[true])
-        LogicalValues(tuples=[[{ 12 }, { 34 }, { 56.4 }]])
+        LogicalValues(tuples=[[{ 12.0E0 }, { 34.0E0 }, { 56.4E0 }]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -15044,6 +15044,34 @@ LogicalProject(C=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSortRemoveAllKeysConstantInVolcano">
+    <Resource name="sql">
+      <![CDATA[select count(*) as c
+from sales.emp
+where deptno = 10
+group by deptno, sal
+order by deptno desc nulls last]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(C=[$0])
+  LogicalSort(sort0=[$1], dir0=[DESC-nulls-last])
+    LogicalProject(C=[$2], DEPTNO=[$0])
+      LogicalAggregate(group=[{0, 1}], C=[COUNT()])
+        LogicalProject(DEPTNO=[$7], SAL=[$5])
+          LogicalFilter(condition=[=($7, 10)])
+            LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+EnumerableProject(C=[$2])
+  EnumerableAggregate(group=[{5, 7}], C=[COUNT()])
+    EnumerableFilter(condition=[=($7, 10)])
+      EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSortRemoveConstantKeyDoesNotRemoveOrderByRand">
     <Resource name="sql">
       <![CDATA[SELECT ename FROM emp ORDER BY RAND()]]>

--- a/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
@@ -158,11 +158,11 @@ LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[
     LogicalUnion(all=[false])
       LogicalUnion(all=[false])
         LogicalUnion(all=[false])
-          LogicalValues(tuples=[[{ 'a', 1, 1, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
-          LogicalValues(tuples=[[{ 'b', 2, 2, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
-        LogicalValues(tuples=[[{ 'c', 3, 3, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
-      LogicalValues(tuples=[[{ 'd', 4, 4, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
-    LogicalValues(tuples=[[{ 'e', 5, 5, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+          LogicalValues(tuples=[[{ 'a', 1, 1, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+          LogicalValues(tuples=[[{ 'b', 2, 2, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+        LogicalValues(tuples=[[{ 'c', 3, 3, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+      LogicalValues(tuples=[[{ 'd', 4, 4, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+    LogicalValues(tuples=[[{ 'e', 5, 5, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
 ]]>
     </Resource>
   </TestCase>
@@ -173,7 +173,7 @@ LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[
     <Resource name="plan">
       <![CDATA[
 LogicalTableModify(table=[[CATALOG, SALES, T1]], operation=[INSERT], flattened=[false])
-  LogicalValues(tuples=[[{ 'a', 1, 1, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'b', 2, 2, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'c', 3, 3, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'd', 4, 4, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'e', 5, 5, 0, 0, 0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
+  LogicalValues(tuples=[[{ 'a', 1, 1, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'b', 2, 2, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'c', 3, 3, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'd', 4, 4, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }, { 'e', 5, 5, 0, 0.0E0, 0.0E0, 0, 2021-11-28 00:00:00, 2021-11-28, X'0a', false }]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/cast.iq
+++ b/core/src/test/resources/sql/cast.iq
@@ -131,7 +131,7 @@ values cast('-123.45' as double);
 (1 row)
 
 !ok
-EnumerableValues(tuples=[[{ -1.2345E2 }]])
+EnumerableValues(tuples=[[{ -123.45E0 }]])
 !plan
 
 values cast('false' as boolean);

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -922,10 +922,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project literal IN null non-correlated
@@ -958,10 +957,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS FALSE($t2)], expr#5=[null:BOOLEA
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null IN literal non-correlated
@@ -994,10 +992,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null IN required
@@ -1030,10 +1027,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null IN nullable
@@ -1066,10 +1062,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project literal IN required
@@ -1135,10 +1130,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS FALSE($t2)], expr#5=[null:BOOLEA
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t0, $t4)], cs=[$t3], $condition=[$t5])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t0, $t4)], cs=[$t3], $condition=[$t5])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null NOT IN null non-correlated
@@ -1171,10 +1165,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[null:BOOLEAN
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project literal NOT IN null non-correlated
@@ -1207,10 +1200,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[IS FALSE($t2
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null NOT IN literal non-correlated
@@ -1243,10 +1235,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[null:BOOLEAN
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null NOT IN required
@@ -1279,10 +1270,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[null:BOOLEAN
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null NOT IN nullable
@@ -1315,10 +1305,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[null:BOOLEAN
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project literal NOT IN required
@@ -1384,10 +1373,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[IS FALSE($t2
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t0, $t4)], cs=[$t3], $condition=[$t5])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t0, $t4)], cs=[$t3], $condition=[$t5])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test project null IN required is unknown
@@ -1420,10 +1408,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null IN null
@@ -1571,10 +1558,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], SAL=[$t1], $conditio
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter literal NOT IN null non-correlated
@@ -1592,10 +1578,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[NOT($t2)], e
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[false], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null NOT IN literal non-correlated
@@ -1613,10 +1598,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], SAL=[$t1], $conditio
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null NOT IN required
@@ -1634,10 +1618,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], SAL=[$t1], $conditio
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null NOT IN nullable
@@ -1655,10 +1638,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], SAL=[$t1], $conditio
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter literal NOT IN required
@@ -1676,10 +1658,8 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[NOT($t2)], e
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t4, $t0)], cs=[$t3], $condition=[$t5])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[1:BIGINT], expr#5=[10], expr#6=[=($t5, $t0)], cs=[$t3], $f1=[$t4], $condition=[$t6])
+        EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter literal NOT IN nullable
@@ -1697,10 +1677,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[IS NULL($t3)], expr#5=[NOT($t2)], e
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t0, $t4)], cs=[$t3], $condition=[$t5])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], expr#4=[10], expr#5=[=($t0, $t4)], cs=[$t3], $condition=[$t5])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test filter null IN required is unknown
@@ -1732,10 +1711,9 @@ EnumerableCalc(expr#0..3=[{inputs}], expr#4=[null:BOOLEAN], expr#5=[IS NOT NULL(
     EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], SAL=[$t5])
       EnumerableTableScan(table=[[scott, EMP]])
     EnumerableLimit(fetch=[1])
-      EnumerableSort(sort0=[$0], dir0=[DESC])
-        EnumerableAggregate(group=[{0}], c=[COUNT()])
-          EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
-            EnumerableTableScan(table=[[scott, DEPT]])
+      EnumerableAggregate(group=[{0}], c=[COUNT()])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[true], cs=[$t3])
+          EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 #-------------------------------
@@ -2970,11 +2948,10 @@ EnumerableCalc(expr#0..1=[{inputs}], expr#2=[IS NULL($t1)], DEPTNO=[$t0], $condi
   EnumerableNestedLoopJoin(condition=[true], joinType=[left])
     EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
       EnumerableTableScan(table=[[scott, DEPT]])
-    EnumerableAggregate(group=[{0}])
-      EnumerableCalc(expr#0..1=[{inputs}], expr#2=[true], expr#3=[1], expr#4=[>($t1, $t3)], i=[$t2], $condition=[$t4])
-        EnumerableAggregate(group=[{7}], c=[COUNT()])
-          EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t7):INTEGER], expr#9=[35], expr#10=[=($t8, $t9)], proj#0..7=[{exprs}], $condition=[$t10])
-            EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..1=[{inputs}], expr#2=[true], expr#3=[1], expr#4=[>($t1, $t3)], i=[$t2], $condition=[$t4])
+      EnumerableAggregate(group=[{7}], c=[COUNT()])
+        EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t7):INTEGER], expr#9=[35], expr#10=[=($t8, $t9)], proj#0..7=[{exprs}], $condition=[$t10])
+          EnumerableTableScan(table=[[scott, EMP]])
 !plan
 
 # Previous, as scalar sub-query.
@@ -2996,11 +2973,10 @@ EnumerableCalc(expr#0..1=[{inputs}], expr#2=[IS NULL($t1)], DEPTNO=[$t0], U=[$t2
   EnumerableNestedLoopJoin(condition=[true], joinType=[left])
     EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
       EnumerableTableScan(table=[[scott, DEPT]])
-    EnumerableAggregate(group=[{0}])
-      EnumerableCalc(expr#0..1=[{inputs}], expr#2=[true], expr#3=[1], expr#4=[>($t1, $t3)], i=[$t2], $condition=[$t4])
-        EnumerableAggregate(group=[{7}], c=[COUNT()])
-          EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t7):INTEGER], expr#9=[35], expr#10=[=($t8, $t9)], proj#0..7=[{exprs}], $condition=[$t10])
-            EnumerableTableScan(table=[[scott, EMP]])
+    EnumerableCalc(expr#0..1=[{inputs}], expr#2=[true], expr#3=[1], expr#4=[>($t1, $t3)], i=[$t2], $condition=[$t4])
+      EnumerableAggregate(group=[{7}], c=[COUNT()])
+        EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t7):INTEGER], expr#9=[35], expr#10=[=($t8, $t9)], proj#0..7=[{exprs}], $condition=[$t10])
+          EnumerableTableScan(table=[[scott, EMP]])
 !plan
 
 # singleton keys which a uniqueness constraint indicates that the relation is already unique.
@@ -3702,16 +3678,16 @@ select deptno from dept d1 where exists (
 (4 rows)
 
 !ok
-EnumerableCalc(expr#0..3=[{inputs}], DEPTNO=[$t2])
-  EnumerableHashJoin(condition=[AND(=($0, $2), =($1, $3))], joinType=[inner])
+EnumerableCalc(expr#0..1=[{inputs}], DEPTNO=[$t0])
+  EnumerableHashJoin(condition=[AND(=($0, $2), =($1, $3))], joinType=[semi])
+    EnumerableCalc(expr#0..2=[{inputs}], proj#0..1=[{exprs}])
+      EnumerableTableScan(table=[[scott, DEPT]])
     EnumerableCalc(expr#0..2=[{inputs}], proj#0..1=[{exprs}])
       EnumerableMergeJoin(condition=[=($0, $2)], joinType=[inner])
         EnumerableCalc(expr#0..2=[{inputs}], DEPTNO=[$t0])
           EnumerableTableScan(table=[[scott, DEPT]])
         EnumerableCalc(expr#0..2=[{inputs}], expr#3=[IS NOT NULL($t1)], DNAME=[$t1], DEPTNO=[$t0], $condition=[$t3])
           EnumerableTableScan(table=[[scott, DEPT]])
-    EnumerableCalc(expr#0..2=[{inputs}], proj#0..1=[{exprs}])
-      EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
 # Test case for CALCITE-5683 which throws an exception during the de-correlation phase

--- a/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
+++ b/druid/src/main/java/org/apache/calcite/adapter/druid/DruidExpressions.java
@@ -33,6 +33,7 @@ import com.google.common.primitives.Chars;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -136,8 +137,11 @@ public class DruidExpressions {
         // deal with this for now
         return null;
       } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
+        // This conversion is lossy for Double values.
+        // However, Druid does not support floating point literal values
+        // if they are formatted using scientific notation.
         return DruidExpressions.numberLiteral(
-            requireNonNull((Number) RexLiteral.value(rexNode)));
+            requireNonNull((RexLiteral) rexNode).getValueAs(BigDecimal.class));
       } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getFamily()) {
         // Calcite represents DAY-TIME intervals in milliseconds.
         final long milliseconds =

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
@@ -2634,7 +2634,10 @@ public class DruidAdapter2IT {
         + "from \"foodmart\" "
         + "where cast(\"product_id\" as double) = 1016.0";
     final String plan = "PLAN=EnumerableInterpreter\n"
-        + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], filter=[=(CAST($1):DOUBLE, 1016.0)], projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
+        + "  DruidQuery(table=[[foodmart, foodmart]], "
+        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
+        + "filter=[=(CAST($1):DOUBLE, 1016.0E0)], "
+        + "projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
     final String druidQuery =
         "{'queryType':'timeseries','dataSource':'foodmart','descending':false,'granularity':'all',"
             + "'filter':{'type':'bound','dimension':'product_id','lower':'1016.0',"
@@ -2660,7 +2663,10 @@ public class DruidAdapter2IT {
         + "from \"foodmart\" "
         + "where cast(\"product_id\" as double) <> 1016.0";
     final String plan = "PLAN=EnumerableInterpreter\n"
-        + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], filter=[<>(CAST($1):DOUBLE, 1016.0)], projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
+        + "  DruidQuery(table=[[foodmart, foodmart]], "
+        + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
+        + "filter=[<>(CAST($1):DOUBLE, 1016.0E0)], "
+        + "projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
     final String druidQuery =
         "{'queryType':'timeseries','dataSource':'foodmart','descending':false,'granularity':'all',"
             + "'filter':{'type':'not','field':{'type':'bound','dimension':'product_id','"
@@ -3078,7 +3084,7 @@ public class DruidAdapter2IT {
     final String plan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]],"
-        + " filter=[=(FLOOR($90), 23)], groups=[{}], aggs=[[COUNT()]]";
+        + " filter=[=(FLOOR($90), 23.0E0)], groups=[{}], aggs=[[COUNT()]]";
     sql(sql)
         .returnsOrdered("EXPR$0=2")
         .explainContains(plan)
@@ -3299,8 +3305,8 @@ public class DruidAdapter2IT {
         .returnsOrdered("EXPR$0=2")
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00"
-            + ".000Z/2992-01-10T00:00:00.000Z]], filter=[AND(>(SIN($91), 9.129452507276277E-1), >"
-            + "(COS($90), 4.08082061813392E-1), =(FLOOR(TAN($91)), 2), <(ABS(-(TAN($91), /(SIN"
+            + ".000Z/2992-01-10T00:00:00.000Z]], filter=[AND(>(SIN($91), 0.9129452507276277E0), >"
+            + "(COS($90), 0.40808206181339196E0), =(FLOOR(TAN($91)), 2.0E0), <(ABS(-(TAN($91), /(SIN"
             + "($91), COS($91)))), 1.0E-6))], groups=[{}], aggs=[[COUNT()]])");
   }
 

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -3124,7 +3124,7 @@ public class DruidAdapterIT {
         + "where cast(\"product_id\" as double) = 1016.0";
     final String plan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[=(CAST($1):DOUBLE, 1016.0)], projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
+        + "filter=[=(CAST($1):DOUBLE, 1016.0E0)], projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
     final String druidQuery =
         "{'queryType':'timeseries','dataSource':'foodmart','descending':false,'granularity':'all',"
             + "'filter':{'type':'bound','dimension':'product_id','lower':'1016.0',"
@@ -3151,7 +3151,7 @@ public class DruidAdapterIT {
         + "where cast(\"product_id\" as double) <> 1016.0";
     final String plan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-        + "filter=[<>(CAST($1):DOUBLE, 1016.0)], projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
+        + "filter=[<>(CAST($1):DOUBLE, 1016.0E0)], projects=[[$91]], groups=[{}], aggs=[[SUM($0)]])";
     final String druidQuery =
         "{'queryType':'timeseries','dataSource':'foodmart','descending':false,'granularity':'all',"
             + "'filter':{'type':'not','field':{'type':'bound','dimension':'product_id','"
@@ -3725,7 +3725,7 @@ public class DruidAdapterIT {
     final String plan = "PLAN=EnumerableInterpreter\n"
         + "  DruidQuery(table=[[foodmart, foodmart]], "
         + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]],"
-        + " filter=[=(FLOOR($90), 23)], groups=[{}], aggs=[[COUNT()]]";
+        + " filter=[=(FLOOR($90), 23.0E0)], groups=[{}], aggs=[[COUNT()]]";
     sql(sql, FOODMART)
         .returnsOrdered("EXPR$0=2")
         .explainContains(plan)
@@ -3957,7 +3957,7 @@ public class DruidAdapterIT {
         .explainContains("PLAN=EnumerableInterpreter\n"
             + "  DruidQuery(table=[[foodmart, foodmart]], "
             + "intervals=[[1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z]], "
-            + "filter=[AND(>(SIN($91), 9.129452507276277E-1), >(COS($90), 4.08082061813392E-1), =(FLOOR(TAN($91)), 2), "
+            + "filter=[AND(>(SIN($91), 0.9129452507276277E0), >(COS($90), 0.40808206181339196E0), =(FLOOR(TAN($91)), 2.0E0), "
             + "<(ABS(-(TAN($91), /(SIN($91), COS($91)))), 1.0E-6))], "
             + "groups=[{}], aggs=[[COUNT()]])");
   }

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchRules.java
@@ -24,7 +24,6 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.InvalidRelException;
-import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.Sort;
@@ -220,7 +219,7 @@ class ElasticsearchRules {
       final Sort sort = (Sort) relNode;
       final RelTraitSet traitSet = sort.getTraitSet().replace(out).replace(sort.getCollation());
       return new ElasticsearchSort(relNode.getCluster(), traitSet,
-        convert(sort.getInput(), traitSet.replace(RelCollations.EMPTY)), sort.getCollation(),
+        convert(sort.getInput(), sort.getInput().getTraitSet().replace(out)), sort.getCollation(),
         sort.offset, sort.fetch);
     }
   }

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSort.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSort.java
@@ -57,7 +57,7 @@ public class ElasticsearchSort extends Sort implements ElasticsearchRel {
   @Override public Sort copy(RelTraitSet traitSet, RelNode input,
       RelCollation relCollation, @Nullable RexNode offset,
       @Nullable RexNode fetch) {
-    return new ElasticsearchSort(getCluster(), traitSet, input, collation,
+    return new ElasticsearchSort(getCluster(), traitSet, input, relCollation,
         offset, fetch);
   }
 

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeRules.java
@@ -223,8 +223,7 @@ public class GeodeRules {
       final Sort sort = call.rel(0);
 
       final RelTraitSet traitSet = sort.getTraitSet()
-          .replace(GeodeRel.CONVENTION)
-          .replace(sort.getCollation());
+          .replace(GeodeRel.CONVENTION);
 
       GeodeSort geodeSort =
           new GeodeSort(sort.getCluster(), traitSet,

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSort.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeSort.java
@@ -66,7 +66,7 @@ public class GeodeSort extends Sort implements GeodeRel {
 
   @Override public Sort copy(RelTraitSet traitSet, RelNode input,
       RelCollation newCollation, RexNode offset, RexNode fetch) {
-    return new GeodeSort(getCluster(), traitSet, input, collation, fetch);
+    return new GeodeSort(getCluster(), traitSet, input, newCollation, fetch);
   }
 
   @Override public void implement(GeodeImplementContext geodeImplementContext) {

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilter.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilter.java
@@ -25,7 +25,9 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 
 import com.alibaba.innodb.java.reader.schema.TableDef;
 
@@ -95,5 +97,10 @@ public class InnodbFilter extends Filter implements InnodbRel {
    */
   public RelCollation getImplicitCollation() {
     return indexCondition.getImplicitCollation();
+  }
+
+  @Override public RexNode getCondition() {
+    RexBuilder rexBuilder = getCluster().getRexBuilder();
+    return RexUtil.composeConjunction(rexBuilder, indexCondition.getPushDownConditions());
   }
 }

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbRules.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbRules.java
@@ -231,8 +231,7 @@ public class InnodbRules {
 
     RelNode convert(Sort sort) {
       final RelTraitSet traitSet =
-          sort.getTraitSet().replace(InnodbRel.CONVENTION)
-              .replace(sort.getCollation());
+          sort.getTraitSet().replace(InnodbRel.CONVENTION);
       return new InnodbSort(sort.getCluster(), traitSet,
           convert(sort.getInput(), traitSet.replace(RelCollations.EMPTY)),
           sort.getCollation());

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbSort.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbSort.java
@@ -60,7 +60,7 @@ public class InnodbSort extends Sort implements InnodbRel {
 
   @Override public Sort copy(RelTraitSet traitSet, RelNode input,
       RelCollation newCollation, RexNode offset, RexNode fetch) {
-    return new InnodbSort(getCluster(), traitSet, input, collation);
+    return new InnodbSort(getCluster(), traitSet, input, newCollation);
   }
 
   @Override public void implement(Implementor implementor) {

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbToEnumerableConverter.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbToEnumerableConverter.java
@@ -73,8 +73,7 @@ public class InnodbToEnumerableConverter extends ConverterImpl
 
   @Override public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner,
       RelMetadataQuery mq) {
-    final RelOptCost cost = requireNonNull(super.computeSelfCost(planner, mq));
-    return cost.multiplyBy(.1);
+    return requireNonNull(super.computeSelfCost(planner, mq));
   }
 
   static List<String> innodbFieldNames(final RelDataType rowType) {

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelExVisitor.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelExVisitor.java
@@ -256,8 +256,12 @@ class PigRelExVisitor extends LogicalExpressionVisitor {
     final RexNode operand = stack.pop();
     if (operand instanceof RexLiteral) {
       final Comparable value = ((RexLiteral) operand).getValue();
-      assert value instanceof BigDecimal;
-      stack.push(builder.literal(((BigDecimal) value).negate()));
+      if (value instanceof BigDecimal) {
+        stack.push(builder.literal(((BigDecimal) value).negate()));
+      } else {
+        assert value instanceof Double;
+        stack.push(builder.literal(- (Double) value));
+      }
     } else {
       stack.push(builder.call(SqlStdOperatorTable.UNARY_MINUS, operand));
     }

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelExTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelExTest.java
@@ -79,7 +79,10 @@ class PigRelExTest extends PigRelTestBase {
   }
 
   @Test void testConstantFloat() {
-    checkTranslation(".1E6 == -2.3", inTree("=(1E5:DOUBLE, -2.3:DECIMAL(2, 1))"));
+    // Add a variable d in the expression to prevent it from being simplified to "false".
+    checkTranslation(".1E6 == -2.3 + d",
+        // Validator converts -2.3 from DECIMAL to DOUBLE
+        inTree("=(100000.0E0, +(-2.3E0, $3))"));
   }
 
   @Test void testConstantString() {

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -227,7 +227,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "A = LOAD 'scott.DEPT' as (DEPTNO:int, DNAME:chararray, LOC:CHARARRAY);\n"
         + "B = SAMPLE A 0.5;\n";
     final String plan = ""
-        + "LogicalFilter(condition=[<(RAND(), 5E-1)])\n"
+        + "LogicalFilter(condition=[<(RAND(), 0.5E0)])\n"
         + "  LogicalTableScan(table=[[scott, DEPT]])\n";
     final String sql = ""
         + "SELECT *\n"

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -53,6 +53,17 @@ using JDK/OpenJDK versions 8 to 23;
 Guava versions 21.0 to 33.3.0-jre;
 other software versions as specified in gradle.properties.
 
+* [a <href="https://issues.apache.org/jira/browse/CALCITE-2067">]
+  **RexLiteral cannot represent accurately floating point values,
+  including NaN, Infinity**.  This fix changes the way RexLiteral
+  represents floating point values.  Previously floating point values
+  were encoded into BigDecimal values.  This caused precision loss
+  when representing the results of simplifying expressions whose
+  results are floating point.  With this change RexLiteral uses
+  internally a Java Double value to represent a SQL DOUBLE, FLOAT, or
+  REAL value.  The result of RexLiteral.getValue() accordingly changes
+  type in this case.
+
 #### New features
 {: #new-features-1-38-0}
 

--- a/testkit/src/main/java/org/apache/calcite/util/TestUtil.java
+++ b/testkit/src/main/java/org/apache/calcite/util/TestUtil.java
@@ -35,8 +35,10 @@ import java.util.regex.Pattern;
 
 import static org.apache.calcite.util.Util.first;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import static java.lang.Double.parseDouble;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 
@@ -91,6 +93,11 @@ public abstract class TestUtil {
             + actual
             + "\nActual java:\n"
             + toJavaString(actual) + '\n');
+  }
+
+  public static void assertThatScientific(String value, org.hamcrest.Matcher<String> matcher) {
+    double d = parseDouble(value);
+    assertThat(Util.toScientificNotation(d), matcher);
   }
 
   /**


### PR DESCRIPTION
This PR supports getPredicates(RelSubset) returning getPredicate(stripped) in place of EMPTY as a temporary solution.
But it exceeds the expected range because some rules are re-fire in VolcanoPlanner.
Major Changes: 
In SortRemoveConstantKey the constant key in the sort is removed. before this PR the traitset of the sort needs to be consistent with the collation. It would result in the new sort having a different traitset than the original one, it would not be in the same RelSubSet and would not be selected.
So I tried to modify the traitSet assert in sort so that it can be set to RelComposetrait.
For example : order by a,b,c 
If we can make sure that b is constant, then the traitSet of the sort can be [[a,b,c],[a,c]]. Also, when collation is empty and there are only offset and fetch, the original input collation traits can be kept in the sort.
There are also a few more changes that I will add comments on. For the Sort changes, we can probably discuss them in Jira if needed. Thanks for the suggestion and review.