### PR TITLE
[CALCITE-7546] NullPointerException in SqlToRelConverter for UNNEST(array) AS alias under conformance with allowAliasUnnestItems=true

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2795,10 +2795,21 @@ public class SqlToRelConverter {
     RelNode uncollect;
     try {
       if (validator().config().conformance().allowAliasUnnestItems()) {
+        // Without an AS column list, mirror SqlUnnestOperator#inferReturnType
+        // so Uncollect's row type stays aligned with the validator.
+        List<String> itemAliases;
+        if (fieldNames != null) {
+          itemAliases = fieldNames;
+        } else {
+          itemAliases = new ArrayList<>(nodes.size());
+          for (int i = 0; i < nodes.size(); i++) {
+            itemAliases.add(SqlUtil.deriveAliasFromOrdinal(i));
+          }
+        }
         uncollect = relBuilder
             .push(child)
             .project(exprs)
-            .uncollect(requireNonNull(fieldNames, "fieldNames"), operator.withOrdinality)
+            .uncollect(itemAliases, operator.withOrdinality)
             .build();
       } else {
         // REVIEW danny 2020-04-26: should we unify the normal field aliases and

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1967,6 +1967,39 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).withConformance(SqlConformanceEnum.BIG_QUERY).ok();
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7546">[CALCITE-7546]
+   * NullPointerException in SqlToRelConverter for UNNEST(array) AS alias under
+   * conformance with allowAliasUnnestItems=true</a>.
+   */
+  @Test void testAliasUnnestArrayPlanWithoutColumnList() {
+    final String sql = "select d.deptno, e.empno\n"
+        + "from dept_nested_expanded as d,\n"
+        + " UNNEST(d.employees) as e";
+    sql(sql).withConformance(SqlConformanceEnum.PRESTO).ok();
+  }
+
+  @Test void testAliasUnnestScalarArrayPlanWithoutColumnList() {
+    final String sql = "select d.deptno, a\n"
+        + "from dept_nested_expanded as d,\n"
+        + " UNNEST(d.admins) as a";
+    sql(sql).withConformance(SqlConformanceEnum.PRESTO).ok();
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7546">[CALCITE-7546]
+   * NullPointerException in SqlToRelConverter for UNNEST(array) AS alias under
+   * conformance with allowAliasUnnestItems=true</a>, using the exact array
+   * literal reproduction from the issue.
+   */
+  @Test void testAliasUnnestArrayLiteralPlanWithoutColumnList() {
+    final String sql = "select t\n"
+        + "from UNNEST(ARRAY[1, 2, 3]) as t";
+    sql(sql).withConformance(SqlConformanceEnum.PRESTO).ok();
+  }
+
   @Test void testArrayOfRecord() {
     sql("select employees[1].detail.skills[2+3].desc from dept_nested").ok();
   }

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -328,6 +328,20 @@ LogicalProject(A=[$0], B=[$1], C=[$2], DEPTNO=[$3], NAME=[$4])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAliasUnnestArrayLiteralPlanWithoutColumnList">
+    <Resource name="sql">
+      <![CDATA[select t
+from UNNEST(ARRAY[1, 2, 3]) as t]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(T=[$0])
+  Uncollect
+    LogicalProject(EXPR$0=[ARRAY(1, 2, 3)])
+      LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAliasUnnestArrayPlanWithDoubleColumn">
     <Resource name="plan">
       <![CDATA[
@@ -394,6 +408,40 @@ LogicalProject(DEPTNO=[$0], EMPNO=[$5.EMPNO])
       <![CDATA[select d.deptno, employee.empno
 from dept_nested_expanded as d,
  UNNEST(d.employees) as t(employee)]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAliasUnnestArrayPlanWithoutColumnList">
+    <Resource name="sql">
+      <![CDATA[select d.deptno, e.empno
+from dept_nested_expanded as d,
+ UNNEST(d.employees) as e]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], EMPNO=[$5.EMPNO])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED_EXPANDED]])
+    Uncollect
+      LogicalProject(EMPLOYEES=[$cor0.EMPLOYEES])
+        LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAliasUnnestScalarArrayPlanWithoutColumnList">
+    <Resource name="sql">
+      <![CDATA[select d.deptno, a
+from dept_nested_expanded as d,
+ UNNEST(d.admins) as a]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], A=[$5])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{3}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED_EXPANDED]])
+    Uncollect
+      LogicalProject(ADMINS=[$cor0.ADMINS])
+        LogicalValues(tuples=[[{ 0 }]])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testAliasWithinGroupingSets">


### PR DESCRIPTION
## Summary

- Fixes [CALCITE-7546](https://issues.apache.org/jira/browse/CALCITE-7546): `SqlToRelConverter` throws `NullPointerException: fieldNames` for `UNNEST(<array>) AS <alias>` (no column list) under a conformance whose `allowAliasUnnestItems()` returns true (`SqlConformanceEnum.PRESTO`, plus user conformances overriding the flag).
- `convertFrom`'s `AS` branch passes `fieldNames=null` to `convertUnnest` when the AS clause omits a column list. The PRESTO-only branch then called `requireNonNull(fieldNames, "fieldNames")` and threw NPE.
- Fall back to default item aliases derived from `SqlUtil#deriveAliasFromOrdinal`, matching the names that `SqlUnnestOperator#inferReturnType` uses during validation. This keeps the relational row type aligned with the validator's underlying namespace, so both struct (e.g. `UNNEST(d.employees) AS e` → `e.empno`) and scalar element types (e.g. `UNNEST(d.admins) AS a` → `a`) resolve correctly.

## Test plan

- [x] Added `testAliasUnnestArrayPlanWithoutColumnList` (struct array, PRESTO) — reproduces the NPE on `main`, passes after the fix.
- [x] Added `testAliasUnnestScalarArrayPlanWithoutColumnList` (scalar varchar array, PRESTO).
- [x] Existing PRESTO/UNNEST regression tests still pass: `testAliasUnnestArrayPlanWithSingleColumn`, `testAliasUnnestArrayPlanWithDoubleColumn`, `testUnnestArrayPlan`, `testUnnestArrayPlanAs`.
- [x] Full `SqlToRelConverterTest` (663) and `RelToSqlConverterTest` (579) suites pass.