### PR TITLE
[CALCITE-6841] Elasticsearch Adapter version should contain 8.x

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchVersion.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchVersion.java
@@ -31,6 +31,7 @@ enum ElasticsearchVersion {
   ES5(5),
   ES6(6),
   ES7(7),
+  ES8(8),
   UNKNOWN(0);
 
   private final int elasticVersionMajor;
@@ -61,6 +62,8 @@ enum ElasticsearchVersion {
       return ES6;
     } else if (major == 7) {
       return ES7;
+    } else if (major == 8) {
+      return ES8;
     } else {
       return UNKNOWN;
     }

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchVersionTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchVersionTest.java
@@ -37,6 +37,7 @@ class ElasticsearchVersionTest {
     assertThat(ElasticsearchVersion.ES5, is(fromString("5.6.1")));
     assertThat(ElasticsearchVersion.ES6, is(fromString("6.0.1")));
     assertThat(ElasticsearchVersion.ES7, is(fromString("7.0.1")));
+    assertThat(ElasticsearchVersion.ES8, is(fromString("8.0.1")));
     assertThat(ElasticsearchVersion.UNKNOWN, is(fromString("111.0.1")));
     assertThat(ElasticsearchVersion.UNKNOWN, is(fromString("2020.12.12")));
 


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-6841