### PR TITLE
[Calcite-6946] Expand predicates from disjunction for inputs of Join

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -894,4 +894,16 @@ public class CoreRules {
    * @see #EXPAND_FILTER_DISJUNCTION_GLOBAL */
   public static final ExpandDisjunctionForTableRule EXPAND_JOIN_DISJUNCTION_GLOBAL =
       ExpandDisjunctionForTableRule.Config.JOIN.toRule();
+
+  /** Rule that expands disjunction in the condition of a {@link Filter} for join inputs.
+   *
+   * @see #EXPAND_JOIN_DISJUNCTION_LOCAL */
+  public static final ExpandDisjunctionForJoinInputsRule EXPAND_FILTER_DISJUNCTION_LOCAL =
+      ExpandDisjunctionForJoinInputsRule.Config.FILTER.toRule();
+
+  /** Rule that expands disjunction in the condition of a {@link Join} for join inputs.
+   *
+   * @see #EXPAND_FILTER_DISJUNCTION_LOCAL */
+  public static final ExpandDisjunctionForJoinInputsRule EXPAND_JOIN_DISJUNCTION_LOCAL =
+      ExpandDisjunctionForJoinInputsRule.Config.JOIN.toRule();
 }

--- a/core/src/main/java/org/apache/calcite/rel/rules/ExpandDisjunctionForJoinInputsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ExpandDisjunctionForJoinInputsRule.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import org.immutables.value.Value;
+
+import java.util.Map;
+
+/**
+ * Rule to expand disjunction for join inputs in condition of a {@link Filter} or {@link Join}.
+ * For example:
+ *
+ * <blockquote><pre>{@code
+ * select t1.id from t1, t2, t3
+ * where t1.id = t2.id
+ * and t1.id = t3.id
+ * and (
+ *     (t1.age < 50 and t3.age > 20)
+ *     or
+ *     (t2.weight > 70 and t3.height < 180)
+ * )
+ * }</pre></blockquote>
+ *
+ * <p>we can expand to obtain the condition
+ *
+ * <blockquote><pre>{@code
+ * select t1.id from t1, t2, t3
+ * where t1.id = t2.id
+ * and t1.id = t3.id
+ * and (
+ *     (t1.age < 50 and t3.age > 20)
+ *     or
+ *     (t2.weight > 70 and t3.height < 180)
+ * )
+ * and (t1.age < 50 or t2.weight > 70)
+ * and (t3.age > 20 or t3.height < 180)
+ * }</pre></blockquote>
+ *
+ * <p>new generated predicates are redundant, but they could be pushed down to
+ * join inputs([t1, t2], [t3]) and reduce the cardinality.
+ *
+ * <p>Note: This rule is similar to the {@link ExpandDisjunctionForTableRule},
+ * but this rule divides the predicates by Join inputs.
+ *
+ * @see CoreRules#EXPAND_FILTER_DISJUNCTION_LOCAL
+ * @see CoreRules#EXPAND_JOIN_DISJUNCTION_LOCAL
+ */
+@Value.Enclosing
+public class ExpandDisjunctionForJoinInputsRule
+    extends RelRule<ExpandDisjunctionForJoinInputsRule.Config>
+    implements TransformationRule {
+
+  /**
+   * Creates a ExpandDisjunctionForJoinInputsRule.
+   */
+  protected ExpandDisjunctionForJoinInputsRule(Config config) {
+    super(config);
+  }
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    config.matchHandler().accept(this, call);
+  }
+
+  private static void matchFilter(ExpandDisjunctionForJoinInputsRule rule, RelOptRuleCall call) {
+    Filter filter = call.rel(0);
+    Join join = call.rel(1);
+    RelBuilder builder = call.builder();
+
+    ExpandDisjunctionForJoinInputsHelper helper =
+        new ExpandDisjunctionForJoinInputsHelper(
+            join.getLeft().getRowType().getFieldCount(),
+            join.getRight().getRowType().getFieldCount(),
+            join.getJoinType().canPushLeftFromAbove(),
+            join.getJoinType().canPushRightFromAbove(),
+            builder,
+            rule.config.bloat());
+    Map<String, RexNode> expandResult = helper.expand(filter.getCondition());
+
+    RexNode newCondition =
+        builder.and(
+            filter.getCondition(),
+            expandResult.getOrDefault(helper.leftKey, builder.literal(true)),
+            expandResult.getOrDefault(helper.rightKey, builder.literal(true)));
+    if (newCondition.equals(filter.getCondition())) {
+      return;
+    }
+    Filter newFilter = filter.copy(filter.getTraitSet(), join, newCondition);
+    call.transformTo(newFilter);
+  }
+
+  private static void matchJoin(ExpandDisjunctionForJoinInputsRule rule, RelOptRuleCall call) {
+    Join join = call.rel(0);
+    RelBuilder builder = call.builder();
+
+    ExpandDisjunctionForJoinInputsHelper helper =
+        new ExpandDisjunctionForJoinInputsHelper(
+            join.getLeft().getRowType().getFieldCount(),
+            join.getRight().getRowType().getFieldCount(),
+            join.getJoinType().canPushLeftFromWithin(),
+            join.getJoinType().canPushRightFromWithin(),
+            builder,
+            rule.config.bloat());
+    Map<String, RexNode> expandResult = helper.expand(join.getCondition());
+
+    RexNode newCondition =
+        call.builder().and(
+            join.getCondition(),
+            expandResult.getOrDefault(helper.leftKey, builder.literal(true)),
+            expandResult.getOrDefault(helper.rightKey, builder.literal(true)));
+    if (newCondition.equals(join.getCondition())) {
+      return;
+    }
+    Join newJoin =
+        join.copy(
+            join.getTraitSet(),
+            newCondition,
+            join.getLeft(),
+            join.getRight(),
+            join.getJoinType(),
+            join.isSemiJoinDone());
+    call.transformTo(newJoin);
+  }
+
+  /**
+   * Helper class to expand predicates.
+   */
+  private static class ExpandDisjunctionForJoinInputsHelper
+      extends RexUtil.ExpandDisjunctionHelper<String> {
+
+    private final ImmutableBitSet leftBitmap;
+
+    private final ImmutableBitSet rightBitmap;
+
+    private final boolean canPushLeft;
+
+    private final boolean canPushRight;
+
+    private final String leftKey = "left";
+
+    private final String rightKey = "right";
+
+    private ExpandDisjunctionForJoinInputsHelper(
+        int leftFieldCount,
+        int rightFieldCount,
+        boolean canPushLeft,
+        boolean canPushRight,
+        RelBuilder relBuilder,
+        int maxNodeCount) {
+      super(relBuilder, maxNodeCount);
+      this.leftBitmap = ImmutableBitSet.range(0, leftFieldCount);
+      this.rightBitmap = ImmutableBitSet.range(leftFieldCount, leftFieldCount + rightFieldCount);
+      this.canPushLeft = canPushLeft;
+      this.canPushRight = canPushRight;
+    }
+
+    @Override protected boolean canReturnEarly(
+        RexNode condition,
+        Map<String, RexNode> additionalConditions) {
+      boolean earlyReturn = false;
+
+      ImmutableBitSet inputRefs = RelOptUtil.InputFinder.bits(condition);
+      if (inputRefs.isEmpty()) {
+        earlyReturn = true;
+      }
+      if (!inputRefs.isEmpty() && leftBitmap.contains(inputRefs)) {
+        earlyReturn = true;
+        if (canPushLeft) {
+          // The condition already belongs to the left input and it can be pushed down.
+          checkExpandCount(condition.nodeCount());
+          additionalConditions.put(leftKey, condition);
+        }
+      }
+      if (!inputRefs.isEmpty() && rightBitmap.contains(inputRefs)) {
+        earlyReturn = true;
+        if (canPushRight) {
+          // The condition already belongs to the right input and it can be pushed down.
+          checkExpandCount(condition.nodeCount());
+          additionalConditions.put(rightKey, condition);
+        }
+      }
+      return earlyReturn;
+    }
+  }
+
+  /** Rule configuration. */
+  @Value.Immutable(singleton = false)
+  public interface Config extends RelRule.Config {
+    Config FILTER = ImmutableExpandDisjunctionForJoinInputsRule.Config.builder()
+        .withMatchHandler(ExpandDisjunctionForJoinInputsRule::matchFilter)
+        .build()
+        .withOperandSupplier(b0 ->
+            b0.operand(Filter.class).oneInput(b1 ->
+                b1.operand(Join.class).anyInputs()));
+
+    Config JOIN = ImmutableExpandDisjunctionForJoinInputsRule.Config.builder()
+        .withMatchHandler(ExpandDisjunctionForJoinInputsRule::matchJoin)
+        .build()
+        .withOperandSupplier(b -> b.operand(Join.class).anyInputs());
+
+    @Override default ExpandDisjunctionForJoinInputsRule toRule() {
+      return new ExpandDisjunctionForJoinInputsRule(this);
+    }
+
+    /**
+     * Limit how much complexity can increase during expanding.
+     * Default is {@link RelOptUtil#DEFAULT_BLOAT} (100).
+     */
+    default int bloat() {
+      return RelOptUtil.DEFAULT_BLOAT;
+    }
+
+    /** Forwards a call to {@link #onMatch(RelOptRuleCall)}. */
+    MatchHandler<ExpandDisjunctionForJoinInputsRule> matchHandler();
+
+    /** Sets {@link #matchHandler()}. */
+    Config withMatchHandler(MatchHandler<ExpandDisjunctionForJoinInputsRule> matchHandler);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -40,6 +40,7 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ControlFlowException;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Litmus;
@@ -2568,7 +2569,7 @@ public class RexUtil {
       try {
         this.currentCount = 0;
         return toCnf2(rex);
-      } catch (OverflowError e) {
+      } catch (PlanTooComplexError e) {
         Util.swallow(e, null);
         return rex;
       }
@@ -2635,17 +2636,8 @@ public class RexUtil {
 
     private void incrementAndCheck() {
       if (maxNodeCount >= 0 && ++currentCount > maxNodeCount) {
-        throw OverflowError.INSTANCE;
+        throw new PlanTooComplexError();
       }
-    }
-
-    /** Exception to catch when we pass the limit. */
-    @SuppressWarnings("serial")
-    private static class OverflowError extends ControlFlowException {
-      @SuppressWarnings("ThrowableInstanceNeverThrown")
-      protected static final OverflowError INSTANCE = new OverflowError();
-
-      private OverflowError() {}
     }
 
     private RexNode pull(RexNode rex) {
@@ -2799,6 +2791,170 @@ public class RexUtil {
     }
   }
 
+  /**
+   * Helper class that expands predicates from disjunctions (split by K).
+   *
+   * @param <K> The dimension used to split predicates in disjunctions. If you want to expand
+   *           predicates that can be pushed down to a single table from the disjunction, K is
+   *           {@link RelTableRef}; if you want to expand predicates that can be pushed down to
+   *           Join inputs from the disjunction, K is string whose value is 'left' or 'right'.
+   */
+  public abstract static class ExpandDisjunctionHelper<K> {
+    private final RelBuilder relBuilder;
+
+    private final int maxNodeCount;
+
+    // Used to record the number of redundant expressions expanded.
+    private int expressionIncreaseAmount;
+
+    public ExpandDisjunctionHelper(RelBuilder relBuilder, int maxNodeCount) {
+      this.relBuilder = relBuilder;
+      this.maxNodeCount = maxNodeCount;
+    }
+
+    public Map<K, RexNode> expand(RexNode condition) {
+      try {
+        this.expressionIncreaseAmount = 0;
+        return expandDeep(condition);
+      } catch (PlanTooComplexError e) {
+        return new HashMap<>();
+      }
+    }
+
+    /**
+     * Expand predicates recursively that can be pushed down to a single K. As mentioned above,
+     * K is the dimension used to split predicates in disjunctions, which can be {@link RelTableRef}
+     * or string whose value is 'left' or 'right'.
+     *
+     * @param condition   Predicate to be expanded
+     * @return  A map from a K to a (combined) predicate that can be pushed down
+     * and only depends on columns of K.
+     */
+    private Map<K, RexNode> expandDeep(RexNode condition) {
+      final Map<K, RexNode> additionalConditions = new HashMap<>();
+
+      if (canReturnEarly(condition, additionalConditions)) {
+        return additionalConditions;
+      }
+
+      // Recursively expand the expression according to whether it is a conjunction
+      // or a disjunction. If it is neither a disjunction nor a conjunction, it cannot
+      // be expanded further and an empty Map is returned.
+      switch (condition.getKind()) {
+      case AND:
+        List<RexNode> andOperands = RexUtil.flattenAnd(((RexCall) condition).getOperands());
+        for (RexNode andOperand : andOperands) {
+          Map<K, RexNode> operandResult = expandDeep(andOperand);
+          combinePredicatesUsingAnd(additionalConditions, operandResult);
+        }
+        break;
+      case OR:
+        List<RexNode> orOperands = RexUtil.flattenOr(((RexCall) condition).getOperands());
+        additionalConditions.putAll(expandDeep(orOperands.get(0)));
+        for (int i = 1; i < orOperands.size(); i++) {
+          Map<K, RexNode> operandResult = expandDeep(orOperands.get(i));
+          combinePredicatesUsingOr(additionalConditions, operandResult);
+
+          if (additionalConditions.isEmpty()) {
+            break;
+          }
+        }
+        break;
+      default:
+        break;
+      }
+
+      return additionalConditions;
+    }
+
+    // If condition already belongs to a certain K, return early.
+    protected abstract boolean canReturnEarly(RexNode condition,
+        Map<K, RexNode> additionalConditions);
+
+    /**
+     * Combine predicates that depend on the same K using conjunctions.
+     * The result is returned by modifying baseMap. For example:
+     *
+     * <p>baseMap: {k1: p1, k2: p2}
+     *
+     * <p>forMergeMap: {k1: p11, k3: p3}
+     *
+     * <p>result: {k1: p1 AND p11, k2: p2, k3: p3}
+     *
+     * @param baseMap       Additional predicates that current conjunction has already saved
+     * @param forMergeMap   Additional predicates that current operand has expanded
+     */
+    private void combinePredicatesUsingAnd(
+        Map<K, RexNode> baseMap,
+        Map<K, RexNode> forMergeMap) {
+      for (Map.Entry<K, RexNode> entry : forMergeMap.entrySet()) {
+        RexNode mergedRex =
+            relBuilder.and(
+                entry.getValue(),
+                baseMap.getOrDefault(entry.getKey(), relBuilder.literal(true)));
+        int originalCount = entry.getValue().nodeCount()
+            + (baseMap.containsKey(entry.getKey())
+            ? baseMap.get(entry.getKey()).nodeCount()
+            : 0);
+        checkExpandCount(mergedRex.nodeCount() - originalCount);
+        baseMap.put(entry.getKey(), mergedRex);
+      }
+    }
+
+    /**
+     * Combine predicates that depend on the same K using disjunctions.
+     * The result is returned by modifying baseMap. For example:
+     *
+     * <p>baseMap: {k1: p1, k2: p2}
+     *
+     * <p>forMergeMap: {k1: p11, k3: p3}
+     *
+     * <p>result: {k1: p1 OR p11}
+     *
+     * @param baseMap       Additional predicates that current disjunction has already saved
+     * @param forMergeMap   Additional predicates that current operand has expanded
+     */
+    private void combinePredicatesUsingOr(
+        Map<K, RexNode> baseMap,
+        Map<K, RexNode> forMergeMap) {
+      if (baseMap.isEmpty()) {
+        return;
+      }
+
+      Iterator<Map.Entry<K, RexNode>> iterator =
+          baseMap.entrySet().iterator();
+      while (iterator.hasNext()) {
+        int forMergeNodeCount = 0;
+
+        Map.Entry<K, RexNode> entry = iterator.next();
+        if (!forMergeMap.containsKey(entry.getKey())) {
+          checkExpandCount(-entry.getValue().nodeCount());
+          iterator.remove();
+          continue;
+        } else {
+          forMergeNodeCount = forMergeMap.get(entry.getKey()).nodeCount();
+        }
+        RexNode mergedRex =
+            relBuilder.or(
+                entry.getValue(),
+                forMergeMap.get(entry.getKey()));
+        int originalCount = entry.getValue().nodeCount() + forMergeNodeCount;
+        checkExpandCount(mergedRex.nodeCount() - originalCount);
+        baseMap.put(entry.getKey(), mergedRex);
+      }
+    }
+
+    /**
+     * Check whether the number of redundant expressions generated in the expansion
+     * exceeds the limit.
+     */
+    protected void checkExpandCount(int changeCount) {
+      expressionIncreaseAmount += changeCount;
+      if (maxNodeCount > 0 && expressionIncreaseAmount > maxNodeCount) {
+        throw new PlanTooComplexError();
+      }
+    }
+  }
 
   /** Shuttle that adds {@code offset} to each {@link RexInputRef} in an
    * expression. */
@@ -2813,6 +2969,12 @@ public class RexUtil {
       return new RexInputRef(input.getIndex() + offset, input.getType());
     }
   }
+
+  /**
+   * Exception to catch when optimizing the plan produces a result that is too complex,
+   * either at the Rel or at the Rex level.
+   */
+  private static class PlanTooComplexError extends ControlFlowException { }
 
   /** Visitor that throws {@link org.apache.calcite.util.Util.FoundOne} if
    * applied to an expression that contains a {@link RexCorrelVariable}. */

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -10447,4 +10447,41 @@ class RelOptRulesTest extends RelOptTestBase {
         .withRule(CoreRules.MINUS_TO_FILTER)
         .check();
   }
+
+  @Test void testExpandFilterDisjunctionForJoinInput() {
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(CoreRules.EXPAND_FILTER_DISJUNCTION_LOCAL)
+        .build();
+
+    sql("select e.empno from emp as e, empnullables as en, emp_b as eb\n"
+        + "where e.empno = en.empno and e.empno = eb.empno\n"
+        + "and\n"
+        + "(\n"
+        + "  (e.mgr > 100 and eb.sal < 200)\n"
+        + "  or\n"
+        + "  (en.comm < 50 and eb.deptno > 10)\n"
+        + ")")
+        .withPre(program)
+        .withRule(CoreRules.JOIN_CONDITION_PUSH, CoreRules.FILTER_INTO_JOIN)
+        .check();
+  }
+
+  @Test void testExpandJoinDisjunctionForJoinInput() {
+    HepProgram program = new HepProgramBuilder()
+        .addRuleInstance(CoreRules.EXPAND_JOIN_DISJUNCTION_LOCAL)
+        .build();
+
+    sql("select e.empno from emp as e inner join empnullables as en\n"
+        + " on e.empno = en.empno\n"
+        + " inner join emp_b as eb\n"
+        + " on e.empno = eb.empno and\n"
+        + "(\n"
+        + "  (e.mgr > 100 and eb.sal < 200)\n"
+        + "  or\n"
+        + "  (en.comm < 50 and eb.deptno > 10)\n"
+        + ")")
+        .withPre(program)
+        .withRule(CoreRules.JOIN_CONDITION_PUSH, CoreRules.FILTER_INTO_JOIN)
+        .check();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4141,6 +4141,40 @@ LogicalProject(EMPNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExpandFilterDisjunctionForJoinInput">
+    <Resource name="sql">
+      <![CDATA[select e.empno from emp as e, empnullables as en, emp_b as eb
+where e.empno = en.empno and e.empno = eb.empno
+and
+(
+  (e.mgr > 100 and eb.sal < 200)
+  or
+  (en.comm < 50 and eb.deptno > 10)
+)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(=($0, $9), =($0, $18), OR(AND(>($3, 100), <($23, 200)), AND(<($15, 50), >($25, 10))), OR(>($3, 100), <($15, 50)), OR(<($23, 200), >($25, 10)))])
+    LogicalJoin(condition=[true], joinType=[inner])
+      LogicalJoin(condition=[true], joinType=[inner])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+        LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalJoin(condition=[AND(=($0, $18), OR(AND(>($3, 100), <($23, 200)), AND(<($15, 50), >($25, 10))))], joinType=[inner])
+    LogicalJoin(condition=[AND(=($0, $9), OR(>($3, 100), <($15, 50)))], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+    LogicalFilter(condition=[OR(<($5, 200), >($7, 10))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testExpandFilterDisjunctionForTable">
     <Resource name="sql">
       <![CDATA[select e.empno from emp as e, empnullables as en where e.empno = en.empno and (   (e.mgr > 100 and en.sal < 200)   or   e.comm < 50 ) ]]>
@@ -4510,6 +4544,40 @@ LogicalProject(EMPNO=[$0])
           LogicalProject(DEPTNO=[$7])
             LogicalFilter(condition=[>($0, 100)])
               LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExpandJoinDisjunctionForJoinInput">
+    <Resource name="sql">
+      <![CDATA[select e.empno from emp as e inner join empnullables as en
+ on e.empno = en.empno
+ inner join emp_b as eb
+ on e.empno = eb.empno and
+(
+  (e.mgr > 100 and eb.sal < 200)
+  or
+  (en.comm < 50 and eb.deptno > 10)
+)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalJoin(condition=[AND(=($0, $18), OR(AND(>($3, 100), <($23, 200)), AND(<($15, 50), >($25, 10))), OR(>($3, 100), <($15, 50)), OR(<($23, 200), >($25, 10)))], joinType=[inner])
+    LogicalJoin(condition=[=($0, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalJoin(condition=[AND(=($0, $18), OR(AND(>($3, 100), <($23, 200)), AND(<($15, 50), >($25, 10))))], joinType=[inner])
+    LogicalJoin(condition=[AND(=($0, $9), OR(>($3, 100), <($15, 50)))], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
+    LogicalFilter(condition=[OR(<($5, 200), >($7, 10))])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/planner.iq
+++ b/core/src/test/resources/sql/planner.iq
@@ -88,4 +88,63 @@ EnumerableIntersect(all=[false])
     EnumerableValues(tuples=[[{ 0 }, { 1 }]])
 !plan
 
+# Test predicate push down with/without expand disjunction.
+!set planner-rules original
+with t1 (id1, col11, col12) as (values (1, 11, 111), (2, 12, 122), (3, 13, 133), (4, 14, 144), (5, 15, 155)),
+t2 (id2, col21, col22) as (values (1, 21, 211), (2, 22, 222), (3, 23, 233), (4, 24, 244), (5, 25, 255)),
+t3 (id3, col31, col32) as (values (1, 31, 311), (2, 32, 322), (3, 33, 333), (4, 34, 344), (5, 35, 355))
+select * from t1, t2, t3 where id1 = id2 and id1 = id3 and
+(
+(col11 > 11 and col31 <= 32)
+or
+(col22 < 255 and col32 >= 344)
+);
++-----+-------+-------+-----+-------+-------+-----+-------+-------+
+| ID1 | COL11 | COL12 | ID2 | COL21 | COL22 | ID3 | COL31 | COL32 |
++-----+-------+-------+-----+-------+-------+-----+-------+-------+
+|   2 |    12 |   122 |   2 |    22 |   222 |   2 |    32 |   322 |
+|   4 |    14 |   144 |   4 |    24 |   244 |   4 |    34 |   344 |
++-----+-------+-------+-----+-------+-------+-----+-------+-------+
+(2 rows)
+
+!ok
+
+EnumerableMergeJoin(condition=[AND(=($0, $6), OR(AND(>($1, 11), <=($7, 32)), AND(<($5, 255), >=($8, 344))))], joinType=[inner])
+  EnumerableMergeJoin(condition=[=($0, $3)], joinType=[inner])
+    EnumerableValues(tuples=[[{ 1, 11, 111 }, { 2, 12, 122 }, { 3, 13, 133 }, { 4, 14, 144 }, { 5, 15, 155 }]])
+    EnumerableValues(tuples=[[{ 1, 21, 211 }, { 2, 22, 222 }, { 3, 23, 233 }, { 4, 24, 244 }, { 5, 25, 255 }]])
+  EnumerableValues(tuples=[[{ 1, 31, 311 }, { 2, 32, 322 }, { 3, 33, 333 }, { 4, 34, 344 }, { 5, 35, 355 }]])
+!plan
+
+!set planner-rules "+CoreRules.EXPAND_FILTER_DISJUNCTION_LOCAL, +CoreRules.EXPAND_JOIN_DISJUNCTION_LOCAL"
+
+with t1 (id1, col11, col12) as (values (1, 11, 111), (2, 12, 122), (3, 13, 133), (4, 14, 144), (5, 15, 155)),
+t2 (id2, col21, col22) as (values (1, 21, 211), (2, 22, 222), (3, 23, 233), (4, 24, 244), (5, 25, 255)),
+t3 (id3, col31, col32) as (values (1, 31, 311), (2, 32, 322), (3, 33, 333), (4, 34, 344), (5, 35, 355))
+select * from t1, t2, t3 where id1 = id2 and id1 = id3 and
+(
+(col11 > 11 and col31 <= 32)
+or
+(col22 < 255 and col32 >= 344)
+);
++-----+-------+-------+-----+-------+-------+-----+-------+-------+
+| ID1 | COL11 | COL12 | ID2 | COL21 | COL22 | ID3 | COL31 | COL32 |
++-----+-------+-------+-----+-------+-------+-----+-------+-------+
+|   2 |    12 |   122 |   2 |    22 |   222 |   2 |    32 |   322 |
+|   4 |    14 |   144 |   4 |    24 |   244 |   4 |    34 |   344 |
++-----+-------+-------+-----+-------+-------+-----+-------+-------+
+(2 rows)
+
+!ok
+
+EnumerableHashJoin(condition=[AND(=($0, $6), OR(AND(>($1, 11), <=($7, 32)), AND(<($5, 255), >=($8, 344))))], joinType=[inner])
+  EnumerableMergeJoin(condition=[AND(=($0, $3), OR(>($1, 11), <($5, 255)))], joinType=[inner])
+    EnumerableValues(tuples=[[{ 1, 11, 111 }, { 2, 12, 122 }, { 3, 13, 133 }, { 4, 14, 144 }, { 5, 15, 155 }]])
+    EnumerableValues(tuples=[[{ 1, 21, 211 }, { 2, 22, 222 }, { 3, 23, 233 }, { 4, 24, 244 }, { 5, 25, 255 }]])
+  EnumerableCalc(expr#0..2=[{inputs}], expr#3=[32], expr#4=[<=($t1, $t3)], expr#5=[344], expr#6=[>=($t2, $t5)], expr#7=[OR($t4, $t6)], proj#0..2=[{exprs}], $condition=[$t7])
+    EnumerableValues(tuples=[[{ 1, 31, 311 }, { 2, 32, 322 }, { 3, 33, 333 }, { 4, 34, 344 }, { 5, 35, 355 }]])
+!plan
+
+!set planner-rules original
+
 # End planner.iq


### PR DESCRIPTION
Similar to Calcite-6914, we can expand redundant predicates from the disjunction and push them down. However, the predicates expanded by Calcite-6914 must belong to a single table, that is, if join_type does not restrict pushdown, the redundant predicates can be pushed directly on TableScan.

However, pushing predicates down to the inputs of Join is also very useful ([link](https://github.com/apache/calcite/pull/4267#discussion_r2021576009)), for example:

```
select t1.id from t1, t2, t3
where t1.id = t2.id
and t1.id = t3.id
and (
    (t1.age < 50 and t3.age > 20)
    or
    (t2.weight > 70 and t3.height < 180)
) 
```
Because `(t1.age < 50 and t3.age > 20)` or `(t2.weight > 70 and t3.height < 180)` a is a disjunction and involves multiple tables, it cannot be pushed down.

However, we can expand it to `(t1.age < 50 or t2.weight > 70)` , `(t3.age > 20 or t3.height < 180)`, and push them down to both sides of Join.

More details: https://issues.apache.org/jira/browse/CALCITE-6946