### PR TITLE
[CALCITE-5101] AggregateExpandDistinctAggregatesRule does not remap WITHIN GROUP collation indices, causing ArrayIndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateExpandDistinctAggregatesRule.java
@@ -19,7 +19,9 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Aggregate.Group;
 import org.apache.calcite.rel.core.AggregateCall;
@@ -555,6 +557,44 @@ public final class AggregateExpandDistinctAggregatesRule
     relBuilder.push(aggregate.getInput());
     final int bottomGroupCount = fullGroupSet.cardinality();
 
+    // A DISTINCT aggregate may order its input on a column that is neither a
+    // group key nor one of its own arguments, e.g.
+    //   LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal).
+    // The inner (distinct) aggregate would otherwise drop that column, so the
+    // outer aggregate could no longer reference it and would fail with an
+    // ArrayIndexOutOfBoundsException (CALCITE-5101). For every such collation
+    // column we ensure the value is carried through the inner aggregate and
+    // record where it lands so the collation can be remapped later:
+    //  - if the column is already a group key it survives unchanged, so map it
+    //    to itself;
+    //  - otherwise add a MIN(column) aggregate ($mc_ = "min collation" marker)
+    //    that preserves the value (one row per group) and map the column to the
+    //    ordinal of that new aggregate output.
+    final Map<Integer, Integer> collations = new HashMap<>();
+    for (AggregateCall aggCall : aggregate.getAggCallList()) {
+      if (!aggCall.isDistinct()) {
+        continue;
+      }
+      List<Integer> collationColumns = aggCall.getCollation().getKeys();
+
+      if (!collationColumns.isEmpty()) {
+        for (int i : collationColumns) {
+          if (!collations.containsKey(i)) {
+            if (fullGroupSet.get(i)) {
+              collations.put(i, fullGroupSet.indexOf(i));
+            } else {
+              collations.put(i, bottomGroupCount + distinctAggCalls.size());
+              distinctAggCalls.add(
+                  AggregateCall.create(SqlStdOperatorTable.MIN, false, false,
+                      false, ImmutableList.of(), ImmutableIntList.of(i), -1,
+                      null, RelCollations.EMPTY, groupSets.isEmpty(), relBuilder.peek(),
+                      null, "$mc_" + i));
+            }
+          }
+        }
+      }
+    }
+
     // Map each (groupSet, filterArg) pair to an output field index in the
     // bottom projection. These fields become boolean/marker columns used to
     // implement FILTER(...) and to detect whether a grouping set had rows.
@@ -646,6 +686,8 @@ public final class AggregateExpandDistinctAggregatesRule
           final int newFilterArg =
               requireNonNull(filters.get(Pair.of(groupingSet, -1)),
                   () -> "filters.get(" + groupingSet + ", -1)");
+          // collation already applied in the inner aggregate
+          final RelCollation newCollation = RelCollations.EMPTY;
           final String upperAggName = upperAggCallName(aggCall, g);
           // Each filtered grouping set emits exactly one row per group,
           // so MIN just passes that value through without re-aggregation
@@ -653,7 +695,7 @@ public final class AggregateExpandDistinctAggregatesRule
               AggregateCall.create(aggCall.getParserPosition(),
                   SqlStdOperatorTable.MIN, false, aggCall.isApproximate(),
                   aggCall.ignoreNulls(), aggCall.rexList, args, newFilterArg,
-                  aggCall.distinctKeys, aggCall.collation, aggregate.hasEmptyGroup(),
+                  aggCall.distinctKeys, newCollation, aggregate.hasEmptyGroup(),
                   relBuilder.peek(), null, upperAggName);
           upperAggCalls.add(newCall);
           ordinals.add(topGroupCount + upperAggCalls.size() - 1);
@@ -668,12 +710,13 @@ public final class AggregateExpandDistinctAggregatesRule
           final int newFilterArg =
               requireNonNull(filters.get(Pair.of(newGroupSet, aggCall.filterArg)),
                   () -> "filters.get(" + newGroupSet + ", " + aggCall.filterArg + ")");
