### PR TITLE
[CALCITE-815] Add an option to allow empty strings to represent null values

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -1153,4 +1153,7 @@ public interface CalciteResource {
 
   @BaseMessage("Index in ROW type does not have a constant integer or string value")
   ExInst<SqlValidatorException> illegalRowIndex();
+
+  @BaseMessage("Nondeterministic parameter is not supported under emptyStringIsNull semantics")
+  ExInst<RuntimeException> nondeterministicParamNotAllowed();
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -346,7 +346,7 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY, ORACLE, POSTGRESQL, SPARK, HIVE})
   public static final SqlFunction LTRIM =
       SqlBasicFunction.create(SqlKind.LTRIM,
-          ReturnTypes.ARG0.andThen(SqlTypeTransforms.TO_NULLABLE)
+          ReturnTypes.ARG0.andThen(SqlTypeTransforms.FORCE_NULLABLE)
               .andThen(SqlTypeTransforms.TO_VARYING),
           OperandTypes.STRING)
           .withFunctionType(SqlFunctionCategory.STRING);
@@ -355,7 +355,7 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY, ORACLE, POSTGRESQL, SPARK, HIVE})
   public static final SqlFunction RTRIM =
       SqlBasicFunction.create(SqlKind.RTRIM,
-          ReturnTypes.ARG0.andThen(SqlTypeTransforms.TO_NULLABLE)
+          ReturnTypes.ARG0.andThen(SqlTypeTransforms.FORCE_NULLABLE)
               .andThen(SqlTypeTransforms.TO_VARYING),
           OperandTypes.STRING)
           .withFunctionType(SqlFunctionCategory.STRING);
