### PR TITLE
[CALCITE-6887] ReduceExpressionsRule applied to 'IN subquery' should make the values distinct if the subquery is a constant Values

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
@@ -61,8 +61,7 @@ public class AggregateValueReduceRule
   protected AggregateValueReduceRule(Config config) {
     super(config);
   }
-
-  @Deprecated // to be removed before 2.0
+  
   public AggregateValueReduceRule(RelBuilderFactory relBuilderFactory) {
     this(Config.DEFAULT
         .withRelBuilderFactory(relBuilderFactory)

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
@@ -41,13 +41,15 @@ import java.util.stream.Collectors;
  * <p>Sample query where this matters:
  *
  * <blockquote><code>
- * SELECT deptno, sal FROM EMP WHERE deptno IN (1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
+ * LogicalAggregate(group=[{0}])
+ * LogicalValues(tuples=[[{ 1 }, { 1 }, { 3 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 },
+ * { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }]])
  * </code></blockquote>
  *
  * <p>should be converted to:
  *
  * <blockquote><code>
- * SELECT deptno, sal FROM EMP WHERE deptno IN (1,3)
+ * LogicalValues(tuples=[[{ 1 }, { 3 }]])
  * </code></blockquote>
  *
  * @see CoreRules#AGGREGATE_VALUES_REDUCE
@@ -70,7 +72,6 @@ public class AggregateValueReduceRule
 
   @Override public void onMatch(RelOptRuleCall call) {
     final Values values = call.rel(1);
-    Util.discard(values);
     final RelBuilder relBuilder = call.builder();
 
     List<ImmutableList<RexLiteral>> distinctValues =

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
@@ -61,7 +61,7 @@ public class AggregateValueReduceRule
   protected AggregateValueReduceRule(Config config) {
     super(config);
   }
-  
+
   public AggregateValueReduceRule(RelBuilderFactory relBuilderFactory) {
     this(Config.DEFAULT
         .withRelBuilderFactory(relBuilderFactory)

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.Util;
+
+import com.google.common.collect.ImmutableList;
+
+import org.immutables.value.Value;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Rule that applies an {@link Aggregate} to a distinct {@link Values}.
+ *
+ * <p>This is useful because such as {@link SubQueryRemoveRule}
+ * doesn't distinct values for IN filter values.
+ *
+ * <p>Sample query where this matters:
+ *
+ * <blockquote><code>
+ * SELECT deptno, sal FROM EMP WHERE deptno IN (1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
+ * </code></blockquote>
+ *
+ * <p>should be converted to:
+ *
+ * <blockquote><code>
+ * SELECT deptno, sal FROM EMP WHERE deptno IN (1,3)
+ * </code></blockquote>
+ *
+ * @see CoreRules#AGGREGATE_VALUES_REDUCE
+ */
+@Value.Enclosing
+public class AggregateValueReduceRule
+    extends RelRule<AggregateValueReduceRule.Config>
+    implements SubstitutionRule {
+
+  /** Creates an AggregateValuesRule. */
+  protected AggregateValueReduceRule(Config config) {
+    super(config);
+  }
+
+  @Deprecated // to be removed before 2.0
+  public AggregateValueReduceRule(RelBuilderFactory relBuilderFactory) {
+    this(Config.DEFAULT
+        .withRelBuilderFactory(relBuilderFactory)
+        .as(Config.class));
+  }
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    final Values values = call.rel(1);
+    Util.discard(values);
+    final RelBuilder relBuilder = call.builder();
+
+    List<ImmutableList<RexLiteral>> distinctValues =
+        values.getTuples().stream().distinct().collect(Collectors.toList());
+
+    relBuilder.values(distinctValues, values.getRowType());
+    call.transformTo(relBuilder.build());
+  }
+
+  /** Rule configuration. */
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    Config DEFAULT = ImmutableAggregateValueReduceRule.Config.of()
+        .withOperandFor(Aggregate.class, Values.class);
+
+    @Override default AggregateValueReduceRule toRule() {
+      return new AggregateValueReduceRule(this);
+    }
+
+    /** Defines an operand tree for the given classes. */
+    default Config withOperandFor(Class<? extends Aggregate> aggregateClass,
+        Class<? extends Values> valuesClass) {
+      return withOperandSupplier(b0 ->
+          b0.operand(aggregateClass)
+              .oneInput(b1 ->
+                  b1.operand(valuesClass)
+                      .noInputs()))
+          .as(Config.class);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.tools.RelBuilder;
-import org.apache.calcite.tools.RelBuilderFactory;
 
 import com.google.common.collect.ImmutableList;
 
@@ -32,7 +31,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Rule that applies an {@link Aggregate} to a distinct {@link Values}.
+ * Rule that applies {@link Aggregate} and {@link Values} to a distinct {@link Values}.
  *
  * <p>This is useful because such as {@link SubQueryRemoveRule}
  * doesn't distinct values for IN filter values.
@@ -61,12 +60,6 @@ public class AggregateValueReduceRule
   /** Creates an AggregateValuesRule. */
   protected AggregateValueReduceRule(Config config) {
     super(config);
-  }
-
-  public AggregateValueReduceRule(RelBuilderFactory relBuilderFactory) {
-    this(Config.DEFAULT
-        .withRelBuilderFactory(relBuilderFactory)
-        .as(Config.class));
   }
 
   @Override public void onMatch(RelOptRuleCall call) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateValueReduceRule.java
@@ -23,7 +23,6 @@ import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
-import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ImmutableList;
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -847,6 +847,10 @@ public class CoreRules {
   public static final AggregateValuesRule AGGREGATE_VALUES =
       AggregateValuesRule.Config.DEFAULT.toRule();
 
+  /** Rule that applies an {@link Aggregate} to a distinct {@link Values}. */
+  public static final AggregateValueReduceRule AGGREGATE_VALUES_REDUCE =
+      AggregateValueReduceRule.Config.DEFAULT.toRule();
+
   /** Rule that merges a {@link Filter} onto an underlying
    * {@link org.apache.calcite.rel.logical.LogicalValues},
    * resulting in a {@code Values} with potentially fewer rows. */

--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -847,7 +847,7 @@ public class CoreRules {
   public static final AggregateValuesRule AGGREGATE_VALUES =
       AggregateValuesRule.Config.DEFAULT.toRule();
 
-  /** Rule that applies an {@link Aggregate} to a distinct {@link Values}. */
+  /** Rule that applies {@link Aggregate} and {@link Values} to a distinct {@link Values}. */
   public static final AggregateValueReduceRule AGGREGATE_VALUES_REDUCE =
       AggregateValueReduceRule.Config.DEFAULT.toRule();
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -8996,7 +8996,8 @@ class RelOptRulesTest extends RelOptTestBase {
 
   @Test void testReduceInValuesWithAggregateValueReduceRule() {
     final Function<RelBuilder, RelNode> relFn = b -> b
-        .values(new String[]{"v"}, 1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
+        .values(new String[]{"v"}, 1, 1 ,3 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1
+            ,1 ,1 ,1 ,1 ,1 ,1 ,1)
         .distinct()
         .build();
     relFn(relFn)

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -8994,6 +8994,16 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  @Test void testReduceInValuesWithAggregateValueReduceRule() {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .values(new String[]{"v"}, 1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
+        .distinct()
+        .build();
+    relFn(relFn)
+        .withRule(CoreRules.AGGREGATE_VALUES_REDUCE)
+        .check();
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-434">[CALCITE-434]
    * Converting predicates on date dimension columns into date ranges</a>,

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -8980,6 +8980,21 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6887">[CALCITE-6887]
+   * ReduceExpressionsRule applied to 'IN subquery' should make the values distinct
+   * if the subquery is a constant Values</a>. */
+  @Test void testReduceInValues() {
+    final String sql = "SELECT deptno, sal "
+        + "FROM EMP "
+        + "WHERE deptno IN (1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)";
+
+    sql(sql)
+        .withPreRule(CoreRules.FILTER_SUB_QUERY_TO_CORRELATE)
+        .withRule(CoreRules.AGGREGATE_VALUES_REDUCE)
+        .check();
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-434">[CALCITE-434]
    * Converting predicates on date dimension columns into date ranges</a>,
    * specifically a rule that converts {@code EXTRACT(YEAR FROM ...) = constant}

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -8996,8 +8996,8 @@ class RelOptRulesTest extends RelOptTestBase {
 
   @Test void testReduceInValuesWithAggregateValueReduceRule() {
     final Function<RelBuilder, RelNode> relFn = b -> b
-        .values(new String[]{"v"}, 1, 1 ,3 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1 ,1
-            ,1 ,1 ,1 ,1 ,1 ,1 ,1)
+        .values(new String[]{"v"}, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1)
         .distinct()
         .build();
     relFn(relFn)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -2474,6 +2474,30 @@ LogicalProject(NAME=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReduceInValues">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, sal FROM EMP WHERE deptno IN (1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], SAL=[$5])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalAggregate(group=[{0}])
+        LogicalValues(tuples=[[{ 1 }, { 1 }, { 3 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], SAL=[$5])
+  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
+    LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalValues(tuples=[[{ 1 }, { 3 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDecorrelateProjectWithFetchOne">
     <Resource name="sql">
       <![CDATA[SELECT name, (SELECT sal FROM emp where dept.deptno = emp.deptno order by sal limit 1) FROM dept]]>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -2498,6 +2498,22 @@ LogicalProject(DEPTNO=[$7], SAL=[$5])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReduceInValuesWithAggregateValueReduceRule">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, sal FROM EMP WHERE deptno IN (1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}])
+  LogicalValues(tuples=[[{ 1 }, { 1 }, { 3 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }, { 1 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalValues(tuples=[[{ 1 }, { 3 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDecorrelateProjectWithFetchOne">
     <Resource name="sql">
       <![CDATA[SELECT name, (SELECT sal FROM emp where dept.deptno = emp.deptno order by sal limit 1) FROM dept]]>


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-6887

According the discussion in: https://github.com/apache/calcite/pull/4242
add a AggregateValueReduceRule to distinct IN filter values.