### PR TITLE
[CALCITE-6771] Convert Type from FLOAT to DOUBLE in PrestoDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
@@ -24,7 +24,9 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlBasicTypeNameSpec;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
@@ -146,7 +148,14 @@ public class PrestoSqlDialect extends SqlDialect {
   }
 
   @Override public @Nullable SqlNode getCastSpec(RelDataType type) {
-    return super.getCastSpec(type);
+    switch (type.getSqlTypeName()) {
+    // PRESTO only supports REAL、DOUBLE for floating point types.
+    case FLOAT:
+      return new SqlDataTypeSpec(
+          new SqlBasicTypeNameSpec(SqlTypeName.DOUBLE, SqlParserPos.ZERO), SqlParserPos.ZERO);
+    default:
+      return super.getCastSpec(type);
+    }
   }
 
   @Override public void unparseCall(SqlWriter writer, SqlCall call,

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -9093,6 +9093,20 @@ class RelToSqlConverterTest {
     sql(query).withOracle().ok(oracle);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6771">[CALCITE-6771]
+   * Convert Type from FLOAT to DOUBLE in PrestoDialect</a>. */
+  @Test void testPrestoFloatingPointTypesCast() {
+    String query = "SELECT CAST(\"department_id\" AS float), "
+        + "CAST(\"department_id\" AS double), "
+        + "CAST(\"department_id\" AS real) FROM \"employee\"";
+    String expected = "SELECT CAST(\"department_id\" AS DOUBLE), "
+        + "CAST(\"department_id\" AS DOUBLE), "
+        + "CAST(\"department_id\" AS REAL)\nFROM \"foodmart\".\"employee\"";
+    sql(query)
+        .withPresto().ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final CalciteAssert.SchemaSpec schemaSpec;


### PR DESCRIPTION
Since FLOAT type is not supported in Presto

According to the documentation: https://prestodb.io/docs/current/language/types.html#real
![image](https://github.com/user-attachments/assets/b7f1862a-4e02-4bee-842a-acf475fd3b2f)
Using CAST(xxxx AS FLOAT) will result in an error:

```

SELECT CAST(message_count AS FLOAT)

FROM applydata_bigdata.kafka_topic_cluster_user_dept_month_one_day_msg_info

WHERE ymd = 20250105

```
![image](https://github.com/user-attachments/assets/83156009-4ac3-434a-8aca-d6f0b80b2b25)
It should be converted to the DOUBLE type instead.