### PR TITLE
[CALCITE-7440] RelToSqlConverter throws NPE (variable $cor1 not found) for correlated projection after semi-join rewrites

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -867,6 +867,7 @@ public abstract class SqlImplementor {
       case ALL:
         if (rex instanceof RexSubQuery) {
           subQuery = (RexSubQuery) rex;
+          registerSubQueryCorrelations(subQuery);
           sqlSubQuery = implementor().visitRoot(subQuery.rel).asQueryOrValues();
           final List<RexNode> operands = subQuery.operands;
           SqlNode op0;
@@ -894,6 +895,7 @@ public abstract class SqlImplementor {
       case UNIQUE:
       case SCALAR_QUERY:
         subQuery = (RexSubQuery) rex;
+        registerSubQueryCorrelations(subQuery);
         sqlSubQuery =
             implementor().visitRoot(subQuery.rel).asQueryOrValues();
         return subQuery.getOperator().createCall(POS, sqlSubQuery);
@@ -936,6 +938,12 @@ public abstract class SqlImplementor {
         }
 
         return callToSql(program, (RexCall) rex, false);
+      }
+    }
+
+    private void registerSubQueryCorrelations(RexSubQuery subQuery) {
+      for (CorrelationId id : RelOptUtil.getVariablesUsed(subQuery.rel)) {
+        implementor().correlTableMap.putIfAbsent(id, this);
       }
     }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -12711,6 +12711,36 @@ class RelToSqlConverterTest {
     sql(sql).schema(CalciteAssert.SchemaSpec.JDBC_SCOTT).ok(expected);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7440">[CALCITE-7440]
+   * RelToSqlConverter throws NPE (variable $cor1 not found) for correlated
+   * projection after semi-join rewrites.</a>. */
+  @Test void testPostgresqlRoundTripCorrelatedProjectWithSemiJoinRules() {
+    final String query = "WITH product_keys AS (\n"
+        + "  SELECT p.\"product_id\",\n"
+        + "         (SELECT MAX(p3.\"product_id\")\n"
+        + "          FROM \"foodmart\".\"product\" p3\n"
+        + "          WHERE p3.\"product_id\" = p.\"product_id\") AS \"mx\"\n"
+        + "  FROM \"foodmart\".\"product\" p\n"
+        + ")\n"
+        + "SELECT DISTINCT pk.\"product_id\"\n"
+        + "FROM product_keys pk\n"
+        + "LEFT JOIN \"foodmart\".\"product\" p2 USING (\"product_id\")\n"
+        + "WHERE pk.\"product_id\" IN (\n"
+        + "  SELECT p4.\"product_id\"\n"
+        + "  FROM \"foodmart\".\"product\" p4\n"
+        + ")";
+
+    final RuleSet rules =
+        RuleSets.ofList(CoreRules.FILTER_SUB_QUERY_TO_MARK_CORRELATE,
+            CoreRules.PROJECT_SUB_QUERY_TO_MARK_CORRELATE,
+            CoreRules.MARK_TO_SEMI_OR_ANTI_JOIN_RULE,
+            CoreRules.SEMI_JOIN_JOIN_TRANSPOSE);
+
+    final String generated = sql(query).withPostgresql().optimize(rules, null).exec();
+    sql(generated).withPostgresql().exec();
+  }
+
   @Test void testNotBetween() {
     Sql f = fixture().withConvertletTable(new SqlRexConvertletTable() {
       @Override public @Nullable SqlRexConvertlet get(SqlCall call) {


### PR DESCRIPTION
## Jira Link

[CALCITE-7440](https://issues.apache.org/jira/browse/CALCITE-7440)

## Changes Proposed

`RelToSqlConverter` can lose correlation context when generated SQL containing a correlated subquery is converted again after semi-join rewrites, failing with `variable $cor1 is not found`.

This change registers correlation IDs used by `RexSubQuery` relations in the enclosing SQL context before visiting each subquery. Alias-generation behavior is unchanged.

## Reproduction

`RelToSqlConverterTest.testPostgresqlRoundTripCorrelatedProjectWithSemiJoinRules` reproduces the NPE on current `main` and passes with this change.

## Testing

- exact current-`main` baseline fails with `variable $cor1 is not found`
- 607 `RelToSqlConverterTest` cases and 4 struct cases passed
- core checkstyle, forbidden APIs, and assemble passed

## Disclaimer

Changes were done with Codex assistance in response to a production bug and manually verified before review.
