### PR TITLE
[CALCITE-6827] Build failure due to json-smart version mismatch

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
         apiv("net.hydromatic:sql-logic-test")
         apiv("net.hydromatic:steelwheels-data-hsqldb")
         apiv("net.hydromatic:tpcds", "hydromatic.tpcds")
+        apiv("net.minidev:json-smart")
         apiv("net.java.dev.jna:jna")
         apiv("net.java.dev.jna:jna-platform")
         apiv("net.sf.opencsv:opencsv")

--- a/gradle.properties
+++ b/gradle.properties
@@ -134,6 +134,7 @@ jna.version=5.14.0
 jna-platform.version=5.14.0
 joda-time.version=2.8.1
 json-path.version=2.9.0
+json-smart.version=2.3
 jsr305.version=3.0.2
 jsoup.version=1.11.3
 junit4.version=4.13.2


### PR DESCRIPTION
Add version contraint ensuring that we are always using the 2.3 version for json-smart.

There is a transitive dependecy to json-smart from the piglet module with a version range [1.3.1,2.3]:

project :piglet > org.apache.hadoop:hadoop-common:2.10.2 > org.apache.hadoop:hadoop-auth:2.10.2 > com.nimbusds:nimbus-jose-jwt:7.9

The maven-metadata.xml of json-smart in Maven central [1] is used to resolve version ranges. After the 2.5.2 relase of json-smart [2] the previous versions were removed from the metadata file leading to failures in the resolution of ranged versions.

Using a version constraint by-passes the ranged version problem and improves build stability.

[1] https://repo.maven.apache.org/maven2/net/minidev/json-smart/maven-metadata.xml
[2] https://github.com/netplex/json-smart-v2/issues/240