### PR TITLE
[CALCITE-6964] SqlDelete#getOperandList return operands' both order and size not match with SqlDelete#setOperand

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDelete.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDelete.java
@@ -66,7 +66,7 @@ public class SqlDelete extends SqlCall {
 
   @SuppressWarnings("nullness")
   @Override public List<SqlNode> getOperandList() {
-    return ImmutableNullableList.of(targetTable, condition, alias);
+    return ImmutableNullableList.of(targetTable, condition, sourceSelect, alias);
   }
 
   @SuppressWarnings("assignment.type.incompatible")

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -79,7 +79,7 @@ public class SqlUpdate extends SqlCall {
   @SuppressWarnings("nullness")
   @Override public List<@Nullable SqlNode> getOperandList() {
     return ImmutableNullableList.of(targetTable, targetColumnList,
-        sourceExpressionList, condition, alias);
+        sourceExpressionList, condition, sourceSelect, alias);
   }
 
   @SuppressWarnings("assignment.type.incompatible")
@@ -99,7 +99,7 @@ public class SqlUpdate extends SqlCall {
       condition = operand;
       break;
     case 4:
-      sourceExpressionList = requireNonNull((SqlNodeList) operand);
+      sourceSelect = (SqlSelect) operand;
       break;
     case 5:
       alias = (SqlIdentifier) operand;

--- a/core/src/test/java/org/apache/calcite/sql/SqlCallOperandsTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/SqlCallOperandsTest.java
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.calcite.sql;
-
 
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -32,14 +31,30 @@ import static org.hamcrest.Matchers.hasSize;
  * Tests for SqlCall operands' order and size match with set.
  */
 public class SqlCallOperandsTest {
-  @Test
-  void testSqlDeleteGetOperandsMatchWithSetOperand() {
-    SqlDelete sqlDelete = new SqlDelete(SqlParserPos.ZERO, new SqlIdentifier("table1", SqlParserPos.ZERO), null, null, null);
+  @Test void testSqlDeleteGetOperandsMatchWithSetOperand() {
+    SqlDelete sqlDelete =
+        new SqlDelete(SqlParserPos.ZERO, new SqlIdentifier("table1", SqlParserPos.ZERO),
+        null,
+        null,
+        null);
     SqlNode targetTable = new SqlIdentifier("table2", SqlParserPos.ZERO);
     final SqlIdentifier field1 = new SqlIdentifier("field1", SqlParserPos.ZERO);
-    SqlNode condition = SqlStdOperatorTable.EQUALS.createCall(SqlParserPos.ZERO, field1, SqlLiteral.createCharString("field1Value", SqlParserPos.ZERO));
-    SqlSelect sourceSelect = new SqlSelect(SqlParserPos.ZERO, null, SqlNodeList.of(field1), null, null, null, null, null,
-        null, null, null, null, null);
+    SqlNode condition =
+            SqlStdOperatorTable.EQUALS.createCall(SqlParserPos.ZERO, field1,
+            SqlLiteral.createCharString("field1Value", SqlParserPos.ZERO));
+    SqlSelect sourceSelect =
+            new SqlSelect(SqlParserPos.ZERO, null,
+            SqlNodeList.of(field1),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     SqlIdentifier alias = new SqlIdentifier("alias", SqlParserPos.ZERO);
     sqlDelete.setOperand(0, targetTable);
     sqlDelete.setOperand(1, condition);
@@ -53,4 +68,3 @@ public class SqlCallOperandsTest {
     assertThat(alias, equalTo(operandList.get(3)));
   }
 }
-

--- a/core/src/test/java/org/apache/calcite/sql/SqlCallOperandsTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/SqlCallOperandsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql;
+
+
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Tests for SqlCall operands' order and size match with set.
+ */
+public class SqlCallOperandsTest {
+  @Test
+  void testSqlDeleteGetOperandsMatchWithSetOperand() {
+    SqlDelete sqlDelete = new SqlDelete(SqlParserPos.ZERO, new SqlIdentifier("table1", SqlParserPos.ZERO), null, null, null);
+    SqlNode targetTable = new SqlIdentifier("table2", SqlParserPos.ZERO);
+    final SqlIdentifier field1 = new SqlIdentifier("field1", SqlParserPos.ZERO);
+    SqlNode condition = SqlStdOperatorTable.EQUALS.createCall(SqlParserPos.ZERO, field1, SqlLiteral.createCharString("field1Value", SqlParserPos.ZERO));
+    SqlSelect sourceSelect = new SqlSelect(SqlParserPos.ZERO, null, SqlNodeList.of(field1), null, null, null, null, null,
+        null, null, null, null, null);
+    SqlIdentifier alias = new SqlIdentifier("alias", SqlParserPos.ZERO);
+    sqlDelete.setOperand(0, targetTable);
+    sqlDelete.setOperand(1, condition);
+    sqlDelete.setOperand(2, sourceSelect);
+    sqlDelete.setOperand(3, alias);
+    final List<SqlNode> operandList = sqlDelete.getOperandList();
+    assertThat(operandList, hasSize(4));
+    assertThat(targetTable, equalTo(operandList.get(0)));
+    assertThat(condition, equalTo(operandList.get(1)));
+    assertThat(sourceSelect, equalTo(operandList.get(2)));
+    assertThat(alias, equalTo(operandList.get(3)));
+  }
+}
+


### PR DESCRIPTION
Please view the detail : [CALCITE-6964]