### PR TITLE
[CALCITE-6677] HAVING clauses fail validation when type coercion is applied to GROUP BY clause

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -4100,7 +4100,6 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
     validateWhereClause(select);
     validateGroupClause(select);
-    validateHavingClause(select);
     validateWindowClause(select);
     validateQualifyClause(select);
     handleOffsetFetch(select.getOffset(), select.getFetch());
@@ -4111,6 +4110,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     final RelDataType rowType =
         validateSelectList(selectItems, select, targetRowType);
     ns.setType(rowType);
+    validateHavingClause(select);
 
     // Deduce which columns must be filtered.
     ns.mustFilterFields = ImmutableBitSet.of();
@@ -4995,8 +4995,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     if (SqlUtil.containsCall(having, call -> call.getOperator() instanceof SqlOverOperator)) {
       throw newValidationError(originalHaving, RESOURCE.windowInHavingNotAllowed());
     }
-    havingScope.checkAggregateExpr(having, true);
     inferUnknownTypes(booleanType, havingScope, having);
+    havingScope.checkAggregateExpr(having, true);
     having.validate(this, havingScope);
     final RelDataType type = deriveType(havingScope, having);
     if (!SqlTypeUtil.inBooleanFamily(type)) {


### PR DESCRIPTION
The fix is to slightly change the validation order: 
- validate the SELECT list before the HAVING 
- perform type inference in HAVING before checking the aggregations