### PR TITLE
[CALCITE-6991] Validator cannot infer type for COALESCE when call is not expanded

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCaseOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCaseOperator.java
@@ -272,7 +272,7 @@ public class SqlCaseOperator extends SqlOperator {
         // (with the correct nullability) in SqlValidator
         // instead of the commonType as the return type.
         if (null != commonType) {
-          coerced = typeCoercion.caseWhenCoercion(callBinding);
+          coerced = typeCoercion.caseOrEquivalentCoercion(callBinding);
           if (coerced) {
             ret = SqlTypeUtil.deriveType(callBinding);
           }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCoalesceFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCoalesceFunction.java
@@ -16,20 +16,33 @@
  */
 package org.apache.calcite.sql.fun;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.implicit.TypeCoercion;
 import org.apache.calcite.util.Util;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The <code>COALESCE</code> function.
@@ -79,5 +92,43 @@ public class SqlCoalesceFunction extends SqlFunction {
     SqlNode elseExpr = Util.last(operands);
     assert call.getFunctionQuantifier() == null;
     return SqlCase.createSwitched(pos, null, whenList, thenList, elseExpr);
+  }
+
+  @Override @NonNull public RelDataType inferReturnType(
+      SqlOperatorBinding opBinding) {
+    RelDataType returnType = getReturnTypeInference().inferReturnType(opBinding);
+    if (returnType == null
+        && opBinding instanceof SqlCallBinding
+        && ((SqlCallBinding) opBinding).isTypeCoercionEnabled()) {
+      SqlCallBinding callBinding = (SqlCallBinding) opBinding;
+      List<RelDataType> argTypes = new ArrayList<>();
+      for (SqlNode operand : callBinding.operands()) {
+        RelDataType type = SqlTypeUtil.deriveType(callBinding, operand);
+        argTypes.add(type);
+      }
+      TypeCoercion typeCoercion = callBinding.getValidator().getTypeCoercion();
+      RelDataType commonType = typeCoercion.getWiderTypeFor(argTypes, true);
+      if (null != commonType) {
+        // COALESCE type coercion, find a common type across all branches and casts
+        // operands to this common type if necessary.
+        boolean coerced = typeCoercion.caseOrEquivalentCoercion(callBinding);
+        if (coerced) {
+          return SqlTypeUtil.deriveType(callBinding);
+        }
+      }
+      throw callBinding.newValidationError(RESOURCE.illegalMixingOfTypes());
+    }
+
+    if (returnType == null) {
+      throw new IllegalArgumentException(
+          "Cannot infer return type for " + opBinding.getOperator() + "; operand types: "
+              + opBinding.collectOperandTypes());
+    }
+
+    return returnType;
+  }
+
+  @Override public SqlReturnTypeInference getReturnTypeInference() {
+    return requireNonNull(super.getReturnTypeInference(), "returnTypeInference");
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercion.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercion.java
@@ -129,10 +129,29 @@ public interface TypeCoercion {
   /**
    * Coerces CASE WHEN statement branches to one common type.
    *
-   * <p>Rules: Find common type for all the then operands and else operands,
-   * then try to coerce the then/else operands to the type if needed.
+   * @deprecated Use {@link #caseOrEquivalentCoercion} instead.
    */
-  boolean caseWhenCoercion(SqlCallBinding binding);
+  @Deprecated boolean caseWhenCoercion(SqlCallBinding binding);
+
+  /**
+   * Type coercion in CASE WHEN, COALESCE, and NULLIF.
+   *
+   * <p>Rules:
+   * <ol>
+   *   <li>
+   *     CASE WHEN collect all the branches types including then
+   *     operands and else operands to find a common type, then cast the operands to the common type
+   *     when needed.</li>
+   *   <li>
+   *     COALESCE collect all the branches types to find a common type,
+   *     then cast the operands to the common type when needed.</li>
+   *   <li>
+   *     NULLIF returns the first operand if the two operands are not equal,
+   *     otherwise it returns a null value of the type of the first operand,
+   *     without return type coercion.</li>
+   * </ol>
+   */
+  boolean caseOrEquivalentCoercion(SqlCallBinding binding);
 
   /**
    * Type coercion with inferred type from passed in arguments and the

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -704,6 +704,16 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .columnType("DECIMAL(5, 2)");
     expr("nullif(345.21, 2e0)")
         .columnType("DECIMAL(5, 2)");
+    expr("nullif(DATE '2020-01-01', '2020-01-01')")
+        .columnType("DATE");
+    expr("nullif('2020-01-01', DATE '2020-01-01')")
+        .columnType("CHAR(10)");
+    expr("nullif(DATE '2020-01-01', '2020-01-01')")
+        .withValidatorConfig(c -> c.withCallRewrite(false))
+        .columnType("DATE");
+    expr("nullif('2020-01-01', DATE '2020-01-01')")
+        .withValidatorConfig(c -> c.withCallRewrite(false))
+        .columnType("CHAR(10)");
     wholeExpr("nullif(1,2,3)")
         .fails("Invalid number of arguments to function 'NULLIF'. Was "
             + "expecting 2 arguments");
@@ -713,7 +723,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("coalesce('a','b')").ok();
     expr("coalesce('a','b','c')")
         .columnType("CHAR(1) NOT NULL");
-
+    expr("COALESCE(DATE '2020-01-01', '2020-01-02')")
+        .columnType("VARCHAR NOT NULL");
+    expr("COALESCE(DATE '2020-01-01', '2020-01-02')")
+        .withValidatorConfig(c -> c.withCallRewrite(false))
+        .columnType("VARCHAR NOT NULL");
     sql("select COALESCE(mgr, 12) as m from EMP")
         .columnType("INTEGER NOT NULL");
   }


### PR DESCRIPTION
details info see [CALCITE-6991](https://issues.apache.org/jira/browse/CALCITE-6991)