### PR TITLE
[CALCITE-7009] AssertionError when converting query containing multiple correlated subqueries referencing different tables in FROM

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1896,6 +1896,14 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).withExpand(false).ok();
   }
 
+  @Test void testMultipleCorrelatedSubQueriesInSelectReferencingDifferentTablesInFrom() {
+    final String sql = "select\n"
+        + "(select ename from emp where empno = empnos.empno) as emp_name,\n"
+        + "(select name from dept where deptno = deptnos.deptno) as dept_name\n"
+        + " from (values (1), (2)) as empnos(empno), (values (1), (2)) as deptnos(deptno)";
+    sql(sql).withExpand(false).ok();
+  }
+
   @Test void testExists() {
     final String sql = "select*from emp\n"
         + "where exists (select 1 from dept where deptno=55)";

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -5010,6 +5010,30 @@ LogicalProject(ENAME=[$cor0.ENAME])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMultipleCorrelatedSubQueriesInSelectReferencingDifferentTablesInFrom">
+    <Resource name="sql">
+      <![CDATA[select
+(select ename from emp where empno = empnos.empno) as emp_name,
+(select name from dept where deptno = deptnos.deptno) as dept_name
+ from (values (1), (2)) as empnos(empno), (values (1), (2)) as deptnos(deptno)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMP_NAME=[$SCALAR_QUERY({
+LogicalProject(ENAME=[$1])
+  LogicalFilter(condition=[=($0, $cor0.EMPNO)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})], DEPT_NAME=[$SCALAR_QUERY({
+LogicalProject(NAME=[$1])
+  LogicalFilter(condition=[=($0, $cor0.DEPTNO)])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+})])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalValues(tuples=[[{ 1 }, { 2 }]])
+    LogicalValues(tuples=[[{ 1 }, { 2 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMultiset">
     <Resource name="plan">
       <![CDATA[

--- a/core/src/test/resources/sql/scalar.iq
+++ b/core/src/test/resources/sql/scalar.iq
@@ -301,4 +301,21 @@ from (values (1), (3)) t1(id);
 
 !ok
 
+# Several scalar sub-queries reference different tables in FROM list
+select
+    (select ename from emp where empno = empnos.empno) as emp_name,
+    (select dname from dept where deptno = deptnos.deptno) as dept_name
+  from (values (7369), (7499)) as empnos(empno), (values (10), (20)) as deptnos(deptno) order by 1, 2;
++----------+------------+
+| EMP_NAME | DEPT_NAME  |
++----------+------------+
+| ALLEN    | ACCOUNTING |
+| ALLEN    | RESEARCH   |
+| SMITH    | ACCOUNTING |
+| SMITH    | RESEARCH   |
++----------+------------+
+(4 rows)
+
+!ok
+
 # End scalar.iq


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-7009

This patch addresses an issue when AssertionError is thrown if multiple correlated subqueries reference different tables in FROM list. Proposed solution is to simply remove assertion check. See attached JIRA for details.