### PR TITLE
[CALCITE-6944] Cannot parse parenthesized partition by in Table Function

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1040,6 +1040,9 @@ void AddArg0(List<SqlNode> list, ExprContext exprContext) :
         e = LambdaExpression()
     |
         LOOKAHEAD(3)
+        <LPAREN> e = TableParam() <RPAREN>
+    |
+        LOOKAHEAD(3)
         e = TableParam()
     |
         e = PartitionedQueryOrQueryOrExpr(firstExprContext)

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -4709,6 +4709,21 @@ public class SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testTableFunctionWithParenPartitionKey() {
+    final String sql = "select * from table(topn((table orders partition by (productid)), 3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(((TABLE `ORDERS`) PARTITION BY `PRODUCTID`), 3))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testTableFunctionWithParenPartitionKeyAndNamedArg() {
+    final String sql = "select * "
+        + "from table(topn(data=>(table orders partition by (productid)), col=>3))";
+    final String expected = "SELECT *\n"
+        + "FROM TABLE(`TOPN`(`DATA` => ((TABLE `ORDERS`) PARTITION BY `PRODUCTID`), `COL` => 3))";
+    sql(sql).ok(expected);
+  }
+
   @Test void testTableFunctionWithMultiplePartitionKeys() {
     // test multiple partition keys for input table
     final String sql =


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-6944