### PR TITLE
[CALCITE-7103] Invalid unparse for named expression in HiveDialect and SparkDialect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HiveSqlDialect.java
@@ -67,10 +67,6 @@ public class HiveSqlDialect extends SqlDialect {
             && context.databaseMinorVersion() < 1);
   }
 
-  @Override protected boolean allowsAs() {
-    return false;
-  }
-
   @Override public boolean requiresAliasForFromItems() {
     return true;
   }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -66,10 +66,6 @@ public class SparkSqlDialect extends SqlDialect {
     super(context);
   }
 
-  @Override protected boolean allowsAs() {
-    return false;
-  }
-
   @Override public boolean supportsCharSet() {
     return false;
   }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2355,6 +2355,21 @@ class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7103">[CALCITE-7103]
+   * Keep ALLOWS_AS in Hive and Spark SqlDialects. */
+  @Test void testAs() {
+    final String query = "select substring(\"brand_name\" from 2) as name "
+        + "from \"product\"\n";
+    final String hiveExpected = "SELECT SUBSTRING(`brand_name`, 2) AS `NAME`\n"
+        + "FROM `foodmart`.`product`";
+    final String sparkExpected = "SELECT SUBSTRING(`brand_name`, 2) AS `NAME`\n"
+        + "FROM `foodmart`.`product`";
+    sql(query)
+        .withHive().ok(hiveExpected)
+        .withSpark().ok(sparkExpected);
+  }
+
   @Test void testSelectQueryWithOrderByClause1() {
     String query =
         "select \"product_id\", \"net_weight\" from \"product\" order by \"net_weight\"";


### PR DESCRIPTION
In Hive and Spark engines, the AS syntax is supported. [https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select.html](http://example.com/)

<img width="671" height="114" alt="image" src="https://github.com/user-attachments/assets/3cb20c0e-42fd-4024-92ab-dd32e8af5597" />


However, currently, the Hive and Spark dialects will remove the AS during parsing.

<img width="717" height="294" alt="image" src="https://github.com/user-attachments/assets/6c2db68b-d4a6-4553-a13d-ecf794e38ae2" />


Therefore, we should set the default value of the method:

<img width="607" height="118" alt="image" src="https://github.com/user-attachments/assets/4c3e4b74-a645-444c-a191-727374342b17" />


to true in their respective dialects.
