### PR TITLE
[CALCITE-7470] Unparse of `DEFINE` in `MATCH_RECOGNIZE` leads to incorrect SQL

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -6483,11 +6483,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       inferUnknownTypes(booleanType, scope, expand);
       expand.validate(this, scope);
 
-      // Some extra work need required here.
       // In PREV, NEXT, FINAL and LAST, only one pattern variable is allowed.
-      sqlNodes.add(
-          SqlStdOperatorTable.AS.createCall(SqlParserPos.ZERO, expand,
-              new SqlIdentifier(alias, SqlParserPos.ZERO)));
+      // It is already parsed into AS operator, see PatternDefinition in Parser.jj
+      sqlNodes.add(expand);
 
       final RelDataType type = deriveType(scope, expand);
       if (!SqlTypeUtil.inBooleanFamily(type)) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2482,7 +2482,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql(sql).fails("DISTINCT/ALL not allowed with "
         + "COUNT\\(DISTINCT `A`\\.`DEPTNO`\\) function");
 
-    sql("SELECT *\n"
+    final String simpleMatchRecognize = "SELECT *\n"
         + "FROM emp\n"
         + "MATCH_RECOGNIZE (\n"
         + "  MEASURES\n"
@@ -2490,12 +2490,19 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "  PATTERN (A B)\n"
         + "  DEFINE\n"
         + "    A AS A.empno = 123\n"
-        + ") AS T")
-        .rewritesTo("SELECT *\n"
-            + "FROM `EMP` MATCH_RECOGNIZE(\n"
-            + "MEASURES FINAL COUNT(`A`.`DEPTNO`) AS `DEPTNO`\n"
-            + "PATTERN (`A` `B`)\n"
-            + "DEFINE `A` AS (PREV(`A`.`EMPNO`, 0) = 123 AS `A`)) AS `T`");
+        + ") AS T";
+
+    final String simpleMatchRecognizeExpected = "SELECT *\n"
+        + "FROM `EMP` MATCH_RECOGNIZE(\n"
+        + "MEASURES FINAL COUNT(`A`.`DEPTNO`) AS `DEPTNO`\n"
+        + "PATTERN (`A` `B`)\n"
+        + "DEFINE `A` AS PREV(`A`.`EMPNO`, 0) = 123) AS `T`";
+
+    sql(simpleMatchRecognize)
+        .rewritesTo(simpleMatchRecognizeExpected);
+
+    sql(simpleMatchRecognizeExpected)
+        .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
   }
 
   @Test void testIntervalTimeUnitEnumeration() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-7470

another issue with unparsing of `MATCH_RECOGNIZE`

where `DEFINE` part is unparsed to an invalid SQL
the PR is fixing it