### PR TITLE
[CALCITE-5390] RelDecorrelator throws NullPointerException

### DIFF
--- a/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowFilter.java
+++ b/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowFilter.java
@@ -21,11 +21,15 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -51,7 +55,9 @@ class ArrowFilter extends Filter implements ArrowRel {
     return requireNonNull(cost, "cost").multiplyBy(0.1);
   }
 
-  @Override public ArrowFilter copy(RelTraitSet traitSet, RelNode input, RexNode condition) {
+  @Override public ArrowFilter copy(RelTraitSet traitSet, RelNode input, RexNode condition,
+      Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new ArrowFilter(getCluster(), traitSet, input, condition);
   }
 

--- a/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowProject.java
+++ b/arrow/src/main/java/org/apache/calcite/adapter/arrow/ArrowProject.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -34,6 +35,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +56,8 @@ class ArrowProject extends Project implements ArrowRel {
   }
 
   @Override public Project copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType) {
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new ArrowProject(getCluster(), traitSet, input, projects,
         rowType);
   }

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraFilter.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraFilter.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -47,6 +48,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static org.apache.calcite.util.DateTimeStringUtils.ISO_DATETIME_FRACTIONAL_SECOND_FORMAT;
 import static org.apache.calcite.util.DateTimeStringUtils.getDateFormatter;
@@ -98,7 +101,8 @@ public class CassandraFilter extends Filter implements CassandraRel {
   }
 
   @Override public CassandraFilter copy(RelTraitSet traitSet, RelNode input,
-      RexNode condition) {
+      RexNode condition, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new CassandraFilter(getCluster(), traitSet, input, condition,
         partitionKeys, clusteringKeys, implicitFieldCollations);
   }

--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraProject.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraProject.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -35,6 +36,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -51,7 +55,8 @@ public class CassandraProject extends Project implements CassandraRel {
   }
 
   @Override public Project copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType) {
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new CassandraProject(getCluster(), traitSet, input, projects,
         rowType);
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAsofJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableAsofJoin.java
@@ -96,8 +96,8 @@ public class EnumerableAsofJoin extends AsofJoin implements EnumerableRel {
   }
 
   @Override public EnumerableAsofJoin copy(RelTraitSet traitSet, RexNode condition,
-                                           RelNode left, RelNode right, JoinRelType joinType,
-                                           boolean semiJoinDone) {
+      RelNode left, RelNode right, Set<CorrelationId> variablesSet, JoinRelType joinType,
+      boolean semiJoinDone) {
     // This method does not know about the matchCondition, so it should not be called
     throw new RuntimeException("This method should not be called");
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableBatchNestedLoopJoin.java
@@ -113,8 +113,8 @@ public class EnumerableBatchNestedLoopJoin extends Join implements EnumerableRel
   }
 
   @Override public EnumerableBatchNestedLoopJoin copy(RelTraitSet traitSet,
-      RexNode condition, RelNode left, RelNode right, JoinRelType joinType,
-      boolean semiJoinDone) {
+      RexNode condition, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
+      JoinRelType joinType, boolean semiJoinDone) {
     return new EnumerableBatchNestedLoopJoin(getCluster(), traitSet,
         left, right, condition, variablesSet, requiredColumns, joinType);
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilter.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableFilter.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMdDistribution;
@@ -35,6 +36,9 @@ import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Filter} in
  * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention enumerable calling convention}. */
@@ -69,7 +73,8 @@ public class EnumerableFilter
   }
 
   @Override public EnumerableFilter copy(RelTraitSet traitSet, RelNode input,
-      RexNode condition) {
+      RexNode condition, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new EnumerableFilter(getCluster(), traitSet, input, condition);
   }
 

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableHashJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableHashJoin.java
@@ -98,9 +98,9 @@ public class EnumerableHashJoin extends Join implements EnumerableRel {
         variablesSet, joinType);
   }
 
