### PR TITLE
[CALCITE-6865] Sonar analysis fails due to OOM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.gradle.jvmargs=-XX:+UseG1GC -Xmx1536m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx2g -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true


### PR DESCRIPTION
- Increased JVM heap max memory to 2GB

As it has been pointed out in the PR where we last increased the JVM heap size (https://github.com/apache/calcite/pull/3864), this change will also affect the local JVM. 

Last time we decided that a 0.5GB increase was modest and not worth the trouble, but it's technically possible to limit the increase to just the sonar task in CI (I had it working at some point, most probably in this commit: https://github.com/apache/calcite/commit/88e7e27e13a1a0cd79c169c5021adc103800e776), so if there are objections to the proposed solutions I can try and make it work only for CI.
