### PR TITLE
[CALCITE-7551] Project/Filter/Join transpose and merge rules should not duplicate non-deterministic expressions (e.g. RAND())

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java
@@ -3346,6 +3346,21 @@ public abstract class RelOptUtil {
       // function? Possibly. But it's invalid SQL, so don't go there.
       return null;
     }
+    // [CALCITE-7551] Refuse to merge if it would duplicate a
+    // non-deterministic expression (e.g. RAND()).
+    final List<RexNode> bottom = project.getProjects();
+    final int[] refs = new int[bottom.size()];
+    new RexVisitorImpl<Void>(true) {
+      @Override public Void visitInputRef(RexInputRef ref) {
+        refs[ref.getIndex()]++;
+        return null;
+      }
+    }.visitEach(nodes);
+    for (int i = 0; i < refs.length; i++) {
+      if (refs[i] > 1 && !RexUtil.isDeterministic(bottom.get(i))) {
+        return null;
+      }
+    }
     final List<RexNode> list = pushPastProject(nodes, project);
     final int bottomCount = RexUtil.nodeCount(project.getProjects());
     final int topCount = RexUtil.nodeCount(nodes);

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
@@ -165,6 +165,13 @@ public class FilterProjectTransposeRule
       // it can be pushed down. For now we don't support this.
       return;
     }
+    // Pushing the filter below the project would split a single
+    // non-deterministic evaluation (e.g. RAND()) into two: one consumed by
+    // the new filter condition, and the original still produced by the
+    // project above. Refuse to transpose in that case.
+    if (!project.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
+      return;
+    }
     // convert the filter to one that references the child of the project
     RexNode newCondition =
         RelOptUtil.pushPastProjectUnlessBloat(filter.getCondition(), project, config.bloat());

--- a/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/FilterProjectTransposeRule.java
@@ -165,12 +165,17 @@ public class FilterProjectTransposeRule
       // it can be pushed down. For now we don't support this.
       return;
     }
-    // Pushing the filter below the project would split a single
-    // non-deterministic evaluation (e.g. RAND()) into two: one consumed by
-    // the new filter condition, and the original still produced by the
-    // project above. Refuse to transpose in that case.
-    if (!project.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
-      return;
+    // Refuse to transpose if the filter references a projected column whose
+    // expression is non-deterministic (e.g. RAND()). Pushing the filter
+    // below the project would inline that expression into the new filter
+    // condition while the original is still produced by the project above,
+    // splitting one evaluation into two. References to deterministic columns
+    // (even when other columns are non-deterministic) are safe to push.
+    final List<RexNode> projects = project.getProjects();
+    for (int ref : RelOptUtil.InputFinder.bits(filter.getCondition())) {
+      if (!RexUtil.isDeterministic(projects.get(ref))) {
+        return;
+      }
     }
     // convert the filter to one that references the child of the project
     RexNode newCondition =

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
@@ -40,6 +40,7 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -119,6 +120,22 @@ public class JoinProjectTransposeRule
     return join.getJoinType().projectsRight();
   }
 
