### PR TITLE
Add JOIN test for MongoDB adapter

### DIFF
--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -217,6 +217,27 @@ public class MongoAdapterTest implements SchemaFactory {
                 "{$project: {STATE: '$state', ID: '$_id'}}"));
   }
 
+  @Test void testJoin() {
+    assertModel(MODEL)
+        .query("select b.state, a.id from zips as a join zips as b on a.id=b.id where a.id='02401' "
+            + "fetch next 3 rows only")
+        .returnsOrdered("STATE=MA; ID=02401")
+        .queryContains(
+            mongoChecker("{$match: {_id: \"02401\"}}",
+                "{$project: {ID: '$_id'}}",
+                "{$sort: {ID: 1}}"));
+
+    assertModel(MODEL)
+        .query("select b.state, a.id from zips as a join zips as b on a.id=b.id "
+            + "fetch next 3 rows only")
+        .returnsOrdered("STATE=MA; ID=01701",
+            "STATE=MA; ID=02154",
+            "STATE=MA; ID=02401")
+        .queryContains(
+            mongoChecker("{$project: {ID: '$_id'}}",
+                "{$sort: {ID: 1}}"));
+  }
+
   @Disabled
   @Test void testFilterSort() {
     // LONGITUDE and LATITUDE are null because of CALCITE-194.


### PR DESCRIPTION
Currently MongoDB Adapter not have a test for join, this is nessary because other adapter may had bug in join such as elastic search( https://issues.apache.org/jira/browse/CALCITE-6274 )