### PR TITLE
Site: Reformat CONCAT_WS and REVERSE document

### DIFF
--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2774,7 +2774,7 @@ In the following:
 | m | CONCAT_WS(separator, str1 [, string ]*)        | Concatenates one or more strings, returns null only when separator is null, otherwise treats null arguments as empty strings
 | p | CONCAT_WS(separator, any [, any ]*)            | Concatenates all but the first argument, returns null only when separator is null, otherwise treats null arguments as empty strings
 | q | CONCAT_WS(separator, str1, str2 [, string ]*)  | Concatenates two or more strings, requires at least 3 arguments (up to 254), treats null arguments as empty strings
-| s | CONCAT_WS(separator [, string | array(string)]*)  | Concatenates one or more strings or arrays. Besides the separator, other arguments can include strings or string arrays. returns null only when separator is null, treats other null arguments as empty strings
+| s | CONCAT_WS(separator [, string \| array(string)]*)  | Concatenates one or more strings or arrays. Besides the separator, other arguments can include strings or string arrays. returns null only when separator is null, treats other null arguments as empty strings
 | m | COMPRESS(string)                               | Compresses a string using zlib compression and returns the result as a binary string
 | b | CONTAINS_SUBSTR(expression, string [ , json_scope =&gt; json_scope_value ]) | Returns whether *string* exists as a substring in *expression*. Optional *json_scope* argument specifies what scope to search if *expression* is in JSON format. Returns NULL if a NULL exists in *expression* that does not result in a match
 | q | CONVERT(type, expression [ , style ])          | Equivalent to `CAST(expression AS type)`; ignores the *style* operand
@@ -2902,7 +2902,7 @@ In the following:
 | b | REGEXP_SUBSTR(string, regexp [, position [, occurrence]]) | Synonym for REGEXP_EXTRACT
 | b m p r s | REPEAT(string, integer)                | Returns a string consisting of *string* repeated of *integer* times; returns an empty string if *integer* is less than 1
 | b m | REVERSE(string)                              | Returns *string* with the order of the characters reversed
-| s | REVERSE(string | array)                        | Returns *string* with the characters in reverse order or array with elements in reverse order
+| s | REVERSE(string \| array)                        | Returns *string* with the characters in reverse order or array with elements in reverse order
 | b m p r s | RIGHT(string, length)                  | Returns the rightmost *length* characters from the *string*
 | h m s | string1 RLIKE string2                      | Whether *string1* matches regex pattern *string2* (similar to `LIKE`, but uses Java regex)
 | h m s | string1 NOT RLIKE string2                  | Whether *string1* does not match regex pattern *string2* (similar to `NOT LIKE`, but uses Java regex)


### PR DESCRIPTION
In reference document - https://calcite.apache.org/docs/reference.html#dialect-specific-operators, `CONCAT_WS` and `REVERSE` functions had rendering problems because their syntax included `|` without using escape characters.

* CONCAT_WS:
<img width="683" alt="image" src="https://github.com/user-attachments/assets/abca01cd-d300-433d-ada9-0b33ed1a31e9">

* REVERSE:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/66b8010f-aaa9-4b7d-9324-41dfc955d0a7">
