### PR TITLE
[CALCITE-6386] Elasticsearch adapter throws NullPointerException when used with with model.json and no username, password or pathPrefix

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchSchemaFactory.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -212,7 +213,18 @@ public class ElasticsearchSchemaFactory implements SchemaFactory {
     checkArgument(!hosts.isEmpty(), "no ES hosts specified");
     // Two lists are considered equal when all of their corresponding elements are equal
     // making a list of RestClient params a suitable cache key.
-    List cacheKey = ImmutableList.of(hosts, pathPrefix, username, password);
+    ArrayList<Object> config = new ArrayList<>();
+    config.add(hosts);
+    if (pathPrefix != null) {
+      config.add(pathPrefix);
+    }
+    if (username != null) {
+      config.add(username);
+    }
+    if (password != null) {
+      config.add(password);
+    }
+    List cacheKey = ImmutableList.copyOf(config);
 
     try {
       return REST_CLIENTS.get(cacheKey, new Callable<RestClient>() {

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ElasticSearchAdapterTest.java
@@ -163,6 +163,24 @@ class ElasticSearchAdapterTest {
         .returnsCount(0);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6386">[CALCITE-6386]
+   * NPE when using ES adapter with model.json and no specified username, password
+   * or pathPrefix</a>. */
+  @Test void testConnectNoSpecifiedUserOrpathPrefix() throws SQLException {
+    Connection connection = DriverManager.getConnection("jdbc:calcite:lex=JAVA");
+    final CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
+    final ElasticsearchSchemaFactory esSchemaFactory = new ElasticsearchSchemaFactory();
+
+    Map<String, Object> options = new HashMap<>();
+    String coordinates = String.format(Locale.ROOT, "[\"%s\"]", NODE.httpHost());
+    options.put("hosts", coordinates);
+
+    final Schema esSchmea =
+        esSchemaFactory.create(calciteConnection.getRootSchema(), "elasticsearch", options);
+    assertNotNull(esSchmea);
+  }
+
   @Test void testDisableSSL() throws SQLException {
     Connection connection =
         DriverManager.getConnection("jdbc:calcite:lex=JAVA");


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/CALCITE-6386

I had reviewed origin PR(https://github.com/apache/calcite/pull/3775)  which maybe not right way to fix and staled for more than one year. so I open a new pr to fix it.