### PR TITLE
[CALCITE-7154] When the offset or limit of a SORT operation is of type BIGINT row count calculation overflows

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMaxRowCount.java
@@ -115,11 +115,11 @@ public class RelMdMaxRowCount
       rowCount = Double.POSITIVE_INFINITY;
     }
 
-    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
+    final long offset = rel.offset instanceof RexLiteral ? RexLiteral.longValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
     final double limit =
-        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+        rel.fetch instanceof RexLiteral ? RexLiteral.longValue(rel.fetch) : rowCount;
     return limit < rowCount ? limit : rowCount;
   }
 
@@ -129,11 +129,11 @@ public class RelMdMaxRowCount
       rowCount = Double.POSITIVE_INFINITY;
     }
 
-    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
+    final long offset = rel.offset instanceof RexLiteral ? RexLiteral.longValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
     final double limit =
-        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+        rel.fetch instanceof RexLiteral ? RexLiteral.longValue(rel.fetch) : rowCount;
     return limit < rowCount ? limit : rowCount;
   }
 
@@ -214,7 +214,7 @@ public class RelMdMaxRowCount
       if (node instanceof Sort) {
         Sort sort = (Sort) node;
         if (sort.fetch instanceof RexLiteral) {
-          return (double) RexLiteral.intValue(sort.fetch);
+          return (double) RexLiteral.longValue(sort.fetch);
         }
       }
     }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdMinRowCount.java
@@ -114,11 +114,11 @@ public class RelMdMinRowCount
       rowCount = 0D;
     }
 
-    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
+    final long offset = rel.offset instanceof RexLiteral ? RexLiteral.longValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
     final double limit =
-        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+        rel.fetch instanceof RexLiteral ? RexLiteral.longValue(rel.fetch) : rowCount;
     return limit < rowCount ? limit : rowCount;
   }
 
@@ -128,11 +128,11 @@ public class RelMdMinRowCount
       rowCount = 0D;
     }
 
-    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
+    final long offset = rel.offset instanceof RexLiteral ? RexLiteral.longValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
     final double limit =
-        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+        rel.fetch instanceof RexLiteral ? RexLiteral.longValue(rel.fetch) : rowCount;
     return limit < rowCount ? limit : rowCount;
   }
 
@@ -174,7 +174,7 @@ public class RelMdMinRowCount
       if (node instanceof Sort) {
         Sort sort = (Sort) node;
         if (sort.fetch instanceof RexLiteral) {
-          return (double) RexLiteral.intValue(sort.fetch);
+          return (double) RexLiteral.longValue(sort.fetch);
         }
       }
     }

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdRowCount.java
@@ -149,11 +149,11 @@ public class RelMdRowCount
       return null;
     }
 
-    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
+    final long offset = rel.offset instanceof RexLiteral ? RexLiteral.longValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
     final double limit =
-        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+        rel.fetch instanceof RexLiteral ? RexLiteral.longValue(rel.fetch) : rowCount;
     return limit < rowCount ? limit : rowCount;
   }
 
@@ -163,11 +163,11 @@ public class RelMdRowCount
       return null;
     }
 
-    final int offset = rel.offset instanceof RexLiteral ? RexLiteral.intValue(rel.offset) : 0;
+    final long offset = rel.offset instanceof RexLiteral ? RexLiteral.longValue(rel.offset) : 0;
     rowCount = Math.max(rowCount - offset, 0D);
 
     final double limit =
-        rel.fetch instanceof RexLiteral ? RexLiteral.intValue(rel.fetch) : rowCount;
+        rel.fetch instanceof RexLiteral ? RexLiteral.longValue(rel.fetch) : rowCount;
     return limit < rowCount ? limit : rowCount;
   }
 

--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -1278,6 +1278,13 @@ public class RexLiteral extends RexNode {
     return number.intValue();
   }
 
+  /** Returns the value of a literal, cast, or unary minus, as a long;
+   * never null. */
+  public static long longValue(RexNode node) {
+    final Number number = numberValue(node);
+    return number.longValue();
+  }
+
   public static @Nullable String stringValue(RexNode node) {
     final Comparable value = findValue(node);
     return (value == null) ? null : ((NlsString) value).getValue();

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -958,6 +958,15 @@ public class RelMetadataTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7154">[CALCITE-7154]
+   * When the offset or limit of a SORT operation is of type BIGINT row count
+   * calculation overflows</a>. */
+  @Test void testRowCountSortLimitOffsetOnFiniteBigint() {
+    final String sql = "select * from emp limit 3000000000 offset 2500000000";
+    sql(sql).assertThatRowCount(is(1d), is(0d), is(3000000000d));
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5944">[CALCITE-5944]
    * Add metadata for Sample</a>. */
   @Test void testRowCountSample() {


### PR DESCRIPTION
See: [CALCITE-7154](https://issues.apache.org/jira/browse/CALCITE-7154)