### PR TITLE
[CALCITE-4099] Unify Strong.Policy and NullPolicy

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/NullPolicy.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/NullPolicy.java
@@ -38,5 +38,9 @@ public enum NullPolicy {
   ANY,
   /** If the first argument is null, return null. */
   ARG0,
+  /** Never returns null no matter the values of the arguments. */
+  NEVER,
+  /** Returns null under certain conditions that depend entirely on the operator/function.
+   *  Operators using this policy have custom rules for when to return null.*/
   NONE
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.calcite.sql;
 
+import org.apache.calcite.adapter.enumerable.NullPolicy;
+import org.apache.calcite.adapter.enumerable.RexImpTable;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.Strong;
 import org.apache.calcite.rel.type.RelDataType;
@@ -1033,8 +1035,28 @@ public abstract class SqlOperator {
    * @see Strong
    */
   @Pure
+  @Deprecated
   public @Nullable Supplier<Strong.Policy> getStrongPolicyInference() {
     return null;
+  }
+
+  /**
+   * Returns the null policy for this operator.
+   *
+   * @return the null policy for this operator
+   */
+  public NullPolicy getNullPolicy() {
+    NullPolicy p = RexImpTable.INSTANCE.getPolicy(this);
+    if (p != null) {
+      return p;
+    }
+    p = Strong.nullPolicy(getKind());
+    if (p != null) {
+      assert p == NullPolicy.NONE
+          : p + " policy is only defined via SqlKind for " + this.getName();
+      return p;
+    }
+    return NullPolicy.NONE;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql.fun;
 
+import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlAggFunction;
@@ -415,7 +416,13 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           true,
           ReturnTypes.BOOLEAN,
           InferTypes.FIRST_KNOWN,
-          OperandTypes.COMPARABLE_UNORDERED_COMPARABLE_UNORDERED);
+          OperandTypes.COMPARABLE_UNORDERED_COMPARABLE_UNORDERED) {
+        @Override public NullPolicy getNullPolicy() {
+          // Missing in RexImpTable mapping but present in Strong.Policy
+          // Override here till we decide where the mapping will leave.
+          return NullPolicy.NEVER;
+        }
+      };
 
   /**
    * <code>IS NOT DISTINCT FROM</code> operator. Is equivalent to <code>NOT(x
@@ -832,7 +839,13 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           28,
           ReturnTypes.BOOLEAN_NOT_NULL,
           InferTypes.BOOLEAN,
-          OperandTypes.BOOLEAN);
+          OperandTypes.BOOLEAN) {
+        @Override public NullPolicy getNullPolicy() {
+          // Missing in RexImpTable mapping but present in Strong.Policy
+          // Override here till we decide where the mapping will leave.
+          return NullPolicy.NEVER;
+        }
+      };
 
   public static final SqlPostfixOperator IS_UNKNOWN =
       new SqlPostfixOperator(
@@ -841,7 +854,13 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           28,
           ReturnTypes.BOOLEAN_NOT_NULL,
           InferTypes.BOOLEAN,
-          OperandTypes.BOOLEAN);
+          OperandTypes.BOOLEAN) {
+        @Override public NullPolicy getNullPolicy() {
+          // Missing in RexImpTable mapping but present in Strong.Policy
+          // Override here till we decide where the mapping will leave.
+          return NullPolicy.NEVER;
+        }
+      };
 
   public static final SqlPostfixOperator IS_A_SET =
       new SqlPostfixOperator(

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.rex;
 
+import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptUtil;
@@ -67,7 +68,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Supplier;
 
 import static org.apache.calcite.test.Matchers.isRangeSet;
 
@@ -4170,16 +4170,16 @@ class RexProgramTest extends RexProgramTestBase {
   /** An operator that overrides the {@link #getStrongPolicyInference}
    * method. */
   private static class SqlSpecialOperatorWithPolicy extends SqlSpecialOperator {
-    private final Strong.Policy policy;
+    private final NullPolicy policy;
     private SqlSpecialOperatorWithPolicy(String name, SqlKind kind, int prec, boolean leftAssoc,
         SqlReturnTypeInference returnTypeInference, SqlOperandTypeInference operandTypeInference,
-        SqlOperandTypeChecker operandTypeChecker, Strong.Policy policy) {
+        SqlOperandTypeChecker operandTypeChecker, NullPolicy policy) {
       super(name, kind, prec, leftAssoc, returnTypeInference, operandTypeInference,
           operandTypeChecker);
       this.policy = policy;
     }
-    @Override public Supplier<Strong.Policy> getStrongPolicyInference() {
-      return () -> policy;
+    @Override public NullPolicy getNullPolicy() {
+      return policy;
     }
   }
 
@@ -4197,7 +4197,7 @@ class RexProgramTest extends RexProgramTestBase {
 
     final SqlOperator opPolicyAsIs =
         new SqlSpecialOperatorWithPolicy("OP2", SqlKind.OTHER_FUNCTION, 0,
-            false, ReturnTypes.BOOLEAN, null, null, Strong.Policy.AS_IS) {
+            false, ReturnTypes.BOOLEAN, null, null, NullPolicy.NONE) {
         };
     // Operator with Strong.Policy.AS_IS but not safe: no simplification can be made
     checkSimplifyUnchanged(rexBuilder.makeCall(opPolicyAsIs, vInt()));
@@ -4206,7 +4206,7 @@ class RexProgramTest extends RexProgramTestBase {
 
     final SqlOperator opPolicyAny =
         new SqlSpecialOperatorWithPolicy("OP3", SqlKind.OTHER_FUNCTION, 0,
-            false, ReturnTypes.BOOLEAN, null, null, Strong.Policy.ANY) {
+            false, ReturnTypes.BOOLEAN, null, null, NullPolicy.STRICT) {
           @Override public Boolean isSafeOperator() {
             return true;
           }

--- a/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcAdapterTest.java
@@ -1479,25 +1479,25 @@ class JdbcAdapterTest {
           + "WHERE\n"
           + "    \"content-owner\" IN (?)")
         .planHasSql("SELECT "
-            + "\"t2\".\"DNAME\" AS \"content-format-owner\", "
-            + "\"t2\".\"DNAME0\" || ' ' AS \"content-owner\"\n"
-            + "FROM (SELECT \"t\".\"DEPTNO\" AS \"DEPTNO\", "
+            + "\"t3\".\"DNAME\" AS \"content-format-owner\", "
+            + "\"t3\".\"DNAME0\" || ' ' AS \"content-owner\"\n"
+            + "FROM (SELECT \"t\".\"DEPTNO\", "
             + "\"t0\".\"DEPTNO\" AS \"DEPTNO0\", "
-            + "\"t0\".\"DNAME\" AS \"DNAME\", "
-            + "\"t1\".\"DEPTNO\" AS \"DEPTNO1\", "
-            + "\"t1\".\"DNAME\" AS \"DNAME0\"\n"
+            + "\"t0\".\"DNAME\", "
+            + "CAST(\"t2\".\"DEPTNO\" AS TINYINT) AS \"DEPTNO1\", "
+            + "\"t2\".\"DNAME\" AS \"DNAME0\"\n"
             + "FROM (SELECT \"DEPTNO\"\n"
             + "FROM \"SCOTT\".\"EMP\") AS \"t\"\n"
             + "LEFT JOIN (SELECT \"DEPTNO\", \"DNAME\"\n"
             + "FROM \"SCOTT\".\"DEPT\") AS \"t0\" ON \"t\".\"DEPTNO\" = \"t0\".\"DEPTNO\"\n"
-            + "LEFT JOIN (SELECT \"DEPTNO\", \"DNAME\"\n"
-            + "FROM \"SCOTT\".\"DEPT\") AS \"t1\" "
-            + "ON \"t\".\"DEPTNO\" = \"t1\".\"DEPTNO\"\n"
-            + "WHERE \"t1\".\"DNAME\" || ' ' = ?) AS \"t2\"\n"
+            + "INNER JOIN (SELECT \"DEPTNO\", \"DNAME\"\n"
+            + "FROM \"SCOTT\".\"DEPT\"\n"
+            + "WHERE \"DNAME\" || ' ' = ?) AS \"t2\" "
+            + "ON \"t\".\"DEPTNO\" = \"t2\".\"DEPTNO\") AS \"t3\"\n"
             + "LEFT JOIN (SELECT \"DEPTNO\"\n"
-            + "FROM \"SCOTT\".\"EMP\") AS \"t3\" "
-            + "ON \"t2\".\"DEPTNO\" = \"t3\".\"DEPTNO\"\n"
-            + "GROUP BY \"t2\".\"DNAME\", \"t2\".\"DNAME0\"")
+            + "FROM \"SCOTT\".\"EMP\") AS \"t4\" "
+            + "ON \"t3\".\"DEPTNO\" = \"t4\".\"DEPTNO\"\n"
+            + "GROUP BY \"t3\".\"DNAME\", \"t3\".\"DNAME0\"")
         .runs();
   }
 

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.config.CalciteConnectionProperty;
@@ -23,7 +24,6 @@ import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.linq4j.function.Function1;
 import org.apache.calcite.linq4j.function.Function2;
 import org.apache.calcite.linq4j.tree.Types;
-import org.apache.calcite.plan.Strong;
 import org.apache.calcite.rel.type.DelegatingTypeSystem;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -17581,9 +17581,9 @@ public class SqlOperatorTest {
               || s.matches("MOD\\(.*, 0\\)")) {
             continue;
           }
-          final Strong.Policy policy = Strong.policy(op);
+          final NullPolicy policy = op.getNullPolicy();
           try {
-            if (nullCount > 0 && policy == Strong.Policy.ANY) {
+            if (nullCount > 0 && policy == NullPolicy.STRICT) {
               f.checkNull(s);
             } else {
               final String query;


### PR DESCRIPTION
1. Deprecate Strong.Policy in favor of NullPolicy
2. Add NullPolicy.NEVER for describing operators that never return null
3. Replace Strong.Policy with NullPolicy using the following mapping: Strong.Policy.ANY -> NullPolicy.STRICT
Strong.Policy.AS_IS -> NullPolicy.NONE
Strong.Policy.CUSTOM -> NullPolicy.NONE
Strong.Policy.NOT_NULL -> NullPolicy.NEVER
essentially AS_IS and CUSTOM are now handled in the same way.
4. Deprecate APIs using/returning Strong.Policy
5. Use NullPolicy mapping from RexImpTable as the primary source of truth
6. Modify NullPolicy for IsXx, NOT, and CAST operators in RexImpTable to be aligned with desired behavior
7. Define fallback mapping using SqlKind in Strong.Policy for projects that define their own operators (most likely will drop that)
8. Hardcode policy for some operators not defined in RexImpTable failing the assertion in SqlOperator#getNullPolicy
9. Update plan/sql in JdbcAdapterTest#testUnknownColumn which changes from LEFT JOIN to INNER JOIN due FilterJoinRule and in particular RelOptUtil#simplifyJoin since the CONCAT operator is now defined as STRICT so we can infer that the filter would reject nulls and thus we are able to simplify.