### PR TITLE
[CALCITE-6955] PruneEmptyRules does not handle the all attribute of SetOp correctly

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -406,6 +406,9 @@ public abstract class PruneEmptyRules {
               + RelOptUtil.toString(union);
           if (nonEmptyInputs == 0) {
             relBuilder.push(union).empty();
+          } else if (nonEmptyInputs == 1 && !union.all) {
+            relBuilder.distinct();
+            relBuilder.convert(union.getRowType(), true);
           } else {
             relBuilder.union(union.all, nonEmptyInputs);
             relBuilder.convert(union.getRowType(), true);
@@ -447,6 +450,9 @@ public abstract class PruneEmptyRules {
               + RelOptUtil.toString(minus);
           if (nonEmptyInputs == 0) {
             relBuilder.push(minus).empty();
+          } else if (nonEmptyInputs == 1 && !minus.all) {
+            relBuilder.distinct();
+            relBuilder.convert(minus.getRowType(), true);
           } else {
             relBuilder.minus(minus.all, nonEmptyInputs);
             relBuilder.convert(minus.getRowType(), true);

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -3744,6 +3744,34 @@ LogicalProject(X=[$0], Y=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEmptyFilterProjectUnion2">
+    <Resource name="sql">
+      <![CDATA[select * from (
+select * from (values (10, 1), (30, 3), (30, 3)) as t (x, y)
+union
+select * from (values (20, 2))
+)
+where x + y > 30]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(X=[$0], Y=[$1])
+  LogicalFilter(condition=[>(+($0, $1), 30)])
+    LogicalUnion(all=[false])
+      LogicalProject(X=[$0], Y=[$1])
+        LogicalValues(tuples=[[{ 10, 1 }, { 30, 3 }, { 30, 3 }]])
+      LogicalProject(EXPR$0=[$0], EXPR$1=[$1])
+        LogicalValues(tuples=[[{ 20, 2 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(X=[$0], Y=[$1])
+  LogicalAggregate(group=[{0, 1}])
+    LogicalValues(tuples=[[{ 30, 3 }, { 30, 3 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEmptyIntersect">
     <Resource name="sql">
       <![CDATA[select * from (values (30, 3))intersect
@@ -3850,6 +3878,30 @@ LogicalMinus(all=[false])
     LogicalValues(tuples=[[{ 30, 3 }]])
   LogicalProject(EXPR$0=[$0], EXPR$1=[$1])
     LogicalValues(tuples=[[{ 40, 4 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEmptyMinus3">
+    <Resource name="sql">
+      <![CDATA[select * from (values (30, 3), (30, 3)) as t (x, y)
+except
+select * from (values (20, 2)) as t (x, y) where x > 30]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalMinus(all=[false])
+  LogicalProject(X=[$0], Y=[$1])
+    LogicalValues(tuples=[[{ 30, 3 }, { 30, 3 }]])
+  LogicalProject(X=[$0], Y=[$1])
+    LogicalFilter(condition=[>($0, 30)])
+      LogicalValues(tuples=[[{ 20, 2 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
+  LogicalProject(X=[$0], Y=[$1])
+    LogicalValues(tuples=[[{ 30, 3 }, { 30, 3 }]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/set-op.iq
+++ b/core/src/test/resources/sql/set-op.iq
@@ -258,4 +258,41 @@ UNION
 (2 rows)
 
 !ok
+
+# [CALCITE-6955] PruneEmptyRules does not handle the all attribute of SetOp correctly
+select * from (values (10, 1), (30, 3), (30, 3)) as t (x, y)
+union
+select * from (values (20, 2)) as t (x, y) where x > 30;
++----+---+
+| X  | Y |
++----+---+
+| 10 | 1 |
+| 30 | 3 |
++----+---+
+(2 rows)
+
+!ok
+
+EnumerableAggregate(group=[{0, 1}])
+  EnumerableValues(tuples=[[{ 10, 1 }, { 30, 3 }, { 30, 3 }]])
+!plan
+
+# [CALCITE-6955] PruneEmptyRules does not handle the all attribute of SetOp correctly
+select * from (values (30, 3), (30, 3)) as t (x, y)
+except
+select * from (values (20, 2)) as t (x, y) where x > 30;
++----+---+
+| X  | Y |
++----+---+
+| 30 | 3 |
++----+---+
+(1 row)
+
+!ok
+
+EnumerableCalc(expr#0=[{inputs}], expr#1=[3], proj#0..1=[{exprs}])
+  EnumerableAggregate(group=[{0}])
+    EnumerableValues(tuples=[[{ 30, 3 }, { 30, 3 }]])
+!plan
+
 # End set-op.iq


### PR DESCRIPTION
Please see: [CALCITE-6955](https://issues.apache.org/jira/browse/CALCITE-6955)