### PR TITLE
[CALCITE-6917] Remove mention to "a list of values" from Javadoc of IN/NOT_IN operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -454,14 +454,12 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           OperandTypes.COMPARABLE_ORDERED_COMPARABLE_ORDERED);
 
   /**
-   * <code>IN</code> operator tests for a value's membership in a sub-query or
-   * a list of values.
+   * <code>IN</code> operator tests for a value's membership in a sub-query.
    */
   public static final SqlBinaryOperator IN = new SqlInOperator(SqlKind.IN);
 
   /**
-   * <code>NOT IN</code> operator tests for a value's membership in a sub-query
-   * or a list of values.
+   * <code>NOT IN</code> operator tests for a value's membership in a sub-query.
    */
   public static final SqlBinaryOperator NOT_IN =
       new SqlInOperator(SqlKind.NOT_IN);


### PR DESCRIPTION
The IN and NOT_IN operator are used exclusively for representing sub-queries and *NOT* a list of values. From CALCITE-4173 onward, the SEARCH operator is used to represent a list of values.