### PR TITLE
[CALCITE-7162] AggregateMergeRule type mismatch on MIN/MAX

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java
@@ -189,7 +189,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
             bottom.isDistinct(), bottom.isApproximate(), false,
             bottom.rexList, bottom.getArgList(), bottom.filterArg,
             bottom.distinctKeys, bottom.getCollation(),
-            bottom.getType(), top.getName());
+            top.getType(), top.getName());
       } else {
         return null;
       }
@@ -234,7 +234,7 @@ public interface SqlSplittableAggFunction extends SqlSingletonAggFunction {
             bottom.isDistinct(), bottom.isApproximate(), false,
             bottom.rexList, bottom.getArgList(), bottom.filterArg,
             bottom.distinctKeys, bottom.getCollation(),
-            bottom.getType(), top.getName());
+            top.getType(), top.getName());
       } else {
         return null;
       }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -7570,6 +7570,26 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7162">[CALCITE-7162]
+   * AggregateMergeRule throws 'type mismatch' AssertionError</a>. The scenario
+   * has the same aggregate functions (MIN and MAX) at multiple levels; the
+   * lower level is NOT NULL (because of GROUP BY) and the upper level is
+   * nullable. */
+  @Test void testAggregateMerge10() {
+    final String sql = "SELECT min(mn), max(mx)\n"
+        + "FROM (\n"
+        + "    SELECT min(deptno) mn, max(deptno) mx\n"
+        + "    FROM dept\n"
+        + "    GROUP BY name)";
+    sql(sql)
+        .withPreRule(CoreRules.AGGREGATE_PROJECT_MERGE,
+            CoreRules.PROJECT_MERGE)
+        .withRule(CoreRules.AGGREGATE_PROJECT_MERGE,
+            CoreRules.AGGREGATE_MERGE)
+        .check();
+  }
+
   /**
    * Test case for AggregateRemoveRule, should remove aggregates since
    * empno is unique and all aggregate functions are splittable.

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -846,6 +846,28 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAggregateMerge10">
+    <Resource name="sql">
+      <![CDATA[SELECT min(mn), max(mx)
+FROM (
+    SELECT min(deptno) mn, max(deptno) mx
+    FROM dept
+    GROUP BY name)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($1)], EXPR$1=[MAX($2)])
+  LogicalAggregate(group=[{1}], MN=[MIN($0)], MX=[MAX($0)])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MAX($0)])
+  LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAggregateMergeSum0">
     <Resource name="sql">
       <![CDATA[select coalesce(sum(count_comm), 0)


### PR DESCRIPTION
Fixes [CALCITE-7162](https://issues.apache.org/jira/browse/CALCITE-7162) by taking the type from the top aggregator rather than the bottom aggregator when merging. A similar fix was made to `AbstractSumSplitter` in [CALCITE-6557](https://issues.apache.org/jira/browse/CALCITE-6557).

This patch also updates `CountSplitter` with a similar change— just in case— even though I'm not sure if that is necessary to fix any actual bug. I believe that in general using the top aggregator type is the correct thing to do, since the merged aggregator is meant to stand in for the top aggregator.