### PR TITLE
[CALCITE-7176] FETCH and OFFSET in SortMergeRule do not support BIGINT

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/MeasureRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MeasureRules.java
@@ -508,8 +508,8 @@ public abstract class MeasureRules {
 
       relBuilder.push(sort.getInput())
           .projectPlus(map.keySet())
-          .sortLimit(sort.offset == null ? 0 : RexLiteral.intValue(sort.offset),
-              sort.fetch == null ? -1 : RexLiteral.intValue(sort.fetch),
+          .sortLimit(sort.offset == null ? 0 : RexLiteral.longValue(sort.offset),
+              sort.fetch == null ? -1 : RexLiteral.longValue(sort.fetch),
               sort.getSortExps())
           .project(newProjects);
       call.transformTo(relBuilder.build());

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortMergeRule.java
@@ -92,18 +92,18 @@ public class SortMergeRule
 
     final RelBuilder builder = call.builder();
 
-    final int topFetch = topSort.fetch instanceof RexLiteral
-        ? RexLiteral.intValue(topSort.fetch) : -1;
+    final long topFetch = topSort.fetch instanceof RexLiteral
+        ? RexLiteral.longValue(topSort.fetch) : -1;
 
-    final int bottomFetch = bottomSort.fetch instanceof RexLiteral
-        ? RexLiteral.intValue(bottomSort.fetch) : -1;
+    final long bottomFetch = bottomSort.fetch instanceof RexLiteral
+        ? RexLiteral.longValue(bottomSort.fetch) : -1;
 
     if (topFetch == -1 || bottomFetch == -1) {
       return;
     }
 
     // Get the minimum limit value from parent and child sort RelNode
-    final int minFetch = Math.min(topFetch, bottomFetch);
+    final long minFetch = Math.min(topFetch, bottomFetch);
 
     builder.push(bottomSort.getInput());
 

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -3720,7 +3720,7 @@ public class RelBuilder {
   }
 
   /** Creates a {@link Sort} by expressions, with limit and offset. */
-  public RelBuilder sortLimit(int offset, int fetch, RexNode... nodes) {
+  public RelBuilder sortLimit(long offset, long fetch, RexNode... nodes) {
     return sortLimit(offset, fetch, ImmutableList.copyOf(nodes));
   }
 
@@ -3739,7 +3739,7 @@ public class RelBuilder {
    * @param fetch Maximum number of rows to fetch; negative means no limit
    * @param nodes Sort expressions
    */
-  public RelBuilder sortLimit(int offset, int fetch,
+  public RelBuilder sortLimit(long offset, long fetch,
       Iterable<? extends RexNode> nodes) {
     final @Nullable RexNode offsetNode = offset <= 0 ? null : literal(offset);
     final @Nullable RexNode fetchNode = fetch < 0 ? null : literal(fetch);
@@ -3770,8 +3770,8 @@ public class RelBuilder {
     final Registrar registrar = new Registrar(fields(), ImmutableList.of());
     final List<RelFieldCollation> fieldCollations =
         registrar.registerFieldCollations(nodes);
-    final int fetch = fetchNode instanceof RexLiteral
-        ? RexLiteral.intValue(fetchNode) : -1;
+    final long fetch = fetchNode instanceof RexLiteral
+        ? RexLiteral.longValue(fetchNode) : -1;
     if (offsetNode == null && fetch == 0 && config.simplifyLimit()) {
       return empty();
     }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1834,6 +1834,19 @@ class RelOptRulesTest extends RelOptTestBase {
         .checkUnchanged();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7176">[CALCITE-7176]
+   * FETCH and OFFSET in SortMergeRule do not support BIGINT</a>. */
+  @Test void testLimitMergeBigint() {
+    final String sql = "select deptno from\n"
+        + "(select deptno from emp where sal > 100 limit 3100000000)\n"
+        + "limit 3000000000";
+    sql(sql)
+        .withPreRule(CoreRules.SORT_PROJECT_TRANSPOSE)
+        .withRule(CoreRules.LIMIT_MERGE, CoreRules.PROJECT_MERGE)
+        .check();
+  }
+
   @Test void testSemiJoinRuleExists() {
     final String sql = "select * from dept where exists (\n"
         + "  select * from emp\n"

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8744,6 +8744,32 @@ LogicalProject(DEPTNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testLimitMergeBigint">
+    <Resource name="sql">
+      <![CDATA[select deptno from
+(select deptno from emp where sal > 100 limit 3100000000)
+limit 3000000000]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalProject(DEPTNO=[$7])
+    LogicalSort(fetch=[3000000000:BIGINT])
+      LogicalSort(fetch=[3100000000:BIGINT])
+        LogicalFilter(condition=[>($5, 100)])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0])
+  LogicalProject(DEPTNO=[$7])
+    LogicalSort(fetch=[3000000000:BIGINT])
+      LogicalFilter(condition=[>($5, 100)])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testLimitSort">
     <Resource name="sql">
       <![CDATA[select mgr from sales.emp

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelOpVisitor.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelOpVisitor.java
@@ -454,7 +454,7 @@ class PigRelOpVisitor extends PigRelOpWalker.PlanPreVisitor {
 
   @Override public void visit(LOSort loSort) throws FrontendException {
     // TODO Hanlde custom sortFunc from Pig???
-    final int limit = (int) loSort.getLimit();
+    final long limit = loSort.getLimit();
     List<RexNode> relSortCols = new ArrayList<>();
     if (loSort.isStar()) {
       // Sort using all columns


### PR DESCRIPTION
See: [CALCITE-7176](https://issues.apache.org/jira/browse/CALCITE-7176)