@@ -404,7 +404,8 @@ public abstract class SqlLibraryOperators {
 
   /** Generic "SUBSTR(string, position [, substringLength ])" function. */
   private static final SqlBasicFunction SUBSTR =
-      SqlBasicFunction.create("SUBSTR", ReturnTypes.ARG0_NULLABLE_VARYING,
+      SqlBasicFunction.create("SUBSTR",
+          ReturnTypes.ARG0_FORCE_NULLABLE.andThen(SqlTypeTransforms.TO_VARYING),
           OperandTypes.STRING_INTEGER_OPTIONAL_INTEGER,
           SqlFunctionCategory.STRING);
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1705,7 +1705,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
    * <p>For example, {@code REPLACE(('ciAao', 'a', 'ciao'))} returns "ciAciaoo" in both
    * Oracle and PostgreSQL, but returns "ciciaociaoo" in Microsoft SQL Server. */
   public static final SqlFunction REPLACE =
-      SqlBasicFunction.create("REPLACE", ReturnTypes.VARCHAR_NULLABLE,
+      SqlBasicFunction.create("REPLACE", ReturnTypes.VARCHAR_FORCE_NULLABLE,
           OperandTypes.STRING_STRING_STRING, SqlFunctionCategory.STRING);
 
   /** The {@code CONVERT(charValue, srcCharsetName, destCharsetName)}
@@ -1755,19 +1755,19 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
 
   public static final SqlFunction UPPER =
       SqlBasicFunction.create("UPPER",
-          ReturnTypes.ARG0_NULLABLE,
+          ReturnTypes.ARG0_FORCE_NULLABLE,
           OperandTypes.CHARACTER,
           SqlFunctionCategory.STRING);
 
   public static final SqlFunction LOWER =
       SqlBasicFunction.create("LOWER",
-          ReturnTypes.ARG0_NULLABLE,
+          ReturnTypes.ARG0_FORCE_NULLABLE,
           OperandTypes.CHARACTER,
           SqlFunctionCategory.STRING);
 
   public static final SqlFunction INITCAP =
       SqlBasicFunction.create("INITCAP",
-          ReturnTypes.ARG0_NULLABLE,
+          ReturnTypes.ARG0_FORCE_NULLABLE,
           OperandTypes.CHARACTER,
           SqlFunctionCategory.STRING);
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlSubstringFunction.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
 
@@ -58,7 +59,7 @@ public class SqlSubstringFunction extends SqlFunction {
     super(
         "SUBSTRING",
         SqlKind.OTHER_FUNCTION,
-        ReturnTypes.ARG0_NULLABLE_VARYING,
+        ReturnTypes.ARG0_FORCE_NULLABLE.andThen(SqlTypeTransforms.TO_VARYING),
         null,
         null,
         SqlFunctionCategory.STRING);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlTrimFunction.java
@@ -45,7 +45,7 @@ import java.util.Arrays;
 public class SqlTrimFunction extends SqlFunction {
   protected static final SqlTrimFunction INSTANCE =
       new SqlTrimFunction("TRIM", SqlKind.TRIM,
-          ReturnTypes.ARG2.andThen(SqlTypeTransforms.TO_NULLABLE)
+          ReturnTypes.ARG2.andThen(SqlTypeTransforms.FORCE_NULLABLE)
               .andThen(SqlTypeTransforms.TO_VARYING),
           OperandTypes.ANY_STRING_STRING.and(
               OperandTypes.same(3, 1, 2)));

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -1332,19 +1332,19 @@ public abstract class ReturnTypes {
 
   /**
    * Same as {@link #DYADIC_STRING_SUM_PRECISION} and using
-   * {@link org.apache.calcite.sql.type.SqlTypeTransforms#TO_NULLABLE},
+   * {@link org.apache.calcite.sql.type.SqlTypeTransforms#FORCE_NULLABLE},
    * {@link org.apache.calcite.sql.type.SqlTypeTransforms#TO_VARYING}.
    */
   public static final SqlReturnTypeInference DYADIC_STRING_SUM_PRECISION_NULLABLE_VARYING =
-      DYADIC_STRING_SUM_PRECISION.andThen(SqlTypeTransforms.TO_NULLABLE)
+      DYADIC_STRING_SUM_PRECISION.andThen(SqlTypeTransforms.FORCE_NULLABLE)
           .andThen(SqlTypeTransforms.TO_VARYING);
 
   /**
    * Same as {@link #DYADIC_STRING_SUM_PRECISION} and using
-   * {@link org.apache.calcite.sql.type.SqlTypeTransforms#TO_NULLABLE}.
+   * {@link org.apache.calcite.sql.type.SqlTypeTransforms#FORCE_NULLABLE}.
    */
   public static final SqlReturnTypeInference DYADIC_STRING_SUM_PRECISION_NULLABLE =
-      DYADIC_STRING_SUM_PRECISION.andThen(SqlTypeTransforms.TO_NULLABLE);
+      DYADIC_STRING_SUM_PRECISION.andThen(SqlTypeTransforms.FORCE_NULLABLE);
 
   /**
    * Type-inference strategy where the expression is assumed to be registered

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -164,4 +164,8 @@ public abstract class SqlAbstractConformance implements SqlConformance {
   @Override public boolean supportsUnsignedTypes() {
     return SqlConformanceEnum.DEFAULT.supportsUnsignedTypes();
   }
+
+  @Override public boolean emptyStringIsNull() {
+    return SqlConformanceEnum.DEFAULT.emptyStringIsNull();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -664,7 +664,7 @@ public interface SqlConformance {
   boolean supportsUnsignedTypes();
 
   /**
-   * Whether to convert empty string to null..
+   * Whether to convert empty string to null.
    *
    * <p>Consider the {@code SUBSTRING} operator. SUBSTRING('abc', 0, 0) will
    * return null in Oracle, and return an empty string in other databases

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -662,4 +662,18 @@ public interface SqlConformance {
    * True when the unsigned versions of integer types are supported.
    */
   boolean supportsUnsignedTypes();
+
+  /**
+   * Whether to convert empty string to null..
+   *
+   * <p>Consider the {@code SUBSTRING} operator. SUBSTRING('abc', 0, 0) will
+   * return null in Oracle, and return an empty string in other databases
+   * like MySQL, PostgreSQL, SQL Server that support SUBSTRING function.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#ORACLE_10},
+   * {@link SqlConformanceEnum#ORACLE_12};
+   * false otherwise.
+   */
+  boolean emptyStringIsNull();
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -518,4 +518,14 @@ public enum SqlConformanceEnum implements SqlConformance {
       return false;
     }
   }
+
+  @Override public boolean emptyStringIsNull() {
+    switch (this) {
+    case ORACLE_10:
+    case ORACLE_12:
+      return true;
+    default:
+      return false;
+    }
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
@@ -169,4 +169,8 @@ public class SqlDelegatingConformance implements SqlConformance {
   @Override public boolean supportsUnsignedTypes() {
     return delegate.supportsUnsignedTypes();
   }
+
+  @Override public boolean emptyStringIsNull() {
+    return delegate.emptyStringIsNull();
+  }
 }

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -377,4 +377,5 @@ AsofCannotBeCorrelated=ASOF JOIN does not support correlated subqueries
 UnknownRowField=ROW type does not have a field named ''{0}'': {1}
 IllegalRowIndexValue=ROW type does not have a field with index {0,number}; legal range is 1 to {1,number}
 IllegalRowIndex=Index in ROW type does not have a constant integer or string value
+NondeterministicParamNotAllowed=Nondeterministic parameter is not supported under emptyStringIsNull semantics
 # End CalciteResource.properties

--- a/core/src/test/java/org/apache/calcite/rex/RexExecutorTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexExecutorTest.java
@@ -250,8 +250,10 @@ class RexExecutorTest {
       executor.reduce(rexBuilder, ImmutableList.of(substring, plus),
           reducedValues);
       assertThat(reducedValues, hasSize(2));
-      assertThat(reducedValues.get(0), instanceOf(RexLiteral.class));
-      assertThat(((RexLiteral) reducedValues.get(0)).getValue2(),
+      // substring can return null even if no arguments is null
+      // so there will be a cast
+      assertThat(reducedValues.get(0), instanceOf(RexCall.class));
+      assertThat(((RexLiteral) ((RexCall) reducedValues.get(0)).getOperands().get(0)).getValue2(),
           equalTo("ello")); // substring('Hello world!, 2, 4)
       assertThat(reducedValues.get(1), instanceOf(RexLiteral.class));
       assertThat(((RexLiteral) reducedValues.get(1)).getValue2(),
@@ -277,8 +279,8 @@ class RexExecutorTest {
       executor.reduce(rexBuilder, ImmutableList.of(substring, plus),
           reducedValues);
       assertThat(reducedValues, hasSize(2));
-      assertThat(reducedValues.get(0), instanceOf(RexLiteral.class));
-      assertThat(((RexLiteral) reducedValues.get(0)).getValue2(),
+      assertThat(reducedValues.get(0), instanceOf(RexCall.class));
+      assertThat(((RexLiteral) ((RexCall) reducedValues.get(0)).getOperands().get(0)).getValue2(),
           hasToString("656c6c6f")); // substring('Hello world!, 2, 4)
       assertThat(reducedValues.get(1), instanceOf(RexLiteral.class));
       assertThat(((RexLiteral) reducedValues.get(1)).getValue2(),

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -810,17 +810,17 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("'a'||'b'").ok();
     expr("x'12'||x'34'").ok();
     expr("'a'||'b'")
-        .columnType("CHAR(2) NOT NULL");
+        .columnType("CHAR(2)");
     expr("cast('a' as char(1))||cast('b' as char(2))")
-        .columnType("CHAR(3) NOT NULL");
+        .columnType("CHAR(3)");
     expr("cast(null as char(1))||cast('b' as char(2))")
         .columnType("CHAR(3)");
     expr("'a'||'b'||'c'")
-        .columnType("CHAR(3) NOT NULL");
+        .columnType("CHAR(3)");
     expr("'a'||'b'||'cde'||'f'")
-        .columnType("CHAR(6) NOT NULL");
+        .columnType("CHAR(6)");
     expr("'a'||'b'||cast('cde' as VARCHAR(3))|| 'f'")
-        .columnType("VARCHAR(6) NOT NULL");
+        .columnType("VARCHAR(6)");
     expr("_UTF16'a'||_UTF16'b'||_UTF16'c'").ok();
   }
 
@@ -1000,12 +1000,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("upper(_UTF16'sadf')").ok();
     expr("lower(n'sadf')").ok();
     expr("lower('sadf')")
-        .columnType("CHAR(4) NOT NULL");
+        .columnType("CHAR(4)");
     wholeExpr("upper(123)")
         .withTypeCoercion(false)
         .fails("(?s).*Cannot apply 'UPPER' to arguments of type 'UPPER.<INTEGER>.'.*");
     expr("upper(123)")
-        .columnType("VARCHAR NOT NULL");
+        .columnType("VARCHAR");
   }
 
   @Test void testPosition() {
@@ -1027,9 +1027,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("trim(leading 'mustache' FROM 'beard')").ok();
     expr("trim(trailing 'mustache' FROM 'beard')").ok();
     expr("trim('mustache' FROM 'beard')")
-        .columnType("VARCHAR(5) NOT NULL");
+        .columnType("VARCHAR(5)");
     expr("trim('beard  ')")
-        .columnType("VARCHAR(7) NOT NULL");
+        .columnType("VARCHAR(7)");
     expr("trim('mustache' FROM cast(null as varchar(4)))")
         .columnType("VARCHAR(4)");
 
@@ -1045,12 +1045,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .withTypeCoercion(false)
         .fails("(?s).*Cannot apply 'TRIM' to arguments of type.*");
     expr("trim(123 FROM 'beard')")
-        .columnType("VARCHAR(5) NOT NULL");
+        .columnType("VARCHAR(5)");
     wholeExpr("trim('a' FROM 123)")
         .withTypeCoercion(false)
         .fails("(?s).*Cannot apply 'TRIM' to arguments of type.*");
     expr("trim('a' FROM 123)")
-        .columnType("VARCHAR NOT NULL");
+        .columnType("VARCHAR");
     wholeExpr("trim('a' FROM _UTF16'b')")
         .fails("(?s).*not comparable to each other.*");
   }
@@ -1159,11 +1159,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .withTypeCoercion(false)
         .fails("(?s).*OVERLAY\\(<STRING> PLACING <STRING> FROM <INTEGER>\\).*");
     expr("overlay('ABCdef' placing 'abc' from '1' for 3)")
-        .columnType("VARCHAR(9) NOT NULL");
+        .columnType("VARCHAR(9)");
     expr("overlay('ABCdef' placing 'abc' from 1 for 3)")
-        .columnType("VARCHAR(9) NOT NULL");
+        .columnType("VARCHAR(9)");
     expr("overlay('ABCdef' placing 'abc' from 6 for 3)")
-        .columnType("VARCHAR(9) NOT NULL");
+        .columnType("VARCHAR(9)");
     expr("overlay('ABCdef' placing cast(null as char(5)) from 1)")
         .columnType("VARCHAR(11)");
 
@@ -1182,15 +1182,15 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("substring(x'ff' FROM 1  FOR 2)").ok();
 
     expr("substring('10' FROM 1  FOR 2)")
-        .columnType("VARCHAR(2) NOT NULL");
+        .columnType("VARCHAR(2)");
     expr("substring('1000' FROM 2)")
-        .columnType("VARCHAR(4) NOT NULL");
+        .columnType("VARCHAR(4)");
     expr("substring('1000' FROM '1'  FOR 'w')")
-        .columnType("VARCHAR(4) NOT NULL");
+        .columnType("VARCHAR(4)");
     expr("substring(cast(' 100 ' as CHAR(99)) FROM '1'  FOR 'w')")
-        .columnType("VARCHAR(99) NOT NULL");
+        .columnType("VARCHAR(99)");
     expr("substring(x'10456b' FROM 1  FOR 2)")
-        .columnType("VARBINARY(3) NOT NULL");
+        .columnType("VARBINARY(3)");
 
     sql("substring('10' FROM 1  FOR 2)")
         .assertCharset(isCharset("ISO-8859-1")); // aka "latin1"
@@ -1200,11 +1200,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("substring('a', 1, 3)").ok();
     // Implicit type coercion.
     expr("substring(12345, '1')")
-        .columnType("VARCHAR NOT NULL");
+        .columnType("VARCHAR");
     expr("substring('a', '1')")
-        .columnType("VARCHAR(1) NOT NULL");
+        .columnType("VARCHAR(1)");
     expr("substring('a', 1, '3')")
-        .columnType("VARCHAR(1) NOT NULL");
+        .columnType("VARCHAR(1)");
 
     // Correctly processed null string and params.
     expr("SUBSTRING(NULL FROM 1 FOR 2)").ok();
@@ -1242,7 +1242,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     s.withExpr("'a' ilike 'b'").columnType("BOOLEAN NOT NULL");
     s.withExpr("'a' ilike cast(null as varchar(99))").columnType("BOOLEAN");
     s.withExpr("cast(null as varchar(99)) not ilike 'b'").columnType("BOOLEAN");
-    s.withExpr("'a' not ilike 'b' || 'c'").columnType("BOOLEAN NOT NULL");
+    s.withExpr("'a' not ilike 'b' || 'c'").columnType("BOOLEAN");
 
     // ILIKE is only available in the PostgreSQL function library
     expr("^'a' ilike 'b'^")
@@ -2024,9 +2024,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
       // Without the "FROM" noise word, TRIM is parsed as a regular
       // function without quoting and built-in function with quoting.
       expr("\"TRIM\"('b', 'FROM', 'a')")
-          .columnType("VARCHAR(1) NOT NULL");
+          .columnType("VARCHAR(1)");
       expr("TRIM('b')")
-          .columnType("VARCHAR(1) NOT NULL");
+          .columnType("VARCHAR(1)");
     }
   }
 
@@ -7901,7 +7901,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("date '2015-03-17' between '2015-03-16' and '2015-03-19'")
         .columnType("BOOLEAN NOT NULL");
     expr("date '2015-03-17' between '2015-03-16' and '2015-03'||'-19'")
-        .columnType("BOOLEAN NOT NULL");
+        .columnType("BOOLEAN");
     expr("'2015-03-17' between date '2015-03-16' and date '2015-03-19'")
         .columnType("BOOLEAN NOT NULL");
     expr("date '2015-03-17' between date '2015-03-16' and '2015-03-19'")

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionTest.java
@@ -691,11 +691,11 @@ class TypeCoercionTest {
   @Test void testBuiltinFunctionCoercion() {
     // concat
     expr("'ab'||'cde'")
-        .columnType("CHAR(5) NOT NULL");
+        .columnType("CHAR(5)");
     expr("null||'cde'")
         .columnType("VARCHAR");
     expr("1||'234'")
-        .columnType("VARCHAR NOT NULL");
+        .columnType("VARCHAR");
     expr("select ^'a'||t1_binary^ from t1")
         .fails("(?s).*Cannot apply.*");
     // smallint int double

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -14933,7 +14933,14 @@ LogicalProject(U=[$0], S=[$1])
     <Resource name="planAfter">
       <![CDATA[
 LogicalCalc(expr#0=[{inputs}], expr#1=[1], expr#2=[2], expr#3=[SUBSTRING($t0, $t1, $t2)], expr#4=[3], expr#5=[SUBSTRING($t0, $t4)], expr#6=[||($t3, $t5)], expr#7=[UPPER($t6)], expr#8=[SUBSTRING($t0, $t1, $t1)], U=[$t7], S=[$t8])
-  LogicalValues(tuples=[[]])
+  LogicalUnion(all=[false])
+    LogicalUnion(all=[false])
+      LogicalCalc(expr#0=[{inputs}], expr#1=['table        '], expr#2=[false], expr#3=[CAST($t2):BOOLEAN], X=[$t1], $condition=[$t3])
+        LogicalValues(tuples=[[{ true }]])
+      LogicalCalc(expr#0=[{inputs}], expr#1=['view         '], expr#2=[false], expr#3=[CAST($t2):BOOLEAN], EXPR$0=[$t1], $condition=[$t3])
+        LogicalValues(tuples=[[{ true }]])
+    LogicalCalc(expr#0=[{inputs}], expr#1=['foreign table'], expr#2=[false], expr#3=[CAST($t2):BOOLEAN], EXPR$0=[$t1], $condition=[$t3])
+      LogicalValues(tuples=[[{ true }]])
 ]]>
     </Resource>
   </TestCase>
@@ -15918,7 +15925,7 @@ LogicalProject(EXPR$0=[REPLACE('abc', 'c', 'cd')])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(EXPR$0=['abcd':VARCHAR])
+LogicalProject(EXPR$0=[CAST('abcd':VARCHAR):VARCHAR])
   LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>

--- a/core/src/test/resources/sql/cast.iq
+++ b/core/src/test/resources/sql/cast.iq
@@ -216,7 +216,7 @@ values cast('TR' || 'UE' as boolean);
 (1 row)
 
 !ok
-EnumerableCalc(expr#0=[{inputs}], expr#1=['TR'], expr#2=['UE'], expr#3=[||($t1, $t2)], expr#4=[CAST($t3):BOOLEAN NOT NULL], EXPR$0=[$t4])
+EnumerableCalc(expr#0=[{inputs}], expr#1=['TR'], expr#2=['UE'], expr#3=[||($t1, $t2)], expr#4=[CAST($t3):BOOLEAN], EXPR$0=[$t4])
   EnumerableValues(tuples=[[{ 0 }]])
 !plan
 

--- a/core/src/test/resources/sql/empty-string.iq
+++ b/core/src/test/resources/sql/empty-string.iq
@@ -1,0 +1,219 @@
+# empty-string.iq - Null semantics for empty strings
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+!use scott-oracle
+!set outputformat mysql
+# Test case for [CALCITE-815] Add an option to allow empty strings to represent null values.
+# CONCAT function
+with t as (select '' || '' as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+# INITCAP function
+with t as (select initcap('') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+# LOWER function
+with t as (select lower('') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+# OVERLAY function
+with t as (select overlay('A' placing '' from 1 for 1) as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select overlay('  ' placing '' from 1 for 1) as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | false     |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select overlay(cast(null as varchar(1)) placing 'abc' from 1) as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+# REPLACE function
+with t as (select replace('ciao', 'ciao', '') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select replace('', 'ciao', 'ci') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+# SUBSTRING function
+with t as (select substring('abc' from 2147483650) as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select substring('' from 1) as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select substring('  ' from 1) as c from dual)
+select c, c is null as c_is_null
+from t;
++----+-----------+
+| C  | C_IS_NULL |
++----+-----------+
+|    | false     |
++----+-----------+
+(1 row)
+
+!ok
+
+# TRIM function
+with t as (select trim(null) as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select trim('  ') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select trim('a' from 'a') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+with t as (select trim('A' from 'AAA') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok
+
+# UPPER function
+with t as (select upper('') as c from dual)
+select c, c is null as c_is_null
+from t;
++---+-----------+
+| C | C_IS_NULL |
++---+-----------+
+|   | true      |
++---+-----------+
+(1 row)
+
+!ok

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapter2IT.java
@@ -3605,7 +3605,7 @@ public class DruidAdapter2IT {
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[CAST(SUBSTRING(CAST($0):VARCHAR"
             + " "
-            + "NOT NULL, 12, 2)):INTEGER NOT NULL, EXTRACT(FLAG(MINUTE), $0), "
+            + "NOT NULL, 12, 2)):INTEGER, EXTRACT(FLAG(MINUTE), $0), "
             + "EXTRACT(FLAG(HOUR), $0), $90]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], fetch=[1])")
         .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
     q.returnsOrdered("HR_T_TIMESTAMP_OK=0; MI_T_TIMESTAMP_OK=0; "

--- a/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
+++ b/druid/src/test/java/org/apache/calcite/test/DruidAdapterIT.java
@@ -4295,7 +4295,7 @@ public class DruidAdapterIT {
             + "    DruidQuery(table=[[foodmart, foodmart]], intervals=[[1900-01-09T00:00:00.000Z/"
             + "2992-01-10T00:00:00.000Z]], projects=[[CAST(SUBSTRING(CAST(CAST($0):TIMESTAMP(0) "
             + "NOT NULL):VARCHAR "
-            + "NOT NULL, 12, 2)):INTEGER NOT NULL, EXTRACT(FLAG(MINUTE), $0), "
+            + "NOT NULL, 12, 2)):INTEGER, EXTRACT(FLAG(MINUTE), $0), "
             + "EXTRACT(FLAG(HOUR), $0), $90]], groups=[{0, 1, 2}], aggs=[[SUM($3)]], fetch=[1])")
         .queryContains(new DruidChecker("\"queryType\":\"groupBy\""));
     q.returnsOrdered("HR_T_TIMESTAMP_OK=0; MI_T_TIMESTAMP_OK=0; "

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -2542,6 +2542,16 @@ public class SqlOperatorTest {
             + "array[cast(null as char)]",
         "[hello, world, !, null]", "CHAR(5) ARRAY NOT NULL");
     f.checkNull("cast(null as integer array) || array[1]");
+
+    final Consumer<SqlOperatorFixture> consumerOracle = f1 -> {
+      f1.checkNull("'' || ''");
+      f1.checkFails("rand() || 'a'",
+          ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+          true);
+    };
+    final List<SqlConformanceEnum> oracleConformanceEnums =
+        list(SqlConformanceEnum.ORACLE_10, SqlConformanceEnum.ORACLE_12);
+    f.forEachConformance(oracleConformanceEnums, consumerOracle);
   }
 
   @Test void testConcatFunc() {
@@ -4799,6 +4809,9 @@ public class SqlOperatorTest {
       f1.checkNull("overlay(cast(null as varchar(1)) placing 'abc' from 1)");
       f1.checkNull("overlay('A' placing '' from 1 for 1)");
       f1.checkNull("overlay('abc' placing '' from 1 for 3)");
+      f1.checkFails("overlay(cast(rand() as varchar) placing '' from 1 for 1)",
+          ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+          true);
     };
     final List<SqlConformanceEnum> oracleConformanceEnums =
             list(SqlConformanceEnum.ORACLE_10, SqlConformanceEnum.ORACLE_12);
@@ -6221,6 +6234,9 @@ public class SqlOperatorTest {
     f1.checkNull("upper('')");
     f1.checkString("upper('a')", "A", "CHAR(1)");
     f.checkString("upper('  ')", "  ", "CHAR(2)");
+    f1.checkFails("upper(cast(rand() as varchar))",
+        ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+        true);
   }
 
   @Test void testLeftFunc() {
@@ -7561,6 +7577,9 @@ public class SqlOperatorTest {
     f1.checkNull("lower('')");
     f1.checkString("lower('A')", "a", "CHAR(1)");
     f.checkString("lower('  ')", "  ", "CHAR(2)");
+    f1.checkFails("lower(cast(rand() as varchar))",
+        ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+        true);
   }
 
   @Test void testInitcapFunc() {
@@ -7588,6 +7607,9 @@ public class SqlOperatorTest {
     final SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.ORACLE_12);
     f1.checkNull("initcap('')");
     f.checkString("initcap('  ')", "  ", "CHAR(2)");
+    f1.checkFails("initcap(cast(rand() as varchar))",
+        ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+        true);
   }
 
   @Test void testPowerFunc() {
@@ -11996,6 +12018,9 @@ public class SqlOperatorTest {
       f1.checkNull("trim('  ')");
       f1.checkNull("trim('a' from 'a')");
       f1.checkNull("trim('A' from 'AAA')");
+      f1.checkFails("trim(cast(rand() as varchar))",
+          ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+          true);
     };
     final List<SqlConformanceEnum> oracleConformanceEnums =
             list(SqlConformanceEnum.ORACLE_10, SqlConformanceEnum.ORACLE_12);
@@ -12021,6 +12046,9 @@ public class SqlOperatorTest {
     final Consumer<SqlOperatorFixture> consumerOracle = f2 -> {
       f2.checkNull("rtrim(null)");
       f2.checkNull("rtrim('  ')");
+      f2.checkFails("rtrim(cast(rand() as varchar))",
+          ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+          true);
     };
     f1.forEachLibrary(libraries, consumerOracle);
   }
@@ -12042,8 +12070,11 @@ public class SqlOperatorTest {
 
     final SqlOperatorFixture f1 = f0.withConformance(SqlConformanceEnum.ORACLE_12);
     final Consumer<SqlOperatorFixture> consumerOracle = f2 -> {
-      f2.checkNull("rtrim(null)");
-      f2.checkNull("rtrim('  ')");
+      f2.checkNull("ltrim(null)");
+      f2.checkNull("ltrim('  ')");
+      f2.checkFails("ltrim(cast(rand() as varchar))",
+          ".*: Nondeterministic parameter is not supported under emptyStringIsNull semantics.*",
+          true);
     };
     f1.forEachLibrary(libraries, consumerOracle);
   }

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -118,7 +118,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.apache.calcite.linq4j.tree.Expressions.list;
-import static org.apache.calcite.rel.type.RelDataTypeImpl.NON_NULLABLE_SUFFIX;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.PI;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.QUANTIFY_OPERATORS;
 import static org.apache.calcite.sql.test.ResultCheckers.isDecimal;
@@ -592,11 +591,11 @@ public class SqlOperatorTest {
     f.checkCastToString("cast(cast('abc' as char(4)) as varchar(6))", null,
         "abc ", castType);
     f.checkString("cast(cast('a' as char(2)) as varchar(3)) || 'x' ",
-        "a x", "VARCHAR(4) NOT NULL");
+        "a x", "VARCHAR(4)");
     f.checkString("cast(cast('a' as char(3)) as varchar(5)) || 'x' ",
-        "a  x", "VARCHAR(6) NOT NULL");
+        "a  x", "VARCHAR(6)");
     f.checkString("cast('a' as char(3)) || 'x'", "a  x",
-        "CHAR(4) NOT NULL");
+        "CHAR(4)");
 
     f.checkScalar("char_length(cast(' x ' as char(4)))", 4,
         "INTEGER NOT NULL");
@@ -2142,7 +2141,7 @@ public class SqlOperatorTest {
 
     f.checkScalar("{fn CHAR(97)}", "a", "CHAR(1)");
 
-    f.checkScalar("{fn CONCAT('foo', 'bar')}", "foobar", "CHAR(6) NOT NULL");
+    f.checkScalar("{fn CONCAT('foo', 'bar')}", "foobar", "CHAR(6)");
 
     f.checkScalar("{fn DIFFERENCE('Miller', 'miller')}", "4",
         "INTEGER NOT NULL");
@@ -2162,9 +2161,8 @@ public class SqlOperatorTest {
 
     // REVIEW: is this result correct? I think it should be "abcCdef"
     f.checkScalar("{fn INSERT('abc', 1, 2, 'ABCdef')}",
-        "ABCdefc", "VARCHAR(9) NOT NULL");
-    f.checkScalar("{fn LCASE('foo' || 'bar')}",
-        "foobar", "CHAR(6) NOT NULL");
+        "ABCdefc", "VARCHAR(9)");
+    f.checkScalar("{fn LCASE('foo' || 'bar')}", "foobar", "CHAR(6)");
     if (false) {
       f.checkScalar("{fn LENGTH(string)}", null, "");
     }
@@ -2172,23 +2170,20 @@ public class SqlOperatorTest {
 
     f.checkScalar("{fn LOCATE('ha', 'alphabet', 6)}", 0, "INTEGER NOT NULL");
 
-    f.checkScalar("{fn LTRIM(' xxx  ')}", "xxx  ", "VARCHAR(6) NOT NULL");
+    f.checkScalar("{fn LTRIM(' xxx  ')}", "xxx  ", "VARCHAR(6)");
 
     f.checkScalar("{fn REPEAT('a', -100)}", "", "VARCHAR NOT NULL");
     f.checkNull("{fn REPEAT('abc', cast(null as integer))}");
     f.checkNull("{fn REPEAT(cast(null as varchar(1)), cast(null as integer))}");
 
-    f.checkString("{fn REPLACE('JACK and JUE','J','BL')}",
-        "BLACK and BLUE", "VARCHAR NOT NULL");
+    f.checkString("{fn REPLACE('JACK and JUE','J','BL')}", "BLACK and BLUE", "VARCHAR");
 
     // REPLACE returns NULL in Oracle but not in Postgres or in Calcite.
     // When [CALCITE-815] is implemented and SqlConformance#emptyStringIsNull is
     // enabled, it will return empty string as NULL.
-    f.checkString("{fn REPLACE('ciao', 'ciao', '')}", "",
-        "VARCHAR NOT NULL");
+    f.checkString("{fn REPLACE('ciao', 'ciao', '')}", "", "VARCHAR");
 
-    f.checkString("{fn REPLACE('hello world', 'o', '')}", "hell wrld",
-        "VARCHAR NOT NULL");
+    f.checkString("{fn REPLACE('hello world', 'o', '')}", "hell wrld", "VARCHAR");
 
     f.checkNull("{fn REPLACE(cast(null as varchar(5)), 'ciao', '')}");
     f.checkNull("{fn REPLACE('ciao', cast(null as varchar(3)), 'zz')}");
@@ -2198,7 +2193,7 @@ public class SqlOperatorTest {
     f.checkScalar(
         "{fn RTRIM(' xxx  ')}",
         " xxx",
-        "VARCHAR(6) NOT NULL");
+        "VARCHAR(6)");
 
     f.checkScalar("{fn SOUNDEX('Miller')}", "M460", "VARCHAR(4) NOT NULL");
     f.checkNull("{fn SOUNDEX(cast(null as varchar(1)))}");
@@ -2209,8 +2204,8 @@ public class SqlOperatorTest {
     f.checkScalar(
         "{fn SUBSTRING('abcdef', 2, 3)}",
         "bcd",
-        "VARCHAR(6) NOT NULL");
-    f.checkScalar("{fn UCASE('xxx')}", "XXX", "CHAR(3) NOT NULL");
+        "VARCHAR(6)");
+    f.checkScalar("{fn UCASE('xxx')}", "XXX", "CHAR(3)");
 
     // Time and Date Functions
     f.checkType("{fn CURDATE()}", "DATE NOT NULL");
@@ -2521,23 +2516,23 @@ public class SqlOperatorTest {
   @Test void testConcatOperator() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.CONCAT, VmName.EXPAND);
-    f.checkString(" 'a'||'b' ", "ab", "CHAR(2) NOT NULL");
+    f.checkString(" 'a'||'b' ", "ab", "CHAR(2)");
     f.checkNull(" 'a' || cast(null as char(2)) ");
     f.checkNull(" cast(null as char(2)) || 'b' ");
     f.checkNull(" cast(null as char(1)) || cast(null as char(2)) ");
 
-    f.checkString(" x'fe'||x'df' ", "fedf", "BINARY(2) NOT NULL");
+    f.checkString(" x'fe'||x'df' ", "fedf", "BINARY(2)");
     f.checkString(" cast('fe' as char(2)) || cast('df' as varchar)",
-        "fedf", "VARCHAR NOT NULL");
+        "fedf", "VARCHAR");
     // Precision is larger than VARCHAR allows, so result is unbounded
     f.checkString(" cast('fe' as char(2)) || cast('df' as varchar(65535))",
-        "fedf", "VARCHAR NOT NULL");
+        "fedf", "VARCHAR");
     f.checkString(" cast('fe' as char(2)) || cast('df' as varchar(33333))",
-        "fedf", "VARCHAR(33335) NOT NULL");
+        "fedf", "VARCHAR(33335)");
     f.checkNull("x'ff' || cast(null as varbinary)");
     f.checkNull(" cast(null as ANY) || cast(null as ANY) ");
     f.checkString("cast('a' as varchar) || cast('b' as varchar) "
-        + "|| cast('c' as varchar)", "abc", "VARCHAR NOT NULL");
+        + "|| cast('c' as varchar)", "abc", "VARCHAR");
 
     f.checkScalar("array[1, 2] || array[2, 3]", "[1, 2, 2, 3]",
         "INTEGER NOT NULL ARRAY NOT NULL");
@@ -2576,7 +2571,7 @@ public class SqlOperatorTest {
   @Test void testManyLibraries() {
     SqlOperatorFixture f =
         fixture().withLibraries(SqlLibrary.STANDARD, SqlLibrary.MYSQL, SqlLibrary.POSTGRESQL);
-    f.checkScalar("substr('a', 1, 2)", "a", "VARCHAR(1) NOT NULL");
+    f.checkScalar("substr('a', 1, 2)", "a", "VARCHAR(1)");
   }
 
   /** Test case for
@@ -4765,38 +4760,49 @@ public class SqlOperatorTest {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.OVERLAY, VmName.EXPAND);
     f.checkString("overlay('ABCdef' placing 'abc' from 1)",
-        "abcdef", "VARCHAR(9) NOT NULL");
+        "abcdef", "VARCHAR(9)");
     f.checkString("overlay('ABCdef' placing 'abc' from 1 for 2)",
-        "abcCdef", "VARCHAR(9) NOT NULL");
+        "abcCdef", "VARCHAR(9)");
     f.checkString("overlay(cast('ABCdef' as varchar(10)) placing "
             + "cast('abc' as char(5)) from 1 for 2)",
-        "abc  Cdef", "VARCHAR(15) NOT NULL");
+        "abc  Cdef", "VARCHAR(15)");
     f.checkString("overlay(cast('ABCdef' as char(10)) placing "
             + "cast('abc' as char(5)) from 1 for 2)",
         "abc  Cdef    ",
-        "VARCHAR(15) NOT NULL");
+        "VARCHAR(15)");
     f.checkNull("overlay('ABCdef' placing 'abc'"
         + " from 1 for cast(null as integer))");
     f.checkNull("overlay(cast(null as varchar(1)) placing 'abc' from 1)");
 
     f.checkString("overlay(x'ABCdef' placing x'abcd' from 1)",
-        "abcdef", "VARBINARY(5) NOT NULL");
+        "abcdef", "VARBINARY(5)");
     f.checkString("overlay(x'ABCDEF1234' placing x'2345' from 1 for 2)",
-        "2345ef1234", "VARBINARY(7) NOT NULL");
+        "2345ef1234", "VARBINARY(7)");
     if (f.brokenTestsEnabled()) {
       f.checkString("overlay(cast(x'ABCdef' as varbinary(5)) placing "
               + "cast(x'abcd' as binary(3)) from 1 for 2)",
-          "abc  Cdef", "VARBINARY(8) NOT NULL");
+          "abc  Cdef", "VARBINARY(8)");
     }
     if (f.brokenTestsEnabled()) {
       f.checkString("overlay(cast(x'ABCdef' as binary(5)) placing "
               + "cast(x'abcd' as binary(3)) from 1 for 2)",
-          "abc  Cdef    ", "VARBINARY(8) NOT NULL");
+          "abc  Cdef    ", "VARBINARY(8)");
     }
     f.checkNull("overlay(x'ABCdef' placing x'abcd'"
         + " from 1 for cast(null as integer))");
     f.checkNull("overlay(cast(null as varbinary(1)) placing x'abcd' from 1)");
     f.checkNull("overlay(x'abcd' placing x'abcd' from cast(null as integer))");
+
+    final Consumer<SqlOperatorFixture> consumerOracle = f1 -> {
+      f.checkString("overlay('  ' placing '' from 1 for 1)",
+          " ", "VARCHAR(2)");
+      f1.checkNull("overlay(cast(null as varchar(1)) placing 'abc' from 1)");
+      f1.checkNull("overlay('A' placing '' from 1 for 1)");
+      f1.checkNull("overlay('abc' placing '' from 1 for 3)");
+    };
+    final List<SqlConformanceEnum> oracleConformanceEnums =
+            list(SqlConformanceEnum.ORACLE_10, SqlConformanceEnum.ORACLE_12);
+    f.forEachConformance(oracleConformanceEnums, consumerOracle);
   }
 
   @Test void testPositionFunc() {
@@ -4838,10 +4844,8 @@ public class SqlOperatorTest {
     final SqlOperatorFixture f = fixture();
     checkReplaceFunc(f);
     // case-sensitive
-    f.checkString("REPLACE('ciAao', 'a', 'ciao')", "ciAciaoo",
-        "VARCHAR NOT NULL");
-    f.checkString("REPLACE('ciAao', 'A', 'ciao')", "ciciaoao",
-        "VARCHAR NOT NULL");
+    f.checkString("REPLACE('ciAao', 'a', 'ciao')", "ciAciaoo", "VARCHAR");
+    f.checkString("REPLACE('ciAao', 'A', 'ciao')", "ciciaoao", "VARCHAR");
   }
 
   /** Test case for
@@ -4853,24 +4857,29 @@ public class SqlOperatorTest {
     checkReplaceFunc(f);
     // case-insensitive
     SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.SQL_SERVER_2008);
-    f1.checkString("REPLACE('ciAao', 'a', 'ciao')", "ciciaociaoo",
-        "VARCHAR NOT NULL");
-    f1.checkString("REPLACE('ciAao', 'A', 'ciao')", "ciciaociaoo",
-        "VARCHAR NOT NULL");
+    f1.checkString("REPLACE('ciAao', 'a', 'ciao')", "ciciaociaoo", "VARCHAR");
+    f1.checkString("REPLACE('ciAao', 'A', 'ciao')", "ciciaociaoo", "VARCHAR");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-815">[CALCITE-815]
+   * Add an option to allow empty strings to represent null values</a>. */
+  @Test void testReplaceFuncEmptyIsNull() {
+    final SqlOperatorFixture f = fixture().withConformance(SqlConformanceEnum.ORACLE_12);
+    f.checkNull("REPLACE('ciao', 'ciao', '')");
+    f.checkNull("REPLACE('', 'ci', 'ciao')");
+    f.checkString("REPLACE('hello world', 'o', '')", "hell wrld", "VARCHAR");
+    f.checkString("REPLACE('ci ao', ' ', 'ciao')", "ciciaoao", "VARCHAR");
+    f.checkNull("REPLACE(cast(null as varchar(5)), 'ciao', '')");
   }
 
   private static void checkReplaceFunc(SqlOperatorFixture f) {
     f.setFor(SqlStdOperatorTable.REPLACE, VmName.EXPAND);
-    f.checkString("REPLACE('ciao', 'ciao', '')", "",
-        "VARCHAR NOT NULL");
-    f.checkString("REPLACE('ciao', '', 'ciao')", "ciao",
-        "VARCHAR NOT NULL");
-    f.checkString("REPLACE('ci ao', ' ', 'ciao')", "ciciaoao",
-        "VARCHAR NOT NULL");
-    f.checkString("REPLACE('', 'ciao', 'ciao')", "",
-        "VARCHAR NOT NULL");
-    f.checkString("REPLACE('hello world', 'o', '')", "hell wrld",
-        "VARCHAR NOT NULL");
+    f.checkString("REPLACE('ciao', 'ciao', '')", "", "VARCHAR");
+    f.checkString("REPLACE('ciao', '', 'ciao')", "ciao", "VARCHAR");
+    f.checkString("REPLACE('ci ao', ' ', 'ciao')", "ciciaoao", "VARCHAR");
+    f.checkString("REPLACE('', 'ciao', 'ciao')", "", "VARCHAR");
+    f.checkString("REPLACE('hello world', 'o', '')", "hell wrld", "VARCHAR");
     f.checkNull("REPLACE(cast(null as varchar(5)), 'ciao', '')");
     f.checkNull("REPLACE('ciao', cast(null as varchar(3)), 'zz')");
     f.checkNull("REPLACE('ciao', 'bella', cast(null as varchar(3)))");
@@ -6202,11 +6211,16 @@ public class SqlOperatorTest {
   @Test void testUpperFunc() {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.UPPER, VmName.EXPAND);
-    f.checkString("upper('a')", "A", "CHAR(1) NOT NULL");
-    f.checkString("upper('A')", "A", "CHAR(1) NOT NULL");
-    f.checkString("upper('1')", "1", "CHAR(1) NOT NULL");
-    f.checkString("upper('aa')", "AA", "CHAR(2) NOT NULL");
+    f.checkString("upper('a')", "A", "CHAR(1)");
+    f.checkString("upper('A')", "A", "CHAR(1)");
+    f.checkString("upper('1')", "1", "CHAR(1)");
+    f.checkString("upper('aa')", "AA", "CHAR(2)");
     f.checkNull("upper(cast(null as varchar(1)))");
+
+    final SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.ORACLE_12);
+    f1.checkNull("upper('')");
+    f1.checkString("upper('a')", "A", "CHAR(1)");
+    f.checkString("upper('  ')", "  ", "CHAR(2)");
   }
 
   @Test void testLeftFunc() {
@@ -7537,11 +7551,16 @@ public class SqlOperatorTest {
     f.setFor(SqlStdOperatorTable.LOWER, VmName.EXPAND);
 
     // SQL:2003 6.29.8 The type of lower is the type of its argument
-    f.checkString("lower('A')", "a", "CHAR(1) NOT NULL");
-    f.checkString("lower('a')", "a", "CHAR(1) NOT NULL");
-    f.checkString("lower('1')", "1", "CHAR(1) NOT NULL");
-    f.checkString("lower('AA')", "aa", "CHAR(2) NOT NULL");
+    f.checkString("lower('A')", "a", "CHAR(1)");
+    f.checkString("lower('a')", "a", "CHAR(1)");
+    f.checkString("lower('1')", "1", "CHAR(1)");
+    f.checkString("lower('AA')", "aa", "CHAR(2)");
     f.checkNull("lower(cast(null as varchar(1)))");
+
+    final SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.ORACLE_12);
+    f1.checkNull("lower('')");
+    f1.checkString("lower('A')", "a", "CHAR(1)");
+    f.checkString("lower('  ')", "  ", "CHAR(2)");
   }
 
   @Test void testInitcapFunc() {
@@ -7551,12 +7570,10 @@ public class SqlOperatorTest {
     final SqlOperatorFixture f = fixture();
     f.setFor(SqlStdOperatorTable.INITCAP);
 
-    f.checkString("initcap('aA')", "Aa", "CHAR(2) NOT NULL");
-    f.checkString("initcap('Aa')", "Aa", "CHAR(2) NOT NULL");
-    f.checkString("initcap('1a')", "1a", "CHAR(2) NOT NULL");
-    f.checkString("initcap('ab cd Ef 12')",
-        "Ab Cd Ef 12",
-        "CHAR(11) NOT NULL");
+    f.checkString("initcap('aA')", "Aa", "CHAR(2)");
+    f.checkString("initcap('Aa')", "Aa", "CHAR(2)");
+    f.checkString("initcap('1a')", "1a", "CHAR(2)");
+    f.checkString("initcap('ab cd Ef 12')", "Ab Cd Ef 12", "CHAR(11)");
     f.checkNull("initcap(cast(null as varchar(1)))");
 
     // dtbug 232
@@ -7567,6 +7584,10 @@ public class SqlOperatorTest {
                 + "'INITCAP\\(<CHARACTER>\\)'",
             false);
     f.checkType("initcap(cast(null as date))", "VARCHAR");
+
+    final SqlOperatorFixture f1 = f.withConformance(SqlConformanceEnum.ORACLE_12);
+    f1.checkNull("initcap('')");
+    f.checkString("initcap('  ')", "  ", "CHAR(2)");
   }
 
   @Test void testPowerFunc() {
@@ -11479,13 +11500,13 @@ public class SqlOperatorTest {
   @Test void testIndexOutOfBounds() {
     final SqlOperatorFixture f = fixture();
     f.checkScalar("substring('abc' from 2 for 2147483650)",
-        "bc", "VARCHAR(3) NOT NULL");
+        "bc", "VARCHAR(3)");
     f.checkScalar("substring('abc' from 2147483650)",
-        "", "VARCHAR(3) NOT NULL");
+        "", "VARCHAR(3)");
     f.checkScalar("substring('abc' from 2147483650 for 2147483650)",
-        "", "VARCHAR(3) NOT NULL");
+        "", "VARCHAR(3)");
     f.checkScalar("substring('abc' from 2147483650 for 2)",
-        "", "VARCHAR(3) NOT NULL");
+        "", "VARCHAR(3)");
     f.checkFails("^substring('abc' from 2 for 2147483650.0)^",
         "Cannot apply 'SUBSTRING' to arguments of type "
             + "'SUBSTRING\\(<CHAR\\(3\\)> FROM <INTEGER> FOR <DECIMAL\\(11, 1\\)>\\)'\\. "
@@ -11517,35 +11538,35 @@ public class SqlOperatorTest {
     f.setFor(SqlStdOperatorTable.SUBSTRING);
     f.checkScalar(
         String.format(Locale.ROOT, "{fn SUBSTRING('abcdef', %d)}", Integer.MIN_VALUE),
-        "abcdef", "VARCHAR(6) NOT NULL");
+        "abcdef", "VARCHAR(6)");
 
     f.checkScalar(
         String.format(Locale.ROOT, "{fn SUBSTRING('abcdef', %d, %d)}", Integer.MIN_VALUE,
-            Integer.MAX_VALUE + 10L), "abcdef", "VARCHAR(6) NOT NULL");
+            Integer.MAX_VALUE + 10L), "abcdef", "VARCHAR(6)");
 
     f.checkScalar(
         String.format(Locale.ROOT, "{fn SUBSTRING('abcdef', CAST(%d AS BIGINT))}",
-            Integer.MIN_VALUE), "abcdef", "VARCHAR(6) NOT NULL");
+            Integer.MIN_VALUE), "abcdef", "VARCHAR(6)");
   }
 
   private static void checkSubstringFunction(SqlOperatorFixture f) {
     f.setFor(SqlStdOperatorTable.SUBSTRING);
     f.checkString("substring('abc' from 1 for 2)",
-        "ab", "VARCHAR(3) NOT NULL");
+        "ab", "VARCHAR(3)");
     f.checkString("substring(x'aabbcc' from 1 for 2)",
-        "aabb", "VARBINARY(3) NOT NULL");
+        "aabb", "VARBINARY(3)");
     f.checkString("substring('abc' from 2 for 2147483646)",
-        "bc", "VARCHAR(3) NOT NULL");
+        "bc", "VARCHAR(3)");
     f.checkString(
         String.format(Locale.ROOT, "substring('string', CAST(%d AS TINYINT), %d)",
-        Byte.MIN_VALUE, Byte.MAX_VALUE + 10), "string", "VARCHAR(6) NOT NULL");
+        Byte.MIN_VALUE, Byte.MAX_VALUE + 10), "string", "VARCHAR(6)");
 
     switch (f.conformance().semantics()) {
     case BIG_QUERY:
       f.checkString("substring('abc' from 1 for -1)", "",
-          "VARCHAR(3) NOT NULL");
+          "VARCHAR(3)");
       f.checkString("substring(x'aabbcc' from 1 for -1)", "",
-          "VARBINARY(3) NOT NULL");
+          "VARBINARY(3)");
       break;
     default:
       f.checkFails(
@@ -11829,7 +11850,7 @@ public class SqlOperatorTest {
         if (binary) {
           expected = DOUBLER.apply(expected);
         }
-        f.checkString(expression, expected, type + NON_NULLABLE_SUFFIX);
+        f.checkString(expression, expected, type);
       }
     }
   }
@@ -11938,12 +11959,12 @@ public class SqlOperatorTest {
     f.setFor(SqlStdOperatorTable.TRIM, VmName.EXPAND);
 
     // SQL:2003 6.29.11 Trimming a CHAR yields a VARCHAR
-    f.checkString("trim('a' from 'aAa')", "A", "VARCHAR(3) NOT NULL");
-    f.checkString("trim(both 'a' from 'aAa')", "A", "VARCHAR(3) NOT NULL");
-    f.checkString("trim(' aAa ')", "aAa", "VARCHAR(5) NOT NULL");
-    f.checkString("trim(both ' ' from ' aAa ')", "aAa", "VARCHAR(5) NOT NULL");
-    f.checkString("trim(leading 'a' from 'aAa')", "Aa", "VARCHAR(3) NOT NULL");
-    f.checkString("trim(trailing 'a' from 'aAa')", "aA", "VARCHAR(3) NOT NULL");
+    f.checkString("trim('a' from 'aAa')", "A", "VARCHAR(3)");
+    f.checkString("trim(both 'a' from 'aAa')", "A", "VARCHAR(3)");
+    f.checkString("trim(' aAa ')", "aAa", "VARCHAR(5)");
+    f.checkString("trim(both ' ' from ' aAa ')", "aAa", "VARCHAR(5)");
+    f.checkString("trim(leading 'a' from 'aAa')", "Aa", "VARCHAR(3)");
+    f.checkString("trim(trailing 'a' from 'aAa')", "aA", "VARCHAR(3)");
     f.checkNull("trim(null)");
     f.checkNull("trim(cast(null as varchar(1)) from 'a')");
     f.checkNull("trim('a' from cast(null as varchar(1)))");
@@ -11961,14 +11982,24 @@ public class SqlOperatorTest {
 
     final Consumer<SqlOperatorFixture> consumer = f1 -> {
       f1.checkString("trim(leading 'eh' from 'hehe__hehe')", "__hehe",
-          "VARCHAR(10) NOT NULL");
+          "VARCHAR(10)");
       f1.checkString("trim(trailing 'eh' from 'hehe__hehe')", "hehe__",
-          "VARCHAR(10) NOT NULL");
-      f1.checkString("trim('eh' from 'hehe__hehe')", "__", "VARCHAR(10) NOT NULL");
+          "VARCHAR(10)");
+      f1.checkString("trim('eh' from 'hehe__hehe')", "__", "VARCHAR(10)");
     };
     final List<SqlConformanceEnum> conformanceEnums =
         list(SqlConformanceEnum.MYSQL_5, SqlConformanceEnum.SQL_SERVER_2008);
     f.forEachConformance(conformanceEnums, consumer);
+
+    final Consumer<SqlOperatorFixture> consumerOracle = f1 -> {
+      f1.checkNull("trim(null)");
+      f1.checkNull("trim('  ')");
+      f1.checkNull("trim('a' from 'a')");
+      f1.checkNull("trim('A' from 'AAA')");
+    };
+    final List<SqlConformanceEnum> oracleConformanceEnums =
+            list(SqlConformanceEnum.ORACLE_10, SqlConformanceEnum.ORACLE_12);
+    f.forEachConformance(oracleConformanceEnums, consumerOracle);
   }
 
   @Test void testRtrimFunc() {
@@ -11978,13 +12009,20 @@ public class SqlOperatorTest {
         "No match found for function signature RTRIM\\(<CHARACTER>\\)",
         false);
     final Consumer<SqlOperatorFixture> consumer = f -> {
-      f.checkString("rtrim(' aAa  ')", " aAa", "VARCHAR(6) NOT NULL");
+      f.checkString("rtrim(' aAa  ')", " aAa", "VARCHAR(6)");
       f.checkNull("rtrim(CAST(NULL AS VARCHAR(6)))");
     };
     final List<SqlLibrary> libraries =
         list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE, SqlLibrary.POSTGRESQL,
             SqlLibrary.REDSHIFT, SqlLibrary.SPARK, SqlLibrary.HIVE);
     f0.forEachLibrary(libraries, consumer);
+
+    final SqlOperatorFixture f1 = f0.withConformance(SqlConformanceEnum.ORACLE_12);
+    final Consumer<SqlOperatorFixture> consumerOracle = f2 -> {
+      f2.checkNull("rtrim(null)");
+      f2.checkNull("rtrim('  ')");
+    };
+    f1.forEachLibrary(libraries, consumerOracle);
   }
 
   @Test void testLtrimFunc() {
@@ -11994,13 +12032,20 @@ public class SqlOperatorTest {
         "No match found for function signature LTRIM\\(<CHARACTER>\\)",
         false);
     final Consumer<SqlOperatorFixture> consumer = f -> {
-      f.checkString("ltrim(' aAa  ')", "aAa  ", "VARCHAR(6) NOT NULL");
+      f.checkString("ltrim(' aAa  ')", "aAa  ", "VARCHAR(6)");
       f.checkNull("ltrim(CAST(NULL AS VARCHAR(6)))");
     };
     final List<SqlLibrary> libraries =
         list(SqlLibrary.BIG_QUERY, SqlLibrary.ORACLE, SqlLibrary.POSTGRESQL,
             SqlLibrary.REDSHIFT, SqlLibrary.SPARK, SqlLibrary.HIVE);
     f0.forEachLibrary(libraries, consumer);
+
+    final SqlOperatorFixture f1 = f0.withConformance(SqlConformanceEnum.ORACLE_12);
+    final Consumer<SqlOperatorFixture> consumerOracle = f2 -> {
+      f2.checkNull("rtrim(null)");
+      f2.checkNull("rtrim('  ')");
+    };
+    f1.forEachLibrary(libraries, consumerOracle);
   }
 
   @Test void testGreatestFunc() {


### PR DESCRIPTION
The following functions will return null if the result is an empty string under Oracle semantics:
- concat (||), UPPER, LOWER, TRIM, OVERLAY, SUBSTRING, INITCAP, REPLACE
- JDBC functions: INSERT, LCASE, UCASE