### PR TITLE
[CALCITE-6744] Support getColumnOrigins for correlate in RelMdColumnOrigins

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.core.Correlate;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Join;
@@ -49,6 +50,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * RelMdColumnOrigins supplies a default implementation of
@@ -160,12 +163,16 @@ public class RelMdColumnOrigins
       for (RelColumnOrigin columnOrigin : columnOrigins) {
         // If corVar, get the origin column of the left input.
         if (columnOrigin.isCorVar()) {
-          Set<RelColumnOrigin> corVarOrigin =
-              mq.getColumnOrigins(rel.getLeft(), columnOrigin.getOriginColumnOrdinal());
-          if (corVarOrigin != null) {
-            result.addAll(corVarOrigin);
+          CorrelationId correlationId =
+              requireNonNull(columnOrigin.getCorrelationId(), "correlationId");
+          if (correlationId.equals(rel.getCorrelationId())) {
+            Set<RelColumnOrigin> corVarOrigin =
+                mq.getColumnOrigins(rel.getLeft(), columnOrigin.getOriginColumnOrdinal());
+            if (corVarOrigin != null) {
+              result.addAll(corVarOrigin);
+            }
+            continue;
           }
-          continue;
         }
         result.add(columnOrigin);
       }

--- a/core/src/main/java/org/apache/calcite/rel/rules/LoptSemiJoinOptimizer.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/LoptSemiJoinOptimizer.java
@@ -418,12 +418,12 @@ public class LoptSemiJoinOptimizer {
           mq.getColumnOrigin(factRel, keyIter.next());
 
       // can't use the rid column as a semijoin key
-      if ((colOrigin == null || !colOrigin.isDerived())
+      if ((colOrigin == null || colOrigin.isCorVar() || !colOrigin.isDerived())
           || LucidDbSpecialOperators.isLcsRidColumnId(
             colOrigin.getOriginColumnOrdinal())) {
         removeKey = true;
       } else {
-        RelOptTable table = colOrigin.getOriginTable();
+        RelOptTable table = requireNonNull(colOrigin.getOriginTable(), "originTable");
         if (theTable == null) {
           if (!(table instanceof LcsTable)) {
             // not a column store table

--- a/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnOriginHandler.java
+++ b/core/src/test/resources/org/apache/calcite/rel/metadata/janino/GeneratedMetadata_ColumnOriginHandler.java
@@ -72,6 +72,8 @@ public final class GeneratedMetadata_ColumnOriginHandler
       return provider0.getColumnOrigins((org.apache.calcite.rel.core.Aggregate) r, mq, a2);
     } else if (r instanceof org.apache.calcite.rel.core.Calc) {
       return provider0.getColumnOrigins((org.apache.calcite.rel.core.Calc) r, mq, a2);
+    } else if (r instanceof org.apache.calcite.rel.core.Correlate) {
+      return provider0.getColumnOrigins((org.apache.calcite.rel.core.Correlate) r, mq, a2);
     } else if (r instanceof org.apache.calcite.rel.core.Exchange) {
       return provider0.getColumnOrigins((org.apache.calcite.rel.core.Exchange) r, mq, a2);
     } else if (r instanceof org.apache.calcite.rel.core.Filter) {

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -68,6 +68,14 @@ large results set to a manageable value. Users that need a bigger/smaller limit
 should create a new instance of `RelMdUniqueKeys` and register it using the
 metadata provider of their choice.
 
+* [<a href="https://issues.apache.org/jira/browse/CALCITE-6744">CALCITE-6744</a>]
+Support getColumnOrigins for correlate in RelMdColumnOrigins.
+In RelMetadataQuery#RelMdColumnOrigin, if the source of the column is an
+external correlation variable, add the isCorVar and correlationId fields
+in RelColumnOrigin to indicate this. When isCorVar is true, the field
+comes from a table outside the input RelNode. This also causes getOriginTable
+to be nullable, so the user needs to first determine isCorVar when getting the originTable.
+
 #### New features
 {: #new-features-1-39-0}
 


### PR DESCRIPTION
This PR introduces support for the getOriginColumn method for Correlate. 
To represent the origin of the corVar field, the ColumnOrigin class has been modified accordingly. This caused breaking changes, so I'm documenting it in history.md. If there's a better way to do it, welcome any suggestions.