### PR TITLE
[CALCITE-7575] Parser can not parse unparsed polymorphic table functions with several table args

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1081,6 +1081,9 @@ void AddArg(List<SqlNode> list, ExprContext exprContext) :
 {
     final SqlIdentifier name;
     SqlNode e;
+    final Span s;
+    SqlNodeList partitionList;
+    SqlNodeList orderList;
 }
 {
     (
@@ -1094,6 +1097,17 @@ void AddArg(List<SqlNode> list, ExprContext exprContext) :
         e = LambdaExpression()
     |
         e = Expression(exprContext)
+        // A set-semantics table argument may be a partitioned sub-query, e.g.
+        // "(SELECT ...) PARTITION BY key [ORDER BY ...]".
+        [
+            { s = span(); }
+            <PARTITION> <BY> partitionList = SimpleIdentifierOrList()
+            (
+                orderList = OrderByOfSetSemanticsTable()
+            |   { orderList = SqlNodeList.EMPTY; }
+            )
+            { e = CreateSetSemanticsTableIfNeeded(s, e, partitionList, orderList); }
+        ]
     |
         e = TableParam()
     )

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1997,6 +1997,21 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "  table emp partition by deptno order by empno,\n"
         + "  table emp_b partition by deptno order by empno))")
         .ok();
+
+    // Test cases for [CALCITE-7575] https://issues.apache.org/jira/browse/CALCITE-7575
+    // Parser can not parse unparsed polymorphic table functions with several table args
+    final String emp = "(SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, "
+        + "`EMP`.`HIREDATE`, `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `EMP`.`SLACKER`\n"
+        + "FROM `CATALOG`.`SALES`.`EMP` AS `EMP`) PARTITION BY `DEPTNO`";
+    final String rewritten = "SELECT `EXPR$0`.`VAL`\n"
+        + "FROM TABLE(SIMILARLITY("
+        + emp + ", " + emp + ")) AS `EXPR$0`";
+    sql("select * from table(SIMILARLITY(\n"
+        + "  table emp partition by deptno,\n"
+        + "  table emp partition by deptno))")
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(rewritten);
+    sql(rewritten).withParserConfig(c -> c.withQuoting(Quoting.BACK_TICK)).ok();
   }
 
   @Test void testUnknownFunctionHandling() {

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -2318,6 +2318,61 @@ each row in the original table to a window. The output table has all
 the same columns as the original table plus two additional columns `window_start`
 and `window_end`, which represent the start and end of the window interval, respectively.
 
+#### Polymorphic table functions
+
+A polymorphic table function (PTF) is a table function that takes one or more
+*table arguments* in addition to scalar and `DESCRIPTOR` arguments. Like any
+table function, it is invoked in the `FROM` clause; the examples below place the
+call inside the `TABLE( ... )` operator, as in `SELECT * FROM TABLE(funcName(...))`,
+which is the form used by the SQL standard, but Calcite also accepts the implicit
+form `SELECT * FROM funcName(...)`.
+
+A table argument is introduced by the `TABLE` keyword and is either a table
+reference or a query. A table argument with set semantics may be followed by a
+`PARTITION BY` clause, an `ORDER BY` clause, or both; each partition is then
+processed independently. A table argument with row semantics may not be
+partitioned or ordered.
+
+A PTF may have more than one table argument, each with its own semantics,
+partitioning and ordering; at most one of them may have row semantics.
+
+| Operator syntax      | Description
+|:-------------------- |:-----------
+| TABLE(funcName(tableArg [, tableArg ]* [, arg ]*))<br/>where tableArg is&nbsp;&nbsp;TABLE tableExpr [ PARTITION BY columns ] [ ORDER BY columns ] | Invokes polymorphic table function *funcName* over one or more table arguments, each optionally partitioned and ordered (set semantics), together with any scalar or `DESCRIPTOR` arguments.
+
+A PTF with a single table argument:
+
+{% highlight sql %}
+SELECT * FROM TABLE(
+topn(
+TABLE orders PARTITION BY product ORDER BY amount DESC,
+3));
+
+-- or with the named params
+SELECT * FROM TABLE(
+topn(
+DATA => TABLE orders PARTITION BY product ORDER BY amount DESC,
+COL => 3));
+{% endhighlight %}
+
+partitions the `orders` table by `product`, orders each partition by `amount`
+descending, and lets the function emit, say, the top 3 rows of each partition.
+
+A PTF with multiple table arguments:
+
+{% highlight sql %}
+SELECT * FROM TABLE(
+similarity(
+TABLE orders PARTITION BY product,
+TABLE returns PARTITION BY product));
+{% endhighlight %}
+
+passes two input tables, each partitioned by `product`, so the function can
+compare the matching partitions of `orders` and `returns`.
+
+The built-in window table functions `TUMBLE`, `HOP` and `SESSION` (described
+below) are concrete polymorphic table functions.
+
 ### Grouped window functions
 **warning**: grouped window functions are deprecated.
 


### PR DESCRIPTION
## Jira Link

[CALCITE-7575](https://issues.apache.org/jira/browse/CALCITE-7575)

## Changes Proposed
The PR is to support parsing of queries with PTF (polymorphic table functions) with several table args like 
```sql
SELECT * FROM TABLE(MY_PTF(
(SELECT * FROM table1) PARTITION BY a,
(SELECT * FROM table2) PARTITION BY b))
```