### PR TITLE
[CALCITE-6698] Add Javadoc to PartiallyOrderedSet#getNonChildren and getNonParents to clarify their behavior

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/PartiallyOrderedSet.java
+++ b/core/src/main/java/org/apache/calcite/util/PartiallyOrderedSet.java
@@ -556,7 +556,7 @@ public class PartiallyOrderedSet<E> extends AbstractSet<E> {
     // breadth-first search, to iterate over every element once, printing
     // those nearest the top element first
     final Set<E> seen = new HashSet<>();
-    final Deque<E> unseen = new ArrayDeque<>(getNonParents());
+    final Deque<E> unseen = new ArrayDeque<>(getNonChildren());
     while (!unseen.isEmpty()) {
       E e = unseen.pop();
       buf.append("  ");
@@ -686,23 +686,23 @@ public class PartiallyOrderedSet<E> extends AbstractSet<E> {
   }
 
   /**
-   * Returns all elements in the set that have no children. These elements are the leaf/minimal
-   * elements of the poset.
+   * Returns all elements in the set that are not children. These elements appear at the top of
+   * the poset, and they usually referred to as roots/maximal elements of the poset.
    *
-   * @return a list of elements that have no children.
+   * @return a list of elements that are not children.
    */
   public List<E> getNonChildren() {
-    return strip(bottomNode.parentList);
+    return strip(topNode.childList);
   }
 
   /**
-   * Returns all elements in the set that have no parents. These elements are the roots/maximal
-   * elements of the poset.
+   * Returns all elements in the set that are not parents. These elements appear at the bottom of
+   * the poset, and they usually referred to as leafs/minimal elements of the poset.
    *
-   * @return a list of elements that have no parents.
+   * @return a list of elements that are not parents.
    */
   public List<E> getNonParents() {
-    return strip(topNode.childList);
+    return strip(bottomNode.parentList);
   }
 
   @Override public void clear() {

--- a/core/src/main/java/org/apache/calcite/util/PartiallyOrderedSet.java
+++ b/core/src/main/java/org/apache/calcite/util/PartiallyOrderedSet.java
@@ -90,6 +90,10 @@ public class PartiallyOrderedSet<E> extends AbstractSet<E> {
    * in the set.
    */
   private final Node<E> topNode;
+  /**
+   * Synthetic node to hold all nodes that have no children. It does not appear
+   * in the set.
+   */
   private final Node<E> bottomNode;
 
   /**
@@ -552,7 +556,7 @@ public class PartiallyOrderedSet<E> extends AbstractSet<E> {
     // breadth-first search, to iterate over every element once, printing
     // those nearest the top element first
     final Set<E> seen = new HashSet<>();
-    final Deque<E> unseen = new ArrayDeque<>(getNonChildren());
+    final Deque<E> unseen = new ArrayDeque<>(getNonParents());
     while (!unseen.isEmpty()) {
       E e = unseen.pop();
       buf.append("  ");
@@ -681,12 +685,24 @@ public class PartiallyOrderedSet<E> extends AbstractSet<E> {
     }
   }
 
+  /**
+   * Returns all elements in the set that have no children. These elements are the leaf/minimal
+   * elements of the poset.
+   *
+   * @return a list of elements that have no children.
+   */
   public List<E> getNonChildren() {
-    return strip(topNode.childList);
+    return strip(bottomNode.parentList);
   }
 
+  /**
+   * Returns all elements in the set that have no parents. These elements are the roots/maximal
+   * elements of the poset.
+   *
+   * @return a list of elements that have no parents.
+   */
   public List<E> getNonParents() {
-    return strip(bottomNode.parentList);
+    return strip(topNode.childList);
   }
 
   @Override public void clear() {

--- a/core/src/test/java/org/apache/calcite/util/PartiallyOrderedSetTest.java
+++ b/core/src/test/java/org/apache/calcite/util/PartiallyOrderedSetTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -110,8 +111,8 @@ class PartiallyOrderedSetTest {
     poset.add(abcd);
     printValidate(poset);
     assertThat(poset, hasSize(2));
-    assertThat(poset.getNonChildren(), hasToString("['abcd']"));
-    assertThat(poset.getNonParents(), hasToString("['']"));
+    assertThat(poset.getNonChildren(), hasToString("['']"));
+    assertThat(poset.getNonParents(), hasToString("['abcd']"));
 
     final String ab = "'ab'";
     poset.add(ab);
@@ -158,8 +159,8 @@ class PartiallyOrderedSetTest {
 
     poset.add(b);
     printValidate(poset);
-    assertThat(poset.getNonChildren(), hasToString("['abcd']"));
-    assertThat(poset.getNonParents(), hasToString("['']"));
+    assertThat(poset.getNonChildren(), hasToString("['']"));
+    assertThat(poset.getNonParents(), hasToString("['abcd']"));
     assertThat(poset.getChildren(b), hasToString("['']"));
     assertEqualsList("['ab', 'bcd']", poset.getParents(b));
     assertThat(poset.getChildren(b), hasToString("['']"));
@@ -180,6 +181,32 @@ class PartiallyOrderedSetTest {
     assertEqualsList("['ab', 'abcd']", poset.getAncestors("'a'"));
   }
 
+  @Test void testGetNonParentsOnLteIntPosetReturnsMaxValue() {
+    PartiallyOrderedSet<Integer> poset =
+        new PartiallyOrderedSet<>((i, j) -> i <= j, Arrays.asList(20, 30, 40));
+    assertThat(poset.getNonParents(), hasToString("[40]"));
+  }
+
+  @Test void testGetNonChildrenOnLteIntPosetReturnsMinValue() {
+    PartiallyOrderedSet<Integer> poset =
+        new PartiallyOrderedSet<>((i, j) -> i <= j, Arrays.asList(20, 30, 40));
+    assertThat(poset.getNonChildren(), hasToString("[20]"));
+  }
+
+  @Test void testGetNonParentsOnGteIntPosetReturnsMinValue() {
+    PartiallyOrderedSet<Integer> poset =
+        new PartiallyOrderedSet<>((i, j) -> i >= j, Arrays.asList(20, 30, 40));
+    assertThat(poset.getNonParents(), hasToString("[20]"));
+  }
+
+  @Test void testGetNonChildrenOnGteIntPosetReturnsMaxValue() {
+    PartiallyOrderedSet<Integer> poset =
+        new PartiallyOrderedSet<>((i, j) -> i >= j, Arrays.asList(20, 30, 40));
+    printValidate(poset);
+    System.out.println(poset.getChildren(20));
+    assertThat(poset.getNonChildren(), hasToString("[40]"));
+  }
+
   @Test void testPosetTricky() {
     final PartiallyOrderedSet<String> poset =
         new PartiallyOrderedSet<>(STRING_SUBSET_ORDERING);
@@ -195,6 +222,8 @@ class PartiallyOrderedSetTest {
     printValidate(poset);
     poset.add("'ab'");
     printValidate(poset);
+    assertThat(poset.getNonChildren(), hasToString("['a', 'b']"));
+    assertThat(poset.getNonParents(), hasToString("['ac', 'ab']"));
   }
 
   @Test void testPosetBits() {

--- a/core/src/test/java/org/apache/calcite/util/PartiallyOrderedSetTest.java
+++ b/core/src/test/java/org/apache/calcite/util/PartiallyOrderedSetTest.java
@@ -111,8 +111,8 @@ class PartiallyOrderedSetTest {
     poset.add(abcd);
     printValidate(poset);
     assertThat(poset, hasSize(2));
-    assertThat(poset.getNonChildren(), hasToString("['']"));
-    assertThat(poset.getNonParents(), hasToString("['abcd']"));
+    assertThat(poset.getNonChildren(), hasToString("['abcd']"));
+    assertThat(poset.getNonParents(), hasToString("['']"));
 
     final String ab = "'ab'";
     poset.add(ab);
@@ -159,8 +159,8 @@ class PartiallyOrderedSetTest {
 
     poset.add(b);
     printValidate(poset);
-    assertThat(poset.getNonChildren(), hasToString("['']"));
-    assertThat(poset.getNonParents(), hasToString("['abcd']"));
+    assertThat(poset.getNonChildren(), hasToString("['abcd']"));
+    assertThat(poset.getNonParents(), hasToString("['']"));
     assertThat(poset.getChildren(b), hasToString("['']"));
     assertEqualsList("['ab', 'bcd']", poset.getParents(b));
     assertThat(poset.getChildren(b), hasToString("['']"));
@@ -181,30 +181,28 @@ class PartiallyOrderedSetTest {
     assertEqualsList("['ab', 'abcd']", poset.getAncestors("'a'"));
   }
 
-  @Test void testGetNonParentsOnLteIntPosetReturnsMaxValue() {
+  @Test void testGetNonParentsOnLteIntPosetReturnsMinValue() {
     PartiallyOrderedSet<Integer> poset =
         new PartiallyOrderedSet<>((i, j) -> i <= j, Arrays.asList(20, 30, 40));
-    assertThat(poset.getNonParents(), hasToString("[40]"));
-  }
-
-  @Test void testGetNonChildrenOnLteIntPosetReturnsMinValue() {
-    PartiallyOrderedSet<Integer> poset =
-        new PartiallyOrderedSet<>((i, j) -> i <= j, Arrays.asList(20, 30, 40));
-    assertThat(poset.getNonChildren(), hasToString("[20]"));
-  }
-
-  @Test void testGetNonParentsOnGteIntPosetReturnsMinValue() {
-    PartiallyOrderedSet<Integer> poset =
-        new PartiallyOrderedSet<>((i, j) -> i >= j, Arrays.asList(20, 30, 40));
     assertThat(poset.getNonParents(), hasToString("[20]"));
   }
 
-  @Test void testGetNonChildrenOnGteIntPosetReturnsMaxValue() {
+  @Test void testGetNonChildrenOnLteIntPosetReturnsMaxValue() {
+    PartiallyOrderedSet<Integer> poset =
+        new PartiallyOrderedSet<>((i, j) -> i <= j, Arrays.asList(20, 30, 40));
+    assertThat(poset.getNonChildren(), hasToString("[40]"));
+  }
+
+  @Test void testGetNonParentsOnGteIntPosetReturnsMaxValue() {
     PartiallyOrderedSet<Integer> poset =
         new PartiallyOrderedSet<>((i, j) -> i >= j, Arrays.asList(20, 30, 40));
-    printValidate(poset);
-    System.out.println(poset.getChildren(20));
-    assertThat(poset.getNonChildren(), hasToString("[40]"));
+    assertThat(poset.getNonParents(), hasToString("[40]"));
+  }
+
+  @Test void testGetNonChildrenOnGteIntPosetReturnsMinValue() {
+    PartiallyOrderedSet<Integer> poset =
+        new PartiallyOrderedSet<>((i, j) -> i >= j, Arrays.asList(20, 30, 40));
+    assertThat(poset.getNonChildren(), hasToString("[20]"));
   }
 
   @Test void testPosetTricky() {
@@ -222,8 +220,8 @@ class PartiallyOrderedSetTest {
     printValidate(poset);
     poset.add("'ab'");
     printValidate(poset);
-    assertThat(poset.getNonChildren(), hasToString("['a', 'b']"));
-    assertThat(poset.getNonParents(), hasToString("['ac', 'ab']"));
+    assertThat(poset.getNonChildren(), hasToString("['ac', 'ab']"));
+    assertThat(poset.getNonParents(), hasToString("['a', 'b']"));
   }
 
   @Test void testPosetBits() {


### PR DESCRIPTION
1. Add Javadoc to clarify the results of each method and avoid potential misinterpretation of their name.
2. Add some test cases with explicit tests for the aforementioned methods.