### PR TITLE
[CALCITE-6819] MSSQL doesn't support TRUE/FALSE keywords in its Join predicate

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -45,6 +45,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import static org.apache.calcite.util.RelToSqlConverterUtil.unparseBoolLiteralToCondition;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -187,6 +189,15 @@ public class MssqlSqlDialect extends SqlDialect {
         super.unparseCall(writer, call, leftPrec, rightPrec);
       }
     }
+  }
+
+  @Override public void unparseBoolLiteral(SqlWriter writer,
+      SqlLiteral literal, int leftPrec, int rightPrec) {
+    Boolean value = (Boolean) literal.getValue();
+    if (value == null) {
+      return;
+    }
+    unparseBoolLiteralToCondition(writer, value);
   }
 
   @Override public boolean supportsCharSet() {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -45,6 +45,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
+import static org.apache.calcite.util.RelToSqlConverterUtil.unparseBoolLiteralToCondition;
+
 /**
  * A <code>SqlDialect</code> implementation for the Oracle database.
  */
@@ -139,11 +141,7 @@ public class OracleSqlDialect extends SqlDialect {
       return;
     }
     // low version oracle not support bool literal
-    final SqlWriter.Frame frame = writer.startList("(", ")");
-    writer.literal("1");
-    writer.sep(SqlStdOperatorTable.EQUALS.getName());
-    writer.literal(value ? "1" : "0");
-    writer.endList(frame);
+    unparseBoolLiteralToCondition(writer, value);
   }
 
   @Override public void unparseDateTimeLiteral(SqlWriter writer,

--- a/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
+++ b/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -195,5 +196,19 @@ public abstract class RelToSqlConverterUtil {
         writer.endList(frame);
       }
     };
+  }
+
+  /**
+   * Writes TRUE/FALSE or 1 = 1/ 1 &lt; &gt; 1 for certain.
+   *
+   * @param writer current SqlWriter object
+   * @param value  boolean value to be unparsed.
+   */
+  public static void unparseBoolLiteralToCondition(SqlWriter writer, boolean value) {
+    final SqlWriter.Frame frame = writer.startList("(", ")");
+    writer.literal("1");
+    writer.sep(SqlStdOperatorTable.EQUALS.getName());
+    writer.literal(value ? "1" : "0");
+    writer.endList(frame);
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -8226,6 +8226,27 @@ class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6819">[CALCITE-6819]
+   * MSSQL doesn't support TRUE/FALSE keywords in its Join predicate</a>. */
+  @Test void testJoinBoolLiteralMSSQL() {
+    final String queryTrue = "SELECT \"hire_date\", \"department_description\" FROM \"employee\" "
+        + "LEFT JOIN \"department\" ON TRUE";
+    final String mssqlExpected1 = "SELECT [employee].[hire_date],"
+        + " [department].[department_description]\nFROM [foodmart].[employee]\nLEFT JOIN"
+        + " [foodmart].[department] ON (1 = 1)";
+    sql(queryTrue)
+        .dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected1);
+
+    final String queryFalse = "SELECT \"hire_date\", \"department_description\" FROM \"employee\" "
+        + "LEFT JOIN \"department\" ON False";
+    final String mssqlExpected2 = "SELECT [employee].[hire_date],"
+        + " [department].[department_description]\nFROM [foodmart].[employee]\nLEFT JOIN"
+        + " [foodmart].[department] ON (1 = 0)";
+    sql(queryFalse)
+        .dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected2);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6480">[CALCITE-6480]
    * OracleDialect does not support CASE WHEN returning boolean</a>. */
   @Test void testBooleanCaseWhenOracle() {


### PR DESCRIPTION
In MSSQL dialect use 1=1 instead of TRUE