### PR TITLE
[CALCITE-6664] Replace GREATEST, LEAST functions in Spark library wit…

### DIFF
--- a/babel/src/test/resources/sql/spark.iq
+++ b/babel/src/test/resources/sql/spark.iq
@@ -667,4 +667,34 @@ SELECT KEY, "set" IS NULL AS N FROM COMPLEX;
 
 !ok
 
+SELECT greatest(1, null, 3) AS x;
++---+
+| X |
++---+
+| 3 |
++---+
+(1 row)
+
+!ok
+
+SELECT least(1, 2, null, 3) AS x;
++---+
+| X |
++---+
+| 1 |
++---+
+(1 row)
+
+!ok
+
+SELECT greatest(null, null) AS x;
++---+
+| X |
++---+
+|   |
++---+
+(1 row)
+
+!ok
+
 # End spark.iq

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -475,10 +475,10 @@ public enum SqlKind {
   /** {@code NVL2} function (Oracle, Spark). */
   NVL2,
 
-  /** {@code GREATEST} function (Oracle, Spark). */
+  /** {@code GREATEST} function (Oracle). */
   GREATEST,
 
-  /** {@code GREATEST} function (PostgreSQL). */
+  /** {@code GREATEST} function (PostgreSQL, Spark). */
   GREATEST_PG,
 
   /** The two-argument {@code CONCAT} function (Oracle). */
@@ -503,7 +503,7 @@ public enum SqlKind {
   /** {@code LEAST} function (Oracle). */
   LEAST,
 
-  /** {@code LEAST} function (PostgreSQL). */
+  /** {@code LEAST} function (PostgreSQL, Spark). */
   LEAST_PG,
 
   /** {@code LOG} function. (Mysql, Spark). */

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -480,28 +480,30 @@ public abstract class SqlLibraryOperators {
           SqlFunctionCategory.STRING);
 
   /** The "GREATEST(value, value)" function. */
-  @LibraryOperator(libraries = {BIG_QUERY, ORACLE, SPARK})
+  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
   public static final SqlFunction GREATEST =
       SqlBasicFunction.create(SqlKind.GREATEST,
           ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.TO_NULLABLE),
           OperandTypes.SAME_VARIADIC);
 
-  /** The "GREATEST(value, value)" function. */
-  @LibraryOperator(libraries = {POSTGRESQL})
+  /** The "GREATEST(value, value)" function. Identical to the standard <code>GREATEST</code>
+   * function except it skips null values and only returns null if all parameters are nulls. */
+  @LibraryOperator(libraries = {POSTGRESQL, SPARK})
   public static final SqlFunction GREATEST_PG =
       SqlBasicFunction.create("GREATEST", SqlKind.GREATEST_PG,
           ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.TO_NULLABLE),
           OperandTypes.SAME_VARIADIC);
 
   /** The "LEAST(value, value)" function. */
-  @LibraryOperator(libraries = {BIG_QUERY, ORACLE, SPARK})
+  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
   public static final SqlFunction LEAST =
       SqlBasicFunction.create(SqlKind.LEAST,
           ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.TO_NULLABLE),
           OperandTypes.SAME_VARIADIC);
 
-  /** The "GREATEST(value, value)" function. */
-  @LibraryOperator(libraries = {POSTGRESQL})
+  /** The "LEAST(value, value)" function. Identical to the standard <code>LEAST</code>
+   * function except it skips null values and only returns null if all parameters are nulls. */
+  @LibraryOperator(libraries = {POSTGRESQL, SPARK})
   public static final SqlFunction LEAST_PG =
       SqlBasicFunction.create("LEAST", SqlKind.LEAST_PG,
           ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.TO_NULLABLE),

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -11664,7 +11664,7 @@ public class SqlOperatorTest {
           "VARCHAR(5) NOT NULL");
     };
     final List<SqlLibrary> libraries =
-        list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE, SqlLibrary.SPARK);
+        list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE);
     f0.forEachLibrary(libraries, consumer);
   }
 
@@ -11686,7 +11686,8 @@ public class SqlOperatorTest {
       f.checkScalar("greatest(CAST(NULL AS INTEGER), CAST(NULL AS INTEGER))", isNullValue(),
           "INTEGER");
     };
-    final List<SqlLibrary> libraries = list(SqlLibrary.POSTGRESQL, SqlLibrary.REDSHIFT);
+    final List<SqlLibrary> libraries =
+        list(SqlLibrary.POSTGRESQL, SqlLibrary.REDSHIFT, SqlLibrary.SPARK);
     f0.forEachLibrary(libraries, consumer);
   }
 
@@ -11710,7 +11711,7 @@ public class SqlOperatorTest {
           "VARCHAR(5) NOT NULL");
     };
     final List<SqlLibrary> libraries =
-        list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE, SqlLibrary.SPARK);
+        list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE);
     f0.forEachLibrary(libraries, consumer);
   }
 
@@ -11732,7 +11733,8 @@ public class SqlOperatorTest {
       f.checkScalar("least(CAST(NULL AS INTEGER), CAST(NULL AS INTEGER))", isNullValue(),
           "INTEGER");
     };
-    final List<SqlLibrary> libraries = list(SqlLibrary.POSTGRESQL, SqlLibrary.REDSHIFT);
+    final List<SqlLibrary> libraries =
+        list(SqlLibrary.POSTGRESQL, SqlLibrary.REDSHIFT, SqlLibrary.SPARK);
     f0.forEachLibrary(libraries, consumer);
   }
 


### PR DESCRIPTION
`GREATEST` or `LEAST` function in Spark library returns null if any of its parameters are null, it is not consistent with the description of Spark [docs](https://spark.apache.org/docs/latest/api/sql/index.html#greatest)

> Returns the greatest value of all parameters, skipping null values.

This PR tries to replacement the implementation of these functions with the implementation in PostgreSQL Library