+  /** Returns whether {@code conditionRefs} (input references of the join
+   * condition, expressed against the join's combined output) references a
+   * non-deterministic expression of {@code project}, whose first output
+   * field is at {@code offset} in that combined output. */
+  private static boolean referencesNonDeterministic(Project project,
+      ImmutableBitSet conditionRefs, int offset) {
+    final List<RexNode> exprs = project.getProjects();
+    for (int i = 0; i < exprs.size(); i++) {
+      if (conditionRefs.get(offset + i)
+          && !RexUtil.isDeterministic(exprs.get(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Override public void onMatch(RelOptRuleCall call) {
     final Join join = call.rel(0);
     final JoinRelType joinType = join.getJoinType();
@@ -158,17 +175,22 @@ public class JoinProjectTransposeRule
       rightJoinChild = join.getRight();
     }
 
-    // Skip projects that contain non-deterministic expressions
-    // (e.g. RAND). The merge below inlines projected expressions
-    // into the join condition via expandLocalRef, which would
-    // duplicate every non-deterministic call referenced more than once.
+    // Skip a project when the join condition references one of its
+    // non-deterministic expressions (e.g. RAND()). The merge below inlines
+    // that expression into the new join condition via expandLocalRef while
+    // the project still re-emits it above, splitting one evaluation into
+    // two. Non-deterministic columns that the condition does not reference
+    // are safe to pull up.
+    final ImmutableBitSet conditionRefs =
+        RelOptUtil.InputFinder.bits(join.getCondition());
+    final int nLeftFields = join.getLeft().getRowType().getFieldCount();
     if (leftProject != null
-        && !leftProject.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
+        && referencesNonDeterministic(leftProject, conditionRefs, 0)) {
       leftProject = null;
       leftJoinChild = join.getLeft();
     }
     if (rightProject != null
-        && !rightProject.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
+        && referencesNonDeterministic(rightProject, conditionRefs, nLeftFields)) {
       rightProject = null;
       rightJoinChild = join.getRight();
     }

--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
@@ -153,6 +154,21 @@ public class JoinProjectTransposeRule
       leftJoinChild = join.getLeft();
     }
     if (rightProject != null && rightProject.containsOver()) {
+      rightProject = null;
+      rightJoinChild = join.getRight();
+    }
+
+    // Skip projects that contain non-deterministic expressions
+    // (e.g. RAND). The merge below inlines projected expressions
+    // into the join condition via expandLocalRef, which would
+    // duplicate every non-deterministic call referenced more than once.
+    if (leftProject != null
+        && !leftProject.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
+      leftProject = null;
+      leftJoinChild = join.getLeft();
+    }
+    if (rightProject != null
+        && !rightProject.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
       rightProject = null;
       rightJoinChild = join.getRight();
     }

--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinProjectTransposeRule.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
@@ -34,6 +35,7 @@ import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableList;
@@ -78,16 +80,19 @@ public class SemiJoinProjectTransposeRule
     final Join join = call.rel(0);
     final Project project = call.rel(1);
 
-    // Convert the LHS semi-join or anti-join keys to reference the child
-    // projection expression; all projection expressions must be RexInputRefs,
-    // otherwise, we wouldn't have created this semi-join or anti-join.
-    // Skip when the project contains a non-deterministic expression
-    // (e.g. RAND). Pulling such a project above the semi-join inlines
-    // its expressions into the join condition via expandLocalRef and
-    // then re-emits the projection above, splitting one evaluation
-    // into many. See [CALCITE-7551].
-    if (!project.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
-      return;
+    // Skip when the semi-join condition references one of the project's
+    // non-deterministic expressions (e.g. RAND()). Pulling such a project
+    // above the semi-join inlines that expression into the join condition
+    // via expandLocalRef while the project still re-emits it above,
+    // splitting one evaluation into two. Non-deterministic columns that the
+    // condition does not reference are safe to pull up. See [CALCITE-7551].
+    final ImmutableBitSet conditionRefs =
+        RelOptUtil.InputFinder.bits(join.getCondition());
+    final List<RexNode> projects = project.getProjects();
+    for (int i = 0; i < projects.size(); i++) {
+      if (conditionRefs.get(i) && !RexUtil.isDeterministic(projects.get(i))) {
+        return;
+      }
     }
 
     // Convert the LHS semi-join keys to reference the child projection

--- a/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SemiJoinProjectTransposeRule.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Pair;
@@ -80,6 +81,18 @@ public class SemiJoinProjectTransposeRule
     // Convert the LHS semi-join or anti-join keys to reference the child
     // projection expression; all projection expressions must be RexInputRefs,
     // otherwise, we wouldn't have created this semi-join or anti-join.
+    // Skip when the project contains a non-deterministic expression
+    // (e.g. RAND). Pulling such a project above the semi-join inlines
+    // its expressions into the join condition via expandLocalRef and
+    // then re-emits the projection above, splitting one evaluation
+    // into many. See [CALCITE-7551].
+    if (!project.getProjects().stream().allMatch(RexUtil::isDeterministic)) {
+      return;
+    }
+
+    // Convert the LHS semi-join keys to reference the child projection
+    // expression; all projection expressions must be RexInputRefs,
+    // otherwise, we wouldn't have created this semi-join.
 
     // convert the join condition to reflect the LHS with the project
     // pulled up

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1615,10 +1615,30 @@ class RelOptRulesTest extends RelOptTestBase {
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
    * Project/Filter/Join transpose and merge rules can duplicate
+   * non-deterministic expressions</a>. The transpose is still allowed when
+   * the join condition only references deterministic projected columns,
+   * even if the project also computes a non-deterministic column (here
+   * {@code r} is RAND() but the join is on DEPTNO). */
+  @Test void testJoinProjectTransposeWithUnrelatedNonDeterministic() {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "r"),
+            b.field("DEPTNO"))
+        .scan("DEPT")
+        .join(JoinRelType.INNER,
+            b.equals(b.field(2, 0, "DEPTNO"), b.field(2, 1, "DEPTNO")))
+        .build();
+    relFn(relFn).withRule(CoreRules.JOIN_PROJECT_LEFT_TRANSPOSE).check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Project/Filter/Join transpose and merge rules can duplicate
    * non-deterministic expressions</a>. SemiJoinProjectTransposeRule
    * uses the same {@code mergePrograms} + {@code expandLocalRef}
    * pattern as JoinProjectTransposeRule, and must not pull a project
-   * containing a non-deterministic expression above the semi-join. */
+   * above the semi-join when the condition references one of its
+   * non-deterministic expressions. */
   @Test void testSemiJoinProjectTransposeShouldIgnoreNonDeterministic() {
     final Function<RelBuilder, RelNode> relFn = b -> b
         .scan("EMP")
@@ -1631,6 +1651,25 @@ class RelOptRulesTest extends RelOptTestBase {
                 b.lessThan(b.field(2, 0, "r"), b.literal(1.0))))
         .build();
     relFn(relFn).withRule(CoreRules.SEMI_JOIN_PROJECT_TRANSPOSE).checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Project/Filter/Join transpose and merge rules can duplicate
+   * non-deterministic expressions</a>. The semi-join transpose is still
+   * allowed when the condition only references deterministic projected
+   * columns, even if the project also computes a non-deterministic column
+   * (here {@code r} is RAND() but the semi-join is on DEPTNO). */
+  @Test void testSemiJoinProjectTransposeWithUnrelatedNonDeterministic() {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "r"),
+            b.field("DEPTNO"))
+        .scan("DEPT")
+        .join(JoinRelType.SEMI,
+            b.equals(b.field(2, 0, "DEPTNO"), b.field(2, 1, "DEPTNO")))
+        .build();
+    relFn(relFn).withRule(CoreRules.SEMI_JOIN_PROJECT_TRANSPOSE).check();
   }
 
   /** Test case for

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1592,6 +1592,48 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Project/Filter/Join transpose and merge rules can duplicate
+   * non-deterministic expressions</a>. JoinProjectTransposeRule must
+   * not pull a project containing a non-deterministic expression above
+   * the join, because it inlines the expression into the new join
+   * condition via {@code mergedProgram.expandLocalRef}. */
+  @Test void testJoinProjectTransposeShouldIgnoreNonDeterministic() {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .project(b.field("EMPNO"),
+            b.alias(b.call(SqlStdOperatorTable.RAND), "r"))
+        .scan("DEPT")
+        .join(JoinRelType.INNER,
+            b.and(
+                b.greaterThan(b.field(2, 0, "r"), b.literal(0.0)),
+                b.lessThan(b.field(2, 0, "r"), b.literal(1.0))))
+        .build();
+    relFn(relFn).withRule(CoreRules.JOIN_PROJECT_LEFT_TRANSPOSE).checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Project/Filter/Join transpose and merge rules can duplicate
+   * non-deterministic expressions</a>. SemiJoinProjectTransposeRule
+   * uses the same {@code mergePrograms} + {@code expandLocalRef}
+   * pattern as JoinProjectTransposeRule, and must not pull a project
+   * containing a non-deterministic expression above the semi-join. */
+  @Test void testSemiJoinProjectTransposeShouldIgnoreNonDeterministic() {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .project(b.field("EMPNO"),
+            b.alias(b.call(SqlStdOperatorTable.RAND), "r"))
+        .scan("DEPT")
+        .join(JoinRelType.SEMI,
+            b.and(
+                b.greaterThan(b.field(2, 0, "r"), b.literal(0.0)),
+                b.lessThan(b.field(2, 0, "r"), b.literal(1.0))))
+        .build();
+    relFn(relFn).withRule(CoreRules.SEMI_JOIN_PROJECT_TRANSPOSE).checkUnchanged();
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1338">[CALCITE-1338]
    * JoinProjectTransposeRule should not pull a literal above the
    * null-generating side of a join</a>. */
@@ -3283,6 +3325,18 @@ class RelOptRulesTest extends RelOptTestBase {
         .withExpand(true)
         .withRule(filterProjectTransposeRule)
         .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Project/Filter/Join transpose and merge rules can duplicate
+   * non-deterministic expressions</a>. FilterProjectTransposeRule must
+   * not pull a filter that references a non-deterministic projected
+   * column below the project. */
+  @Test void testFilterProjectTransposeShouldIgnoreNonDeterministic() {
+    final String sql = "select * from (select rand() as a from emp)\n"
+        + "where a > 0 and a < 1";
+    sql(sql).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).checkUnchanged();
   }
 
   private static final String NOT_STRONG_EXPR =
@@ -7000,6 +7054,18 @@ class RelOptRulesTest extends RelOptTestBase {
         + "  from emp)";
     sql(sql).withRule(CoreRules.PROJECT_MERGE).checkUnchanged();
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Project/Filter/Join transpose and merge rules can duplicate
+   * non-deterministic expressions</a>. ProjectMergeRule must not merge
+   * adjacent projects when doing so would duplicate a non-deterministic
+   * expression. */
+  @Test void testProjectMergeShouldIgnoreNonDeterministic() {
+    final String sql = "select a, a + 1 as b from (select rand() as a from emp)";
+    sql(sql).withRule(CoreRules.PROJECT_MERGE).checkUnchanged();
+  }
+
 
   @Test void testAggregateProjectPullUpConstants() {
     final String sql = "select job, empno, sal, sum(sal) as s\n"

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -3334,9 +3334,38 @@ class RelOptRulesTest extends RelOptTestBase {
    * not pull a filter that references a non-deterministic projected
    * column below the project. */
   @Test void testFilterProjectTransposeShouldIgnoreNonDeterministic() {
-    final String sql = "select * from (select rand() as a from emp)\n"
-        + "where a > 0 and a < 1";
-    sql(sql).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).checkUnchanged();
+    // Filter(a > 0 AND a < 1) over Project(a = RAND()). The filter
+    // references the non-deterministic column, so the transpose must be
+    // refused: otherwise the pushed-down filter and the re-emitted project
+    // would each evaluate RAND() independently.
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "a"))
+        .filter(
+            b.and(
+                b.greaterThan(b.field("a"), b.literal(0.0)),
+                b.lessThan(b.field("a"), b.literal(1.0))))
+        .build();
+    relFn(relFn).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).checkUnchanged();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Project/Filter/Join transpose and merge rules can duplicate
+   * non-deterministic expressions</a>. The transpose is still allowed when
+   * the filter only references deterministic projected columns, even if
+   * other columns in the project are non-deterministic (here {@code r} is
+   * RAND() but the filter is on {@code b}). */
+  @Test void testFilterProjectTransposeWithUnrelatedNonDeterministic() {
+    // Filter(b > 0) over Project(r = RAND(), b = DEPTNO). The filter only
+    // references the deterministic column b, so the transpose is safe.
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "r"),
+            b.alias(b.field("DEPTNO"), "b"))
+        .filter(b.greaterThan(b.field("b"), b.literal(0)))
+        .build();
+    relFn(relFn).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).check();
   }
 
   private static final String NOT_STRONG_EXPR =

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1599,17 +1599,9 @@ class RelOptRulesTest extends RelOptTestBase {
    * the join, because it inlines the expression into the new join
    * condition via {@code mergedProgram.expandLocalRef}. */
   @Test void testJoinProjectTransposeShouldIgnoreNonDeterministic() {
-    final Function<RelBuilder, RelNode> relFn = b -> b
-        .scan("EMP")
-        .project(b.field("EMPNO"),
-            b.alias(b.call(SqlStdOperatorTable.RAND), "r"))
-        .scan("DEPT")
-        .join(JoinRelType.INNER,
-            b.and(
-                b.greaterThan(b.field(2, 0, "r"), b.literal(0.0)),
-                b.lessThan(b.field(2, 0, "r"), b.literal(1.0))))
-        .build();
-    relFn(relFn).withRule(CoreRules.JOIN_PROJECT_LEFT_TRANSPOSE).checkUnchanged();
+    final String sql = "select * from (select empno, rand() as r from emp) e\n"
+        + "join dept d on e.r = d.deptno";
+    sql(sql).withRule(CoreRules.JOIN_PROJECT_LEFT_TRANSPOSE).checkUnchanged();
   }
 
   /** Test case for
@@ -1620,15 +1612,9 @@ class RelOptRulesTest extends RelOptTestBase {
    * even if the project also computes a non-deterministic column (here
    * {@code r} is RAND() but the join is on DEPTNO). */
   @Test void testJoinProjectTransposeWithUnrelatedNonDeterministic() {
-    final Function<RelBuilder, RelNode> relFn = b -> b
-        .scan("EMP")
-        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "r"),
-            b.field("DEPTNO"))
-        .scan("DEPT")
-        .join(JoinRelType.INNER,
-            b.equals(b.field(2, 0, "DEPTNO"), b.field(2, 1, "DEPTNO")))
-        .build();
-    relFn(relFn).withRule(CoreRules.JOIN_PROJECT_LEFT_TRANSPOSE).check();
+    final String sql = "select * from (select rand() as r, deptno from emp) e\n"
+        + "join dept d on e.deptno = d.deptno";
+    sql(sql).withRule(CoreRules.JOIN_PROJECT_LEFT_TRANSPOSE).check();
   }
 
   /** Test case for
@@ -1640,17 +1626,14 @@ class RelOptRulesTest extends RelOptTestBase {
    * above the semi-join when the condition references one of its
    * non-deterministic expressions. */
   @Test void testSemiJoinProjectTransposeShouldIgnoreNonDeterministic() {
-    final Function<RelBuilder, RelNode> relFn = b -> b
-        .scan("EMP")
-        .project(b.field("EMPNO"),
-            b.alias(b.call(SqlStdOperatorTable.RAND), "r"))
-        .scan("DEPT")
-        .join(JoinRelType.SEMI,
-            b.and(
-                b.greaterThan(b.field(2, 0, "r"), b.literal(0.0)),
-                b.lessThan(b.field(2, 0, "r"), b.literal(1.0))))
-        .build();
-    relFn(relFn).withRule(CoreRules.SEMI_JOIN_PROJECT_TRANSPOSE).checkUnchanged();
+    final String sql = "select * from (select empno, rand() as r from emp) e\n"
+        + "where e.r in (select sal from emp)";
+    sql(sql)
+        .withDecorrelate(false)
+        .withExpand(true)
+        .withPreRule(CoreRules.PROJECT_TO_SEMI_JOIN)
+        .withRule(CoreRules.SEMI_JOIN_PROJECT_TRANSPOSE)
+        .checkUnchanged();
   }
 
   /** Test case for
@@ -1661,15 +1644,14 @@ class RelOptRulesTest extends RelOptTestBase {
    * columns, even if the project also computes a non-deterministic column
    * (here {@code r} is RAND() but the semi-join is on DEPTNO). */
   @Test void testSemiJoinProjectTransposeWithUnrelatedNonDeterministic() {
-    final Function<RelBuilder, RelNode> relFn = b -> b
-        .scan("EMP")
-        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "r"),
-            b.field("DEPTNO"))
-        .scan("DEPT")
-        .join(JoinRelType.SEMI,
-            b.equals(b.field(2, 0, "DEPTNO"), b.field(2, 1, "DEPTNO")))
-        .build();
-    relFn(relFn).withRule(CoreRules.SEMI_JOIN_PROJECT_TRANSPOSE).check();
+    final String sql = "select * from (select rand() as r, deptno from emp) e\n"
+        + "where e.deptno in (select deptno from dept)";
+    sql(sql)
+        .withDecorrelate(false)
+        .withExpand(true)
+        .withPreRule(CoreRules.PROJECT_TO_SEMI_JOIN)
+        .withRule(CoreRules.SEMI_JOIN_PROJECT_TRANSPOSE)
+        .check();
   }
 
   /** Test case for
@@ -3373,19 +3355,9 @@ class RelOptRulesTest extends RelOptTestBase {
    * not pull a filter that references a non-deterministic projected
    * column below the project. */
   @Test void testFilterProjectTransposeShouldIgnoreNonDeterministic() {
-    // Filter(a > 0 AND a < 1) over Project(a = RAND()). The filter
-    // references the non-deterministic column, so the transpose must be
-    // refused: otherwise the pushed-down filter and the re-emitted project
-    // would each evaluate RAND() independently.
-    final Function<RelBuilder, RelNode> relFn = b -> b
-        .scan("EMP")
-        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "a"))
-        .filter(
-            b.and(
-                b.greaterThan(b.field("a"), b.literal(0.0)),
-                b.lessThan(b.field("a"), b.literal(1.0))))
-        .build();
-    relFn(relFn).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).checkUnchanged();
+    final String sql = "select * from (select rand() as a from emp)\n"
+        + "where a > 0 and a < 1";
+    sql(sql).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).checkUnchanged();
   }
 
   /** Test case for
@@ -3396,15 +3368,9 @@ class RelOptRulesTest extends RelOptTestBase {
    * other columns in the project are non-deterministic (here {@code r} is
    * RAND() but the filter is on {@code b}). */
   @Test void testFilterProjectTransposeWithUnrelatedNonDeterministic() {
-    // Filter(b > 0) over Project(r = RAND(), b = DEPTNO). The filter only
-    // references the deterministic column b, so the transpose is safe.
-    final Function<RelBuilder, RelNode> relFn = b -> b
-        .scan("EMP")
-        .project(b.alias(b.call(SqlStdOperatorTable.RAND), "r"),
-            b.alias(b.field("DEPTNO"), "b"))
-        .filter(b.greaterThan(b.field("b"), b.literal(0)))
-        .build();
-    relFn(relFn).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).check();
+    final String sql = "select * from (select rand() as r, deptno as b from emp)\n"
+        + "where b > 0";
+    sql(sql).withRule(CoreRules.FILTER_PROJECT_TRANSPOSE).check();
   }
 
   private static final String NOT_STRONG_EXPR =

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -6270,4 +6270,13 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         + "LIMIT 5";
     sql(sql).withConformance(SqlConformanceEnum.LENIENT).ok();
   }
