### PR TITLE
[CALCITE-6825] Add support for ALL, SOME, ANY in RelToSqlConverter

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -776,6 +776,8 @@ public abstract class SqlImplementor {
         return new SqlDynamicParam(caseParam.getIndex(), POS);
 
       case IN:
+      case SOME:
+      case ALL:
         subQuery = (RexSubQuery) rex;
         sqlSubQuery = implementor().visitRoot(subQuery.rel).asQueryOrValues();
         final List<RexNode> operands = subQuery.operands;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlQuantifyOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlQuantifyOperator.java
@@ -21,6 +21,7 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlValidator;
@@ -117,5 +118,46 @@ public class SqlQuantifyOperator extends SqlInOperator {
       }
     }
     return null;
+  }
+
+  @Override public SqlOperator not() {
+    switch (kind) {
+    case SOME:
+      switch (comparisonKind) {
+      case EQUALS:
+        return SqlStdOperatorTable.ALL_NE;
+      case NOT_EQUALS:
+        return SqlStdOperatorTable.ALL_EQ;
+      case LESS_THAN_OR_EQUAL:
+        return SqlStdOperatorTable.ALL_GT;
+      case LESS_THAN:
+        return SqlStdOperatorTable.ALL_GE;
+      case GREATER_THAN_OR_EQUAL:
+        return SqlStdOperatorTable.ALL_LT;
+      case GREATER_THAN:
+        return SqlStdOperatorTable.ALL_LE;
+      default:
+        throw new AssertionError("unexpected SOME comparisonKind " + kind);
+      }
+    case ALL:
+      switch (comparisonKind) {
+      case EQUALS:
+        return SqlStdOperatorTable.SOME_NE;
+      case NOT_EQUALS:
+        return SqlStdOperatorTable.SOME_EQ;
+      case LESS_THAN_OR_EQUAL:
+        return SqlStdOperatorTable.SOME_GT;
+      case LESS_THAN:
+        return SqlStdOperatorTable.SOME_GE;
+      case GREATER_THAN_OR_EQUAL:
+        return SqlStdOperatorTable.SOME_LT;
+      case GREATER_THAN:
+        return SqlStdOperatorTable.SOME_LE;
+      default:
+        throw new AssertionError("unexpected ALL comparisonKind " + kind);
+      }
+    default:
+      throw new AssertionError("unexpected " + kind);
+    }
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -9458,6 +9458,27 @@ class RelToSqlConverterTest {
     assertEquals(project, forceProject);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6825">[CALCITE-6825]
+   * Add support for ALL, SOME, ANY in RelToSqlConverter</a>. */
+  @Test void testSome() {
+    final String sql = "SELECT 1, \"gross_weight\" < SOME(SELECT \"gross_weight\" "
+        + "FROM \"foodmart\".\"product\") AS \"t\" "
+        + "FROM \"foodmart\".\"product\"";
+    final String expected = "SELECT 1, \"gross_weight\" < SOME (SELECT \"gross_weight\"\n"
+        + "FROM \"foodmart\".\"product\") AS \"t\"\nFROM \"foodmart\".\"product\"";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testAll() {
+    final String sql = "SELECT 1, \"gross_weight\" < ALL(SELECT \"gross_weight\" "
+        + "FROM \"foodmart\".\"product\") AS \"t\" "
+        + "FROM \"foodmart\".\"product\"";
+    final String expected = "SELECT 1, \"gross_weight\" < ALL (SELECT \"gross_weight\"\n"
+        + "FROM \"foodmart\".\"product\") AS \"t\"\nFROM \"foodmart\".\"product\"";
+    sql(sql).ok(expected);
+  }
+
   /** Fluid interface to run tests. */
   static class Sql {
     private final CalciteAssert.SchemaSpec schemaSpec;


### PR DESCRIPTION
- Add support for `ALL`, `SOME`, `ANY` on subQuery like `IN`.
- Add overrite `not` in `SqlQuantifyOperator` to NOT SOME/ALL.

JIRA: https://issues.apache.org/jira/browse/CALCITE-6825
