### PR TITLE
[CALCITE-7471] Alias is not auto generated for `MATCH_RECOGNIZE`

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2640,7 +2640,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     case MATCH_RECOGNIZE:
       registerMatchRecognize(parentScope, usingScope,
           (SqlMatchRecognize) node, enclosingNode, alias, forceNullable);
-      return node;
+      return newNode;
 
     case PIVOT:
       registerPivot(parentScope, usingScope, (SqlPivot) node, enclosingNode,

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2575,6 +2575,31 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .rewritesTo(expected5);
     sql(expected5)
         .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
+
+    // Test cases for [CALCITE-7471] https://issues.apache.org/jira/browse/CALCITE-7471
+    // Alias is not auto generated for `MATCH_RECOGNIZE`
+    final String sql6 = "SELECT *\n"
+        + "FROM emp\n"
+        + "MATCH_RECOGNIZE (\n"
+        + "  MEASURES\n"
+        + "     FINAL COUNT(A.deptno) AS deptno\n"
+        + "  PATTERN (A B)\n"
+        + "  DEFINE\n"
+        + "    A AS A.empno = 123\n"
+        + ")";
+
+    final String expected6 = "SELECT `EXPR$0`.`DEPTNO`\n"
+        + "FROM `CATALOG`.`SALES`.`EMP` AS `EMP` MATCH_RECOGNIZE(\n"
+        + "MEASURES FINAL COUNT(`A`.`DEPTNO`) AS `DEPTNO`\n"
+        + "PATTERN (`A` `B`)\n"
+        + "DEFINE `A` AS PREV(`A`.`EMPNO`, 0) = 123) AS `EXPR$0`";
+
+    sql(sql6)
+        .withValidatorConfig(c -> c.withIdentifierExpansion(true))
+        .rewritesTo(expected6);
+
+    sql(expected6)
+        .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
   }
 
   @Test void testIntervalTimeUnitEnumeration() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7471](https://issues.apache.org/jira/browse/CALCITE-7471)

in case of toggled `identifierExpansion` and missed alias for table there should be generated one.
However in case of `MATCH_RECOGNIZE` it is missed (the PR is going to fix it)
example of query
```sql
SELECT *
FROM emp
MATCH_RECOGNIZE (
  MEASURES
     FINAL COUNT(A.deptno) AS deptno
  PATTERN (A B)
  DEFINE
    A AS A.empno = 123
)
```
unparsed query (there is `EXPR$0` in `SELECT` however it is not defined anywhere)
```sql
SELECT `EXPR$0`.`DEPTNO`
FROM `CATALOG`.`SALES`.`EMP` AS `EMP` MATCH_RECOGNIZE(
MEASURES FINAL COUNT(`A`.`DEPTNO`) AS `DEPTNO`
PATTERN (`A` `B`)
DEFINE `A` AS PREV(`A`.`EMPNO`, 0) = 123)
```