+
+  /** Test case of
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7551">[CALCITE-7551]
+   * Non-deterministic expressions (e.g. {@code RAND()}) should not be
+   * duplicated when projections are merged</a>. */
+  @Test void testRandNotDuplicatedInProjectionMerge() {
+    final String sql = "select a, a + 1 as b from (select rand() as a)";
+    sql(sql).ok();
+  }
 }

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8562,6 +8562,24 @@ LogicalProject(DEPTNO=[$0], NAME=[$1], R=[$3], EXPR$1=[$4])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinProjectTransposeWithUnrelatedNonDeterministic">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($1, $2)], joinType=[inner])
+  LogicalProject(r=[RAND()], DEPTNO=[$7])
+    LogicalTableScan(table=[[scott, EMP]])
+  LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(r=[RAND()], DEPTNO=[$7], DEPTNO0=[$8], DNAME=[$9], LOC=[$10])
+  LogicalJoin(condition=[=($7, $8)], joinType=[inner])
+    LogicalTableScan(table=[[scott, EMP]])
+    LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinPushTransitivePredicatesNullabilityIssue">
     <Resource name="sql">
       <![CDATA[WITH
@@ -18097,6 +18115,24 @@ LogicalProject(DNAME=[$1], DEPTNO=[$0])
   LogicalJoin(condition=[=($0, $10)], joinType=[anti])
     LogicalTableScan(table=[[scott, DEPT]])
     LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSemiJoinProjectTransposeWithUnrelatedNonDeterministic">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($1, $2)], joinType=[semi])
+  LogicalProject(r=[RAND()], DEPTNO=[$7])
+    LogicalTableScan(table=[[scott, EMP]])
+  LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(r=[RAND()], DEPTNO=[$7])
+  LogicalJoin(condition=[=($7, $8)], joinType=[semi])
+    LogicalTableScan(table=[[scott, EMP]])
+    LogicalTableScan(table=[[scott, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5926,16 +5926,27 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
     </Resource>
   </TestCase>
   <TestCase name="testFilterProjectTransposeShouldIgnoreNonDeterministic">
-    <Resource name="sql">
-      <![CDATA[select * from (select rand() as a from emp)
-where a > 0 and a < 1]]>
-    </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(A=[$0])
-  LogicalFilter(condition=[AND(>($0, CAST(0):DOUBLE NOT NULL), <($0, CAST(1):DOUBLE NOT NULL))])
-    LogicalProject(A=[RAND()])
-      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+LogicalFilter(condition=[SEARCH($0, Sarg[(0.0E0:DOUBLE..1.0E0:DOUBLE)]:DOUBLE)])
+  LogicalProject(a=[RAND()])
+    LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFilterProjectTransposeWithUnrelatedNonDeterministic">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalFilter(condition=[>($1, 0)])
+  LogicalProject(r=[RAND()], b=[$7])
+    LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(r=[RAND()], b=[$7])
+  LogicalFilter(condition=[>($7, 0)])
+    LogicalTableScan(table=[[scott, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5925,6 +5925,20 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFilterProjectTransposeShouldIgnoreNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select * from (select rand() as a from emp)
+where a > 0 and a < 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(A=[$0])
+  LogicalFilter(condition=[AND(>($0, CAST(0):DOUBLE NOT NULL), <($0, CAST(1):DOUBLE NOT NULL))])
+    LogicalProject(A=[RAND()])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFilterReduceCrash">
     <Resource name="sql">
       <![CDATA[SELECT + 54 FROM emp WHERE NOT CAST ( CAST(empno AS DOUBLE) AS INTEGER ) NOT BETWEEN ( NULL ) AND 89]]>
@@ -8496,6 +8510,16 @@ LogicalJoin(condition=[=($0, $1)], joinType=[semi])
     LogicalTableScan(table=[[scott, EMP]])
   LogicalProject(DEPTNO=[$0])
     LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinProjectTransposeShouldIgnoreNonDeterministic">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[SEARCH($1, Sarg[(0.0E0:DOUBLE..1.0E0:DOUBLE)]:DOUBLE)], joinType=[inner])
+  LogicalProject(EMPNO=[$0], r=[RAND()])
+    LogicalTableScan(table=[[scott, EMP]])
+  LogicalTableScan(table=[[scott, DEPT]])
 ]]>
     </Resource>
   </TestCase>
@@ -11998,6 +12022,18 @@ LogicalProject(EXPR$0=[+($0, 1)])
 })])
   LogicalProject(X=[ARRAY(1, 2, 3)])
     LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectMergeShouldIgnoreNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select a, a + 1 as b from (select rand() as a from emp)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(A=[$0], B=[+($0, 1)])
+  LogicalProject(A=[RAND()])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>
@@ -18022,6 +18058,16 @@ LogicalProject(DNAME=[$1])
       LogicalAggregate(group=[{0}])
         LogicalProject($f0=[*(2, $0)])
           LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSemiJoinProjectTransposeShouldIgnoreNonDeterministic">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[SEARCH($1, Sarg[(0.0E0:DOUBLE..1.0E0:DOUBLE)]:DOUBLE)], joinType=[semi])
+  LogicalProject(EMPNO=[$0], r=[RAND()])
+    LogicalTableScan(table=[[scott, EMP]])
+  LogicalTableScan(table=[[scott, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -5926,27 +5926,38 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
     </Resource>
   </TestCase>
   <TestCase name="testFilterProjectTransposeShouldIgnoreNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select * from (select rand() as a from emp)
+where a > 0 and a < 1]]>
+    </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalFilter(condition=[SEARCH($0, Sarg[(0.0E0:DOUBLE..1.0E0:DOUBLE)]:DOUBLE)])
-  LogicalProject(a=[RAND()])
-    LogicalTableScan(table=[[scott, EMP]])
+LogicalProject(A=[$0])
+  LogicalFilter(condition=[AND(>($0, CAST(0):DOUBLE NOT NULL), <($0, CAST(1):DOUBLE NOT NULL))])
+    LogicalProject(A=[RAND()])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testFilterProjectTransposeWithUnrelatedNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select * from (select rand() as r, deptno as b from emp)
+where b > 0]]>
+    </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalFilter(condition=[>($1, 0)])
-  LogicalProject(r=[RAND()], b=[$7])
-    LogicalTableScan(table=[[scott, EMP]])
+LogicalProject(R=[$0], B=[$1])
+  LogicalFilter(condition=[>($1, 0)])
+    LogicalProject(R=[RAND()], B=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(r=[RAND()], b=[$7])
-  LogicalFilter(condition=[>($7, 0)])
-    LogicalTableScan(table=[[scott, EMP]])
+LogicalProject(R=[$0], B=[$1])
+  LogicalProject(R=[RAND()], B=[$7])
+    LogicalFilter(condition=[>($7, 0)])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>
@@ -8525,12 +8536,18 @@ LogicalJoin(condition=[=($0, $1)], joinType=[semi])
     </Resource>
   </TestCase>
   <TestCase name="testJoinProjectTransposeShouldIgnoreNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select * from (select empno, rand() as r from emp) e
+join dept d on e.r = d.deptno]]>
+    </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalJoin(condition=[SEARCH($1, Sarg[(0.0E0:DOUBLE..1.0E0:DOUBLE)]:DOUBLE)], joinType=[inner])
-  LogicalProject(EMPNO=[$0], r=[RAND()])
-    LogicalTableScan(table=[[scott, EMP]])
-  LogicalTableScan(table=[[scott, DEPT]])
+LogicalProject(EMPNO=[$0], R=[$1], DEPTNO=[$2], NAME=[$3])
+  LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+    LogicalProject(EMPNO=[$0], R=[RAND()])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[CAST($0):DOUBLE NOT NULL])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>
@@ -8563,20 +8580,26 @@ LogicalProject(DEPTNO=[$0], NAME=[$1], R=[$3], EXPR$1=[$4])
     </Resource>
   </TestCase>
   <TestCase name="testJoinProjectTransposeWithUnrelatedNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select * from (select rand() as r, deptno from emp) e
