### PR TITLE
[CALCITE-7035] SQL calls without an implementor or convertLet (NULLIF, YEAR, ...)throw an error when having a subquery as parameter

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCoalesceFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCoalesceFunction.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
@@ -68,6 +69,10 @@ public class SqlCoalesceFunction extends SqlFunction {
 
   // override SqlOperator
   @Override public SqlNode rewriteCall(SqlValidator validator, SqlCall call) {
+    // Do not rewrite subquery
+    if (SqlUtil.containsCall(call, c -> c.getKind() == SqlKind.SELECT)) {
+      return call;
+    }
     validateQuantifier(validator, call); // check DISTINCT/ALL
 
     List<SqlNode> operands = call.getOperandList();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1528,9 +1528,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
           ((SqlBasicCall) call).setOperator(overloads.get(0));
         }
       }
-      if (config.callRewrite()
-          // Do not rewrite calls that contain subqueries
-          && !SqlUtil.containsCall(call, c -> c.getKind() == SqlKind.SELECT)) {
+      if (config.callRewrite()) {
         node = call.getOperator().rewriteCall(this, call);
       }
     } else if (node instanceof SqlNodeList) {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1690,6 +1690,22 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7035">[CALCITE-7035]
+   * SQL calls without an implementor or convertLet (NULLIF, YEAR, ...)
+   * throw an error when having a subquery as parameter</a>. */
+  @Test void testNullIfSubquery() {
+    final String sql = "select nullif((select max(empno) from emp), 0)";
+    sql(sql).ok();
+  }
+
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7035">[CALCITE-7035]
+   * SQL calls without an implementor or convertLet (NULLIF, YEAR, ...)
+   * throw an error when having a subquery as parameter</a>. */
+  @Test void testYearSubquery() {
+    final String sql = "select year(select max(t) from (SELECT DATE '2007-12-31' as t))";
+    sql(sql).ok();
+  }
+
   @Test void testSampleBernoulliQuery() {
     final String sql = "select * from (\n"
         + " select * from emp as e tablesample bernoulli(10) repeatable(1)\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -5637,6 +5637,25 @@ LogicalProject(EXPR$0=[1])
   select 1 from dept where emp.deptno=dept.deptno)]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNullIfSubquery">
+    <Resource name="sql">
+      <![CDATA[select nullif((select max(empno) from emp), 0)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[CASE(=($1, 0), null:INTEGER, $2)])
+  LogicalJoin(condition=[true], joinType=[left])
+    LogicalJoin(condition=[true], joinType=[left])
+      LogicalValues(tuples=[[{ 0 }]])
+      LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+        LogicalProject(EMPNO=[$0])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+      LogicalProject(EMPNO=[$0])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testOffset">
     <Resource name="sql">
       <![CDATA[select empno from emp offset 10 rows]]>
@@ -9874,6 +9893,20 @@ group by deptno]]>
 LogicalAggregate(group=[{0}], EXPR$1=[COLLECT($1) WITHIN GROUP ([2])], EXPR$2=[COUNT()])
   LogicalProject(DEPTNO=[$7], EMPNO=[$0], $f2=[SEARCH($0, Sarg[(-∞..1), (1..2), (2..+∞)])])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testYearSubquery">
+    <Resource name="sql">
+      <![CDATA[select year(select max(t) from (SELECT DATE '2007-12-31' as t))]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[EXTRACT(FLAG(YEAR), $1)])
+  LogicalJoin(condition=[true], joinType=[left])
+    LogicalValues(tuples=[[{ 0 }]])
+    LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
+      LogicalValues(tuples=[[{ 2007-12-31 }]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
Jira: [CALCITE-7035](https://issues.apache.org/jira/browse/CALCITE-7035)