### PR TITLE
[CALCITE-7193] In an aggregation validator treats lambda variable names as column names

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/AggChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AggChecker.java
@@ -123,11 +123,19 @@ class AggChecker extends SqlBasicVisitor<Void> {
       return call.accept(this);
     }
 
+    SqlValidatorScope firstScope = scopes.getFirst();
+    if (firstScope instanceof SqlLambdaScope) {
+      SqlLambdaScope lambdaScope = (SqlLambdaScope) firstScope;
+      if (lambdaScope.isParameter(id)) {
+        return null;
+      }
+    }
+
     // Didn't find the identifier in the group-by list as is, now find
     // it fully-qualified.
     // TODO: It would be better if we always compared fully-qualified
     // to fully-qualified.
-    final SqlQualified fqId = scopes.getFirst().fullyQualify(id);
+    final SqlQualified fqId = firstScope.fullyQualify(id);
     if (isGroupExpr(fqId.identifier)) {
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlLambdaScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlLambdaScope.java
@@ -52,6 +52,11 @@ public class SqlLambdaScope extends ListScope {
     lambdaExpr.getParameters().forEach(param -> parameterTypes.put(param.toString(), any));
   }
 
+  /** True if the identifier matches one of the parameter names. */
+  public boolean isParameter(SqlIdentifier id) {
+    return this.parameterTypes.containsKey(id.toString());
+  }
+
   @Override public SqlNode getNode() {
     return lambdaExpr;
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -43,6 +43,7 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlLibrary;
 import org.apache.calcite.sql.fun.SqlLibraryOperatorTableFactory;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -7829,6 +7830,21 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     s.withSql("select HIGHER_ORDER_FUNCTION(1, (x, y) -> x + 1 + ^deptno^) from emp")
         .fails("Param 'DEPTNO' not found in lambda expression "
             + "'\\(`X`, `Y`\\) -> `X` \\+ 1 \\+ `DEPTNO`'");
+  }
+
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7193">[CALCITE-7193]
+   * In an aggregation validator treats lambda variable names as column names</a>. */
+  @Test void testGroupByLambda() {
+    SqlOperatorTable chain =
+        SqlOperatorTables.chain(
+            SqlOperatorTables.of(
+                SqlLibraryOperators.ARRAY_AGG,
+                SqlLibraryOperators.EXISTS),
+            SqlStdOperatorTable.instance());
+    final String sql = "SELECT \"EXISTS\"(ARRAY_AGG(empno), x -> x > 1) FROM emp GROUP BY deptno";
+    sql(sql)
+        .withOperatorTable(chain)
+        .ok();
   }
 
   @Test void testPercentileFunctionsBigQuery() {


### PR DESCRIPTION
I am not 100% of this logic, it would be great if someone familiar with the namespace structure could take a look.
Most of the lambda code was written by @macroguo-ghy 