### PR TITLE
[CALCITE-6704] Limit result size of RelMdUniqueKeys handler

### DIFF
--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -57,6 +57,17 @@ this behavior.  The BIG_QUERY and SQL_SERVER_2008 conformance have
 been changed to use checked arithmetic, matching the specification of
 these dialects.
 
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-6704">CALCITE-6704</a>]
+Limit result size of `RelMdUniqueKeys` handler. Certain query patterns can lead
+to an exponentially large number of unique keys that can cause crashes and OOM
+errors. To prevent this kind of issues the `RelMdUniqueKeys` handler is now using
+a limit to restrict the number of keys for each relational expression. The limit
+is set to `1000` by default. The value is reasonably large to ensure that
+most common use-cases will not be affected and at the same time bounds exponentially
+large results set to a manageable value. Users that need a bigger/smaller limit
+should create a new instance of `RelMdUniqueKeys` and register it using the
+metadata provider of their choice.
+
 #### New features
 {: #new-features-1-39-0}
 


### PR DESCRIPTION
For certain query patterns `RelMdUniqueKeys` handler generates an exponentially large number of unique keys that results into crashes and OOM errors. The limit guards against the combinatoric explosion that may appear for such use-cases and provides the users of a way to tune further the upper bound if needed.

For more info check: CALCITE-6704

Diff outline:
1. Add limit parameter in `RelMdUniqueKeys` handler, document it, and use it to bound the output of supported relational expressions.
2. Replace `ImmutableSet` with `HashSet` since the former does not allow to easily check the current size of the collection.
3. Enhance `RelMetadataFixture` to be able to test the uniqueKeys API with different values for `ignoreNulls`.
4. Modify `RelMetadataFixture#checkUniqueConsistent` to enforce consistency only for the keys returned `RelMetadataQuery#getUniqueKeys` method and not for every combination of columns since due to the limit the results may necessarily differ.
5. Add unit tests `RelMetadataTest` for each relational expression that is handled by `RelMdUniqueKeys` handler.
7. Document behavior changes regarding the default limit in `history.md`