### PR TITLE
[CALCITE-6688] Allow operators of SqlKind.SYMMETRICAL to be reversed

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlBasicFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBasicFunction.java
@@ -159,6 +159,10 @@ public final class SqlBasicFunction extends SqlFunction {
     return deterministic;
   }
 
+  @Override public @Nullable SqlOperator reverse() {
+    return isSymmetrical() ? this : null;
+  }
+
   @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
     return monotonicityInference.apply(call);
   }

--- a/core/src/test/java/org/apache/calcite/rex/RexNormalizeTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexNormalizeTest.java
@@ -91,6 +91,14 @@ class RexNormalizeTest extends RexProgramTestBase {
     assertNodeEquals(
         ne(vBool(0), vBool(1)),
         ne(vBool(1), vBool(0)));
+
+    assertNodeEquals(
+        greatest(vInt(0), vInt(1)),
+        greatest(vInt(1), vInt(0)));
+
+    assertNodeEquals(
+        least(vInt(0), vInt(1)),
+        least(vInt(1), vInt(0)));
   }
 
   @Test void reversibleDifferentArgOps() {

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramBuilderBase.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramBuilderBase.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.fun.SqlInternalOperators;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -325,6 +326,13 @@ public abstract class RexProgramBuilderBase {
 
   protected RexNode add(RexNode n1, RexNode n2) {
     return rexBuilder.makeCall(SqlStdOperatorTable.PLUS, n1, n2);
+  }
+  protected RexNode greatest(RexNode... nodes) {
+    return rexBuilder.makeCall(SqlLibraryOperators.GREATEST, nodes);
+  }
+
+  protected RexNode least(RexNode... nodes) {
+    return rexBuilder.makeCall(SqlLibraryOperators.LEAST, nodes);
   }
 
   protected RexNode m2v(RexNode n) {


### PR DESCRIPTION
`SqlBasicFunction` did not override `SqlOperator#reverse()` so functions belonging to the `SqlKind.SYMMETRICAL` set threw a NPE [during normalization](https://github.com/apache/calcite/blob/8b4136bbd183f10e72c2ec02bef9caf1748631c2/core/src/main/java/org/apache/calcite/rex/RexNormalize.java#L102). 

This PR adds a overridden `reverse()` method to `SqlBasicFunction` that returns the operator if `isSymmetrical()` is true.