### PR TITLE
[CALCITE-1221] Implement DESCRIBE DATABASE, CATALOG, STATEMENT

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -49,7 +49,10 @@ import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlCollectionTypeNameSpec;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDelete;
+import org.apache.calcite.sql.SqlDescribeCatalog;
+import org.apache.calcite.sql.SqlDescribeDatabase;
 import org.apache.calcite.sql.SqlDescribeSchema;
+import org.apache.calcite.sql.SqlDescribeStatement;
 import org.apache.calcite.sql.SqlDescribeTable;
 import org.apache.calcite.sql.SqlDynamicParam;
 import org.apache.calcite.sql.SqlExplain;
@@ -1518,11 +1521,18 @@ SqlNode SqlDescribe() :
 {
     <DESCRIBE> { s = span(); }
     (
-        LOOKAHEAD(2) (<DATABASE> | <CATALOG> | <SCHEMA>)
+        <DATABASE>
         id = CompoundIdentifier() {
-            // DESCRIBE DATABASE and DESCRIBE CATALOG currently do the same as
-            // DESCRIBE SCHEMA but should be different. See
-            //   [CALCITE-1221] Implement DESCRIBE DATABASE, CATALOG, STATEMENT
+            return new SqlDescribeDatabase(s.end(id), id);
+        }
+    |
+        <CATALOG>
+        id = CompoundIdentifier() {
+            return new SqlDescribeCatalog(s.end(id), id);
+        }
+    |
+        <SCHEMA>
+        id = CompoundIdentifier() {
             return new SqlDescribeSchema(s.end(id), id);
         }
     |
@@ -1545,17 +1555,7 @@ SqlNode SqlDescribe() :
     |
         (LOOKAHEAD(1) <STATEMENT>)?
         stmt = SqlQueryOrDml() {
-            // DESCRIBE STATEMENT currently does the same as EXPLAIN. See
-            //   [CALCITE-1221] Implement DESCRIBE DATABASE, CATALOG, STATEMENT
-            final SqlExplainLevel detailLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES;
-            final SqlExplain.Depth depth = SqlExplain.Depth.PHYSICAL;
-            final SqlExplainFormat format = SqlExplainFormat.TEXT;
-            return new SqlExplain(s.end(stmt),
-                stmt,
-                detailLevel.symbol(SqlParserPos.ZERO),
-                depth.symbol(SqlParserPos.ZERO),
-                format.symbol(SqlParserPos.ZERO),
-                nDynamicParams);
+            return new SqlDescribeStatement(s.end(stmt), stmt);
         }
     )
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlDescribeCatalog.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDescribeCatalog.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+/**
+ * A <code>SqlDescribeCatalog</code> is a node of a parse tree that represents a
+ * {@code DESCRIBE CATALOG} statement.
+ */
+public class SqlDescribeCatalog extends SqlCall {
+
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("DESCRIBE_CATALOG", SqlKind.DESCRIBE_CATALOG) {
+        @SuppressWarnings("argument.type.incompatible")
+        @Override public SqlCall createCall(@Nullable SqlLiteral functionQualifier,
+            SqlParserPos pos, @Nullable SqlNode... operands) {
+          return new SqlDescribeSchema(pos, (SqlIdentifier) operands[0]);
+        }
+      };
+
+  SqlIdentifier catalog;
+
+  /** Creates a SqlDescribeCatalog. */
+  public SqlDescribeCatalog(SqlParserPos pos, SqlIdentifier catalog) {
+    super(pos);
+    this.catalog = catalog;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DESCRIBE");
+    writer.keyword("CATALOG");
+    catalog.unparse(writer, leftPrec, rightPrec);
+  }
+
+  @SuppressWarnings("assignment.type.incompatible")
+  @Override public void setOperand(int i, @Nullable SqlNode operand) {
+    switch (i) {
+    case 0:
+      catalog = (SqlIdentifier) operand;
+      break;
+    default:
+      throw new AssertionError(i);
+    }
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(catalog);
+  }
+
+  public SqlIdentifier getCatalog() {
+    return catalog;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDescribeDatabase.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDescribeDatabase.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+/**
+ * A <code>SqlDescribeDatabase</code> is a node of a parse tree that represents a
+ * {@code DESCRIBE DATABASE} statement.
+ */
+public class SqlDescribeDatabase extends SqlCall {
+
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("DESCRIBE_DATABASE", SqlKind.DESCRIBE_DATABASE) {
+        @SuppressWarnings("argument.type.incompatible")
+        @Override public SqlCall createCall(@Nullable SqlLiteral functionQualifier,
+            SqlParserPos pos, @Nullable SqlNode... operands) {
+          return new SqlDescribeSchema(pos, (SqlIdentifier) operands[0]);
+        }
+      };
+
+  SqlIdentifier database;
+
+  /** Creates a SqlDescribeDatabase. */
+  public SqlDescribeDatabase(SqlParserPos pos, SqlIdentifier database) {
+    super(pos);
+    this.database = database;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DESCRIBE");
+    writer.keyword("DATABASE");
+    database.unparse(writer, leftPrec, rightPrec);
+  }
+
+  @SuppressWarnings("assignment.type.incompatible")
+  @Override public void setOperand(int i, @Nullable SqlNode operand) {
+    switch (i) {
+    case 0:
+      database = (SqlIdentifier) operand;
+      break;
+    default:
+      throw new AssertionError(i);
+    }
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(database);
+  }
+
+  public SqlIdentifier getDatabase() {
+    return database;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDescribeStatement.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDescribeStatement.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+/**
+ * A <code>SqlDescribeStatement</code> is a node of a parse tree that represents a
+ * {@code DESCRIBE STATEMENT} statement.
+ */
+public class SqlDescribeStatement extends SqlCall {
+
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("DESCRIBE_STATEMENT", SqlKind.DESCRIBE_STATEMENT) {
+        @SuppressWarnings("argument.type.incompatible")
+        @Override public SqlCall createCall(@Nullable SqlLiteral functionQualifier,
+            SqlParserPos pos, @Nullable SqlNode... operands) {
+          return new SqlDescribeSchema(pos, (SqlIdentifier) operands[0]);
+        }
+      };
+
+  SqlNode statement;
+
+  /** Creates a SqlDescribeStatement. */
+  public SqlDescribeStatement(SqlParserPos pos, SqlNode statement) {
+    super(pos);
+    this.statement = statement;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DESCRIBE");
+    writer.keyword("STATEMENT");
+    writer.newlineAndIndent();
+    statement.unparse(
+        writer, getOperator().getLeftPrec(), getOperator().getRightPrec());
+  }
+
+  @SuppressWarnings("assignment.type.incompatible")
+  @Override public void setOperand(int i, @Nullable SqlNode operand) {
+    switch (i) {
+    case 0:
+      statement = operand;
+      break;
+    default:
+      throw new AssertionError(i);
+    }
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(statement);
+  }
+
+  public SqlNode getStatement() {
+    return statement;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -159,11 +159,20 @@ public enum SqlKind {
   /** EXPLAIN statement. */
   EXPLAIN,
 
+  /** DESCRIBE DATABASE statement. */
+  DESCRIBE_DATABASE,
+
+  /** DESCRIBE CATALOG statement. */
+  DESCRIBE_CATALOG,
+
   /** DESCRIBE SCHEMA statement. */
   DESCRIBE_SCHEMA,
 
   /** DESCRIBE TABLE statement. */
   DESCRIBE_TABLE,
+
+  /** DESCRIBE STATEMENT statement. */
+  DESCRIBE_STATEMENT,
 
   /** INSERT statement. */
   INSERT,

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4857,12 +4857,10 @@ public class SqlParserTest {
   @Test void testDescribeSchema() {
     sql("describe schema A")
         .ok("DESCRIBE SCHEMA `A`");
-    // Currently DESCRIBE DATABASE, DESCRIBE CATALOG become DESCRIBE SCHEMA.
-    // See [CALCITE-1221] Implement DESCRIBE DATABASE, CATALOG, STATEMENT
     sql("describe database A")
-        .ok("DESCRIBE SCHEMA `A`");
+        .ok("DESCRIBE DATABASE `A`");
     sql("describe catalog A")
-        .ok("DESCRIBE SCHEMA `A`");
+        .ok("DESCRIBE CATALOG `A`");
   }
 
   @Test void testDescribeTable() {
@@ -4897,15 +4895,13 @@ public class SqlParserTest {
   }
 
   @Test void testDescribeStatement() {
-    // Currently DESCRIBE STATEMENT becomes EXPLAIN.
-    // See [CALCITE-1221] Implement DESCRIBE DATABASE, CATALOG, STATEMENT
     final String expected0 = ""
-        + "EXPLAIN PLAN INCLUDING ATTRIBUTES WITH IMPLEMENTATION FOR\n"
+        + "DESCRIBE STATEMENT\n"
         + "SELECT *\n"
         + "FROM `EMPS`";
     sql("describe statement select * from emps").ok(expected0);
     final String expected1 = ""
-        + "EXPLAIN PLAN INCLUDING ATTRIBUTES WITH IMPLEMENTATION FOR\n"
+        + "DESCRIBE STATEMENT\n"
         + "(SELECT *\n"
         + "FROM `EMPS`\n"
         + "ORDER BY 2)";
@@ -4914,7 +4910,7 @@ public class SqlParserTest {
     sql("describe (select * from emps)").ok(expected0);
     sql("describe statement (select * from emps)").ok(expected0);
     final String expected2 = ""
-        + "EXPLAIN PLAN INCLUDING ATTRIBUTES WITH IMPLEMENTATION FOR\n"
+        + "DESCRIBE STATEMENT\n"
         + "SELECT `DEPTNO`\n"
         + "FROM `EMPS`\n"
         + "UNION\n"
@@ -4922,7 +4918,7 @@ public class SqlParserTest {
         + "FROM `DEPTS`";
     sql("describe select deptno from emps union select deptno from depts").ok(expected2);
     final String expected3 = ""
-        + "EXPLAIN PLAN INCLUDING ATTRIBUTES WITH IMPLEMENTATION FOR\n"
+        + "DESCRIBE STATEMENT\n"
         + "INSERT INTO `EMPS`\n"
         + "VALUES (ROW(1, 'a'))";
     sql("describe insert into emps values (1, 'a')").ok(expected3);


### PR DESCRIPTION
Adds `SqlNode`s for DescribeDatabase, DescribeCatalog, and DescribeStatement.

JIRA: https://issues.apache.org/jira/browse/CALCITE-1221
