### PR TITLE
Addendum to [CALCITE-7475]: correction for unparse method

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -625,6 +625,11 @@ class BabelParserTest extends SqlParserTest {
     f.sql("DISCARD TEMP").same();
   }
 
+  @Test void testColonUnparse() {
+    final SqlParserFixture f = fixture().withDialect(PostgresqlSqlDialect.DEFAULT);
+    f.expression().sql("1::INT").ok("(1 :: INTEGER)");
+  }
+
   @Test void testSparkLeftAntiJoin() {
     final SqlParserFixture f = fixture().withDialect(SparkSqlDialect.DEFAULT);
     final String sql = "select a.cid, a.cname, count(1) as amount\n"

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCastOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCastOperator.java
@@ -49,12 +49,13 @@ class SqlCastOperator extends SqlBinaryOperator {
   }
 
   @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
-    writer.sep("(");
+    writer.print("(");
     call.operand(0).unparse(writer, 0, 0);
     writer.keyword("::");
     call.operand(1).unparse(writer, 0, 0);
-    writer.sep(")");
+    writer.print(")");
   }
+
   @Override public RelDataType inferReturnType(
       SqlOperatorBinding opBinding) {
     return SqlStdOperatorTable.CAST.inferReturnType(opBinding);


### PR DESCRIPTION
## Jira Link

[CALCITE-7475](https://issues.apache.org/jira/browse/CALCITE-7475)

## Changes Proposed

This fix prevents crashes during unparse of expressions involving `::`