### PR TITLE
[CALCITE-7178] FETCH and OFFSET in EnumerableMergeUnionRule do not support BIGINT

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeUnionRule.java
@@ -92,8 +92,8 @@ public class EnumerableMergeUnionRule extends RelRule<EnumerableMergeUnionRule.C
         inputFetch = sort.fetch;
       } else if (sort.fetch instanceof RexLiteral && sort.offset instanceof RexLiteral) {
         inputFetch =
-            call.builder().literal(RexLiteral.intValue(sort.fetch)
-                + RexLiteral.intValue(sort.offset));
+            call.builder().literal(RexLiteral.longValue(sort.fetch)
+                + RexLiteral.longValue(sort.offset));
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PruneEmptyRules.java
@@ -500,7 +500,7 @@ public abstract class PruneEmptyRules {
           Sort sort = call.rel(0);
           return sort.fetch != null
               && !(sort.fetch instanceof RexDynamicParam)
-              && RexLiteral.intValue(sort.fetch) == 0;
+              && RexLiteral.longValue(sort.fetch) == 0;
         }
 
       };

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -4112,6 +4112,39 @@ EnumerableProject(R_REGIONKEY=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEnumerableMergeUnionRule">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, job, sal
+FROM emp
+UNION ALL
+SELECT deptno, job, sal
+FROM emp order by deptno limit 3000000000 offset 2500000000]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], JOB=[$1], SAL=[$2])
+  LogicalSort(sort0=[$0], dir0=[ASC], offset=[2500000000:BIGINT], fetch=[3000000000:BIGINT])
+    LogicalUnion(all=[true])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalProject(DEPTNO=[$7], JOB=[$2], SAL=[$5])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+EnumerableProject(DEPTNO=[$0], JOB=[$1], SAL=[$2])
+  EnumerableLimit(offset=[2500000000:BIGINT], fetch=[3000000000:BIGINT])
+    EnumerableMergeUnion(all=[true])
+      EnumerableSort(sort0=[$0], dir0=[ASC])
+        EnumerableProject(DEPTNO=[$7], JOB=[$2], SAL=[$5])
+          EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
+      EnumerableSort(sort0=[$0], dir0=[ASC])
+        EnumerableProject(DEPTNO=[$7], JOB=[$2], SAL=[$5])
+          EnumerableTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEnumerableProjectRule">
     <Resource name="sql">
       <![CDATA[select R_REGIONKEY > all (select R_REGIONKEY from SALES.CUSTOMER)

--- a/core/src/test/resources/sql/sort.iq
+++ b/core/src/test/resources/sql/sort.iq
@@ -419,7 +419,7 @@ order by arr desc;
 
 # [CALCITE-7156] OFFSET and FETCH in EnumerableLimit need to support BIGINT
 select * from "hr"."emps" limit 3000000000 offset 2500000000;
-Caused by: java.lang.ArithmeticException: Integer overflow: 3000000000 is out of range for INT
+java.lang.ArithmeticException: Integer overflow: 2500000000 is out of range for INT
 !error
 
 # End sort.iq


### PR DESCRIPTION
See: [CALCITE-7178](https://issues.apache.org/jira/browse/CALCITE-7178)