### PR TITLE
calcite-file: Support custom CSV separator in CsvTableFactory

### DIFF
--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvEnumerator.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvEnumerator.java
@@ -27,6 +27,7 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Source;
 import org.apache.calcite.util.trace.CalciteLogger;
 
+
 import au.com.bytecode.opencsv.CSVReader;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -116,11 +117,11 @@ public class CsvEnumerator<E> implements Enumerator<E> {
       List<RelDataType> fieldTypes, List<Integer> fields) {
     //noinspection unchecked
     this(source, cancelFlag, false, null,
-        (RowConverter<E>) converter(fieldTypes, fields));
+        (RowConverter<E>) converter(fieldTypes, fields), au.com.bytecode.opencsv.CSVParser.DEFAULT_SEPARATOR);
   }
 
   public CsvEnumerator(Source source, AtomicBoolean cancelFlag, boolean stream,
-      @Nullable String @Nullable [] filterValues, RowConverter<E> rowConverter) {
+      @Nullable String @Nullable [] filterValues, RowConverter<E> rowConverter, char separator) {
     this.cancelFlag = cancelFlag;
     this.rowConverter = rowConverter;
     this.filterValues =
@@ -128,9 +129,9 @@ public class CsvEnumerator<E> implements Enumerator<E> {
             : ImmutableNullableList.copyOf(filterValues);
     try {
       if (stream) {
-        this.reader = new CsvStreamReader(source);
+        this.reader = new CsvStreamReader(source, separator);
       } else {
-        this.reader = openCsv(source);
+        this.reader = openCsv(source, separator);
       }
       this.reader.readNext(); // skip header row
     } catch (IOException e) {
@@ -157,13 +158,20 @@ public class CsvEnumerator<E> implements Enumerator<E> {
    * of a CSV file. */
   public static RelDataType deduceRowType(JavaTypeFactory typeFactory,
       Source source, @Nullable List<RelDataType> fieldTypes, Boolean stream) {
+    return deduceRowType(typeFactory, source, fieldTypes, stream, au.com.bytecode.opencsv.CSVParser.DEFAULT_SEPARATOR);
+  }
+
+  /** Deduces the names and types of a table's columns by reading the first line
+   * of a CSV file. */
+  public static RelDataType deduceRowType(JavaTypeFactory typeFactory,
+      Source source, @Nullable List<RelDataType> fieldTypes, Boolean stream, char separator) {
     final List<RelDataType> types = new ArrayList<>();
     final List<String> names = new ArrayList<>();
     if (stream) {
       names.add(FileSchemaFactory.ROWTIME_COLUMN_NAME);
       types.add(typeFactory.createSqlType(SqlTypeName.TIMESTAMP));
     }
-    try (CSVReader reader = openCsv(source)) {
+    try (CSVReader reader = openCsv(source, separator)) {
       String[] strings = reader.readNext();
       if (strings == null) {
         strings = new String[]{"EmptyFileHasNoColumns:boolean"};
@@ -248,8 +256,12 @@ public class CsvEnumerator<E> implements Enumerator<E> {
   }
 
   static CSVReader openCsv(Source source) throws IOException {
+    return openCsv(source, au.com.bytecode.opencsv.CSVParser.DEFAULT_SEPARATOR);
+  }
+
+  static CSVReader openCsv(Source source, char separator) throws IOException {
     requireNonNull(source, "source");
-    return new CSVReader(source.reader());
+    return new CSVReader(source.reader(), separator);
   }
 
   @Override public E current() {

--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvStreamReader.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvStreamReader.java
@@ -53,9 +53,9 @@ class CsvStreamReader extends CSVReader implements Closeable {
    */
   public static final long DEFAULT_MONITOR_DELAY = 2000;
 
-  CsvStreamReader(Source source) {
+  CsvStreamReader(Source source, char separator) {
     this(source,
-        CSVParser.DEFAULT_SEPARATOR,
+        separator,
         CSVParser.DEFAULT_QUOTE_CHARACTER,
         CSVParser.DEFAULT_ESCAPE_CHARACTER,
         DEFAULT_SKIP_LINES,

--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvTable.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvTable.java
@@ -23,6 +23,8 @@ import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.util.Source;
 
+import au.com.bytecode.opencsv.CSVParser;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
@@ -37,13 +39,20 @@ import java.util.List;
 public abstract class CsvTable extends AbstractTable {
   protected final Source source;
   protected final @Nullable RelProtoDataType protoRowType;
+  protected final char separator;
   private @Nullable RelDataType rowType;
   private @Nullable List<RelDataType> fieldTypes;
 
   /** Creates a CsvTable. */
   CsvTable(Source source, @Nullable RelProtoDataType protoRowType) {
+    this(source, protoRowType, CSVParser.DEFAULT_SEPARATOR);
+  }
+
+  /** Creates a CsvTable. */
+  CsvTable(Source source, @Nullable RelProtoDataType protoRowType, char separator) {
     this.source = source;
     this.protoRowType = protoRowType;
+    this.separator = separator;
   }
 
   @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
@@ -53,7 +62,7 @@ public abstract class CsvTable extends AbstractTable {
     if (rowType == null) {
       rowType =
           CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source,
-              null, isStream());
+              null, isStream(), separator);
     }
     return rowType;
   }
@@ -63,7 +72,7 @@ public abstract class CsvTable extends AbstractTable {
     if (fieldTypes == null) {
       fieldTypes = new ArrayList<>();
       CsvEnumerator.deduceRowType((JavaTypeFactory) typeFactory, source,
-          fieldTypes, isStream());
+          fieldTypes, isStream(), separator);
     }
     return fieldTypes;
   }

--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvTableFactory.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvTableFactory.java
@@ -48,8 +48,19 @@ public class CsvTableFactory implements TableFactory<CsvTable> {
     final File base =
         (File) operand.get(ModelHandler.ExtraOperand.BASE_DIRECTORY.camelName);
     final Source source = Sources.file(base, fileName);
+    String separatorString = (String) operand.get("separator");
+    final char separator;
+    if (separatorString == null) {
+      separator = ',';
+    } else if (separatorString.length() == 1) {
+      separator = separatorString.charAt(0);
+    } else {
+      throw new IllegalArgumentException(
+          "Invalid separator '" + separatorString
+              + "'. Separator must be a single character.");
+    }
     final RelProtoDataType protoRowType =
         rowType != null ? RelDataTypeImpl.proto(rowType) : null;
-    return new CsvTranslatableTable(source, protoRowType);
+    return new CsvTranslatableTable(source, protoRowType, separator);
   }
 }

--- a/file/src/main/java/org/apache/calcite/adapter/file/CsvTranslatableTable.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/CsvTranslatableTable.java
@@ -34,6 +34,8 @@ import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Source;
 
+import au.com.bytecode.opencsv.CSVParser;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Type;
@@ -49,7 +51,11 @@ public class CsvTranslatableTable extends CsvTable
     implements QueryableTable, TranslatableTable {
   /** Creates a CsvTable. */
   CsvTranslatableTable(Source source, @Nullable RelProtoDataType protoRowType) {
-    super(source, protoRowType);
+    this(source, protoRowType, CSVParser.DEFAULT_SEPARATOR);
+  }
+
+  CsvTranslatableTable(Source source, @Nullable RelProtoDataType protoRowType, char separator) {
+    super(source, protoRowType, separator);
   }
 
   @Override public String toString() {
@@ -64,8 +70,11 @@ public class CsvTranslatableTable extends CsvTable
     return new AbstractEnumerable<Object>() {
       @Override public Enumerator<Object> enumerator() {
         JavaTypeFactory typeFactory = root.getTypeFactory();
-        return new CsvEnumerator<>(source, cancelFlag,
-            getFieldTypes(typeFactory), ImmutableIntList.of(fields));
+        //noinspection unchecked
+        return new CsvEnumerator<Object>(source, cancelFlag, false, null,
+            (CsvEnumerator.RowConverter) CsvEnumerator.arrayConverter(
+                getFieldTypes(typeFactory), ImmutableIntList.of(fields), false),
+            separator);
       }
     };
   }

--- a/file/src/test/java/org/apache/calcite/adapter/file/CsvSeparatorTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/CsvSeparatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.file;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Tests for custom separator support in CSV adapter.
+ */
+class CsvSeparatorTest {
+  @Test void testPipeSeparatorViaJdbc() throws Exception {
+    String path = new java.io.File("src/test/resources/pipe_separated.csv").getAbsolutePath().replace("\\", "\\\\");
+    Properties info = new Properties();
+    String model = "{\n"
+        + "  version: '1.0',\n"
+        + "  defaultSchema: 'TEST',\n"
+        + "  schemas: [\n"
+        + "    {\n"
+        + "      name: 'TEST',\n"
+        + "      type: 'map',\n"
+        + "      tables: [\n"
+        + "        {\n"
+        + "          name: 'PIPE_SEPARATED',\n"
+        + "          type: 'custom',\n"
+        + "          factory: 'org.apache.calcite.adapter.file.CsvTableFactory',\n"
+        + "          operand: {\n"
+        + "            file: '" + path + "',\n"
+        + "            separator: '\\t'\n"
+        + "          }\n"
+        + "        }\n"
+        + "      ]\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    info.put("model", "inline:" + model);
+
+    try (Connection connection = DriverManager.getConnection("jdbc:calcite:", info);
+         Statement statement = connection.createStatement();
+         ResultSet resultSet = statement.executeQuery("select * from \"PIPE_SEPARATED\"")) {
+
+      ResultSetMetaData metaData = resultSet.getMetaData();
+      int columnCount = metaData.getColumnCount();
+
+      System.out.println("DEBUG: Detected Column Count: " + columnCount);
+      for (int i = 1; i <= columnCount; i++) {
+        System.out.println("DEBUG: Column " + i + ": " + metaData.getColumnName(i));
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
# Title: [FILE] Support custom separator in CSV adapter

## Description
This PR adds support for custom field delimiters (separators) in the CSV adapter. previously, the adapter hardcoded the comma (`,`) as the separator, preventing the use of other common delimiters like pipes (`|`) or tabs (`\t`).

## Changes
- Modified [CsvTableFactory] to parse an optional `separator` property from the operand map.
- Updated [CsvTable], [CsvTranslatableTable], and [CsvEnumerator] to propagate the separator character down to the reader.
- Updated `CsvStreamReader` to accept a custom separator in its constructor.
- Defaults to comma (`,`) if no separator is specified, preserving backward compatibility.

## Example Configuration
Users can now specify a `separator` in their model JSON:

```json
{
  "version": "1.0",
  "defaultSchema": "TEST",
  "schemas": [
    {
      "name": "TEST",
      "type": "custom",
      "factory": "org.apache.calcite.adapter.file.CsvTableFactory",
      "operand": {
        "file": "data.csv",
        "separator": "|"
      }
    }
  ]
}