### PR TITLE
 [CALCITE-7574] RelDecorrelator.isFieldNotNullRecursive throws IndexOutOfBoundsException when decorrelating correlated scalar subquery with Aggregate

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -3853,7 +3853,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
       Aggregate agg = (Aggregate) rel;
       ImmutableBitSet groupSet = agg.getGroupSet();
 
-      if (index >= groupSet.size()) {
+      if (index >= agg.getGroupCount()) {
         return false;
       }
       return isFieldNotNullRecursive(agg.getInput(), groupSet.asList().get(index));

--- a/core/src/test/java/org/apache/calcite/sql2rel/RelDecorrelatorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql2rel/RelDecorrelatorTest.java
@@ -2124,4 +2124,84 @@ public class RelDecorrelatorTest {
         + "        LogicalTableScan(table=[[scott, DEPT]])\n";
     assertThat(afterDecorrelation, hasTree(planAfterDecorrelation));
   }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7574">[CALCITE-7574]
+   * RelDecorrelator.isFieldNotNullRecursive throws IndexOutOfBoundsException
+   * when decorrelating correlated scalar subquery with Aggregate</a>.
+   *
+   * <p>When decorrelating a correlated scalar subquery containing an Aggregate,
+   * {@code isFieldNotNullRecursive} incorrectly used {@code ImmutableBitSet.size()}
+   * (which returns the bitset capacity, typically 64 * words) instead of
+   * {@code Aggregate.getGroupCount()} (which returns the number of group keys).
+   * This caused an {@code IndexOutOfBoundsException} when the field index
+   * corresponded to an aggregate result field (not a group field).
+   */
+  @Test void testDecorrelateScalarSubQueryWithAggregate() {
+    final FrameworkConfig frameworkConfig = config().build();
+    final RelBuilder builder = RelBuilder.create(frameworkConfig);
+    final RelOptCluster cluster = builder.getCluster();
+    final Planner planner = Frameworks.getPlanner(frameworkConfig);
+    // Minimal case: outer FROM is an Aggregate, correlated subquery
+    // references the aggregate result field (s) in the correlation
+    // condition, triggering isFieldNotNullRecursive on an Aggregate with
+    // an index pointing to an aggregate result field.
+    final String sql = "select t.deptno,\n"
+        + "  (select count(*) from emp e\n"
+        + "   where e.deptno = t.deptno\n"
+        + "     and e.sal > t.s)\n"
+        + "from (select deptno, sum(sal) as s\n"
+        + "      from emp group by deptno) t";
+    final RelNode originalRel;
+    try {
+      final SqlNode parse = planner.parse(sql);
+      final SqlNode validate = planner.validate(parse);
+      originalRel = planner.rel(validate).rel;
+    } catch (Exception e) {
+      throw TestUtil.rethrow(e);
+    }
+
+    final HepProgram hepProgram = HepProgram.builder()
+        .addRuleCollection(
+            ImmutableList.of(
+                CoreRules.FILTER_SUB_QUERY_TO_CORRELATE,
+                CoreRules.PROJECT_SUB_QUERY_TO_CORRELATE,
+                CoreRules.JOIN_SUB_QUERY_TO_CORRELATE))
+        .build();
+    final Program program =
+        Programs.of(hepProgram, true,
+            requireNonNull(cluster.getMetadataProvider()));
+    final RelNode before =
+        program.run(cluster.getPlanner(), originalRel, cluster.traitSet(),
+            Collections.emptyList(), Collections.emptyList());
+
+    // Before the fix, decorrelateQuery would throw:
+    // java.lang.IndexOutOfBoundsException: index out of range: 0
+    //   at org.apache.calcite.util.ImmutableBitSet.nth
+    //   at ...RelDecorrelator.isFieldNotNullRecursive
+    final RelNode after =
+        RelDecorrelator.decorrelateQuery(before, builder, RuleSets.ofList(Collections.emptyList()),
+            RuleSets.ofList(Collections.emptyList()));
+
+    // Verify decorrelation produced a valid plan (no Correlate nodes)
+    final String planAfter = ""
+        + "LogicalProject(DEPTNO=[$0], EXPR$1=[$4])\n"
+        + "  LogicalJoin(condition=[AND(IS NOT DISTINCT FROM($0, $2), IS NOT DISTINCT FROM($1, $3))], joinType=[left])\n"
+        + "    LogicalAggregate(group=[{0}], S=[SUM($1)])\n"
+        + "      LogicalProject(DEPTNO=[$7], SAL=[$5])\n"
+        + "        LogicalTableScan(table=[[scott, EMP]])\n"
+        + "    LogicalProject(DEPTNO0=[$0], S=[$1], EXPR$0=[CASE(IS NOT NULL($4), $4, 0)])\n"
+        + "      LogicalJoin(condition=[AND(IS NOT DISTINCT FROM($0, $2), IS NOT DISTINCT FROM($1, $3))], joinType=[left])\n"
+        + "        LogicalAggregate(group=[{0}], S=[SUM($1)])\n"
+        + "          LogicalProject(DEPTNO=[$7], SAL=[$5])\n"
+        + "            LogicalTableScan(table=[[scott, EMP]])\n"
+        + "        LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT()])\n"
+        + "          LogicalProject(DEPTNO0=[$8], S=[$9])\n"
+        + "            LogicalJoin(condition=[AND(=($7, $8), >(CAST($5):DECIMAL(19, 2), $9))], joinType=[inner])\n"
+        + "              LogicalTableScan(table=[[scott, EMP]])\n"
+        + "              LogicalAggregate(group=[{0}], S=[SUM($1)])\n"
+        + "                LogicalProject(DEPTNO=[$7], SAL=[$5])\n"
+        + "                  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(after, hasTree(planAfter));
+  }
 }

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -9237,4 +9237,23 @@ SELECT deptno, dname > SOME(SELECT empno FROM emp) AS b FROM dept;
 For input string: "ACCOUNTING"
 !error
 
