### PR TITLE
[CALCITE-6762] Preserving the CAST conversion for String type operands in Presto

### DIFF
--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7918,6 +7918,27 @@ class RelToSqlConverterTest {
     sql(query).withClickHouse().ok(expectedSql);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6762">[CALCITE-6762]
+   * Preserving the CAST conversion for operands in Presto</a>. */
+  @Test void testImplicitTypeCoercion() {
+    final String query = "select \"employee_id\" "
+        + "from \"foodmart\".\"employee\" "
+        + "where 10 = cast('10' as int) and \"birth_date\" = cast('1914-02-02' as date) or "
+        + "\"hire_date\" = cast('1996-01-01 '||'00:00:00' as timestamp)";
+    final String expected = "SELECT \"employee_id\"\n"
+        + "FROM \"foodmart\".\"employee\"\n"
+        + "WHERE 10 = '10' AND \"birth_date\" = '1914-02-02' OR \"hire_date\" = '1996-01-01 ' || "
+        + "'00:00:00'";
+    final String expectedPresto = "SELECT \"employee_id\"\n"
+        + "FROM \"foodmart\".\"employee\"\n"
+        + "WHERE 10 = CAST('10' AS INTEGER) AND \"birth_date\" = CAST('1914-02-02' AS DATE) OR "
+        + "\"hire_date\" = CAST('1996-01-01 ' || '00:00:00' AS TIMESTAMP)";
+    sql(query)
+        .ok(expected)
+        .withPresto().ok(expectedPresto);
+  }
+
   @Test void testDialectQuoteStringLiteral() {
     dialects().forEach((dialect, databaseProduct) -> {
       assertThat(dialect.quoteStringLiteral(""), is("''"));


### PR DESCRIPTION
In Calcite, if the dialect's `supportsImplicitTypeCoercion` is set to `true` (the default value is `true`), Calcite will remove the cast in the `SqlImplementor#stripCastFromString()` method. For example, the following SQL:

```
FROM applydata_bigdata.kafka_topic_cluster_user_dept_month_one_day_msg_info
WHERE ymd > CAST('20240801' AS INTEGER)
ORDER BY ymd DESC
```

will be transformed into:

```
FROM "hive"."applydata_bigdata"."kafka_topic_cluster_user_dept_month_one_day_msg_info"
WHERE "ymd" > '20240801'
ORDER BY "ymd" IS NULL DESC, "ymd" DESC LIMIT 200
```

Here, the `CAST` is removed.

However, in Presto, different data types cannot be directly compared, which will result in an error. 

Similar situations also exist:

```
select * from hive.applydata_bigdata.kafka_topic_cluster_user_dept_month_one_day_msg_info 
where CURRENT_DATE > '2024-08-01'
order by ymd desc LIMIT 200
```

![image](https://github.com/user-attachments/assets/aceed558-386a-442d-ae6c-37e29369d98f)



To avoid this issue, `supportsImplicitTypeCoercion` should be set to `false` in `PrestoSqlDialect`.