+          final RelCollation newCollation = remapCollation(aggCall.collation, collations);
           final String upperAggName = upperAggCallName(aggCall, g);
           final AggregateCall newCall =
               AggregateCall.create(aggCall.getParserPosition(), aggCall.getAggregation(), false,
                   aggCall.isApproximate(), aggCall.ignoreNulls(),
                   aggCall.rexList, newArgList, newFilterArg,
-                  aggCall.distinctKeys, aggCall.collation,
+                  aggCall.distinctKeys, newCollation,
                   aggregate.hasEmptyGroup(), relBuilder.peek(), null, upperAggName);
           upperAggCalls.add(newCall);
           ordinals.add(topGroupCount + upperAggCalls.size() - 1);
@@ -830,6 +873,27 @@ public final class AggregateExpandDistinctAggregatesRule
       x >>= 1;
     }
     return v;
+  }
+
+  /**
+   * Rewrites {@code collation}'s field indices through {@code map} (original
+   * column ordinal -> new column ordinal). Every field referenced by the
+   * collation must be present as a key in the map; throws otherwise.
+   * Direction and null-direction are preserved.
+   */
+  private static RelCollation remapCollation(RelCollation collation,
+      Map<Integer, Integer> map) {
+    final List<RelFieldCollation> fcs = collation.getFieldCollations();
+    final List<RelFieldCollation> newFcs = new ArrayList<>(fcs.size());
+    for (RelFieldCollation fc : fcs) {
+      final Integer newIndex =
+          requireNonNull(map.get(fc.getFieldIndex()),
+              () -> "no remap entry for collation field " + fc.getFieldIndex());
+      newFcs.add(
+          new RelFieldCollation(newIndex, fc.getDirection(),
+              fc.nullDirection));
+    }
+    return RelCollations.of(newFcs);
   }
 
   static ImmutableBitSet remap(ImmutableBitSet groupSet,
@@ -1022,7 +1086,7 @@ public final class AggregateExpandDistinctAggregatesRule
       final AggregateCall newAggCall =
           AggregateCall.create(aggCall.getParserPosition(), aggCall.getAggregation(), false,
               aggCall.isApproximate(), aggCall.ignoreNulls(), aggCall.rexList,
-              newArgs, -1, aggCall.distinctKeys, aggCall.collation,
+              newArgs, -1, aggCall.distinctKeys, remapCollation(aggCall.collation, sourceOf),
               aggCall.getType(), aggCall.getName());
       assert refs.get(i) == null;
       if (leftFields == null) {
@@ -1111,7 +1175,7 @@ public final class AggregateExpandDistinctAggregatesRule
           AggregateCall.create(aggCall.getParserPosition(), aggCall.getAggregation(), false,
               aggCall.isApproximate(), aggCall.ignoreNulls(),
               aggCall.rexList, newArgs, -1,
-              aggCall.distinctKeys, aggCall.collation,
+              aggCall.distinctKeys, remapCollation(aggCall.collation, sourceOf),
               aggCall.getType(), aggCall.getName());
       newAggCalls.set(i, newAggCall);
     }
@@ -1122,7 +1186,7 @@ public final class AggregateExpandDistinctAggregatesRule
    * and the ordinals of the arguments to a
    * particular call to an aggregate function, creates a 'select distinct'
    * relational expression which projects the group columns and those
-   * arguments but nothing else.
+   * arguments (plus any collation columns needed for ordering, see below).
    *
    * <p>For example, given
    *
@@ -1144,12 +1208,21 @@ public final class AggregateExpandDistinctAggregatesRule
    * <p>The <code>sourceOf</code> map is populated with the source of each
    * column; in this case sourceOf.get(0) = 0, and sourceOf.get(1) = 2.
    *
+   * <p>If an aggregate call orders its input on a column that is neither a
+   * group key nor one of {@code argList} (for example the {@code sal} column in
+   * {@code LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal)}), that column
+   * is also projected and a {@code MIN(column)} aggregate (named
+   * {@code $mc_<ordinal>}, "min collation" marker) is added so the ordering
+   * value survives the distinct aggregate and remains available to the caller;
+   * {@code sourceOf} records its output ordinal. See CALCITE-5101.
+   *
    * @param relBuilder Relational expression builder
    * @param aggregate Aggregate relational expression
    * @param argList   Ordinals of columns to make distinct
    * @param filterArg Ordinal of column to filter on, or -1
    * @param sourceOf  Out parameter, is populated with a map of where each
