### PR TITLE
[CALCITE-7468] The SPLIT_PART implementation is incorrect for regex patterns

### DIFF
--- a/babel/src/test/resources/sql/postgresql.iq
+++ b/babel/src/test/resources/sql/postgresql.iq
@@ -60,7 +60,7 @@ EXPR$0
 false
 !ok
 
-#Test string function split_part
+#Test string function split_part, validated on Postgres
 select split_part('abc~@~def~@~ghi', '~@~', 2);
 EXPR$0
 def
@@ -69,6 +69,41 @@ def
 select split_part('abc,def,ghi,jkl', ',', -2);
 EXPR$0
 ghi
+!ok
+
+select split_part('abc.def', '.', 1);
+EXPR$0
+abc
+!ok
+
+select split_part('abc.def', '', 1);
+EXPR$0
+abc.def
+!ok
+
+select split_part('abc.def', '', 2);
+EXPR$0
+
+!ok
+
+select split_part(NULL, '.', 1);
+EXPR$0
+null
+!ok
+
+select split_part(NULL, NULL, NULL);
+EXPR$0
+null
+!ok
+
+select split_part('abc.abc', '.', NULL);
+EXPR$0
+null
+!ok
+
+select split_part('abc', NULL, 1);
+EXPR$0
+null
 !ok
 
 # Test string_to_array function

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1004,11 +1004,18 @@ public class SqlFunctions {
 
   /** SQL {@code SPLIT_PART(string, string, int)} function. */
   public static String splitPart(String s, String delimiter, int n) {
-    if (Strings.isNullOrEmpty(s) || Strings.isNullOrEmpty(delimiter)) {
+    // Function is strict, so arguments cannot be null
+    if (s.isEmpty()) {
       return "";
     }
 
-    String[] parts = s.split(delimiter, -1);
+
+    String[] parts;
+    if (delimiter.isEmpty()) {
+      parts = new String[] { s };
+    } else {
+      parts = s.split(Pattern.quote(delimiter), -1);
+    }
     int partCount = parts.length;
 
     if (n < 0) {
@@ -1021,8 +1028,6 @@ public class SqlFunctions {
 
     return parts[n - 1];
   }
-
-
 
   /** SQL {@code SPLIT(string)} function. */
   public static List<String> split(String s) {

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -1085,14 +1085,17 @@ class SqlFunctionsTest {
 
     assertThat(SqlFunctions.splitPart("abc,,ghi", ",", 2), is(""));
     assertThat(SqlFunctions.splitPart("", ",", 1), is(""));
-    assertThat(SqlFunctions.splitPart("abc", "", 1), is(""));
-
-    assertThat(SqlFunctions.splitPart(null, ",", 1), is(""));
-    assertThat(SqlFunctions.splitPart("abc,def", null, 1), is(""));
+    // Tested on Postgres 17: empty delimiter
+    assertThat(SqlFunctions.splitPart("abc", "", 1), is("abc"));
+    assertThat(SqlFunctions.splitPart("abc", "", 2), is(""));
     assertThat(SqlFunctions.splitPart("abc,def", ",", 0), is(""));
 
     assertThat(SqlFunctions.splitPart("abc,def", ",", 3), is(""));
     assertThat(SqlFunctions.splitPart("abc,def", ",", -3), is(""));
+
+    // Test case for https://issues.apache.org/jira/browse/CALCITE-7468
+    // The SPLIT_PART implementation is incorrect for regex patterns
+    assertThat(SqlFunctions.splitPart("abc.def", ".", 1), is("abc"));
   }
 
   @Test void testByteString() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7468](https://issues.apache.org/jira/browse/CALCITE-7468)

## Changes Proposed

The implementation matches Postgres 18.