### PR TITLE
[CALCITE-7407] Illegal use of dynamic parameter with ||

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -284,7 +284,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
             }
             return type;
           }),
-          null,
+          InferTypes.RETURN_TYPE,
           OperandTypes.STRING_SAME_SAME_OR_ARRAY_SAME_SAME);
 
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -5968,6 +5968,17 @@ public class JdbcTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7407">[CALCITE-7407]
+   * Illegal use of dynamic parameter with ||</a>. */
+  @Test void testPreparedStatementConcatDynamicParameter() {
+    CalciteAssert.hr()
+        .query("select \"name\" from \"hr\".\"emps\"\n"
+            + "where \"name\" = (? || 'odore')")
+        .consumesPreparedStatement(p -> p.setString(1, "The"))
+        .returns("name=Theodore\n");
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2061">[CALCITE-2061]
    * Dynamic parameters in offset/fetch</a>. */
   @Test void testPreparedOffsetFetch() throws Exception {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -822,6 +822,10 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .columnType("CHAR(6) NOT NULL");
     expr("'a'||'b'||cast('cde' as VARCHAR(3))|| 'f'")
         .columnType("VARCHAR(6) NOT NULL");
+    expr("null||'b'")
+        .columnType("VARCHAR");
+    expr("cast(null as ANY)||cast(null as ANY)")
+        .columnType("ANY");
     expr("_UTF16'a'||_UTF16'b'||_UTF16'c'").ok();
   }
 
@@ -8293,6 +8297,16 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   @Test void testBindConcat() {
     sql("select * from emp where ename = (? || 'KI')").ok();
     sql("select * from emp where ename = ('SM' || ?)").ok();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7407">[CALCITE-7407]
+   * Illegal use of dynamic parameter with ||</a>. */
+  @Test void testConcatNullAndAnyWithContext() {
+    sql("select * from emp where ename = (null || 'KI')").ok();
+    sql("select * from emp where ename = ('SM' || null)").ok();
+    sql("select * from emp where ename = (cast(null as any) || 'KI')").ok();
+    sql("select * from emp where ename = ('SM' || cast(null as any))").ok();
   }
 
   /** Test case for

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8288,6 +8288,14 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7407">[CALCITE-7407]
+   * Illegal use of dynamic parameter with ||</a>. */
+  @Test void testBindConcat() {
+    sql("select * from emp where ename = (? || 'KI')").ok();
+    sql("select * from emp where ename = ('SM' || ?)").ok();
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1310">[CALCITE-1310]
    * Infer type of arguments to BETWEEN operator</a>. */
   @Test void testBindBetween() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7407](https://issues.apache.org/jira/browse/CALCITE-7407)

## Changes Proposed

- Change `||` to use `InferTypes.RETURN_TYPE` so dynamic parameters are typed from the string concatenation context instead of being rejected as illegal `ANY` operands.
- Add validator regression coverage for concatenation with dynamic parameters, `NULL`, and `CAST(NULL AS ANY)`.
- Add a JDBC prepared statement regression covering `? || 'odore'`.

## Reproduction

```sql
select * from emp where ename = (? || 'KI')
```

Before this change, Calcite rejected the dynamic parameter in the concatenation expression with `Illegal use of dynamic parameter`.
