### PR TITLE
[CALCITE-7069] Invalid unparse for INT UNSIGNED and BIGINT UNSIGNED in MysqlSqlDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/DorisSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/DorisSqlDialect.java
@@ -17,11 +17,15 @@
 package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static org.apache.calcite.util.RelToSqlConverterUtil.unparseSparkArrayAndMap;
 
@@ -59,5 +63,19 @@ public class DorisSqlDialect extends StarRocksSqlDialect {
       super.unparseCall(writer, call, leftPrec, rightPrec);
       break;
     }
+  }
+
+  @Override public @Nullable SqlNode getCastSpec(RelDataType type) {
+    switch (type.getSqlTypeName()) {
+    case UTINYINT:
+    case USMALLINT:
+    case UINTEGER:
+    case UBIGINT:
+      throw new RuntimeException(
+          "Doris doesn't support UNSIGNED TINYINT/SMALLINT/INTEGER/BIGINT!");
+    default:
+      break;
+    }
+    return super.getCastSpec(type);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -196,6 +196,18 @@ public class MysqlSqlDialect extends SqlDialect {
               type.getSqlTypeName(),
               SqlParserPos.ZERO),
           SqlParserPos.ZERO);
+    case UTINYINT:
+    case USMALLINT:
+    case UINTEGER:
+      throw new RuntimeException(
+          "MySQL doesn't support UNSIGNED TINYINT/SMALLINT/INTEGER!");
+    case UBIGINT:
+      return new SqlDataTypeSpec(
+          new SqlAlienSystemTypeNameSpec(
+              "UNSIGNED",
+              type.getSqlTypeName(),
+              SqlParserPos.ZERO),
+          SqlParserPos.ZERO);
     case TIMESTAMP:
       return new SqlDataTypeSpec(
           new SqlAlienSystemTypeNameSpec(

--- a/core/src/main/java/org/apache/calcite/sql/dialect/StarRocksSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/StarRocksSqlDialect.java
@@ -189,6 +189,11 @@ public class StarRocksSqlDialect extends MysqlSqlDialect {
       return new SqlDataTypeSpec(
           new SqlBasicTypeNameSpec(SqlTypeName.BIGINT, SqlParserPos.ZERO),
           SqlParserPos.ZERO);
+    case UTINYINT:
+    case USMALLINT:
+    case UINTEGER:
+      throw new RuntimeException(
+          "StarRocks doesn't support UNSIGNED TINYINT/SMALLINT/INTEGER!");
     case TIMESTAMP:
       return new SqlDataTypeSpec(
           new SqlAlienSystemTypeNameSpec(


### PR DESCRIPTION
JIRA：https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-7069