### PR TITLE
[CALCITE-7463] UnionToFilterRule incorrectly rewrites UNION with LIMIT

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
@@ -18,6 +18,8 @@ package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Intersect;
@@ -26,6 +28,7 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.tools.RelBuilder;
@@ -119,13 +122,18 @@ public class SetOpToFilterRule
 
   private static void match(RelOptRuleCall call) {
     final SetOp setOp = call.rel(0);
+    final RelMetadataQuery mq = call.getMetadataQuery();
     final List<RelNode> inputs = setOp.getInputs();
     if (setOp.all || inputs.size() < 2) {
       return;
     }
 
     final RelBuilder builder = call.builder();
-    Pair<RelNode, @Nullable RexNode> first = extractSourceAndCond(inputs.get(0).stripped());
+    final RelNode firstClause = inputs.get(0).stripped();
+    final List<RelCollation> firstCollations = mq.collations(firstClause);
+    Pair<RelNode, @Nullable RexNode> first = extractSourceAndCond(firstClause,
+        firstCollations != null
+            && firstCollations.stream().anyMatch(c -> c != RelCollations.EMPTY));
 
     // Groups conditions by their source relational node and input position.
     // - Key: Pair of (sourceRelNode, inputPosition)
@@ -145,7 +153,14 @@ public class SetOpToFilterRule
 
     for (int i = 1; i < inputs.size(); i++) {
       final RelNode input = inputs.get(i).stripped();
-      final Pair<RelNode, @Nullable RexNode> pair = extractSourceAndCond(input);
+      boolean isSorted = false;
+      final List<RelCollation> inputCollations = mq.collations(input);
+      if (inputCollations != null
+          && inputCollations.stream().anyMatch(c -> c != RelCollations.EMPTY)
+          && inputCollations.equals(firstCollations)) {
+        isSorted = true;
+      }
+      final Pair<RelNode, @Nullable RexNode> pair = extractSourceAndCond(input, isSorted);
       sourceToConds.computeIfAbsent(Pair.of(pair.left, pair.right != null ? null : i),
           k -> new ArrayList<>()).add(pair.right);
     }
@@ -199,7 +214,8 @@ public class SetOpToFilterRule
     throw new IllegalStateException("unreachable code");
   }
 
