### PR TITLE
[CALCITE-7208] Allow downstream projects implement `CREATE OR ALTER`

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4596,6 +4596,8 @@ SqlCreate SqlCreate() :
 {
     <CREATE> { s = span(); }
     [
+        // Allow downstream projects implement different syntax, for instance CREATE OR REPLACE
+        LOOKAHEAD(2)
         <OR> <REPLACE> {
             replace = true;
         }


### PR DESCRIPTION
## Jira Link

[CALCITE-7208](https://issues.apache.org/jira/browse/CALCITE-7208)

Current `Parser.jj` allows to have only `CREATE OR REPLACE` however doesn't allow `CREATE OR ALTER`
the PR allows it