### PR TITLE
Add getter method for Uncollect.itemAliases

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/core/Uncollect.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Uncollect.java
@@ -200,4 +200,9 @@ public class Uncollect extends SingleRel {
     }
     return builder.build();
   }
+
+  /** Get the aliases for the unnest items. */
+  public List<String> getItemAliases() {
+    return itemAliases;
+  }
 }


### PR DESCRIPTION
Without this method one cannot easily write optimization rules that manipulate Uncollect operations, since the field is private.