-   *                  output field came from
+   *                  output field came from, including any collation columns
+   *                  carried through via {@code $mc_} aggregates
    * @return Aggregate relational expression which projects the required
    * columns
    */
@@ -1193,13 +1266,42 @@ public final class AggregateExpandDistinctAggregatesRule
       sourceOf.put(arg, projects.size());
       RexInputRef.add2(projects, arg, childFields);
     }
-    relBuilder.project(projects.leftList(), projects.rightList());
+    int groupCount = projects.size();
+
+    Set<Integer> collationKeys = aggregate.getAggCallList().stream()
+        .map(aggCall -> aggCall.collation.getKeys())
+        .flatMap(Collection::stream).collect(Collectors.toSet());
+
+    for (int key : collationKeys) {
+      if (!sourceOf.containsKey(key)) {
+        sourceOf.put(key, projects.size());
+        projects.add(RexInputRef.of2(key, childFields));
+      }
+    }
+
+    relBuilder.project(Pair.left(projects), Pair.right(projects));
+
+    List<AggregateCall> aggregateCalls = new ArrayList<>();
+    for (int key : collationKeys) {
+      // Group keys and distinct arguments survive as group keys of the inner
+      // aggregate at their existing positions, so they need no MIN. Only a
+      // genuine ORDER BY column (neither a group key nor an argument) must be
+      // carried through via MIN(column), referencing its projected position.
+      if (!aggregate.getGroupSet().get(key) && !argList.contains(key)) {
+        final int projectIndex = sourceOf.get(key);
+        aggregateCalls.add(
+            AggregateCall.create(SqlStdOperatorTable.MIN, false, false,
+                false, ImmutableList.of(), ImmutableIntList.of(projectIndex), -1, null,
+                RelCollations.EMPTY, false, relBuilder.peek(),
+                null, "$mc_" + key));
+      }
+    }
 
     // Get the distinct values of the GROUP BY fields and the arguments
     // to the agg functions.
     relBuilder.push(
         aggregate.copy(aggregate.getTraitSet(), relBuilder.build(),
-            ImmutableBitSet.range(projects.size()), null, ImmutableList.of()));
+            ImmutableBitSet.range(groupCount), null, aggregateCalls));
     return relBuilder;
   }
 

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -2643,6 +2643,46 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5101">[CALCITE-5101]
+   * LISTAGG(DISTINCT x) WITHIN GROUP (ORDER BY y) throws
+   * ArrayIndexOutOfBoundsException when the ORDER BY column differs from
+   * both the GROUP BY column and the DISTINCT column</a>. */
+  @Test void testDistinctListAggWithinGroupOrderByOtherColumn() {
+    final String sql = "SELECT deptno, LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal)\n"
+        + "FROM emp\n"
+        + "GROUP BY deptno";
+    sql(sql).withRule(CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES)
+        .check();
+  }
+
+  @Test void testDistinctListAggWithinGroupOrderByOtherColumn1() {
+    final String sql = "SELECT deptno, LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal),"
+        + "LISTAGG(DISTINCT deptno) WITHIN GROUP (ORDER BY ename)\n"
+        + "FROM emp\n"
+        + "GROUP BY deptno";
+    sql(sql).withRule(CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES)
+        .check();
+  }
+
+  @Test void testDistinctListAggWithinGroupOrderByDistinctColumn() {
+    final String sql = "SELECT deptno, LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY ename)\n"
+        + "FROM emp\n"
+        + "GROUP BY deptno";
+    sql(sql).withRule(CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES)
+        .check();
+  }
+
+  @Test void testDistinctListAggWithinGroupMultipleOrderBy() {
+    final String sql = "SELECT deptno,\n"
+        + "  LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal),\n"
+        + "  LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY comm)\n"
+        + "FROM emp\n"
+        + "GROUP BY deptno";
+    sql(sql).withRule(CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES)
+        .check();
+  }
+
   @Test void testDistinctWithGrouping() {
     final String sql = "SELECT sal, SUM(comm), MIN(comm), SUM(DISTINCT sal)\n"
         + "FROM emp\n"

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -3536,6 +3536,98 @@ LogicalProject(EXPR$0=[$0], EXPR$1=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDistinctListAggWithinGroupMultipleOrderBy">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno,
+  LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal),
+  LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY comm)
+FROM emp
+GROUP BY deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1) WITHIN GROUP ([2])], EXPR$2=[LISTAGG(DISTINCT $1) WITHIN GROUP ([3])])
+  LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5], COMM=[$6])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG($1) WITHIN GROUP ([2])], EXPR$2=[LISTAGG($1) WITHIN GROUP ([3])])
+  LogicalAggregate(group=[{0, 1}], $mc_2=[MIN($2)], $mc_3=[MIN($3)])
+    LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5], COMM=[$6])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDistinctListAggWithinGroupOrderByDistinctColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY ename)
+FROM emp
+GROUP BY deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1) WITHIN GROUP ([1])])
+  LogicalProject(DEPTNO=[$7], ENAME=[$1])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG($1) WITHIN GROUP ([1])])
+  LogicalAggregate(group=[{0, 1}])
+    LogicalProject(DEPTNO=[$7], ENAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDistinctListAggWithinGroupOrderByOtherColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal)
+FROM emp
+GROUP BY deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1) WITHIN GROUP ([2])])
+  LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG($1) WITHIN GROUP ([2])])
+  LogicalAggregate(group=[{0, 1}], $mc_2=[MIN($2)])
+    LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDistinctListAggWithinGroupOrderByOtherColumn1">
+    <Resource name="sql">
+      <![CDATA[SELECT deptno, LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal),LISTAGG(DISTINCT deptno) WITHIN GROUP (ORDER BY ename)
+FROM emp
+GROUP BY deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1) WITHIN GROUP ([2])], EXPR$2=[LISTAGG(DISTINCT $3) WITHIN GROUP ([1])])
+  LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5], $f3=[CAST($7):VARCHAR NOT NULL])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(DEPTNO=[$0], EXPR$1=[CAST($1):VARCHAR(20) NOT NULL], EXPR$2=[CAST($2):VARCHAR NOT NULL])
+  LogicalAggregate(group=[{0}], EXPR$1_g0=[LISTAGG($1) WITHIN GROUP ([3]) FILTER $4], EXPR$2_g0=[LISTAGG($2) WITHIN GROUP ([1]) FILTER $5])
+    LogicalProject(DEPTNO=[$0], ENAME=[$1], $f3=[$2], $mc_2=[$3], $g_1=[=($4, 1)], $g_2=[=($4, 2)])
+      LogicalAggregate(group=[{0, 1, 3}], groups=[[{0, 1}, {0, 3}, {0}]], $mc_2=[MIN($2)], $g=[GROUPING($0, $1, $3)])
+        LogicalProject(DEPTNO=[$7], ENAME=[$1], SAL=[$5], $f3=[CAST($7):VARCHAR NOT NULL])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDistinctNonDistinctAggregates">
     <Resource name="sql">
       <![CDATA[select emp.empno, count(*), avg(distinct dept.deptno)

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3385,6 +3385,46 @@ from emp group by gender;
 
 !ok
 
+# [CALCITE-5101] LISTAGG(DISTINCT x) WITHIN GROUP (ORDER BY y) where the ORDER BY
+# column differs from the DISTINCT column. The result must be ordered by the
+# ORDER BY column (ord), not by the aggregated value (val), so the expected
+# output is 'c,a,b' (ord 1,2,3) and not 'a,b,c'.
+select listagg(distinct val) within group (order by ord) as agg
+from (values
+  ('c', 1),
+  ('a', 2),
+  ('b', 3),
+  ('a', 2)) as t(val, ord);
++-------+
+| AGG   |
++-------+
+| c,a,b |
++-------+
+(1 row)
+
+!ok
+
+# [CALCITE-5101] Two DISTINCT LISTAGGs with different arguments force the
+# grouping-sets expansion path; each WITHIN GROUP ORDER BY references a column
+# that is neither the group key nor that aggregate's own argument. Each distinct
+# value maps to a single ordering value, so the order is deterministic.
+select grp,
+  listagg(distinct a) within group (order by b) as la,
+  listagg(distinct c) within group (order by d) as lc
+from (values
+  (1, 'a1', 'b3', 'c1', 'd2'),
+  (1, 'a2', 'b1', 'c2', 'd1'),
+  (1, 'a3', 'b2', 'c3', 'd3')) as t(grp, a, b, c, d)
+group by grp;
++-----+----------+----------+
+| GRP | LA       | LC       |
++-----+----------+----------+
+|   1 | a2,a3,a1 | c2,c1,c3 |
++-----+----------+----------+
+(1 row)
+
+!ok
+
 !use mysqlfunc
 
 # GROUP_CONCAT (MySQL) is very similar to LISTAGG.


### PR DESCRIPTION
## [CALCITE-5101] LISTAGG(DISTINCT x) WITHIN GROUP (ORDER BY y) throws ArrayIndexOutOfBoundsException when the ORDER BY column differs from the GROUP BY and DISTINCT columns

### Problem

A query such as

```sql
SELECT deptno, LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY sal)
FROM emp
GROUP BY deptno
```

fails with an `ArrayIndexOutOfBoundsException` (surfaced as `IllegalStateException: Unable to implement EnumerableAggregate(...)`, thrown from `PhysTypeImpl.generateCollationKey`). The failure occurs whenever the `WITHIN GROUP (ORDER BY ...)` column is neither the `GROUP BY` column nor the `DISTINCT` argument.

These variants already worked:
- `LISTAGG(DISTINCT ename)` — no `ORDER BY`
- `LISTAGG(ename) WITHIN GROUP (ORDER BY sal)` — no `DISTINCT`
- `LISTAGG(DISTINCT ename) WITHIN GROUP (ORDER BY ename)` — ordering matches the aggregated column

### Root cause

`AggregateExpandDistinctAggregatesRule` rewrites a distinct aggregate into an inner "distinct" aggregate feeding an outer aggregate. When building the outer `AggregateCall` it correctly remapped the **argument** indices to the post-expansion input shape, but left the **`WITHIN GROUP` collation** indices untouched. The collation then referenced a pre-expansion column that the inner aggregate had dropped, yielding an out-of-bounds (or simply wrong) field index.

### Fix

The rule now carries every ORDER BY column through the inner aggregate and remaps the outer collation accordingly:

- Added a `remapCollation` helper that rewrites a `RelCollation`'s field indices through an index map, preserving direction and null-direction.
- **Grouping-sets path** (`rewriteUsingGroupingSets`): for each distinct aggregate's collation column, if it is already a group key it is mapped to its position in the bottom group set; otherwise it is carried through via a `MIN(column)` marker (`$mc_*`) added to the bottom aggregate. The upper aggregate's collation is remapped through this map.
- **Monopole / join path** (`createSelectDistinct`, `doRewrite`, `rewriteAggCalls`): collation columns that are not already projected are projected, genuine ORDER BY columns (neither a group key nor a distinct argument) are carried through via `MIN(column)` markers, and the outer collation is remapped via the `sourceOf` map (now recording each marker's output ordinal).

The result is that the ORDER BY value survives the distinct aggregate and the outer `LISTAGG` orders by the correct column.

### Tests

- `RelOptRulesTest` plan tests covering both expansion paths:
  - `testDistinctListAggWithinGroupOrderByOtherColumn` / `...OrderByOtherColumn1` — ORDER BY a non-group, non-distinct column (single and multiple distinct aggregates).
  - `testDistinctListAggWithinGroupOrderByDistinctColumn` — ORDER BY the distinct argument (no marker needed).
  - `testDistinctListAggWithinGroupMultipleOrderBy` — multiple ORDER BY columns over the same argument (one marker each).
- `agg.iq` execution tests that assert the actual `LISTAGG` output ordering (not just that the query completes), covering both the monopole and grouping-sets paths.
