### PR TITLE
[CALCITE-5212] Include DECIMAL scale in digest when precision unspecified 

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -205,6 +205,13 @@ public class BasicSqlType extends AbstractSqlType {
         sb.append(getScale());
       }
       sb.append(')');
+    } else if (printScale && typeName == SqlTypeName.DECIMAL) {
+      // Include scale in the digest when precision is not specified (CALCITE-5212).
+      sb.append('(');
+      sb.append(PRECISION_NOT_SPECIFIED);
+      sb.append(", ");
+      sb.append(scale);
+      sb.append(')');
     }
     if (!withDetail) {
       return;

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -19,6 +19,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.rel.type.StructKind;
 
@@ -35,7 +36,9 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -237,6 +240,27 @@ class SqlTypeFactoryTest {
     assertThat(SqlTypeUtil.comparePrecision(p0, p1), is(expectedComparison));
     assertThat(SqlTypeUtil.comparePrecision(p0, p0), is(0));
     assertThat(SqlTypeUtil.comparePrecision(p1, p1), is(0));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5212">[CALCITE-5212]
+   * Decimal with scale but unspecified precision collides in type cache</a>. */
+  @Test void testCreateSqlTypeDecimalUnspecifiedPrecisionWithScale() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataTypeFactory tf = f.typeFactory;
+    final int pUn = RelDataType.PRECISION_NOT_SPECIFIED;
+    RelDataType d5 = tf.createSqlType(SqlTypeName.DECIMAL, pUn, 5);
+    RelDataType d3 = tf.createSqlType(SqlTypeName.DECIMAL, pUn, 3);
+    assertEquals(5, d5.getScale());
+    assertEquals(3, d3.getScale());
+    assertNotEquals(d5, d3);
+    assertNotEquals(d5.getFullTypeString(), d3.getFullTypeString());
+    // Order independence: first created shape must not be returned for another scale.
+    SqlTypeFactoryImpl tf2 = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataType d3b = tf2.createSqlType(SqlTypeName.DECIMAL, pUn, 3);
+    RelDataType d5b = tf2.createSqlType(SqlTypeName.DECIMAL, pUn, 5);
+    assertEquals(3, d3b.getScale());
+    assertEquals(5, d5b.getScale());
   }
 
   /** Test case for


### PR DESCRIPTION
[CALCITE-5212] Include DECIMAL scale in type digest when precision unspecified
Problem:
createSqlType(DECIMAL, PRECISION_NOT_SPECIFIED, scale) could return types that
collided in DATATYPE_CACHE: same digest/hash for different scales because
BasicSqlType.generateTypeString() only appended scale when printPrecision was
true, so scale was omitted when precision was PRECISION_NOT_SPECIFIED.

Root cause:
The digest string did not distinguish DECIMAL types that differed only by
scale while precision stayed unspecified, breaking equals/hashCode/canonize.

Fix:
When precision is not specified but scale is, append "(PRECISION_NOT_SPECIFIED, scale)"
to the digest for DECIMAL (see generateTypeString).

Testing:
./gradlew :core:test --tests "org.apache.calcite.sql.type.SqlTypeFactoryTest"

https://issues.apache.org/jira/browse/CALCITE-5212
