### PR TITLE
[CALCITE-6796] Convert Type from BINARY to VARBINARY in PrestoDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
@@ -153,6 +153,10 @@ public class PrestoSqlDialect extends SqlDialect {
     case FLOAT:
       return new SqlDataTypeSpec(
           new SqlBasicTypeNameSpec(SqlTypeName.DOUBLE, SqlParserPos.ZERO), SqlParserPos.ZERO);
+    // https://prestodb.io/docs/current/language/types.html#varbinary
+    case BINARY:
+      return new SqlDataTypeSpec(
+          new SqlBasicTypeNameSpec(SqlTypeName.VARBINARY, SqlParserPos.ZERO), SqlParserPos.ZERO);
     default:
       return super.getCastSpec(type);
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -9147,6 +9147,17 @@ class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6796">[CALCITE-6796]
+   * Convert Type from BINARY to VARBINARY in PrestoDialect</a>. */
+  @Test void testPrestoBinaryCast() {
+    String query = "SELECT cast(cast(\"employee_id\" as varchar) as binary)"
+        + "from \"foodmart\".\"reserve_employee\" ";
+    String expected = "SELECT CAST(CAST(\"employee_id\" AS VARCHAR) AS VARBINARY)"
+        + "\nFROM \"foodmart\".\"reserve_employee\"";
+    sql(query).withPresto().ok(expected);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6771">[CALCITE-6771]
    * Convert Type from FLOAT to DOUBLE in PrestoDialect</a>. */
   @Test void testPrestoFloatingPointTypesCast() {


### PR DESCRIPTION
Since BINARY  type is not supported in Presto

According to the documentation:

https://prestodb.io/docs/current/language/types.html#varbinary


Using CAST(xxxx AS BINARY) will result in an error:

```
SELECT cast(task_id as binary)
from applydata_bigdata.xflink_task_info
where reader_info like '%mongodbreader%' or writer_info like '%mongodbwriter%';
```
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/8b70afb8-994d-4306-a993-2c09badd4491" />


It should be converted to the VARBINARY type instead.