+# [CALCITE-7574] RelDecorrelator.isFieldNotNullRecursive throws
+# IndexOutOfBoundsException when decorrelating correlated scalar subquery
+# with Aggregate
+# Before fix: java.lang.IndexOutOfBoundsException: index out of range: 0
+SELECT t.deptno,
+  (SELECT COUNT(*) FROM emp e
+   WHERE e.deptno = t.deptno AND e.sal > t.s)
+FROM (SELECT deptno, SUM(sal) AS s FROM emp GROUP BY deptno) t;
++--------+--------+
+| DEPTNO | EXPR$1 |
++--------+--------+
+|     10 |      0 |
+|     20 |      0 |
+|     30 |      0 |
++--------+--------+
+(3 rows)
+
+!ok
+
 # End sub-query.iq


### PR DESCRIPTION
## Jira Link

  [CALCITE-7574](https://issues.apache.org/jira/browse/CALCITE-7574)

  ## Changes Proposed

  In `RelDecorrelator.isFieldNotNullRecursive`, the Aggregate branch used `ImmutableBitSet.size()` for bounds checking, which returns the bitset **capacity** (`words.length * 64`,
   typically ≥ 64) rather than the actual number of group keys. When a field index corresponds to an aggregate result field (not a group field), the check was too lenient, causing
   `groupSet.asList().get(index)` to call `nth(index)` which throws `IndexOutOfBoundsException`.

  Changed `groupSet.size()` to `agg.getGroupCount()` (equivalent to `groupSet.cardinality()`), which correctly returns the number of group keys. Aggregate result fields now
  correctly return `false` instead of throwing an exception.

  Bug introduced by [CALCITE-6962].

  ### Reproduction

  ```sql
  SELECT t1.deptno, t1.total_sal,
    (SELECT COUNT(DISTINCT t2.total_sal) + 1
     FROM (SELECT deptno, SUM(sal) AS total_sal
           FROM emp WHERE deptno IS NOT NULL
           GROUP BY deptno) t2
     WHERE t2.deptno = t1.deptno
       AND t2.total_sal > t1.total_sal) AS rank_sal
  FROM (SELECT deptno, SUM(sal) AS total_sal
        FROM emp WHERE deptno IS NOT NULL
        GROUP BY deptno) t1
  ORDER BY t1.deptno, t1.total_sal DESC
```