### PR TITLE
[CALCITE-7538] `SqlValidatorImpl` should reject `MATCH_RECOGNIZE` with duplicate `MEASURE` alias

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -1192,4 +1192,7 @@ public interface CalciteResource {
 
   @BaseMessage("The argument of DESCRIPTOR must be an identifier")
   ExInst<SqlValidatorException> descriptorMustBeIdentifier();
+
+  @BaseMessage("Duplicate name ''{0}'' in MATCH_RECOGNIZE MEASURE alias list")
+  ExInst<CalciteException> measureAliasDuplicate(String aliasName);
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -6638,7 +6638,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
   private PairList<String, RelDataType> validateMeasure(SqlMatchRecognize mr,
       MatchRecognizeScope scope, boolean allRows) {
-    final List<String> aliases = new ArrayList<>();
+    final Set<String> aliases = new HashSet<>();
     final List<SqlNode> sqlNodes = new ArrayList<>();
     final SqlNodeList measures = mr.getMeasureList();
     final PairList<String, RelDataType> fields = PairList.of();
@@ -6646,7 +6646,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     for (SqlNode measure : measures) {
       assert measure instanceof SqlCall;
       final String alias = SqlValidatorUtil.alias(measure, aliases.size());
-      aliases.add(alias);
+      if (!aliases.add(alias)) {
+        throw RESOURCE.measureAliasDuplicate(alias).ex();
+      }
 
       SqlNode expand = expand(measure, scope);
       expand = navigationInMeasure(expand, allRows);

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -390,4 +390,5 @@ CannotInferReturnType=Cannot infer return type for {0}; operand types: {1}
 SelectByCannotWithGroupBy=SELECT BY cannot be used with GROUP BY
 SelectByCannotWithOrderBy=SELECT BY cannot be used with ORDER BY
 DescriptorMustBeIdentifier=The argument of DESCRIPTOR must be an identifier
+MeasureAliasDuplicate=Duplicate name ''{0}'' in MATCH_RECOGNIZE MEASURE alias list
 # End CalciteResource.properties

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2760,6 +2760,59 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .rewritesTo(expected11);
     sql(expected11)
         .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
+
+    // Test cases for [CALCITE-7538] https://issues.apache.org/jira/browse/CALCITE-7538
+    // SqlValidatorImpl should reject MATCH_RECOGNIZE with duplicate MEASURE alias
+    final String sql12 = "SELECT *\n"
+        + "FROM emp\n"
+        + "MATCH_RECOGNIZE (\n"
+        + "  MEASURES\n"
+        + "    A.deptno AS deptno,\n"
+        + "    A.deptno AS deptno\n"
+        + "  PATTERN (A B)\n"
+        + "  DEFINE\n"
+        + "    A AS A.empno = 123\n"
+        + ")";
+
+    sql(sql12)
+        .fails("Duplicate name 'DEPTNO' in MATCH_RECOGNIZE MEASURE alias list");
+
+    final String sql13 = "SELECT *\n"
+        + "FROM emp\n"
+        + "MATCH_RECOGNIZE (\n"
+        + "  MEASURES\n"
+        + "    A.deptno AS deptno,\n"
+        + "    A.deptno AS DePtNo\n"
+        + "  PATTERN (A B)\n"
+        + "  DEFINE\n"
+        + "    A AS A.empno = 123\n"
+        + ")";
+
+    sql(sql13)
+        .fails("Duplicate name 'DEPTNO' in MATCH_RECOGNIZE MEASURE alias list");
+
+    final String sql14 = "SELECT *\n"
+        + "FROM emp\n"
+        + "MATCH_RECOGNIZE (\n"
+        + "  MEASURES\n"
+        + "    A.deptno AS deptno,\n"
+        + "    A.deptno AS \"DePtNo\"\n"
+        + "  PATTERN (A B)\n"
+        + "  DEFINE\n"
+        + "    A AS A.empno = 123\n"
+        + ")";
+
+    final String expected14 = "SELECT `EXPR$0`.`DEPTNO`, `EXPR$0`.`DePtNo`\n"
+        + "FROM `CATALOG`.`SALES`.`EMP` AS `EMP` MATCH_RECOGNIZE(\n"
+        + "MEASURES FINAL `A`.`DEPTNO` AS `DEPTNO`, FINAL `A`.`DEPTNO` AS `DePtNo`\n"
+        + "PATTERN (`A` `B`)\n"
+        + "DEFINE `A` AS PREV(`A`.`EMPNO`, 0) = 123) AS `EXPR$0`";
+
+    sql(sql14)
+        .withValidatorConfig(c -> c.withIdentifierExpansion(true))
+        .rewritesTo(expected14);
+    sql(expected14)
+        .withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
   }
 
   @Test void testIntervalTimeUnitEnumeration() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7538](https://issues.apache.org/jira/browse/CALCITE-7538)

## Changes Proposed
The PR makes validator (SqlValidatorImpl) rejecting sql with duplicate aliases in `MEASURE` for `MATCH_RECOGNIZE`