### PR TITLE
[CALCITE-7156] OFFSET and FETCH in EnumerableLimit need to support BIGINT

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimit.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableLimit.java
@@ -127,7 +127,7 @@ public class EnumerableLimit extends SingleRel implements EnumerableRel {
               Expressions.constant("?" + param.getIndex())),
           Integer.class);
     } else {
-      return Expressions.constant(RexLiteral.intValue(rexNode));
+      return Expressions.constant(RexLiteral.longValue(rexNode));
     }
   }
 }

--- a/core/src/test/resources/sql/sort.iq
+++ b/core/src/test/resources/sql/sort.iq
@@ -417,4 +417,16 @@ order by arr desc;
 
 !ok
 
+select * from "hr"."emps" limit 3000000000 offset 2500000000;
++-------+--------+------+--------+------------+
+| empid | deptno | name | salary | commission |
++-------+--------+------+--------+------------+
++-------+--------+------+--------+------------+
+(0 rows)
+
+!ok
+EnumerableLimit(offset=[2500000000:BIGINT], fetch=[3000000000:BIGINT])
+  EnumerableTableScan(table=[[hr, emps]])
+!plan
+
 # End sort.iq

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/DefaultEnumerable.java
@@ -651,6 +651,10 @@ public abstract class DefaultEnumerable<T> implements OrderedEnumerable<T> {
     return EnumerableDefaults.skip(getThis(), count);
   }
 
+  @Override public Enumerable<T> skip(long count) {
+    return EnumerableDefaults.skip(getThis(), count);
+  }
+
   @Override public Enumerable<T> skipWhile(Predicate1<T> predicate) {
     return EnumerableDefaults.skipWhile(getThis(), predicate);
   }
@@ -700,6 +704,10 @@ public abstract class DefaultEnumerable<T> implements OrderedEnumerable<T> {
   }
 
   @Override public Enumerable<T> take(int count) {
+    return EnumerableDefaults.take(getThis(), count);
+  }
+
+  @Override public Enumerable<T> take(long count) {
     return EnumerableDefaults.take(getThis(), count);
   }
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -3438,6 +3438,18 @@ public abstract class EnumerableDefaults {
   }
 
   /**
+   * Bypasses a specified number of elements in a
+   * sequence and then returns the remaining elements.
+   */
+  public static <TSource> Enumerable<TSource> skip(Enumerable<TSource> source,
+      final long count) {
+    return skipWhile(source, (v1, v2) -> {
+      // Count is 1-based
+      return v2 < count;
+    });
+  }
+
+  /**
    * Bypasses elements in a sequence as long as a
    * specified condition is true and then returns the remaining
    * elements.

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableQueryable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableQueryable.java
@@ -135,7 +135,15 @@ class EnumerableQueryable<T> extends DefaultEnumerable<T>
     return EnumerableDefaults.take(getThis(), count).asQueryable();
   }
 
+  @Override public Queryable<T> take(long count) {
+    return EnumerableDefaults.take(getThis(), count).asQueryable();
+  }
+
   @Override public Queryable<T> skip(int count) {
+    return EnumerableDefaults.skip(getThis(), count).asQueryable();
+  }
+
+  @Override public Queryable<T> skip(long count) {
     return EnumerableDefaults.skip(getThis(), count).asQueryable();
   }
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/ExtendedEnumerable.java
@@ -1004,6 +1004,12 @@ public interface ExtendedEnumerable<TSource> {
   Enumerable<TSource> skip(int count);
 
   /**
+   * Bypasses a specified number of elements in a
+   * sequence and then returns the remaining elements.
+   */
+  Enumerable<TSource> skip(long count);
+
+  /**
    * Bypasses elements in a sequence as long as a
    * specified condition is true and then returns the remaining
    * elements.
@@ -1093,6 +1099,12 @@ public interface ExtendedEnumerable<TSource> {
    * from the start of a sequence.
    */
   Enumerable<TSource> take(int count);
+
+  /**
+   * Returns a specified number of contiguous elements
+   * from the start of a sequence.
+   */
+  Enumerable<TSource> take(long count);
 
   /**
    * Returns elements from a sequence as long as a


### PR DESCRIPTION
See: [CALCITE-7156](https://issues.apache.org/jira/browse/CALCITE-7156)