### PR TITLE
[CALCITE-7465] Make `MATCH_RECOGNIZE` tolerant to `FINAL` and `RUNNING` non function `MEASURES`

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -7505,7 +7505,7 @@ SqlCall MatchRecognizeCallWithModifier() :
 {
     final Span s;
     final SqlOperator runningOp;
-    final SqlNode func;
+    final SqlNode e;
 }
 {
     (
@@ -7514,8 +7514,8 @@ SqlCall MatchRecognizeCallWithModifier() :
         <FINAL> { runningOp = SqlStdOperatorTable.FINAL; }
     )
     { s = span(); }
-    func = NamedFunctionCall() {
-        return runningOp.createCall(s.end(func), func);
+    e = Expression3(ExprContext.ACCEPT_NON_QUERY) {
+        return runningOp.createCall(s.end(e), e);
     }
 }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2655,6 +2655,53 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .rewritesTo(expected8);
     sql(expected8)
         .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
+
+    // Test cases for [CALCITE-7465] https://issues.apache.org/jira/browse/CALCITE-7465
+    // Unparse of MATCH_RECOGNIZE MEASURES might produce unparsable sql
+    // Accepted by Snowflake (it doesn't accept FINAL or RUNNING before non function measure)
+    final String sql9 = "SELECT *\n"
+        + "FROM emp\n"
+        + "MATCH_RECOGNIZE (\n"
+        + "  MEASURES\n"
+        + "    A.deptno AS deptno\n"
+        + "  PATTERN (A B)\n"
+        + "  DEFINE\n"
+        + "    A AS A.empno = 123\n"
+        + ")";
+    final String expected9 = "SELECT `EXPR$0`.`DEPTNO`\n"
+        + "FROM `CATALOG`.`SALES`.`EMP` AS `EMP` MATCH_RECOGNIZE(\n"
+        + "MEASURES FINAL `A`.`DEPTNO` AS `DEPTNO`\n"
+        + "PATTERN (`A` `B`)\n"
+        + "DEFINE `A` AS PREV(`A`.`EMPNO`, 0) = 123) AS `EXPR$0`";
+
+    sql(sql9)
+        .withValidatorConfig(c -> c.withIdentifierExpansion(true))
+        .rewritesTo(expected9);
+    sql(expected9)
+        .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
+
+    final String sql10 = "SELECT deptno\n"
+        + "FROM emp\n"
+        + "MATCH_RECOGNIZE (\n"
+        + "  MEASURES\n"
+        + "    A.deptno AS deptno\n"
+        + "ALL ROWS PER MATCH\n"
+        + "  PATTERN (A B)\n"
+        + "  DEFINE\n"
+        + "    A AS A.empno = 123\n"
+        + ")";
+    final String expected10 = "SELECT `EXPR$0`.`DEPTNO`\n"
+        + "FROM `CATALOG`.`SALES`.`EMP` AS `EMP` MATCH_RECOGNIZE(\n"
+        + "MEASURES RUNNING `A`.`DEPTNO` AS `DEPTNO`\n"
+        + "ALL ROWS PER MATCH\n"
+        + "PATTERN (`A` `B`)\n"
+        + "DEFINE `A` AS PREV(`A`.`EMPNO`, 0) = 123) AS `EXPR$0`";
+
+    sql(sql10)
+        .withValidatorConfig(c -> c.withIdentifierExpansion(true))
+        .rewritesTo(expected10);
+    sql(expected10)
+        .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
   }
 
   @Test void testIntervalTimeUnitEnumeration() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7465](https://issues.apache.org/jira/browse/CALCITE-7465)

Current issue is that some of `MEASURES` 
1. might be without `FINAL` or `RUNNING` keyword
2. might be with a keyword however the computed one is different.
In both cases unparsed sql is wrong.

Since calculation is happenning during validation it impacts unparse logic,
The proposal is movement calculation to `SqlToRelConverter` then unparse will work as expected

query for the first case
```sql
SELECT *
FROM emp
MATCH_RECOGNIZE (
  MEASURES
     FINAL COUNT(A.deptno) AS deptno,
     A.ename AS ename
  PATTERN (A B)
  DEFINE
    A AS A.empno = 123
) AS T
```
if not all rows then the default operation will be `FINAL` and it will be unparsed (non parsable anymore) to
```sql
SELECT *
FROM `EMP` MATCH_RECOGNIZE(
MEASURES FINAL COUNT(`A`.`DEPTNO`) AS `DEPTNO`, FINAL `A`.`ENAME` AS `ENAME`
PATTERN (`A` `B`)
DEFINE `A` AS (PREV(`A`.`EMPNO`, 0) = 123)) AS `T`

```

for the second case
```sql
SELECT *
  from "product" match_recognize
  (
   measures STRT."net_weight" as start_nw,
   FINAL COUNT("net_weight") as down_cnt,
   RUNNING COUNT("net_weight") as running_cnt
    pattern (strt down+ up+)
    define
      down as down."net_weight" < PREV(down."net_weight"),
      up as up."net_weight" > prev(up."net_weight")
  ) mr
```
here for one of the measures it is `RUNNING` however it is not `ALL ROWS` then will be replaced with `FINAL`
the problem is  that it is unparsed as
```sql
SELECT *
FROM (SELECT *
FROM "foodmart"."product") 
MATCH_RECOGNIZE(
MEASURES 
FINAL "STRT"."net_weight" AS "START_NW",
FINAL COUNT("product"."net_weight") AS "DOWN_CNT", 
FINAL (RUNNING COUNT("product"."net_weight")) AS "RUNNING_CNT"
ONE ROW PER MATCH
AFTER MATCH SKIP TO NEXT ROW
PATTERN ("STRT" "DOWN" + "UP" +)
DEFINE 
"DOWN" AS PREV("DOWN"."net_weight", 0) < 
PREV("DOWN"."net_weight", 1), 
"UP" AS PREV("UP"."net_weight", 0) > 
PREV("UP"."net_weight", 1))
```
i.e. there is `FINAL` and `RUNNING` together for the same measure which makes the query unparsable.