### PR TITLE
[CALCITE-7567] `LeastRestrictiveSqlType` for `TIMESTAMP`, `TIMESTAMP_LTZ` might ignore precision

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -561,7 +561,7 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
           }
         }
 
-        if (type.getSqlTypeName() == resultType.getSqlTypeName()
+        if (type.getSqlTypeName().getFamily() == resultType.getSqlTypeName().getFamily()
             && type.getSqlTypeName().allowsPrec()
             && type.getPrecision() != resultType.getPrecision()) {
           final int precision =

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -169,6 +170,30 @@ class SqlTypeFactoryTest {
             Lists.newArrayList(f.sqlTimestampPrec3, f.sqlTimestampPrec0));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.TIMESTAMP));
     assertThat(leastRestrictive.isNullable(), is(false));
+    assertThat(leastRestrictive.getPrecision(), is(3));
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7567">
+   * LeastRetrictiveSqlType for TIMESTAMP, TIMESTAMP_LTZ might ignore precision</a>. */
+  @Test void testLeastRestrictiveForTimestampAndTimestampLtz() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType ltz0 =
+        f.typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 0);
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(Lists.newArrayList(ltz0, f.sqlTimestampPrec3));
+    assertThat(leastRestrictive, is(notNullValue()));
+    assertThat(leastRestrictive.getPrecision(), is(3));
+  }
+
+  @Test void testLeastRestrictiveForTimestampLtzAndTimestamp() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType ltz0 =
+        f.typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 0);
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(Lists.newArrayList(f.sqlTimestampPrec3, ltz0));
+    assertThat(leastRestrictive, is(notNullValue()));
     assertThat(leastRestrictive.getPrecision(), is(3));
   }
 


### PR DESCRIPTION
## Jira Link

[CALCITE-7567](https://issues.apache.org/jira/browse/CALCITE-7567)

## Changes Proposed
The PR makes sure that leastRestrictive for TIMESTAMP(3) and TIMESTAMP_LTZ(0) will return result with same precision as for TIMESTAMP_LTZ(0) and TIMESTAMP_LTZ(3)