### PR TITLE
[CALCITE-7141] Add missing getter to FunctionSqlType

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
@@ -29,20 +29,20 @@ import static java.util.Objects.requireNonNull;
  * <p>The type of lambda expression can be represented by a function type.
  */
 public class FunctionSqlType extends AbstractSqlType {
-  private final RelDataType parameterType;
+  private final RelDataType parameterTypes;
   private final RelDataType returnType;
 
   /**
    * Constructs a new function SQL type. This should only be called from a factory method.
    *
-   * @param parameterType a struct type wrapping function's input parameter types.
+   * @param parameterTypes a struct type wrapping function's input parameter types.
    * @param returnType function's return type.
    */
   public FunctionSqlType(
-      RelDataType parameterType, RelDataType returnType) {
+      RelDataType parameterTypes, RelDataType returnType) {
     super(SqlTypeName.FUNCTION, true, null);
-    this.parameterType = requireNonNull(parameterType, "parameterType");
-    if (!parameterType.isStruct()) {
+    this.parameterTypes = requireNonNull(parameterTypes, "parameterTypes");
+    if (!parameterTypes.isStruct()) {
       throw new IllegalArgumentException("ParameterType must be a struct");
     }
     this.returnType = requireNonNull(returnType, "returnType");
@@ -52,7 +52,7 @@ public class FunctionSqlType extends AbstractSqlType {
   @Override protected void generateTypeString(StringBuilder sb, boolean withDetail) {
     sb.append("Function");
     sb.append("(");
-    for (Ord<RelDataTypeField> ord : Ord.zip(parameterType.getFieldList())) {
+    for (Ord<RelDataTypeField> ord : Ord.zip(parameterTypes.getFieldList())) {
       if (ord.i > 0) {
         sb.append(", ");
       }
@@ -69,12 +69,12 @@ public class FunctionSqlType extends AbstractSqlType {
   }
 
   /**
-   * Returns the parameter type of the function.
+   * Returns the parameter types of the function.
    *
    * @return a struct wrapping function's parameter types.
    */
-  public RelDataType getParameterType() {
-    return parameterType;
+  public RelDataType getParameterTypes() {
+    return parameterTypes;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
@@ -59,7 +59,7 @@ public class FunctionSqlType extends AbstractSqlType {
   }
 
   public RelDataType getParameterType() {
-    return parameterTypeType;
+    return parameterType;
   }
 
   public RelDataType getReturnType() {

--- a/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
@@ -43,7 +43,7 @@ public class FunctionSqlType extends AbstractSqlType {
     super(SqlTypeName.FUNCTION, true, null);
     this.parameterType = requireNonNull(parameterType, "parameterType");
     if (!parameterType.isStruct()) {
-      throw new IllegalArgumentException("parameterType must be a struct");
+      throw new IllegalArgumentException("ParameterType must be a struct");
     }
     this.returnType = requireNonNull(returnType, "returnType");
     computeDigest();

--- a/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
@@ -32,6 +32,12 @@ public class FunctionSqlType extends AbstractSqlType {
   private final RelDataType parameterType;
   private final RelDataType returnType;
 
+  /**
+   * Constructs a new function SQL type. This should only be called from a factory method.
+   *
+   * @param parameterType a struct type wrapping function's input parameter types.
+   * @param returnType function's return type.
+   */
   public FunctionSqlType(
       RelDataType parameterType, RelDataType returnType) {
     super(SqlTypeName.FUNCTION, true, null);
@@ -62,10 +68,20 @@ public class FunctionSqlType extends AbstractSqlType {
     return this;
   }
 
+  /**
+   * Returns the parameter type of the function.
+   *
+   * @return a struct wrapping function's parameter types.
+   */
   public RelDataType getParameterType() {
     return parameterType;
   }
 
+  /**
+   * Returns the return type of the function.
+   *
+   * @return the function's return type.
+   */
   public RelDataType getReturnType() {
     return returnType;
   }

--- a/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
@@ -58,6 +58,10 @@ public class FunctionSqlType extends AbstractSqlType {
     return this;
   }
 
+  public RelDataType getParameterType() {
+    return parameterTypeType;
+  }
+
   public RelDataType getReturnType() {
     return returnType;
   }

--- a/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
@@ -25,7 +25,8 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Function type.
- * The type of lambda expression can be represented by a function type.
+ *
+ * <p>The type of lambda expression can be represented by a function type.
  */
 public class FunctionSqlType extends AbstractSqlType {
   private final RelDataType parameterType;
@@ -36,7 +37,7 @@ public class FunctionSqlType extends AbstractSqlType {
     super(SqlTypeName.FUNCTION, true, null);
     this.parameterType = requireNonNull(parameterType, "parameterType");
     if (!parameterType.isStruct()) {
-      throw new IllegalArgumentException("paramType must be a struct");
+      throw new IllegalArgumentException("parameterType must be a struct");
     }
     this.returnType = requireNonNull(returnType, "returnType");
     computeDigest();

--- a/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FunctionSqlType.java
@@ -35,6 +35,9 @@ public class FunctionSqlType extends AbstractSqlType {
       RelDataType parameterType, RelDataType returnType) {
     super(SqlTypeName.FUNCTION, true, null);
     this.parameterType = requireNonNull(parameterType, "parameterType");
+    if (!parameterType.isStruct()) {
+      throw new IllegalArgumentException("paramType must be a struct");
+    }
     this.returnType = requireNonNull(returnType, "returnType");
     computeDigest();
   }

--- a/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
@@ -46,13 +46,13 @@ public class FunctionSqlTypeTest {
   @Test void testFailsOnNullParameterType() {
     assertThrows(NullPointerException.class, () -> {
       new FunctionSqlType(null, returnType);
-    });
+    }, "parameterType");
   }
 
   @Test void testFailsOnNonStructParameterType() {
     assertThrows(IllegalArgumentException.class, () -> {
       new FunctionSqlType(nonStructParameterType, returnType);
-    });
+    }, "ParameterType must be a struct");
   }
 
   @Test void testFailsOnNullReturnType() {

--- a/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
@@ -34,14 +34,14 @@ public class FunctionSqlTypeTest {
   final RelDataTypeFactory sqlTypeFactory =
       new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
 
-  final RelDataType parameterType =
+  final RelDataType parameterTypes =
       sqlTypeFactory.createStructType(
           ImmutableList.of(sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN)),
           ImmutableList.of("field1"));
-  final RelDataType nonStructParameterType = sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN);
+  final RelDataType nonStructParameterTypes = sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN);
   final RelDataType returnType = sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN);
   final FunctionSqlType functionSqlType =
-      new FunctionSqlType(parameterType, returnType);
+      new FunctionSqlType(parameterTypes, returnType);
 
   @Test void testFailsOnNullParameterType() {
     assertThrows(NullPointerException.class, () -> {
@@ -49,20 +49,20 @@ public class FunctionSqlTypeTest {
     }, "parameterType");
   }
 
-  @Test void testFailsOnNonStructParameterType() {
+  @Test void testFailsOnNonStructParameterTypes() {
     assertThrows(IllegalArgumentException.class, () -> {
-      new FunctionSqlType(nonStructParameterType, returnType);
+      new FunctionSqlType(nonStructParameterTypes, returnType);
     }, "ParameterType must be a struct");
   }
 
   @Test void testFailsOnNullReturnType() {
     assertThrows(NullPointerException.class, () -> {
-      new FunctionSqlType(parameterType, null);
+      new FunctionSqlType(parameterTypes, null);
     });
   }
 
-  @Test void testGetParameterType() {
-    assertEquals(parameterType, functionSqlType.getParameterType());
+  @Test void testGetParameterTypes() {
+    assertEquals(parameterTypes, functionSqlType.getParameterTypes());
   }
 
   @Test void testGetReturnType() {

--- a/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link FunctionSqlType}.
+ */
+public class FunctionSqlTypeTest {
+  final RelDataTypeFactory sqlTypeFactory =
+      new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+
+  final RelDataType parameterType =
+      sqlTypeFactory.createStructType(
+          ImmutableList.of(sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN)),
+          ImmutableList.of("field1"));
+  final RelDataType returnType = sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN);
+  final FunctionSqlType functionSqlType =
+      new FunctionSqlType(parameterType, returnType);
+
+  @Test void testGetParamType() {
+    assertEquals(parameterType, functionSqlType.getParameterType());
+  }
+
+  @Test void testGetReturnType() {
+    assertEquals(returnType, functionSqlType.getReturnType());
+  }
+
+}

--- a/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/FunctionSqlTypeTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link FunctionSqlType}.
@@ -37,11 +38,30 @@ public class FunctionSqlTypeTest {
       sqlTypeFactory.createStructType(
           ImmutableList.of(sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN)),
           ImmutableList.of("field1"));
+  final RelDataType nonStructParameterType = sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN);
   final RelDataType returnType = sqlTypeFactory.createSqlType(SqlTypeName.BOOLEAN);
   final FunctionSqlType functionSqlType =
       new FunctionSqlType(parameterType, returnType);
 
-  @Test void testGetParamType() {
+  @Test void testFailsOnNullParameterType() {
+    assertThrows(NullPointerException.class, () -> {
+      new FunctionSqlType(null, returnType);
+    });
+  }
+
+  @Test void testFailsOnNonStructParameterType() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      new FunctionSqlType(nonStructParameterType, returnType);
+    });
+  }
+
+  @Test void testFailsOnNullReturnType() {
+    assertThrows(NullPointerException.class, () -> {
+      new FunctionSqlType(parameterType, null);
+    });
+  }
+
+  @Test void testGetParameterType() {
     assertEquals(parameterType, functionSqlType.getParameterType());
   }
 


### PR DESCRIPTION
`FunctionSqlType` misses a getter for `parameterType`. This PR adds it.