### PR TITLE
[CALCITE-7246] UNNEST in Spark should  convert to EXPLODE/POSEXPLODE

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlUnnestOperator;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlCase;
@@ -154,6 +155,20 @@ public class SparkSqlDialect extends SqlDialect {
       break;
     case POSITION:
       SqlUtil.unparseFunctionSyntax(SqlStdOperatorTable.POSITION, writer, call, false);
+      break;
+    case UNNEST:
+      if (call.getOperator() instanceof SqlUnnestOperator
+          && ((SqlUnnestOperator) call.getOperator()).withOrdinality) {
+        writer.keyword("POSEXPLODE");
+      } else {
+        writer.keyword("EXPLODE");
+      }
+      final SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+      for (SqlNode operand : call.getOperandList()) {
+        writer.sep(",");
+        operand.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
       break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);


### PR DESCRIPTION
See: [[CALCITE-6469](https://issues.apache.org/jira/browse/CALCITE-6469)]