### PR TITLE
[CALCITE-6967] Unparsing STARTS_WITH/ENDS_WITH/BIT functions is incorrect for the Clickhouse dialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
@@ -241,6 +241,52 @@ public class ClickHouseSqlDialect extends SqlDialect {
       }
       unparseFloor(writer, call);
       break;
+    case STARTS_WITH:
+      writer.print("startsWith");
+      final SqlWriter.Frame startList = writer.startList("(", ")");
+      call.operand(0).unparse(writer, 0, 0);
+      writer.sep(",");
+      call.operand(1).unparse(writer, 0, 0);
+      writer.endList(startList);
+      break;
+    case ENDS_WITH:
+      writer.print("endsWith");
+      final SqlWriter.Frame endsList = writer.startList("(", ")");
+      call.operand(0).unparse(writer, 0, 0);
+      writer.sep(",");
+      call.operand(1).unparse(writer, 0, 0);
+      writer.endList(endsList);
+      break;
+    case BITAND:
+      writer.print("bitAnd");
+      final SqlWriter.Frame bitAndList = writer.startList("(", ")");
+      call.operand(0).unparse(writer, 0, 0);
+      writer.sep(",");
+      call.operand(1).unparse(writer, 0, 0);
+      writer.endList(bitAndList);
+      break;
+    case BITOR:
+      writer.print("bitOr");
+      final SqlWriter.Frame bitOrList = writer.startList("(", ")");
+      call.operand(0).unparse(writer, 0, 0);
+      writer.sep(",");
+      call.operand(1).unparse(writer, 0, 0);
+      writer.endList(bitOrList);
+      break;
+    case BITXOR:
+      writer.print("bitXor");
+      final SqlWriter.Frame bitXorList = writer.startList("(", ")");
+      call.operand(0).unparse(writer, 0, 0);
+      writer.sep(",");
+      call.operand(1).unparse(writer, 0, 0);
+      writer.endList(bitXorList);
+      break;
+    case BITNOT:
+      writer.print("bitNot");
+      final SqlWriter.Frame bitNotList = writer.startList("(", ")");
+      call.operand(0).unparse(writer, 0, 0);
+      writer.endList(bitNotList);
+      break;
     case COUNT:
       // CH returns NULL rather than 0 for COUNT(DISTINCT) of NULL values.
       // https://github.com/yandex/ClickHouse/issues/2494

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7718,7 +7718,9 @@ class RelToSqlConverterTest {
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6156">[CALCITE-6156]
    * Add ENDSWITH, STARTSWITH functions (enabled in Postgres, Snowflake libraries)</a>,
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6931">[CALCITE-6931]
-   * STARTSWITH/ENDSWITH in SPARK should not convert to STARTS_WITH/ENDS_WITH</a>. */
+   * STARTSWITH/ENDSWITH in SPARK should not convert to STARTS_WITH/ENDS_WITH</a>,
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6967">[CALCITE-6967]
+   * Unparsing STARTS_WITH/ENDS_WITH/BIT functions is incorrect for the Clickhouse dialect</a>.*/
   @Test void testStartsWith() {
     final String query = "select startswith(\"brand_name\", 'a')\n"
         + "from \"product\"";
@@ -7730,17 +7732,44 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"product\"";
     final String expectedSpark = "SELECT STARTSWITH(`brand_name`, 'a')\n"
         + "FROM `foodmart`.`product`";
+    final String expectedClickHouse = "SELECT startsWith(`brand_name`, 'a')\n"
+        + "FROM `foodmart`.`product`";
     sql(query).withLibrary(SqlLibrary.SNOWFLAKE).withBigQuery().ok(expectedBigQuery);
     sql(query).withLibrary(SqlLibrary.SNOWFLAKE).withPostgresql().ok(expectedPostgres);
     sql(query).withLibrary(SqlLibrary.SNOWFLAKE).withSnowflake().ok(expectedSnowflake);
     sql(query).withLibrary(SqlLibrary.SPARK).withSpark().ok(expectedSpark);
+    sql(query).withLibrary(SqlLibrary.SPARK).withClickHouse().ok(expectedClickHouse);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6967">[CALCITE-6967]
+   * Unparsing STARTS_WITH/ENDS_WITH/BIT functions is incorrect for the Clickhouse dialect</a>.*/
+  @Test void testClickHouseBitFunctions() {
+    final String bitQuery = "select bitand(\"product_id\", \"product_id\"),\n"
+        + "bitor(\"product_id\", \"product_id\"),\n"
+        + "bitxor(\"product_id\", \"product_id\"),\n"
+        + "bitnot(\"product_id\")\n"
+        + "from \"product\"";
+    final String clickHouseExpected = "SELECT bitAnd(`product_id`, `product_id`),"
+        + " bitOr(`product_id`, `product_id`),"
+        + " bitXor(`product_id`, `product_id`),"
+        + " bitNot(`product_id`)\n"
+        + "FROM `foodmart`.`product`";
+
+    sql(bitQuery).withClickHouse().ok(clickHouseExpected);
+  }
+
+  @Test void testClickHouseArrayFunctions() {
+
   }
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6156">[CALCITE-6156]
    * Add ENDSWITH, STARTSWITH functions (enabled in Postgres, Snowflake libraries)</a>,
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6931">[CALCITE-6931]
-   * STARTSWITH/ENDSWITH in SPARK should not convert to STARTS_WITH/ENDS_WITH</a>. */
+   * STARTSWITH/ENDSWITH in SPARK should not convert to STARTS_WITH/ENDS_WITH</a>,
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6967">[CALCITE-6967]
+   * STARTSWITH/ENDSWITH can not parse correctly in ClickHouse</a>.*/
   @Test void testEndsWith() {
     final String query = "select endswith(\"brand_name\", 'a')\n"
         + "from \"product\"";
@@ -7752,10 +7781,13 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"product\"";
     final String expectedSpark = "SELECT ENDSWITH(`brand_name`, 'a')\n"
         + "FROM `foodmart`.`product`";
+    final String expectedClickHouse = "SELECT endsWith(`brand_name`, 'a')\n"
+        + "FROM `foodmart`.`product`";
     sql(query).withLibrary(SqlLibrary.SNOWFLAKE).withBigQuery().ok(expectedBigQuery);
     sql(query).withLibrary(SqlLibrary.SNOWFLAKE).withPostgresql().ok(expectedPostgres);
     sql(query).withLibrary(SqlLibrary.SNOWFLAKE).withSnowflake().ok(expectedSnowflake);
     sql(query).withLibrary(SqlLibrary.SPARK).withSpark().ok(expectedSpark);
+    sql(query).withLibrary(SqlLibrary.SPARK).withClickHouse().ok(expectedClickHouse);
   }
 
   /** Test case for


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-6967