### PR TITLE
[CALCITE-7539] Upgrade Arrow adapter dependencies to 16.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -81,8 +81,8 @@ jandex.version=3.5.3
 # elasticsearch does not like asm:6.2.1+
 aggdesigner-algorithm.version=6.1
 apiguardian-api.version=1.1.2
-arrow-gandiva.version=15.0.0
-arrow.version=15.0.0
+arrow-gandiva.version=17.0.0
+arrow.version=17.0.0
 asm.version=9.9.1
 byte-buddy.version=1.18.8
 cassandra-all.version=4.1.6


### PR DESCRIPTION
Upgrade Arrow adapter dependencies to 16.0.0.\n\nNotes from compatibility checks:\n- Arrow 18.0.0 was evaluated but is blocked because arrow-vector is Java 11 bytecode while Calcite CI still includes JDK 8.\n- Arrow 17.0.0 and 16.1.0 were evaluated but are blocked on JDK 8 runtime by Java 9+ ByteBuffer.flip() binary incompatibility.\n- Arrow/Gandiva 16.0.0 is the current safe upgrade target for the existing CI matrix.\n\nValidation:\n- JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :arrow:clean :arrow:test