### PR TITLE
[CALCITE-7190] FETCH and OFFSET in SortMergeRule only supports BIGINT

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/MeasureRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/MeasureRules.java
@@ -508,8 +508,8 @@ public abstract class MeasureRules {
 
       relBuilder.push(sort.getInput())
           .projectPlus(map.keySet())
-          .sortLimit(sort.offset == null ? 0 : RexLiteral.longValue(sort.offset),
-              sort.fetch == null ? -1 : RexLiteral.longValue(sort.fetch),
+          .sortLimit(sort.offset == null ? 0 : RexLiteral.numberValue(sort.offset),
+              sort.fetch == null ? -1 : RexLiteral.numberValue(sort.fetch),
               sort.getSortExps())
           .project(newProjects);
       call.transformTo(relBuilder.build());

--- a/core/src/main/java/org/apache/calcite/rel/rules/SortMergeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SortMergeRule.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableList;
 
 import org.immutables.value.Value;
 
+import java.math.BigDecimal;
+
 /**
  * This rule try to merge the double {@link Sort},one is Limit semantics,
  * another sort is Limit or TOPN semantics.
@@ -92,18 +94,18 @@ public class SortMergeRule
 
     final RelBuilder builder = call.builder();
 
-    final long topFetch = topSort.fetch instanceof RexLiteral
-        ? RexLiteral.longValue(topSort.fetch) : -1;
+    final Number topFetch = topSort.fetch instanceof RexLiteral
+        ? RexLiteral.numberValue(topSort.fetch) : null;
 
-    final long bottomFetch = bottomSort.fetch instanceof RexLiteral
-        ? RexLiteral.longValue(bottomSort.fetch) : -1;
+    final Number bottomFetch = bottomSort.fetch instanceof RexLiteral
+        ? RexLiteral.numberValue(bottomSort.fetch) : null;
 
-    if (topFetch == -1 || bottomFetch == -1) {
+    if (topFetch == null || bottomFetch == null) {
       return;
     }
 
     // Get the minimum limit value from parent and child sort RelNode
-    final long minFetch = Math.min(topFetch, bottomFetch);
+    final Number minFetch = ((BigDecimal) topFetch).min((BigDecimal) bottomFetch);
 
     builder.push(bottomSort.getInput());
 

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -3674,7 +3674,7 @@ public class RelBuilder {
    * @param offset Number of rows to skip; non-positive means don't skip any
    * @param fetch Maximum number of rows to fetch; negative means no limit
    */
-  public RelBuilder limit(int offset, int fetch) {
+  public RelBuilder limit(Number offset, Number fetch) {
     return sortLimit(offset, fetch, ImmutableList.of());
   }
 
@@ -3720,7 +3720,7 @@ public class RelBuilder {
   }
 
   /** Creates a {@link Sort} by expressions, with limit and offset. */
-  public RelBuilder sortLimit(long offset, long fetch, RexNode... nodes) {
+  public RelBuilder sortLimit(Number offset, Number fetch, RexNode... nodes) {
     return sortLimit(offset, fetch, ImmutableList.copyOf(nodes));
   }
 
@@ -3739,10 +3739,16 @@ public class RelBuilder {
    * @param fetch Maximum number of rows to fetch; negative means no limit
    * @param nodes Sort expressions
    */
-  public RelBuilder sortLimit(long offset, long fetch,
+  public RelBuilder sortLimit(Number offset, Number fetch,
       Iterable<? extends RexNode> nodes) {
-    final @Nullable RexNode offsetNode = offset <= 0 ? null : literal(offset);
-    final @Nullable RexNode fetchNode = fetch < 0 ? null : literal(fetch);
+    final @Nullable RexNode offsetNode =
+        new BigDecimal(offset.toString()).compareTo(BigDecimal.ZERO) <= 0
+            ? null
+            : literal(offset);
+    final @Nullable RexNode fetchNode =
+        new BigDecimal(fetch.toString()).compareTo(BigDecimal.ZERO) < 0
+            ? null
+            : literal(fetch);
     return sortLimit(offsetNode, fetchNode, nodes);
   }
 
@@ -3770,9 +3776,12 @@ public class RelBuilder {
     final Registrar registrar = new Registrar(fields(), ImmutableList.of());
     final List<RelFieldCollation> fieldCollations =
         registrar.registerFieldCollations(nodes);
-    final long fetch = fetchNode instanceof RexLiteral
-        ? RexLiteral.longValue(fetchNode) : -1;
-    if (offsetNode == null && fetch == 0 && config.simplifyLimit()) {
+    final Number fetch = fetchNode instanceof RexLiteral
+        ? RexLiteral.numberValue(fetchNode) : null;
+    if (offsetNode == null
+        && fetch != null
+        && ((BigDecimal) fetch).compareTo(BigDecimal.ZERO) == 0
+        && config.simplifyLimit()) {
       return empty();
     }
     if (offsetNode == null && fetchNode == null && fieldCollations.isEmpty()) {


### PR DESCRIPTION
See: [CALCITE-7190](https://issues.apache.org/jira/browse/CALCITE-7190)