### PR TITLE
[CALCITE-6919] Invalid unparse for CHAR without precision in PostgreSQL

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
@@ -75,6 +75,13 @@ public class PostgresqlSqlDialect extends SqlDialect {
             return super.getMaxPrecision(typeName);
           }
         }
+
+        @Override public int getDefaultPrecision(SqlTypeName typeName) {
+          if (typeName == SqlTypeName.CHAR) {
+            return RelDataType.PRECISION_NOT_SPECIFIED;
+          }
+          return super.getDefaultPrecision(typeName);
+        }
       };
 
   public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3895,12 +3895,15 @@ class RelToSqlConverterTest {
         + "FROM `foodmart`.`product`";
     final String expectedClickHouse = "SELECT CAST(`product_id` AS `FixedString(1)`)\n"
         + "FROM `foodmart`.`product`";
+    final String expectedPostgresql = "SELECT CAST(\"product_id\" AS CHAR)\n"
+        + "FROM \"foodmart\".\"product\"";
     sql(query)
         .withMysql().ok(expectedMysql)
         .withMssql().ok(expectedMssql)
         .withHive().ok(expectedHive)
         .withSpark().ok(expectedSpark)
-        .withClickHouse().ok(expectedClickHouse);
+        .withClickHouse().ok(expectedClickHouse)
+        .withPostgresql().ok(expectedPostgresql);
   }
 
   @Test void testCastToCharWithPrecision() {


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-6919