### PR TITLE
[CALCITE-6676] DiffRepository does not update log (_actual) file when assertion fails

### DIFF
--- a/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
+++ b/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.Assertions;
 import org.opentest4j.AssertionFailedError;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
@@ -56,9 +57,6 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import static java.util.Objects.requireNonNull;
 
@@ -266,6 +264,10 @@ public class DiffRepository {
           + "\ndiff " + logFile.getAbsolutePath() + " " + resourceFile + "\n"
           + diff);
     }
+  }
+
+  String logFilePath() {
+    return logFile.getAbsolutePath();
   }
 
   private static URL findFile(Class<?> clazz, final String suffix) {
@@ -503,7 +505,7 @@ public class DiffRepository {
             expected2.replace(Util.LINE_SEPARATOR, "\n");
         String actualCanonical =
             actual.replace(Util.LINE_SEPARATOR, "\n");
-        assertThat(tag, actualCanonical, is(expected2Canonical));
+        Assertions.assertEquals(expected2Canonical, actualCanonical, tag);
       } catch (AssertionFailedError e) {
         amend(expected, actual);
         throw e;

--- a/testkit/src/test/java/org/apache/calcite/test/DiffRepositoryTest.java
+++ b/testkit/src/test/java/org/apache/calcite/test/DiffRepositoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link DiffRepository} class.
+ */
+public class DiffRepositoryTest {
+
+  @Test void testAssertEqualsUpdatesLogFileUponFailure() throws IOException {
+    DiffRepository r = DiffRepository.lookup(DiffRepositoryTest.class);
+    final String actual = "Random sentence not present in resources file";
+    boolean assertPassed = false;
+    try {
+      r.assertEquals("content", "${content}", actual);
+      assertPassed = true;
+    } catch (AssertionError e) {
+      String logContent = String.join("", Files.readAllLines(Paths.get(r.logFilePath())));
+      assertThat(logContent, containsString(actual));
+    }
+    assertThat("First assertion must always fail", assertPassed, is(false));
+  }
+}

--- a/testkit/src/test/resources/org/apache/calcite/test/DiffRepositoryTest.xml
+++ b/testkit/src/test/resources/org/apache/calcite/test/DiffRepositoryTest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Root>
+  <TestCase name="testAssertEqualsUpdatesLogFileUponFailure">
+    <Resource name="content">
+      <![CDATA[Some test content should always make assertEquals to fail
+]]>
+    </Resource>
+  </TestCase>
+</Root>


### PR DESCRIPTION
Use JUnit instead of Hamcrest assert methods since the latter are not using/throwing the `AssertionFailedError` so we never enter the catch block that updates the log file.

Basically revert the DiffRepository part from https://github.com/apache/calcite/commit/9985b6af156d41fc4a986a9aadbf7f8227981388.