### PR TITLE
[CALCITE-6816] Support DAY_OF_WEEK_IN_MONTH function format

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/format/FormatElementEnum.java
+++ b/core/src/main/java/org/apache/calcite/util/format/FormatElementEnum.java
@@ -390,6 +390,14 @@ public enum FormatElementEnum implements FormatElement {
       sb.append(String.format(Locale.ROOT, "%d", calendar.get(Calendar.WEEK_OF_MONTH)));
     }
   },
+  WM("WM", "The day of week number in the month (Sunday as the first day of the week) as a decimal "
+      + "number (1-5)") {
+    @Override public void format(StringBuilder sb, Date date) {
+      final Calendar calendar = Work.get().calendar;
+      calendar.setTime(date);
+      sb.append(String.format(Locale.ROOT, "%d", calendar.get(Calendar.DAY_OF_WEEK_IN_MONTH)));
+    }
+  },
   WW("w", "The week number of the year (Sunday as the first day of the week) as a decimal "
       + "number (00-53)") {
     @Override public void format(StringBuilder sb, Date date) {

--- a/core/src/main/java/org/apache/calcite/util/format/FormatModels.java
+++ b/core/src/main/java/org/apache/calcite/util/format/FormatModels.java
@@ -68,6 +68,7 @@ import static org.apache.calcite.util.format.FormatElementEnum.SS;
 import static org.apache.calcite.util.format.FormatElementEnum.SSSSS;
 import static org.apache.calcite.util.format.FormatElementEnum.TZR;
 import static org.apache.calcite.util.format.FormatElementEnum.W;
+import static org.apache.calcite.util.format.FormatElementEnum.WM;
 import static org.apache.calcite.util.format.FormatElementEnum.WW;
 import static org.apache.calcite.util.format.FormatElementEnum.Y;
 import static org.apache.calcite.util.format.FormatElementEnum.YY;
@@ -208,6 +209,7 @@ public class FormatModels {
     map.put("D", D);
     map.put("WW", WW);
     map.put("W", W);
+    map.put("WM", WM);
     map.put("IW", IW);
     map.put("Q", Q);
     map.put("AM", AMPM);

--- a/core/src/test/java/org/apache/calcite/util/format/FormatElementEnumTest.java
+++ b/core/src/test/java/org/apache/calcite/util/format/FormatElementEnumTest.java
@@ -164,8 +164,14 @@ class FormatElementEnumTest {
     assertFormatElement(FormatElementEnum.SS, "2014-09-30T10:00:00Z", "00");
   }
 
-  @Test void testWM() {
+  @Test void testW() {
     assertFormatElement(FormatElementEnum.W, "2014-09-30T10:00:00Z", "5");
+  }
+
+  @Test void testWM() {
+    assertFormatElement(FormatElementEnum.WM, "2014-09-30T10:00:00Z", "5");
+    assertFormatElement(FormatElementEnum.WM, "2014-09-10T10:00:00Z", "2");
+    assertFormatElement(FormatElementEnum.WM, "2014-09-02T10:00:00Z", "1");
   }
 
   @Test void testWW() {


### PR DESCRIPTION
Currently DAY_OF_WEEK_IN_MONTH format not support, need to support it.
JIRA: https://issues.apache.org/jira/browse/CALCITE-6816