### PR TITLE
[CALCITE-7547] BIG_QUERY conformance should allow field access on UNNEST(array_of_struct) AS alias

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -375,6 +375,7 @@ public interface SqlConformance {
    * fields of T if T is a STRUCT type.
    *
    * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#BIG_QUERY},
    * {@link SqlConformanceEnum#PRESTO};
    * false otherwise.
    */

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -435,6 +435,7 @@ public enum SqlConformanceEnum implements SqlConformance {
 
   @Override public boolean allowAliasUnnestItems() {
     switch (this) {
+    case BIG_QUERY:
     case PRESTO:
       return true;
     default:

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -1939,6 +1939,32 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).withConformance(SqlConformanceEnum.PRESTO).ok();
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7547">[CALCITE-7547]
+   * BIG_QUERY conformance should allow field access on
+   * UNNEST(array_of_struct) AS alias</a>.
+   */
+  @Test void testAliasUnnestArrayPlanWithSingleColumnBigQuery() {
+    final String sql = "select d.deptno, employee.empno\n"
+        + "from dept_nested_expanded as d,\n"
+        + " UNNEST(d.employees) as t(employee)";
+    sql(sql).withConformance(SqlConformanceEnum.BIG_QUERY).ok();
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7547">[CALCITE-7547]
+   * BIG_QUERY conformance should allow field access on
+   * UNNEST(array_of_struct) AS alias</a>.
+   */
+  @Test void testAliasUnnestArrayPlanWithDoubleColumnBigQuery() {
+    final String sql = "select d.deptno, e, k.empno\n"
+        + "from dept_nested_expanded as d CROSS JOIN\n"
+        + " UNNEST(d.admins, d.employees) as t(e, k)";
+    sql(sql).withConformance(SqlConformanceEnum.BIG_QUERY).ok();
+  }
+
   @Test void testArrayOfRecord() {
     sql("select employees[1].detail.skills[2+3].desc from dept_nested").ok();
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8816,6 +8816,37 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             + "\\('EMPNO', 'ENAME', 'DETAIL'\\), whereas alias list has 1 columns");
   }
 
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7547">[CALCITE-7547]
+   * BIG_QUERY conformance should allow field access on
+   * UNNEST(array_of_struct) AS alias</a>.
+   */
+  @Test void testAliasUnnestMultipleArraysBigQuery() {
+    // for accessing a field in STRUCT type unnested from array
+    sql("select e.ENAME\n"
+        + "from dept_nested_expanded as d CROSS JOIN\n"
+        + " UNNEST(d.employees) as t(e)")
+        .withConformance(SqlConformanceEnum.BIG_QUERY).columnType("VARCHAR(10) NOT NULL");
+
+    // for unnesting multiple arrays at the same time
+    sql("select d.deptno, e, k.empno, l.\"unit\", l.\"X\" * l.\"Y\"\n"
+        + "from dept_nested_expanded as d CROSS JOIN\n"
+        + " UNNEST(d.admins, d.employees, d.offices) as t(e, k, l)")
+        .withConformance(SqlConformanceEnum.BIG_QUERY).ok();
+
+    // Make sure validation fails properly given illegal select items
+    sql("select d.deptno, ^e^.some_column, k.empno\n"
+        + "from dept_nested_expanded as d CROSS JOIN\n"
+        + " UNNEST(d.admins, d.employees) as t(e, k)")
+        .withConformance(SqlConformanceEnum.BIG_QUERY)
+        .fails("Table 'E' not found");
+    sql("select d.deptno, e.detail, ^unknown^.detail\n"
+        + "from dept_nested_expanded as d CROSS JOIN\n"
+        + " UNNEST(d.employees) as t(e)")
+        .withConformance(SqlConformanceEnum.BIG_QUERY).fails("Incompatible types");
+  }
+
   @Test void testUnnestArray() {
     sql("select*from unnest(array[1])")
         .columnType("INTEGER NOT NULL");

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -345,7 +345,41 @@ from dept_nested_expanded as d CROSS JOIN
  UNNEST(d.admins, d.employees) as t(e, k)]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAliasUnnestArrayPlanWithDoubleColumnBigQuery">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], E=[$5], EMPNO=[$6.EMPNO])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2, 3}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED_EXPANDED]])
+    Uncollect
+      LogicalProject(ADMINS=[$cor0.ADMINS], EMPLOYEES=[$cor0.EMPLOYEES])
+        LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[select d.deptno, e, k.empno
+from dept_nested_expanded as d CROSS JOIN
+ UNNEST(d.admins, d.employees) as t(e, k)]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAliasUnnestArrayPlanWithSingleColumn">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], EMPNO=[$5.EMPNO])
+  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED_EXPANDED]])
+    Uncollect
+      LogicalProject(EMPLOYEES=[$cor0.EMPLOYEES])
+        LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[select d.deptno, employee.empno
+from dept_nested_expanded as d,
+ UNNEST(d.employees) as t(employee)]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAliasUnnestArrayPlanWithSingleColumnBigQuery">
     <Resource name="plan">
       <![CDATA[
 LogicalProject(DEPTNO=[$0], EMPNO=[$5.EMPNO])


### PR DESCRIPTION
## Jira Link

[CALCITE-7547](https://issues.apache.org/jira/browse/CALCITE-7547)

## Changes Proposed

Under `SqlConformanceEnum.BIG_QUERY`, the following query failed validation with `Column 'NAME' not found in table 'I'`, even though BigQuery itself supports the pattern:

```sql
SELECT i.name FROM t, UNNEST(t.items) AS i
-- t(items ARRAY<ROW<name VARCHAR>>), ROW kind = PEEK_FIELDS_NO_EXPAND
```

Root cause: `SqlConformanceEnum.BIG_QUERY.allowAliasUnnestItems()` returned `false`. With the flag off, `SqlUnnestOperator#inferReturnType` flattens the `ROW` element type into one column per field instead of producing a single struct-typed column the alias can wrap, and `AliasNamespace` cannot remap the flattened result back under the alias. The identical query already validates under `SqlConformanceEnum.PRESTO`. The flag was added in CALCITE-3789 for Presto and was never extended to BigQuery.

Extend the existing PRESTO case in `SqlConformanceEnum#allowAliasUnnestItems()` to also cover `BIG_QUERY`, matching BigQuery's actual semantics. No other conformance is affected.

> **Depends on #4962 ([CALCITE-7546](https://issues.apache.org/jira/browse/CALCITE-7546))** — without that fix, enabling the flag for BIG_QUERY would shift the failure from validation to an NPE in `SqlToRelConverter#convertUnnest` for the 2-operand `AS(UNNEST, alias)` form. The tests in this PR therefore use the column-list form `AS t(<col>)` so they pass on `main` alone; the bare-alias form is covered by CALCITE-7546's own tests once both land.

## Test plan

- [x] `SqlValidatorTest#testAliasUnnestMultipleArraysBigQuery` — new, mirrors the existing PRESTO test under BIG_QUERY conformance (positive struct-field access, multi-array unnest, two negative cases).
- [x] `SqlToRelConverterTest#testAliasUnnestArrayPlanWithSingleColumnBigQuery` and `testAliasUnnestArrayPlanWithDoubleColumnBigQuery` — new, with matching XML plan blocks. Plans are identical to the PRESTO equivalents because `allowAliasUnnestItems()` is the only relevant dial.
- [x] Existing PRESTO regression tests still pass: `testAliasUnnestMultipleArrays`, `testAliasUnnestArrayPlanWithSingleColumn`, `testAliasUnnestArrayPlanWithDoubleColumn`.
- [x] Full `SqlValidatorTest` (562) and `SqlToRelConverterTest` (663) suites pass.