### PR TITLE
[CALCITE-7014] Support EQUAL/GreaterThanOrEqual/LessThanOrEqual expressions to RexNode in CalcitePrepare

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -1327,10 +1327,16 @@ public class CalcitePrepareImpl implements CalcitePrepare {
             toRex(targetExpression),
             field.getName(),
             true);
+      case Equal:
+        return binary(expression, SqlStdOperatorTable.EQUALS);
       case GreaterThan:
         return binary(expression, SqlStdOperatorTable.GREATER_THAN);
+      case GreaterThanOrEqual:
+        return binary(expression, SqlStdOperatorTable.GREATER_THAN_OR_EQUAL);
       case LessThan:
         return binary(expression, SqlStdOperatorTable.LESS_THAN);
+      case LessThanOrEqual:
+        return binary(expression, SqlStdOperatorTable.LESS_THAN_OR_EQUAL);
       case Parameter:
         return parameter((ParameterExpression) expression);
       case Call:

--- a/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/org/apache/calcite/test/ReflectiveSchemaTest.java
@@ -176,6 +176,136 @@ public class ReflectiveSchemaTest {
     assertThat(list, isListOf(100, 200, 150, 110));
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7014">[CALCITE-7014]
+   * Support EQUAL/GreaterThanOrEqual/LessThanOrEqual expressions to RexNode
+   * in CalcitePrepare</a>. */
+  @Test void testQueryProviderWithFilter() throws Exception {
+    Connection connection = CalciteAssert
+        .that(CalciteAssert.Config.REGULAR).connect();
+    QueryProvider queryProvider = connection.unwrap(QueryProvider.class);
+    ParameterExpression e = Expressions.parameter(Employee.class, "e");
+
+    // test where empid>150 and empid<=160, result size would be 0
+    List<Object[]> list =
+        queryProvider.createQuery(
+                Expressions.call(
+                    Expressions.call(
+                        Types.of(Enumerable.class, Employee.class),
+                        null,
+                        LINQ4J_AS_ENUMERABLE_METHOD,
+                        Expressions.constant(
+                            new HrSchema().emps)),
+                    "asQueryable"),
+                Employee.class)
+            .where(
+                Expressions.lambda(
+                    Expressions.lessThanOrEqual(
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.constant(160)),
+                    e))
+            .where(
+                Expressions.lambda(
+                    Expressions.greaterThan(
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.constant(150)),
+                    e))
+            .select(
+                Expressions.<Function1<Employee, Object[]>>lambda(
+                    Expressions.new_(
+                        Object[].class,
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.call(
+                            Expressions.field(
+                                e, "name"),
+                            "toUpperCase")),
+                    e))
+            .toList();
+    assertThat(list, hasSize(0));
+
+    // test where empid>=150 and empid<=160, result size would be 1
+    list =
+        queryProvider.createQuery(
+                Expressions.call(
+                    Expressions.call(
+                        Types.of(Enumerable.class, Employee.class),
+                        null,
+                        LINQ4J_AS_ENUMERABLE_METHOD,
+                        Expressions.constant(
+                            new HrSchema().emps)),
+                    "asQueryable"),
+                Employee.class)
+            .where(
+                Expressions.lambda(
+                    Expressions.lessThanOrEqual(
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.constant(160)),
+                    e))
+            .where(
+                Expressions.lambda(
+                    Expressions.greaterThanOrEqual(
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.constant(150)),
+                    e))
+            .select(
+                Expressions.<Function1<Employee, Object[]>>lambda(
+                    Expressions.new_(
+                        Object[].class,
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.call(
+                            Expressions.field(
+                                e, "name"),
+                            "toUpperCase")),
+                    e))
+            .toList();
+    assertThat(list, hasSize(1));
+    assertThat(list.get(0), arrayWithSize(2));
+    assertThat(list.get(0)[0], is(150));
+    assertThat(list.get(0)[1], is("SEBASTIAN"));
+
+    // test where empid=150, result size would be 1
+    list =
+        queryProvider.createQuery(
+                Expressions.call(
+                    Expressions.call(
+                        Types.of(Enumerable.class, Employee.class),
+                        null,
+                        LINQ4J_AS_ENUMERABLE_METHOD,
+                        Expressions.constant(
+                            new HrSchema().emps)),
+                    "asQueryable"),
+                Employee.class)
+            .where(
+                Expressions.lambda(
+                    Expressions.equal(
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.constant(150)),
+                    e))
+            .select(
+                Expressions.<Function1<Employee, Object[]>>lambda(
+                    Expressions.new_(
+                        Object[].class,
+                        Expressions.field(
+                            e, "empid"),
+                        Expressions.call(
+                            Expressions.field(
+                                e, "name"),
+                            "toUpperCase")),
+                    e))
+            .toList();
+    assertThat(list, hasSize(1));
+    assertThat(list.get(0), arrayWithSize(2));
+    assertThat(list.get(0)[0], is(150));
+    assertThat(list.get(0)[1], is("SEBASTIAN"));
+  }
+
   /**
    * Tests a relation that is accessed via method syntax.
    * The function returns a {@link org.apache.calcite.linq4j.Queryable}.


### PR DESCRIPTION
As description in JIRA: https://issues.apache.org/jira/browse/CALCITE-7014