### PR TITLE
[CALCITE-6974] Default typesystem has incorrect limits for DECIMAL for Presto/MySQL/Phoenix

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -71,10 +71,25 @@ public class MysqlSqlDialect extends SqlDialect {
             return 65535;
           case TIMESTAMP:
             return 6;
+          case DECIMAL:
+            return 65;
           default:
             return super.getMaxPrecision(typeName);
           }
         }
+
+        // We can refer to document of MySQL 5.x and 8.x:
+        // https://dev.mysql.com/doc/refman/8.4/en/precision-math-decimal-characteristics.html
+        // https://dev.mysql.com/doc/refman/5.7/en/precision-math-decimal-characteristics.html
+        @Override public int getMaxScale(SqlTypeName typeName) {
+          switch (typeName) {
+          case DECIMAL:
+            return 30;
+          default:
+            return super.getMaxScale(typeName);
+          }
+        }
+
         @Override public int getDefaultPrecision(SqlTypeName typeName) {
           if (typeName == SqlTypeName.CHAR) {
             return RelDataType.PRECISION_NOT_SPECIFIED;

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PhoenixSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PhoenixSqlDialect.java
@@ -17,12 +17,15 @@
 package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.sql.SqlAlienSystemTypeNameSpec;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.AbstractSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -30,9 +33,38 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * A <code>SqlDialect</code> implementation for the Apache Phoenix database.
  */
 public class PhoenixSqlDialect extends SqlDialect {
+  public static final RelDataTypeSystem TYPE_SYSTEM =
+      new RelDataTypeSystemImpl() {
+
+        // We can refer to document of Phoenix 5.x:
+        // https://phoenix.apache.org/language/datatypes.html#decimal_type
+        @Override public int getMaxPrecision(SqlTypeName typeName) {
+          switch (typeName) {
+          case DECIMAL:
+            return 38;
+          default:
+            return super.getMaxPrecision(typeName);
+          }
+        }
+
+        @Override public int getMaxScale(SqlTypeName typeName) {
+          switch (typeName) {
+          case DECIMAL:
+            return 38;
+          default:
+            return super.getMaxScale(typeName);
+          }
+        }
+
+        @Override public int getMaxNumericScale() {
+          return getMaxScale(SqlTypeName.DECIMAL);
+        }
+      };
+
   public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
       .withDatabaseProduct(SqlDialect.DatabaseProduct.PHOENIX)
-      .withIdentifierQuoteString("\"");
+      .withIdentifierQuoteString("\"")
+      .withDataTypeSystem(TYPE_SYSTEM);
 
   public static final SqlDialect DEFAULT = new PhoenixSqlDialect(DEFAULT_CONTEXT);
 


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-6974