### PR TITLE
Test case for [CALCITE-6882] RelMdColumnUniqueness incorrectly claims fields are not unique if constant refinement occurs in a node above join

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -109,8 +109,10 @@ public class RelMdColumnUniqueness
 
   public @Nullable Boolean areColumnsUnique(Filter rel, RelMetadataQuery mq,
       ImmutableBitSet columns, boolean ignoreNulls) {
-    columns = decorateWithConstantColumnsFromPredicates(columns, rel, mq);
-    return mq.areColumnsUnique(rel.getInput(), columns, ignoreNulls);
+    ImmutableBitSet columns2 = decorateWithConstantColumnsFromPredicates(columns, rel, mq);
+    @Nullable Boolean b1 = mq.areColumnsUnique(rel.getInput(), columns, ignoreNulls);
+    @Nullable Boolean b2 = mq.areColumnsUnique(rel.getInput(), columns2, ignoreNulls);
+    return b1;
   }
 
   /** Catch-all implementation for

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1410,6 +1410,32 @@ public class RelMetadataTest {
         .assertThatAreColumnsUnique(bitSetOf(2), is(false));
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6882">[CALCITE-6882]
+   * RelMdColumnUniqueness incorrectly claims fields are not unique if constant
+   * refinement occurs in a node above join</a>. */
+  @Test void testColumnUniquenessForFilterOnJoin() {
+    // Calcite should deduce that emp.empno is unique (knowing that empno is
+    // a key for emp and deptno is a key for dept).
+    sql("select emp.empno, dept.deptno\n"
+        + "from emp\n"
+        + "  inner join dept\n"
+        + "on emp.deptno = dept.deptno\n"
+        + "where dept.name = 'foo'")
+        .assertThatAreColumnsUnique(bitSetOf(0), is(true));
+  }
+
+  @Test void testColumnUniquenessForJoin() {
+    // Calcite should deduce that emp.empno is unique (knowing that empno is
+    // a key for emp and deptno is a key for dept).
+    sql("select emp.empno, dept.name, dept.deptno\n"
+        + "from emp\n"
+        + "  inner join dept\n"
+        + "on emp.deptno = dept.deptno")
+        .assertThatAreColumnsUnique(bitSetOf(0), is(true))
+        .assertThatAreColumnsUnique(bitSetOf(0, 1), is(true));
+  }
+
   @Test void testGroupBy() {
     sql("select deptno, count(*), sum(sal) from emp group by deptno")
         .assertThatUniqueKeysAre(bitSetOf(0));


### PR DESCRIPTION
Test case for [CALCITE-6882] RelMdColumnUniqueness incorrectly claims fields are not unique if constant refinement occurs in a node above join

If you comment out the first line of the method
RelMdColumnUniqueness.areColumnsUnique(Filter, ...), the test passes. But all that line does is broaden columns from {0} to {0, 10}, which ordinarily should make areColumnsUnique more likely to return true.

The problem seems to be in areColumnsUnique(Join, ...), which will returns true for {0} (one column from the left side of the join) and false for a {0, 10} (one column from the each side of the join).

A few places in that method have 'if (columns.cardinality() > 0)', and I see no good reason why the empty set should be treated differently.