+join dept d on e.deptno = d.deptno]]>
+    </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalJoin(condition=[=($1, $2)], joinType=[inner])
-  LogicalProject(r=[RAND()], DEPTNO=[$7])
-    LogicalTableScan(table=[[scott, EMP]])
-  LogicalTableScan(table=[[scott, DEPT]])
+LogicalProject(R=[$0], DEPTNO=[$1], DEPTNO0=[$2], NAME=[$3])
+  LogicalJoin(condition=[=($1, $2)], joinType=[inner])
+    LogicalProject(R=[RAND()], DEPTNO=[$7])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(r=[RAND()], DEPTNO=[$7], DEPTNO0=[$8], DNAME=[$9], LOC=[$10])
-  LogicalJoin(condition=[=($7, $8)], joinType=[inner])
-    LogicalTableScan(table=[[scott, EMP]])
-    LogicalTableScan(table=[[scott, DEPT]])
+LogicalProject(R=[$0], DEPTNO=[$1], DEPTNO0=[$2], NAME=[$3])
+  LogicalProject(R=[RAND()], DEPTNO=[$7], DEPTNO0=[$9], NAME=[$10])
+    LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>
@@ -18091,12 +18114,17 @@ LogicalProject(DNAME=[$1])
     </Resource>
   </TestCase>
   <TestCase name="testSemiJoinProjectTransposeShouldIgnoreNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select * from (select empno, rand() as r from emp) e
