### PR TITLE
[CALCITE-7531] Add to `BasicSqlType` constructor accepting precision, scale and nullability

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -76,6 +76,20 @@ public class BasicSqlType extends AbstractSqlType {
       int precision) {
     this(typeSystem, typeName, false, precision, SCALE_NOT_SPECIFIED, null,
         null);
+  }
+
+  /**
+   * Constructs a type with precision/length and nullability.
+   *
+   * @param typeSystem Type system
+   * @param typeName Type name
+   * @param isNullable Whether the type is nullable
+   * @param precision Precision (called length for some types)
+   */
+  public BasicSqlType(RelDataTypeSystem typeSystem, SqlTypeName typeName,
+      boolean isNullable, int precision) {
+    this(typeSystem, typeName, isNullable, precision, SCALE_NOT_SPECIFIED,
+        null, null);
     checkPrecScale(typeName, true, false);
   }
 


### PR DESCRIPTION
## Jira Link

[CALCITE-7531](https://issues.apache.org/jira/browse/CALCITE-7531)

## Changes Proposed
before Calcite 1.38 it was possible to set nullability with setter
now it is impossible, also it is impossible to pass it via constructor together with precision and scale.

so Flink's code stops working after attempting to bump Calcite.
The PR adds constructor to resolve it

here it is Flink code using this https://github.com/apache/flink/blob/1990310135edfec7021f77e64dbb976100458909/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/TimeIndicatorRelDataType.scala#L30-L38