### PR TITLE
[CALCITE-6914] Expand join-dependent predicates from disjuction

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -841,4 +841,16 @@ public class CoreRules {
   @Experimental
   public static final DphypJoinReorderRule HYPER_GRAPH_OPTIMIZE =
       DphypJoinReorderRule.Config.DEFAULT.toRule();
+
+  /** Rule that expand disjuction in condition of a {@link Filter}.
+   *
+   * @see #EXPAND_JOIN_DISJUCTION */
+  public static final ExpandDisjuctionRule EXPAND_FILTER_DISJUCTION =
+      ExpandDisjuctionRule.Config.FILTER.toRule();
+
+  /** Rule that expand disjuction in condition of a {@link Join}.
+   *
+   * @see #EXPAND_FILTER_DISJUCTION */
+  public static final ExpandDisjuctionRule EXPAND_JOIN_DISJUCTION =
+      ExpandDisjuctionRule.Config.JOIN.toRule();
 }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ExpandDisjuctionRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ExpandDisjuctionRule.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexTableInputRef;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import com.google.common.collect.Lists;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Rule to expand disjuction in condition of a {@link Filter} or {@link Join},
+ * It makes sense to make this optimization part of the predicate pushdown. For example:
+ *
+ * <blockquote><pre>
+ * select t1.name from t1, t2
+ * where t1.id = t2.id
+ * and (
+ *  (t1.id > 20 and t2.height < 50)
+ *  or
+ *  (t1.weight < 200 and t2.sales > 100)
+ * )
+ * </pre></blockquote>
+ *
+ * we can expand to obtain the condition
+ *
+ * <blockquote><pre>
+ * t1.id > 20 or t1.weight < 200
+ * t2.height < 50 or t2.sales > 100
+ * </pre></blockquote>
+ *
+ * new generated predicates are redundant, but they could be pushed down to
+ * scan operator of t1/t2 and reduce the cardinality.
+ *
+ * <p>This rule should only be applied once to avoid generate same redundant expression and
+ * it should be used before {@link CoreRules#FILTER_INTO_JOIN} and {@link CoreRules#JOIN_CONDITION_PUSH}.
+ *
+ * @see CoreRules#EXPAND_FILTER_DISJUCTION
+ * @see CoreRules#EXPAND_JOIN_DISJUCTION
+ */
+@Value.Enclosing
+public class ExpandDisjuctionRule
+    extends RelRule<ExpandDisjuctionRule.Config>
+    implements TransformationRule {
+
+  /**
+   * Creates a ExpandDisjuctionRule.
+   */
+  protected ExpandDisjuctionRule(Config config) {
+    super(config);
+  }
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    config.matchHandler().accept(this, call);
+  }
+
+  /**
+   * Expand predicates for condition of a {@link Filter} or {@link Join}.
+   */
+  private static RexNode apply(
+      RexNode condition,
+      RelNode relNode,
+      List<RelDataTypeField> fieldList,
+      RelBuilder relBuilder,
+      RelMetadataQuery mq) {
+    HashMap<Integer, RexTableInputRef.RelTableRef> inputRefToTableRef = new HashMap<>();
+    ImmutableBitSet columnBits = RelOptUtil.InputFinder.bits(condition);
+    if (columnBits.isEmpty()) {
+      return condition;
+    }
+    // Trace which table does the column referenced in the condition come from
+    for (int columnBit : columnBits.asList()) {
+      Set<RexNode> exprLineage =
+          mq.getExpressionLineage(
+              relNode,
+              RexInputRef.of(columnBit, fieldList));
+      // If mq.getExpressionLineage cannot get result, skip it
+      if (exprLineage == null) {
+        continue;
+      }
+      Set<RexTableInputRef.RelTableRef> relTableRefs =
+          RexUtil.gatherTableReferences(Lists.newArrayList(exprLineage));
+      // If the column come from multiple tables, skip it
+      if (relTableRefs.isEmpty() || relTableRefs.size() > 1) {
+        continue;
+      }
+      inputRefToTableRef.put(columnBit, relTableRefs.iterator().next());
+    }
+
+    ExpandDisjuctionHelper expandHelper =
+        new ExpandDisjuctionHelper(inputRefToTableRef, relBuilder);
+    Map<RexTableInputRef.RelTableRef, RexNode> expandResult = expandHelper.expandDeep(condition);
+    RexNode newCondition = condition;
+    for (RexNode expandCondition : expandResult.values()) {
+      newCondition = relBuilder.and(newCondition, expandCondition);
+    }
+    return newCondition;
+  }
+
+  private static void matchFilter(ExpandDisjuctionRule rule, RelOptRuleCall call) {
+    Filter filter = call.rel(0);
+    RelMetadataQuery mq = call.getMetadataQuery();
+    RelBuilder relBuilder = call.builder();
+
+    RexNode newCondition =
+        apply(
+            filter.getCondition(),
+            filter,
+            filter.getRowType().getFieldList(),
+            relBuilder,
+            mq);
+    if (newCondition.equals(filter.getCondition())) {
+      return;
+    }
+    Filter newFilter = filter.copy(filter.getTraitSet(), filter.getInput(), newCondition);
+    call.transformTo(newFilter);
+  }
+
+  private static void matchJoin(ExpandDisjuctionRule rule, RelOptRuleCall call) {
+    Join join = call.rel(0);
+    RelMetadataQuery mq = call.getMetadataQuery();
+    RelBuilder relBuilder = call.builder();
+
+    List<RelDataTypeField> fieldList =
+        Lists.newArrayList(join.getLeft().getRowType().getFieldList());
+    fieldList.addAll(join.getRight().getRowType().getFieldList());
+    RexNode newCondition =
+        apply(
+            join.getCondition(),
+            join,
+            fieldList,
+            relBuilder,
+            mq);
+    if (newCondition.equals(join.getCondition())) {
+      return;
+    }
+    Join newJoin =
+        join.copy(
+            join.getTraitSet(),
+            newCondition,
+            join.getLeft(),
+            join.getRight(),
+            join.getJoinType(),
+            join.isSemiJoinDone());
+    call.transformTo(newJoin);
+  }
+
+  /**
+   * Helper class to expand predicates.
+   */
+  private static class ExpandDisjuctionHelper {
+
+    private final Map<Integer, RexTableInputRef.RelTableRef> inputRefToTableRef;
+
+    private final RelBuilder relBuilder;
+
+    private ExpandDisjuctionHelper(
+        Map<Integer, RexTableInputRef.RelTableRef> inputRefToTableRef,
+        RelBuilder relBuilder) {
+      this.inputRefToTableRef = inputRefToTableRef;
+      this.relBuilder = relBuilder;
+    }
+
+    /**
+     * Expand predicates recursively that can be pushed down to single table.
+     *
+     * @param condition   Predicate to be expanded
+     * @return  Additional predicates that can be pushed down for each table
+     */
+    private Map<RexTableInputRef.RelTableRef, RexNode> expandDeep(RexNode condition) {
+      Map<RexTableInputRef.RelTableRef, RexNode> additionalConditions = new HashMap<>();
+      ImmutableBitSet inputRefs = RelOptUtil.InputFinder.bits(condition);
+      if (inputRefs.isEmpty()) {
+        return additionalConditions;
+      }
+      RexTableInputRef.RelTableRef tableRef = inputRefsBelongOneTable(inputRefs);
+      // The condition already belongs to one table, return it directly
+      if (tableRef != null) {
+        additionalConditions.put(tableRef, condition);
+        return additionalConditions;
+      }
+
+      // Recursively expand the expression according to whether it is a conjunction
+      // or a disjunction. If it is neither a disjunction nor a conjunction, it cannot
+      // be expanded further and an empty Map is returned.
+      switch (condition.getKind()) {
+      case AND:
+        List<RexNode> andOperands = RexUtil.flattenAnd(((RexCall) condition).getOperands());
+        for (RexNode andOperand : andOperands) {
+          Map<RexTableInputRef.RelTableRef, RexNode> operandResult = expandDeep(andOperand);
+          mergeAnd(additionalConditions, operandResult);
+        }
+        break;
+      case OR:
+        List<RexNode> orOperands = RexUtil.flattenOr(((RexCall) condition).getOperands());
+        additionalConditions.putAll(expandDeep(orOperands.get(0)));
+        for (int i = 1; i < orOperands.size(); i++) {
+          Map<RexTableInputRef.RelTableRef, RexNode> operandResult =
+              expandDeep(orOperands.get(i));
+          mergeOr(additionalConditions, operandResult);
+        }
+        break;
+      }
+
+      return additionalConditions;
+    }
+
+    private RexTableInputRef.@Nullable RelTableRef inputRefsBelongOneTable(
+        ImmutableBitSet inputRefs) {
+      RexTableInputRef.RelTableRef tableRef = inputRefToTableRef.get(inputRefs.nth(0));
+      if (tableRef == null) {
+        return null;
+      }
+      for (int inputBit : inputRefs.asList()) {
+        RexTableInputRef.RelTableRef inputBitTableRef = inputRefToTableRef.get(inputBit);
+        if (inputBitTableRef == null || !inputBitTableRef.equals(tableRef)) {
+          return null;
+        }
+      }
+      return tableRef;
+    }
+
+    /**
+     * For additional predicates of each operand in conjuction, all of them should be retained and
+     * use 'AND' to combine expressions.
+     *
+     * @param baseMap       Additional predicates that current conjunction has already saved
+     * @param forMergeMap   Additional predicates that current operand has expanded
+     */
+    private void mergeAnd(
+        Map<RexTableInputRef.RelTableRef, RexNode> baseMap,
+        Map<RexTableInputRef.RelTableRef, RexNode> forMergeMap) {
+      for (Map.Entry<RexTableInputRef.RelTableRef, RexNode> entry : forMergeMap.entrySet()) {
+        RexNode mergeExpression =
+            relBuilder.and(
+                entry.getValue(),
+                baseMap.getOrDefault(entry.getKey(), relBuilder.literal(true)));
+        baseMap.put(entry.getKey(), mergeExpression);
+      }
+    }
+
+    /**
+     * Only if all operands in disjunction have additional predicates for table t1, we use 'OR'
+     * to combine expressions and retain them as additional predicates of table t1.
+     *
+     * @param baseMap       Additional predicates that current disjunction has already saved
+     * @param forMergeMap   Additional predicates that current operand has expanded
+     */
+    private void mergeOr(
+        Map<RexTableInputRef.RelTableRef, RexNode> baseMap,
+        Map<RexTableInputRef.RelTableRef, RexNode> forMergeMap) {
+      if (baseMap.isEmpty()) {
+        return;
+      }
+      for (Map.Entry<RexTableInputRef.RelTableRef, RexNode> entry : baseMap.entrySet()) {
+        if (!forMergeMap.containsKey(entry.getKey())) {
+          baseMap.remove(entry.getKey());
+          continue;
+        }
+        RexNode mergedRex =
+            relBuilder.or(
+                entry.getValue(),
+                forMergeMap.get(entry.getKey()));
+        baseMap.put(entry.getKey(), mergedRex);
+      }
+    }
+  }
+
+  /** Rule configuration. */
+  @Value.Immutable(singleton = false)
+  public interface Config extends RelRule.Config {
+    Config FILTER = ImmutableExpandDisjuctionRule.Config.builder()
+        .withMatchHandler(ExpandDisjuctionRule::matchFilter)
+        .build()
+        .withOperandSupplier(b ->
+            b.operand(Filter.class).anyInputs());
+
+    Config JOIN = ImmutableExpandDisjuctionRule.Config.builder()
+        .withMatchHandler(ExpandDisjuctionRule::matchJoin)
+        .build()
+        .withOperandSupplier(b ->
+            b.operand(Join.class).anyInputs());
+
+    @Override default ExpandDisjuctionRule toRule() {
+      return new ExpandDisjuctionRule(this);
+    }
+
+    /** Forwards a call to {@link #onMatch(RelOptRuleCall)}. */
+    MatchHandler<ExpandDisjuctionRule> matchHandler();
+
+    /** Sets {@link #matchHandler()}. */
+    ExpandDisjuctionRule.Config withMatchHandler(MatchHandler<ExpandDisjuctionRule> matchHandler);
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -10048,4 +10048,40 @@ class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(CoreRules.INTERSECT_TO_EXISTS)
         .checkUnchanged();
   }
+
+  @Test void testExpandFilterDisjuction() {
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(CoreRules.EXPAND_FILTER_DISJUCTION)
+        .build();
+
+    sql("select e.empno from emp as e, empnullables as en " +
+        "where e.empno = en.empno " +
+        "and " +
+        "( " +
+        "  (e.mgr > 100 and en.sal < 200) " +
+        "  or " +
+        "  (e.comm < 50 and en.deptno > 10) " +
+        ") ")
+        .withPre(program)
+        .withRule(CoreRules.FILTER_INTO_JOIN)
+        .check();
+  }
+
+  @Test void testExpandJoinDisjuction() {
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(CoreRules.EXPAND_JOIN_DISJUCTION)
+        .build();
+
+    sql("select e.empno from emp as e inner join empnullables as en " +
+        "on e.empno = en.empno " +
+        "and " +
+        "( " +
+        "  (e.mgr > 100 and en.sal < 200) " +
+        "  or " +
+        "  (e.comm < 50 and en.deptno > 10) " +
+        ") ")
+        .withPre(program)
+        .withRule(CoreRules.JOIN_CONDITION_PUSH)
+        .check();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4234,6 +4234,30 @@ LogicalProject(EMPNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExpandFilterDisjuction">
+    <Resource name="sql">
+      <![CDATA[select e.empno from emp as e, empnullables as en where e.empno = en.empno and (   (e.mgr > 100 and en.sal < 200)   or   (e.comm < 50 and en.deptno > 10) ) ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(=($0, $9), OR(AND(>($3, 100), <($14, 200)), AND(<($6, 50), >($16, 10))), OR(<($14, 200), >($16, 10)), OR(>($3, 100), <($6, 50)))])
+    LogicalJoin(condition=[true], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalJoin(condition=[AND(=($0, $9), OR(AND(>($3, 100), <($14, 200)), AND(<($6, 50), >($16, 10))))], joinType=[inner])
+    LogicalFilter(condition=[OR(>($3, 100), <($6, 50))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalFilter(condition=[OR(<($5, 200), >($7, 10))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testExpandFilterExists">
     <Resource name="sql">
       <![CDATA[select empno
@@ -4623,6 +4647,29 @@ LogicalProject(EMPNO=[$0])
           LogicalProject(DEPTNO=[$7])
             LogicalFilter(condition=[>($0, 100)])
               LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExpandJoinDisjuction">
+    <Resource name="sql">
+      <![CDATA[select e.empno from emp as e inner join empnullables as en on e.empno = en.empno and (   (e.mgr > 100 and en.sal < 200)   or   (e.comm < 50 and en.deptno > 10) ) ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalJoin(condition=[AND(=($0, $9), OR(AND(>($3, 100), <($14, 200)), AND(<($6, 50), >($16, 10))), OR(<($14, 200), >($16, 10)), OR(>($3, 100), <($6, 50)))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalJoin(condition=[AND(=($0, $9), OR(AND(>($3, 100), <($14, 200)), AND(<($6, 50), >($16, 10))))], joinType=[inner])
+    LogicalFilter(condition=[OR(>($3, 100), <($6, 50))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalFilter(condition=[OR(<($5, 200), >($7, 10))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
For the following SQL:
`
select t1.name from t1, t2 
where t1.id = t2.id 
and ( 
    (t1.id > 20 and t2.height < 50)  
    or 
    (t1.weight < 200 and t2.sales > 100) 
) 
`
The disjuction `(t1.id > 20 and t2.height < 50) or (t1.weight < 200 and t2.sales > 100)` uses t1 and t2, thus cannot be pushed below the join. 
In fact, we can extract redundant `(t1.id > 20 or t1.weight < 200)` , `(t2.height < 50 or t2.sales > 100)` from this predicate by a new rule and push down these two predicates to both side of Join input.
More detail: https://issues.apache.org/jira/browse/CALCITE-6914