### PR TITLE
[CALCITE-7533] Parser rejects parenthesized query as the body of a WITH clause

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3715,8 +3715,12 @@ SqlNode Query(ExprContext exprContext) :
     final List<Object> list = new ArrayList<Object>();
 }
 {
-    [ withList = WithList() ]
-    e = LeafQuery(exprContext) { list.add(e); }
+    (
+        withList = WithList()
+        e = LeafQueryOrExpr(exprContext) { list.add(e); }
+    |
+        e = LeafQuery(exprContext) { list.add(e); }
+    )
     ( AddSetOpQuery(list, exprContext) )*
     { return addWith(withList, SqlParserUtil.toTree(list)); }
 }

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2827,6 +2827,22 @@ public class SqlParserTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7533">[CALCITE-7533]
+   * Parser rejects parenthesized query as the body of a WITH clause</a>. */
+  @Test void testWithParenthesizedBody() {
+    final String sql = "select * from (\n"
+        + "  with q as (select 1 as id)\n"
+        + "  (select id from q) union all (select id from q)) t";
+    final String expected = "SELECT *\n"
+        + "FROM (WITH `Q` AS (SELECT 1 AS `ID`) SELECT `ID`\n"
+        + "FROM `Q`\n"
+        + "UNION ALL\n"
+        + "SELECT `ID`\n"
+        + "FROM `Q`) AS `T`";
+    sql(sql).ok(expected);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5252">[CALCITE-5252]
    * JDBC adapter sometimes miss parentheses around SELECT in WITH_ITEM body</a>. */
   @Test void testWithAsUnion() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7533](https://issues.apache.org/jira/browse/CALCITE-7533)

## Changes Proposed

The parser rejects a parenthesized query expression as the body of a `WITH` clause, even though this is permitted by SQL:2016 (`<query expression body>` → `( <query expression body> )`) and accepted by PostgreSQL.

### Reproduction

```sql
SELECT * FROM (
  WITH q AS (SELECT 1 AS id)
  (SELECT id FROM q) UNION ALL (SELECT id FROM q)
) t
```

Fails with:

```
SqlParseException: Encountered "(" at line 1, column 46.
Was expecting one of:
    "SELECT" ... "TABLE" ... "VALUE" ... "VALUES" ... "," ...
```

### Root cause

In `Parser.jj`, the `Query` production only accepts `LeafQuery` (i.e. `SELECT` / `VALUES` / `TABLE`) as the body after a `WithList`. The parallel `QueryOrExpr` rule already uses `LeafQueryOrExpr` after `WithList`, and `AddSetOpQuery` (used for the 2nd…Nth set-op operands) also uses `LeafQueryOrExpr`. So the parser accepts `… UNION ALL (SELECT 1)` but rejects `(SELECT 1) UNION ALL …` when it appears as the first operand after `WITH`.

Without `WITH`, the same shape parses fine via `ExprOrJoinOrOrderedQuery`'s alt-2 (`TableRef1`) path.

### Fix

Branch `Query` so the post-`WithList` body uses `LeafQueryOrExpr` (mirroring `QueryOrExpr`), while the no-`WITH` path keeps `LeafQuery`. This preserves `Query`'s first-set (`{SELECT, VALUE, VALUES, TABLE}`), so the `LOOKAHEAD(2)` decision in `ExprOrJoinOrOrderedQuery` is unchanged and existing parses (e.g. `(SELECT 1) UNION ALL (SELECT 2)`) take the same path and produce the same tree.

#### Note on permissiveness

Using `LeafQueryOrExpr` after `WithList` inherits the same looseness `QueryOrExpr` already has: a non-query body such as `WITH q AS (SELECT 1) 1+2` will now parse successfully and be rejected by the validator (rather than rejected at parse time). This is consistent with Calcite's existing "parse permissively, validate strictly" approach for `WITH` — `QueryOrExpr` exhibits the same behavior today, so this isn't a new failure mode, just a new place it surfaces.

### Testing

- `SqlParserTest.testWithParenthesizedBody` covers the reported query.
- All existing `testWith*` tests pass across `CoreSqlParserTest`, `SqlUnParserTest`, and `ExtensionSqlParserTest` (66 tests, 0 failures) — confirms no regression in the WITH grammar or unparse behavior, and that the LOOKAHEAD boundary in `ExprOrJoinOrOrderedQuery` is unchanged.