### PR TITLE
[CALCITE-6897] AbstractConverter of root node is not needed in topdown mode

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -562,7 +562,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
   void ensureRootConverters() {
     final Set<RelSubset> subsets = new HashSet<>();
     for (RelNode rel : root.getRels()) {
-      if (rel instanceof AbstractConverter) {
+      if (rel instanceof AbstractConverter && !topDownOpt) {
         subsets.add((RelSubset) ((AbstractConverter) rel).getInput());
       }
     }


### PR DESCRIPTION
Jira link: https://issues.apache.org/jira/browse/CALCITE-6897