### PR TITLE
[CALCITE-7542] RexCall.isAlwaysTrue()/isAlwaysFalse() incorrectly returns true for CAST(boolean AS non-boolean)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -219,6 +219,12 @@ public class RexCall extends RexNode {
   @Override public boolean isAlwaysTrue() {
     // "c IS NOT NULL" occurs when we expand EXISTS.
     // This reduction allows us to convert it to a semi-join.
+    // Only boolean-valued calls can be always-true; e.g. CAST(TRUE AS INTEGER)
+    // evaluates to 1 (INTEGER), not a boolean, even though its operand is
+    // always true.
+    if (getType().getSqlTypeName() != SqlTypeName.BOOLEAN) {
+      return false;
+    }
     switch (getKind()) {
     case IS_NOT_NULL:
       return !operands.get(0).getType().isNullable();
@@ -241,6 +247,10 @@ public class RexCall extends RexNode {
   }
 
   @Override public boolean isAlwaysFalse() {
+    // Only boolean-valued calls can be always-false; see isAlwaysTrue().
+    if (getType().getSqlTypeName() != SqlTypeName.BOOLEAN) {
+      return false;
+    }
     switch (getKind()) {
     case IS_NULL:
       return !operands.get(0).getType().isNullable();

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -4131,6 +4131,55 @@ class RexProgramTest extends RexProgramTestBase {
   }
 
   /** Unit tests for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7542">[CALCITE-7542]
+   * RexCall.isAlwaysTrue()/isAlwaysFalse() incorrectly returns true
+   * for CAST(boolean AS non-boolean)</a>. */
+  @Test void testIsAlwaysTrueCastBooleanToInteger() {
+    // CAST(TRUE AS INTEGER) is not a boolean expression; isAlwaysTrue() must be false.
+    final RexNode castTrueToInt = abstractCast(trueLiteral, tInt());
+    assertThat("CAST(TRUE AS INTEGER).isAlwaysTrue()",
+        castTrueToInt.isAlwaysTrue(), is(false));
+    assertThat("CAST(TRUE AS INTEGER).isAlwaysFalse()",
+        castTrueToInt.isAlwaysFalse(), is(false));
+  }
+
+  @Test void testIsAlwaysFalseCastBooleanToInteger() {
+    // CAST(FALSE AS INTEGER) is not a boolean expression; isAlwaysFalse() must be false.
+    final RexNode castFalseToInt = abstractCast(falseLiteral, tInt());
+    assertThat("CAST(FALSE AS INTEGER).isAlwaysFalse()",
+        castFalseToInt.isAlwaysFalse(), is(false));
+    assertThat("CAST(FALSE AS INTEGER).isAlwaysTrue()",
+        castFalseToInt.isAlwaysTrue(), is(false));
+  }
+
+  @Test void testIsAlwaysTrueCastBooleanToBoolean() {
+    // CAST(TRUE AS BOOLEAN) preserves the always-true property.
+    final RexNode castTrueToBool = abstractCast(trueLiteral, tBool());
+    assertThat("CAST(TRUE AS BOOLEAN).isAlwaysTrue()",
+        castTrueToBool.isAlwaysTrue(), is(true));
+  }
+
+  @Test void testIsAlwaysFalseCastBooleanToBoolean() {
+    // CAST(FALSE AS BOOLEAN) preserves the always-false property.
+    final RexNode castFalseToBool = abstractCast(falseLiteral, tBool());
+    assertThat("CAST(FALSE AS BOOLEAN).isAlwaysFalse()",
+        castFalseToBool.isAlwaysFalse(), is(true));
+  }
+
+  @Test void testIsAlwaysTrueFalseCastNonBooleanCallToBoolean() {
+    // CAST(1 + 1 AS BOOLEAN): the inner operand is a non-literal, non-boolean
+    // RexCall. isAlwaysTrue()/isAlwaysFalse() must safely return false on the
+    // recursive call rather than crashing — the contract is "ask freely, get
+    // a safe false for non-boolean expressions," matching RexLiteral and the
+    // RexNode base class.
+    final RexNode castIntExprToBool = abstractCast(plus(literal(1), literal(1)), tBool());
+    assertThat("CAST(1 + 1 AS BOOLEAN).isAlwaysTrue()",
+        castIntExprToBool.isAlwaysTrue(), is(false));
+    assertThat("CAST(1 + 1 AS BOOLEAN).isAlwaysFalse()",
+        castIntExprToBool.isAlwaysFalse(), is(false));
+  }
+
+  /** Unit tests for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-2438">[CALCITE-2438]
    * RexCall#isAlwaysTrue returns incorrect result</a>. */
   @Test void testIsAlwaysTrueAndFalseXisNullisNotNullisFalse() {

--- a/core/src/test/resources/sql/conditions.iq
+++ b/core/src/test/resources/sql/conditions.iq
@@ -595,4 +595,21 @@ where 5 < cast(deptno as integer) OR 5 >= cast(deptno as integer) OR deptno IS N
 EnumerableTableScan(table=[[scott, EMP]])
 !plan
 
+# Probe: CAST(int_expr AS BOOLEAN) in a WHERE clause exercises the recursion
+# path of RexCall.isAlwaysTrue/False through the CAST case.
+!use scott-babel
+
+with t(a) as (values (0), (1), (2))
+select * from t where cast(a + 1 as boolean);
++---+
+| A |
++---+
+| 0 |
+| 1 |
+| 2 |
++---+
+(3 rows)
+
+!ok
+
 # End conditions.iq


### PR DESCRIPTION
Summary
RexCall.isAlwaysTrue() and isAlwaysFalse() group CAST together with IS_TRUE / IS_NOT_FALSE (and IS_FALSE / IS_NOT_TRUE) and simply delegate to the operand. That is wrong when the cast changes the type: CAST(TRUE AS INTEGER) is an INTEGER expression that evaluates to 1, not a boolean, so it must report isAlwaysTrue() == false. Today it returns true.

This is an API-contract violation. RexSimplify happens not to mis-fire on this expression upstream (its Comparison helper requires a LITERAL-kind operand, which CAST is not), but any caller that consults isAlwaysTrue/False on an arbitrary RexNode and trusts the result to be boolean-valued can be misled.

Tests
core/src/test/java/org/apache/calcite/rex/RexProgramTest.java:

  - testIsAlwaysTrueCastBooleanToInteger — CAST(TRUE AS INTEGER).isAlwaysTrue() is false. Fails on unfixed code.
  - testIsAlwaysFalseCastBooleanToInteger — CAST(FALSE AS INTEGER).isAlwaysFalse() is false. Fails on unfixed code.
  - testIsAlwaysTrueCastBooleanToBoolean — CAST(TRUE AS BOOLEAN).isAlwaysTrue() is still true (no regression for same-type casts).
  - testIsAlwaysFalseCastBooleanToBoolean — CAST(FALSE AS BOOLEAN).isAlwaysFalse() is still true.

core/src/test/resources/sql/conditions.iq
  - Add end-to-end probe for RexCall.isAlwaysTrue/False CAST recursion
  
Repro (against unfixed code)

  ./gradlew :core:test \
    --tests "org.apache.calcite.rex.RexProgramTest.testIsAlwaysTrueCastBooleanToInteger" \
    --tests "org.apache.calcite.rex.RexProgramTest.testIsAlwaysFalseCastBooleanToInteger"

  Both fail with Expected: is <false> but: was <true>. With the fix applied, all four tests pass.

[CALCITE-7542](https://issues.apache.org/jira/browse/CALCITE-7542)

Fix
Return early in RexCall in both methods and only delegate to the operand when the result type is BOOLEAN.

  - core/src/main/java/org/apache/calcite/rex/RexCall.java
