### PR TITLE
[CALCITE-7089]Implement a rule for converting a RIGHT JOIN to a LEFT JOIN

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/CoreRules.java
@@ -913,6 +913,10 @@ public class CoreRules {
       ReduceExpressionsRule.WindowReduceExpressionsRule.WindowReduceExpressionsRuleConfig
           .DEFAULT.toRule();
 
+  /** Rule that converts a RIGHT join {@link Join} into a LEFT join by swapping inputs. */
+  public static final RightToLeftJoinRule RIGHT_TO_LEFT_JOIN_RULE =
+      RightToLeftJoinRule.Config.DEFAULT.toRule();
+
   /** Rule that flattens a tree of {@link LogicalJoin}s
    * into a single {@link HyperGraph} with N inputs. */
   @Experimental

--- a/core/src/main/java/org/apache/calcite/rel/rules/RightToLeftJoinRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/RightToLeftJoinRule.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.tools.RelBuilder;
+import org.immutables.value.Value;
+
+/**
+ * Planner rule that matches a {@link Join} whose join type is RIGHT,
+ * and converts it to a LEFT join by swapping the inputs and join type.
+ *
+ * <p>This transformation is useful because many optimization rules and
+ * implementations are written to handle LEFT joins, and RIGHT joins can
+ * often be handled by converting them to LEFT joins with swapped inputs.
+ *
+ * <p>For example, the following SQL:
+ *
+ * <pre>{@code
+ * SELECT *
+ * FROM Employees e
+ * RIGHT JOIN Departments d ON e.deptno = d.deptno
+ * }</pre>
+ *
+ * <p>is transformed into:
+ *
+ * <pre>{@code
+ * SELECT *
+ * FROM Departments d
+ * LEFT JOIN Employees e ON e.deptno = d.deptno
+ * }</pre>
+ *
+ * <p>This rule uses {@link JoinCommuteRule#swap} to perform the input swap and
+ * join type conversion. The transformation preserves the semantics of the original
+ * RIGHT join.
+ *
+ * <p>Limitations:
+ * <ul>
+ *   <li>Only applies to joins of type {@link JoinRelType#RIGHT}.</li>
+ *   <li>Does not match FULL, LEFT, INNER, SEMI, or ANTI joins.</li>
+ *   <li>Column order in the output may be affected by the swap; a projection is used to restore the original order if needed.</li>
+ * </ul>
+ *
+ * <p>See also:
+ * <ul>
+ *   <li>{@link JoinCommuteRule} - for general join input permutation</li>
+ *   <li>{@link CoreRules#RIGHT_TO_LEFT_JOIN_RULE} - the public rule instance</li>
+ * </ul>
+ *
+ * @see JoinCommuteRule
+ * @see JoinRelType#RIGHT
+ * @see CoreRules#RIGHT_TO_LEFT_JOIN_RULE
+ */
+@Value.Enclosing
+public class RightToLeftJoinRule
+    extends RelRule<RightToLeftJoinRule.Config>
+    implements TransformationRule {
+
+  /** Creates a RightToLeftJoinRule. */
+  protected RightToLeftJoinRule(Config config) {
+    super(config);
+  }
+
+  @Override public void onMatch(RelOptRuleCall call) {
+    final Join join = call.rel(0);
+    RelBuilder relBuilder = call.builder();
+    RelNode swapped = JoinCommuteRule.swap(join, true, relBuilder);
+    if (swapped != null) {
+      call.transformTo(swapped);
+    }
+  }
+
+  /** Rule configuration. */
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    Config DEFAULT = ImmutableRightToLeftJoinRule.Config.of()
+        .withOperandFor(Join.class);
+
+    @Override default RightToLeftJoinRule toRule() {
+      return new RightToLeftJoinRule(this);
+    }
+
+    /** Defines an operand tree for the given classes. */
+    default Config withOperandFor(Class<? extends Join> joinClass) {
+      return withOperandSupplier(b -> b.operand(joinClass)
+          .predicate(join -> join.getJoinType() == JoinRelType.RIGHT)
+          .anyInputs())
+          .as(Config.class);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -11087,4 +11087,21 @@ class RelOptRulesTest extends RelOptTestBase {
         .withRule(CoreRules.FULL_TO_LEFT_AND_RIGHT_JOIN)
         .checkUnchanged();
   }
+
+  @Test void testRightToLeftJoinRule() {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .scan("DEPT")
+        .join(JoinRelType.RIGHT,
+            b.equals(b.field(2, 0, "DEPTNO"), b.field(2, 1, "DEPTNO")))
+        .build();
+  
+    HepProgram program = new HepProgramBuilder()
+        .addMatchLimit(1)
+        .addRuleInstance(org.apache.calcite.rel.rules.RightToLeftJoinRule.Config.DEFAULT.toRule())
+        .build();
+    HepPlanner hepPlanner = new HepPlanner(program);
+  
+    relFn(relFn).withPlanner(hepPlanner).check();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -20489,4 +20489,21 @@ LogicalValues(tuples=[[{ 1, 'a' }, { 2, 'b' }, { 1, 'b' }]])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testRightToLeftJoinRule">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($7, $8)], joinType=[right])
+  LogicalTableScan(table=[[scott, EMP]])
+  LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$3], ENAME=[$4], JOB=[$5], MGR=[$6], HIREDATE=[$7], SAL=[$8], COMM=[$9], DEPTNO=[$10], DEPTNO0=[$0], DNAME=[$1], LOC=[$2])
+  LogicalJoin(condition=[=($10, $0)], joinType=[left])
+    LogicalTableScan(table=[[scott, DEPT]])
+    LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
 </Root>


### PR DESCRIPTION
This is because SQLite versions before 3.39.0 do not support RIGHT/FULL JOIN. Currently, the rule for converting FULL JOIN to LEFT + RIGHT JOIN has been implemented. There is a lack of a rule for converting RIGHT JOIN to LEFT JOIN (which may also be used in other scenarios). This rule can be implemented with the help of the static method in JoinCommuteRule. The reason for not using JoinCommuteRule directly is that it supports both LEFT JOIN to RIGHT JOIN and RIGHT JOIN to LEFTJOIN, and there is no way to control only RIGHT JOIN to LEFT JOIN.