### PR TITLE
[CALCITE-6801] Linter should disallow tags such as 'Chore' in commit messages

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/LintTest.java
+++ b/core/src/test/java/org/apache/calcite/test/LintTest.java
@@ -412,6 +412,9 @@ class LintTest {
     if (subject2.matches("[a-z].*")) {
       consumer.accept("Message must start with upper-case letter");
     }
+    if (subject2.matches("^Chore.*\\b")) {
+      consumer.accept("Message cannot start with the Chore keyword");
+    }
 
     // Check for keywords that should be capitalized
     for (Map.Entry<String, String> entry : TERMINOLOGY_MAP.entrySet()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6801