### PR TITLE
[CALCITE-6593] NPE when outer joining tables with many fields and unmatching rows

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/JavaRowFormat.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/JavaRowFormat.java
@@ -24,6 +24,7 @@ import org.apache.calcite.linq4j.tree.IndexExpression;
 import org.apache.calcite.linq4j.tree.MemberExpression;
 import org.apache.calcite.linq4j.tree.MethodCallExpression;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
+import org.apache.calcite.linq4j.tree.Statement;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.runtime.FlatLists;
@@ -34,9 +35,11 @@ import org.apache.calcite.util.BuiltInMethod;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.calcite.util.BuiltInMethod.ARRAY_COPY;
+import static org.apache.calcite.util.BuiltInMethod.LIST_TO_ARRAY;
 import static org.apache.calcite.util.BuiltInMethod.ROW_COPY_VALUES;
 
 /**
@@ -80,6 +83,24 @@ public enum JavaRowFormat {
         return Expressions.field(expression, Types.nthField(field, type));
       }
     }
+
+    @Override public List<Statement> copy(ParameterExpression parameter,
+        ParameterExpression outputArray, int outputStartIndex, int length) {
+      // Parameter holds an expression representing a POJO Object
+      // Results in:
+      // outputArray[outputStartIndex] = parameter.field{1};
+      // ...
+      // outputArray[outputStartIndex + length - 1] = parameter.field{length - 1};
+      final List<Statement> statements = new ArrayList<>(length);
+      for (int i = 0; i < length; i++) {
+        statements.add(
+            Expressions.statement(
+                Expressions.assign(
+            Expressions.arrayIndex(outputArray, Expressions.constant(outputStartIndex + i)),
+            field(parameter, i, null, Object.class))));
+      }
+      return statements;
+    }
   },
 
   SCALAR {
@@ -110,6 +131,19 @@ public enum JavaRowFormat {
         Type fieldType) {
       assert field == 0;
       return expression;
+    }
+
+    @Override public List<Statement> copy(ParameterExpression parameter,
+        ParameterExpression outputArray, int outputStartIndex, int length) {
+      // Parameter holds an expression representing a scalar Object
+      // Results in:
+      // outputArray[outputStartIndex] = parameter;
+      assert length == 1;
+      return FlatLists.of(
+          Expressions.statement(
+              Expressions.assign(
+              Expressions.arrayIndex(outputArray,
+                  Expressions.constant(outputStartIndex)), parameter)));
     }
   },
 
@@ -199,6 +233,18 @@ public enum JavaRowFormat {
       }
       return EnumUtils.convert(e, fromType, fieldType);
     }
+
+    @Override public List<Statement> copy(ParameterExpression parameter,
+        ParameterExpression outputArray, int outputStartIndex, int length) {
+      // Parameter holds an expression representing a List
+      // Results in:
+      // System.arraycopy(parameter.toArray(), 0, outputArray, outputStartIndex, length);
+      return FlatLists.of(
+          Expressions.statement(
+              Expressions.call(ARRAY_COPY.method, Expressions.call(parameter, LIST_TO_ARRAY.method),
+              Expressions.constant(0), outputArray, Expressions.constant(outputStartIndex),
+              Expressions.constant(length))));
+    }
   },
 
   /**
@@ -230,9 +276,17 @@ public enum JavaRowFormat {
       return EnumUtils.convert(e, fromType, fieldType);
     }
 
-    @Override public Expression fieldDynamic(Expression expression, Expression field) {
-      return Expressions.call(expression,
-          BuiltInMethod.ROW_VALUE.method, Expressions.constant(field));
+    @Override public List<Statement> copy(ParameterExpression parameter,
+      ParameterExpression outputArray, int outputStartIndex, int length) {
+      // Parameter holds an expression representing a org.apache.calcite.interpreter.Row
+      // Results in:
+      // System.arraycopy(parameter.copyValues(), 0, outputArray, outputStartIndex, length);
+      return FlatLists.of(
+          Expressions.statement(
+          Expressions.call(ARRAY_COPY.method,
+              Expressions.call(Object[].class, parameter, ROW_COPY_VALUES.method),
+              Expressions.constant(0), outputArray, Expressions.constant(outputStartIndex),
+              Expressions.constant(length))));
     }
   },
 
@@ -266,21 +320,15 @@ public enum JavaRowFormat {
       return EnumUtils.convert(e, fromType, fieldType);
     }
 
-    @Override public Expression fieldDynamic(Expression expression, Expression field) {
-      return Expressions.arrayIndex(expression, field);
-    }
-
-    @Override public Expression setFieldDynamic(Expression expression, Expression field,
-        Expression value) {
-      final IndexExpression e =
-          Expressions.arrayIndex(expression, Expressions.constant(field));
-      return Expressions.assign(e, value);
-    }
-
-    @Override public Expression copy(ParameterExpression parameter,
+    @Override public List<Statement> copy(ParameterExpression parameter,
         ParameterExpression outputArray, int outputStartIndex, int length) {
-      return Expressions.call(ARRAY_COPY.method, parameter, Expressions.constant(0),
-          outputArray, Expressions.constant(outputStartIndex), Expressions.constant(length));
+      // Parameter holds an expression representing an Object[]
+      // Results in:
+      // System.arraycopy(parameter, 0, outputArray, outputStartIndex, length);
+      return FlatLists.of(
+          Expressions.statement(
+          Expressions.call(ARRAY_COPY.method, parameter, Expressions.constant(0),
+              outputArray, Expressions.constant(outputStartIndex), Expressions.constant(length))));
     }
   };
 
@@ -329,31 +377,8 @@ public enum JavaRowFormat {
       @Nullable Type fromType, Type fieldType);
 
   /**
-   * Similar to {@link #field(Expression, int, Type, Type)}, where the field index is determined
-   * dynamically at runtime.
-   */
-  public Expression fieldDynamic(Expression expression, Expression field) {
-    throw new UnsupportedOperationException(this.toString());
-  }
-
-  public Expression setFieldDynamic(Expression expression, Expression field, Expression value) {
-    throw new UnsupportedOperationException(this.toString());
-  }
-
-  /**
    * Returns an expression that copies the fields of a row of this type to the array.
    */
