### PR TITLE
[CALCITE-6702] Strong Policy for the POWER Function is wrong

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/Strong.java
+++ b/core/src/main/java/org/apache/calcite/plan/Strong.java
@@ -336,6 +336,7 @@ public class Strong {
     map.put(SqlKind.TIMESTAMP_ADD, Policy.ANY);
     map.put(SqlKind.TIMESTAMP_DIFF, Policy.ANY);
     map.put(SqlKind.ITEM, Policy.ANY);
+    map.put(SqlKind.POWER, Policy.ANY);
 
     // Assume that any other expressions cannot be simplified.
     for (SqlKind k

--- a/core/src/main/java/org/apache/calcite/sql/SqlBasicFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBasicFunction.java
@@ -118,6 +118,17 @@ public final class SqlBasicFunction extends SqlFunction {
         SqlFunctionCategory.SYSTEM, call -> SqlMonotonicity.NOT_MONOTONIC, false);
   }
 
+  /** Creates a {@code SqlBasicFunction} whose name is the same as its kind. */
+  public static SqlBasicFunction create(SqlKind kind,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeChecker operandTypeChecker,
+      SqlFunctionCategory category) {
+    return new SqlBasicFunction(kind.name(), kind,
+        SqlSyntax.FUNCTION, true, returnTypeInference, null,
+        OperandHandlers.DEFAULT, operandTypeChecker, 0,
+        category, call -> SqlMonotonicity.NOT_MONOTONIC, false);
+  }
+
   /** Creates a {@code SqlBasicFunction}
    * with kind {@link SqlKind#OTHER_FUNCTION}
    * and category {@link SqlFunctionCategory#NUMERIC}. */

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -319,6 +319,9 @@ public enum SqlKind {
    */
   PATTERN_CONCAT,
 
+  /** Exponentiation. **/
+  POWER,
+
   // comparison operators
 
   /** {@code IN} operator. */

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1700,7 +1700,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
    * second operand is negative.
    */
   public static final SqlBasicFunction POWER =
-      SqlBasicFunction.create("POWER",
+      SqlBasicFunction.create(SqlKind.POWER,
           ReturnTypes.DOUBLE_NULLABLE,
           OperandTypes.NUMERIC_NUMERIC,
           SqlFunctionCategory.NUMERIC);


### PR DESCRIPTION
CALCITE-6702: Strong Policy for the `SqlStdOperatorTable.POWER` Function is wrongly assigned `AS_IS` when it should be `ANY`.

**Context:**
In various SQL db implementations, the `POWER(a, b)` function returns `NULL` when either or both operands are null.
```
SELECT POWER(NULL, 2) AS "ALIAS1"; -- => Returns NULL
SELECT POWER(2, NULL) AS "ALIAS2"; -- => Returns NULL
SELECT POWER(NULL ,NULL) AS "ALIAS3"; -- => Returns NULL
```

These are all the cases I could think of:
![image](https://github.com/user-attachments/assets/1d6ee100-65a4-4c87-9c87-d7c893c2393b)

This means that the correct null policy for the `POWER` function is `ANY` instead of `AS_IS`, since this expression is `NULL` **if and only if** at least one of its arguments is `NULL`.