-  @Override public EnumerableHashJoin copy(RelTraitSet traitSet, RexNode condition,
-      RelNode left, RelNode right, JoinRelType joinType,
-      boolean semiJoinDone) {
+  @Override public EnumerableHashJoin copy(RelTraitSet traitSet,
+      RexNode condition, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
+      JoinRelType joinType, boolean semiJoinDone) {
     return new EnumerableHashJoin(getCluster(), traitSet, left, right,
         condition, variablesSet, joinType);
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -416,8 +416,8 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
   }
 
   @Override public EnumerableMergeJoin copy(RelTraitSet traitSet,
-      RexNode condition, RelNode left, RelNode right, JoinRelType joinType,
-      boolean semiJoinDone) {
+      RexNode condition, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
+      JoinRelType joinType, boolean semiJoinDone) {
     return new EnumerableMergeJoin(getCluster(), traitSet, left, right,
         condition, variablesSet, joinType);
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableNestedLoopJoin.java
@@ -64,8 +64,8 @@ public class EnumerableNestedLoopJoin extends Join implements EnumerableRel {
   }
 
   @Override public EnumerableNestedLoopJoin copy(RelTraitSet traitSet,
-      RexNode condition, RelNode left, RelNode right, JoinRelType joinType,
-      boolean semiJoinDone) {
+      RexNode condition, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
+      JoinRelType joinType, boolean semiJoinDone) {
     return new EnumerableNestedLoopJoin(getCluster(), traitSet, left, right,
         condition, variablesSet, joinType);
   }

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableProject.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMdCollation;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
@@ -34,6 +35,9 @@ import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Project} in
  * {@link org.apache.calcite.adapter.enumerable.EnumerableConvention enumerable calling convention}. */
@@ -81,7 +85,8 @@ public class EnumerableProject extends Project implements EnumerableRel {
   }
 
   @Override public EnumerableProject copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType) {
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new EnumerableProject(getCluster(), traitSet, input,
         projects, rowType);
   }

--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -401,9 +401,9 @@ public class JdbcRules {
           CorrelationId.setOf(variablesStopped), joinType);
     }
 