-  public @Nullable Expression copy(ParameterExpression parameter,
-      ParameterExpression outputArray, int outputStartIndex, int length) {
-    // Note: parameter holds an expression representing a org.apache.calcite.interpreter.Row.
-
-    // Copy the Row as an Object[].
-    final Expression rowParameterAsArrayExpression =
-        Expressions.call(Object[].class, parameter, ROW_COPY_VALUES.method);
-
-    // Use System.arraycopy() with the contents of the Row as the source.
-    return Expressions.call(ARRAY_COPY.method, rowParameterAsArrayExpression,
-        Expressions.constant(0), outputArray, Expressions.constant(outputStartIndex),
-        Expressions.constant(length));
-  }
+  public abstract List<Statement> copy(ParameterExpression parameter,
+      ParameterExpression outputArray, int outputStartIndex, int length);
 }

--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -420,6 +420,23 @@ public final class CalciteSystemProperty<T> {
   public static final CalciteSystemProperty<Integer> FUNCTION_LEVEL_CACHE_MAX_SIZE =
       intProperty("calcite.function.cache.maxSize", 1_000, v -> v >= 0);
 
+  /**
+   * Minimum numbers of fields in a Join result that will trigger the "compact code generation".
+   * This feature reduces the risk of running into a compilation error due to the code of a
+   * dynamically generated method growing beyond the 64KB limit.
+   *
+   * <p>Note that the compact code makes use of arraycopy operations when possible,
+   * instead of using a static array initialization. For joins with a large number of fields
+   * the resulting code should be faster, but it can be slower for joins with a very small number
+   * of fields.
+   *
+   * <p>The default value is 100, a negative value disables completely the "compact code" feature.
+   *
+   * @see org.apache.calcite.adapter.enumerable.EnumUtils
+   */
+  public static final CalciteSystemProperty<Integer> JOIN_SELECTOR_COMPACT_CODE_THRESHOLD =
+      intProperty("calcite.join.selector.compact.code.threshold", 100);
+
   private static CalciteSystemProperty<Boolean> booleanProperty(String key,
       boolean defaultValue) {
     // Note that "" -> true (convenient for command-lines flags like '-Dflag')

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -369,6 +369,7 @@ public enum BuiltInMethod {
   COLLECTION_RETAIN_ALL(Collection.class, "retainAll", Collection.class),
   LIST_CONTAINS(List.class, "contains", Object.class),
   LIST_GET(List.class, "get", int.class),
+  LIST_TO_ARRAY(List.class, "toArray"),
   ITERATOR_HAS_NEXT(Iterator.class, "hasNext"),
   ITERATOR_NEXT(Iterator.class, "next"),
   MATH_MAX(Math.class, "max", int.class, int.class),


### PR DESCRIPTION
The fix is quite simple. I added tests for left join and right join with empty tables.

The test file changed a bit more than expected because: 

- I extracted some code to be reused in the other tests;
- I removed a `query.WithHook` because it was not being used, as this call doesn't mutate the query object;
- I changed the field names to be able to select them easily on the right outer join.