### PR TITLE
[CALCITE-6699] Invalid unparse for Varchar in StarRocksDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/StarRocksSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/StarRocksSqlDialect.java
@@ -19,6 +19,8 @@ package org.apache.calcite.sql.dialect;
 import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.sql.SqlAbstractDateTimeLiteral;
 import org.apache.calcite.sql.SqlAlienSystemTypeNameSpec;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
@@ -41,9 +43,33 @@ import static org.apache.calcite.util.RelToSqlConverterUtil.unparseHiveTrim;
  */
 public class StarRocksSqlDialect extends MysqlSqlDialect {
 
+  /** StarRocks type system. */
+  public static final RelDataTypeSystem STARROCKS_TYPE_SYSTEM =
+      new RelDataTypeSystemImpl() {
+        @Override public int getMaxPrecision(SqlTypeName typeName) {
+          switch (typeName) {
+          case CHAR:
+            return 255;
+          case VARCHAR:
+            return 65533;
+          case VARBINARY:
+            return 1048576;
+          default:
+            return super.getMaxPrecision(typeName);
+          }
+        }
+        @Override public int getDefaultPrecision(SqlTypeName typeName) {
+          if (typeName == SqlTypeName.CHAR) {
+            return RelDataType.PRECISION_NOT_SPECIFIED;
+          }
+          return super.getDefaultPrecision(typeName);
+        }
+      };
+
   public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
       .withDatabaseProduct(SqlDialect.DatabaseProduct.STARROCKS)
       .withIdentifierQuoteString("`")
+      .withDataTypeSystem(STARROCKS_TYPE_SYSTEM)
       .withNullCollation(NullCollation.LOW);
 
   public static final SqlDialect DEFAULT = new StarRocksSqlDialect(DEFAULT_CONTEXT);
@@ -127,6 +153,10 @@ public class StarRocksSqlDialect extends MysqlSqlDialect {
               "DATETIME",
               type.getSqlTypeName(),
               SqlParserPos.ZERO),
+          SqlParserPos.ZERO);
+    case VARCHAR:
+      return new SqlDataTypeSpec(
+          new SqlBasicTypeNameSpec(SqlTypeName.VARCHAR, type.getPrecision(), SqlParserPos.ZERO),
           SqlParserPos.ZERO);
     default:
       return super.getCastSpec(type);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3748,6 +3748,39 @@ class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6699">[CALCITE-6699]
+   * Invalid unparse for Varchar in StarRocksDialect </a>. */
+  @Test void testStarRocksCastToVarcharWithLessThanMaxPrecision() {
+    final String query = "select cast(\"product_id\" as varchar(50)), \"product_id\" "
+        + "from \"product\" ";
+    final String expected = "SELECT CAST(`product_id` AS VARCHAR(50)), `product_id`\n"
+        + "FROM `foodmart`.`product`";
+    sql(query).withStarRocks().ok(expected);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6699">[CALCITE-6699]
+   * Invalid unparse for Varchar in StarRocksDialect </a>. */
+  @Test void testStarRocksCastToVarcharWithGreaterThanMaxPrecision() {
+    final String query = "select cast(\"product_id\" as varchar(150000)), \"product_id\" "
+        + "from \"product\" ";
+    final String expected = "SELECT CAST(`product_id` AS VARCHAR(65533)), `product_id`\n"
+        + "FROM `foodmart`.`product`";
+    sql(query).withStarRocks().ok(expected);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6699">[CALCITE-6699]
+   * Invalid unparse for Varchar in StarRocksDialect </a>. */
+  @Test void testStarRocksCastToVarcharWithDefaultPrecision() {
+    final String query = "select cast(\"product_id\" as varchar), \"product_id\" "
+        + "from \"product\" ";
+    final String expected = "SELECT CAST(`product_id` AS VARCHAR), `product_id`\n"
+        + "FROM `foodmart`.`product`";
+    sql(query).withStarRocks().ok(expected);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6419">[CALCITE-6419]
    * Invalid unparse for VARCHAR without precision in HiveSqlDialect And SparkSqlDialect</a>. */
   @Test void testCastToVarchar() {


### PR DESCRIPTION
When performing starrocks dialect conversion for varchar, it defaults to using MySQL dialect，MySQL doesn't have a VARCHAR type, only CHAR,So during StarRocks dialect conversion, VARCHAR will also be converted to CHAR

Since StarRocks supports the VARCHAR type, we should modify the StarRocks dialect

<img width="683" alt="image" src="https://github.com/user-attachments/assets/ffcb836d-c4fd-4cf7-a620-3ba7a9d3c1a5" />

https://docs.starrocks.io/docs/sql-reference/data-types/string-type/VARCHAR/