-  private static Pair<RelNode, @Nullable RexNode> extractSourceAndCond(RelNode input) {
+  private static Pair<RelNode, @Nullable RexNode> extractSourceAndCond(RelNode input,
+      boolean isSorted) {
     if (input instanceof Filter) {
       Filter filter = (Filter) input;
       if (!RexUtil.isDeterministic(filter.getCondition())
@@ -208,12 +224,12 @@ public class SetOpToFilterRule
         return Pair.of(input, null);
       }
       final RelNode source = filter.getInput().stripped();
-      if (containsLimitOrOffsetInProjectFilterChain(source)) {
+      if (containsBlockingSortInProjectFilterChain(source, isSorted)) {
         return Pair.of(input, null);
       }
       return Pair.of(source, filter.getCondition());
     }
-    if (containsLimitOrOffsetInProjectFilterChain(input)) {
+    if (containsBlockingSortInProjectFilterChain(input, isSorted)) {
       return Pair.of(input, null);
     }
     // For non-filter inputs, use TRUE literal as default condition.
@@ -221,12 +237,13 @@ public class SetOpToFilterRule
         input.getCluster().getRexBuilder().makeLiteral(true));
   }
 
-  private static boolean containsLimitOrOffsetInProjectFilterChain(RelNode input) {
+  private static boolean containsBlockingSortInProjectFilterChain(RelNode input,
+      boolean isSorted) {
     RelNode current = input.stripped();
     while (true) {
       if (current instanceof Sort) {
         Sort sort = (Sort) current;
-        return sort.fetch != null || sort.offset != null;
+        return !isSorted && (sort.fetch != null || sort.offset != null);
       }
       if (current instanceof Project
           || current instanceof Filter) {

--- a/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
@@ -131,8 +131,8 @@ public class SetOpToFilterRule
     final RelBuilder builder = call.builder();
     final RelNode firstClause = inputs.get(0).stripped();
     final List<RelCollation> firstCollations = mq.collations(firstClause);
-    Pair<RelNode, @Nullable RexNode> first = extractSourceAndCond(firstClause,
-        firstCollations != null
+    Pair<RelNode, @Nullable RexNode> first =
+        extractSourceAndCond(firstClause, firstCollations != null
             && firstCollations.stream().anyMatch(c -> c != RelCollations.EMPTY));
 
     // Groups conditions by their source relational node and input position.

--- a/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
@@ -208,12 +208,12 @@ public class SetOpToFilterRule
         return Pair.of(input, null);
       }
       final RelNode source = filter.getInput().stripped();
-      if (containsSortInProjectFilterChain(source)) {
+      if (containsLimitOrOffsetInProjectFilterChain(source)) {
         return Pair.of(input, null);
       }
       return Pair.of(source, filter.getCondition());
     }
-    if (containsSortInProjectFilterChain(input)) {
+    if (containsLimitOrOffsetInProjectFilterChain(input)) {
       return Pair.of(input, null);
     }
     // For non-filter inputs, use TRUE literal as default condition.
@@ -221,15 +221,16 @@ public class SetOpToFilterRule
         input.getCluster().getRexBuilder().makeLiteral(true));
   }
 
-  private static boolean containsSortInProjectFilterChain(RelNode input) {
+  private static boolean containsLimitOrOffsetInProjectFilterChain(RelNode input) {
     RelNode current = input.stripped();
     while (true) {
       if (current instanceof Sort) {
-        return true;
+        Sort sort = (Sort) current;
+        return sort.fetch != null || sort.offset != null;
       }
       if (current instanceof Project
           || current instanceof Filter) {
-        current = current.getInput(0).stripped();
+        current = current.getInput(0);
         continue;
       }
       return false;

--- a/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
@@ -22,7 +22,9 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Intersect;
 import org.apache.calcite.rel.core.Minus;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
@@ -205,11 +207,33 @@ public class SetOpToFilterRule
         // Skip non-deterministic conditions or those containing subqueries
         return Pair.of(input, null);
       }
-      return Pair.of(filter.getInput().stripped(), filter.getCondition());
+      final RelNode source = filter.getInput().stripped();
+      if (containsSortInProjectFilterChain(source)) {
+        return Pair.of(input, null);
+      }
+      return Pair.of(source, filter.getCondition());
+    }
+    if (containsSortInProjectFilterChain(input)) {
+      return Pair.of(input, null);
     }
     // For non-filter inputs, use TRUE literal as default condition.
     return Pair.of(input.stripped(),
         input.getCluster().getRexBuilder().makeLiteral(true));
+  }
+
+  private static boolean containsSortInProjectFilterChain(RelNode input) {
+    RelNode current = input.stripped();
+    while (true) {
+      if (current instanceof Sort) {
+        return true;
+      }
+      if (current instanceof Project
+          || current instanceof Filter) {
+        current = current.getInput(0).stripped();
+        continue;
+      }
+      return false;
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SetOpToFilterRule.java
@@ -230,7 +230,7 @@ public class SetOpToFilterRule
       }
       if (current instanceof Project
           || current instanceof Filter) {
-        current = current.getInput(0);
+        current = current.getInput(0).stripped();
         continue;
       }
       return false;

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -11500,6 +11500,55 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7463">[CALCITE-7463]
+   * UnionToFilterRule incorrectly rewrites UNION with LIMIT</a>. */
+  @Test void testUnionToFilterRuleWithSortLimit() {
+    final Function<RelBuilder, RelNode> relFn = b -> {
+      final RelNode left = b.scan("EMP")
+          .project(b.field("MGR"), b.field("COMM"))
+          .sortLimit(10, 2, b.field(0))
+          .filter(b.call(SqlStdOperatorTable.GREATER_THAN, b.field(1), b.literal(5)))
+          .build();
+      final RelNode right = b.scan("EMP")
+          .project(b.field("MGR"), b.field("COMM"))
+          .sortLimit(10, 2, b.field(0))
+          .filter(b.call(SqlStdOperatorTable.GREATER_THAN, b.field(1), b.literal(10)))
+          .build();
+      return b.push(left)
+          .push(right)
+          .union(false, 2)
+          .build();
+    };
+    relFn(relFn)
+        .withRule(CoreRules.UNION_FILTER_TO_FILTER)
+        .check();
+  }
+
+  /** Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7463">[CALCITE-7463]
+   * UnionToFilterRule incorrectly rewrites UNION with LIMIT</a>. */
+  @Test void testUnionToFilterRuleWithUnmergeableFirstInput() {
+    final Function<RelBuilder, RelNode> relFn = b -> {
+      final RelNode left = b.scan("EMP")
+          .project(b.field("MGR"), b.field("COMM"))
+          .sortLimit(10, 2, b.field(0))
+          .filter(b.call(SqlStdOperatorTable.GREATER_THAN, b.field(1), b.literal(5)))
+          .build();
+      final RelNode right = b.scan("EMP")
+          .project(b.field("MGR"), b.field("COMM"))
+          .filter(b.call(SqlStdOperatorTable.GREATER_THAN, b.field(1), b.literal(10)))
+          .build();
+      return b.push(left)
+          .push(right)
+          .union(false, 2)
+          .build();
+    };
+    relFn(relFn)
+        .withRule(CoreRules.UNION_FILTER_TO_FILTER)
+        .checkUnchanged();
+  }
+
+  /** Test case of
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7002">[CALCITE-7002]
    * Create an optimization rule to eliminate UNION
    * from the same source with different filters</a>. */

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -11436,6 +11436,33 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7463">[CALCITE-7463]
+   * UnionToFilterRule incorrectly rewrites UNION with LIMIT</a>. */
+  @Test void testUnionToFilterRuleWithLimit() {
+    final String sql = "(SELECT mgr, comm FROM emp LIMIT 2)\n"
+        + "UNION\n"
+        + "(SELECT mgr, comm FROM emp LIMIT 2)\n";
+    sql(sql)
+        .withRule(CoreRules.UNION_FILTER_TO_FILTER)
+        .checkUnchanged();
+  }
+
+  /** Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7463">[CALCITE-7463]
+   * UnionToFilterRule incorrectly rewrites UNION with LIMIT</a>. */
+  @Test void testUnionToFilterRuleWithNestedLimit() {
+    final String sql = "SELECT comm FROM (SELECT mgr, comm FROM emp LIMIT 2) t\n"
+        + "WHERE comm > 5\n"
+        + "UNION\n"
+        + "SELECT comm FROM (SELECT mgr, comm FROM emp LIMIT 2) t\n"
+        + "WHERE comm > 10\n";
+    sql(sql)
+        .withPreRule(CoreRules.PROJECT_FILTER_TRANSPOSE)
+        .withRule(CoreRules.UNION_FILTER_TO_FILTER)
+        .checkUnchanged();
+  }
+
+  /** Test case of
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7002">[CALCITE-7002]
    * Create an optimization rule to eliminate UNION
    * from the same source with different filters</a>. */

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -11475,6 +11475,31 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7463">[CALCITE-7463]
+   * UnionToFilterRule incorrectly rewrites UNION with LIMIT</a>. */
+  @Test void testUnionToFilterRuleWithSortOnly() {
+    final Function<RelBuilder, RelNode> relFn = b -> {
+      final RelNode left = b.scan("EMP")
+          .project(b.field("MGR"), b.field("COMM"))
+          .sort(b.field(0))
+          .filter(b.call(SqlStdOperatorTable.GREATER_THAN, b.field(1), b.literal(5)))
+          .build();
+      final RelNode right = b.scan("EMP")
+          .project(b.field("MGR"), b.field("COMM"))
+          .sort(b.field(0))
+          .filter(b.call(SqlStdOperatorTable.GREATER_THAN, b.field(1), b.literal(10)))
+          .build();
+      return b.push(left)
+          .push(right)
+          .union(false, 2)
+          .build();
+    };
+    relFn(relFn)
+        .withRule(CoreRules.UNION_FILTER_TO_FILTER)
+        .check();
+  }
+
+  /** Test case of
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7002">[CALCITE-7002]
    * Create an optimization rule to eliminate UNION
    * from the same source with different filters</a>. */

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -11450,6 +11450,18 @@ class RelOptRulesTest extends RelOptTestBase {
   /** Test case of
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7463">[CALCITE-7463]
    * UnionToFilterRule incorrectly rewrites UNION with LIMIT</a>. */
+  @Test void testUnionAllToFilterRuleWithLimit() {
+    final String sql = "(SELECT mgr, comm FROM emp LIMIT 2)\n"
+        + "UNION ALL\n"
+        + "(SELECT mgr, comm FROM emp LIMIT 2)\n";
+    sql(sql)
+        .withRule(CoreRules.UNION_FILTER_TO_FILTER)
+        .checkUnchanged();
+  }
+
+  /** Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7463">[CALCITE-7463]
+   * UnionToFilterRule incorrectly rewrites UNION with LIMIT</a>. */
   @Test void testUnionToFilterRuleWithNestedLimit() {
     final String sql = "SELECT comm FROM (SELECT mgr, comm FROM emp LIMIT 2) t\n"
         + "WHERE comm > 5\n"

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -21607,6 +21607,30 @@ LogicalAggregate(group=[{0, 1}])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnionToFilterRuleWithSortLimit">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[false])
+  LogicalFilter(condition=[>($1, 5)])
+    LogicalSort(sort0=[$0], dir0=[ASC], offset=[10], fetch=[2])
+      LogicalProject(MGR=[$3], COMM=[$6])
+        LogicalTableScan(table=[[scott, EMP]])
+  LogicalFilter(condition=[>($1, 10)])
+    LogicalSort(sort0=[$0], dir0=[ASC], offset=[10], fetch=[2])
+      LogicalProject(MGR=[$3], COMM=[$6])
+        LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
+  LogicalFilter(condition=[>($1, 5)])
+    LogicalSort(sort0=[$0], dir0=[ASC], offset=[10], fetch=[2])
+      LogicalProject(MGR=[$3], COMM=[$6])
+        LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnionToFilterRuleWithSortOnly">
     <Resource name="planBefore">
       <![CDATA[
@@ -21686,6 +21710,20 @@ LogicalAggregate(group=[{0, 1}])
   LogicalFilter(condition=[OR(=($0, 12), =($1, 5))])
     LogicalProject(MGR=[$3], COMM=[$6])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionToFilterRuleWithUnmergeableFirstInput">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[false])
+  LogicalFilter(condition=[>($1, 5)])
+    LogicalSort(sort0=[$0], dir0=[ASC], offset=[10], fetch=[2])
+      LogicalProject(MGR=[$3], COMM=[$6])
+        LogicalTableScan(table=[[scott, EMP]])
+  LogicalFilter(condition=[>($1, 10)])
+    LogicalProject(MGR=[$3], COMM=[$6])
+      LogicalTableScan(table=[[scott, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -21607,6 +21607,30 @@ LogicalAggregate(group=[{0, 1}])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnionToFilterRuleWithSortOnly">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[false])
+  LogicalFilter(condition=[>($1, 5)])
+    LogicalSort(sort0=[$0], dir0=[ASC])
+      LogicalProject(MGR=[$3], COMM=[$6])
+        LogicalTableScan(table=[[scott, EMP]])
+  LogicalFilter(condition=[>($1, 10)])
+    LogicalSort(sort0=[$0], dir0=[ASC])
+      LogicalProject(MGR=[$3], COMM=[$6])
+        LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}])
+  LogicalFilter(condition=[>($1, 5)])
+    LogicalSort(sort0=[$0], dir0=[ASC])
+      LogicalProject(MGR=[$3], COMM=[$6])
+        LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnionToFilterRuleWithSubqueryProject">
     <Resource name="sql">
       <![CDATA[SELECT 1, (SELECT COUNT(*) FROM dept)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -21498,6 +21498,50 @@ LogicalUnion(all=[false])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnionToFilterRuleWithLimit">
+    <Resource name="sql">
+      <![CDATA[(SELECT mgr, comm FROM emp LIMIT 2)
+UNION
+(SELECT mgr, comm FROM emp LIMIT 2)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[false])
+  LogicalSort(fetch=[2])
+    LogicalProject(MGR=[$3], COMM=[$6])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalSort(fetch=[2])
+    LogicalProject(MGR=[$3], COMM=[$6])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionToFilterRuleWithNestedLimit">
+    <Resource name="sql">
+      <![CDATA[SELECT comm FROM (SELECT mgr, comm FROM emp LIMIT 2) t
+WHERE comm > 5
+UNION
+SELECT comm FROM (SELECT mgr, comm FROM emp LIMIT 2) t
+WHERE comm > 10
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[false])
+  LogicalFilter(condition=[>($0, 5)])
+    LogicalProject(COMM=[$1])
+      LogicalSort(fetch=[2])
+        LogicalProject(MGR=[$3], COMM=[$6])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalFilter(condition=[>($0, 10)])
+    LogicalProject(COMM=[$1])
+      LogicalSort(fetch=[2])
+        LogicalProject(MGR=[$3], COMM=[$6])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnionToFilterRuleWithNonDeterministicProject">
     <Resource name="sql">
       <![CDATA[SELECT mgr, comm, rand() FROM emp WHERE mgr = 12

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -21339,6 +21339,25 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnionAllToFilterRuleWithLimit">
+    <Resource name="sql">
+      <![CDATA[(SELECT mgr, comm FROM emp LIMIT 2)
+UNION ALL
+(SELECT mgr, comm FROM emp LIMIT 2)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[true])
+  LogicalSort(fetch=[2])
+    LogicalProject(MGR=[$3], COMM=[$6])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalSort(fetch=[2])
+    LogicalProject(MGR=[$3], COMM=[$6])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnionEliminatorRuleIntersect">
     <Resource name="planBefore">
       <![CDATA[


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7463](https://issues.apache.org/jira/browse/CALCITE-7463)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
The UnionToFilterRule produces incorrect results when applied to inputs that contain LIMIT.

Specifically, the rule incorrectly collapses:
```
(SELECT mgr, comm FROM emp LIMIT 2)
UNION
(SELECT mgr, comm FROM emp LIMIT 2) 
```
into:
```
SELECT DISTINCT mgr, comm FROM emp LIMIT 2 
```
This transformation is not semantically equivalent.
Reproduction
```
(SELECT mgr, comm FROM emp LIMIT 2)
UNION
(SELECT mgr, comm FROM emp LIMIT 2) 
```
Plan Before
```
LogicalUnion(all=[false])
  LogicalSort(fetch=[2])
    LogicalProject(MGR=[$3], COMM=[$6])
      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
  LogicalSort(fetch=[2])
    LogicalProject(MGR=[$3], COMM=[$6])
      LogicalTableScan(table=[[CATALOG, SALES, EMP]]) 
```
Plan After (Incorrect)
```
LogicalAggregate(group=[{0, 1}])
  LogicalSort(fetch=[2])
    LogicalProject(MGR=[$3], COMM=[$6])
      LogicalTableScan(table=[[CATALOG, SALES, EMP]]) 
```
Expected Behavior
The transformation should NOT be applied when any input of UNION contains LogicalSort(That contains ORDER BY, LIMIT, OFFSET). 
 

