### PR TITLE
[CALCITE-6976] Assertion failure while typechecking SUBSTR(TIMESTAMP,…)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -1077,9 +1077,8 @@ public abstract class OperandTypes {
           SqlTypeFamily.INTEGER);
 
   public static final SqlSingleOperandTypeChecker STRING_INTEGER_OPTIONAL_INTEGER =
-      family(
-          ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER,
-              SqlTypeFamily.INTEGER), i -> i == 2);
+      family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER)
+          .or(family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER));
 
   public static final SqlSingleOperandTypeChecker STRING_NUMERIC =
       family(SqlTypeFamily.STRING, SqlTypeFamily.NUMERIC);

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -11573,6 +11573,14 @@ public class SqlOperatorTest {
     f.checkNull("substring('abc' FROM 2 FOR cast(null as integer))");
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-6976">[CALCITE-6976]
+   * Assertion failure while typechecking SUBSTR(TIMESTAMP, ...)</a>. */
+  @Test void testSubstrTimestamp() {
+    final SqlOperatorFixture f = fixture()
+        .withLibrary(SqlLibrary.BIG_QUERY);
+    f.checkScalar("SUBSTR(TIMESTAMP '2020-01-01 10:00:00', 10)", "1 10:00:00", "VARCHAR NOT NULL");
+  }
+
   /** Tests the non-standard SUBSTR function, that has syntax
    * "SUBSTR(value, start [, length ])", as used in BigQuery. */
   @Test void testBigQuerySubstrFunction() {


### PR DESCRIPTION
It looks like the family type checker for optional arguments is broken, so I have filed https://issues.apache.org/jira/browse/CALCITE-6984
This is a workaround for this particular narrower issue