+where e.r in (select sal from emp)]]>
+    </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalJoin(condition=[SEARCH($1, Sarg[(0.0E0:DOUBLE..1.0E0:DOUBLE)]:DOUBLE)], joinType=[semi])
-  LogicalProject(EMPNO=[$0], r=[RAND()])
-    LogicalTableScan(table=[[scott, EMP]])
-  LogicalTableScan(table=[[scott, DEPT]])
+LogicalJoin(condition=[=($1, $2)], joinType=[semi])
+  LogicalProject(EMPNO=[$0], R=[RAND()])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(SAL=[CAST($5):DOUBLE NOT NULL])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>
@@ -18119,20 +18147,26 @@ LogicalProject(DNAME=[$1], DEPTNO=[$0])
     </Resource>
   </TestCase>
   <TestCase name="testSemiJoinProjectTransposeWithUnrelatedNonDeterministic">
+    <Resource name="sql">
+      <![CDATA[select * from (select rand() as r, deptno from emp) e
+where e.deptno in (select deptno from dept)]]>
+    </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalJoin(condition=[=($1, $2)], joinType=[semi])
-  LogicalProject(r=[RAND()], DEPTNO=[$7])
-    LogicalTableScan(table=[[scott, EMP]])
-  LogicalTableScan(table=[[scott, DEPT]])
+  LogicalProject(R=[RAND()], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+  LogicalProject(DEPTNO=[$0])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(r=[RAND()], DEPTNO=[$7])
-  LogicalJoin(condition=[=($7, $8)], joinType=[semi])
-    LogicalTableScan(table=[[scott, EMP]])
-    LogicalTableScan(table=[[scott, DEPT]])
+LogicalProject(R=[RAND()], DEPTNO=[$7])
+  LogicalJoin(condition=[=($7, $9)], joinType=[semi])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalProject(DEPTNO=[$0])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -7411,6 +7411,18 @@ LogicalProject(EXPR$0=[= SOME(1970-01-01 01:23:45, CAST(ARRAY('1970-01-01 01:23:
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testRandNotDuplicatedInProjectionMerge">
+    <Resource name="sql">
+      <![CDATA[select a, a + 1 as b from (select rand() as a)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(A=[$0], B=[+($0, 1)])
+  LogicalProject(A=[RAND()])
+    LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testRecursiveQuery">
     <Resource name="sql">
       <![CDATA[WITH RECURSIVE aux(i) AS (


### PR DESCRIPTION
## Jira Link

[CALCITE-7551](https://issues.apache.org/jira/browse/CALCITE-7551)

## Changes Proposed

Several optimizer and `RelBuilder`-level transformations inline a lower-projection expression into multiple positions of an upper expression without checking whether the inlined expression is non-deterministic. When the lower expression is non-deterministic (e.g. `RAND()`), this silently turns one evaluation into many, changing query semantics.

### Reproduction

```sql
SELECT a, a + 1 AS b FROM (SELECT rand() AS a)
```

Before the fix, `SqlToRelConverter` produces:

```
LogicalProject(A=[RAND()], B=[+(RAND(), 1)])
  LogicalValues(tuples=[[{ 0 }]])
```

The two `RAND()` calls are evaluated independently, so `B - A` is no longer always `1`. After the fix the inner projection is preserved and `A`, `B` share a single evaluation:

```
LogicalProject(A=[$0], B=[+($0, 1)])
  LogicalProject(A=[RAND()])
    LogicalValues(tuples=[[{ 0 }]])
```

### Scope

The bug only affects operators that can return *different values across call sites within a single statement* — i.e. operators with `isDeterministic() == false` (`SqlRandFunction`, `SqlRandIntegerFunction`). Per-statement-stable operators such as `CURRENT_TIMESTAMP`, `CURRENT_DATE`, `CURRENT_USER`, etc. resolve to the same value at every occurrence in one execution, so duplicating them in the plan is observationally a no-op; they don't need to be blocked.

The guard uses `RexUtil.isDeterministic(...)`, which consults `SqlOperator.isDeterministic()` and correctly partitions the two sets.

### Affected code paths and fixes

The guard only kicks in when the transform would *actually* duplicate a non-deterministic evaluation — not whenever a non-deterministic column merely exists. The precise condition depends on whether the lower project is **consumed** by the transform or **re-emitted** above the new node:

| Component | Mechanism | Guard |
|---|---|---|
| `RelOptUtil.pushPastProjectUnlessBloat` | `pushShuttle(Project)` substitutes every `RexInputRef` with the underlying projection. Only `RexOver` was guarded; determinism was not. The bottom project is **consumed** (inlined away). | Count `RexInputRef` uses per bottom slot; return `null` only if a non-deterministic bottom expression is referenced **more than once** (a single reference yields a single inlined copy, which is safe). Covers `ProjectMergeRule` and `FilterProjectTransposeRule`'s helper call, plus the `RelBuilder` bloat merge that `SqlToRelConverter` relies on. |
| `FilterProjectTransposeRule` | Pushes the filter below the project, but **re-emits** the original project above the new filter. So even one reference splits a single evaluation in two (one inlined into the pushed-down filter, one in the re-emitted project). | Skip only when the **filter condition references** a non-deterministic projected column (`RelOptUtil.InputFinder.bits`). Filters on deterministic columns are pushed even if the project computes an unrelated `RAND()`. |
| `JoinProjectTransposeRule` | Uses `RexProgramBuilder.mergePrograms` + `mergedProgram.expandLocalRef`, inlining projected expressions into the new join condition while **re-emitting** the project above. | Skip a side only when the **join condition references** one of that side's non-deterministic projected columns (left at offset 0, right at `nLeftFields`). |
| `SemiJoinProjectTransposeRule` | Same `mergePrograms` + `expandLocalRef` pattern as `JoinProjectTransposeRule`. | Skip only when the **semi-join condition references** a non-deterministic projected column on the LHS. |

The "consumed vs re-emitted" distinction is why the threshold differs: `ProjectMergeRule` blocks at `> 1` references (the bottom project disappears, so one reference = one surviving copy), while the transpose rules block at `>= 1` (the project survives on top, so a single referenced occurrence already yields two evaluations).

### Tests

Blocked cases (transform must not fire / not duplicate):

- `RelOptRulesTest.testProjectMergeShouldIgnoreNonDeterministic`
- `RelOptRulesTest.testFilterProjectTransposeShouldIgnoreNonDeterministic`
- `RelOptRulesTest.testJoinProjectTransposeShouldIgnoreNonDeterministic`
- `RelOptRulesTest.testSemiJoinProjectTransposeShouldIgnoreNonDeterministic`
- `SqlToRelConverterTest.testRandNotDuplicatedInProjectionMerge`

Allowed cases (transform still fires when the non-deterministic column is unrelated to the condition):

- `RelOptRulesTest.testFilterProjectTransposeWithUnrelatedNonDeterministic`
- `RelOptRulesTest.testJoinProjectTransposeWithUnrelatedNonDeterministic`
- `RelOptRulesTest.testSemiJoinProjectTransposeWithUnrelatedNonDeterministic`

### Confirmed unaffected (verified by additional probing during investigation)

`CalcMergeRule` (RexProgram preserves CSE via local refs), `ProjectReduceExpressionsRule`, `ProjectValuesMergeRule`, `ProjectFilterTransposeRule`, `ProjectJoinTransposeRule`, `ProjectCorrelateTransposeRule`, `AggregateProjectMergeRule`, `FilterSetOpTransposeRule` (textual duplication only — each row flows through one branch of a `UNION ALL`, so per-row evaluation count is unchanged), `ProjectToWindowRule`.