### PR TITLE
[CALCITE-6909] ClickHouse dialect should limit the Precision and Scale of the Decimal type to be within 76

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
@@ -19,6 +19,8 @@ package org.apache.calcite.sql.dialect;
 import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.sql.SqlAbstractDateTimeLiteral;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
 import org.apache.calcite.sql.SqlCall;
@@ -48,10 +50,36 @@ import static java.util.Objects.requireNonNull;
  * A <code>SqlDialect</code> implementation for the ClickHouse database.
  */
 public class ClickHouseSqlDialect extends SqlDialect {
+  public static final RelDataTypeSystem TYPE_SYSTEM =
+      new RelDataTypeSystemImpl() {
+        @Override public int getMaxPrecision(SqlTypeName typeName) {
+          switch (typeName) {
+          case DECIMAL:
+            return 76;
+          default:
+            return super.getMaxPrecision(typeName);
+          }
+        }
+
+        @Override public int getMaxScale(SqlTypeName typeName) {
+          switch (typeName) {
+          case DECIMAL:
+            return 76;
+          default:
+            return super.getMaxScale(typeName);
+          }
+        }
+
+        @Override public int getMaxNumericScale() {
+          return getMaxScale(SqlTypeName.DECIMAL);
+        }
+      };
+
   public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
       .withDatabaseProduct(SqlDialect.DatabaseProduct.CLICKHOUSE)
       .withIdentifierQuoteString("`")
-      .withNullCollation(NullCollation.LOW);
+      .withNullCollation(NullCollation.LOW)
+      .withDataTypeSystem(TYPE_SYSTEM);
 
   public static final SqlDialect DEFAULT = new ClickHouseSqlDialect(DEFAULT_CONTEXT);
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1374,9 +1374,13 @@ class RelToSqlConverterTest {
         + "from \"product\" ";
     final String expectedRedshift = "SELECT CAST(\"product_id\" AS DECIMAL(38, 2))\n"
         + "FROM \"foodmart\".\"product\"";
+    final String expectedClickHouse = "SELECT CAST(`product_id` AS DECIMAL(60, 2))\n"
+        + "FROM `foodmart`.`product`";
     sql(query)
         .withRedshift()
-        .ok(expectedRedshift);
+        .ok(expectedRedshift)
+        .withClickHouse()
+        .ok(expectedClickHouse);
   }
 
   /**
@@ -5763,6 +5767,16 @@ class RelToSqlConverterTest {
         .ok(expected);
   }
 
+  /** Test for <a href="https://issues.apache.org/jira/browse/CALCITE-6909">[CALCITE-6909]
+   *  ClickHouse dialect should limit the Precision and Scale of the Decimal type
+   *  to be within 76</a>. */
+  @Test void testClickHouseDecimalPrecision() {
+    final String sql = "SELECT CAST(1.23 AS DECIMAL(76, 20))";
+    final String expected = "SELECT 1.23000000000000000000";
+    sql(sql).withClickHouseModifiedDecimalTypeSystem()
+        .ok(expected);
+  }
+
   /** Test for <a href="https://issues.apache.org/jira/browse/CALCITE-5651">[CALCITE-5651]
    * Inferred scale for decimal should not exceed maximum allowed scale</a>. */
   @Test void testNumericScale() {
@@ -9650,6 +9664,12 @@ class RelToSqlConverterTest {
                     }
                   }));
       return dialect(postgresqlSqlDialect);
+    }
+
+    Sql withClickHouseModifiedDecimalTypeSystem() {
+      final ClickHouseSqlDialect clickHouseSqlDialect =
+          new ClickHouseSqlDialect(ClickHouseSqlDialect.DEFAULT_CONTEXT);
+      return dialect(clickHouseSqlDialect);
     }
 
     Sql withOracleModifiedTypeSystem() {


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-6909