### PR TITLE
[CALCITE-6718] Optimize SubstitutionVisitor's splitFilter with early return and uniform simplification for equivalence checking

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/SubstitutionVisitor.java
@@ -297,8 +297,11 @@ public class SubstitutionVisitor {
       RexNode condition, RexNode target) {
     final RexBuilder rexBuilder = simplify.rexBuilder;
     condition = simplify.simplify(condition);
-    target = simplify.simplify(target);
     RexNode condition2 = canonizeNode(rexBuilder, condition);
+    if (target.isAlwaysTrue()) {
+      return condition2;
+    }
+    target = simplify.simplify(target);
     RexNode target2 = canonizeNode(rexBuilder, target);
 
     // First, try splitting into ORs.
@@ -321,7 +324,7 @@ public class SubstitutionVisitor {
           RexUtil.composeConjunction(rexBuilder,
               ImmutableList.of(condition2, target2));
       RexNode r =
-          canonizeNode(rexBuilder, simplify.simplifyUnknownAsFalse(x2));
+          canonizeNode(rexBuilder, simplify.simplify(x2));
       if (!r.isAlwaysFalse() && isEquivalent(condition2, r)) {
         List<RexNode> conjs = RelOptUtil.conjunctions(r);
         for (RexNode e : RelOptUtil.conjunctions(target2)) {

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -1526,7 +1526,7 @@ public class RexSimplify {
     if (unknownAs == FALSE && predicateElimination) {
       simplifyAndTerms(operands, FALSE);
     } else {
-      simplifyList(operands, unknownAs);
+      simplifyAndTerms(operands, unknownAs);
     }
 
     final List<RexNode> terms = new ArrayList<>();


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Implement early return for materialized view range checking.
2. Apply uniform simplification for expression equivalence checking.

### Why are the changes needed?
Early Return: Many materialized views do not have filters, so implementing early return can avoid unnecessary checks and improve performance.
Uniform Simplification: In user-customized applications, we cannot guarantee that both sides of the equivalence check have been simplified using simplifyUnknownAsFalse. Adding this ensures consistent behavior.

### Does this PR introduce any user-facing change?
No.
