### PR TITLE
[CALCITE-6645] Support user-defined function without parentheses when db dialect's allowNiladicParentheses property is false

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedFunction.java
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
@@ -41,6 +42,8 @@ import java.util.List;
 */
 public class SqlUserDefinedFunction extends SqlFunction {
   public final Function function;
+
+  public final SqlSyntax syntax;
 
   @Deprecated // to be removed before 2.0
   public SqlUserDefinedFunction(SqlIdentifier opName,
@@ -63,7 +66,17 @@ public class SqlUserDefinedFunction extends SqlFunction {
       @Nullable SqlOperandMetadata operandMetadata,
       Function function) {
     this(opName, kind, returnTypeInference, operandTypeInference,
-        operandMetadata, function, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+        operandMetadata, function, SqlFunctionCategory.USER_DEFINED_FUNCTION, SqlSyntax.FUNCTION);
+  }
+
+  /** Creates a {@link SqlUserDefinedFunction} with sql syntax. */
+  public SqlUserDefinedFunction(SqlIdentifier opName, SqlKind kind,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeInference operandTypeInference,
+      @Nullable SqlOperandMetadata operandMetadata,
+      Function function, SqlSyntax syntax) {
+    this(opName, kind, returnTypeInference, operandTypeInference,
+        operandMetadata, function, SqlFunctionCategory.USER_DEFINED_FUNCTION, syntax);
   }
 
   /** Constructor used internally and by derived classes. */
@@ -72,14 +85,19 @@ public class SqlUserDefinedFunction extends SqlFunction {
       SqlOperandTypeInference operandTypeInference,
       @Nullable SqlOperandMetadata operandMetadata,
       Function function,
-      SqlFunctionCategory category) {
+      SqlFunctionCategory category, SqlSyntax syntax) {
     super(Util.last(opName.names), opName, kind, returnTypeInference,
         operandTypeInference, operandMetadata, category);
     this.function = function;
+    this.syntax = syntax;
   }
 
   @Override public @Nullable SqlOperandMetadata getOperandTypeChecker() {
     return (@Nullable SqlOperandMetadata) super.getOperandTypeChecker();
+  }
+
+  @Override public SqlSyntax getSyntax() {
+    return syntax;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlUserDefinedTableFunction.java
@@ -22,6 +22,7 @@ import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlTableFunction;
 import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
@@ -64,7 +65,7 @@ public class SqlUserDefinedTableFunction extends SqlUserDefinedFunction
       TableFunction function) {
     super(opName, kind, returnTypeInference, operandTypeInference,
         operandMetadata, function,
-        SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
+        SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION, SqlSyntax.FUNCTION);
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1957,7 +1957,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   }
 
   @Override public @Nullable SqlCall makeNullaryCall(SqlIdentifier id) {
-    if (id.names.size() == 1 && !id.isComponentQuoted(0)) {
+    if (!id.isComponentQuoted(id.names.size() - 1)) {
       final List<SqlOperator> list = new ArrayList<>();
       opTab.lookupOperatorOverloads(id, null, SqlSyntax.FUNCTION, list,
           catalogReader.nameMatcher());

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigUserDefinedFunction.java
@@ -20,6 +20,7 @@ import org.apache.calcite.schema.Function;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
@@ -42,7 +43,7 @@ public class PigUserDefinedFunction extends SqlUserDefinedFunction {
       FuncSpec funcSpec) {
     super(opName, SqlKind.OTHER_FUNCTION, returnTypeInference,
         operandTypeInference, operandMetadata, function,
-        SqlFunctionCategory.USER_DEFINED_CONSTRUCTOR);
+        SqlFunctionCategory.USER_DEFINED_CONSTRUCTOR, SqlSyntax.FUNCTION);
     this.funcSpec = funcSpec;
   }
 

--- a/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
+++ b/plus/src/main/java/org/apache/calcite/chinook/CalciteConnectionProvider.java
@@ -44,6 +44,7 @@ public class CalciteConnectionProvider {
     Properties info = new Properties();
     info.setProperty("lex", "MYSQL");
     info.setProperty("model", "inline:" + provideSchema());
+    info.setProperty("conformance", "MYSQL_5");
     return info;
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
+++ b/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
@@ -205,6 +205,10 @@ public class CalciteAssert {
           return this;
         }
 
+        @Override public AssertThat with(SqlConformanceEnum conformance) {
+          return this;
+        }
+
         @Override public AssertThat with(
             ConnectionPostProcessor postProcessor) {
           return this;
@@ -1212,6 +1216,11 @@ public class CalciteAssert {
     /** Sets the Lex property. */
     public AssertThat with(Lex lex) {
       return with(CalciteConnectionProperty.LEX, lex);
+    }
+
+    /** Sets the conformance property. */
+    public AssertThat with(SqlConformanceEnum conformance) {
+      return with(CalciteConnectionProperty.CONFORMANCE, conformance);
     }
 
     /** Sets the default schema to a given schema. */

--- a/testkit/src/main/java/org/apache/calcite/util/Smalls.java
+++ b/testkit/src/main/java/org/apache/calcite/util/Smalls.java
@@ -683,6 +683,15 @@ public class Smalls {
     }
   }
 
+  /** User-defined function with niladic parentheses. */
+  public static class MyNiladicParenthesesFunction {
+    // This is a constant function that tests for niladic parentheses,
+    // and it returns the constant value foo
+    public String eval() {
+      return "foo";
+    }
+  }
+
   /** Example of a UDF that has overloaded UDFs (same name, different args). */
   public abstract static class CountArgs0Function {
     private CountArgs0Function() {}


### PR DESCRIPTION
* pass SqlSyntax.FUNCTION_ID to SqlUserDefinedFunction when function has no parameters, and allowNiladicParentheses is false
* add udf test case for function without parentheses