### PR TITLE
[CALCITE-6790] Write LIMIT for fetch operations in Vertica

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
@@ -19,7 +19,11 @@ package org.apache.calcite.sql.dialect;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlWriter;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
@@ -52,5 +56,10 @@ public class VerticaSqlDialect extends SqlDialect {
     default:
       return super.supportsFunction(operator, type, paramTypes);
     }
+  }
+
+  @Override public void unparseOffsetFetch(SqlWriter writer, @Nullable SqlNode offset,
+      @Nullable SqlNode fetch) {
+    unparseFetchUsingLimit(writer, offset, fetch);
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3012,7 +3012,12 @@ class RelToSqlConverterTest {
         + "FROM `foodmart`.`product`\n"
         + "LIMIT 100\n"
         + "OFFSET 10";
+    final String expectedVertica = "SELECT \"product_id\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "LIMIT 100\n"
+        + "OFFSET 10";
     sql(query).withHive().ok(expected)
+        .withVertica().ok(expectedVertica)
         .withStarRocks().ok(expectedStarRocks);
   }
 


### PR DESCRIPTION
correctly unparse Vertica [LIMIT](https://docs.vertica.com/24.2.x/en/sql-reference/statements/select/limit-clause/) ... [OFFSET](https://docs.vertica.com/24.2.x/en/sql-reference/statements/select/offset-clause/)