### PR TITLE
[CALCITE-6912] Test showing a sample failure of Enumerable codes handling of byte[] columns

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -8799,6 +8799,18 @@ public class JdbcTest {
         .returnsUnordered("VAL=2500.55");
   }
 
+  @Test void bindBytesParameter() {
+    final String sql = "select \"primitiveBoolean\" from \"s\".\"everyTypes\" where \"bytes\" = ?";
+
+    CalciteAssert.that()
+        .withSchema("s", new ReflectiveSchema(new CatchallSchema()))
+        .query(sql)
+        .consumesPreparedStatement(p -> {
+          p.setBytes(1, new byte[] { 00 });
+        })
+        .returnsUnordered("primitiveBoolean=false");
+  }
+
   @Test void bindNullParameter() {
     final String sql =
         "with cte as (select 2500.55 as val)"

--- a/testkit/src/main/java/org/apache/calcite/test/schemata/catchall/CatchallSchema.java
+++ b/testkit/src/main/java/org/apache/calcite/test/schemata/catchall/CatchallSchema.java
@@ -56,13 +56,13 @@ public class CatchallSchema {
           false, (byte) 0, (char) 0, (short) 0, 0, 0L, 0F, 0D,
           false, (byte) 0, (char) 0, (short) 0, 0, 0L, 0F, 0D,
           new java.sql.Date(0), new Time(0), new Timestamp(0),
-          new Date(0), "1", BigDecimal.ZERO, Collections.emptyList()),
+          new Date(0), "1", BigDecimal.ZERO, Collections.emptyList(), new byte[] { 00 }),
       new EveryType(
           true, Byte.MAX_VALUE, Character.MAX_VALUE, Short.MAX_VALUE,
           Integer.MAX_VALUE, Long.MAX_VALUE, Float.MAX_VALUE,
           Double.MAX_VALUE,
           null, null, null, null, null, null, null, null,
-          null, null, null, null, null, null, null),
+          null, null, null, null, null, null, null, null),
   };
 
   public final AllPrivate[] allPrivates =
@@ -130,6 +130,7 @@ public class CatchallSchema {
     public final @Nullable String string;
     public final @Nullable BigDecimal bigDecimal;
     public final @Nullable @Array(component = String.class) List<String> list;
+    public final @Nullable byte[] bytes;
 
     public EveryType(
         boolean primitiveBoolean,
@@ -154,7 +155,8 @@ public class CatchallSchema {
         @Nullable Date utilDate,
         @Nullable String string,
         @Nullable BigDecimal bigDecimal,
-        @Nullable List<String> list) {
+        @Nullable List<String> list,
+        @Nullable byte[] bytes) {
       this.primitiveBoolean = primitiveBoolean;
       this.primitiveByte = primitiveByte;
       this.primitiveChar = primitiveChar;
@@ -178,6 +180,7 @@ public class CatchallSchema {
       this.string = string;
       this.bigDecimal = bigDecimal;
       this.list = list;
+      this.bytes = bytes;
     }
 
     public static Enumerable<Field> fields() {


### PR DESCRIPTION
This test fails due to the impossible cast of byte[] to ByteString in the moveNext() method: 
```
public org.apache.calcite.linq4j.Enumerable bind(final org.apache.calcite.DataContext root) {
  final org.apache.calcite.linq4j.Enumerable _inputEnumerable = org.apache.calcite.linq4j.Linq4j.asEnumerable(((org.apache.calcite.test.schemata.catchall.CatchallSchema) ((org.apache.calcite.adapter.java.ReflectiveSchema) root.getRootSchema().getSubSchema("s").unwrap(org.apache.calcite.adapter.java.ReflectiveSchema.class)).getTarget()).everyTypes).select(new org.apache.calcite.linq4j.function.Function1() {
    public org.apache.calcite.test.schemata.catchall.CatchallSchema.EveryType apply(org.apache.calcite.test.schemata.catchall.CatchallSchema.EveryType row) {
      return new org.apache.calcite.test.schemata.catchall.CatchallSchema.EveryType(
          row.primitiveBoolean,
          row.primitiveByte,
          row.primitiveChar,
          row.primitiveShort,
          row.primitiveInt,
          row.primitiveLong,
          row.primitiveFloat,
          row.primitiveDouble,
          row.wrapperBoolean,
          row.wrapperByte,
          row.wrapperCharacter,
          row.wrapperShort,
          row.wrapperInteger,
          row.wrapperLong,
          row.wrapperFloat,
          row.wrapperDouble,
          row.sqlDate,
          row.sqlTime,
          row.sqlTimestamp,
          row.utilDate,
          row.string,
          row.bigDecimal,
          row.list,
          row.bytes);
    }
    public Object apply(Object row) {
      return apply(
        (org.apache.calcite.test.schemata.catchall.CatchallSchema.EveryType) row);
    }
  }
  );
  return new org.apache.calcite.linq4j.AbstractEnumerable(){
      public org.apache.calcite.linq4j.Enumerator enumerator() {
        return new org.apache.calcite.linq4j.Enumerator(){
            public final org.apache.calcite.linq4j.Enumerator inputEnumerator = _inputEnumerable.enumerator();
            public void reset() {
              inputEnumerator.reset();
            }

            public boolean moveNext() {
              while (inputEnumerator.moveNext()) {
                final byte[] input_value = ((org.apache.calcite.test.schemata.catchall.CatchallSchema.EveryType) inputEnumerator.current()).bytes;
                final org.apache.calcite.avatica.util.ByteString cast_value = input_value == null ? null : (org.apache.calcite.avatica.util.ByteString) input_value;
                final byte[] value_dynamic_param = (byte[]) root.get("?0");
                final org.apache.calcite.avatica.util.ByteString cast_value0 = value_dynamic_param == null ? null : (org.apache.calcite.avatica.util.ByteString) value_dynamic_param;
                final Boolean binary_call_value = cast_value == null || cast_value0 == null ? null : Boolean.valueOf(org.apache.calcite.runtime.SqlFunctions.eq(cast_value, cast_value0));
                if (binary_call_value != null && org.apache.calcite.runtime.SqlFunctions.toBoolean(binary_call_value)) {
                  return true;
                }
              }
              return false;
            }

            public void close() {
              inputEnumerator.close();
            }

            public Object current() {
              return ((org.apache.calcite.test.schemata.catchall.CatchallSchema.EveryType) inputEnumerator.current()).primitiveBoolean;
            }

          };
      }

    };
}


public Class getElementType() {
  return boolean.class;
}
```