### PR TITLE
[CALCITE-6693] Add Source SQL Dialect to RelToSqlConverterTest

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/PlannerImpl.java
@@ -46,6 +46,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParser.Config;
 import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.RelDecorrelator;
@@ -117,14 +118,14 @@ public class PlannerImpl implements Planner, ViewExpander {
     this.convertletTable = config.getConvertletTable();
     this.executor = config.getExecutor();
     this.context = config.getContext();
-    this.connectionConfig = connConfig(context, parserConfig);
+    this.connectionConfig = connConfig(context, parserConfig, sqlValidatorConfig);
     this.typeSystem = config.getTypeSystem();
     reset();
   }
 
   /** Gets a user-defined config and appends default connection values. */
   private static CalciteConnectionConfig connConfig(Context context,
-      SqlParser.Config parserConfig) {
+      Config parserConfig, SqlValidator.Config sqlValidatorConfig) {
     CalciteConnectionConfigImpl config =
         context.maybeUnwrap(CalciteConnectionConfigImpl.class)
             .orElse(CalciteConnectionConfig.DEFAULT);
@@ -137,6 +138,11 @@ public class PlannerImpl implements Planner, ViewExpander {
       config =
           config.set(CalciteConnectionProperty.CONFORMANCE,
               String.valueOf(parserConfig.conformance()));
+    }
+    if (!config.isSet(CalciteConnectionProperty.DEFAULT_NULL_COLLATION)) {
+      config =
+          config.set(CalciteConnectionProperty.DEFAULT_NULL_COLLATION,
+              String.valueOf(sqlValidatorConfig.defaultNullCollation()));
     }
     return config;
   }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
@@ -35,7 +35,8 @@ class RelToSqlConverterStructsTest {
 
   private RelToSqlConverterTest.Sql sql(String sql) {
     return new RelToSqlConverterTest.Sql(CalciteAssert.SchemaSpec.MY_DB, sql,
-        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT, ImmutableSet.of(),
+        CalciteSqlDialect.DEFAULT, CalciteSqlDialect.DEFAULT,
+        SqlParser.Config.DEFAULT, ImmutableSet.of(),
         UnaryOperator.identity(), null, ImmutableList.of());
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Source SQL Dialect to RelToSqlConverterTest to make dialect translation more clear.

### Why are the changes needed?
Currently, RelToSqlConverterTest converts the original SQL to RelNode using the default validator config and the target dialect's type system, which is confusing. We should ensure the conversion conforms to the source dialect's specifications, and then convert from the source dialect's RelNode to the target dialect's SQL.

### Does this PR introduce any user-facing change?
Yes, the null collation the PlannerImpl use will be validator config's null collation when calcite connection property unset.