### PR TITLE
[CALCITE-7060] Enable dumping high-level plans in quidem tests

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/CoreQuidemTest.java
+++ b/core/src/test/java/org/apache/calcite/test/CoreQuidemTest.java
@@ -19,12 +19,22 @@ package org.apache.calcite.test;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.sql.fun.SqlLibrary;
+import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 
+import com.google.common.collect.ImmutableSet;
+
+import net.hydromatic.quidem.Command;
+import net.hydromatic.quidem.CommandHandler;
 import net.hydromatic.quidem.Quidem;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.sql.Connection;
 import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.calcite.util.Util.discard;
 
@@ -185,5 +195,32 @@ class CoreQuidemTest extends QuidemTest {
       return;
     }
     checkRun(path);
+  }
+
+  @Override protected CommandHandler createCommandHandler() {
+    return new ExtendedCommandHandler();
+  }
+
+  /** Command handler that adds a "!explain-validated-on dialect..." command
+   * (see {@link QuidemTest.ExplainValidatedCommand}). */
+  private static class ExtendedCommandHandler implements CommandHandler {
+    @Override public @Nullable Command parseCommand(List<String> lines,
+        List<String> content, String line) {
+      final String prefix = "explain-validated-on";
+      if (line.startsWith(prefix)) {
+        final Pattern pattern =
+            Pattern.compile("explain-validated-on( [-_+a-zA-Z0-9]+)*?");
+        final Matcher matcher = pattern.matcher(line);
+        if (matcher.matches()) {
+          final ImmutableSet.Builder<String> set = ImmutableSet.builder();
+          for (int i = 0; i < matcher.groupCount(); i++) {
+            set.add(matcher.group(i + 1));
+          }
+          return new QuidemTest.ExplainValidatedCommand(
+              SqlParserImpl.FACTORY, lines, content, set.build());
+        }
+      }
+      return null;
+    }
   }
 }

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -18,6 +18,13 @@
 !use post
 !set outputformat mysql
 
+# [CALCITE-7060] Enable dumping high-level plans in quidem tests
+SELECT * FROM EMP WHERE DEPTNO > 20;
+SELECT "EMP"."ENAME", "EMP"."DEPTNO", "EMP"."GENDER"
+FROM "POST"."EMP" AS "EMP"
+WHERE "EMP"."DEPTNO" > 20
+!explain-validated-on Calcite
+
 # [CALCITE-6751] Reduction of CAST from string to interval is incorrect
 SELECT TIME '10:00:00' + CAST('1' AS INTERVAL SECOND);
 +----------+


### PR DESCRIPTION
This just moves a class around so the command !explain... is available both in CoreQuidemTests and in BabelQuidemTests (where the command was originally added).