### PR TITLE
[CALCITE-6962] Exists subquery returns incorrect result when or condi…

### DIFF
--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1931,7 +1931,7 @@ LogicalProject(NAME=[$1], EXPR$1=[+($0, $2)])
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(NAME=[$1], EXPR$1=[+($0, $3)])
-  LogicalJoin(condition=[=($0, $2)], joinType=[left])
+  LogicalJoin(condition=[IS NOT DISTINCT FROM($0, $2)], joinType=[left])
     LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
     LogicalAggregate(group=[{0}], agg#0=[SINGLE_VALUE($1)])
       LogicalProject(DEPTNO00=[$11], EMPNO=[$0])
@@ -7601,7 +7601,7 @@ where n1.SAL IN (
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(SAL=[$5])
-  LogicalJoin(condition=[AND(=($5, $11), =($9, $12))], joinType=[inner])
+  LogicalJoin(condition=[AND(=($5, $11), IS NOT DISTINCT FROM($9, $12))], joinType=[inner])
     LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8], SAL0=[$5], $f9=[=($5, 4)])
       LogicalFilter(condition=[AND(=($7, 20), >($5, 1000))])
         LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -5178,7 +5178,7 @@ from (select 2+deptno d2, 3+deptno d3 from emp) e
       <![CDATA[
 LogicalProject(D2=[$0], D3=[$1])
   LogicalProject(D2=[$0], D3=[$1], D1=[CAST($2):INTEGER], D6=[$3], $f2=[CAST($4):BOOLEAN])
-    LogicalJoin(condition=[AND(=($0, $2), =($1, $3))], joinType=[inner])
+    LogicalJoin(condition=[AND(=($0, $2), IS NOT DISTINCT FROM($1, $3))], joinType=[inner])
       LogicalProject(D2=[+(2, $7)], D3=[+(3, $7)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalAggregate(group=[{0, 1}], agg#0=[MIN($2)])
@@ -5208,7 +5208,7 @@ from (select 2+deptno d2, 3+deptno d3 from emp) e
       <![CDATA[
 LogicalProject(D2=[$0], D3=[$1])
   LogicalProject(D2=[$0], D3=[$1], D1=[CAST($2):INTEGER], D6=[$3], $f2=[CAST($4):BOOLEAN])
-    LogicalJoin(condition=[AND(=($0, $2), =($1, $3))], joinType=[inner])
+    LogicalJoin(condition=[AND(=($0, $2), IS NOT DISTINCT FROM($1, $3))], joinType=[inner])
       LogicalProject(D2=[+(2, $7)], D3=[+(3, $7)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalAggregate(group=[{0, 1}], agg#0=[MIN($2)])

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -4178,6 +4178,92 @@ where "scott".emp.deptno in (select "scott".dept.deptno
 
 !ok
 
+select *
+from "scott".emp as e
+where exists (
+  select empno
+  from "scott".emp as ee
+  where e.empno = ee.empno or e.comm >= ee.sal
+);
++-------+--------+-----------+------+------------+---------+---------+--------+
+| EMPNO | ENAME  | JOB       | MGR  | HIREDATE   | SAL     | COMM    | DEPTNO |
++-------+--------+-----------+------+------------+---------+---------+--------+
+|  7369 | SMITH  | CLERK     | 7902 | 1980-12-17 |  800.00 |         |     20 |
+|  7499 | ALLEN  | SALESMAN  | 7698 | 1981-02-20 | 1600.00 |  300.00 |     30 |
+|  7521 | WARD   | SALESMAN  | 7698 | 1981-02-22 | 1250.00 |  500.00 |     30 |
+|  7566 | JONES  | MANAGER   | 7839 | 1981-02-04 | 2975.00 |         |     20 |
+|  7654 | MARTIN | SALESMAN  | 7698 | 1981-09-28 | 1250.00 | 1400.00 |     30 |
+|  7698 | BLAKE  | MANAGER   | 7839 | 1981-01-05 | 2850.00 |         |     30 |
+|  7782 | CLARK  | MANAGER   | 7839 | 1981-06-09 | 2450.00 |         |     10 |
+|  7788 | SCOTT  | ANALYST   | 7566 | 1987-04-19 | 3000.00 |         |     20 |
+|  7839 | KING   | PRESIDENT |      | 1981-11-17 | 5000.00 |         |     10 |
+|  7844 | TURNER | SALESMAN  | 7698 | 1981-09-08 | 1500.00 |    0.00 |     30 |
+|  7876 | ADAMS  | CLERK     | 7788 | 1987-05-23 | 1100.00 |         |     20 |
+|  7900 | JAMES  | CLERK     | 7698 | 1981-12-03 |  950.00 |         |     30 |
+|  7902 | FORD   | ANALYST   | 7566 | 1981-12-03 | 3000.00 |         |     20 |
+|  7934 | MILLER | CLERK     | 7782 | 1982-01-23 | 1300.00 |         |     10 |
++-------+--------+-----------+------+------------+---------+---------+--------+
+(14 rows)
+
+!ok
+
+
+SELECT
+  e1.COMM,
+  EXISTS (
+    SELECT 1
+    FROM EMP e2
+    WHERE e2.COMM IS NULL OR e2.COMM > e1.COMM * 10
+  ) AS exists_flag
+FROM EMP e1;
++---------+-------------+
+| COMM    | EXISTS_FLAG |
++---------+-------------+
+|    0.00 | true        |
+| 1400.00 | true        |
+|  300.00 | true        |
+|  500.00 | true        |
+|         | true        |
+|         | true        |
+|         | true        |
+|         | true        |
+|         | true        |
+|         | true        |
+|         | true        |
+|         | true        |
+|         | true        |
+|         | true        |
++---------+-------------+
+(14 rows)
+
+!ok
+
+SELECT
+  i1.COMM,
+  i1.COMM = ANY(SELECT COMM FROM EMP WHERE COMM=i1.COMM)
+FROM EMP i1 ORDER BY COMM;
++---------+--------+
+| COMM    | EXPR$1 |
++---------+--------+
+|    0.00 | true   |
+|  300.00 | true   |
+|  500.00 | true   |
+| 1400.00 | true   |
+|         |        |
+|         |        |
+|         |        |
+|         |        |
+|         |        |
+|         |        |
+|         |        |
+|         |        |
+|         |        |
+|         |        |
++---------+--------+
+(14 rows)
+
+!ok
+
 # Test case for [CALCITE-5789]
 select deptno from dept d1 where exists (
  select 1 from dept d2 where d2.deptno = d1.deptno and exists (


### PR DESCRIPTION
Link: [CALCITE-6962]

When converting Correlate to Join, we should use null_equal join (i.e., `is not distinct from`).

Fixing this is straightforward - we just need to change:
```
conditions.add(
   relBuilder.equals(RexInputRef.of(newLeftPos, newLeftOutput),
      new RexInputRef(newLeftFieldCount + newRightPos,
         newRightOutput.get(newRightPos).getType())));
```
to `is not distinct from`.  

However, this will impact a large number of tests and even downstream applications (on engines that support null-equal joins, I believe this won't cause any performance difference).

Therefore, I made some adjustments, with the core change being the use of `equal` in non-null columns. However, this change still led to several test modifications, partly due to the current approach's incomplete handling of certain cases.

Before fully fixing these tests, I'd appreciate any suggestions. Thanks!  