-    @Override public JdbcJoin copy(RelTraitSet traitSet, RexNode condition,
-        RelNode left, RelNode right, JoinRelType joinType,
-        boolean semiJoinDone) {
+    @Override public JdbcJoin copy(RelTraitSet traitSet,
+        RexNode condition, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
+        JoinRelType joinType, boolean semiJoinDone) {
       try {
         return new JdbcJoin(getCluster(), traitSet, left, right,
             condition, variablesSet, joinType);
@@ -559,7 +559,8 @@ public class JdbcRules {
     }
 
     @Override public JdbcProject copy(RelTraitSet traitSet, RelNode input,
-        List<RexNode> projects, RelDataType rowType) {
+        List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+      checkArgument(variablesSet.isEmpty());
       return new JdbcProject(getCluster(), traitSet, input, projects, rowType);
     }
 
@@ -627,7 +628,8 @@ public class JdbcRules {
     }
 
     @Override public JdbcFilter copy(RelTraitSet traitSet, RelNode input,
-        RexNode condition) {
+        RexNode condition, Set<CorrelationId> variablesSet) {
+      checkArgument(variablesSet.isEmpty());
       return new JdbcFilter(getCluster(), traitSet, input, condition);
     }
 

--- a/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
+++ b/core/src/main/java/org/apache/calcite/interpreter/Bindables.java
@@ -358,7 +358,8 @@ public class Bindables {
     }
 
     @Override public BindableFilter copy(RelTraitSet traitSet, RelNode input,
-        RexNode condition) {
+        RexNode condition, Set<CorrelationId> variablesSet) {
+      checkArgument(variablesSet.isEmpty());
       return new BindableFilter(getCluster(), traitSet, input, condition);
     }
 
@@ -421,7 +422,8 @@ public class Bindables {
     }
 
     @Override public BindableProject copy(RelTraitSet traitSet, RelNode input,
-        List<RexNode> projects, RelDataType rowType) {
+        List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+      checkArgument(variablesSet.isEmpty());
       return new BindableProject(getCluster(), traitSet, input,
           projects, rowType);
     }
@@ -550,7 +552,7 @@ public class Bindables {
     }
 
     @Override public BindableJoin copy(RelTraitSet traitSet, RexNode conditionExpr,
-        RelNode left, RelNode right, JoinRelType joinType,
+        RelNode left, RelNode right, Set<CorrelationId> variablesSet, JoinRelType joinType,
         boolean semiJoinDone) {
       return new BindableJoin(getCluster(), traitSet, left, right,
           conditionExpr, variablesSet, joinType);

--- a/core/src/main/java/org/apache/calcite/plan/volcano/AbstractConverter.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/AbstractConverter.java
@@ -27,6 +27,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.convert.ConverterImpl;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilderFactory;
 
@@ -34,6 +35,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.immutables.value.Value;
 
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Converts a relational expression to any given output convention.
@@ -64,7 +68,9 @@ public class AbstractConverter extends ConverterImpl {
   //~ Methods ----------------------------------------------------------------
 
 
-  @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+  @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs,
+      Set<CorrelationId> variableSet) {
+    checkArgument(variableSet.isEmpty());
     return new AbstractConverter(
         getCluster(),
         (RelSubset) sole(inputs),

--- a/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/AbstractRelNode.java
@@ -103,12 +103,13 @@ public abstract class AbstractRelNode implements RelNode {
 
   //~ Methods ----------------------------------------------------------------
 
-  @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+  @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs,
+      Set<CorrelationId> variableSet) {
     // Note that empty set equals empty set, so relational expressions
     // with zero inputs do not generally need to implement their own copy
     // method.
     if (getInputs().equals(inputs)
-        && traitSet == getTraitSet()) {
+        && traitSet == getTraitSet() && variableSet == getVariablesSet()) {
       return this;
     }
     throw new AssertionError("Relational expression should override copy. "

--- a/core/src/main/java/org/apache/calcite/rel/RelNode.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelNode.java
@@ -371,9 +371,30 @@ public interface RelNode extends RelOptNode, Cloneable {
    * @return Copy of this relational expression, substituting traits and
    * inputs
    */
+  default RelNode copy(
+      RelTraitSet traitSet,
+      List<RelNode> inputs) {
+    return copy(traitSet, inputs, getVariablesSet());
+  }
+
+  /**
+   * Creates a copy of this relational expression, perhaps changing traits and
+   * inputs and variable set.
+   *
+   * <p>Sub-classes with other important attributes are encouraged to create
+   * variants of this method with more parameters.
+   *
+   * @param traitSet     Trait set
+   * @param inputs       Inputs
+   * @param variablesSet the variables that are set in this relational
+   *                     expression
+   * @return Copy of this relational expression, substituting traits and
+   * inputs
+   */
   RelNode copy(
       RelTraitSet traitSet,
-      List<RelNode> inputs);
+      List<RelNode> inputs,
+      Set<CorrelationId> variablesSet);
 
   /**
    * Registers any special rules specific to this kind of relational

--- a/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Aggregate.java
@@ -233,7 +233,8 @@ public abstract class Aggregate extends SingleRel implements Hintable {
   //~ Methods ----------------------------------------------------------------
 
   @Override public final RelNode copy(RelTraitSet traitSet,
-      List<RelNode> inputs) {
+      List<RelNode> inputs, Set<CorrelationId> variableSet) {
+    assert variableSet.isEmpty();
     return copy(traitSet, sole(inputs), groupSet, groupSets, aggCalls);
   }
 

--- a/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Correlate.java
@@ -35,11 +35,14 @@ import org.apache.calcite.util.Litmus;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -147,12 +150,15 @@ public abstract class Correlate extends BiRel implements Hintable {
         && RelOptUtil.notContainsCorrelation(left, correlationId, litmus);
   }
 
-  @Override public Correlate copy(RelTraitSet traitSet, List<RelNode> inputs) {
-    assert inputs.size() == 2;
+  @Override public Correlate copy(RelTraitSet traitSet, List<RelNode> inputs,
+      Set<CorrelationId> variablesSet) {
+    checkArgument(inputs.size() == 2);
+    checkArgument(variablesSet.size() == 1);
+
     return copy(traitSet,
         inputs.get(0),
         inputs.get(1),
-        correlationId,
+        requireNonNull(Iterables.getOnlyElement(variablesSet)),
         requiredColumns,
         joinType);
   }

--- a/core/src/main/java/org/apache/calcite/rel/core/Filter.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Filter.java
@@ -46,6 +46,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -120,12 +121,21 @@ public abstract class Filter extends SingleRel implements Hintable {
   //~ Methods ----------------------------------------------------------------
 
   @Override public final RelNode copy(RelTraitSet traitSet,
-      List<RelNode> inputs) {
-    return copy(traitSet, sole(inputs), getCondition());
+      List<RelNode> inputs, Set<CorrelationId> variablesSet) {
+    return copy(traitSet, sole(inputs), getCondition(), variablesSet);
   }
 
-  public abstract Filter copy(RelTraitSet traitSet, RelNode input,
-      RexNode condition);
+  public Filter copy(RelTraitSet traitSet, RelNode input,
+      RexNode condition) {
+    return copy(traitSet, input, condition, getVariablesSet());
+  }
+
+  public Filter copy(RelTraitSet traitSet, RelNode input,
+      RexNode condition, Set<CorrelationId> variablesSet) {
+    // This method cannot be abstract because it would break compatibility
+    throw new UnsupportedOperationException(
+        "Must implement copy in " + getClass().getName());
+  }
 
   @Override public RelNode accept(RexShuttle shuttle) {
     RexNode condition = shuttle.apply(this.condition);

--- a/core/src/main/java/org/apache/calcite/rel/core/Join.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Join.java
@@ -311,9 +311,10 @@ public abstract class Join extends BiRel implements Hintable {
         fieldNameList, systemFieldList);
   }
 
-  @Override public Join copy(RelTraitSet traitSet, List<RelNode> inputs) {
+  @Override public Join copy(RelTraitSet traitSet, List<RelNode> inputs,
+      Set<CorrelationId> variablesSet) {
     assert inputs.size() == 2;
-    return copy(traitSet, getCondition(), inputs.get(0), inputs.get(1),
+    return copy(traitSet, getCondition(), inputs.get(0), inputs.get(1), variablesSet,
         joinType, isSemiJoinDone());
   }
 
@@ -332,8 +333,30 @@ public abstract class Join extends BiRel implements Hintable {
    *                      semi-join
    * @return Copy of this join
    */
+  public final Join copy(RelTraitSet traitSet, RexNode conditionExpr,
+      RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone) {
+    return copy(traitSet, conditionExpr, left, right, getVariablesSet(), joinType, semiJoinDone);
+  }
+
+  /**
+   * Creates a copy of this join, overriding condition, system fields and
+   * inputs.
+   *
+   * <p>General contract as {@link RelNode#copy}.
+   *
+   * @param traitSet      Traits
+   * @param conditionExpr Condition
+   * @param left          Left input
+   * @param right         Right input
+   * @param joinType      Join type
+   * @param variablesSet  the variables that are set in this relational expression
+   * @param semiJoinDone  Whether this join has been translated to a
+   *                      semi-join
+   * @return Copy of this join
+   */
   public abstract Join copy(RelTraitSet traitSet, RexNode conditionExpr,
-      RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone);
+      RelNode left, RelNode right, Set<CorrelationId> variablesSet, JoinRelType joinType,
+      boolean semiJoinDone);
 
   /**
    * Analyzes the join condition.

--- a/core/src/main/java/org/apache/calcite/rel/core/Project.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/Project.java
@@ -150,7 +150,7 @@ public abstract class Project extends SingleRel implements Hintable {
   //~ Methods ----------------------------------------------------------------
 
   @Override public final RelNode copy(RelTraitSet traitSet,
-      List<RelNode> inputs) {
+      List<RelNode> inputs, Set<CorrelationId> variablesSet) {
     return copy(traitSet, sole(inputs), exps, getRowType());
   }
 
@@ -167,8 +167,32 @@ public abstract class Project extends SingleRel implements Hintable {
    *
    * @see #copy(RelTraitSet, List)
    */
-  public abstract Project copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType);
+  public final Project copy(RelTraitSet traitSet, RelNode input,
+      List<RexNode> projects, RelDataType rowType) {
+    return copy(traitSet, input, projects, rowType, variablesSet);
+  }
+
+  /**
+   * Copies a project.
+   *
+   * @param traitSet Traits
+   * @param input Input
+   * @param projects Project expressions
+   * @param rowType Output row type
+   * @param variablesSet the variables that are set in this relational
+   *                     expression
+   * @return New {@code Project} if any parameter differs from the value of this
+   *   {@code Project}, or just {@code this} if all the parameters are
+   *   the same
+   *
+   * @see #copy(RelTraitSet, List, Set)
+   */
+  public Project copy(RelTraitSet traitSet, RelNode input,
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+    // This method cannot be abstract because it would break compatibility
+    throw new UnsupportedOperationException(
+        "Must implement copy in " + getClass().getName());
+  }
 
   @Deprecated // to be removed before 2.0
   public Project copy(RelTraitSet traitSet, RelNode input,

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalAsofJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalAsofJoin.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.AsofJoin;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.hint.RelHint;
@@ -37,6 +38,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -137,8 +139,8 @@ public final class LogicalAsofJoin extends AsofJoin {
     return systemFieldList;
   }
 
-  @Override public Join copy(
-      RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right,
+  @Override public LogicalAsofJoin copy(RelTraitSet traitSet,
+      RexNode condition, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
       JoinRelType joinType, boolean semiJoinDone) {
     // This method does not provide the matchCondition as an argument, so it should never be called
     throw new RuntimeException("This method should not be called");

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalFilter.java
@@ -148,10 +148,10 @@ public final class LogicalFilter extends Filter {
   }
 
   @Override public LogicalFilter copy(RelTraitSet traitSet, RelNode input,
-      RexNode condition) {
+      RexNode condition, Set<CorrelationId> variablesSet) {
     assert traitSet.containsIfApplicable(Convention.NONE);
     return new LogicalFilter(getCluster(), traitSet, hints, input, condition,
-        variablesSet);
+        ImmutableSet.copyOf(variablesSet));
   }
 
   @Override public RelNode accept(RelShuttle shuttle) {

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalJoin.java
@@ -173,8 +173,9 @@ public final class LogicalJoin extends Join {
 
   //~ Methods ----------------------------------------------------------------
 
-  @Override public LogicalJoin copy(RelTraitSet traitSet, RexNode conditionExpr,
-      RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone) {
+  @Override public LogicalJoin copy(RelTraitSet traitSet,
+      RexNode conditionExpr, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
+      JoinRelType joinType, boolean semiJoinDone) {
     assert traitSet.containsIfApplicable(Convention.NONE);
     return new LogicalJoin(getCluster(),
         getCluster().traitSetOf(Convention.NONE), hints, left, right, conditionExpr,

--- a/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
+++ b/core/src/main/java/org/apache/calcite/rel/logical/LogicalProject.java
@@ -169,7 +169,7 @@ public final class LogicalProject extends Project {
   }
 
   @Override public LogicalProject copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType) {
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
     return new LogicalProject(getCluster(), traitSet, hints, input, projects, rowType,
         variablesSet);
   }

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -237,6 +237,8 @@ public class RelDecorrelator implements ReflectiveVisitor {
    */
   public static RelNode decorrelateQuery(RelNode rootRel,
       RelBuilder relBuilder, @Nullable RuleSet decorrelationRules) {
+    rootRel = RelOptUtil.CorrelVarNormalizer.normalize(rootRel);
+
     final CorelMap corelMap = new CorelMapBuilder().build(rootRel);
     if (!corelMap.hasCorrelation()) {
       return rootRel;

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -466,7 +466,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
     RexNode oldCondition = rel.getCondition();
     RelNode newInput = getNewForOldRel(rel.getInput());
     RexNode newCondition = oldCondition.accept(rewriteRexShuttle);
-    LogicalFilter newRel = rel.copy(traits, newInput, newCondition);
+    LogicalFilter newRel = rel.copy(traits, newInput, newCondition, rel.getVariablesSet());
     setNewForOldRel(rel, newRel);
   }
 

--- a/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/TraitPropagationTest.java
@@ -43,6 +43,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalAggregate;
@@ -83,6 +84,9 @@ import java.sql.DriverManager;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -391,7 +395,8 @@ class TraitPropagationTest {
     }
 
     public PhysProj copy(RelTraitSet traitSet, RelNode input,
-        List<RexNode> exps, RelDataType rowType) {
+        List<RexNode> exps, RelDataType rowType, Set<CorrelationId> variablesSet) {
+      checkArgument(variablesSet.isEmpty());
       return new PhysProj(getCluster(), traitSet, input, exps, rowType);
     }
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -156,8 +156,11 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static org.apache.calcite.test.SqlToRelTestBase.NL;
 
@@ -9838,7 +9841,8 @@ class RelOptRulesTest extends RelOptTestBase {
     }
 
     @Override public MyFilter copy(RelTraitSet traitSet, RelNode input,
-        RexNode condition) {
+        RexNode condition, Set<CorrelationId> variablesSet) {
+      checkArgument(variablesSet.isEmpty());
       return new MyFilter(getCluster(), traitSet, input, condition);
     }
   }
@@ -9895,7 +9899,8 @@ class RelOptRulesTest extends RelOptTestBase {
     }
 
     public MyProject copy(RelTraitSet traitSet, RelNode input,
-        List<RexNode> projects, RelDataType rowType) {
+        List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+      checkArgument(variablesSet.isEmpty());
       return new MyProject(getCluster(), traitSet, input, projects, rowType);
     }
   }

--- a/core/src/test/resources/sql/dummy.iq
+++ b/core/src/test/resources/sql/dummy.iq
@@ -15,10 +15,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-!use post
-values 1;
-EXPR$0
-1
+!use scott
+SELECT
+  (SELECT 1 FROM emp d WHERE d.job = a.job LIMIT 1) AS t1,
+  (SELECT a.job = 'PRESIDENT' FROM emp s LIMIT 1) as t2
+FROM emp a
+ORDER BY a.empno
+LIMIT 1;
+T1, T2
+1, false
 !ok
+EnumerableCalc(expr#0..4=[{inputs}], T1=[$t1], T2=[$t3], EMPNO=[$t0])
+  EnumerableLimit(fetch=[1])
+    EnumerableNestedLoopJoin(condition=[IS NOT DISTINCT FROM($2, $4)], joinType=[left])
+      EnumerableCalc(expr#0..3=[{inputs}], expr#4=['PRESIDENT':VARCHAR(9)], expr#5=[=($t1, $t4)], EMPNO=[$t0], EXPR$0=[$t2], $f3=[$t5])
+        EnumerableLimit(fetch=[1])
+          EnumerableHashJoin(condition=[=($1, $3)], joinType=[left])
+            EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], JOB=[$t2])
+              EnumerableLimit(fetch=[1])
+                EnumerableTableScan(table=[[scott, EMP]])
+            EnumerableCalc(expr#0..1=[{inputs}], w0$o0=[$t1], JOB=[$t0])
+              EnumerableAggregate(group=[{0, 1}])
+                EnumerableWindow(window#0=[window(partition {0} aggs [FIRST_VALUE($1)])], constants=[[1]])
+                  EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NOT NULL($t2)], JOB=[$t2], $condition=[$t8])
+                    EnumerableTableScan(table=[[scott, EMP]])
+      EnumerableCalc(expr#0..1=[{inputs}], w0$o0=[$t1], $f3=[$t0])
+        EnumerableAggregate(group=[{1, 2}])
+          EnumerableWindow(window#0=[window(partition {1} aggs [FIRST_VALUE($1)])])
+            EnumerableNestedLoopJoin(condition=[true], joinType=[inner])
+              EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0])
+                EnumerableTableScan(table=[[scott, EMP]])
+              EnumerableAggregate(group=[{0}])
+                EnumerableCalc(expr#0..3=[{inputs}], expr#4=['PRESIDENT':VARCHAR(9)], expr#5=[=($t1, $t4)], $f3=[$t5])
+                  EnumerableMergeJoin(condition=[=($1, $3)], joinType=[left])
+                    EnumerableSort(sort0=[$1], dir0=[ASC])
+                      EnumerableCalc(expr#0..7=[{inputs}], EMPNO=[$t0], JOB=[$t2])
+                        EnumerableTableScan(table=[[scott, EMP]])
+                    EnumerableSort(sort0=[$1], dir0=[ASC])
+                      EnumerableCalc(expr#0..1=[{inputs}], w0$o0=[$t1], JOB=[$t0])
+                        EnumerableAggregate(group=[{0, 1}])
+                          EnumerableWindow(window#0=[window(partition {0} aggs [FIRST_VALUE($1)])], constants=[[1]])
+                            EnumerableCalc(expr#0..7=[{inputs}], expr#8=[IS NOT NULL($t2)], JOB=[$t2], $condition=[$t8])
+                              EnumerableTableScan(table=[[scott, EMP]])
+!plan
 # do not modify this file, this is intended only for temporary debugging code
 # End dummy.iq

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchFilter.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchFilter.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexCall;
@@ -36,6 +37,9 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -57,7 +61,9 @@ public class ElasticsearchFilter extends Filter implements ElasticsearchRel {
     return cost.multiplyBy(0.1);
   }
 
-  @Override public Filter copy(RelTraitSet relTraitSet, RelNode input, RexNode condition) {
+  @Override public Filter copy(RelTraitSet relTraitSet, RelNode input, RexNode condition,
+      Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new ElasticsearchFilter(getCluster(), relTraitSet, input, condition);
   }
 

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchProject.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -35,7 +36,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +56,8 @@ public class ElasticsearchProject extends Project implements ElasticsearchRel {
   }
 
   @Override public Project copy(RelTraitSet relTraitSet, RelNode input, List<RexNode> projects,
-      RelDataType relDataType) {
+      RelDataType relDataType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new ElasticsearchProject(getCluster(), traitSet, input, projects, relDataType);
   }
 

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -79,7 +80,9 @@ public class GeodeFilter extends Filter implements GeodeRel {
     return cost.multiplyBy(0.1);
   }
 
-  @Override public GeodeFilter copy(RelTraitSet traitSet, RelNode input, RexNode condition) {
+  @Override public GeodeFilter copy(RelTraitSet traitSet, RelNode input, RexNode condition,
+      Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new GeodeFilter(getCluster(), traitSet, input, condition);
   }
 

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeProject.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeProject.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -36,6 +37,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -54,7 +58,8 @@ public class GeodeProject extends Project implements GeodeRel {
   }
 
   @Override public Project copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType) {
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new GeodeProject(getCluster(), traitSet, input, projects, rowType);
   }
 

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilter.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbFilter.java
@@ -23,6 +23,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
@@ -30,6 +31,10 @@ import org.apache.calcite.rex.RexNode;
 import com.alibaba.innodb.java.reader.schema.TableDef;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -71,7 +76,8 @@ public class InnodbFilter extends Filter implements InnodbRel {
   }
 
   @Override public InnodbFilter copy(RelTraitSet traitSet, RelNode input,
-      RexNode condition) {
+      RexNode condition, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new InnodbFilter(getCluster(), traitSet, input, condition,
         indexCondition, tableDef, forceIndexName);
   }

--- a/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbProject.java
+++ b/innodb/src/main/java/org/apache/calcite/adapter/innodb/InnodbProject.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -35,6 +36,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import static java.util.Objects.requireNonNull;
 
@@ -51,7 +55,8 @@ public class InnodbProject extends Project implements InnodbRel {
   }
 
   @Override public Project copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType) {
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new InnodbProject(getCluster(), traitSet, input, projects, rowType);
   }
 

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoFilter.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoFilter.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -45,6 +46,9 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Implementation of a {@link org.apache.calcite.rel.core.Filter}
@@ -67,7 +71,8 @@ public class MongoFilter extends Filter implements MongoRel {
   }
 
   @Override public MongoFilter copy(RelTraitSet traitSet, RelNode input,
-      RexNode condition) {
+      RexNode condition, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new MongoFilter(getCluster(), traitSet, input, condition);
   }
 

--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoProject.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoProject.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
@@ -36,6 +37,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Implementation of {@link org.apache.calcite.rel.core.Project}
@@ -57,7 +61,8 @@ public class MongoProject extends Project implements MongoRel {
   }
 
   @Override public Project copy(RelTraitSet traitSet, RelNode input,
-      List<RexNode> projects, RelDataType rowType) {
+      List<RexNode> projects, RelDataType rowType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new MongoProject(getCluster(), traitSet, input, projects,
         rowType);
   }

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigFilter.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigFilter.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
@@ -29,7 +30,9 @@ import org.apache.calcite.rex.RexNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import static org.apache.calcite.sql.SqlKind.INPUT_REF;
@@ -45,7 +48,9 @@ public class PigFilter extends Filter implements PigRel {
     assert getConvention() == PigRel.CONVENTION;
   }
 
-  @Override public Filter copy(RelTraitSet traitSet, RelNode input, RexNode condition) {
+  @Override public Filter copy(RelTraitSet traitSet, RelNode input, RexNode condition,
+      Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new PigFilter(getCluster(), traitSet, input, condition);
   }
 

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigJoin.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigJoin.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexCall;
@@ -32,6 +33,9 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Join} in
  * {@link PigRel#CONVENTION Pig calling convention}. */
@@ -45,8 +49,10 @@ public class PigJoin extends Join implements PigRel {
     assert getConvention() == PigRel.CONVENTION;
   }
 
-  @Override public Join copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left,
-      RelNode right, JoinRelType joinType, boolean semiJoinDone) {
+  @Override public PigJoin copy(RelTraitSet traitSet,
+      RexNode conditionExpr, RelNode left, RelNode right, Set<CorrelationId> variablesSet,
+      JoinRelType joinType, boolean semiJoinDone) {
+    checkArgument(variablesSet.isEmpty());
     return new PigJoin(getCluster(), traitSet, left, right, conditionExpr, joinType);
   }
 

--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigProject.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigProject.java
@@ -20,6 +20,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
@@ -28,6 +29,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /** Implementation of {@link org.apache.calcite.rel.core.Project} in
  * {@link PigRel#CONVENTION Pig calling convention}. */
@@ -41,7 +45,8 @@ public class PigProject extends Project implements PigRel {
   }
 
   @Override public Project copy(RelTraitSet traitSet, RelNode input, List<RexNode> projects,
-      RelDataType rowType) {
+      RelDataType rowType, Set<CorrelationId> variablesSet) {
+    checkArgument(variablesSet.isEmpty());
     return new PigProject(input.getCluster(), traitSet, input, projects, rowType);
   }
 


### PR DESCRIPTION
Ticket: [CALCITE-5390]

I will have time to continue this work only next month. If anyone wishes to take over or continue this task in the meantime, please feel free to do so. I currently have a draft solution, but it has a few problems that need resolving:

- Solution logic throws a `NullPointerException` in cases where a correlation variable is used but has not been properly introduced. This specifically happens in join plans where a subquery exists in the ON clause, but not in the WHERE clause. (See example: [CALCITE-7286]). Also in this case of  [CALCITE-7286] `LogicalJoin` should be replaced by `LogicalCorrelate`
- Solution depends on a proposal to introduce a new `RelNode.copy` method with a 3rd parameter to replace the variablesSet [CALCITE-7280]. As suggested by Stamatis in a comment on this task, this functionality should probably be implemented using the `RelBuilder`  instead.
- Better test coverage
- At the moment, code only compiles with Guava version 32.0 or higher because of `buildKeepingLast`.

PR contains two commits. The first commit relates to [CALCITE-7280] (introducing copy method) and second contains the logic for the main fix itself. Feel free to add any comment you wish, especially if you know a better solution.