### PR TITLE
[CALCITE-6727] Column uniqueness constrain should only apply to inner join

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -321,15 +321,16 @@ public class RelMdColumnUniqueness
     }
 
     final JoinInfo joinInfo = rel.analyzeCondition();
-
-    // Joining with a singleton constrains the keys on the other table
-    final Double rightMaxRowCount = mq.getMaxRowCount(right);
-    if (rightMaxRowCount != null && rightMaxRowCount <= 1.0) {
-      leftColumns = leftColumns.union(joinInfo.leftSet());
-    }
-    final Double leftMaxRowCount = mq.getMaxRowCount(left);
-    if (leftMaxRowCount != null && leftMaxRowCount <= 1.0) {
-      rightColumns = rightColumns.union(joinInfo.rightSet());
+    if (rel.getJoinType() == JoinRelType.INNER) {
+      // Joining with a singleton constrains the keys on the other table
+      final Double rightMaxRowCount = mq.getMaxRowCount(right);
+      if (rightMaxRowCount != null && rightMaxRowCount <= 1.0) {
+        leftColumns = leftColumns.union(joinInfo.leftSet());
+      }
+      final Double leftMaxRowCount = mq.getMaxRowCount(left);
+      if (leftMaxRowCount != null && leftMaxRowCount <= 1.0) {
+        rightColumns = rightColumns.union(joinInfo.rightSet());
+      }
     }
 
     // If the original column mask contains columns from both the left and

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1193,6 +1193,48 @@ public class RelMetadataTest {
         .assertThatUniqueKeysAre(bitSetOf());
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6727">[CALCITE-6727]
+   * Column uniqueness constrain should only apply to inner join</a>. */
+  @Test void testColumnUniquenessForLeftJoinOnLimit1() {
+    final String sql = ""
+        + "select A.empno as a_empno,\n"
+        + " A.ename as a_ename,\n"
+        + " B.empno as b_empno,\n"
+        + " B.ename as b_ename\n"
+        + "from emp A\n"
+        + "left join (\n"
+        + "  select * from emp\n"
+        + "  limit 1) B\n"
+        + "on A.empno = B.empno";
+    sql(sql)
+        .assertThatAreColumnsUnique(bitSetOf(0), is(true))
+        .assertThatAreColumnsUnique(bitSetOf(1), is(false))
+        .assertThatAreColumnsUnique(bitSetOf(2), is(false))
+        .assertThatAreColumnsUnique(bitSetOf(3), is(false));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6727">[CALCITE-6727]
+   * Column uniqueness constrain should only apply to inner join</a>. */
+  @Test void testColumnUniquenessForRightJoinOnLimit1() {
+    final String sql = ""
+        + "select A.empno as a_empno,\n"
+        + " A.ename as a_ename,\n"
+        + " B.empno as b_empno,\n"
+        + " B.ename as b_ename\n"
+        + "from emp A\n"
+        + "right join (\n"
+        + "  select * from emp\n"
+        + "  limit 1) B\n"
+        + "on A.empno = B.empno";
+    sql(sql)
+        .assertThatAreColumnsUnique(bitSetOf(0), is(false))
+        .assertThatAreColumnsUnique(bitSetOf(1), is(false))
+        .assertThatAreColumnsUnique(bitSetOf(2), is(true))
+        .assertThatAreColumnsUnique(bitSetOf(3), is(true));
+  }
+
   @Test void testColumnUniquenessForJoinOnAggregation() {
     final String sql = ""
         + "select *\n"


### PR DESCRIPTION
In the existing test
```
// RelMetadataTest.java
@Test void testColumnUniquenessForJoinOnLimit1() {
  final String sql = ""
      + "select *\n"
      + "from emp A\n"
      + "join (\n"
      + "  select * from emp\n"
      + "  limit 1) B\n"
      + "on A.empno = B.empno";
  sql(sql)
      .assertThatAreColumnsUnique(bitSetOf(0), is(true))
      .assertThatAreColumnsUnique(bitSetOf(1), is(true))
      .assertThatAreColumnsUnique(bitSetOf(9), is(true))
      .assertThatAreColumnsUnique(bitSetOf(10), is(true))
      .assertThatAreColumnsUnique(bitSetOf(), is(true))
      .assertThatUniqueKeysAre(bitSetOf());
} 
```
the join result column `A.ENAME` is considered to be unique because `A.EMPNO` is the unique key. The test still passes when the query changes to left join, in which case `A.ENAME` is not guaranteed to be unique. 