### PR TITLE
[CALCITE-7550] SqlUpdate and SqlDelete unparse EXISTS subqueries without parentheses

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDelete.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDelete.java
@@ -152,8 +152,7 @@ public class SqlDelete extends SqlCall {
     }
     SqlNode condition = this.condition;
     if (condition != null) {
-      writer.sep("WHERE");
-      condition.unparse(writer, opLeft, opRight);
+      SqlUtil.unparseWhereClause(writer, condition, opLeft, opRight);
     }
     writer.endList(frame);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.sql;
 
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
@@ -24,7 +23,6 @@ import org.apache.calcite.sql.util.SqlVisitor;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
@@ -175,34 +173,7 @@ public class SqlSelectOperator extends SqlOperator {
 
     SqlNode where = select.where;
     if (where != null) {
-      writer.sep("WHERE");
-
-      if (!writer.isAlwaysUseParentheses()) {
-        SqlNode node = where;
-
-        // decide whether to split on ORs or ANDs
-        SqlBinaryOperator whereSep = SqlStdOperatorTable.AND;
-        if ((node instanceof SqlCall)
-            && node.getKind() == SqlKind.OR) {
-          whereSep = SqlStdOperatorTable.OR;
-        }
-
-        // unroll whereClause
-        final List<SqlNode> list = new ArrayList<>(0);
-        while (node.getKind() == whereSep.kind) {
-          assert node instanceof SqlCall;
-          final SqlCall call1 = (SqlCall) node;
-          list.add(0, call1.operand(1));
-          node = call1.operand(0);
-        }
-        list.add(0, node);
-
-        // unparse in a WHERE_LIST frame
-        writer.list(SqlWriter.FrameTypeEnum.WHERE_LIST, whereSep,
-            new SqlNodeList(list, where.getParserPosition()));
-      } else {
-        where.unparse(writer, 0, 0);
-      }
+      SqlUtil.unparseWhereClause(writer, where, 0, 0);
     }
     if (select.groupBy != null) {
       SqlNodeList groupBy =

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -202,8 +202,7 @@ public class SqlUpdate extends SqlCall {
     writer.endList(setFrame);
     SqlNode condition = this.condition;
     if (condition != null) {
-      writer.sep("WHERE");
-      condition.unparse(writer, opLeft, opRight);
+      SqlUtil.unparseWhereClause(writer, condition, opLeft, opRight);
     }
     writer.endList(frame);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -455,6 +455,49 @@ public abstract class SqlUtil {
   }
 
   /**
+   * Unparses a WHERE clause.
+   *
+   * <p>Unparsing the condition in a {@link SqlWriter.FrameTypeEnum#WHERE_LIST}
+   * frame lets sub-queries in predicates recognize that they need
+   * parentheses.
+   *
+   * @param writer   Writer
+   * @param where WHERE condition
+   * @param leftPrec Left precedence
+   * @param rightPrec Right precedence
+   */
+  public static void unparseWhereClause(SqlWriter writer, SqlNode where,
+      int leftPrec, int rightPrec) {
+    writer.sep("WHERE");
+
+    if (!writer.isAlwaysUseParentheses()) {
+      SqlNode node = where;
+
+      // Decide whether to split on ORs or ANDs.
+      SqlBinaryOperator whereSep = SqlStdOperatorTable.AND;
+      if ((node instanceof SqlCall)
+          && node.getKind() == SqlKind.OR) {
+        whereSep = SqlStdOperatorTable.OR;
+      }
+
+      // Unroll whereClause.
+      final List<SqlNode> list = new ArrayList<>(0);
+      while (node.getKind() == whereSep.kind) {
+        assert node instanceof SqlCall;
+        final SqlCall call1 = (SqlCall) node;
+        list.add(0, call1.operand(1));
+        node = call1.operand(0);
+      }
+      list.add(0, node);
+
+      writer.list(SqlWriter.FrameTypeEnum.WHERE_LIST, whereSep,
+          new SqlNodeList(list, where.getParserPosition()));
+    } else {
+      where.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+
+  /**
    * Concatenates string literals.
    *
    * <p>This method takes an array of arguments, since pairwise concatenation

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10163,6 +10163,30 @@ class RelToSqlConverterTest {
     final String expected2 = "UPDATE \"foodmart\".\"product\" SET \"product_name\" = 'calcite', "
         + "\"product_id\" = 10\nWHERE \"product_id\" = 1";
     sql(sql2).ok(expected2);
+
+    final String sql3 = "update \"foodmart\".\"product\"\n"
+        + "set \"product_name\" = 'calcite'\n"
+        + "where exists (\n"
+        + "   select 1 from \"foodmart\".\"product_class\")";
+    final String expected3 = "UPDATE \"foodmart\".\"product\" SET \"product_name\" = "
+        + "'calcite'\nWHERE EXISTS (SELECT *\nFROM \"foodmart\".\"product_class\")";
+    sql(sql3).ok(expected3);
+  }
+
+  @Test void testDelete() {
+    final String sql0 = "delete from \"foodmart\".\"product\"\n"
+        + "where exists (\n"
+        + "   select 1 from \"foodmart\".\"product_class\")";
+    final String expected0 = "DELETE FROM \"foodmart\".\"product\"\n"
+        + "WHERE EXISTS (SELECT *\nFROM \"foodmart\".\"product_class\")";
+    sql(sql0).ok(expected0);
+
+    final String sql1 = "delete from \"foodmart\".\"product\"\n"
+        + "where not exists (\n"
+        + "   select 1 from \"foodmart\".\"product_class\")";
+    final String expected1 = "DELETE FROM \"foodmart\".\"product\"\n"
+        + "WHERE NOT EXISTS (SELECT *\nFROM \"foodmart\".\"product_class\")";
+    sql(sql1).ok(expected1);
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7550](https://issues.apache.org/jira/browse/CALCITE-7550)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->

Fixes unparsing of `EXISTS` subqueries in `UPDATE` and `DELETE` statements.

`SqlUpdate` and `SqlDelete` were unparsing the `WHERE` condition directly, which could produce invalid SQL such as `WHERE EXISTS SELECT ...`.

This change moves the existing `WHERE` unparsing logic from `SqlSelectOperator` into `SqlUtil.unparseWhereClause` and reuses it for `SELECT`, `UPDATE`, and `DELETE`, so DML statements use the same `WHERE_LIST` frame behavior as queries.

Adds regression tests for `UPDATE` and `DELETE` with `EXISTS` predicates.