### PR TITLE
[CALCITE-3190] ElasticsearchJson throws Exception when visitMappingProperties

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJson.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableSet;
 
@@ -109,9 +110,10 @@ final class ElasticsearchJson {
       BiConsumer<String, String> consumer) {
     requireNonNull(mapping, "mapping");
     requireNonNull(consumer, "consumer");
-    if (mapping.has("properties")) {
-      visitMappingProperties(new ArrayDeque<>(), mapping, consumer);
+    if (mapping.findPath("properties") instanceof MissingNode) {
+      return;
     }
+    visitMappingProperties(new ArrayDeque<>(), mapping.findParent("properties"), consumer);
   }
 
   private static void visitMappingProperties(Deque<String> path,

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJsonTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchJsonTest.java
@@ -295,6 +295,42 @@ class ElasticsearchJsonTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-3190">[CALCITE-3190]
+   * ElasticsearchJson throws Exception when visitMappingProperties</a>. */
+  @Test public void visitMappingPropertiesTest() throws Exception {
+    String mappingJson = "{"
+        + "\"mappings\":{"
+        + "    \"default\":{"
+        + "        \"properties\":{"
+        + "            \"city\":{"
+        + "                \"type\":\"keyword\""
+        + "            },"
+        + "            \"state\":{"
+        + "                \"type\":\"text\""
+        + "            },"
+        + "            \"pop\":{"
+        + "                \"type\":\"long\""
+        + "            }"
+        + "        }"
+        + "    },"
+        + "    \"type1\":{"
+        + "        \"_source\":{"
+        + "            \"enabled\":false"
+        + "        }"
+        + "    }"
+        + "}}";
+    ObjectNode root = new ObjectMapper().readValue(mappingJson, ObjectNode.class);
+    ObjectNode properties = (ObjectNode) root.get("mappings");
+
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    ElasticsearchJson.visitMappingProperties(properties, builder::put);
+    Map<String, String> mapping = builder.build();
+    assertThat(mapping.get("city"), is("keyword"));
+    assertThat(mapping.get("state"), is("text"));
+    assertThat(mapping.get("pop"), is("long"));
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6498">[CALCITE-6498]
    * Elasticsearch multi-field mappings do not work</a>. */
   @Test void testVisitMappingPropertiesWithNestedAndMultiFieldMappings()


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/CALCITE-3190

The issue is staled for several years，and I reviewed previous PR which fix way is not suitable，so I continue to fix it in this pr.