### PR TITLE
[CALCITE-7566] Support BigQuery-style bare bracket array literals

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -5249,28 +5249,55 @@ SqlNode ArrayConstructor() :
     final String p;
 }
 {
-    <ARRAY> { s = span(); }
     (
+        <ARRAY> { s = span(); }
         (
-            // nullary array function call: "array()" (Apache Spark)
-            LOOKAHEAD(2)
-            <LPAREN> <RPAREN> { args = SqlNodeList.EMPTY; }
-        |
-            args = ParenthesizedQueryOrCommaList(ExprContext.ACCEPT_ALL)
-        )
-        {
-            if (args.size() == 1 && args.get(0).isA(SqlKind.QUERY)) {
-                // Array query constructor, 'ARRAY (SELECT * FROM t)'
-                return SqlStdOperatorTable.ARRAY_QUERY.createCall(s.end(this), args.get(0));
-            } else {
-                // Spark ARRAY function, 'ARRAY(1, 2)',
-                // equivalent to standard 'ARRAY [1, 2]'
-                return SqlLibraryOperators.ARRAY.createCall(s.end(this), args.getList());
+            (
+                // nullary array function call: "array()" (Apache Spark)
+                LOOKAHEAD(2)
+                <LPAREN> <RPAREN> { args = SqlNodeList.EMPTY; }
+            |
+                args = ParenthesizedQueryOrCommaList(ExprContext.ACCEPT_ALL)
+            )
+            {
+                if (args.size() == 1 && args.get(0).isA(SqlKind.QUERY)) {
+                    // Array query constructor, 'ARRAY (SELECT * FROM t)'
+                    return SqlStdOperatorTable.ARRAY_QUERY.createCall(s.end(this), args.get(0));
+                } else {
+                    // Spark ARRAY function, 'ARRAY(1, 2)',
+                    // equivalent to standard 'ARRAY [1, 2]'
+                    return SqlLibraryOperators.ARRAY.createCall(s.end(this), args.getList());
+                }
             }
-        }
+        |
+            // by enumeration "ARRAY[e0, e1, ..., eN]"
+            <LBRACKET> // TODO: do trigraph as well ??( ??)
+            (
+                args = ExpressionCommaList(s, ExprContext.ACCEPT_SUB_QUERY)
+            |
+                { args = SqlNodeList.EMPTY; }
+            )
+            <RBRACKET>
+            {
+                return SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR.createCall(
+                    s.end(this), args.getList());
+            }
+<#if (parser.includeParsingStringLiteralAsArrayLiteral!default.parser.includeParsingStringLiteralAsArrayLiteral) >
+        |
+            p = SimpleStringLiteral() {
+                try {
+                    return SqlParserUtil.parseArrayLiteral(p);
+                } catch (SqlParseException ex) {
+                    throw SqlUtil.newContextException(getPos(),
+                        RESOURCE.illegalArrayExpression(p));
+                }
+            }
+</#if>
+        )
     |
-        // by enumeration "ARRAY[e0, e1, ..., eN]"
-        <LBRACKET> // TODO: do trigraph as well ??( ??)
+        // BigQuery bare bracket array literal "[e0, e1, ..., eN]"
+        LOOKAHEAD({ this.conformance.allowBareBracketArrayLiteral() })
+        <LBRACKET> { s = span(); }
         (
             args = ExpressionCommaList(s, ExprContext.ACCEPT_SUB_QUERY)
         |
@@ -5281,17 +5308,6 @@ SqlNode ArrayConstructor() :
             return SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR.createCall(
                 s.end(this), args.getList());
         }
-<#if (parser.includeParsingStringLiteralAsArrayLiteral!default.parser.includeParsingStringLiteralAsArrayLiteral) >
-    |
-        p = SimpleStringLiteral() {
-            try {
-                return SqlParserUtil.parseArrayLiteral(p);
-            } catch (SqlParseException ex) {
-                throw SqlUtil.newContextException(getPos(),
-                    RESOURCE.illegalArrayExpression(p));
-            }
-        }
-</#if>
     )
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -141,6 +141,10 @@ public abstract class SqlAbstractConformance implements SqlConformance {
     return SqlConformanceEnum.DEFAULT.allowExtendedTrim();
   }
 
+  @Override public boolean allowBareBracketArrayLiteral() {
+    return SqlConformanceEnum.DEFAULT.allowBareBracketArrayLiteral();
+  }
+
   @Override public boolean allowPluralTimeUnits() {
     return SqlConformanceEnum.DEFAULT.allowPluralTimeUnits();
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -571,6 +571,18 @@ public interface SqlConformance {
   boolean allowExtendedTrim();
 
   /**
+   * Whether array literals may omit the {@code ARRAY} keyword, using
+   * bare square brackets, as in BigQuery, e.g. {@code SELECT [1, 2, 3]}.
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#BABEL},
+   * {@link SqlConformanceEnum#BIG_QUERY},
+   * {@link SqlConformanceEnum#LENIENT};
+   * false otherwise.
+   */
+  boolean allowBareBracketArrayLiteral();
+
+  /**
    * Whether interval literals should allow plural time units
    * such as "YEARS" and "DAYS" in interval literals.
    *

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -409,6 +409,17 @@ public enum SqlConformanceEnum implements SqlConformance {
     }
   }
 
+  @Override public boolean allowBareBracketArrayLiteral() {
+    switch (this) {
+    case BABEL:
+    case BIG_QUERY:
+    case LENIENT:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   @Override public boolean allowPluralTimeUnits() {
     switch (this) {
     case BABEL:

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlDelegatingConformance.java
@@ -150,6 +150,10 @@ public class SqlDelegatingConformance implements SqlConformance {
     return delegate.allowExtendedTrim();
   }
 
+  @Override public boolean allowBareBracketArrayLiteral() {
+    return delegate.allowBareBracketArrayLiteral();
+  }
+
   @Override public boolean allowPluralTimeUnits() {
     return delegate.allowPluralTimeUnits();
   }

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -6511,6 +6511,37 @@ public class SqlParserTest {
     expr("array[^select^ 1]").fails("(?s)Encountered \"select\".*");
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7566">[CALCITE-7566]
+   * Support BigQuery-style bare bracket array literals</a>. */
+  @Test void testBareBracketArrayLiteral() {
+    final SqlParserFixture bq =
+        fixture().withConformance(SqlConformanceEnum.BIG_QUERY).expression();
+    bq.sql("[1, 2, 3]").ok("(ARRAY[1, 2, 3])");
+    // parser allows empty array; validator will reject it
+    bq.sql("[]").ok("(ARRAY[])");
+    // nested bare bracket literals
+    bq.sql("[[1, 2], [3, 4]]")
+        .ok("(ARRAY[(ARRAY[1, 2]), (ARRAY[3, 4])])");
+    // subscript directly on a bare bracket literal
+    bq.sql("[10, 20, 30][1]").ok("(ARRAY[10, 20, 30])[1]");
+    // SELECT context
+    fixture().withConformance(SqlConformanceEnum.BIG_QUERY)
+        .sql("select [1, 2, 3]")
+        .ok("SELECT (ARRAY[1, 2, 3])");
+
+    // BABEL and LENIENT also accept the bare bracket syntax
+    fixture().withConformance(SqlConformanceEnum.BABEL).expression()
+        .sql("[1, 2, 3]").ok("(ARRAY[1, 2, 3])");
+    fixture().withConformance(SqlConformanceEnum.LENIENT).expression()
+        .sql("[1, 2, 3]").ok("(ARRAY[1, 2, 3])");
+
+    // Strict conformance levels still reject the bare bracket syntax
+    expr("^[^1, 2, 3]").fails("(?s).*Encountered \"\\[\".*");
+    fixture().withConformance(SqlConformanceEnum.STRICT_2003).expression()
+        .sql("^[^1, 2, 3]")
+        .fails("(?s).*Encountered \"\\[\".*");
+  }
+
   @Test void testArrayFunction() {
     expr("array()").ok("ARRAY()");
     expr("array(1)").ok("ARRAY(1)");


### PR DESCRIPTION
## Summary

- Adds support for BigQuery-style array literals written without the `ARRAY` keyword, e.g. `SELECT [1, 2, 3]`, when conformance is `BIG_QUERY` (also `BABEL`, `LENIENT`).
- Introduces `SqlConformance#allowBareBracketArrayLiteral()` and gates a new alternative in the JavaCC `ArrayConstructor` production with it. The new alternative emits the same `ARRAY_VALUE_CONSTRUCTOR` call used by `ARRAY[...]`, so validation, type derivation, and unparse paths require no other changes.
- Fixes [CALCITE-7566](https://issues.apache.org/jira/browse/CALCITE-7566).

## Test plan

- [x] New `SqlParserTest#testBareBracketArrayLiteral` covers `[1, 2, 3]`, empty `[]`, nested `[[1, 2], [3, 4]]`, subscript `[10, 20, 30][1]`, and `SELECT [1, 2, 3]` under `BIG_QUERY`; also asserts `BABEL`/`LENIENT` accept and `DEFAULT`/`STRICT_2003` reject.
- [x] `./gradlew :core:test --tests CoreSqlParserTest --tests SqlUnParserTest` — 991 passed, 0 failed (9 pre-existing skips).
- [x] JavaCC reports no new choice conflicts (the two pre-existing warnings near lines 1975 and 3703 are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)