### PR TITLE
[CALCITE-7147] Comparison of INTEGER and BOOLEAN produces strange results

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
@@ -346,12 +346,12 @@ public class TypeCoercionImpl extends AbstractTypeCoercion {
       // Case1: numeric literal and boolean
       if (lNode.getKind() == SqlKind.LITERAL) {
         BigDecimal val = ((SqlLiteral) lNode).getValueAs(BigDecimal.class);
-        if (val.compareTo(BigDecimal.ONE) == 0) {
-          SqlNode lNode1 = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
+        if (val.compareTo(BigDecimal.ZERO) == 0) {
+          SqlNode lNode1 = SqlLiteral.createBoolean(false, SqlParserPos.ZERO);
           binding.getCall().setOperand(0, lNode1);
           return true;
         } else {
-          SqlNode lNode1 = SqlLiteral.createBoolean(false, SqlParserPos.ZERO);
+          SqlNode lNode1 = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
           binding.getCall().setOperand(0, lNode1);
           return true;
         }
@@ -366,12 +366,12 @@ public class TypeCoercionImpl extends AbstractTypeCoercion {
       // Case1: literal numeric + boolean
       if (rNode.getKind() == SqlKind.LITERAL) {
         BigDecimal val = ((SqlLiteral) rNode).getValueAs(BigDecimal.class);
-        if (val.compareTo(BigDecimal.ONE) == 0) {
-          SqlNode rNode1 = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
+        if (val.compareTo(BigDecimal.ZERO) == 0) {
+          SqlNode rNode1 = SqlLiteral.createBoolean(false, SqlParserPos.ZERO);
           binding.getCall().setOperand(1, rNode1);
           return true;
         } else {
-          SqlNode rNode1 = SqlLiteral.createBoolean(false, SqlParserPos.ZERO);
+          SqlNode rNode1 = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
           binding.getCall().setOperand(1, rNode1);
           return true;
         }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -754,6 +754,22 @@ class RelToSqlConverterTest {
     relFn(relFn).ok(expected);
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7147">[CALCITE-7147]
+   * Comparison of INTEGER and BOOLEAN produces strange results</a>. */
+  @Test void testIntBool() {
+    String query = "select FALSE = 256";
+    String expected = "SELECT *\nFROM (VALUES (FALSE)) AS \"t\" (\"EXPR$0\")";
+    sql(query).ok(expected);
+
+    query = "select FALSE = 0.0001e0";
+    expected = "SELECT *\nFROM (VALUES (FALSE)) AS \"t\" (\"EXPR$0\")";
+    sql(query).ok(expected);
+
+    query = "select FALSE = 0.0e0";
+    expected = "SELECT *\nFROM (VALUES (TRUE)) AS \"t\" (\"EXPR$0\")";
+    sql(query).ok(expected);
+  }
+
   @Test void testSelectQueryWithWhereClauseOfBasicOperators() {
     String query = "select * from \"product\" "
         + "where (\"product_id\" = 10 OR \"product_id\" <= 5) "

--- a/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/TypeCoercionConverterTest.java
@@ -127,10 +127,6 @@ class TypeCoercionConverterTest extends SqlToRelTestBase {
   /** Test case for
    * {@link org.apache.calcite.sql.validate.implicit.TypeCoercionImpl}.{@code booleanEquality}. */
   @Test void testBooleanEquality() {
-    // REVIEW Danny 2018-05-16: Now we do not support cast between numeric <-> boolean for
-    // Calcite execution runtime, but we still add cast in the plan so other systems
-    // using Calcite can rewrite Cast operator implementation.
-    // for this case, we replace the boolean literal with numeric 1.
     sql("select\n"
         + "1=true as f0,\n"
         + "1.0=true as f1,\n"

--- a/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/TypeCoercionConverterTest.xml
@@ -50,7 +50,7 @@ from t1]]>
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(F0=[true], F1=[true], F2=[false], F3=[NOT($10)], F4=[=($1, CASE($10, 1:SMALLINT, 0:SMALLINT))], F5=[false])
+LogicalProject(F0=[true], F1=[true], F2=[false], F3=[$10], F4=[=($1, CASE($10, 1:SMALLINT, 0:SMALLINT))], F5=[true])
   LogicalTableScan(table=[[CATALOG, SALES, T1]])
 ]]>
     </Resource>


### PR DESCRIPTION
The fix is to consider only 0 as FALSE, and everything else as TRUE in type coercion.