### PR TITLE
[CALCITE-6645] Support user-defined function without parentheses when db dialect's allowNiladicParentheses property is false

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -283,7 +283,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
    * or classes.
    *
    * @see ModelHandler#addFunctions */
-  public static SqlOperatorTable operatorTable(String... classNames) {
+  public SqlOperatorTable operatorTable(String... classNames) {
     // Dummy schema to collect the functions
     final CalciteSchema schema =
         CalciteSchema.createRootSchema(false, false);
@@ -303,7 +303,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
   }
 
   /** Converts a function to a {@link org.apache.calcite.sql.SqlOperator}. */
-  private static SqlOperator toOp(SqlIdentifier name,
+  private SqlOperator toOp(SqlIdentifier name,
       final org.apache.calcite.schema.Function function) {
     final Function<RelDataTypeFactory, List<RelDataType>> argTypesFactory =
         typeFactory -> function.getParameters()
@@ -344,8 +344,12 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
     if (function instanceof ScalarFunction) {
       final SqlReturnTypeInference returnTypeInference =
           infer((ScalarFunction) function);
+      SqlSyntax syntax = function.getParameters().isEmpty()
+          && !config.conformance().allowNiladicParentheses()
+          ? SqlSyntax.FUNCTION_ID
+          : SqlSyntax.FUNCTION;
       return new SqlUserDefinedFunction(name, kind, returnTypeInference,
-          operandTypeInference, operandMetadata, function);
+          operandTypeInference, operandMetadata, function, syntax);
     } else if (function instanceof AggregateFunction) {
       final SqlReturnTypeInference returnTypeInference =
           infer((AggregateFunction) function);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
@@ -42,17 +43,19 @@ import java.util.List;
 public class SqlUserDefinedFunction extends SqlFunction {
   public final Function function;
 
+  public final SqlSyntax syntax;
+
   @Deprecated // to be removed before 2.0
   public SqlUserDefinedFunction(SqlIdentifier opName,
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       @Nullable SqlOperandTypeChecker operandTypeChecker,
       List<RelDataType> paramTypes,
-      Function function) {
+      Function function, SqlSyntax syntax) {
     this(opName, SqlKind.OTHER_FUNCTION, returnTypeInference,
         operandTypeInference,
         operandTypeChecker instanceof SqlOperandMetadata
-            ? (SqlOperandMetadata) operandTypeChecker : null, function);
+            ? (SqlOperandMetadata) operandTypeChecker : null, function, syntax);
     Util.discard(paramTypes); // no longer used
   }
 
@@ -61,9 +64,9 @@ public class SqlUserDefinedFunction extends SqlFunction {
       SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeInference operandTypeInference,
       @Nullable SqlOperandMetadata operandMetadata,
-      Function function) {
+      Function function, SqlSyntax syntax) {
     this(opName, kind, returnTypeInference, operandTypeInference,
-        operandMetadata, function, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+        operandMetadata, function, SqlFunctionCategory.USER_DEFINED_FUNCTION, syntax);
   }
 
   /** Constructor used internally and by derived classes. */
@@ -72,14 +75,19 @@ public class SqlUserDefinedFunction extends SqlFunction {
       SqlOperandTypeInference operandTypeInference,
       @Nullable SqlOperandMetadata operandMetadata,
       Function function,
-      SqlFunctionCategory category) {
+      SqlFunctionCategory category, SqlSyntax syntax) {
     super(Util.last(opName.names), opName, kind, returnTypeInference,
         operandTypeInference, operandMetadata, category);
     this.function = function;
+    this.syntax = syntax;
   }
 
   @Override public @Nullable SqlOperandMetadata getOperandTypeChecker() {
     return (@Nullable SqlOperandMetadata) super.getOperandTypeChecker();
+  }
+
+  @Override public SqlSyntax getSyntax() {
+    return syntax;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
@@ -22,6 +22,7 @@ import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlTableFunction;
 import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
@@ -64,7 +65,7 @@ public class SqlUserDefinedTableFunction extends SqlUserDefinedFunction
       TableFunction function) {
     super(opName, kind, returnTypeInference, operandTypeInference,
         operandMetadata, function,
-        SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
+        SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION, SqlSyntax.FUNCTION);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1957,7 +1957,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   }
 
   @Override public @Nullable SqlCall makeNullaryCall(SqlIdentifier id) {
-    if (id.names.size() == 1 && !id.isComponentQuoted(0)) {
+    if (!id.isComponentQuoted(id.names.size() - 1)) {
       final List<SqlOperator> list = new ArrayList<>();
       opTab.lookupOperatorOverloads(id, null, SqlSyntax.FUNCTION, list,
           catalogReader.nameMatcher());

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -34,6 +34,7 @@ import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.test.schemata.hr.HrSchema;
 import org.apache.calcite.util.Smalls;
 
@@ -119,6 +120,12 @@ class UdfTest {
         + "           name: 'MY_EXCEPTION',\n"
         + "           className: '"
         + Smalls.MyExceptionFunction.class.getName()
+        + "'\n"
+        + "         },\n"
+        + "         {\n"
+        + "           name: 'MY_NILADIC_PARENTHESES',\n"
+        + "           className: '"
+        + Smalls.MyNiladicParenthesesFunction.class.getName()
         + "'\n"
         + "         },\n"
         + "         {\n"
@@ -407,14 +414,31 @@ class UdfTest {
         .returns("P=null\n");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-937">[CALCITE-937]
+   * User-defined function with niladic parentheses</a>. */
+  @Test void testUserDefinedFunctionWithNiladicParentheses() {
+    final CalciteAssert.AssertThat with = withUdf();
+    with.with(SqlConformanceEnum.MYSQL_5)
+        .query("select \"adhoc\".my_niladic_parentheses() as p\n"
+            + "from \"adhoc\".EMPLOYEES limit 1")
+        .returns("P=foo\n");
+    with.with(SqlConformanceEnum.ORACLE_10)
+        .query("select \"adhoc\".my_niladic_parentheses as p\n"
+            + "from \"adhoc\".EMPLOYEES limit 1")
+        .returns("P=foo\n");
+  }
+
   /** Tests a user-defined function that has multiple overloads. */
   @Test void testUdfOverloaded() {
     final CalciteAssert.AssertThat with = withUdf();
-    with.query("values (\"adhoc\".count_args(),\n"
+    with.with(SqlConformanceEnum.MYSQL_5)
+        .query("values (\"adhoc\".count_args(),\n"
         + " \"adhoc\".count_args(0),\n"
         + " \"adhoc\".count_args(0, 0))")
         .returns("EXPR$0=0; EXPR$1=1; EXPR$2=2\n");
-    with.query("select max(\"adhoc\".count_args()) as p0,\n"
+    with.with(SqlConformanceEnum.MYSQL_5)
+        .query("select max(\"adhoc\".count_args()) as p0,\n"
         + " min(\"adhoc\".count_args(0)) as p1,\n"
         + " max(\"adhoc\".count_args(0, 0)) as p2\n"
         + "from \"adhoc\".EMPLOYEES limit 1")
@@ -423,7 +447,8 @@ class UdfTest {
 
   @Test void testUdfOverloadedNullable() {
     final CalciteAssert.AssertThat with = withUdf();
-    with.query("values (\"adhoc\".count_args(),\n"
+    with.with(SqlConformanceEnum.MYSQL_5)
+        .query("values (\"adhoc\".count_args(),\n"
         + " \"adhoc\".count_args(cast(null as smallint)),\n"
         + " \"adhoc\".count_args(0, 0))")
         .returns("EXPR$0=0; EXPR$1=-1; EXPR$2=2\n");

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -415,7 +415,7 @@ class UdfTest {
   }
 
   /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-937">[CALCITE-937]
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6645">[CALCITE-6645]
    * User-defined function with niladic parentheses</a>. */
   @Test void testUserDefinedFunctionWithNiladicParentheses() {
     final CalciteAssert.AssertThat with = withUdf();

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
@@ -20,6 +20,7 @@ import org.apache.calcite.schema.Function;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
@@ -42,7 +43,7 @@ public class PigUserDefinedFunction extends SqlUserDefinedFunction {
       FuncSpec funcSpec) {
     super(opName, SqlKind.OTHER_FUNCTION, returnTypeInference,
         operandTypeInference, operandMetadata, function,
-        SqlFunctionCategory.USER_DEFINED_CONSTRUCTOR);
+        SqlFunctionCategory.USER_DEFINED_CONSTRUCTOR, SqlSyntax.FUNCTION);
     this.funcSpec = funcSpec;
   }
 

--- a/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
+++ b/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
@@ -44,6 +44,7 @@ public class CalciteConnectionProvider {
     Properties info = new Properties();
     info.setProperty("lex", "MYSQL");
     info.setProperty("model", "inline:" + provideSchema());
+    info.setProperty("conformance", "MYSQL_5");
     return info;
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
+++ b/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
@@ -205,6 +205,10 @@ public class CalciteAssert {
           return this;
         }
 
+        @Override public AssertThat with(SqlConformanceEnum conformance) {
+          return this;
+        }
+
         @Override public AssertThat with(
             ConnectionPostProcessor postProcessor) {
           return this;
@@ -1212,6 +1216,11 @@ public class CalciteAssert {
     /** Sets the Lex property. */
     public AssertThat with(Lex lex) {
       return with(CalciteConnectionProperty.LEX, lex);
+    }
+
+    /** Sets the conformance property. */
+    public AssertThat with(SqlConformanceEnum conformance) {
+      return with(CalciteConnectionProperty.CONFORMANCE, conformance);
     }
 
     /** Sets the default schema to a given schema. */

--- a/testkit/src/main/java/org/apache/calcite/util/Smalls.java
+++ b/testkit/src/main/java/org/apache/calcite/util/Smalls.java
@@ -683,6 +683,13 @@ public class Smalls {
     }
   }
 
+  /** User-defined function with niladic parentheses. */
+  public static class MyNiladicParenthesesFunction {
+    public String eval() {
+      return "foo";
+    }
+  }
+
   /** Example of a UDF that has overloaded UDFs (same name, different args). */
   public abstract static class CountArgs0Function {
     private CountArgs0Function() {}


### PR DESCRIPTION
* pass SqlSyntax.FUNCTION_ID to SqlUserDefinedFunction when function has no parameters, and allowNiladicParentheses is false
* add udf test case for function without parentheses