### PR TITLE
[CALCITE-7473] Better IntelliJ and VSCode .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,26 +16,18 @@
 *~
 .DS_Store
 .gradle
-/target
-/*/target
-/example/*/target
-/build
-/*/build
-/example/*/build
-/buildSrc/build
-/buildSrc/subprojects/*/build
+/**/target
+/**/build
 /site/.jekyll-cache
 
-# VSCode Java plugin
-/example/*/bin
-/*/bin
-/bin
-/.vscode/*
+# VSCode and plugins
+/**/bin
+.vscode
+.metals
 
 # IDEA
-/out
-/*/out/
-/example/*/out
+/**/out
+/**/generated
 # The star is required for further !/.idea/ to work, see https://git-scm.com/docs/gitignore
 /.idea/*
 # Icon for JetBrains Toolbox


### PR DESCRIPTION
## Jira Link

[CALCITE-7473](https://issues.apache.org/jira/browse/CALCITE-7473)

## Changes Proposed
Improve .gitignore for IntelliJ and VSCode developers
Add generated directories coming from IntelliJ builds.
Add .metals from the metals VSCode plugin.
Use globstar for out, bin, generated, build, target for more generalized matching of these directories.