### PR TITLE
[CALCITE-7027] Improve error message in case of several `UNION`, `INTERSECT`, `EXCEPT` in a query

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -835,6 +835,12 @@ public abstract class SqlUtil {
       assert row.operandCount() > i : "VALUES has too few columns";
       return row.operand(i);
 
+    case EXCEPT:
+    case INTERSECT:
+    case UNION:
+      final List<SqlNode> operandList = ((SqlBasicCall) query).getOperandList();
+      return getSelectListItem(operandList.get(0), i);
+
     default:
       // Unexpected type of query.
       throw Util.needToImplement(query);

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -5238,6 +5238,35 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("Type mismatch in column 1 of UNION");
 
     sql("select ^slacker^ from emp union select name from dept").ok();
+
+    sql("select ^name^ from dept union select name from dept union select slacker from emp")
+        .withTypeCoercion(false)
+        .fails("Type mismatch in column 1 of UNION");
+
+    sql("select ^name^ from dept except select name from dept except select slacker from emp")
+        .withTypeCoercion(false)
+        .fails("Type mismatch in column 1 of EXCEPT");
+
+    sql("select ^name^ from dept intersect select name from dept intersect select slacker from emp")
+        .withTypeCoercion(false)
+        .fails("Type mismatch in column 1 of INTERSECT");
+
+    sql("select ^name^ from dept minus select name from dept minus select slacker from emp")
+        .withTypeCoercion(false)
+        .withConformance(SqlConformanceEnum.ORACLE_12) // in order to enable isMinusAllowed()
+        .fails("Type mismatch in column 1 of EXCEPT");
+
+    sql("select name from dept union select name from dept union select ename from emp")
+        .withTypeCoercion(false)
+        .ok();
+
+    sql("select name from dept except select name from dept except select ename from emp")
+        .withTypeCoercion(false)
+        .ok();
+
+    sql("select name from dept intersect select name from dept intersect select ename from emp")
+        .withTypeCoercion(false)
+        .ok();
   }
 
   @Test void testUnionTypeMismatchWithStarFails() {


### PR DESCRIPTION
~~This is a sort of poc for the jira issue.~~
~~I can add similar to other places of `Util#needToImplement` usage if the approach is ok~~

UPD: it looks the reason of failures we faced is unsupported UNION, INTERSECT, EXCEPT, MINUS in SqlUtil#getSelectListItem

added support for this and changes in this file reverted