### PR TITLE
[CALCITE-6769] Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ concurrency:
 # This avoids never-ending GC trashing if memory gets too low in case of a memory leak
 env:
   _JAVA_OPTIONS: '-XX:GCTimeLimit=90 -XX:GCHeapFreeLimit=35'
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
   GUAVA_MIN: '21.0' # oldest supported Guava version
   GUAVA_MAX: '33.3.0-jre' # latest supported Guava version
   GUAVA: '21.0' # most jobs test against oldest Guava version

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ org.jetbrains.gradle.plugin.idea-ext.version=0.5
 org.nosphere.apache.rat.version=0.8.1
 org.owasp.dependencycheck.version=6.1.6
 org.sonarqube.version=3.5.0.2730
-com.gradle.develocity.version=3.17.6
+com.gradle.develocity.version=3.18.2
 com.gradle.common-custom-user-data-gradle-plugin.version=2.0.2
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -103,7 +103,7 @@ fun property(name: String) =
 val isCiServer = System.getenv().containsKey("CI")
 
 develocity {
-    server = "https://ge.apache.org"
+    server = "https://develocity.apache.org"
     projectId = "calcite"
 
     buildScan {


### PR DESCRIPTION
This PR migrates the Calcite project to publish Build Scans to the the new Develocity instance at develocity.apache.org.