### PR TITLE
[CALCITE-6728] Introduce new methods to lookup tables and schemas inside schemas

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelQuidemTest.java
@@ -181,7 +181,7 @@ class BabelQuidemTest extends QuidemTest {
         final String schemaName = calciteConnection.getSchema();
         final SchemaPlus schema =
             schemaName != null
-                ? calciteConnection.getRootSchema().getSubSchema(schemaName)
+                ? calciteConnection.getRootSchema().subSchemas().get(schemaName)
                 : calciteConnection.getRootSchema();
         final Frameworks.ConfigBuilder config =
             Frameworks.newConfigBuilder()

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSchema.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraSchema.java
@@ -29,6 +29,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.MaterializedViewTable;
+import org.apache.calcite.schema.lookup.LikePattern;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.SqlWriterConfig;
@@ -325,8 +326,8 @@ public class CassandraSchema extends AbstractSchema {
       query = buf.toString();
 
       // Add the view for this query
-      String viewName = "$" + getTableNames().size();
-      SchemaPlus schema = parentSchema.getSubSchema(name);
+      String viewName = "$" + tables().getNames(LikePattern.any()).size();
+      SchemaPlus schema = parentSchema.subSchemas().get(name);
       if (schema == null) {
         throw new IllegalStateException("Cannot find schema " + name
             + " in parent schema " + parentSchema.getName());

--- a/core/src/main/java/org/apache/calcite/adapter/clone/CloneSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/clone/CloneSchema.java
@@ -33,6 +33,8 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.lookup.LikePattern;
+import org.apache.calcite.schema.lookup.Lookup;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -68,8 +70,9 @@ public class CloneSchema extends AbstractSchema {
 
   @Override protected Map<String, Table> getTableMap() {
     final Map<String, Table> map = new LinkedHashMap<>();
-    for (String name : sourceSchema.getTableNames()) {
-      final Table table = sourceSchema.getTable(name);
+    final Lookup<Table> tables = sourceSchema.tables();
+    for (String name : tables.getNames(LikePattern.any())) {
+      final Table table = tables.get(name);
       if (table instanceof QueryableTable) {
         final QueryableTable sourceTable = (QueryableTable) table;
         map.put(name,

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcBaseSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcBaseSchema.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.jdbc;
+
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.Function;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.SchemaVersion;
+import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.lookup.LikePattern;
+import org.apache.calcite.schema.lookup.Lookup;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class for JDBC schemas.
+ */
+public abstract class JdbcBaseSchema implements Schema {
+
+  @Override public abstract Lookup<Table> tables();
+
+
+  @Deprecated @Override public @Nullable Table getTable(String name) {
+    return tables().get(name);
+  }
+
+  @Deprecated @Override public Set<String> getTableNames() {
+    return tables().getNames(LikePattern.any());
+  }
+
+  @Override public abstract Lookup<? extends Schema> subSchemas();
+
+  @Deprecated @Override public @Nullable Schema getSubSchema(String name) {
+    return subSchemas().get(name);
+  }
+
+  @Deprecated @Override public Set<String> getSubSchemaNames() {
+    return subSchemas().getNames(LikePattern.any());
+  }
+
+
+  @Override public @Nullable RelProtoDataType getType(String name) {
+    return null;
+  }
+
+  @Override public Set<String> getTypeNames() {
+    return Collections.emptySet();
+  }
+
+  @Override public final Collection<Function> getFunctions(String name) {
+    return Collections.emptyList();
+  }
+
+  @Override public final Set<String> getFunctionNames() {
+    return Collections.emptySet();
+  }
+
+  @Override public Expression getExpression(final @Nullable SchemaPlus parentSchema,
+      final String name) {
+    requireNonNull(parentSchema, "parentSchema");
+    return Schemas.subSchemaExpression(parentSchema, name, getClass());
+  }
+
+  @Override public boolean isMutable() {
+    return false;
+  }
+
+  @Override public Schema snapshot(final SchemaVersion version) {
+    return this;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcCatalogSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcCatalogSchema.java
@@ -22,22 +22,27 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.Wrapper;
-import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.lookup.IgnoreCaseLookup;
+import org.apache.calcite.schema.lookup.LikePattern;
+import org.apache.calcite.schema.lookup.LoadingCacheLookup;
+import org.apache.calcite.schema.lookup.Lookup;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlDialectFactory;
 import org.apache.calcite.sql.SqlDialectFactoryImpl;
 import org.apache.calcite.util.BuiltInMethod;
 
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import javax.sql.DataSource;
 
@@ -51,20 +56,21 @@ import static java.util.Objects.requireNonNull;
  * an instance of {@link JdbcSchema}.
  *
  * <p>This schema is lazy: it does not compute the list of schema names until
- * the first call to {@link #getSubSchemaMap()}. Then it creates a
- * {@link JdbcSchema} for each schema name. Each JdbcSchema will populate its
+ * the first call to {@link #subSchemas()} and {@link Lookup#get(String)}. Then it creates a
+ * {@link JdbcSchema} for this schema name. Each JdbcSchema will populate its
  * tables on demand.
  */
-public class JdbcCatalogSchema extends AbstractSchema implements Wrapper {
+public class JdbcCatalogSchema extends JdbcBaseSchema implements Wrapper {
   final DataSource dataSource;
   public final SqlDialect dialect;
   final JdbcConvention convention;
   final String catalog;
+  private final Lookup<JdbcSchema> subSchemas;
 
-  /** Sub-schemas by name, lazily initialized. */
+  /** default schema name, lazily initialized. */
   @SuppressWarnings({"method.invocation.invalid", "Convert2MethodRef"})
-  final Supplier<SubSchemaMap> subSchemaMapSupplier =
-      Suppliers.memoize(() -> computeSubSchemaMap());
+  private final Supplier<Optional<String>> defaultSchemaName =
+      Suppliers.memoize(() -> Optional.ofNullable(computeDefaultSchemaName()));
 
   /** Creates a JdbcCatalogSchema. */
   public JdbcCatalogSchema(DataSource dataSource, SqlDialect dialect,
@@ -73,6 +79,40 @@ public class JdbcCatalogSchema extends AbstractSchema implements Wrapper {
     this.dialect = requireNonNull(dialect, "dialect");
     this.convention = requireNonNull(convention, "convention");
     this.catalog = catalog;
+    this.subSchemas = new LoadingCacheLookup<>(new IgnoreCaseLookup<JdbcSchema>() {
+      @Override public @Nullable JdbcSchema get(String name) {
+        try (Connection connection = dataSource.getConnection();
+            ResultSet resultSet =
+                connection.getMetaData().getSchemas(catalog, name)) {
+          while (resultSet.next()) {
+            final String schemaName =
+                requireNonNull(resultSet.getString(1),
+                    "got null schemaName from the database");
+            return new JdbcSchema(dataSource, dialect, convention, catalog, schemaName);
+          }
+        } catch (SQLException e) {
+          throw new RuntimeException(e);
+        }
+        return null;
+      }
+
+      @Override public Set<String> getNames(LikePattern pattern) {
+        final ImmutableSet.Builder<String> builder =
+            ImmutableSet.builder();
+        try (Connection connection = dataSource.getConnection();
+            ResultSet resultSet =
+                connection.getMetaData().getSchemas(catalog, pattern.pattern)) {
+          while (resultSet.next()) {
+            builder.add(
+                requireNonNull(resultSet.getString(1),
+                    "got null schemaName from the database"));
+          }
+        } catch (SQLException e) {
+          throw new RuntimeException(e);
+        }
+        return builder.build();
+      }
+    });
   }
 
   public static JdbcCatalogSchema create(
@@ -103,34 +143,25 @@ public class JdbcCatalogSchema extends AbstractSchema implements Wrapper {
     return new JdbcCatalogSchema(dataSource, dialect, convention, catalog);
   }
 
-  private SubSchemaMap computeSubSchemaMap() {
-    final ImmutableMap.Builder<String, Schema> builder =
-        ImmutableMap.builder();
-    @Nullable String defaultSchemaName;
-    try (Connection connection = dataSource.getConnection();
-         ResultSet resultSet =
-             connection.getMetaData().getSchemas(catalog, null)) {
-      defaultSchemaName = connection.getSchema();
-      while (resultSet.next()) {
-        final String schemaName =
-            requireNonNull(resultSet.getString(1),
-                "got null schemaName from the database");
-        builder.put(schemaName,
-            new JdbcSchema(dataSource, dialect, convention, catalog, schemaName));
-      }
+  @Override public Lookup<Table> tables() {
+    return Lookup.empty();
+  }
+
+  @Override public Lookup<? extends Schema> subSchemas() {
+    return subSchemas;
+  }
+
+  private @Nullable String computeDefaultSchemaName() {
+    try (Connection connection = dataSource.getConnection()) {
+      return connection.getSchema();
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
-    return new SubSchemaMap(defaultSchemaName, builder.build());
-  }
-
-  @Override protected Map<String, Schema> getSubSchemaMap() {
-    return subSchemaMapSupplier.get().map;
   }
 
   /** Returns the name of the default sub-schema. */
   public @Nullable String getDefaultSubSchemaName() {
-    return subSchemaMapSupplier.get().defaultSchemaName;
+    return defaultSchemaName.get().orElse(null);
   }
 
   /** Returns the data source. */
@@ -147,17 +178,5 @@ public class JdbcCatalogSchema extends AbstractSchema implements Wrapper {
       return clazz.cast(getDataSource());
     }
     return null;
-  }
-
-  /** Contains sub-schemas by name, and the name of the default schema. */
-  private static class SubSchemaMap {
-    final @Nullable String defaultSchemaName;
-    final ImmutableMap<String, Schema> map;
-
-    private SubSchemaMap(@Nullable String defaultSchemaName,
-        ImmutableMap<String, Schema> map) {
-      this.defaultSchemaName = defaultSchemaName;
-      this.map = map;
-    }
   }
 }

--- a/core/src/main/java/org/apache/calcite/interpreter/TableScanNode.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/TableScanNode.java
@@ -131,7 +131,7 @@ public class TableScanNode implements Node {
       requireNonNull(schema, () ->
           "schema is null while resolving " + name + " for table"
               + relOptTable.getQualifiedName());
-      schema = schema.getSubSchema(name);
+      schema = schema.subSchemas().get(name);
     }
     final Enumerable<Row> rowEnumerable;
     if (elementType instanceof Class) {

--- a/core/src/main/java/org/apache/calcite/jdbc/CachingCalciteSchema.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CachingCalciteSchema.java
@@ -22,13 +22,12 @@ import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaVersion;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.TableMacro;
+import org.apache.calcite.schema.lookup.Lookup;
+import org.apache.calcite.schema.lookup.SnapshotLookup;
 import org.apache.calcite.util.NameMap;
 import org.apache.calcite.util.NameMultimap;
 import org.apache.calcite.util.NameSet;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -37,7 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
 
@@ -46,8 +45,7 @@ import static org.apache.calcite.linq4j.Nullness.castNonNull;
  * functions and sub-schemas.
  */
 class CachingCalciteSchema extends CalciteSchema {
-  private final Cached<SubSchemaCache> implicitSubSchemaCache;
-  private final Cached<NameSet> implicitTableCache;
+  private final ConcurrentLinkedDeque<SnapshotLookup<?>> caches = new ConcurrentLinkedDeque<>();
   private final Cached<NameSet> implicitFunctionCache;
   private final Cached<NameSet> implicitTypeCache;
 
@@ -72,20 +70,6 @@ class CachingCalciteSchema extends CalciteSchema {
       @Nullable List<? extends List<String>> path) {
     super(parent, schema, name, subSchemaMap, tableMap, latticeMap, typeMap,
         functionMap, functionNames, nullaryFunctionMap, path);
-    this.implicitSubSchemaCache =
-        new AbstractCached<SubSchemaCache>() {
-          @Override public SubSchemaCache build() {
-            return new SubSchemaCache(CachingCalciteSchema.this,
-                CachingCalciteSchema.this.schema.getSubSchemaNames());
-          }
-        };
-    this.implicitTableCache =
-        new AbstractCached<NameSet>() {
-          @Override public NameSet build() {
-            return NameSet.immutableCopyOf(
-                CachingCalciteSchema.this.schema.getTableNames());
-          }
-        };
     this.implicitFunctionCache =
         new AbstractCached<NameSet>() {
           @Override public NameSet build() {
@@ -106,9 +90,8 @@ class CachingCalciteSchema extends CalciteSchema {
     if (cache == this.cache) {
       return;
     }
+    enableCaches(cache);
     final long now = System.currentTimeMillis();
-    implicitSubSchemaCache.enable(now, cache);
-    implicitTableCache.enable(now, cache);
     implicitFunctionCache.enable(now, cache);
     this.cache = cache;
   }
@@ -117,15 +100,14 @@ class CachingCalciteSchema extends CalciteSchema {
     return this.cache;
   }
 
-  @Override protected @Nullable CalciteSchema getImplicitSubSchema(String schemaName,
-      boolean caseSensitive) {
-    final long now = System.currentTimeMillis();
-    final SubSchemaCache subSchemaCache = implicitSubSchemaCache.get(now);
-    for (String schemaName2
-        : subSchemaCache.names.range(schemaName, caseSensitive)) {
-      return subSchemaCache.cache.getUnchecked(schemaName2);
-    }
-    return null;
+  @Override protected CalciteSchema createSubSchema(Schema schema, String name) {
+    return new CachingCalciteSchema(this, schema, name);
+  }
+
+  @Override protected <S> Lookup<S> enhanceLookup(Lookup<S> lookup) {
+    SnapshotLookup<S> snapshotLookup = new SnapshotLookup<>(lookup);
+    caches.add(snapshotLookup);
+    return snapshotLookup;
   }
 
   /** Adds a child schema of this schema. */
@@ -134,20 +116,6 @@ class CachingCalciteSchema extends CalciteSchema {
         new CachingCalciteSchema(this, schema, name);
     subSchemaMap.put(name, calciteSchema);
     return calciteSchema;
-  }
-
-  @Override protected @Nullable TableEntry getImplicitTable(String tableName,
-      boolean caseSensitive) {
-    final long now = System.currentTimeMillis();
-    final NameSet implicitTableNames = implicitTableCache.get(now);
-    for (String tableName2
-        : implicitTableNames.range(tableName, caseSensitive)) {
-      final Table table = schema.getTable(tableName2);
-      if (table != null) {
-        return tableEntry(tableName2, table);
-      }
-    }
-    return null;
   }
 
   @Override protected @Nullable TypeEntry getImplicitType(String name,
@@ -162,29 +130,6 @@ class CachingCalciteSchema extends CalciteSchema {
       }
     }
     return null;
-  }
-
-  @Override protected void addImplicitSubSchemaToBuilder(
-      ImmutableSortedMap.Builder<String, CalciteSchema> builder) {
-    ImmutableSortedMap<String, CalciteSchema> explicitSubSchemas =
-        builder.build();
-    final long now = System.currentTimeMillis();
-    final SubSchemaCache subSchemaCache = implicitSubSchemaCache.get(now);
-    for (String name : subSchemaCache.names.iterable()) {
-      if (explicitSubSchemas.containsKey(name)) {
-        // explicit sub-schema wins.
-        continue;
-      }
-      builder.put(name, subSchemaCache.cache.getUnchecked(name));
-    }
-  }
-
-  @Override protected void addImplicitTableToBuilder(
-      ImmutableSortedSet.Builder<String> builder) {
-    // Add implicit tables, case-sensitive.
-    final long now = System.currentTimeMillis();
-    final NameSet set = implicitTableCache.get(now);
-    builder.addAll(set.iterable());
   }
 
   @Override protected void addImplicitFunctionsToBuilder(
@@ -270,9 +215,8 @@ class CachingCalciteSchema extends CalciteSchema {
 
   @Override public boolean removeTable(String name) {
     if (cache) {
-      final long now = System.nanoTime();
-      implicitTableCache.enable(now, false);
-      implicitTableCache.enable(now, true);
+      enableCaches(false);
+      enableCaches(true);
     }
     return super.removeTable(name);
   }
@@ -284,6 +228,12 @@ class CachingCalciteSchema extends CalciteSchema {
       implicitFunctionCache.enable(now, true);
     }
     return super.removeFunction(name);
+  }
+
+  private void enableCaches(final boolean cache) {
+    for (SnapshotLookup<?> lookupCache : caches) {
+      lookupCache.enable(cache);
+    }
   }
 
   /** Strategy for caching the value of an object and re-creating it if its
@@ -326,34 +276,6 @@ class CachingCalciteSchema extends CalciteSchema {
         t = null;
       }
       built = false;
-    }
-  }
-
-  /** Information about the implicit sub-schemas of an {@link CalciteSchema}. */
-  private static class SubSchemaCache {
-    /** The names of sub-schemas returned from the {@link Schema} SPI. */
-    final NameSet names;
-    /** Cached {@link CalciteSchema} wrappers. It is
-     * worth caching them because they contain maps of their own sub-objects. */
-    final LoadingCache<String, CalciteSchema> cache;
-
-    private SubSchemaCache(final CalciteSchema calciteSchema,
-        Set<String> names) {
-      this.names = NameSet.immutableCopyOf(names);
-      this.cache =
-          CacheBuilder.newBuilder()
-              .build(new CacheLoader<String, CalciteSchema>() {
-                @Override public CalciteSchema load(String schemaName) {
-                  final Schema subSchema =
-                      calciteSchema.schema.getSubSchema(schemaName);
-                  if (subSchema == null) {
-                    throw new RuntimeException("sub-schema " + schemaName
-                        + " not found");
-                  }
-                  return new CachingCalciteSchema(calciteSchema, subSchema,
-                      schemaName);
-                }
-              });
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteSchema.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteSchema.java
@@ -29,6 +29,10 @@ import org.apache.calcite.schema.TableMacro;
 import org.apache.calcite.schema.Wrapper;
 import org.apache.calcite.schema.impl.MaterializedViewTable;
 import org.apache.calcite.schema.impl.StarTable;
+import org.apache.calcite.schema.lookup.LikePattern;
+import org.apache.calcite.schema.lookup.Lookup;
+import org.apache.calcite.schema.lookup.Named;
+import org.apache.calcite.util.LazyReference;
 import org.apache.calcite.util.NameMap;
 import org.apache.calcite.util.NameMultimap;
 import org.apache.calcite.util.NameSet;
@@ -65,12 +69,14 @@ public abstract class CalciteSchema {
   /** Tables explicitly defined in this schema. Does not include tables in
    * {@link #schema}. */
   protected final NameMap<TableEntry> tableMap;
+  private final LazyReference<Lookup<TableEntry>> tables = new LazyReference<>();
   protected final NameMultimap<FunctionEntry> functionMap;
   protected final NameMap<TypeEntry> typeMap;
   protected final NameMap<LatticeEntry> latticeMap;
   protected final NameSet functionNames;
   protected final NameMap<FunctionEntry> nullaryFunctionMap;
   protected final NameMap<CalciteSchema> subSchemaMap;
+  private final LazyReference<Lookup<CalciteSchema>> subSchemas = new LazyReference<>();
   private @Nullable List<? extends List<String>> path;
 
   protected CalciteSchema(@Nullable CalciteSchema parent, Schema schema,
@@ -109,17 +115,29 @@ public abstract class CalciteSchema {
     this.path = path;
   }
 
-  /** Returns a sub-schema with a given name that is defined implicitly
-   * (that is, by the underlying {@link Schema} object, not explicitly
-   * by a call to {@link #add(String, Schema)}), or null. */
-  protected abstract @Nullable CalciteSchema getImplicitSubSchema(String schemaName,
-      boolean caseSensitive);
+  public Lookup<TableEntry> tables() {
+    return this.tables.getOrCompute(() ->
+        Lookup.concat(
+            Lookup.of(this.tableMap),
+            enhanceLookup(schema.tables().map((s, n) -> tableEntry(n, s)))));
 
-  /** Returns a table with a given name that is defined implicitly
-   * (that is, by the underlying {@link Schema} object, not explicitly
-   * by a call to {@link #add(String, Table)}), or null. */
-  protected abstract @Nullable TableEntry getImplicitTable(String tableName,
-      boolean caseSensitive);
+  }
+
+  public Lookup<CalciteSchema> subSchemas() {
+    return subSchemas.getOrCompute(() ->
+        Lookup.concat(
+            Lookup.of(this.subSchemaMap),
+            enhanceLookup(schema.subSchemas().map((s, n) -> createSubSchema(s, n)))));
+  }
+
+  /** The derived class is able to enhance the lookup e.g. by introducing a cache. */
+  protected <S> Lookup<S> enhanceLookup(Lookup<S> lookup) {
+    return lookup;
+  }
+
+  /** Creates a sub-schema with a given name that is defined implicitly. */
+  protected abstract CalciteSchema createSubSchema(CalciteSchema this,
+      Schema schema, String name);
 
   /** Returns a type with a given name that is defined implicitly
    * (that is, by the underlying {@link Schema} object, not explicitly
@@ -132,14 +150,6 @@ public abstract class CalciteSchema {
    * not explicitly by a call to {@link #add(String, Function)}), or null. */
   protected abstract @Nullable TableEntry getImplicitTableBasedOnNullaryFunction(String tableName,
       boolean caseSensitive);
-
-  /** Adds implicit sub-schemas to a builder. */
-  protected abstract void addImplicitSubSchemaToBuilder(
-      ImmutableSortedMap.Builder<String, CalciteSchema> builder);
-
-  /** Adds implicit tables to a builder. */
-  protected abstract void addImplicitTableToBuilder(
-      ImmutableSortedSet.Builder<String> builder);
 
   /** Adds implicit functions to a builder. */
   protected abstract void addImplicitFunctionsToBuilder(
@@ -250,13 +260,9 @@ public abstract class CalciteSchema {
 
   public final @Nullable CalciteSchema getSubSchema(String schemaName,
       boolean caseSensitive) {
-    // Check explicit schemas.
-    //noinspection LoopStatementThatDoesntLoop
-    for (Map.Entry<String, CalciteSchema> entry
-        : subSchemaMap.range(schemaName, caseSensitive).entrySet()) {
-      return entry.getValue();
-    }
-    return getImplicitSubSchema(schemaName, caseSensitive);
+    return caseSensitive
+        ? subSchemas().get(schemaName)
+        : Named.entityOrNull(subSchemas().getIgnoreCase(schemaName));
   }
 
   /** Adds a child schema of this schema. */
@@ -274,13 +280,7 @@ public abstract class CalciteSchema {
 
   /** Returns a table with the given name. Does not look for views. */
   public final @Nullable TableEntry getTable(String tableName, boolean caseSensitive) {
-    // Check explicit tables.
-    //noinspection LoopStatementThatDoesntLoop
-    for (Map.Entry<String, TableEntry> entry
-        : tableMap.range(tableName, caseSensitive).entrySet()) {
-      return entry.getValue();
-    }
-    return getImplicitTable(tableName, caseSensitive);
+    return Lookup.get(tables(), tableName, caseSensitive);
   }
 
   public String getName() {
@@ -322,7 +322,6 @@ public abstract class CalciteSchema {
     final ImmutableSortedMap.Builder<String, CalciteSchema> builder =
         new ImmutableSortedMap.Builder<>(NameSet.COMPARATOR);
     builder.putAll(subSchemaMap.map());
-    addImplicitSubSchemaToBuilder(builder);
     return builder.build();
   }
 
@@ -335,14 +334,14 @@ public abstract class CalciteSchema {
 
   /** Returns the set of all table names. Includes implicit and explicit tables
    * and functions with zero parameters. */
-  public final NavigableSet<String> getTableNames() {
-    final ImmutableSortedSet.Builder<String> builder =
-        new ImmutableSortedSet.Builder<>(NameSet.COMPARATOR);
-    // Add explicit tables, case-sensitive.
-    builder.addAll(tableMap.map().keySet());
-    // Add implicit tables, case-sensitive.
-    addImplicitTableToBuilder(builder);
-    return builder.build();
+  public final Set<String> getTableNames() {
+    return getTableNames(LikePattern.any());
+  }
+
+  /** Returns the set of table names filtered by the given pattern.
+   * Includes implicit and explicit tables and functions with zero parameters. */
+  public final Set<String> getTableNames(LikePattern pattern) {
+    return tables().getNames(pattern);
   }
 
   /** Returns the set of all types names. */
@@ -649,13 +648,21 @@ public abstract class CalciteSchema {
       return schema.getExpression(parentSchema, name);
     }
 
-    @Override public @Nullable Table getTable(String name) {
+    @Override public Lookup<Table> tables() {
+      return CalciteSchema.this.tables().map((table, name) -> table.getTable());
+    }
+
+    @Override public Lookup<? extends SchemaPlus> subSchemas() {
+      return CalciteSchema.this.subSchemas().map((schema, name) -> schema.plus());
+    }
+
+    @Deprecated @Override public @Nullable Table getTable(String name) {
       final TableEntry entry = CalciteSchema.this.getTable(name, true);
       return entry == null ? null : entry.getTable();
     }
 
-    @Override public NavigableSet<String> getTableNames() {
-      return CalciteSchema.this.getTableNames();
+    @Deprecated @Override public Set<String> getTableNames() {
+      return CalciteSchema.this.getTableNames(LikePattern.any());
     }
 
     @Override public @Nullable RelProtoDataType getType(String name) {
@@ -675,15 +682,12 @@ public abstract class CalciteSchema {
       return CalciteSchema.this.getFunctionNames();
     }
 
-    @Override public @Nullable SchemaPlus getSubSchema(String name) {
-      final CalciteSchema subSchema =
-          CalciteSchema.this.getSubSchema(name, true);
-      return subSchema == null ? null : subSchema.plus();
+    @Deprecated @Override public @Nullable SchemaPlus getSubSchema(String name) {
+      return subSchemas().get(name);
     }
 
-    @Override public Set<String> getSubSchemaNames() {
-      //noinspection RedundantCast
-      return (Set<String>) CalciteSchema.this.getSubSchemaMap().keySet();
+    @Deprecated @Override public Set<String> getSubSchemaNames() {
+      return subSchemas().getNames(LikePattern.any());
     }
 
     @Override public SchemaPlus add(String name, Schema schema) {

--- a/core/src/main/java/org/apache/calcite/jdbc/SimpleCalciteSchema.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/SimpleCalciteSchema.java
@@ -100,36 +100,8 @@ class SimpleCalciteSchema extends CalciteSchema {
     return null;
   }
 
-  @Override protected @Nullable CalciteSchema getImplicitSubSchema(String schemaName,
-      boolean caseSensitive) {
-    // Check implicit schemas.
-    final String schemaName2 =
-        caseSensitive ? schemaName
-            : caseInsensitiveLookup(schema.getSubSchemaNames(), schemaName);
-    if (schemaName2 == null) {
-      return null;
-    }
-    final Schema s = schema.getSubSchema(schemaName2);
-    if (s == null) {
-      return null;
-    }
-    return new SimpleCalciteSchema(this, s, schemaName2);
-  }
-
-  @Override protected @Nullable TableEntry getImplicitTable(String tableName,
-      boolean caseSensitive) {
-    // Check implicit tables.
-    final String tableName2 =
-        caseSensitive ? tableName
-            : caseInsensitiveLookup(schema.getTableNames(), tableName);
-    if (tableName2 == null) {
-      return null;
-    }
-    final Table table = schema.getTable(tableName2);
-    if (table == null) {
-      return null;
-    }
-    return tableEntry(tableName2, table);
+  @Override protected CalciteSchema createSubSchema(Schema schema, String name) {
+    return new SimpleCalciteSchema(this, schema, name);
   }
 
   @Override protected @Nullable TypeEntry getImplicitType(String name, boolean caseSensitive) {
@@ -145,26 +117,6 @@ class SimpleCalciteSchema extends CalciteSchema {
       return null;
     }
     return typeEntry(name2, type);
-  }
-
-  @Override protected void addImplicitSubSchemaToBuilder(
-      ImmutableSortedMap.Builder<String, CalciteSchema> builder) {
-    ImmutableSortedMap<String, CalciteSchema> explicitSubSchemas = builder.build();
-    for (String schemaName : schema.getSubSchemaNames()) {
-      if (explicitSubSchemas.containsKey(schemaName)) {
-        // explicit subschema wins.
-        continue;
-      }
-      Schema s = schema.getSubSchema(schemaName);
-      if (s != null) {
-        CalciteSchema calciteSchema = new SimpleCalciteSchema(this, s, schemaName);
-        builder.put(schemaName, calciteSchema);
-      }
-    }
-  }
-
-  @Override protected void addImplicitTableToBuilder(ImmutableSortedSet.Builder<String> builder) {
-    builder.addAll(schema.getTableNames());
   }
 
   @Override protected void addImplicitFunctionsToBuilder(

--- a/core/src/main/java/org/apache/calcite/model/ModelHandler.java
+++ b/core/src/main/java/org/apache/calcite/model/ModelHandler.java
@@ -40,6 +40,7 @@ import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.calcite.schema.impl.TableFunctionImpl;
 import org.apache.calcite.schema.impl.TableMacroImpl;
 import org.apache.calcite.schema.impl.ViewTable;
+import org.apache.calcite.schema.lookup.LikePattern;
 import org.apache.calcite.sql.SqlDialectFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Pair;
@@ -361,7 +362,7 @@ public class ModelHandler {
       if (jsonMaterialization.view == null) {
         // If the user did not supply a view name, that means the materialized
         // view is pre-populated. Generate a synthetic view name.
-        viewName = "$" + schema.getTableNames().size();
+        viewName = "$" + schema.tables().getNames(LikePattern.any()).size();
         existing = true;
       } else {
         viewName = jsonMaterialization.view;

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -33,6 +33,7 @@ import org.apache.calcite.schema.TableFunction;
 import org.apache.calcite.schema.TableMacro;
 import org.apache.calcite.schema.Wrapper;
 import org.apache.calcite.schema.impl.ScalarFunctionImpl;
+import org.apache.calcite.schema.lookup.LikePattern;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -206,7 +207,7 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
       result.add(moniker(schema, subSchema, SqlMonikerType.SCHEMA));
     }
 
-    for (String table : schema.getTableNames()) {
+    for (String table : schema.getTableNames(LikePattern.any())) {
       result.add(moniker(schema, table, SqlMonikerType.TABLE));
     }
 

--- a/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/RelOptTableImpl.java
@@ -47,12 +47,15 @@ import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.TemporalTable;
 import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.schema.Wrapper;
+import org.apache.calcite.schema.lookup.LikePattern;
+import org.apache.calcite.schema.lookup.Lookup;
 import org.apache.calcite.sql.SqlAccessType;
 import org.apache.calcite.sql.validate.SqlModality;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
 import org.apache.calcite.sql2rel.InitializerExpressionFactory;
 import org.apache.calcite.sql2rel.NullInitializerExpressionFactory;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.LazyReference;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
@@ -429,6 +432,8 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
     private final @Nullable SchemaPlus parent;
     private final String name;
     private final Schema schema;
+    private final LazyReference<Lookup<? extends SchemaPlus>> subSchemas = new LazyReference<>();
+
 
     MySchemaPlus(@Nullable SchemaPlus parent, String name, Schema schema) {
       this.parent = parent;
@@ -455,9 +460,8 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
       return name;
     }
 
-    @Override public @Nullable SchemaPlus getSubSchema(String name) {
-      final Schema subSchema = schema.getSubSchema(name);
-      return subSchema == null ? null : new MySchemaPlus(this, name, subSchema);
+    @Deprecated @Override public @Nullable SchemaPlus getSubSchema(String name) {
+      return subSchemas().get(name);
     }
 
     @Override public SchemaPlus add(String name, Schema schema) {
@@ -505,12 +509,21 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
       return false;
     }
 
-    @Override public @Nullable Table getTable(String name) {
-      return schema.getTable(name);
+    @Override public Lookup<Table> tables() {
+      return schema.tables();
     }
 
-    @Override public Set<String> getTableNames() {
-      return schema.getTableNames();
+    @Override public Lookup<? extends SchemaPlus> subSchemas() {
+      return subSchemas.getOrCompute(
+          () -> schema.subSchemas().map((s, key) -> new MySchemaPlus(this, key, s)));
+    }
+
+    @Deprecated @Override public @Nullable Table getTable(String name) {
+      return tables().get(name);
+    }
+
+    @Deprecated @Override public Set<String> getTableNames() {
+      return schema.tables().getNames(LikePattern.any());
     }
 
     @Override public @Nullable RelProtoDataType getType(String name) {
@@ -530,8 +543,8 @@ public class RelOptTableImpl extends Prepare.AbstractPreparingTable {
       return schema.getFunctionNames();
     }
 
-    @Override public Set<String> getSubSchemaNames() {
-      return schema.getSubSchemaNames();
+    @Deprecated @Override public Set<String> getSubSchemaNames() {
+      return schema.subSchemas().getNames(LikePattern.any());
     }
 
     @Override public Expression getExpression(@Nullable SchemaPlus parentSchema,

--- a/core/src/main/java/org/apache/calcite/schema/Schema.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schema.java
@@ -18,6 +18,9 @@ package org.apache.calcite.schema;
 
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.lookup.CompatibilityLookup;
+import org.apache.calcite.schema.lookup.LikePattern;
+import org.apache.calcite.schema.lookup.Lookup;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -56,19 +59,50 @@ import java.util.Set;
  * {@link Schema#getSubSchema(String)}.
  */
 public interface Schema {
+
+  /**
+   * Returns a lookup object to find tables.
+   *
+   * @return Lookup
+   */
+  default Lookup<Table> tables() {
+    return new CompatibilityLookup<>(this::getTable, this::getTableNames);
+  }
+
+  /**
+   * Returns a lookup object to find sub schemas.
+   *
+   * @return Lookup
+   */
+  default Lookup<? extends Schema> subSchemas() {
+    return new CompatibilityLookup<>(this::getSubSchema, this::getSubSchemaNames);
+  }
+
   /**
    * Returns a table with a given name, or null if not found.
    *
+   * <p>Using `getTable` directly does not allow to distinguish between
+   * case sensitive and case insensitive lookups. This method always does a
+   * case sensitive lookup. Caseinsensitive lookup can be done by loading
+   * all table names using {@link Schema#getTableNames()}. This can be
+   * quite timeconsuming for huge databases. To speed this up,
+   * all table names must be cached. This will require
+   * a huge amount of additional memory.
+   *
    * @param name Table name
    * @return Table, or null
+   * @deprecated Use {@link Schema#tables()} and {@link Lookup#get(String)} instead.
    */
+  @Deprecated // to be removed before 2.0
   @Nullable Table getTable(String name);
 
   /**
    * Returns the names of the tables in this schema.
    *
    * @return Names of the tables in this schema
+   * @deprecated Use {@link Schema#tables()} and {@link Lookup#getNames(LikePattern)} instead.
    */
+  @Deprecated // to be removed before 2.0
   Set<String> getTableNames();
 
   /**
@@ -105,16 +139,23 @@ public interface Schema {
   /**
    * Returns a sub-schema with a given name, or null.
    *
+   * <p>See also comment for {@link Schema#getTable(String)} to find out why
+   * you should do so.
+   *
    * @param name Sub-schema name
    * @return Sub-schema with a given name, or null
+   * @deprecated Use {@link Schema#subSchemas()} and {@link Lookup#get(String)} instead.
    */
+  @Deprecated // to be removed before 2.0
   @Nullable Schema getSubSchema(String name);
 
   /**
    * Returns the names of this schema's child schemas.
    *
    * @return Names of this schema's child schemas
+   * @deprecated Use {@link Schema#subSchemas()} and {@link Lookup#getNames(LikePattern)} instead.
    */
+  @Deprecated // to be removed before 2.0
   Set<String> getSubSchemaNames();
 
   /**

--- a/core/src/main/java/org/apache/calcite/schema/SchemaPlus.java
+++ b/core/src/main/java/org/apache/calcite/schema/SchemaPlus.java
@@ -18,6 +18,7 @@ package org.apache.calcite.schema;
 
 import org.apache.calcite.materialize.Lattice;
 import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.lookup.Lookup;
 
 import com.google.common.collect.ImmutableList;
 
@@ -45,6 +46,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * {@link Schema}, or indeed might not.
  */
 public interface SchemaPlus extends Schema {
+
+  /**
+   * Returns a lookup object to find sub schemas.
+   */
+  @Override Lookup<? extends SchemaPlus> subSchemas();
   /**
    * Returns the parent schema, or null if this schema has no parent.
    */
@@ -59,7 +65,7 @@ public interface SchemaPlus extends Schema {
   String getName();
 
   // override with stricter return
-  @Override @Nullable SchemaPlus getSubSchema(String name);
+  @Deprecated @Override @Nullable SchemaPlus getSubSchema(String name);
 
   /** Adds a schema as a sub-schema of this schema, and returns the wrapped
    * object. */

--- a/core/src/main/java/org/apache/calcite/schema/Schemas.java
+++ b/core/src/main/java/org/apache/calcite/schema/Schemas.java
@@ -235,7 +235,7 @@ public final class Schemas {
       String name = iterator.next();
       requireNonNull(schema, "schema");
       if (iterator.hasNext()) {
-        SchemaPlus next = schema.getSubSchema(name);
+        SchemaPlus next = schema.subSchemas().get(name);
         if (next == null) {
           throw new IllegalArgumentException("schema " + name + " is not found in " + schema);
         }
@@ -250,7 +250,7 @@ public final class Schemas {
   public static <E> Queryable<E> queryable(DataContext root, SchemaPlus schema,
       Class<E> clazz, String tableName) {
     QueryableTable table =
-        (QueryableTable) requireNonNull(schema.getTable(tableName),
+        (QueryableTable) requireNonNull(schema.tables().get(tableName),
             () -> "table " + tableName + " is not found in " + schema);
     QueryProvider queryProvider = root.getQueryProvider();
     return table.asQueryable(queryProvider, schema, tableName);
@@ -299,13 +299,13 @@ public final class Schemas {
       String name = iterator.next();
       requireNonNull(schema, "schema");
       if (iterator.hasNext()) {
-        SchemaPlus next = schema.getSubSchema(name);
+        SchemaPlus next = schema.subSchemas().get(name);
         if (next == null) {
           throw new IllegalArgumentException("schema " + name + " is not found in " + schema);
         }
         schema = next;
       } else {
-        return schema.getTable(name);
+        return schema.tables().get(name);
       }
     }
   }
@@ -576,7 +576,7 @@ public final class Schemas {
       if (!iterator.hasNext()) {
         return path(builder.build());
       }
-      Schema next = schema.getSubSchema(name);
+      Schema next = schema.subSchemas().get(name);
       if (next == null) {
         throw new IllegalArgumentException("schema " + name + " is not found in " + schema);
       }

--- a/core/src/main/java/org/apache/calcite/schema/impl/AbstractSchema.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/AbstractSchema.java
@@ -25,6 +25,9 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.SchemaVersion;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.lookup.CompatibilityLookup;
+import org.apache.calcite.schema.lookup.Lookup;
+import org.apache.calcite.util.LazyReference;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -56,7 +59,18 @@ import static java.util.Objects.requireNonNull;
  * </ul>
  */
 public class AbstractSchema implements Schema {
-  public AbstractSchema() {
+
+  private LazyReference<Lookup<Table>> tables = new LazyReference<>();
+  private LazyReference<Lookup<Schema>> subSchemas = new LazyReference<>();
+
+  @Override public Lookup<Table> tables() {
+    return tables.getOrCompute(
+        () -> new CompatibilityLookup<>(this::getTable, this::getTableNames));
+  }
+
+  @Override public Lookup<? extends Schema> subSchemas() {
+    return subSchemas.getOrCompute(
+        () -> new CompatibilityLookup<>(this::getSubSchema, this::getSubSchemaNames));
   }
 
   @Override public boolean isMutable() {
@@ -86,12 +100,12 @@ public class AbstractSchema implements Schema {
     return ImmutableMap.of();
   }
 
-  @Override public final Set<String> getTableNames() {
+  @Deprecated @Override public final Set<String> getTableNames() {
     //noinspection RedundantCast
     return (Set<String>) getTableMap().keySet();
   }
 
-  @Override public final @Nullable Table getTable(String name) {
+  @Deprecated @Override public final @Nullable Table getTable(String name) {
     return getTableMap().get(name);
   }
 
@@ -157,12 +171,12 @@ public class AbstractSchema implements Schema {
     return ImmutableMap.of();
   }
 
-  @Override public final Set<String> getSubSchemaNames() {
+  @Deprecated @Override public final Set<String> getSubSchemaNames() {
     //noinspection RedundantCast
     return (Set<String>) getSubSchemaMap().keySet();
   }
 
-  @Override public final @Nullable Schema getSubSchema(String name) {
+  @Deprecated @Override public final @Nullable Schema getSubSchema(String name) {
     return getSubSchemaMap().get(name);
   }
 

--- a/core/src/main/java/org/apache/calcite/schema/impl/DelegatingSchema.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/DelegatingSchema.java
@@ -23,6 +23,8 @@ import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.SchemaVersion;
 import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.lookup.LikePattern;
+import org.apache.calcite.schema.lookup.Lookup;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -61,12 +63,16 @@ public class DelegatingSchema implements Schema {
     return schema.getExpression(parentSchema, name);
   }
 
-  @Override public @Nullable Table getTable(String name) {
-    return schema.getTable(name);
+  @Override public Lookup<Table> tables() {
+    return schema.tables();
   }
 
-  @Override public Set<String> getTableNames() {
-    return schema.getTableNames();
+  @Deprecated @Override public @Nullable Table getTable(String name) {
+    return schema.tables().get(name);
+  }
+
+  @Deprecated @Override public Set<String> getTableNames() {
+    return schema.tables().getNames(LikePattern.any());
   }
 
   @Override public @Nullable RelProtoDataType getType(String name) {
@@ -85,11 +91,15 @@ public class DelegatingSchema implements Schema {
     return schema.getFunctionNames();
   }
 
-  @Override public @Nullable Schema getSubSchema(String name) {
-    return schema.getSubSchema(name);
+  @Override public Lookup<? extends Schema> subSchemas() {
+    return schema.subSchemas();
   }
 
-  @Override public Set<String> getSubSchemaNames() {
-    return schema.getSubSchemaNames();
+  @Deprecated @Override public @Nullable Schema getSubSchema(String name) {
+    return subSchemas().get(name);
+  }
+
+  @Deprecated @Override public Set<String> getSubSchemaNames() {
+    return subSchemas().getNames(LikePattern.any());
   }
 }

--- a/core/src/main/java/org/apache/calcite/schema/lookup/CompatibilityLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/CompatibilityLookup.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.apache.calcite.linq4j.function.Predicate1;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * This class warps a {@code Function} and a {@code Supplier} into a
+ * {@code Lookup} interface.
+ *
+ * <p>This class can be used to implement the methods {@code Schema.tables()}
+ * and {@code Schema.subSchemas()} of existing schemas.
+ *
+ * <p>Existing schema classes are implementing a pair of {@code getTable()}
+ * and {@code getTableNames()} methods. But these schemas should
+ * also provide a {@code tables()} method. This class can be used
+ * to implement this method. See {@code Schema.tables()} for
+ * an example.
+ *
+ * @param <T> Element type
+ */
+public class CompatibilityLookup<T> extends IgnoreCaseLookup<T> {
+
+  private final Function<String, @Nullable T> get;
+  private final Supplier<Set<String>> getNames;
+
+  /**
+   * Constructor to create a {@code Lookup} instance using a `Function` and a `Supplier`.
+   *
+   * @param get a function to lookup tables or sub schemas by name
+   * @param getNames a function to list all tables or sub schemas
+   */
+  public CompatibilityLookup(Function<String, @Nullable T> get, Supplier<Set<String>> getNames) {
+    this.get = get;
+    this.getNames = getNames;
+  }
+
+  @Override public @Nullable T get(String name) {
+    return get.apply(name);
+  }
+
+  @Override public Set<String> getNames(LikePattern pattern) {
+    final Predicate1<String> matcher = pattern.matcher();
+    return getNames.get().stream()
+        .filter(name -> matcher.apply(name))
+        .collect(Collectors.toSet());
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/ConcatLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/ConcatLookup.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This creats a {@code Lookup} object from an ordered sequence of {@code Lookup} objects.
+ *
+ * <p>The lookup is done from left to right. The first match is returned
+ * if a name can be found in two or more lookups.
+ *
+ * @param <T> Element type
+ */
+class ConcatLookup<T> implements Lookup<T> {
+  private final Lookup<T>[] lookups;
+
+  ConcatLookup(Lookup<T>[] lookups) {
+    this.lookups = lookups;
+  }
+
+  @Override public @Nullable T get(String name) {
+    for (Lookup<T> lookup : lookups) {
+      T t = lookup.get(name);
+      if (t != null) {
+        return t;
+      }
+    }
+    return null;
+  }
+
+  @Override public @Nullable Named<T> getIgnoreCase(String name) {
+    for (Lookup<T> lookup : lookups) {
+      Named<T> t = lookup.getIgnoreCase(name);
+      if (t != null) {
+        return t;
+      }
+    }
+    return null;
+  }
+
+  @Override public Set<String> getNames(LikePattern pattern) {
+    return Stream.of(lookups)
+        .flatMap(lookup -> lookup.getNames(pattern).stream())
+        .collect(Collectors.toSet());
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/EmptyLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/EmptyLookup.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Set;
+
+/**
+ * This class implements an empty Lookup.
+ *
+ * <p>This class returns null for any call to {@code EmptyLookup.get(String)} or
+ * {@code EmptyLookup.getIgnoreCase(String)}.
+ *
+ * @param <T> Element type
+ */
+class EmptyLookup<T> implements Lookup<T> {
+
+  static final Lookup<?> INSTANCE = new EmptyLookup<>();
+
+  @Override public @Nullable T get(String name) {
+    return null;
+  }
+
+  @Override public @Nullable Named<T> getIgnoreCase(String name) {
+    return null;
+  }
+
+  @Override public Set<String> getNames(LikePattern pattern) {
+    return ImmutableSet.of();
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/IgnoreCaseLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/IgnoreCaseLookup.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.apache.calcite.util.LazyReference;
+import org.apache.calcite.util.NameMap;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An abstract base class for lookups implementing case insensitive lookup.
+ *
+ * @param <T> Element type
+ */
+public abstract class IgnoreCaseLookup<T> implements Lookup<T> {
+
+  /**
+   * This member is used to lazily load the list of all names into memory.
+   *
+   * <p>A {@link NameMap} is used, which is capable to lookup names in a
+   * case insensitive way.
+   */
+  private LazyReference<NameMap<String>> nameMap = new LazyReference<>();
+
+  /**
+   * Returns a named entity with a given name, or null if not found.
+   *
+   * @return Entity with the specified name, or null when the entity is not found.
+   */
+  @Override public abstract @Nullable T get(String name);
+
+  /**
+   * Returns a named entity with a given name ignoring the case, or null if not found.
+   *
+   * @return Entity with the specified name, or null when the entity is not found.
+   */
+  @Override @Nullable public Named<T> getIgnoreCase(String name) {
+    int retryCounter = 0;
+    while (true) {
+      Map.Entry<String, String> entry = nameMap.getOrCompute(this::loadNames)
+          .range(name, false)
+          .firstEntry();
+      if (entry != null) {
+        T result = get(entry.getValue());
+        return result == null ? null : new Named<>(entry.getKey(), result);
+      }
+      // if the name was not found in the cached list of names,
+      // we try to reload the cache once because the table/schema
+      // might have been created in the meantime.
+      retryCounter++;
+      if (retryCounter > 1) {
+        return null;
+      }
+      nameMap.reset();
+    }
+  }
+
+  @Override public abstract Set<String> getNames(LikePattern pattern);
+
+  private NameMap<String> loadNames() {
+    NameMap<String> result = new NameMap<>();
+    for (String name : getNames(LikePattern.any())) {
+      result.put(name, name);
+    }
+    return result;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/LikePattern.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/LikePattern.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.apache.calcite.linq4j.function.Predicate1;
+
+import java.util.regex.Pattern;
+
+/**
+ * This class is used to hold a pattern, which is typically
+ * used in SQL LIKE statements.
+ *
+ * <p>The pattern can contain wildcards (`%`) or character ranges (`[a-z]`).
+ *
+ * <p>The pattern can also be translated to a {@code Predicate1<String>} which
+ * can be used to do filtering inside java.
+ */
+public class LikePattern {
+  private static final String ANY = "%";
+  public final String pattern;
+
+  public LikePattern(String pattern) {
+    if (pattern == null) {
+      pattern = ANY;
+    }
+    this.pattern = pattern;
+  }
+
+  @Override public String toString() {
+    return "LikePattern[" + this.pattern + "]";
+  }
+
+  public Predicate1<String> matcher() {
+    return matcher(pattern);
+  }
+
+  public static LikePattern any() {
+    return new LikePattern(ANY);
+  }
+
+  public static Predicate1<String> matcher(String likePattern) {
+    if (likePattern == null || likePattern.equals(ANY)) {
+      return v1 -> true;
+    }
+    final Pattern regex = likeToRegex(likePattern);
+    return v1 -> regex.matcher(v1).matches();
+  }
+
+  /**
+   * Converts a LIKE-style pattern (where '%' represents a wild-card, escaped
+   * using '\') to a Java regex. It's always case sensitive.
+   */
+  public static Pattern likeToRegex(String pattern) {
+    StringBuilder buf = new StringBuilder("^");
+    char[] charArray = pattern.toCharArray();
+    int slash = -2;
+    for (int i = 0; i < charArray.length; i++) {
+      char c = charArray[i];
+      if (slash == i - 1) {
+        buf.append('[').append(c).append(']');
+      } else {
+        switch (c) {
+        case '\\':
+          slash = i;
+          break;
+        case '%':
+          buf.append(".*");
+          break;
+        case '[':
+          buf.append("\\[");
+          break;
+        case ']':
+          buf.append("\\]");
+          break;
+        default:
+          buf.append('[').append(c).append(']');
+        }
+      }
+    }
+    buf.append("$");
+    return Pattern.compile(buf.toString());
+  }
+
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/LoadingCacheLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/LoadingCacheLookup.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is using a {@code LoadingCache} to speed up lookups,
+ * delegated to another {@link Lookup} instance.
+ *
+ * <p>This class is thread safe. All entries are evicted after one minute.
+ * Negative matches are never cached. If a new entry
+ * becomes available in the associated {@code Lookup}, it's immediately
+ * visible outside. If an entry is deleted in the associated {@code Lookup},
+ * it takes one minute until it disappears if it was cached in the last minute.
+ * Otherwise, it disappears immediately.
+ *
+ * @param <T> Element Type
+ */
+public class LoadingCacheLookup<T> implements Lookup<T> {
+  private final Lookup<T> delegate;
+
+  private final LoadingCache<String, T> cache;
+  private final LoadingCache<String, Named<T>> cacheIgnoreCase;
+
+  /**
+   * Creates a {@code Lookup} object with a `LoadingCache`inside.
+   *
+   * @param delegate The {@code Lookup} object, which should be cached
+   * @param expiration The duration after which the entries are evicted from
+   *                   the loading cache.
+   */
+  public LoadingCacheLookup(Lookup<T> delegate, Duration expiration) {
+    this.delegate = delegate;
+    this.cache = CacheBuilder.newBuilder()
+        .expireAfterWrite(expiration.toMillis(), TimeUnit.MILLISECONDS)
+        .build(CacheLoader.from(name -> requireNonNull(delegate.get(name))));
+    this.cacheIgnoreCase = CacheBuilder.newBuilder()
+        .expireAfterWrite(expiration.toMillis(), TimeUnit.MILLISECONDS)
+        .build(CacheLoader.from(name -> requireNonNull(delegate.getIgnoreCase(name))));
+  }
+
+  /**
+   * Creates a {@code Lookup} object with a `LoadingCache`inside.
+   *
+   * <p>The expiration is set to 1 minute.
+   *
+   * @param delegate The {@code Lookup} object, which should be cached
+   */
+  public LoadingCacheLookup(Lookup<T> delegate) {
+    this(delegate, Duration.ofMinutes(1));
+  }
+
+  @Override public @Nullable T get(String name) {
+    try {
+      return cache.get(name);
+    } catch (UncheckedExecutionException e) {
+      if (e.getCause() instanceof NullPointerException) {
+        return null;
+      }
+      throw e;
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override public @Nullable Named<T> getIgnoreCase(String name) {
+    try {
+      return cacheIgnoreCase.get(name);
+    } catch (UncheckedExecutionException e) {
+      if (e.getCause() instanceof NullPointerException) {
+        return null;
+      }
+      throw e;
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override public Set<String> getNames(LikePattern pattern) {
+    return delegate.getNames(pattern);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/Lookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/Lookup.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.apache.calcite.util.NameMap;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * A case sensitive/insensitive lookup for tables, schemas, functions, types ...
+ *
+ * @param <T> Element type
+ */
+public interface Lookup<T> {
+  /**
+   * Returns a named entity with a given name, or null if not found.
+   *
+   * @param name Name
+   * @return Entity with the specified name, or null when the entity is
+   *         not found.
+   */
+  @Nullable T get(String name);
+
+  /**
+   * Returns a named entity with a given name ignoring the case, or null if not found.
+   *
+   * @param name Name
+   * @return Entity with the specified name (case insensitive),
+   *         or null when the entity is not found.
+   */
+  @Nullable Named<T> getIgnoreCase(String name);
+
+  /**
+   * Returns the names of the entities in matching pattern.
+   * The search is always case sensitive. This is caused by the fact that
+   * {@code DatabaseMetaData.getTables(...)} doesn't support case insensitive
+   * lookups.
+   *
+   * @return The names of all entities matching the pattern.
+   */
+  Set<String> getNames(LikePattern pattern);
+
+  default <S> Lookup<S> map(BiFunction<T, String, S> mapper) {
+    return new TransformingLookup<>(this, mapper);
+  }
+
+  /**
+   * Helper method to call {@code Lookup.get(String)} or
+   * {@code Lookup.getIgnoreCase(String)} depending on the parameter
+   * caseSensitive.
+   *
+   * @return Entity with the specified name, or null when the entity is
+   *         not found.
+   */
+  static <T> @Nullable T get(Lookup<T> lookup, String name, boolean caseSensitive) {
+    if (caseSensitive) {
+      T entry = lookup.get(name);
+      if (entry == null) {
+        return null;
+      }
+      return entry;
+    }
+    return Named.entityOrNull(lookup.getIgnoreCase(name));
+  }
+
+  /**
+   * Returns an empty lookup.
+   */
+  static <T> Lookup<T> empty() {
+    return (Lookup<T>) EmptyLookup.INSTANCE;
+  }
+
+  /**
+   * Creates a new lookup object based on a NameMap.
+   */
+  static <T> Lookup<T> of(NameMap<T> map) {
+    return new NameMapLookup<>(map);
+  }
+
+  /**
+   * Concat a list of lookups.
+   */
+  static <T> Lookup<T> concat(Lookup<T>... lookups) {
+    return new ConcatLookup<>(lookups);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/NameMapLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/NameMapLookup.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.apache.calcite.linq4j.function.Predicate1;
+import org.apache.calcite.util.NameMap;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A Lookup class which is based on a NameMap.
+ *
+ * @param <T> Element type
+ */
+class NameMapLookup<T> implements Lookup<T> {
+  private final NameMap<T> map;
+
+  NameMapLookup(NameMap<T> map) {
+    this.map = map;
+  }
+
+  @Override public @Nullable T get(String name) {
+    Map.Entry<String, T> entry = map.range(name, true).firstEntry();
+    if (entry != null) {
+      return entry.getValue();
+    }
+    return null;
+  }
+
+  @Override public @Nullable Named<T> getIgnoreCase(String name) {
+    Map.Entry<String, T> entry = map.range(name, false).firstEntry();
+    if (entry != null) {
+      return new Named<>(entry.getKey(), entry.getValue());
+    }
+    return null;
+  }
+
+  @Override public Set<String> getNames(LikePattern pattern) {
+    final Predicate1<String> matcher = pattern.matcher();
+    return map.map().keySet().stream()
+        .filter(name -> matcher.apply(name))
+        .collect(Collectors.toSet());
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/Named.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/Named.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is used to hold an object including its name.
+ *
+ * @param <T> Element type
+ */
+public class Named<T> {
+  private final String name;
+  private final @NonNull T entity;
+
+  public Named(String name, T entity) {
+    this.name = name;
+    this.entity = requireNonNull(entity, "entity");
+  }
+
+  public final String name() {
+    return name;
+  }
+
+  public final T entity() {
+    return entity;
+  }
+
+  public static <T> @Nullable T entityOrNull(@Nullable Named<T> named) {
+    return named == null ? null : named.entity;
+  }
+
+  @Override public boolean equals(final @Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final Named<?> named = (Named<?>) o;
+    return name.equals(named.name) && entity.equals(named.entity);
+  }
+
+  @Override public int hashCode() {
+    int result = name.hashCode();
+    result = 31 * result + entity.hashCode();
+    return result;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/SnapshotLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/SnapshotLookup.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.apache.calcite.util.LazyReference;
+import org.apache.calcite.util.NameMap;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Set;
+
+/**
+ * This class can be used to make a snapshot of a lookups.
+ *
+ * @param <T> Element Type
+ */
+public class SnapshotLookup<T> implements Lookup<T> {
+
+  private final Lookup<T> delegate;
+  private LazyReference<Lookup<T>> cachedDelegate = new LazyReference<>();
+  private boolean enabled = true;
+
+  public SnapshotLookup(Lookup<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public @Nullable T get(final String name) {
+    return delegate().get(name);
+  }
+
+  @Override public @Nullable Named<T> getIgnoreCase(final String name) {
+    return delegate().getIgnoreCase(name);
+  }
+
+  @Override public Set<String> getNames(final LikePattern pattern) {
+    return delegate().getNames(pattern);
+  }
+
+  private Lookup<T> delegate() {
+    if (!enabled) {
+      return delegate;
+    }
+    return cachedDelegate.getOrCompute(() -> new NameMapLookup<>(loadNameMap()));
+  }
+
+  private NameMap<T> loadNameMap() {
+    NameMap<T> map = new NameMap<>();
+    for (String name : delegate.getNames(LikePattern.any())) {
+      T entry = delegate.get(name);
+      if (entry != null) {
+        map.put(name, entry);
+      }
+    }
+    return map;
+  }
+
+  public void enable(boolean enabled) {
+    if (!enabled) {
+      cachedDelegate.reset();
+    }
+    this.enabled = enabled;
+  }
+
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/TransformingLookup.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/TransformingLookup.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * This class implements a {@code Lookup} on base of another {@code Lookup}
+ * transforming all entities using a given function.
+ *
+ * @param <S> Source element type
+ * @param <T> Target element type
+ */
+class TransformingLookup<S, T> implements Lookup<T> {
+  private final Lookup<S> lookup;
+  private final BiFunction<S, String, T> transform;
+
+  TransformingLookup(Lookup<S> lookup, BiFunction<S, String, T> transform) {
+    this.lookup = lookup;
+    this.transform = transform;
+  }
+
+  @Override public @Nullable T get(String name) {
+    S entity = lookup.get(name);
+    return entity == null ? null : transform.apply(entity, name);
+  }
+
+  @Override public @Nullable Named<T> getIgnoreCase(String name) {
+    Named<S> named = lookup.getIgnoreCase(name);
+    return named == null
+        ? null
+        : new Named<>(named.name(), transform.apply(named.entity(), named.name()));
+  }
+
+  @Override public Set<String> getNames(LikePattern pattern) {
+    return lookup.getNames(pattern);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/schema/lookup/package-info.java
+++ b/core/src/main/java/org/apache/calcite/schema/lookup/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Schema Lookup SPI.
+ *
+ * <p>The interfaces and classes in this package are used to lookup
+ * tables and subschemas within a schema.
+ */
+@DefaultQualifier(value = NonNull.class, locations = TypeUseLocation.FIELD)
+@DefaultQualifier(value = NonNull.class, locations = TypeUseLocation.PARAMETER)
+@DefaultQualifier(value = NonNull.class, locations = TypeUseLocation.RETURN)
+package org.apache.calcite.schema.lookup;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;

--- a/core/src/main/java/org/apache/calcite/util/LazyReference.java
+++ b/core/src/main/java/org/apache/calcite/util/LazyReference.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * This class can is able to do a lazy initiaization
+ * of an object based on a {@code Supplier}.
+ *
+ * <p>In contrast to {@code Suppliers.memoize}, the supplier is passed
+ * at the later point in time, during the call to {@code getOrCompute}.
+ * This allows the usage in abstract base classes with a supplier
+ * method, implemented in a derived class.
+ *
+ * @param <T> Element Type
+ */
+public class LazyReference<T> {
+
+  private final AtomicReference<T> value = new AtomicReference<>();
+
+  /**
+   * Atomically sets the value to {@code supplier.get()}
+   * if the current value was not set yet.
+   *
+   * <p>This method is reentrant. Different threads will
+   * get the same result.
+   *
+   * @param supplier supplier for the new value
+   * @return the current value.
+   */
+  public T getOrCompute(Supplier<T> supplier) {
+    while (true) {
+      T result = value.get();
+      if (result != null) {
+        return result;
+      }
+      T computed = supplier.get();
+      if (value.compareAndSet((T) null, computed)) {
+        return computed;
+      }
+    }
+  }
+
+  /**
+   * Resets the current value.
+   */
+  public void reset() {
+    value.set((T) null);
+  }
+}

--- a/core/src/test/java/org/apache/calcite/schema/lookup/ConcatLookupTest.java
+++ b/core/src/test/java/org/apache/calcite/schema/lookup/ConcatLookupTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test for ConcatLookup.
+ */
+class ConcatLookupTest {
+  private final Lookup<String> testee =
+      Lookup.concat(new FakeLookup("a", "1"),
+          new FakeLookup("b", "2"),
+          new FakeLookup("d", "4"),
+          new FakeLookup("d", "5"));
+
+  @Test void testNull() {
+    assertThat(testee.get("c"), nullValue());
+  }
+
+  @Test void test() {
+    assertThat(testee.get("a"), equalTo("1"));
+  }
+
+  @Test void testIgnoreCase() {
+    assertThat(testee.getIgnoreCase("B"), equalTo(new Named<>("b", "2")));
+  }
+
+  @Test void testCommonNames() {
+    assertThat(testee.getIgnoreCase("D"), equalTo(new Named<>("d", "4")));
+  }
+}

--- a/core/src/test/java/org/apache/calcite/schema/lookup/FakeLookup.java
+++ b/core/src/test/java/org/apache/calcite/schema/lookup/FakeLookup.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.apache.calcite.linq4j.function.Predicate1;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Simple utility class to test other implementations of Lookup.
+ */
+class FakeLookup implements Lookup<String> {
+  private final Map<String, String> map;
+  private final Map<String, Named<String>> ignoreCaseMap;
+
+  FakeLookup(String... keyAndValues) {
+    this.map = new HashMap<>();
+    for (int i = 0; i < keyAndValues.length - 1; i += 2) {
+      map.put(keyAndValues[i], keyAndValues[i + 1]);
+    }
+    this.ignoreCaseMap = this.map.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                entry -> entry.getKey().toLowerCase(Locale.ROOT),
+                entry -> new Named<>(entry.getKey(), entry.getValue())));
+  }
+
+  @Override public @Nullable String get(final String name) {
+    return map.get(name);
+  }
+
+  @Override public @Nullable Named<String> getIgnoreCase(final String name) {
+    return ignoreCaseMap.get(name.toLowerCase(Locale.ROOT));
+  }
+
+  @Override public Set<String> getNames(final LikePattern pattern) {
+    Predicate1<String> predicate = pattern.matcher();
+    return map.keySet().stream().filter(predicate::apply).collect(Collectors.toSet());
+  }
+}

--- a/core/src/test/java/org/apache/calcite/schema/lookup/IgnoreCaseLookupTest.java
+++ b/core/src/test/java/org/apache/calcite/schema/lookup/IgnoreCaseLookupTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test for IgnoreCaseLookup.
+ */
+class IgnoreCaseLookupTest {
+  private final Lookup<String> testee = new IgnoreCaseLookup<String>() {
+    @Override public @Nullable String get(final String name) {
+      if ("a".equals(name)) {
+        return "1";
+      }
+      return null;
+    }
+
+    @Override public Set<String> getNames(final LikePattern pattern) {
+      return Collections.singleton("a");
+    }
+  };
+
+  @Test void testNull() {
+    assertThat(testee.get("c"), nullValue());
+  }
+
+  @Test void test() {
+    assertThat(testee.get("a"), equalTo("1"));
+  }
+
+  @Test void testIgnoreCase() {
+    assertThat(testee.getIgnoreCase("A"), equalTo(new Named<>("a", "1")));
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/schema/lookup/LoadingCacheLookupTest.java
+++ b/core/src/test/java/org/apache/calcite/schema/lookup/LoadingCacheLookupTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test for LoadingCacheLookup.
+ */
+public class LoadingCacheLookupTest {
+
+  private final Lookup<String> testee =
+      new LoadingCacheLookup<>(new FakeLookup("test", "xxxx"));
+
+  @Test void testNull() {
+    assertThat(testee.get("unknown"), nullValue());
+  }
+
+  @Test void test() {
+    assertThat(testee.get("test"), equalTo("xxxx"));
+  }
+
+  @Test void testIgnoreCase() {
+    assertThat(testee.getIgnoreCase("TEST"), equalTo(new Named<>("test", "xxxx")));
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/schema/lookup/SnapshotLookupTest.java
+++ b/core/src/test/java/org/apache/calcite/schema/lookup/SnapshotLookupTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test for CachedLookup.
+ */
+class SnapshotLookupTest {
+  private final Lookup<String> testee = new SnapshotLookup<>(new FakeLookup("a", "1"));
+
+  @Test void testNull() {
+    assertThat(testee.get("c"), nullValue());
+  }
+
+  @Test void test() {
+    assertThat(testee.get("a"), equalTo("1"));
+  }
+
+  @Test void testIgnoreCase() {
+    assertThat(testee.getIgnoreCase("A"), equalTo(new Named<>("a", "1")));
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/schema/lookup/TransformingLookupTest.java
+++ b/core/src/test/java/org/apache/calcite/schema/lookup/TransformingLookupTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.lookup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test for MappedLookup.
+ */
+class TransformingLookupTest {
+  private final Lookup<String> testee =
+      (new FakeLookup("a", "1")).map((value, name) -> name + "_" + value);
+
+  @Test void testNull() {
+    assertThat(testee.get("c"), nullValue());
+  }
+
+  @Test void test() {
+    assertThat(testee.get("a"), equalTo("a_1"));
+  }
+
+  @Test void testIgnoreCase() {
+    assertThat(testee.getIgnoreCase("A"), equalTo(new Named<>("a", "a_1")));
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/test/LatticeTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LatticeTest.java
@@ -206,8 +206,8 @@ class LatticeTest {
         .doWithConnection(c -> {
           final SchemaPlus schema = c.getRootSchema();
           final SchemaPlus adhoc =
-              requireNonNull(schema.getSubSchema("adhoc"));
-          assertThat(adhoc.getTableNames().contains("EMPLOYEES"), is(true));
+              requireNonNull(schema.subSchemas().get("adhoc"));
+          assertThat(adhoc.tables().get("EMPLOYEES") != null, is(true));
           final CalciteSchema adhocSchema =
               requireNonNull(adhoc.unwrap(CalciteSchema.class));
           final Map.Entry<String, CalciteSchema.LatticeEntry> entry =
@@ -238,8 +238,8 @@ class LatticeTest {
         .doWithConnection(c -> {
           final SchemaPlus schema = c.getRootSchema();
           final SchemaPlus adhoc =
-              requireNonNull(schema.getSubSchema("adhoc"));
-          assertThat(adhoc.getTableNames().contains("EMPLOYEES"), is(true));
+              requireNonNull(schema.subSchemas().get("adhoc"));
+          assertThat(adhoc.tables().get("EMPLOYEES") != null, is(true));
           final CalciteSchema adhocSchema =
               requireNonNull(adhoc.unwrap(CalciteSchema.class));
           final Map.Entry<String, CalciteSchema.LatticeEntry> entry =
@@ -269,8 +269,8 @@ class LatticeTest {
         .doWithConnection(c -> {
           final SchemaPlus schema = c.getRootSchema();
           final SchemaPlus adhoc =
-              requireNonNull(schema.getSubSchema("adhoc"));
-          assertThat(adhoc.getTableNames().contains("EMPLOYEES"), is(true));
+              requireNonNull(schema.subSchemas().get("adhoc"));
+          assertThat(adhoc.tables().get("EMPLOYEES") != null, is(true));
           final CalciteSchema adhocSchema =
               requireNonNull(adhoc.unwrap(CalciteSchema.class));
           final Map.Entry<String, CalciteSchema.LatticeEntry> entry =

--- a/core/src/test/java/org/apache/calcite/test/LinqFrontJdbcBackTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LinqFrontJdbcBackTest.java
@@ -45,7 +45,7 @@ class LinqFrontJdbcBackTest {
         Expressions.parameter(JdbcTest.Customer.class, "c");
     String s =
         Schemas.queryable(DataContexts.of(calciteConnection, rootSchema),
-            requireNonNull(rootSchema.getSubSchema("foodmart")),
+                requireNonNull(rootSchema.subSchemas().get("foodmart")),
             JdbcTest.Customer.class, "customer")
             .where(
                 Expressions.lambda(

--- a/core/src/test/java/org/apache/calcite/test/MultiJdbcSchemaJoinTest.java
+++ b/core/src/test/java/org/apache/calcite/test/MultiJdbcSchemaJoinTest.java
@@ -25,6 +25,7 @@ import org.apache.calcite.jdbc.CalciteJdbc41Factory;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.lookup.LikePattern;
 import org.apache.calcite.test.schemata.hr.HrSchema;
 
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -105,7 +106,7 @@ class MultiJdbcSchemaJoinTest {
     dataSource.setPassword("");
     final JdbcCatalogSchema schema =
         JdbcCatalogSchema.create(null, "", dataSource, "PUBLIC");
-    assertThat(schema.getSubSchemaNames(),
+    assertThat(schema.subSchemas().getNames(LikePattern.any()),
         is(Sets.newHashSet("INFORMATION_SCHEMA", "PUBLIC", "SYSTEM_LOBS")));
     final CalciteSchema rootSchema0 =
         CalciteSchema.createRootSchema(false, false, "", schema);

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -957,7 +957,7 @@ public class ReflectiveSchemaTest {
    */
   @Test void testArrayFieldTableHasRowCount() {
     ReflectiveSchema schema = new ReflectiveSchema(new HrSchema());
-    Table table = schema.getTable("emps");
+    Table table = schema.tables().get("emps");
     assertNotNull(table);
     Statistic statistic = table.getStatistic();
     assertNotNull(statistic);
@@ -966,7 +966,7 @@ public class ReflectiveSchemaTest {
 
   @Test void testCollectionFieldTableHasRowCount() {
     ReflectiveSchema schema = new ReflectiveSchema(new HrSchemaPlus());
-    Table table = schema.getTable("xlocations");
+    Table table = schema.tables().get("xlocations");
     assertNotNull(table);
     Statistic statistic = table.getStatistic();
     assertNotNull(statistic);

--- a/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TableFunctionTest.java
@@ -358,7 +358,7 @@ class TableFunctionTest {
       CalciteConnection calciteConnection =
           connection.unwrap(CalciteConnection.class);
       SchemaPlus rootSchema = calciteConnection.getRootSchema();
-      SchemaPlus schema = rootSchema.getSubSchema("s");
+      SchemaPlus schema = rootSchema.subSchemas().get("s");
       final TableFunction table =
           TableFunctionImpl.create(Smalls.GENERATE_STRINGS_METHOD);
       schema.add("GenerateStrings", table);

--- a/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
+++ b/core/src/test/java/org/apache/calcite/tools/FrameworksTest.java
@@ -59,6 +59,7 @@ import org.apache.calcite.schema.Statistics;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.schema.lookup.LikePattern;
 import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlNode;
@@ -152,7 +153,7 @@ public class FrameworksTest {
   /** Unit test to test create root schema which has no "metadata" schema. */
   @Test void testCreateRootSchemaWithNoMetadataSchema() {
     SchemaPlus rootSchema = Frameworks.createRootSchema(false);
-    assertThat(rootSchema.getSubSchemaNames(), hasSize(0));
+    assertThat(rootSchema.subSchemas().getNames(LikePattern.any()), hasSize(0));
   }
 
   /** Tests that validation (specifically, inferring the result of adding

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
@@ -2635,7 +2635,7 @@ public class DruidAdapter2IT {
   @Test void testTableMapReused() {
     AbstractSchema schema =
         new DruidSchema("http://localhost:8082", "http://localhost:8081", true);
-    assertSame(schema.getTable("wikiticker"), schema.getTable("wikiticker"));
+    assertSame(schema.tables().get("wikiticker"), schema.tables().get("wikiticker"));
   }
 
   @Test void testPushEqualsCastDimension() {

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -3124,7 +3124,7 @@ public class DruidAdapterIT {
    * */
   @Test void testTableMapReused() {
     AbstractSchema schema = new DruidSchema("http://localhost:8082", "http://localhost:8081", true);
-    assertSame(schema.getTable("wikipedia"), schema.getTable("wikipedia"));
+    assertSame(schema.tables().get("wikipedia"), schema.tables().get("wikipedia"));
   }
 
   @Test void testPushEqualsCastDimension() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/MatchTest.java
@@ -164,7 +164,7 @@ class MatchTest {
    */
   @Test void testMatchQuery() throws Exception {
     CalciteConnection con = createConnection();
-    SchemaPlus postSchema = con.getRootSchema().getSubSchema("elastic");
+    SchemaPlus postSchema = con.getRootSchema().subSchemas().get("elastic");
 
     FrameworkConfig postConfig = Frameworks.newConfigBuilder()
         .parserConfig(SqlParser.Config.DEFAULT)

--- a/plus/src/test/java/org/apache/calcite/adapter/tpcds/TpcdsTest.java
+++ b/plus/src/test/java/org/apache/calcite/adapter/tpcds/TpcdsTest.java
@@ -306,7 +306,7 @@ class TpcdsTest {
     final Holder<@Nullable SchemaPlus> root = Holder.empty();
     CalciteAssert.model(TPCDS_MODEL)
         .doWithConnection(connection -> {
-          root.set(connection.getRootSchema().getSubSchema("TPCDS"));
+          root.set(connection.getRootSchema().subSchemas().get("TPCDS"));
         });
     return Frameworks.newConfigBuilder()
         .parserConfig(SqlParser.Config.DEFAULT)

--- a/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
+++ b/server/src/main/java/org/apache/calcite/server/ServerDdlExecutor.java
@@ -260,7 +260,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
     final Pair<@Nullable CalciteSchema, String> pair =
         schema(context, true, create.name);
     requireNonNull(pair.left); // TODO: should not assume parent schema exists
-    if (pair.left.plus().getSubSchema(pair.right) != null) {
+    if (pair.left.plus().subSchemas().get(pair.right) != null) {
       if (!create.getReplace() && !create.ifNotExists) {
         throw SqlUtil.newContextException(create.name.getParserPosition(),
             RESOURCE.schemaExists(pair.right));
@@ -330,7 +330,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
       Table materializedView =
           schema != null
               && drop.getKind() == SqlKind.DROP_MATERIALIZED_VIEW
-              ? schema.plus().getTable(objectName)
+              ? schema.plus().tables().get(objectName)
               : null;
 
       existed = schema != null && schema.removeTable(objectName);
@@ -382,7 +382,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
     final Pair<@Nullable CalciteSchema, String> pair =
         schema(context, true, truncate.name);
     if (pair.left == null
-        || pair.left.plus().getTable(pair.right) == null) {
+        || pair.left.plus().tables().get(pair.right) == null) {
       throw SqlUtil.newContextException(truncate.name.getParserPosition(),
           RESOURCE.tableNotFound(pair.right));
     }
@@ -401,7 +401,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
     final Pair<@Nullable CalciteSchema, String> pair =
         schema(context, true, create.name);
     if (pair.left != null
-        && pair.left.plus().getTable(pair.right) != null) {
+        && pair.left.plus().tables().get(pair.right) != null) {
       // Materialized view exists.
       if (!create.ifNotExists) {
         // They did not specify IF NOT EXISTS, so give error.
@@ -436,7 +436,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
     final Pair<@Nullable CalciteSchema, String> pair =
         schema(context, true, create.name);
     requireNonNull(pair.left); // TODO: should not assume parent schema exists
-    if (pair.left.plus().getSubSchema(pair.right) != null) {
+    if (pair.left.plus().subSchemas().get(pair.right) != null) {
       if (create.ifNotExists) {
         return;
       }
@@ -561,7 +561,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
             return super.newColumnDefaultValue(table, iColumn, context);
           }
         };
-    if (pair.left.plus().getTable(pair.right) != null) {
+    if (pair.left.plus().tables().get(pair.right) != null) {
       // Table exists.
       if (create.ifNotExists) {
         return;
@@ -588,7 +588,7 @@ public class ServerDdlExecutor extends DdlExecutorImpl {
     final Pair<@Nullable CalciteSchema, String> pair =
         schema(context, true, create.name);
     requireNonNull(pair.left); // TODO: should not assume parent schema exists
-    if (pair.left.plus().getTable(pair.right) != null) {
+    if (pair.left.plus().tables().get(pair.right) != null) {
       // Table exists.
       if (create.ifNotExists) {
         return;

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -78,6 +78,12 @@ large results set to a manageable value. Users that need a bigger/smaller limit
 should create a new instance of `RelMdUniqueKeys` and register it using the
 metadata provider of their choice.
 
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-6728">CALCITE-6728</a>]
+introduces new methods to lookup tables and sub schemas inside schemas.
+The methods used before (`Schema:getTable(String name)`, `Schema:getTableNames()`,
+`Schema.getSubSchema(String name)` and `Schema.getSubSchemaNames(String name)`)
+have been marked as deprecated.
+
 #### New features
 {: #new-features-1-39-0}
 

--- a/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
+++ b/testkit/src/main/java/org/apache/calcite/test/CalciteAssert.java
@@ -1028,7 +1028,7 @@ public class CalciteAssert {
       // FOODMART, and this allows statistics queries to be executed.
       foodmart = addSchemaIfNotExists(rootSchema, SchemaSpec.JDBC_FOODMART);
       final Wrapper salesTable =
-          requireNonNull((Wrapper) foodmart.getTable("sales_fact_1997"));
+          requireNonNull((Wrapper) foodmart.tables().get("sales_fact_1997"));
       SchemaPlus fake =
           rootSchema.add(schema.schemaName, new AbstractSchema());
       fake.add("time_by_day", new AbstractTable() {
@@ -1101,7 +1101,7 @@ public class CalciteAssert {
 
   private static SchemaPlus addSchemaIfNotExists(SchemaPlus rootSchema,
         SchemaSpec schemaSpec) {
-    final SchemaPlus schema = rootSchema.getSubSchema(schemaSpec.schemaName);
+    final SchemaPlus schema = rootSchema.subSchemas().get(schemaSpec.schemaName);
     if (schema != null) {
       return schema;
     }
@@ -2299,11 +2299,11 @@ public class CalciteAssert {
       }
     };
 
-    @Override public Table getTable(String name) {
+    @Deprecated @Override public Table getTable(String name) {
       return table;
     }
 
-    @Override public Set<String> getTableNames() {
+    @Deprecated @Override public Set<String> getTableNames() {
       return ImmutableSet.of("myTable");
     }
 
@@ -2324,11 +2324,11 @@ public class CalciteAssert {
       return ImmutableSet.of();
     }
 
-    @Override public @Nullable Schema getSubSchema(String name) {
+    @Deprecated @Override public @Nullable Schema getSubSchema(String name) {
       return null;
     }
 
-    @Override public Set<String> getSubSchemaNames() {
+    @Deprecated @Override public Set<String> getSubSchemaNames() {
       return ImmutableSet.of();
     }
 

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -350,7 +350,7 @@ public abstract class QuidemTest {
             .withSchema("s", new AbstractSchema())
             .connect();
         connection.unwrap(CalciteConnection.class).getRootSchema()
-            .getSubSchema("s")
+            .subSchemas().get("s")
             .add("my_seq",
                 new AbstractTable() {
                   @Override public RelDataType getRowType(


### PR DESCRIPTION
### Motivation

For databases with a huge set of schemas and tables it takes quite long to prepare queries. Currently all tables/schemas are loaded into memory.

Caching all these schemas and tables is not an option
1. It will require a lot of memory
2. The eviction of the cache must happen quite often since it's likely that every second one of these table is changed.

Therefore, we tried to find a way to load only those tables/schemas, which are required to prepare a query.

### API Changes

This PR introduces a new mechanism to lookup tables and schemas within a schema. For this purpose a new interface is introduced

```java
public interface Lookup<T> {
  @Nullable T get(String name);
  @Nullable Named<T> getIgnoreCase(String name);
  Set<String> getNames(LikePattern pattern);
}
```

The `LikePattern` was extracted from `CalciteMetaImpl` to hold a pattern, which can be used to query tables and schemas inside a JDBC database using the `LIKE` operator. Additionally, it also supports the conversion to a `Predicate1<String>` which can be used to implement filters in plain java.

The `Schema` is now using this `Lookup` interface to find schemas and tables. It could be also extended to functions and types.

```java
public interface Schema {
  default Lookup<Table> tables() {
    ...
  }
  default Lookup<? extends Schema> subSchemas() {
    ...
  }
  ...
}
```

### Implementation

The case insensitive search is now directly implemented in the specific `Schema` using matching implementation of the `Lookup` interface. Formerly, it was done in the `CalciteSchema`.

`JdbcSchema` and `JdbcCatalogSchema` are using a special implementation of `Lookup`: `LoadingCacheLookup`. This implementation is using a `LoadingCache` inside to speed up things. If only case sensitive schema/table lookup is required, this can be done quite fast since `DatabaseMetaData#getTables` can be used to query a single table. The result is cached inside the `LoadingCache` for one minute.

Unfortunately `DatabaseMetaData#getTables` doesn't support case insensitive queries. In this case, it's still required to load all database tables to perform case insensitive lookups.

The performance gain for huge sets of tables/schemas in database schemas can only be achieved if caching is turned off in Calcite (`SimpleCalciteSchema` is used instead of `CachingCalciteSchema`). 

I tried to keep the behavior of `CachingCalciteSchema` exactly the same. This behavior includes that all tables/schemas are loaded into memory.  `CachedLookup` is used to achieve this.
 