### PR TITLE
[CALCITE-5094] Calcite JDBC Adapter and Avatica should support MySQL UNSIGNED types of TINYINT, SMALLINT, INT, BIGINT

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcSchema.java
@@ -423,7 +423,9 @@ public class JdbcSchema extends JdbcBaseSchema implements Schema, Wrapper {
       int precision, int scale, @Nullable String typeString) {
     // Fall back to ANY if type is unknown
     final SqlTypeName sqlTypeName =
-        Util.first(SqlTypeName.getNameForJdbcType(dataType), SqlTypeName.ANY);
+        Util.first(typeString != null && typeString.toUpperCase(Locale.ROOT).contains("UNSIGNED")
+            ? SqlTypeName.getNameForUnsignedJdbcType(dataType)
+            : SqlTypeName.getNameForJdbcType(dataType), SqlTypeName.ANY);
     switch (sqlTypeName) {
     case ARRAY:
       RelDataType component = null;

--- a/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalcitePrepareImpl.java
@@ -793,7 +793,7 @@ public class CalcitePrepareImpl implements CalcitePrepare {
         type.isNullable()
             ? DatabaseMetaData.columnNullable
             : DatabaseMetaData.columnNoNulls,
-        true,
+        !SqlTypeName.UNSIGNED_TYPES.contains(type.getSqlTypeName()),
         type.getPrecision(),
         fieldName,
         origin(origins, 0),

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -290,6 +290,18 @@ public enum SqlTypeName {
           .build();
 
   /**
+   * Mapping between JDBC type codes and their corresponding
+   * {@link org.apache.calcite.sql.type.SqlTypeName} for unsigned types.
+   */
+  private static final Map<Integer, SqlTypeName> UNSIGNED_JDBC_TYPE_TO_NAME =
+      ImmutableMap.<Integer, SqlTypeName>builder()
+          .put(Types.TINYINT, UTINYINT)
+          .put(Types.SMALLINT, USMALLINT)
+          .put(Types.INTEGER, UINTEGER)
+          .put(Types.BIGINT, UBIGINT)
+          .build();
+
+  /**
    * Bitwise-or of flags indicating allowable precision/scale combinations.
    */
   private final int signatures;
@@ -445,6 +457,16 @@ public enum SqlTypeName {
    */
   public static @Nullable SqlTypeName getNameForJdbcType(int jdbcType) {
     return JDBC_TYPE_TO_NAME.get(jdbcType);
+  }
+
+  /**
+   * Gets the SqlTypeName corresponding to an unsigned JDBC type.
+   *
+   * @param jdbcType the unsigned JDBC type of interest
+   * @return corresponding SqlTypeName, or null if the type is not known
+   */
+  public static @Nullable SqlTypeName getNameForUnsignedJdbcType(int jdbcType) {
+    return UNSIGNED_JDBC_TYPE_TO_NAME.get(jdbcType);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlTypeNameTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlTypeNameTest.java
@@ -40,6 +40,10 @@ import static org.apache.calcite.sql.type.SqlTypeName.STRUCTURED;
 import static org.apache.calcite.sql.type.SqlTypeName.TIME;
 import static org.apache.calcite.sql.type.SqlTypeName.TIMESTAMP;
 import static org.apache.calcite.sql.type.SqlTypeName.TINYINT;
+import static org.apache.calcite.sql.type.SqlTypeName.UBIGINT;
+import static org.apache.calcite.sql.type.SqlTypeName.UINTEGER;
+import static org.apache.calcite.sql.type.SqlTypeName.USMALLINT;
+import static org.apache.calcite.sql.type.SqlTypeName.UTINYINT;
 import static org.apache.calcite.sql.type.SqlTypeName.VARBINARY;
 import static org.apache.calcite.sql.type.SqlTypeName.VARCHAR;
 
@@ -79,6 +83,30 @@ class SqlTypeNameTest {
     SqlTypeName tn =
         SqlTypeName.getNameForJdbcType(Types.BIGINT);
     assertThat("BIGINT did not map to BIGINT", tn, is(BIGINT));
+  }
+
+  @Test void testUnsignedTinyint() {
+    SqlTypeName tn =
+        SqlTypeName.getNameForUnsignedJdbcType(Types.TINYINT);
+    assertThat("TINYINT did not map to UTINYINT", tn, is(UTINYINT));
+  }
+
+  @Test void testUnsignedSmallint() {
+    SqlTypeName tn =
+        SqlTypeName.getNameForUnsignedJdbcType(Types.SMALLINT);
+    assertThat("SMALLINT did not map to USMALLINT", tn, is(USMALLINT));
+  }
+
+  @Test void testUnsignedInteger() {
+    SqlTypeName tn =
+        SqlTypeName.getNameForUnsignedJdbcType(Types.INTEGER);
+    assertThat("INTEGER did not map to UINTEGER", tn, is(UINTEGER));
+  }
+
+  @Test void testUnsignedBigint() {
+    SqlTypeName tn =
+        SqlTypeName.getNameForUnsignedJdbcType(Types.BIGINT);
+    assertThat("BIGINT did not map to UBIGINT", tn, is(UBIGINT));
   }
 
   @Test void testFloat() {

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -9077,6 +9077,39 @@ public class JdbcTest {
         });
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5094">[CALCITE-5094]
+   * Calcite JDBC Adapter and Avatica should support
+   * MySQL UNSIGNED types of TINYINT, SMALLINT, INT, BIGINT</a>. */
+  @Test void testMySQLUnsignedType() {
+    CalciteAssert.that()
+        .with(CalciteAssert.SchemaSpec.UNSIGNED_TYPE)
+        .with(Lex.MYSQL)
+        .query("SELECT * FROM test_unsigned WHERE utiny_value = ? "
+            + "AND usmall_value = ? AND uint_value = ? AND ubig_value = ?")
+        .consumesPreparedStatement(p -> {
+          p.setInt(1, 255);
+          p.setInt(2, 65535);
+          p.setLong(3, 4294967295L);
+          p.setBigDecimal(4, new BigDecimal("18446744073709551615"));
+        })
+        .returns(resultSet -> {
+          try {
+            assertTrue(resultSet.next());
+            final Integer uTinyInt = resultSet.getInt(1);
+            final Integer uSmallInt = resultSet.getInt(2);
+            final Long uInteger = resultSet.getLong(3);
+            final BigDecimal uBigInt = resultSet.getBigDecimal(4);
+            assertThat(uTinyInt, is(255));
+            assertThat(uSmallInt, is(65535));
+            assertThat(uInteger, is(4294967295L));
+            assertThat(uBigInt, is(new BigDecimal("18446744073709551615")));
+          } catch (SQLException e) {
+            throw TestUtil.rethrow(e);
+          }
+        });
+  }
+
   @Test void bindByteParameter() {
     for (SqlTypeName tpe : SqlTypeName.INT_TYPES) {
       final String sql =

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/tree/UnsignedType.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/tree/UnsignedType.java
@@ -278,7 +278,7 @@ public enum UnsignedType {
   private static ULong toULongNonNull(Number n, RoundingMode mode) {
     if (n instanceof BigDecimal) {
       BigDecimal d = ((BigDecimal) n).setScale(0, mode);
-      return Unsigned.ulong(d.longValueExact());
+      return Unsigned.ulong(d.toBigIntegerExact());
     } else if (n instanceof Byte || n instanceof Short || n instanceof Integer
         || n instanceof Long || n instanceof Float || n instanceof Double
         || n instanceof UByte || n instanceof UShort || n instanceof UInteger) {


### PR DESCRIPTION
For more details, refer jira: https://issues.apache.org/jira/browse/CALCITE-5094