### PR TITLE
[CALCITE-6908] Add Apache Kvrocks adapter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,7 +237,7 @@ val javadocAggregateIncludingTests by tasks.registering(Javadoc::class) {
 
 val adaptersForSqlline = listOf(
     ":arrow", ":babel", ":cassandra", ":druid", ":elasticsearch",
-    ":file", ":geode", ":innodb", ":kafka", ":mongodb",
+    ":file", ":geode", ":innodb", ":kafka", ":kvrocks", ":mongodb",
     ":pig", ":piglet", ":plus", ":redis", ":server", ":spark", ":splunk")
 
 val dataSetsForSqlline = listOf(

--- a/kvrocks/build.gradle.kts
+++ b/kvrocks/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+dependencies {
+    api(project(":core"))
+    api(project(":linq4j"))
+    api("redis.clients:jedis")
+
+    implementation("com.fasterxml.jackson.core:jackson-core")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.google.guava:guava")
+    implementation("org.apache.calcite.avatica:avatica-core")
+    implementation("org.apache.commons:commons-pool2")
+    implementation("org.slf4j:slf4j-api")
+
+    testImplementation(project(":testkit"))
+    testImplementation("org.mockito:mockito-core")
+    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl")
+    testImplementation("org.testcontainers:testcontainers")
+}

--- a/kvrocks/gradle.properties
+++ b/kvrocks/gradle.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+description=Kvrocks adapter for Calcite
+artifact.name=Calcite Kvrocks

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksConfig.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksConfig.java
@@ -22,23 +22,20 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Connection configuration for the Kvrocks adapter.
  *
  * <p>Holds all parameters needed to establish a connection to a Kvrocks
- * instance: host, port, database index, optional password, and optional
- * namespace (Kvrocks-specific multi-tenancy feature).
+ * instance: host, port, database index, and optional password.
  */
 public class KvrocksConfig {
   private final String host;
   private final int port;
   private final int database;
   private final @Nullable String password;
-  private final @Nullable String namespace;
 
   KvrocksConfig(String host, int port, int database,
-      @Nullable String password, @Nullable String namespace) {
+      @Nullable String password) {
     this.host = host;
     this.port = port;
     this.database = database;
     this.password = password;
-    this.namespace = namespace;
   }
 
   public String getHost() {
@@ -55,9 +52,5 @@ public class KvrocksConfig {
 
   public @Nullable String getPassword() {
     return password;
-  }
-
-  public @Nullable String getNamespace() {
-    return namespace;
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksConfig.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Connection configuration for the Kvrocks adapter.
+ *
+ * <p>Holds all parameters needed to establish a connection to a Kvrocks
+ * instance: host, port, database index, optional password, and optional
+ * namespace (Kvrocks-specific multi-tenancy feature).
+ */
+public class KvrocksConfig {
+  private final String host;
+  private final int port;
+  private final int database;
+  private final @Nullable String password;
+  private final @Nullable String namespace;
+
+  KvrocksConfig(String host, int port, int database,
+      @Nullable String password, @Nullable String namespace) {
+    this.host = host;
+    this.port = port;
+    this.database = database;
+    this.password = password;
+    this.namespace = namespace;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public int getDatabase() {
+    return database;
+  }
+
+  public @Nullable String getPassword() {
+    return password;
+  }
+
+  public @Nullable String getNamespace() {
+    return namespace;
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksConfig.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksConfig.java
@@ -22,20 +22,28 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Connection configuration for the Kvrocks adapter.
  *
  * <p>Holds all parameters needed to establish a connection to a Kvrocks
- * instance: host, port, database index, and optional password.
+ * instance: host, port, database index, optional administrator password,
+ * and optional namespace token.
  */
 public class KvrocksConfig {
   private final String host;
   private final int port;
   private final int database;
   private final @Nullable String password;
+  private final @Nullable String namespace;
 
   KvrocksConfig(String host, int port, int database,
       @Nullable String password) {
+    this(host, port, database, password, null);
+  }
+
+  KvrocksConfig(String host, int port, int database,
+      @Nullable String password, @Nullable String namespace) {
     this.host = host;
     this.port = port;
     this.database = database;
     this.password = password;
+    this.namespace = namespace;
   }
 
   public String getHost() {
@@ -52,5 +60,20 @@ public class KvrocksConfig {
 
   public @Nullable String getPassword() {
     return password;
+  }
+
+  /**
+   * Returns the token associated with a Kvrocks namespace.
+   *
+   * <p>Kvrocks selects a namespace by authenticating with its token; clients
+   * do not send the namespace name separately.
+   */
+  public @Nullable String getNamespace() {
+    return namespace;
+  }
+
+  /** Returns the credential used to authenticate the connection. */
+  @Nullable String getAuthToken() {
+    return namespace == null || namespace.isEmpty() ? password : namespace;
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataFormat.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataFormat.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * How values stored in Kvrocks should be interpreted as relational rows.
+ */
+public enum KvrocksDataFormat {
+
+  /** Treat each value as a single raw string column. */
+  RAW("raw"),
+
+  /** Split each value by a delimiter to extract columns. */
+  CSV("csv"),
+
+  /** Parse each value as a JSON object and extract fields by mapping. */
+  JSON("json");
+
+  private final String typeName;
+
+  KvrocksDataFormat(String typeName) {
+    this.typeName = typeName;
+  }
+
+  public static @Nullable KvrocksDataFormat fromTypeName(String typeName) {
+    for (KvrocksDataFormat format : values()) {
+      if (format.typeName.equals(typeName)) {
+        return format;
+      }
+    }
+    return null;
+  }
+
+  public String getTypeName() {
+    return typeName;
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntry;
+import redis.clients.jedis.StreamEntryID;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Reads data from a single Kvrocks key and converts it to relational rows.
+ *
+ * <p>The reading strategy depends on the Kvrocks data type of the key
+ * (detected via the {@code TYPE} command), and the parsing strategy depends
+ * on the configured {@link KvrocksDataFormat}.
+ */
+public class KvrocksDataProcess {
+  private final Jedis jedis;
+  private final String tableName;
+  private final String keyDelimiter;
+  private final KvrocksDataType dataType;
+  private final KvrocksDataFormat dataFormat;
+  private final List<LinkedHashMap<String, Object>> fields;
+  private final ObjectMapper objectMapper;
+
+  KvrocksDataProcess(Jedis jedis, KvrocksTableFieldInfo fieldInfo) {
+    this.jedis = jedis;
+    this.tableName = fieldInfo.getTableName();
+    this.keyDelimiter = fieldInfo.getKeyDelimiter();
+    this.fields = fieldInfo.getFields();
+
+    String type = jedis.type(tableName);
+    this.dataType =
+        requireNonNull(KvrocksDataType.fromTypeName(type));
+    this.dataFormat =
+        requireNonNull(
+            KvrocksDataFormat.fromTypeName(
+                fieldInfo.getDataFormat()));
+
+    this.objectMapper = new ObjectMapper();
+    objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+    objectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+    objectMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+  }
+
+  /** Reads all values for the key and returns them as relational rows. */
+  public List<Object[]> read() {
+    switch (dataType) {
+    case STRING:
+      return readString();
+    case LIST:
+      return parseValues(jedis.lrange(tableName, 0, -1));
+    case SET:
+      return parseValues(jedis.smembers(tableName));
+    case SORTED_SET:
+      return parseValues(jedis.zrange(tableName, 0, -1));
+    case HASH:
+      return parseValues(jedis.hvals(tableName));
+    case STREAM:
+      return readStream();
+    default:
+      return new ArrayList<>();
+    }
+  }
+
+  /** STRING type: the key name itself is the lookup key; value is the data. */
+  private List<Object[]> readString() {
+    List<Object[]> rows = new ArrayList<>();
+    for (String key : jedis.keys(tableName)) {
+      String value = jedis.get(key);
+      if (value != null) {
+        rows.add(parseRow(value));
+      }
+    }
+    return rows;
+  }
+
+  /** Reads entries from a Kvrocks Stream via XRANGE. */
+  private List<Object[]> readStream() {
+    List<Object[]> rows = new ArrayList<>();
+    List<StreamEntry> entries =
+        jedis.xrange(tableName, (StreamEntryID) null,
+            (StreamEntryID) null, Integer.MAX_VALUE);
+    for (StreamEntry entry : entries) {
+      try {
+        String json =
+            objectMapper.writeValueAsString(entry.getFields());
+        rows.add(parseRow(json));
+      } catch (Exception e) {
+        throw new RuntimeException(
+            "Failed to serialize stream entry", e);
+      }
+    }
+    return rows;
+  }
+
+  /** Parses a collection of string values into rows. */
+  private List<Object[]> parseValues(Iterable<String> values) {
+    List<Object[]> rows = new ArrayList<>();
+    for (String value : values) {
+      rows.add(parseRow(value));
+    }
+    return rows;
+  }
+
+  /** Converts a single string value into a row array. */
+  private Object[] parseRow(String value) {
+    switch (dataFormat) {
+    case RAW:
+      return new Object[]{value};
+    case CSV:
+      return parseCsv(value);
+    case JSON:
+      return parseJson(value);
+    default:
+      throw new AssertionError("unexpected format: " + dataFormat);
+    }
+  }
+
+  private Object[] parseCsv(String value) {
+    String[] parts = value.split(keyDelimiter);
+    Object[] row = new Object[fields.size()];
+    for (int i = 0; i < row.length; i++) {
+      row[i] = i < parts.length ? parts[i] : "";
+    }
+    return row;
+  }
+
+  private Object[] parseJson(String value) {
+    Object[] row = new Object[fields.size()];
+    try {
+      JsonNode node = objectMapper.readTree(value);
+      for (int i = 0; i < row.length; i++) {
+        Object mapping = fields.get(i).get("mapping");
+        if (mapping == null) {
+          row[i] = "";
+        } else {
+          JsonNode found = node.findValue(mapping.toString());
+          row[i] = found != null ? found : "";
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to parse JSON value: " + value, e);
+    }
+    return row;
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.StreamEntry;
@@ -141,7 +142,7 @@ public class KvrocksDataProcess {
   }
 
   private Object[] parseCsv(String value) {
-    String[] parts = value.split(keyDelimiter);
+    String[] parts = value.split(Pattern.quote(keyDelimiter));
     Object[] row = new Object[fields.size()];
     for (int i = 0; i < row.length; i++) {
       row[i] = i < parts.length ? parts[i] : "";

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
@@ -20,7 +20,12 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -28,6 +33,7 @@ import java.util.regex.Pattern;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.StreamEntry;
 import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.commands.ProtocolCommand;
 
 import static java.util.Objects.requireNonNull;
 
@@ -82,6 +88,11 @@ public class KvrocksDataProcess {
       return parseValues(jedis.hvals(tableName));
     case STREAM:
       return readStream();
+    case JSON:
+      return readJson();
+    case BLOOM:
+      throw new UnsupportedOperationException(
+          "Kvrocks Bloom filters cannot be scanned as relational rows");
     default:
       return new ArrayList<>();
     }
@@ -97,6 +108,16 @@ public class KvrocksDataProcess {
       }
     }
     return rows;
+  }
+
+  /** Reads a native Kvrocks JSON value via JSON.GET. */
+  private List<Object[]> readJson() {
+    String value =
+        commandResponseToString(jedis.sendCommand(KvrocksCommand.JSON_GET, tableName));
+    if (value == null) {
+      return new ArrayList<>();
+    }
+    return Collections.singletonList(parseRow(value));
   }
 
   /** Reads entries from a Kvrocks Stream via XRANGE. */
@@ -167,5 +188,32 @@ public class KvrocksDataProcess {
       throw new RuntimeException("Failed to parse JSON value: " + value, e);
     }
     return row;
+  }
+
+  private static @Nullable String commandResponseToString(
+      @Nullable Object response) {
+    if (response == null) {
+      return null;
+    }
+    if (response instanceof byte[]) {
+      return StandardCharsets.UTF_8.decode(
+          ByteBuffer.wrap((byte[]) response)).toString();
+    }
+    return response.toString();
+  }
+
+  /** Kvrocks module commands not exposed by Jedis 3.3. */
+  private enum KvrocksCommand implements ProtocolCommand {
+    JSON_GET("JSON.GET");
+
+    private final byte[] raw;
+
+    KvrocksCommand(String command) {
+      this.raw = command.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override public byte[] getRaw() {
+      return raw;
+    }
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcess.java
@@ -25,7 +25,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -112,12 +111,14 @@ public class KvrocksDataProcess {
 
   /** Reads a native Kvrocks JSON value via JSON.GET. */
   private List<Object[]> readJson() {
+    List<Object[]> rows = new ArrayList<>();
     String value =
         commandResponseToString(jedis.sendCommand(KvrocksCommand.JSON_GET, tableName));
     if (value == null) {
-      return new ArrayList<>();
+      return rows;
     }
-    return Collections.singletonList(parseRow(value));
+    rows.add(parseRow(value));
+    return rows;
   }
 
   /** Reads entries from a Kvrocks Stream via XRANGE. */
@@ -206,14 +207,14 @@ public class KvrocksDataProcess {
   private enum KvrocksCommand implements ProtocolCommand {
     JSON_GET("JSON.GET");
 
-    private final byte[] raw;
+    private final String command;
 
     KvrocksCommand(String command) {
-      this.raw = command.getBytes(StandardCharsets.UTF_8);
+      this.command = command;
     }
 
     @Override public byte[] getRaw() {
-      return raw;
+      return command.getBytes(StandardCharsets.UTF_8);
     }
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataType.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataType.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Data types supported by Kvrocks.
+ *
+ * <p>Kvrocks supports all classic Redis data types plus additional types
+ * such as JSON, Stream, and Bloom Filter.
+ */
+public enum KvrocksDataType {
+
+  /** Basic key-value string. */
+  STRING("string"),
+
+  /** Field-value map. */
+  HASH("hash"),
+
+  /** Ordered list of strings. */
+  LIST("list"),
+
+  /** Unordered collection of unique strings. */
+  SET("set"),
+
+  /** Scored, sorted collection of unique strings. */
+  SORTED_SET("zset"),
+
+  /** Append-only log with consumer group support (since Kvrocks 2.2). */
+  STREAM("stream"),
+
+  /** Native JSON document storage (since Kvrocks 2.7). */
+  JSON("ReJSON-RL"),
+
+  /** Probabilistic membership filter (since Kvrocks 2.6). */
+  BLOOM("MBbloom--");
+
+  private final String typeName;
+
+  KvrocksDataType(String typeName) {
+    this.typeName = typeName;
+  }
+
+  /** Resolves a Kvrocks {@code TYPE} command response to an enum value. */
+  public static @Nullable KvrocksDataType fromTypeName(String typeName) {
+    for (KvrocksDataType type : values()) {
+      if (type.typeName.equals(typeName)) {
+        return type;
+      }
+    }
+    return null;
+  }
+
+  public String getTypeName() {
+    return typeName;
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataType.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksDataType.java
@@ -19,10 +19,11 @@ package org.apache.calcite.adapter.kvrocks;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Data types supported by Kvrocks.
+ * Data types returned by the Kvrocks {@code TYPE} command.
  *
- * <p>Kvrocks supports all classic Redis data types plus additional types
- * such as JSON, Stream, and Bloom Filter.
+ * <p>The adapter can scan most enumerable Kvrocks structures. Bloom filters
+ * are recognized so callers receive a clear unsupported error instead of
+ * silently getting an empty result.
  */
 public enum KvrocksDataType {
 
@@ -47,7 +48,7 @@ public enum KvrocksDataType {
   /** Native JSON document storage (since Kvrocks 2.7). */
   JSON("ReJSON-RL"),
 
-  /** Probabilistic membership filter (since Kvrocks 2.6). */
+  /** Probabilistic membership filter (since Kvrocks 2.6), not enumerable. */
   BLOOM("MBbloom--");
 
   private final String typeName;

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksEnumerator.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksEnumerator.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.Linq4j;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import redis.clients.jedis.Jedis;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Enumerator that reads rows from a single Kvrocks key.
+ *
+ * <p>On construction it eagerly fetches all data from Kvrocks via
+ * {@link KvrocksDataProcess}, then delegates iteration to a Linq4j
+ * enumerator over the materialised list.
+ */
+class KvrocksEnumerator implements Enumerator<Object[]> {
+  private final Enumerator<Object[]> enumerator;
+
+  KvrocksEnumerator(KvrocksConfig config, KvrocksSchema schema,
+      String tableName) {
+    KvrocksTableFieldInfo fieldInfo = schema.getTableFieldInfo(tableName);
+
+    KvrocksJedisManager manager =
+        new KvrocksJedisManager(config.getHost(), config.getPort(),
+            config.getDatabase(), config.getPassword());
+
+    try (Jedis jedis = manager.getResource()) {
+      if (config.getPassword() != null && !config.getPassword().isEmpty()) {
+        jedis.auth(config.getPassword());
+      }
+      KvrocksDataProcess process = new KvrocksDataProcess(jedis, fieldInfo);
+      List<Object[]> rows = process.read();
+      enumerator = Linq4j.enumerator(rows);
+    }
+  }
+
+  /**
+   * Derives the column name/type map from field metadata.
+   *
+   * <p>For {@link KvrocksDataFormat#RAW} a single {@code "key"} column is
+   * produced; for CSV and JSON the configured field list is used.
+   */
+  static Map<String, Object> deduceRowType(KvrocksTableFieldInfo fieldInfo) {
+    final Map<String, Object> columns = new LinkedHashMap<>();
+    KvrocksDataFormat format =
+        requireNonNull(KvrocksDataFormat.fromTypeName(fieldInfo.getDataFormat()));
+    if (format == KvrocksDataFormat.RAW) {
+      columns.put("key", "key");
+    } else {
+      for (LinkedHashMap<String, Object> field : fieldInfo.getFields()) {
+        columns.put(field.get("name").toString(),
+            field.get("type").toString());
+      }
+    }
+    return columns;
+  }
+
+  @Override public Object[] current() {
+    return enumerator.current();
+  }
+
+  @Override public boolean moveNext() {
+    return enumerator.moveNext();
+  }
+
+  @Override public void reset() {
+    enumerator.reset();
+  }
+
+  @Override public void close() {
+    enumerator.close();
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksEnumerator.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksEnumerator.java
@@ -30,26 +30,27 @@ import static java.util.Objects.requireNonNull;
 /**
  * Enumerator that reads rows from a single Kvrocks key.
  *
- * <p>On construction it eagerly fetches all data from Kvrocks via
- * {@link KvrocksDataProcess}, then delegates iteration to a Linq4j
- * enumerator over the materialised list.
+ * <p>On construction it borrows a {@link Jedis} connection from the
+ * schema-level {@link KvrocksJedisManager}, eagerly fetches all data
+ * via {@link KvrocksDataProcess}, then returns the connection to the
+ * pool. Iteration is over the materialised list.
  */
 class KvrocksEnumerator implements Enumerator<Object[]> {
   private final Enumerator<Object[]> enumerator;
 
   KvrocksEnumerator(KvrocksConfig config, KvrocksSchema schema,
       String tableName) {
-    KvrocksTableFieldInfo fieldInfo = schema.getTableFieldInfo(tableName);
-
-    KvrocksJedisManager manager =
-        new KvrocksJedisManager(config.getHost(), config.getPort(),
-            config.getDatabase(), config.getPassword());
+    KvrocksTableFieldInfo fieldInfo =
+        schema.getTableFieldInfo(tableName);
+    KvrocksJedisManager manager = schema.getManager();
 
     try (Jedis jedis = manager.getResource()) {
-      if (config.getPassword() != null && !config.getPassword().isEmpty()) {
+      if (config.getPassword() != null
+          && !config.getPassword().isEmpty()) {
         jedis.auth(config.getPassword());
       }
-      KvrocksDataProcess process = new KvrocksDataProcess(jedis, fieldInfo);
+      KvrocksDataProcess process =
+          new KvrocksDataProcess(jedis, fieldInfo);
       List<Object[]> rows = process.read();
       enumerator = Linq4j.enumerator(rows);
     }
@@ -61,7 +62,8 @@ class KvrocksEnumerator implements Enumerator<Object[]> {
    * <p>For {@link KvrocksDataFormat#RAW} a single {@code "key"} column is
    * produced; for CSV and JSON the configured field list is used.
    */
-  static Map<String, Object> deduceRowType(KvrocksTableFieldInfo fieldInfo) {
+  static Map<String, Object> deduceRowType(
+      KvrocksTableFieldInfo fieldInfo) {
     final Map<String, Object> columns = new LinkedHashMap<>();
     KvrocksDataFormat format =
         requireNonNull(KvrocksDataFormat.fromTypeName(fieldInfo.getDataFormat()));

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksEnumerator.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksEnumerator.java
@@ -45,9 +45,9 @@ class KvrocksEnumerator implements Enumerator<Object[]> {
     KvrocksJedisManager manager = schema.getManager();
 
     try (Jedis jedis = manager.getResource()) {
-      if (config.getPassword() != null
-          && !config.getPassword().isEmpty()) {
-        jedis.auth(config.getPassword());
+      final String authToken = config.getAuthToken();
+      if (authToken != null && !authToken.isEmpty()) {
+        jedis.auth(authToken);
       }
       KvrocksDataProcess process =
           new KvrocksDataProcess(jedis, fieldInfo);

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksJedisManager.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksJedisManager.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.util.trace.CalciteTrace;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Manages pooled connections to a Kvrocks instance via Jedis.
+ *
+ * <p>Because Kvrocks speaks the Redis wire protocol, the standard Jedis
+ * client works without modification. Connections are pooled per host using
+ * a Guava {@link LoadingCache}.
+ */
+public class KvrocksJedisManager implements AutoCloseable {
+  private static final Logger LOGGER = CalciteTrace.getPlannerTracer();
+
+  private final LoadingCache<String, JedisPool> poolCache;
+  private final JedisPoolConfig poolConfig;
+  private final String host;
+  private final int port;
+  private final int database;
+  private final @Nullable String password;
+
+  KvrocksJedisManager(String host, int port, int database,
+      @Nullable String password) {
+    this.host = host;
+    this.port = port;
+    this.database = database;
+    this.password = password;
+
+    this.poolConfig = new JedisPoolConfig();
+    poolConfig.setMaxTotal(GenericObjectPoolConfig.DEFAULT_MAX_TOTAL);
+    poolConfig.setMaxIdle(GenericObjectPoolConfig.DEFAULT_MAX_IDLE);
+    poolConfig.setMinIdle(GenericObjectPoolConfig.DEFAULT_MIN_IDLE);
+
+    this.poolCache = CacheBuilder.newBuilder()
+        .removalListener(new PoolRemovalListener())
+        .build(CacheLoader.from(this::createPool));
+  }
+
+  /** Returns a pooled {@link JedisPool} for the configured host. */
+  public JedisPool getJedisPool() {
+    return poolCache.getUnchecked(host);
+  }
+
+  /** Borrows a single {@link Jedis} connection from the pool. */
+  public Jedis getResource() {
+    return getJedisPool().getResource();
+  }
+
+  private JedisPool createPool() {
+    String pwd = (password == null || password.isEmpty()) ? null : password;
+    return new JedisPool(poolConfig, host, port,
+        Protocol.DEFAULT_TIMEOUT, pwd, database);
+  }
+
+  @Override public void close() {
+    poolCache.invalidateAll();
+  }
+
+  /** Destroys evicted pools so connections are released. */
+  private static class PoolRemovalListener
+      implements RemovalListener<String, JedisPool> {
+    @Override public void onRemoval(
+        RemovalNotification<String, JedisPool> notification) {
+      try {
+        requireNonNull(notification.getValue()).destroy();
+      } catch (Exception e) {
+        LOGGER.warn("Error destroying JedisPool for {}", notification.getKey(), e);
+      }
+    }
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchema.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchema.java
@@ -42,7 +42,8 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>Each entry in the {@code tables} list of the model JSON becomes a
  * {@link KvrocksTable}. The schema holds connection parameters shared by
- * all tables.
+ * all tables and owns a single {@link KvrocksJedisManager} that is reused
+ * across all scans.
  */
 class KvrocksSchema extends AbstractSchema {
   private static final String DATA_FORMAT = "dataFormat";
@@ -54,18 +55,24 @@ class KvrocksSchema extends AbstractSchema {
   final int port;
   final int database;
   final @Nullable String password;
-  final @Nullable String namespace;
   final List<Map<String, Object>> tables;
+  private final KvrocksJedisManager manager;
 
   KvrocksSchema(String host, int port, int database,
-      @Nullable String password, @Nullable String namespace,
+      @Nullable String password,
       List<Map<String, Object>> tables) {
     this.host = host;
     this.port = port;
     this.database = database;
     this.password = password;
-    this.namespace = namespace;
     this.tables = tables;
+    this.manager =
+        new KvrocksJedisManager(host, port, database, password);
+  }
+
+  /** Returns the shared connection manager for this schema. */
+  KvrocksJedisManager getManager() {
+    return manager;
   }
 
   @Override protected Map<String, Table> getTableMap() {
@@ -80,14 +87,16 @@ class KvrocksSchema extends AbstractSchema {
 
   private Table table(String tableName) {
     KvrocksConfig config =
-        new KvrocksConfig(host, port, database, password, namespace);
-    return KvrocksTable.create(KvrocksSchema.this, tableName, config, null);
+        new KvrocksConfig(host, port, database, password);
+    return KvrocksTable.create(KvrocksSchema.this, tableName,
+        config, null);
   }
 
   /**
    * Extracts field metadata for the named table from the model definition.
    *
-   * @throws RuntimeException if dataFormat is missing/invalid or fields are empty
+   * @throws RuntimeException if dataFormat is missing/invalid or fields
+   *         are empty
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   KvrocksTableFieldInfo getTableFieldInfo(String tableName) {
@@ -96,7 +105,8 @@ class KvrocksSchema extends AbstractSchema {
     String dataFormat = "";
     String keyDelimiter = "";
 
-    List<JsonCustomTable> jsonTables = (List<JsonCustomTable>) (List) this.tables;
+    List<JsonCustomTable> jsonTables =
+        (List<JsonCustomTable>) (List) this.tables;
     for (JsonCustomTable jsonTable : jsonTables) {
       if (jsonTable.name.equals(tableName)) {
         Map<String, Object> operand =
@@ -121,7 +131,8 @@ class KvrocksSchema extends AbstractSchema {
         }
 
         dataFormat = operand.get(DATA_FORMAT).toString();
-        fields = (List<LinkedHashMap<String, Object>>) operand.get(FIELDS);
+        fields =
+            (List<LinkedHashMap<String, Object>>) operand.get(FIELDS);
         if (operand.get(KEY_DELIMITER) != null) {
           keyDelimiter = operand.get(KEY_DELIMITER).toString();
         }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchema.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchema.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.model.JsonCustomTable;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Schema that exposes Kvrocks keys as relational tables.
+ *
+ * <p>Each entry in the {@code tables} list of the model JSON becomes a
+ * {@link KvrocksTable}. The schema holds connection parameters shared by
+ * all tables.
+ */
+class KvrocksSchema extends AbstractSchema {
+  private static final String DATA_FORMAT = "dataFormat";
+  private static final String FIELDS = "fields";
+  private static final String KEY_DELIMITER = "keyDelimiter";
+  private static final String OPERAND = "operand";
+
+  final String host;
+  final int port;
+  final int database;
+  final @Nullable String password;
+  final @Nullable String namespace;
+  final List<Map<String, Object>> tables;
+
+  KvrocksSchema(String host, int port, int database,
+      @Nullable String password, @Nullable String namespace,
+      List<Map<String, Object>> tables) {
+    this.host = host;
+    this.port = port;
+    this.database = database;
+    this.password = password;
+    this.namespace = namespace;
+    this.tables = tables;
+  }
+
+  @Override protected Map<String, Table> getTableMap() {
+    JsonCustomTable[] array = new JsonCustomTable[tables.size()];
+    Set<String> tableNames = Arrays.stream(tables.toArray(array))
+        .map(t -> t.name)
+        .collect(Collectors.toSet());
+    return Maps.asMap(ImmutableSet.copyOf(tableNames),
+        CacheBuilder.newBuilder()
+            .build(CacheLoader.from(this::table)));
+  }
+
+  private Table table(String tableName) {
+    KvrocksConfig config =
+        new KvrocksConfig(host, port, database, password, namespace);
+    return KvrocksTable.create(KvrocksSchema.this, tableName, config, null);
+  }
+
+  /**
+   * Extracts field metadata for the named table from the model definition.
+   *
+   * @throws RuntimeException if dataFormat is missing/invalid or fields are empty
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  KvrocksTableFieldInfo getTableFieldInfo(String tableName) {
+    KvrocksTableFieldInfo info = new KvrocksTableFieldInfo();
+    List<LinkedHashMap<String, Object>> fields = new ArrayList<>();
+    String dataFormat = "";
+    String keyDelimiter = "";
+
+    List<JsonCustomTable> jsonTables = (List<JsonCustomTable>) (List) this.tables;
+    for (JsonCustomTable jsonTable : jsonTables) {
+      if (jsonTable.name.equals(tableName)) {
+        Map<String, Object> operand =
+            requireNonNull(jsonTable.operand, OPERAND);
+
+        Object rawFormat = operand.get(DATA_FORMAT);
+        if (rawFormat == null || rawFormat.toString().isEmpty()) {
+          throw new RuntimeException(
+              "dataFormat is invalid, it must be raw, csv or json");
+        }
+        KvrocksDataFormat fmt =
+            KvrocksDataFormat.fromTypeName(rawFormat.toString());
+        if (fmt == null) {
+          throw new RuntimeException(
+              "dataFormat is invalid, it must be raw, csv or json");
+        }
+        Object rawFields = operand.get(FIELDS);
+        if (rawFields == null
+            || (rawFields instanceof List
+                && ((List) rawFields).isEmpty())) {
+          throw new RuntimeException("fields is null");
+        }
+
+        dataFormat = operand.get(DATA_FORMAT).toString();
+        fields = (List<LinkedHashMap<String, Object>>) operand.get(FIELDS);
+        if (operand.get(KEY_DELIMITER) != null) {
+          keyDelimiter = operand.get(KEY_DELIMITER).toString();
+        }
+        break;
+      }
+    }
+
+    info.setTableName(tableName);
+    info.setDataFormat(dataFormat);
+    info.setFields(fields);
+    if (keyDelimiter != null && !keyDelimiter.isEmpty()) {
+      info.setKeyDelimiter(keyDelimiter);
+    }
+    return info;
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchema.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchema.java
@@ -55,19 +55,29 @@ class KvrocksSchema extends AbstractSchema {
   final int port;
   final int database;
   final @Nullable String password;
+  final @Nullable String namespace;
   final List<Map<String, Object>> tables;
   private final KvrocksJedisManager manager;
 
   KvrocksSchema(String host, int port, int database,
       @Nullable String password,
       List<Map<String, Object>> tables) {
+    this(host, port, database, password, null, tables);
+  }
+
+  KvrocksSchema(String host, int port, int database,
+      @Nullable String password, @Nullable String namespace,
+      List<Map<String, Object>> tables) {
     this.host = host;
     this.port = port;
     this.database = database;
     this.password = password;
+    this.namespace = namespace;
     this.tables = tables;
+    final String authToken =
+        namespace == null || namespace.isEmpty() ? password : namespace;
     this.manager =
-        new KvrocksJedisManager(host, port, database, password);
+        new KvrocksJedisManager(host, port, database, authToken);
   }
 
   /** Returns the shared connection manager for this schema. */
@@ -87,7 +97,7 @@ class KvrocksSchema extends AbstractSchema {
 
   private Table table(String tableName) {
     KvrocksConfig config =
-        new KvrocksConfig(host, port, database, password);
+        new KvrocksConfig(host, port, database, password, namespace);
     return KvrocksTable.create(KvrocksSchema.this, tableName,
         config, null);
   }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactory.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaFactory;
+import org.apache.calcite.schema.SchemaPlus;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import static java.lang.Integer.parseInt;
+
+/**
+ * Factory that creates a {@link KvrocksSchema}.
+ *
+ * <p>Reads connection parameters and table definitions from the model JSON.
+ *
+ * <p>Required operand keys: {@code host}, {@code port}, {@code database},
+ * {@code tables}. Optional: {@code password}, {@code namespace}.
+ */
+@SuppressWarnings("UnusedDeclaration")
+public class KvrocksSchemaFactory implements SchemaFactory {
+
+  public KvrocksSchemaFactory() {
+  }
+
+  @Override public Schema create(SchemaPlus parentSchema, String name,
+      Map<String, Object> operand) {
+    checkArgument(operand.get("host") != null, "host must be specified");
+    checkArgument(operand.get("port") != null, "port must be specified");
+    checkArgument(operand.get("database") != null, "database must be specified");
+    checkArgument(operand.get("tables") != null, "tables must be specified");
+
+    String host = operand.get("host").toString();
+    int port = (int) operand.get("port");
+    int database = parseInt(operand.get("database").toString());
+
+    String password = operand.get("password") == null
+        ? null : operand.get("password").toString();
+    String namespace = operand.get("namespace") == null
+        ? null : operand.get("namespace").toString();
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> tables = (List) operand.get("tables");
+
+    return new KvrocksSchema(host, port, database, password, namespace, tables);
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactory.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactory.java
@@ -33,7 +33,7 @@ import static java.lang.Integer.parseInt;
  * <p>Reads connection parameters and table definitions from the model JSON.
  *
  * <p>Required operand keys: {@code host}, {@code port}, {@code database},
- * {@code tables}. Optional: {@code password}, {@code namespace}.
+ * {@code tables}. Optional: {@code password}.
  */
 @SuppressWarnings("UnusedDeclaration")
 public class KvrocksSchemaFactory implements SchemaFactory {
@@ -45,8 +45,10 @@ public class KvrocksSchemaFactory implements SchemaFactory {
       Map<String, Object> operand) {
     checkArgument(operand.get("host") != null, "host must be specified");
     checkArgument(operand.get("port") != null, "port must be specified");
-    checkArgument(operand.get("database") != null, "database must be specified");
-    checkArgument(operand.get("tables") != null, "tables must be specified");
+    checkArgument(operand.get("database") != null,
+        "database must be specified");
+    checkArgument(operand.get("tables") != null,
+        "tables must be specified");
 
     String host = operand.get("host").toString();
     int port = (int) operand.get("port");
@@ -54,12 +56,10 @@ public class KvrocksSchemaFactory implements SchemaFactory {
 
     String password = operand.get("password") == null
         ? null : operand.get("password").toString();
-    String namespace = operand.get("namespace") == null
-        ? null : operand.get("namespace").toString();
 
     @SuppressWarnings("unchecked")
     List<Map<String, Object>> tables = (List) operand.get("tables");
 
-    return new KvrocksSchema(host, port, database, password, namespace, tables);
+    return new KvrocksSchema(host, port, database, password, tables);
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactory.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactory.java
@@ -33,7 +33,8 @@ import static java.lang.Integer.parseInt;
  * <p>Reads connection parameters and table definitions from the model JSON.
  *
  * <p>Required operand keys: {@code host}, {@code port}, {@code database},
- * {@code tables}. Optional: {@code password}.
+ * {@code tables}. Optional: {@code password}, {@code namespace}. The
+ * {@code namespace} value is the token associated with a Kvrocks namespace.
  */
 @SuppressWarnings("UnusedDeclaration")
 public class KvrocksSchemaFactory implements SchemaFactory {
@@ -56,10 +57,12 @@ public class KvrocksSchemaFactory implements SchemaFactory {
 
     String password = operand.get("password") == null
         ? null : operand.get("password").toString();
+    String namespace = operand.get("namespace") == null
+        ? null : operand.get("namespace").toString();
 
     @SuppressWarnings("unchecked")
     List<Map<String, Object>> tables = (List) operand.get("tables");
 
-    return new KvrocksSchema(host, port, database, password, tables);
+    return new KvrocksSchema(host, port, database, password, namespace, tables);
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTable.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTable.java
@@ -99,8 +99,8 @@ public class KvrocksTable extends AbstractTable implements ScannableTable {
   static Table create(KvrocksSchema schema, String tableName,
       Map operand, @Nullable RelProtoDataType protoRowType) {
     KvrocksConfig config =
-        new KvrocksConfig(schema.host, schema.port, schema.database,
-        schema.password, schema.namespace);
+        new KvrocksConfig(schema.host, schema.port,
+            schema.database, schema.password);
     return create(schema, tableName, config, protoRowType);
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTable.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTable.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.linq4j.AbstractEnumerable;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Calcite {@link Table} backed by a single Kvrocks key.
+ *
+ * <p>Implements {@link ScannableTable}: every SQL query triggers a full
+ * read of the underlying Kvrocks data structure.
+ */
+public class KvrocksTable extends AbstractTable implements ScannableTable {
+
+  final KvrocksSchema schema;
+  final String tableName;
+  final @Nullable RelProtoDataType protoRowType;
+  final ImmutableMap<String, Object> allFields;
+  final String dataFormat;
+  final KvrocksConfig kvrocksConfig;
+
+  KvrocksTable(KvrocksSchema schema, String tableName,
+      @Nullable RelProtoDataType protoRowType,
+      Map<String, Object> allFields, String dataFormat,
+      KvrocksConfig kvrocksConfig) {
+    this.schema = schema;
+    this.tableName = tableName;
+    this.protoRowType = protoRowType;
+    this.allFields = allFields == null
+        ? ImmutableMap.of() : ImmutableMap.copyOf(allFields);
+    this.dataFormat = dataFormat;
+    this.kvrocksConfig = kvrocksConfig;
+  }
+
+  @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+    if (protoRowType != null) {
+      return protoRowType.apply(typeFactory);
+    }
+    final List<String> names = new ArrayList<>(allFields.size());
+    final List<RelDataType> types = new ArrayList<>(allFields.size());
+    for (Map.Entry<String, Object> entry : allFields.entrySet()) {
+      names.add(entry.getKey());
+      types.add(typeFactory.createJavaType(entry.getValue().getClass()));
+    }
+    return typeFactory.createStructType(Pair.zip(names, types));
+  }
+
+  @Override public Enumerable<@Nullable Object[]> scan(DataContext root) {
+    return new AbstractEnumerable<Object[]>() {
+      @Override public Enumerator<Object[]> enumerator() {
+        return new KvrocksEnumerator(kvrocksConfig, schema, tableName);
+      }
+    };
+  }
+
+  /** Creates a table from schema-level metadata. */
+  static Table create(KvrocksSchema schema, String tableName,
+      KvrocksConfig config, @Nullable RelProtoDataType protoRowType) {
+    KvrocksTableFieldInfo fieldInfo = schema.getTableFieldInfo(tableName);
+    Map<String, Object> allFields =
+        KvrocksEnumerator.deduceRowType(fieldInfo);
+    return new KvrocksTable(schema, tableName, protoRowType,
+        allFields, fieldInfo.getDataFormat(), config);
+  }
+
+  /** Creates a table from an operand map (used by {@link KvrocksTableFactory}). */
+  static Table create(KvrocksSchema schema, String tableName,
+      Map operand, @Nullable RelProtoDataType protoRowType) {
+    KvrocksConfig config =
+        new KvrocksConfig(schema.host, schema.port, schema.database,
+        schema.password, schema.namespace);
+    return create(schema, tableName, config, protoRowType);
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTable.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTable.java
@@ -100,7 +100,7 @@ public class KvrocksTable extends AbstractTable implements ScannableTable {
       Map operand, @Nullable RelProtoDataType protoRowType) {
     KvrocksConfig config =
         new KvrocksConfig(schema.host, schema.port,
-            schema.database, schema.password);
+            schema.database, schema.password, schema.namespace);
     return create(schema, tableName, config, protoRowType);
   }
 }

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTableFactory.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTableFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.TableFactory;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Map;
+
+/**
+ * Implementation of {@link TableFactory} for Kvrocks.
+ *
+ * <p>Called by Calcite when a table is defined in the model JSON with
+ * {@code "factory": "...KvrocksTableFactory"}.
+ */
+public class KvrocksTableFactory implements TableFactory {
+
+  @SuppressWarnings("unused")
+  public static final KvrocksTableFactory INSTANCE = new KvrocksTableFactory();
+
+  private KvrocksTableFactory() {
+  }
+
+  @Override public Table create(SchemaPlus schema, String tableName,
+      Map operand, @Nullable RelDataType rowType) {
+    final KvrocksSchema kvrocksSchema = schema.unwrap(KvrocksSchema.class);
+    final RelProtoDataType protoRowType =
+        rowType != null ? RelDataTypeImpl.proto(rowType) : null;
+    return KvrocksTable.create(kvrocksSchema, tableName, operand, protoRowType);
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTableFieldInfo.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/KvrocksTableFieldInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Metadata describing how a Kvrocks key maps to a relational table.
+ *
+ * <p>Carries the key name (used as Kvrocks key), the data format that
+ * determines how stored values are parsed, the column definitions, and
+ * an optional delimiter for CSV parsing.
+ */
+public class KvrocksTableFieldInfo {
+  private String tableName;
+  private String dataFormat;
+  private List<LinkedHashMap<String, Object>> fields;
+  private String keyDelimiter = ":";
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public void setTableName(String tableName) {
+    this.tableName = tableName;
+  }
+
+  public String getDataFormat() {
+    return dataFormat;
+  }
+
+  public void setDataFormat(String dataFormat) {
+    this.dataFormat = dataFormat;
+  }
+
+  public List<LinkedHashMap<String, Object>> getFields() {
+    return fields;
+  }
+
+  public void setFields(List<LinkedHashMap<String, Object>> fields) {
+    this.fields = fields;
+  }
+
+  public String getKeyDelimiter() {
+    return keyDelimiter;
+  }
+
+  public void setKeyDelimiter(String keyDelimiter) {
+    this.keyDelimiter = keyDelimiter;
+  }
+}

--- a/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/package-info.java
+++ b/kvrocks/src/main/java/org/apache/calcite/adapter/kvrocks/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Calcite query provider that reads from Apache Kvrocks.
+ *
+ * <p>Kvrocks is a distributed key-value NoSQL database that uses RocksDB as
+ * its storage engine and is compatible with the Redis protocol. This adapter
+ * maps Kvrocks data structures (String, Hash, List, Set, Sorted Set, JSON,
+ * Stream) onto relational tables that can be queried via SQL.
+ */
+@DefaultQualifier(value = NonNull.class, locations = TypeUseLocation.FIELD)
+@DefaultQualifier(value = NonNull.class, locations = TypeUseLocation.PARAMETER)
+@DefaultQualifier(value = NonNull.class, locations = TypeUseLocation.RETURN)
+package org.apache.calcite.adapter.kvrocks;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksAdapterCaseBase.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksAdapterCaseBase.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.util.Sources;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for the Kvrocks adapter.
+ *
+ * <p>Validates SQL queries against data populated into a live Kvrocks
+ * instance via Docker.
+ */
+public class KvrocksAdapterCaseBase extends KvrocksDataCaseBase {
+
+  private final String filePath =
+      Sources.of(KvrocksAdapterCaseBase.class.getResource("/kvrocks-mix-model.json"))
+          .file().getAbsolutePath();
+
+  private String model;
+
+  @SuppressWarnings("unchecked")
+  private static final Map<String, Integer> TABLE_ROW_COUNTS = new HashMap<>(15);
+
+  static {
+    TABLE_ROW_COUNTS.put("raw_01", 1);
+    TABLE_ROW_COUNTS.put("raw_02", 2);
+    TABLE_ROW_COUNTS.put("raw_03", 2);
+    TABLE_ROW_COUNTS.put("raw_04", 2);
+    TABLE_ROW_COUNTS.put("raw_05", 2);
+    TABLE_ROW_COUNTS.put("csv_01", 1);
+    TABLE_ROW_COUNTS.put("csv_02", 2);
+    TABLE_ROW_COUNTS.put("csv_03", 2);
+    TABLE_ROW_COUNTS.put("csv_04", 2);
+    TABLE_ROW_COUNTS.put("csv_05", 2);
+    TABLE_ROW_COUNTS.put("json_01", 1);
+    TABLE_ROW_COUNTS.put("json_02", 2);
+    TABLE_ROW_COUNTS.put("json_03", 2);
+    TABLE_ROW_COUNTS.put("json_04", 2);
+    TABLE_ROW_COUNTS.put("json_05", 2);
+  }
+
+  @BeforeEach
+  @Override public void makeData() {
+    super.makeData();
+    readModelJson();
+  }
+
+  private CalciteAssert.AssertQuery sql(String sql) {
+    assertNotNull(model, "model cannot be null");
+    return CalciteAssert.model(model)
+        .enable(isKvrocksRunning())
+        .query(sql);
+  }
+
+  private void readModelJson() {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+      mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+      mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+
+      File file = new File(filePath);
+      if (file.exists()) {
+        JsonNode root = mapper.readTree(file);
+        model = root.toString()
+            .replace("6666",
+                Integer.toString(getKvrocksServerPort()));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read model JSON", e);
+    }
+  }
+
+  @Test void testKvrocksBySql() {
+    assumeTrue(isKvrocksRunning());
+    TABLE_ROW_COUNTS.forEach((table, count) -> {
+      String query = "SELECT count(*) AS c FROM \"" + table + "\" WHERE true";
+      sql(query).returnsUnordered("C=" + count);
+    });
+  }
+
+  @Test void testSqlWithJoin() {
+    assumeTrue(isKvrocksRunning());
+    String query = "SELECT a.DEPTNO, b.NAME "
+        + "FROM \"csv_01\" a LEFT JOIN \"json_02\" b "
+        + "ON a.DEPTNO = b.DEPTNO WHERE true";
+    sql(query).returnsUnordered("DEPTNO=10; NAME=\"Sales1\"");
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksAdapterConfigCaseBase.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksAdapterConfigCaseBase.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.test.CalciteAssert;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Tests that invalid model configurations are rejected with clear errors.
+ */
+public class KvrocksAdapterConfigCaseBase extends KvrocksAdapterCaseBase {
+
+  private String configModel;
+
+  private void readModelFromJsonString(String jsonString) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+      mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+      mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+      JsonNode root = mapper.readTree(jsonString);
+      configModel = root.toString()
+          .replace("6666",
+              Integer.toString(getKvrocksServerPort()));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read model from JSON string", e);
+    }
+  }
+
+  @Test void testDataFormatEmptyException() {
+    assumeTrue(isKvrocksRunning());
+    String json = "{"
+        + "  \"version\": \"1.0\","
+        + "  \"defaultSchema\": \"kvrocks\","
+        + "  \"schemas\": [{"
+        + "    \"type\": \"custom\","
+        + "    \"name\": \"foodmart\","
+        + "    \"factory\": \"org.apache.calcite.adapter.kvrocks.KvrocksSchemaFactory\","
+        + "    \"operand\": {"
+        + "      \"host\": \"localhost\","
+        + "      \"port\": 6666,"
+        + "      \"database\": 0,"
+        + "      \"password\": \"\""
+        + "    },"
+        + "    \"tables\": [{"
+        + "      \"name\": \"csv_05\","
+        + "      \"type\": \"custom\","
+        + "      \"factory\": \"org.apache.calcite.adapter.kvrocks.KvrocksTableFactory\","
+        + "      \"operand\": {"
+        + "        \"dataFormat\": \"\","
+        + "        \"keyDelimiter\": \":\","
+        + "        \"fields\": ["
+        + "          {\"name\": \"DEPTNO\", \"type\": \"varchar\", \"mapping\": 0},"
+        + "          {\"name\": \"NAME\", \"type\": \"varchar\", \"mapping\": 1}"
+        + "        ]"
+        + "      }"
+        + "    }]"
+        + "  }]"
+        + "}";
+    readModelFromJsonString(json);
+    assertNotNull(configModel, "model cannot be null");
+    CalciteAssert.model(configModel)
+        .enable(isKvrocksRunning())
+        .connectThrows("dataFormat is invalid, it must be raw, csv or json");
+  }
+
+  @Test void testDataFieldsEmptyException() {
+    assumeTrue(isKvrocksRunning());
+    String json = "{"
+        + "  \"version\": \"1.0\","
+        + "  \"defaultSchema\": \"kvrocks\","
+        + "  \"schemas\": [{"
+        + "    \"type\": \"custom\","
+        + "    \"name\": \"foodmart\","
+        + "    \"factory\": \"org.apache.calcite.adapter.kvrocks.KvrocksSchemaFactory\","
+        + "    \"operand\": {"
+        + "      \"host\": \"localhost\","
+        + "      \"port\": 6666,"
+        + "      \"database\": 0,"
+        + "      \"password\": \"\""
+        + "    },"
+        + "    \"tables\": [{"
+        + "      \"name\": \"csv_05\","
+        + "      \"type\": \"custom\","
+        + "      \"factory\": \"org.apache.calcite.adapter.kvrocks.KvrocksTableFactory\","
+        + "      \"operand\": {"
+        + "        \"dataFormat\": \"csv\","
+        + "        \"keyDelimiter\": \":\","
+        + "        \"fields\": []"
+        + "      }"
+        + "    }]"
+        + "  }]"
+        + "}";
+    readModelFromJsonString(json);
+    assertNotNull(configModel, "model cannot be null");
+    CalciteAssert.model(configModel)
+        .enable(isKvrocksRunning())
+        .connectThrows("fields is null");
+  }
+
+  @Test void testDataFormatInvalidException() {
+    assumeTrue(isKvrocksRunning());
+    String json = "{"
+        + "  \"version\": \"1.0\","
+        + "  \"defaultSchema\": \"kvrocks\","
+        + "  \"schemas\": [{"
+        + "    \"type\": \"custom\","
+        + "    \"name\": \"foodmart\","
+        + "    \"factory\": \"org.apache.calcite.adapter.kvrocks.KvrocksSchemaFactory\","
+        + "    \"operand\": {"
+        + "      \"host\": \"localhost\","
+        + "      \"port\": 6666,"
+        + "      \"database\": 0,"
+        + "      \"password\": \"\""
+        + "    },"
+        + "    \"tables\": [{"
+        + "      \"name\": \"csv_05\","
+        + "      \"type\": \"custom\","
+        + "      \"factory\": \"org.apache.calcite.adapter.kvrocks.KvrocksTableFactory\","
+        + "      \"operand\": {"
+        + "        \"dataFormat\": \"CSV\","
+        + "        \"keyDelimiter\": \":\","
+        + "        \"fields\": ["
+        + "          {\"name\": \"DEPTNO\", \"type\": \"varchar\", \"mapping\": 0},"
+        + "          {\"name\": \"NAME\", \"type\": \"varchar\", \"mapping\": 1}"
+        + "        ]"
+        + "      }"
+        + "    }]"
+        + "  }]"
+        + "}";
+    readModelFromJsonString(json);
+    assertNotNull(configModel, "model cannot be null");
+    CalciteAssert.model(configModel)
+        .enable(isKvrocksRunning())
+        .connectThrows("dataFormat is invalid, it must be raw, csv or json");
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksCaseBase.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksCaseBase.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.config.CalciteSystemProperty;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.logging.Logger;
+
+/**
+ * Base class for Kvrocks adapter tests.
+ *
+ * <p>Uses a Kvrocks Docker container ({@code apache/kvrocks:latest}) when
+ * Docker is available; otherwise tests are skipped via
+ * {@link #isKvrocksRunning()}.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+public abstract class KvrocksCaseBase {
+
+  private static final Logger LOGGER = Logger.getLogger(KvrocksCaseBase.class.getName());
+
+  /** Default Kvrocks port inside the container. */
+  private static final int KVROCKS_PORT = 6666;
+
+  private static final GenericContainer<?> KVROCKS_CONTAINER =
+      new GenericContainer<>("apache/kvrocks:latest")
+          .withExposedPorts(KVROCKS_PORT);
+
+  private static boolean containerStarted = false;
+
+  @BeforeAll
+  public static void startContainer() {
+    if (CalciteSystemProperty.TEST_WITH_DOCKER_CONTAINER.value()
+        && DockerClientFactory.instance().isDockerAvailable()) {
+      KVROCKS_CONTAINER.start();
+      containerStarted = true;
+      LOGGER.info("Kvrocks container started on port " + getKvrocksServerPort());
+    } else {
+      LOGGER.warning("Docker is not available; Kvrocks tests will be skipped");
+    }
+  }
+
+  @AfterAll
+  public static void stopContainer() {
+    if (containerStarted && KVROCKS_CONTAINER.isRunning()) {
+      KVROCKS_CONTAINER.stop();
+    }
+  }
+
+  /** Whether the Kvrocks server is reachable. */
+  static boolean isKvrocksRunning() {
+    return containerStarted && KVROCKS_CONTAINER.isRunning();
+  }
+
+  static int getKvrocksServerPort() {
+    return KVROCKS_CONTAINER.getMappedPort(KVROCKS_PORT);
+  }
+
+  static String getKvrocksServerHost() {
+    return KVROCKS_CONTAINER.getHost();
+  }
+
+  /**
+   * Finds a free port on the host.
+   */
+  static int getAvailablePort() {
+    for (int i = 0; i < 50; i++) {
+      try (ServerSocket socket = new ServerSocket(0)) {
+        int port = socket.getLocalPort();
+        if (port != 0) {
+          return port;
+        }
+      } catch (IOException ignored) {
+      }
+    }
+    throw new RuntimeException("Could not find an available port");
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksConfigTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksConfigTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link KvrocksConfig}.
+ *
+ * <p>These tests do not require a running Kvrocks instance.
+ */
+class KvrocksConfigTest {
+
+  @Test void getters() {
+    KvrocksConfig config = new KvrocksConfig("localhost", 6666, 0, "secret");
+    assertEquals("localhost", config.getHost());
+    assertEquals(6666, config.getPort());
+    assertEquals(0, config.getDatabase());
+    assertEquals("secret", config.getPassword());
+  }
+
+  @Test void nullPasswordIsAllowed() {
+    KvrocksConfig config = new KvrocksConfig("127.0.0.1", 6379, 1, null);
+    assertEquals("127.0.0.1", config.getHost());
+    assertEquals(6379, config.getPort());
+    assertEquals(1, config.getDatabase());
+    assertNull(config.getPassword());
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksConfigTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksConfigTest.java
@@ -43,4 +43,22 @@ class KvrocksConfigTest {
     assertEquals(1, config.getDatabase());
     assertNull(config.getPassword());
   }
+
+  @Test void namespaceTokenTakesPrecedenceOverPassword() {
+    KvrocksConfig config =
+        new KvrocksConfig("localhost", 6666, 0,
+            "administrator-token", "namespace-token");
+
+    assertEquals("administrator-token", config.getPassword());
+    assertEquals("namespace-token", config.getNamespace());
+    assertEquals("namespace-token", config.getAuthToken());
+  }
+
+  @Test void passwordIsUsedWithoutNamespaceToken() {
+    KvrocksConfig config =
+        new KvrocksConfig("localhost", 6666, 0, "administrator-token", null);
+
+    assertNull(config.getNamespace());
+    assertEquals("administrator-token", config.getAuthToken());
+  }
 }

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataCaseBase.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataCaseBase.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Base class that populates test data into Kvrocks before each test.
+ *
+ * <p>Creates 15 tables across 3 data formats (raw, csv, json) x 5 data
+ * types (string, list, set, sorted-set, hash).
+ */
+public class KvrocksDataCaseBase extends KvrocksCaseBase {
+  private JedisPool pool;
+
+  final String[] tableNames = {
+      "raw_01", "raw_02", "raw_03", "raw_04", "raw_05",
+      "csv_01", "csv_02", "csv_03", "csv_04", "csv_05",
+      "json_01", "json_02", "json_03", "json_04", "json_05"
+  };
+
+  @BeforeEach
+  public void setUp() {
+    assumeTrue(isKvrocksRunning(), "Kvrocks container is not running");
+
+    JedisPoolConfig config = new JedisPoolConfig();
+    config.setMaxTotal(10);
+    pool = new JedisPool(config, getKvrocksServerHost(), getKvrocksServerPort());
+
+    try (Jedis jedis = pool.getResource()) {
+      jedis.flushAll();
+    }
+  }
+
+  /** Populates all 15 test tables into Kvrocks. */
+  public void makeData() {
+    try (Jedis jedis = pool.getResource()) {
+      jedis.del(tableNames);
+
+      // STRING type
+      jedis.set("raw_01", "123");
+      jedis.set("json_01", "{\"DEPTNO\":10,\"NAME\":\"Sales\"}");
+      jedis.set("csv_01", "10:Sales");
+
+      // LIST type
+      jedis.lpush("raw_02", "book1", "book2");
+      jedis.lpush("json_02",
+          "{\"DEPTNO\":10,\"NAME\":\"Sales1\"}",
+          "{\"DEPTNO\":20,\"NAME\":\"Sales2\"}");
+      jedis.lpush("csv_02", "10:Sales", "20:Sales");
+
+      // SET type
+      jedis.sadd("raw_03", "user1", "user2");
+      jedis.sadd("json_03",
+          "{\"DEPTNO\":10,\"NAME\":\"Sales1\"}",
+          "{\"DEPTNO\":20,\"NAME\":\"Sales1\"}");
+      jedis.sadd("csv_03", "10:Sales", "20:Sales");
+
+      // SORTED SET type
+      jedis.zadd("raw_04", 22, "user3");
+      jedis.zadd("raw_04", 24, "user4");
+      jedis.zadd("json_04", 1, "{\"DEPTNO\":10,\"NAME\":\"Sales1\"}");
+      jedis.zadd("json_04", 2, "{\"DEPTNO\":11,\"NAME\":\"Sales2\"}");
+      jedis.zadd("csv_04", 1, "10:Sales");
+      jedis.zadd("csv_04", 2, "20:Sales");
+
+      // HASH type
+      Map<String, String> rawHash = new HashMap<>();
+      rawHash.put("stuA", "a1");
+      rawHash.put("stuB", "b2");
+      jedis.hmset("raw_05", rawHash);
+
+      Map<String, String> jsonHash = new HashMap<>();
+      jsonHash.put("stuA", "{\"DEPTNO\":10,\"NAME\":\"stuA\"}");
+      jsonHash.put("stuB", "{\"DEPTNO\":10,\"NAME\":\"stuB\"}");
+      jedis.hmset("json_05", jsonHash);
+
+      Map<String, String> csvHash = new HashMap<>();
+      csvHash.put("stuA", "10:Sales");
+      csvHash.put("stuB", "20:Sales");
+      jedis.hmset("csv_05", csvHash);
+    }
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (pool != null) {
+      pool.destroy();
+    }
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataFormatTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataFormatTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link KvrocksDataFormat}.
+ *
+ * <p>These tests do not require a running Kvrocks instance.
+ */
+class KvrocksDataFormatTest {
+
+  @Test void fromTypeNameReturnsMatchingEnum() {
+    assertEquals(KvrocksDataFormat.RAW,
+        KvrocksDataFormat.fromTypeName("raw"));
+    assertEquals(KvrocksDataFormat.CSV,
+        KvrocksDataFormat.fromTypeName("csv"));
+    assertEquals(KvrocksDataFormat.JSON,
+        KvrocksDataFormat.fromTypeName("json"));
+  }
+
+  @Test void fromTypeNameRejectsUppercaseAndUnknown() {
+    assertNull(KvrocksDataFormat.fromTypeName("RAW"));
+    assertNull(KvrocksDataFormat.fromTypeName("CSV"));
+    assertNull(KvrocksDataFormat.fromTypeName("xml"));
+    assertNull(KvrocksDataFormat.fromTypeName(""));
+  }
+
+  @Test void getTypeNameReturnsWireValue() {
+    assertEquals("raw", KvrocksDataFormat.RAW.getTypeName());
+    assertEquals("csv", KvrocksDataFormat.CSV.getTypeName());
+    assertEquals("json", KvrocksDataFormat.JSON.getTypeName());
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcessTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcessTest.java
@@ -107,7 +107,8 @@ class KvrocksDataProcessTest {
 
     assertEquals(2, rows.size());
     assertEquals(members,
-        new HashSet<>(Arrays.asList(rows.get(0)[0].toString(),
+        new HashSet<>(
+            Arrays.asList(rows.get(0)[0].toString(),
             rows.get(1)[0].toString())));
   }
 
@@ -121,8 +122,8 @@ class KvrocksDataProcessTest {
         new KvrocksDataProcess(jedis, fieldInfo("csv_zset", "csv")).read();
 
     assertEquals(2, rows.size());
-    Set<String> departments = new HashSet<>(Arrays.asList(
-        rows.get(0)[0].toString(), rows.get(1)[0].toString()));
+    Set<String> departments =
+        new HashSet<>(Arrays.asList(rows.get(0)[0].toString(), rows.get(1)[0].toString()));
     assertEquals(new HashSet<>(Arrays.asList("10", "20")), departments);
   }
 
@@ -130,7 +131,8 @@ class KvrocksDataProcessTest {
     Jedis jedis = Mockito.mock(Jedis.class);
     Mockito.when(jedis.type("json_hash")).thenReturn("hash");
     Mockito.when(jedis.hvals("json_hash"))
-        .thenReturn(Arrays.asList("{\"DEPTNO\":10,\"NAME\":\"Sales\"}",
+        .thenReturn(
+            Arrays.asList("{\"DEPTNO\":10,\"NAME\":\"Sales\"}",
             "{\"DEPTNO\":20,\"NAME\":\"Marketing\"}"));
 
     List<Object[]> rows =
@@ -147,9 +149,11 @@ class KvrocksDataProcessTest {
     Map<String, String> fields = new HashMap<>();
     fields.put("DEPTNO", "10");
     fields.put("NAME", "Sales");
-    Mockito.when(jedis.xrange(eq("stream"), eq((StreamEntryID) null),
+    Mockito.when(
+        jedis.xrange(eq("stream"), eq((StreamEntryID) null),
         eq((StreamEntryID) null), eq(Integer.MAX_VALUE)))
-        .thenReturn(Collections.singletonList(
+        .thenReturn(
+            Collections.singletonList(
             new StreamEntry(new StreamEntryID("1-0"), fields)));
 
     List<Object[]> rows =

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcessTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcessTest.java
@@ -20,13 +20,21 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntry;
+import redis.clients.jedis.StreamEntryID;
 import redis.clients.jedis.commands.ProtocolCommand;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +42,123 @@ import static org.mockito.ArgumentMatchers.eq;
 
 /** Unit tests for {@link KvrocksDataProcess}. */
 class KvrocksDataProcessTest {
+
+  @Test void readsStringValuesAsRawRows() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("raw_string")).thenReturn("string");
+    Mockito.when(jedis.keys("raw_string"))
+        .thenReturn(Collections.singleton("raw_string"));
+    Mockito.when(jedis.get("raw_string")).thenReturn("hello");
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("raw_string", "raw")).read();
+
+    assertEquals(1, rows.size());
+    assertArrayEquals(new Object[]{"hello"}, rows.get(0));
+  }
+
+  @Test void skipsMissingStringValues() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("raw_string")).thenReturn("string");
+    Mockito.when(jedis.keys("raw_string"))
+        .thenReturn(Collections.singleton("raw_string"));
+    Mockito.when(jedis.get("raw_string")).thenReturn(null);
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("raw_string", "raw")).read();
+
+    assertEquals(0, rows.size());
+  }
+
+  @Test void readsListValuesAsCsvRows() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("csv_list")).thenReturn("list");
+    Mockito.when(jedis.lrange("csv_list", 0, -1))
+        .thenReturn(Arrays.asList("10:Sales", "20:Marketing"));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("csv_list", "csv")).read();
+
+    assertEquals(2, rows.size());
+    assertArrayEquals(new Object[]{"10", "Sales"}, rows.get(0));
+    assertArrayEquals(new Object[]{"20", "Marketing"}, rows.get(1));
+  }
+
+  @Test void padsMissingCsvColumnsWithEmptyString() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("csv_list")).thenReturn("list");
+    Mockito.when(jedis.lrange("csv_list", 0, -1))
+        .thenReturn(Collections.singletonList("10"));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("csv_list", "csv")).read();
+
+    assertArrayEquals(new Object[]{"10", ""}, rows.get(0));
+  }
+
+  @Test void readsSetValues() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("raw_set")).thenReturn("set");
+    Set<String> members = new HashSet<>(Arrays.asList("user1", "user2"));
+    Mockito.when(jedis.smembers("raw_set")).thenReturn(members);
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("raw_set", "raw")).read();
+
+    assertEquals(2, rows.size());
+    assertEquals(members,
+        new HashSet<>(Arrays.asList(rows.get(0)[0].toString(),
+            rows.get(1)[0].toString())));
+  }
+
+  @Test void readsSortedSetValues() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("csv_zset")).thenReturn("zset");
+    Mockito.when(jedis.zrange("csv_zset", 0, -1))
+        .thenReturn(new HashSet<>(Arrays.asList("10:Sales", "20:Marketing")));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("csv_zset", "csv")).read();
+
+    assertEquals(2, rows.size());
+    Set<String> departments = new HashSet<>(Arrays.asList(
+        rows.get(0)[0].toString(), rows.get(1)[0].toString()));
+    assertEquals(new HashSet<>(Arrays.asList("10", "20")), departments);
+  }
+
+  @Test void readsHashValues() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("json_hash")).thenReturn("hash");
+    Mockito.when(jedis.hvals("json_hash"))
+        .thenReturn(Arrays.asList("{\"DEPTNO\":10,\"NAME\":\"Sales\"}",
+            "{\"DEPTNO\":20,\"NAME\":\"Marketing\"}"));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("json_hash", "json")).read();
+
+    assertEquals(2, rows.size());
+    assertEquals("10", rows.get(0)[0].toString());
+    assertEquals("\"Sales\"", rows.get(0)[1].toString());
+  }
+
+  @Test void readsStreamEntriesAsJsonRows() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("stream")).thenReturn("stream");
+    Map<String, String> fields = new HashMap<>();
+    fields.put("DEPTNO", "10");
+    fields.put("NAME", "Sales");
+    Mockito.when(jedis.xrange(eq("stream"), eq((StreamEntryID) null),
+        eq((StreamEntryID) null), eq(Integer.MAX_VALUE)))
+        .thenReturn(Collections.singletonList(
+            new StreamEntry(new StreamEntryID("1-0"), fields)));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("stream", "json")).read();
+
+    assertEquals(1, rows.size());
+    assertEquals("\"10\"", rows.get(0)[0].toString());
+    assertEquals("\"Sales\"", rows.get(0)[1].toString());
+  }
 
   @Test void nativeJsonUsesJsonGetCommand() {
     Jedis jedis = Mockito.mock(Jedis.class);
@@ -61,6 +186,59 @@ class KvrocksDataProcessTest {
 
     assertEquals("20", rows.get(0)[0].toString());
     assertEquals("\"Marketing\"", rows.get(0)[1].toString());
+  }
+
+  @Test void nativeJsonReturnsNoRowsForNullResponse() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("native_json")).thenReturn("ReJSON-RL");
+    Mockito.when(jedis.sendCommand(any(ProtocolCommand.class), eq("native_json")))
+        .thenReturn(null);
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("native_json", "json")).read();
+
+    assertEquals(0, rows.size());
+  }
+
+  @Test void jsonMissingMappingReturnsEmptyString() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("json_list")).thenReturn("list");
+    Mockito.when(jedis.lrange("json_list", 0, -1))
+        .thenReturn(Collections.singletonList("{\"DEPTNO\":10}"));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("json_list", "json")).read();
+
+    assertEquals("10", rows.get(0)[0].toString());
+    assertEquals("", rows.get(0)[1]);
+  }
+
+  @Test void jsonFieldWithoutMappingReturnsEmptyString() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("json_list")).thenReturn("list");
+    Mockito.when(jedis.lrange("json_list", 0, -1))
+        .thenReturn(Collections.singletonList("{\"DEPTNO\":10}"));
+
+    KvrocksTableFieldInfo info = fieldInfo("json_list", "json");
+    info.getFields().get(1).remove("mapping");
+
+    List<Object[]> rows = new KvrocksDataProcess(jedis, info).read();
+
+    assertEquals("10", rows.get(0)[0].toString());
+    assertEquals("", rows.get(0)[1]);
+  }
+
+  @Test void invalidJsonThrowsClearException() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("json_list")).thenReturn("list");
+    Mockito.when(jedis.lrange("json_list", 0, -1))
+        .thenReturn(Collections.singletonList("{"));
+
+    KvrocksDataProcess process =
+        new KvrocksDataProcess(jedis, fieldInfo("json_list", "json"));
+
+    RuntimeException e = assertThrows(RuntimeException.class, process::read);
+    assertEquals("Failed to parse JSON value: {", e.getMessage());
   }
 
   @Test void bloomThrowsClearUnsupportedException() {

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcessTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataProcessTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.commands.ProtocolCommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+/** Unit tests for {@link KvrocksDataProcess}. */
+class KvrocksDataProcessTest {
+
+  @Test void nativeJsonUsesJsonGetCommand() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("native_json")).thenReturn("ReJSON-RL");
+    Mockito.when(jedis.sendCommand(any(ProtocolCommand.class), eq("native_json")))
+        .thenReturn("{\"DEPTNO\":10,\"NAME\":\"Sales\"}");
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("native_json", "json")).read();
+
+    assertEquals(1, rows.size());
+    assertEquals("10", rows.get(0)[0].toString());
+    assertEquals("\"Sales\"", rows.get(0)[1].toString());
+  }
+
+  @Test void nativeJsonAcceptsByteArrayResponse() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("native_json")).thenReturn("ReJSON-RL");
+    Mockito.when(jedis.sendCommand(any(ProtocolCommand.class), eq("native_json")))
+        .thenReturn("{\"DEPTNO\":20,\"NAME\":\"Marketing\"}"
+            .getBytes(StandardCharsets.UTF_8));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis, fieldInfo("native_json", "json")).read();
+
+    assertEquals("20", rows.get(0)[0].toString());
+    assertEquals("\"Marketing\"", rows.get(0)[1].toString());
+  }
+
+  @Test void bloomThrowsClearUnsupportedException() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("members")).thenReturn("MBbloom--");
+
+    KvrocksDataProcess process =
+        new KvrocksDataProcess(jedis, fieldInfo("members", "raw"));
+
+    UnsupportedOperationException e =
+        assertThrows(UnsupportedOperationException.class, process::read);
+    assertEquals("Kvrocks Bloom filters cannot be scanned as relational rows",
+        e.getMessage());
+  }
+
+  private static KvrocksTableFieldInfo fieldInfo(String tableName,
+      String dataFormat) {
+    KvrocksTableFieldInfo info = new KvrocksTableFieldInfo();
+    info.setTableName(tableName);
+    info.setDataFormat(dataFormat);
+    info.setFields(fields());
+    return info;
+  }
+
+  private static List<LinkedHashMap<String, Object>> fields() {
+    LinkedHashMap<String, Object> deptno = new LinkedHashMap<>();
+    deptno.put("name", "DEPTNO");
+    deptno.put("type", "varchar");
+    deptno.put("mapping", "DEPTNO");
+
+    LinkedHashMap<String, Object> name = new LinkedHashMap<>();
+    name.put("name", "NAME");
+    name.put("type", "varchar");
+    name.put("mapping", "NAME");
+
+    return Collections.unmodifiableList(java.util.Arrays.asList(deptno, name));
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataTypeTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksDataTypeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link KvrocksDataType}.
+ *
+ * <p>These tests do not require a running Kvrocks instance.
+ */
+class KvrocksDataTypeTest {
+
+  @Test void fromTypeNameReturnsMatchingEnum() {
+    assertEquals(KvrocksDataType.STRING,
+        KvrocksDataType.fromTypeName("string"));
+    assertEquals(KvrocksDataType.HASH,
+        KvrocksDataType.fromTypeName("hash"));
+    assertEquals(KvrocksDataType.LIST,
+        KvrocksDataType.fromTypeName("list"));
+    assertEquals(KvrocksDataType.SET,
+        KvrocksDataType.fromTypeName("set"));
+    assertEquals(KvrocksDataType.SORTED_SET,
+        KvrocksDataType.fromTypeName("zset"));
+    assertEquals(KvrocksDataType.STREAM,
+        KvrocksDataType.fromTypeName("stream"));
+    assertEquals(KvrocksDataType.JSON,
+        KvrocksDataType.fromTypeName("ReJSON-RL"));
+    assertEquals(KvrocksDataType.BLOOM,
+        KvrocksDataType.fromTypeName("MBbloom--"));
+  }
+
+  @Test void fromTypeNameReturnsNullForUnknown() {
+    assertNull(KvrocksDataType.fromTypeName("unknown"));
+    assertNull(KvrocksDataType.fromTypeName(""));
+    assertNull(KvrocksDataType.fromTypeName("STRING"));
+  }
+
+  @Test void getTypeNameReturnsWireValue() {
+    assertEquals("string", KvrocksDataType.STRING.getTypeName());
+    assertEquals("zset", KvrocksDataType.SORTED_SET.getTypeName());
+    assertEquals("ReJSON-RL", KvrocksDataType.JSON.getTypeName());
+    assertEquals("MBbloom--", KvrocksDataType.BLOOM.getTypeName());
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactoryTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactoryTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -70,5 +71,18 @@ class KvrocksSchemaFactoryTest {
     KvrocksSchemaFactory factory = new KvrocksSchemaFactory();
     assertThrows(IllegalArgumentException.class,
         () -> factory.create(null, "kv", operand));
+  }
+
+  @Test void readsNamespaceToken() {
+    Map<String, Object> operand = baseOperand();
+    operand.put("password", "administrator-token");
+    operand.put("namespace", "namespace-token");
+
+    KvrocksSchema schema =
+        (KvrocksSchema) new KvrocksSchemaFactory()
+            .create(null, "kv", operand);
+
+    assertEquals("administrator-token", schema.password);
+    assertEquals("namespace-token", schema.namespace);
   }
 }

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactoryTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link KvrocksSchemaFactory} argument validation.
+ *
+ * <p>These tests do not require a running Kvrocks instance.
+ */
+class KvrocksSchemaFactoryTest {
+
+  private static Map<String, Object> baseOperand() {
+    Map<String, Object> operand = new HashMap<>();
+    operand.put("host", "localhost");
+    operand.put("port", 6666);
+    operand.put("database", 0);
+    operand.put("tables", Collections.emptyList());
+    return operand;
+  }
+
+  @Test void missingHostThrows() {
+    Map<String, Object> operand = baseOperand();
+    operand.remove("host");
+    KvrocksSchemaFactory factory = new KvrocksSchemaFactory();
+    assertThrows(IllegalArgumentException.class,
+        () -> factory.create(null, "kv", operand));
+  }
+
+  @Test void missingPortThrows() {
+    Map<String, Object> operand = baseOperand();
+    operand.remove("port");
+    KvrocksSchemaFactory factory = new KvrocksSchemaFactory();
+    assertThrows(IllegalArgumentException.class,
+        () -> factory.create(null, "kv", operand));
+  }
+
+  @Test void missingDatabaseThrows() {
+    Map<String, Object> operand = baseOperand();
+    operand.remove("database");
+    KvrocksSchemaFactory factory = new KvrocksSchemaFactory();
+    assertThrows(IllegalArgumentException.class,
+        () -> factory.create(null, "kv", operand));
+  }
+
+  @Test void missingTablesThrows() {
+    Map<String, Object> operand = baseOperand();
+    operand.remove("tables");
+    KvrocksSchemaFactory factory = new KvrocksSchemaFactory();
+    assertThrows(IllegalArgumentException.class,
+        () -> factory.create(null, "kv", operand));
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaTableTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaTableTest.java
@@ -171,6 +171,30 @@ class KvrocksSchemaTableTest {
     Mockito.verify(jedis).close();
   }
 
+  @Test void tableScanAuthenticatesWithNamespaceToken() {
+    KvrocksTableFieldInfo info = info("raw_01", "raw", rawField());
+    KvrocksJedisManager manager = Mockito.mock(KvrocksJedisManager.class);
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(manager.getResource()).thenReturn(jedis);
+    Mockito.when(jedis.type("raw_01")).thenReturn("string");
+    Mockito.when(jedis.keys("raw_01"))
+        .thenReturn(java.util.Collections.singleton("raw_01"));
+    Mockito.when(jedis.get("raw_01")).thenReturn("hello");
+    KvrocksSchema schema = new TestKvrocksSchema(info, manager);
+    KvrocksTable table =
+        (KvrocksTable) KvrocksTable.create(schema, "raw_01",
+            new KvrocksConfig("localhost", 6666, 0,
+                "administrator-token", "namespace-token"), null);
+
+    org.apache.calcite.linq4j.Enumerator<Object[]> enumerator =
+        table.scan(null).enumerator();
+
+    assertTrue(enumerator.moveNext());
+    enumerator.close();
+    Mockito.verify(jedis).auth("namespace-token");
+    Mockito.verify(jedis, Mockito.never()).auth("administrator-token");
+  }
+
   @Test void tableFactoryCreatesKvrocksTable() {
     KvrocksSchema kvrocksSchema = schema(table("raw_01", "raw", ":", rawField()));
     SchemaPlus schemaPlus = Mockito.mock(SchemaPlus.class);

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaTableTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaTableTest.java
@@ -45,11 +45,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class KvrocksSchemaTableTest {
 
   @Test void schemaBuildsTableMapFromModelTables() {
-    KvrocksSchema schema = schema(table("raw_01", "raw", ":", rawField()),
-        table("csv_01", "csv", ":", deptField(), nameField()));
+    KvrocksSchema schema =
+        schema(table("raw_01", "raw", ":", rawField()),
+            table("csv_01", "csv", ":", deptField(), nameField()));
 
-    assertTrue(schema.getTableMap().keySet().containsAll(
-        ImmutableList.of("raw_01", "csv_01")));
+    assertTrue(
+        schema.getTableMap().keySet().containsAll(
+            ImmutableList.of("raw_01", "csv_01")));
     assertTrue(schema.getTableMap().get("raw_01") instanceof KvrocksTable);
   }
 
@@ -66,8 +68,10 @@ class KvrocksSchemaTableTest {
   }
 
   @Test void schemaRejectsMissingOperand() {
-    KvrocksSchema schema = schema(new JsonCustomTable("bad", null,
-        "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory", null));
+    KvrocksSchema schema =
+        schema(
+            new JsonCustomTable("bad", null,
+            "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory", null));
 
     assertThrows(NullPointerException.class,
         () -> schema.getTableFieldInfo("bad"));
@@ -103,10 +107,11 @@ class KvrocksSchemaTableTest {
   }
 
   @Test void tableDerivesRowTypeFromFields() {
-    KvrocksSchema schema = schema(table("csv_01", "csv", ":",
-        deptField(), nameField()));
-    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
-        "csv_01", new KvrocksConfig("localhost", 6666, 0, ""), null);
+    KvrocksSchema schema =
+        schema(table("csv_01", "csv", ":", deptField(), nameField()));
+    KvrocksTable table =
+        (KvrocksTable) KvrocksTable.create(schema, "csv_01",
+            new KvrocksConfig("localhost", 6666, 0, ""), null);
 
     RelDataType rowType = table.getRowType(new JavaTypeFactoryImpl());
 
@@ -116,15 +121,16 @@ class KvrocksSchemaTableTest {
   }
 
   @Test void tableUsesProtoRowTypeWhenProvided() {
-    KvrocksSchema schema = schema(table("csv_01", "csv", ":",
-        deptField(), nameField()));
+    KvrocksSchema schema =
+        schema(table("csv_01", "csv", ":", deptField(), nameField()));
     RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
     RelDataType protoType = typeFactory.builder()
         .add("ID", typeFactory.createJavaType(Integer.class))
         .build();
-    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
-        "csv_01", new KvrocksConfig("localhost", 6666, 0, ""),
-        factory -> protoType);
+    KvrocksTable table =
+        (KvrocksTable) KvrocksTable.create(schema, "csv_01",
+            new KvrocksConfig("localhost", 6666, 0, ""),
+            factory -> protoType);
 
     RelDataType rowType = table.getRowType(typeFactory);
 
@@ -134,8 +140,9 @@ class KvrocksSchemaTableTest {
 
   @Test void tableScanCreatesEnumerable() {
     KvrocksSchema schema = schema(table("raw_01", "raw", ":", rawField()));
-    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
-        "raw_01", new KvrocksConfig("localhost", 6666, 0, ""), null);
+    KvrocksTable table =
+        (KvrocksTable) KvrocksTable.create(schema, "raw_01",
+            new KvrocksConfig("localhost", 6666, 0, ""), null);
 
     assertNotNull(table.scan(null));
   }
@@ -150,8 +157,9 @@ class KvrocksSchemaTableTest {
         .thenReturn(java.util.Collections.singleton("raw_01"));
     Mockito.when(jedis.get("raw_01")).thenReturn("hello");
     KvrocksSchema schema = new TestKvrocksSchema(info, manager);
-    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
-        "raw_01", new KvrocksConfig("localhost", 6666, 0, "secret"), null);
+    KvrocksTable table =
+        (KvrocksTable) KvrocksTable.create(schema, "raw_01",
+            new KvrocksConfig("localhost", 6666, 0, "secret"), null);
 
     org.apache.calcite.linq4j.Enumerator<Object[]> enumerator =
         table.scan(null).enumerator();
@@ -168,8 +176,9 @@ class KvrocksSchemaTableTest {
     SchemaPlus schemaPlus = Mockito.mock(SchemaPlus.class);
     Mockito.when(schemaPlus.unwrap(KvrocksSchema.class)).thenReturn(kvrocksSchema);
 
-    Table table = KvrocksTableFactory.INSTANCE.create(schemaPlus, "raw_01",
-        java.util.Collections.emptyMap(), null);
+    Table table =
+        KvrocksTableFactory.INSTANCE.create(schemaPlus, "raw_01",
+            java.util.Collections.emptyMap(), null);
 
     assertTrue(table instanceof KvrocksTable);
   }

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaTableTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksSchemaTableTest.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.model.JsonCustomTable;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import redis.clients.jedis.Jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link KvrocksSchema}, {@link KvrocksTable}, and helpers. */
+class KvrocksSchemaTableTest {
+
+  @Test void schemaBuildsTableMapFromModelTables() {
+    KvrocksSchema schema = schema(table("raw_01", "raw", ":", rawField()),
+        table("csv_01", "csv", ":", deptField(), nameField()));
+
+    assertTrue(schema.getTableMap().keySet().containsAll(
+        ImmutableList.of("raw_01", "csv_01")));
+    assertTrue(schema.getTableMap().get("raw_01") instanceof KvrocksTable);
+  }
+
+  @Test void schemaExtractsFieldInfo() {
+    KvrocksSchema schema =
+        schema(table("csv_01", "csv", "|", deptField(), nameField()));
+
+    KvrocksTableFieldInfo info = schema.getTableFieldInfo("csv_01");
+
+    assertEquals("csv_01", info.getTableName());
+    assertEquals("csv", info.getDataFormat());
+    assertEquals("|", info.getKeyDelimiter());
+    assertEquals(2, info.getFields().size());
+  }
+
+  @Test void schemaRejectsMissingOperand() {
+    KvrocksSchema schema = schema(new JsonCustomTable("bad", null,
+        "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory", null));
+
+    assertThrows(NullPointerException.class,
+        () -> schema.getTableFieldInfo("bad"));
+  }
+
+  @Test void schemaReturnsEmptyInfoForUnknownTable() {
+    KvrocksSchema schema = schema(table("csv_01", "csv", ":", deptField()));
+
+    KvrocksTableFieldInfo info = schema.getTableFieldInfo("missing");
+
+    assertEquals("missing", info.getTableName());
+    assertEquals("", info.getDataFormat());
+    assertTrue(info.getFields().isEmpty());
+  }
+
+  @Test void deduceRowTypeUsesRawKeyColumn() {
+    KvrocksTableFieldInfo info = info("raw_01", "raw", rawField());
+
+    Map<String, Object> columns = KvrocksEnumerator.deduceRowType(info);
+
+    assertEquals(1, columns.size());
+    assertEquals("key", columns.get("key"));
+  }
+
+  @Test void deduceRowTypeUsesConfiguredFields() {
+    KvrocksTableFieldInfo info =
+        info("csv_01", "csv", deptField(), nameField());
+
+    Map<String, Object> columns = KvrocksEnumerator.deduceRowType(info);
+
+    assertEquals("varchar", columns.get("DEPTNO"));
+    assertEquals("varchar", columns.get("NAME"));
+  }
+
+  @Test void tableDerivesRowTypeFromFields() {
+    KvrocksSchema schema = schema(table("csv_01", "csv", ":",
+        deptField(), nameField()));
+    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
+        "csv_01", new KvrocksConfig("localhost", 6666, 0, ""), null);
+
+    RelDataType rowType = table.getRowType(new JavaTypeFactoryImpl());
+
+    assertEquals(2, rowType.getFieldCount());
+    assertEquals("DEPTNO", rowType.getFieldList().get(0).getName());
+    assertEquals("NAME", rowType.getFieldList().get(1).getName());
+  }
+
+  @Test void tableUsesProtoRowTypeWhenProvided() {
+    KvrocksSchema schema = schema(table("csv_01", "csv", ":",
+        deptField(), nameField()));
+    RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    RelDataType protoType = typeFactory.builder()
+        .add("ID", typeFactory.createJavaType(Integer.class))
+        .build();
+    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
+        "csv_01", new KvrocksConfig("localhost", 6666, 0, ""),
+        factory -> protoType);
+
+    RelDataType rowType = table.getRowType(typeFactory);
+
+    assertEquals(1, rowType.getFieldCount());
+    assertEquals("ID", rowType.getFieldList().get(0).getName());
+  }
+
+  @Test void tableScanCreatesEnumerable() {
+    KvrocksSchema schema = schema(table("raw_01", "raw", ":", rawField()));
+    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
+        "raw_01", new KvrocksConfig("localhost", 6666, 0, ""), null);
+
+    assertNotNull(table.scan(null));
+  }
+
+  @Test void tableScanEnumeratorReadsRowsThroughManager() {
+    KvrocksTableFieldInfo info = info("raw_01", "raw", rawField());
+    KvrocksJedisManager manager = Mockito.mock(KvrocksJedisManager.class);
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(manager.getResource()).thenReturn(jedis);
+    Mockito.when(jedis.type("raw_01")).thenReturn("string");
+    Mockito.when(jedis.keys("raw_01"))
+        .thenReturn(java.util.Collections.singleton("raw_01"));
+    Mockito.when(jedis.get("raw_01")).thenReturn("hello");
+    KvrocksSchema schema = new TestKvrocksSchema(info, manager);
+    KvrocksTable table = (KvrocksTable) KvrocksTable.create(schema,
+        "raw_01", new KvrocksConfig("localhost", 6666, 0, "secret"), null);
+
+    org.apache.calcite.linq4j.Enumerator<Object[]> enumerator =
+        table.scan(null).enumerator();
+
+    assertTrue(enumerator.moveNext());
+    assertEquals("hello", enumerator.current()[0]);
+    enumerator.close();
+    Mockito.verify(jedis).auth("secret");
+    Mockito.verify(jedis).close();
+  }
+
+  @Test void tableFactoryCreatesKvrocksTable() {
+    KvrocksSchema kvrocksSchema = schema(table("raw_01", "raw", ":", rawField()));
+    SchemaPlus schemaPlus = Mockito.mock(SchemaPlus.class);
+    Mockito.when(schemaPlus.unwrap(KvrocksSchema.class)).thenReturn(kvrocksSchema);
+
+    Table table = KvrocksTableFactory.INSTANCE.create(schemaPlus, "raw_01",
+        java.util.Collections.emptyMap(), null);
+
+    assertTrue(table instanceof KvrocksTable);
+  }
+
+  @Test void schemaFactoryCreatesKvrocksSchema() {
+    Map<String, Object> operand = new java.util.HashMap<>();
+    operand.put("host", "localhost");
+    operand.put("port", 6666);
+    operand.put("database", "0");
+    operand.put("tables", java.util.Collections.emptyList());
+
+    Schema schema = new KvrocksSchemaFactory()
+        .create(Mockito.mock(SchemaPlus.class), "kvrocks", operand);
+
+    assertTrue(schema instanceof KvrocksSchema);
+    KvrocksSchema kvrocksSchema = (KvrocksSchema) schema;
+    assertEquals("localhost", kvrocksSchema.host);
+    assertEquals(6666, kvrocksSchema.port);
+    assertEquals(0, kvrocksSchema.database);
+  }
+
+  @Test void jedisManagerCreatesPoolAndCloses() {
+    KvrocksJedisManager manager =
+        new KvrocksJedisManager("localhost", 6666, 0, "");
+
+    assertNotNull(manager.getJedisPool());
+    manager.close();
+  }
+
+  private static KvrocksSchema schema(JsonCustomTable... tables) {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    List<Map<String, Object>> tableList = (List) Arrays.asList(tables);
+    return new KvrocksSchema("localhost", 6666, 0, "",
+        tableList);
+  }
+
+  private static JsonCustomTable table(String name, String format,
+      String delimiter, LinkedHashMap<String, Object>... fields) {
+    LinkedHashMap<String, Object> operand = new LinkedHashMap<>();
+    operand.put("dataFormat", format);
+    operand.put("keyDelimiter", delimiter);
+    operand.put("fields", Arrays.asList(fields));
+    return new JsonCustomTable(name, null,
+        "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory", operand);
+  }
+
+  private static KvrocksTableFieldInfo info(String tableName, String format,
+      LinkedHashMap<String, Object>... fields) {
+    KvrocksTableFieldInfo info = new KvrocksTableFieldInfo();
+    info.setTableName(tableName);
+    info.setDataFormat(format);
+    info.setFields(Arrays.asList(fields));
+    return info;
+  }
+
+  private static LinkedHashMap<String, Object> rawField() {
+    LinkedHashMap<String, Object> field = new LinkedHashMap<>();
+    field.put("name", "key");
+    field.put("type", "varchar");
+    field.put("mapping", "key");
+    return field;
+  }
+
+  private static LinkedHashMap<String, Object> deptField() {
+    LinkedHashMap<String, Object> field = new LinkedHashMap<>();
+    field.put("name", "DEPTNO");
+    field.put("type", "varchar");
+    field.put("mapping", "DEPTNO");
+    return field;
+  }
+
+  private static LinkedHashMap<String, Object> nameField() {
+    LinkedHashMap<String, Object> field = new LinkedHashMap<>();
+    field.put("name", "NAME");
+    field.put("type", "varchar");
+    field.put("mapping", "NAME");
+    return field;
+  }
+
+  /** Schema that injects mocked table metadata and connection manager. */
+  private static class TestKvrocksSchema extends KvrocksSchema {
+    private final KvrocksTableFieldInfo fieldInfo;
+    private final KvrocksJedisManager manager;
+
+    TestKvrocksSchema(KvrocksTableFieldInfo fieldInfo,
+        KvrocksJedisManager manager) {
+      super("localhost", 6666, 0, "",
+          java.util.Collections.emptyList());
+      this.fieldInfo = fieldInfo;
+      this.manager = manager;
+    }
+
+    @Override KvrocksJedisManager getManager() {
+      return manager;
+    }
+
+    @Override KvrocksTableFieldInfo getTableFieldInfo(String tableName) {
+      assertEquals(fieldInfo.getTableName(), tableName);
+      return fieldInfo;
+    }
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksTableFieldInfoTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksTableFieldInfoTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link KvrocksTableFieldInfo}.
+ *
+ * <p>These tests do not require a running Kvrocks instance.
+ */
+class KvrocksTableFieldInfoTest {
+
+  @Test void defaultKeyDelimiterIsColon() {
+    assertEquals(":", new KvrocksTableFieldInfo().getKeyDelimiter());
+  }
+
+  @Test void gettersReflectSetters() {
+    KvrocksTableFieldInfo info = new KvrocksTableFieldInfo();
+    LinkedHashMap<String, Object> field = new LinkedHashMap<>();
+    field.put("name", "DEPTNO");
+    field.put("type", "varchar");
+    field.put("mapping", 0);
+    List<LinkedHashMap<String, Object>> fields =
+        Collections.singletonList(field);
+
+    info.setTableName("emp");
+    info.setDataFormat("csv");
+    info.setFields(fields);
+    info.setKeyDelimiter("|");
+
+    assertEquals("emp", info.getTableName());
+    assertEquals("csv", info.getDataFormat());
+    assertEquals(fields, info.getFields());
+    assertEquals("|", info.getKeyDelimiter());
+  }
+}

--- a/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksUnsupportedFeaturesTest.java
+++ b/kvrocks/src/test/java/org/apache/calcite/adapter/kvrocks/KvrocksUnsupportedFeaturesTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.kvrocks;
+
+import org.apache.calcite.schema.FilterableTable;
+import org.apache.calcite.schema.ModifiableTable;
+import org.apache.calcite.schema.ProjectableFilterableTable;
+import org.apache.calcite.schema.ScannableTable;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntry;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.commands.ProtocolCommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+/**
+ * Documents Kvrocks features that are deliberately not exposed by the
+ * adapter.
+ *
+ * <p>These tests define the current boundary of the adapter. When a feature
+ * is implemented, its corresponding test should be replaced by a positive
+ * behavior test.
+ */
+class KvrocksUnsupportedFeaturesTest {
+
+  @Test void hashScanDoesNotExposeFieldNames() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("departments")).thenReturn("hash");
+    Mockito.when(jedis.hvals("departments"))
+        .thenReturn(Collections.singletonList("Sales"));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis,
+            fieldInfo("departments", "raw", field("value", "value"))).read();
+
+    assertEquals(1, rows.size());
+    assertEquals("Sales", rows.get(0)[0]);
+    Mockito.verify(jedis).hvals("departments");
+  }
+
+  @Test void sortedSetScanDoesNotExposeScores() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("ranking")).thenReturn("zset");
+    Mockito.when(jedis.zrange("ranking", 0, -1))
+        .thenReturn(Collections.singleton("Alice"));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis,
+            fieldInfo("ranking", "raw", field("member", "member"))).read();
+
+    assertEquals(1, rows.size());
+    assertEquals("Alice", rows.get(0)[0]);
+    Mockito.verify(jedis).zrange("ranking", 0, -1);
+  }
+
+  @Test void streamScanDoesNotExposeEntryIds() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("events")).thenReturn("stream");
+    Map<String, String> values = Collections.singletonMap("NAME", "Sales");
+    Mockito.when(
+        jedis.xrange(eq("events"), eq((StreamEntryID) null),
+            eq((StreamEntryID) null), eq(Integer.MAX_VALUE)))
+        .thenReturn(
+            Collections.singletonList(
+                new StreamEntry(new StreamEntryID("123-0"), values)));
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis,
+            fieldInfo("events", "json",
+                field("ENTRY_ID", "ENTRY_ID"),
+                field("NAME", "NAME"))).read();
+
+    assertEquals(1, rows.size());
+    assertEquals("", rows.get(0)[0]);
+    assertEquals("\"Sales\"", rows.get(0)[1].toString());
+  }
+
+  @Test void jsonMappingsDoNotSupportJsonPath() {
+    Jedis jedis = Mockito.mock(Jedis.class);
+    Mockito.when(jedis.type("department")).thenReturn("ReJSON-RL");
+    Mockito.when(jedis.sendCommand(any(ProtocolCommand.class), eq("department")))
+        .thenReturn("{\"DEPTNO\":10}");
+
+    List<Object[]> rows =
+        new KvrocksDataProcess(jedis,
+            fieldInfo("department", "json",
+                field("DEPTNO", "$.DEPTNO"))).read();
+
+    assertEquals(1, rows.size());
+    assertEquals("", rows.get(0)[0]);
+  }
+
+  @Test void tableSupportsOnlyReadOnlyFullScans() {
+    KvrocksTable table =
+        new KvrocksTable(Mockito.mock(KvrocksSchema.class), "values", null,
+            ImmutableMap.of("key", "key"), "raw",
+            new KvrocksConfig("localhost", 6666, 0, ""));
+
+    assertTrue(table instanceof ScannableTable);
+    assertFalse(table instanceof FilterableTable);
+    assertFalse(table instanceof ProjectableFilterableTable);
+    assertFalse(table instanceof ModifiableTable);
+  }
+
+  @SafeVarargs
+  private static KvrocksTableFieldInfo fieldInfo(String tableName,
+      String format, LinkedHashMap<String, Object>... fields) {
+    KvrocksTableFieldInfo info = new KvrocksTableFieldInfo();
+    info.setTableName(tableName);
+    info.setDataFormat(format);
+    info.setFields(Arrays.asList(fields));
+    return info;
+  }
+
+  private static LinkedHashMap<String, Object> field(String name,
+      String mapping) {
+    LinkedHashMap<String, Object> field = new LinkedHashMap<>();
+    field.put("name", name);
+    field.put("type", "varchar");
+    field.put("mapping", mapping);
+    return field;
+  }
+}

--- a/kvrocks/src/test/resources/kvrocks-mix-model.json
+++ b/kvrocks/src/test/resources/kvrocks-mix-model.json
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "foodmart",
+  "schemas": [
+    {
+      "type": "custom",
+      "name": "foodmart",
+      "factory": "org.apache.calcite.adapter.kvrocks.KvrocksSchemaFactory",
+      "operand": {
+        "host": "localhost",
+        "port": 6666,
+        "database": 0,
+        "password": ""
+      },
+      "tables": [
+        {
+          "name": "csv_01",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "csv",
+            "keyDelimiter": ":",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": 0 },
+              { "name": "NAME",   "type": "varchar", "mapping": 1 }
+            ]
+          }
+        },
+        {
+          "name": "csv_02",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "csv",
+            "keyDelimiter": ":",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": 0 },
+              { "name": "NAME",   "type": "varchar", "mapping": 1 }
+            ]
+          }
+        },
+        {
+          "name": "csv_03",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "csv",
+            "keyDelimiter": ":",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": 0 },
+              { "name": "NAME",   "type": "varchar", "mapping": 1 }
+            ]
+          }
+        },
+        {
+          "name": "csv_04",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "csv",
+            "keyDelimiter": ":",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": 0 },
+              { "name": "NAME",   "type": "varchar", "mapping": 1 }
+            ]
+          }
+        },
+        {
+          "name": "csv_05",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "csv",
+            "keyDelimiter": ":",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": 0 },
+              { "name": "NAME",   "type": "varchar", "mapping": 1 }
+            ]
+          }
+        },
+        {
+          "name": "json_01",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "json",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": "DEPTNO" },
+              { "name": "NAME",   "type": "varchar", "mapping": "NAME" }
+            ]
+          }
+        },
+        {
+          "name": "json_02",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "json",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": "DEPTNO" },
+              { "name": "NAME",   "type": "varchar", "mapping": "NAME" }
+            ]
+          }
+        },
+        {
+          "name": "json_03",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "json",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": "DEPTNO" },
+              { "name": "NAME",   "type": "varchar", "mapping": "NAME" }
+            ]
+          }
+        },
+        {
+          "name": "json_04",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "json",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": "DEPTNO" },
+              { "name": "NAME",   "type": "varchar", "mapping": "NAME" }
+            ]
+          }
+        },
+        {
+          "name": "json_05",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "json",
+            "fields": [
+              { "name": "DEPTNO", "type": "varchar", "mapping": "DEPTNO" },
+              { "name": "NAME",   "type": "varchar", "mapping": "NAME" }
+            ]
+          }
+        },
+        {
+          "name": "raw_01",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "raw",
+            "fields": [
+              { "name": "key", "type": "varchar", "mapping": "key" }
+            ]
+          }
+        },
+        {
+          "name": "raw_02",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "raw",
+            "fields": [
+              { "name": "key", "type": "varchar", "mapping": "key" }
+            ]
+          }
+        },
+        {
+          "name": "raw_03",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "raw",
+            "fields": [
+              { "name": "key", "type": "varchar", "mapping": "key" }
+            ]
+          }
+        },
+        {
+          "name": "raw_04",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "raw",
+            "fields": [
+              { "name": "key", "type": "varchar", "mapping": "key" }
+            ]
+          }
+        },
+        {
+          "name": "raw_05",
+          "factory": "org.apache.calcite.adapter.kvrocks.KvrocksTableFactory",
+          "operand": {
+            "dataFormat": "raw",
+            "fields": [
+              { "name": "key", "type": "varchar", "mapping": "key" }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/kvrocks/src/test/resources/log4j2-test.xml
+++ b/kvrocks/src/test/resources/log4j2-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -77,6 +77,7 @@ include(
     "geode",
     "innodb",
     "kafka",
+    "kvrocks",
     "linq4j",
     "mongodb",
     "pig",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6908

## Summary

This PR adds an Apache Kvrocks adapter. Kvrocks keys are exposed as read-only Calcite tables and scanned using the Redis-compatible protocol.

## Supported data types

- STRING
- HASH
- LIST
- SET
- SORTED SET
- STREAM
- Native JSON (`JSON.GET`)

Bloom filters are recognized, but cannot be scanned as relational rows because they are not enumerable.

## Supported value formats

- Raw values
- Delimiter-separated values
- JSON object field mapping

## Namespace support

The optional `namespace` model operand is the token associated with a Kvrocks namespace. Kvrocks selects a namespace by authenticating with that token; therefore, when `namespace` is configured, it is used as the authentication credential instead of the administrator `password`.

## Current capability boundaries

Tests explicitly document the current adapter contract:

- HASH scans expose values, but not hash field names.
- SORTED SET scans expose members, but not scores.
- STREAM scans expose entry fields, but not entry IDs.
- JSON field mappings are field names, not JSONPath expressions.
- Tables are read-only `ScannableTable` implementations. Filter, projection, limit, and write operations are not pushed down.
- Bloom filters cannot be converted to relational rows.

These tests are intended to be replaced with positive behavior tests when the corresponding features are implemented.

## Test infrastructure

- Integration tests use the `apache/kvrocks:latest` Docker image.
- Docker-independent unit tests cover configuration, data conversion, namespace authentication, schema behavior, and unsupported-feature boundaries.

## Verification

- `./gradlew :kvrocks:check --no-daemon`
- 58 tests completed with 0 failures; 7 Docker-dependent tests were skipped when Docker was unavailable.