### PR TITLE
[CALCITE-7563] Oracle dialect generates invalid CAST to VARCHAR without precision

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -116,6 +116,13 @@ public class OracleSqlDialect extends SqlDialect {
     case DOUBLE:
       castSpec = "DOUBLE PRECISION";
       break;
+    case VARCHAR:
+      if (type.getPrecision() == RelDataType.PRECISION_NOT_SPECIFIED) {
+        final int precision = getTypeSystem().getMaxPrecision(SqlTypeName.VARCHAR);
+        castSpec = "VARCHAR(" + precision + ")";
+        break;
+      }
+      return super.getCastSpec(type);
     default:
       return super.getCastSpec(type);
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1709,6 +1709,21 @@ class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7563">[CALCITE-7563]
+   * Oracle dialect generates invalid CAST to VARCHAR without precision</a>. */
+  @Test void testCastVarcharWithoutPrecisionOracle() {
+    final String query = "select cast(\"store_id\" as VARCHAR)\n"
+        + " from \"expense_fact\"";
+    final String expected = "SELECT CAST(\"store_id\" AS VARCHAR(4000))\n"
+        + "FROM \"foodmart\".\"expense_fact\"";
+    final String expectedModifiedTypeSystem = "SELECT CAST(\"store_id\" AS VARCHAR(512))\n"
+        + "FROM \"foodmart\".\"expense_fact\"";
+    sql(query)
+        .withOracle().ok(expected)
+        .withOracleModifiedTypeSystem().ok(expectedModifiedTypeSystem);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1174">[CALCITE-1174]
    * When generating SQL, translate SUM0(x) to COALESCE(SUM(x), 0)</a>. */
   @Test void testSum0BecomesCoalesce() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7563](https://issues.apache.org/jira/browse/CALCITE-7563)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->

Oracle treats VARCHAR as synonymous with VARCHAR2, and VARCHAR2 requires a size. RelToSqlConverter with OracleSqlDialect could generate invalid SQL such as CAST(expr AS VARCHAR) when the target VARCHAR type had unspecified precision.

Use the Oracle type system's max precision for VARCHAR in this case, and add a regression test.
