### PR TITLE
[CALCITE-7016] Sql resources should not be included in XML when using relFn in RelOptRulesTest testing

### DIFF
--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1228,11 +1228,6 @@ LogicalTableScan(table=[[scott, EMP]])
     </Resource>
   </TestCase>
   <TestCase name="testAntiJoinProjectTranspose">
-    <Resource name="sql">
-      <![CDATA[select a.name from dept a
-where a.deptno not in (select b.deptno * 2 from dept);
-]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(DNAME=[$1])
@@ -1478,11 +1473,6 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     </Resource>
   </TestCase>
   <TestCase name="testCanNotPushAntiJoinConditionsToLeft">
-    <Resource name="sql">
-      <![CDATA[select * from emp
-where emp.deptno not in
-(select dept.deptno from dept where emp.deptno > 20)]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0])
@@ -1493,11 +1483,6 @@ LogicalProject(EMPNO=[$0])
     </Resource>
   </TestCase>
   <TestCase name="testCanNotPushAntiJoinConditionsToRight">
-    <Resource name="sql">
-      <![CDATA[select * from emp
-where emp.deptno
-not in (select dept.deptno from dept where dept.dname = 'ddd')]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0])
@@ -7075,12 +7060,6 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     </Resource>
   </TestCase>
   <TestCase name="testJoinConditionPushdown4">
-    <Resource name="sql">
-      <![CDATA[select *
-from emp e semi join dept d
-on e.deptno = d.deptno and e.empno = d.deptno
-]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(DEPTNO=[$0])
@@ -7791,11 +7770,6 @@ LogicalProject(DEPTNO=[$0])
     </Resource>
   </TestCase>
   <TestCase name="testJoinToMultiJoinDoesNotMatchAntiJoin">
-    <Resource name="sql">
-      <![CDATA[select * from
-(select * from emp join dept ON emp.deptno = emp.deptno) t
-where not exists (select job from bonus where emp.job = bonus.job)]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalJoin(condition=[=($2, $12)], joinType=[anti])
@@ -7816,11 +7790,6 @@ LogicalJoin(condition=[=($2, $12)], joinType=[anti])
     </Resource>
   </TestCase>
   <TestCase name="testJoinToMultiJoinDoesNotMatchSemiJoin">
-    <Resource name="sql">
-      <![CDATA[select * from
-(select * from emp join dept ON emp.deptno = emp.deptno) t
-where emp.job in (select job from bonus))]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalJoin(condition=[=($2, $12)], joinType=[semi])
@@ -12989,9 +12958,6 @@ LogicalProject(SAL=[$5])
     </Resource>
   </TestCase>
   <TestCase name="testPushJoinThroughUnionOnRightDoesNotMatchAntiJoin">
-    <Resource name="sql">
-      <![CDATA[select r1.sal from emp r1 where r1.deptno not in (select deptno from dept d1 where deptno < 10 union all select deptno from dept d2 where deptno > 20)]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(SAL=[$5])
@@ -13008,9 +12974,6 @@ LogicalProject(SAL=[$5])
     </Resource>
   </TestCase>
   <TestCase name="testPushJoinThroughUnionOnRightDoesNotMatchSemiJoin">
-    <Resource name="sql">
-      <![CDATA[select r1.sal from emp r1 where r1.deptno in (select deptno from dept d1 where deptno > 100 union all select deptno from dept d2 where deptno > 20)]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(SAL=[$5])
@@ -13791,11 +13754,6 @@ LogicalProject(DEPTNO=[$0])
     </Resource>
   </TestCase>
   <TestCase name="testPushSemiJoinConditionsToLeft">
-    <Resource name="sql">
-      <![CDATA[select * from emp
-where emp.deptno
-in (select dept.deptno from dept where emp.empno > 20)]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EMPNO=[$0])
@@ -15021,11 +14979,6 @@ LogicalProject(EMPNO=[$0])
     </Resource>
   </TestCase>
   <TestCase name="testReduceConstantsNonDeterministicFunction">
-    <Resource name="sql">
-      <![CDATA[select sal, r
-from (select sal, rand() as r from emp)
-where r > 0.5]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalFilter(condition=[>($1, 10)])
@@ -16034,11 +15987,6 @@ LogicalValues(tuples=[[]])
     </Resource>
   </TestCase>
   <TestCase name="testSemiJoinProjectTranspose">
-    <Resource name="sql">
-      <![CDATA[select a.name from dept a
-where a.deptno in (select b.deptno * 2 from dept);
-]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(DNAME=[$1])

--- a/testkit/src/main/java/org/apache/calcite/test/RelSupplier.java
+++ b/testkit/src/main/java/org/apache/calcite/test/RelSupplier.java
@@ -128,6 +128,11 @@ interface RelSupplier {
     }
 
     @Override public RelNode apply(RelOptFixture fixture) {
+      String sql = fixture.diffRepos().expand("sql", "${sql}");
+      if (!sql.equals("${sql}")) {
+        throw new AssertionError(
+            "relFn test case should not contain sql resource in XML file");
+      }
       return relFn.apply(RelBuilder.create(FRAMEWORK_CONFIG));
     }
 


### PR DESCRIPTION
JIRA link: [CALCITE-7016](https://issues.apache.org/jira/browse/CALCITE-7016)